### PR TITLE
feat(cloud): shared-to-dedicated memory transfer push service

### DIFF
--- a/packages/agent/src/api/memory-import.test.ts
+++ b/packages/agent/src/api/memory-import.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Contract tests for the bulk transferred-memory import surface. Deterministic:
+ * the runtime is a recorder double so every assertion inspects exactly what
+ * would be persisted — verbatim ids/timestamps/content/vectors, the deliberate
+ * agent/authored-entity remap, scaffolding upserts with preserved ids, and
+ * idempotent re-import. The wire shape mirrors the cloud-side fidelity
+ * transform's output.
+ */
+
+import { describe, expect, test } from "vitest";
+import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import {
+  importTransferredMemories,
+  type MemoryImportItem,
+  PostMemoryImportRequestSchema,
+} from "./memory-import.ts";
+
+const LOCAL_AGENT = "11111111-1111-4111-8111-111111111111" as UUID;
+const SOURCE_AGENT = "8f1f7f72-0577-4b4a-b15b-229c751d5484";
+const USER_ENTITY = "1d88c441-09a2-47ac-a8fd-a502884390c3";
+const ROOM = "866e5ec5-5e66-4387-9333-6be867377d63";
+const WORLD = "d04cf4d3-a60e-4209-ad78-d67d6a38ff95";
+
+interface RecordedRuntime {
+  runtime: AgentRuntime;
+  createdMemories: Array<{ memory: Memory; tableName: string }>;
+  worlds: Array<Record<string, unknown>>;
+  rooms: Array<Record<string, unknown>>;
+  entities: Array<Record<string, unknown>>;
+  existingMemoryIds: Set<string>;
+  existingEntityIds: Set<string>;
+}
+
+function recorderRuntime(): RecordedRuntime {
+  const state: RecordedRuntime = {
+    runtime: undefined as unknown as AgentRuntime,
+    createdMemories: [],
+    worlds: [],
+    rooms: [],
+    entities: [],
+    existingMemoryIds: new Set(),
+    existingEntityIds: new Set(),
+  };
+  state.runtime = {
+    agentId: LOCAL_AGENT,
+    ensureWorldExists: async (world: Record<string, unknown>) => {
+      state.worlds.push(world);
+    },
+    ensureRoomExists: async (room: Record<string, unknown>) => {
+      state.rooms.push(room);
+    },
+    getEntityById: async (id: string) =>
+      state.existingEntityIds.has(id)
+        ? { id, names: [], agentId: LOCAL_AGENT }
+        : null,
+    createEntity: async (entity: Record<string, unknown>) => {
+      state.entities.push(entity);
+      return true;
+    },
+    getMemoryById: async (id: string) =>
+      state.existingMemoryIds.has(id) ? ({ id } as Memory) : null,
+    adapter: {
+      createMemories: async (
+        batch: Array<{ memory: Memory; tableName: string }>,
+      ) => {
+        state.createdMemories.push(...batch);
+        return batch.map((entry) => entry.memory.id as UUID);
+      },
+    },
+  } as unknown as AgentRuntime;
+  return state;
+}
+
+function transferItem(
+  overrides: Partial<MemoryImportItem["memory"]> = {},
+): MemoryImportItem {
+  return {
+    memory: {
+      id: "96a23079-4032-49f3-ae44-d8a25471e473",
+      type: "messages",
+      created_at: "2026-08-17T03:44:45.770Z",
+      content: { text: "hi", source: "shared-runtime", channelType: "DM" },
+      entity_id: USER_ENTITY,
+      agent_id: SOURCE_AGENT,
+      room_id: ROOM,
+      world_id: WORLD,
+      unique: true,
+      metadata: { source: "shared-runtime-transfer" },
+      ...overrides,
+    },
+    embedding: {
+      memory_id:
+        (overrides.id as string) ?? "96a23079-4032-49f3-ae44-d8a25471e473",
+      dim_384: Array.from({ length: 384 }, (_, i) => Math.sin(i) / 2),
+    },
+  };
+}
+
+describe("transferred memory import", () => {
+  test("persists rows verbatim while remapping only the agent-owned identities", async () => {
+    const state = recorderRuntime();
+    const userRow = transferItem();
+    const assistantRow = transferItem({
+      id: "ada43714-95cf-4418-a568-a7ea232287fc",
+      entity_id: SOURCE_AGENT,
+      content: { text: "hello there", source: "shared-runtime" },
+    });
+
+    const result = await importTransferredMemories(state.runtime, [
+      userRow,
+      assistantRow,
+    ]);
+
+    expect(result).toEqual({
+      ok: true,
+      requested: 2,
+      imported: 2,
+      skippedExisting: 0,
+      embeddingsWritten: 2,
+      remappedAgentRows: 1,
+    });
+
+    const [user, assistant] = state.createdMemories;
+    expect(user?.tableName).toBe("messages");
+    expect(user?.memory.id).toBe(userRow.memory.id as UUID);
+    expect(user?.memory.createdAt).toBe(Date.parse("2026-08-17T03:44:45.770Z"));
+    expect(JSON.stringify(user?.memory.content)).toBe(
+      JSON.stringify(userRow.memory.content),
+    );
+    expect(user?.memory.unique).toBe(true);
+    expect(user?.memory.embedding).toEqual(
+      userRow.embedding?.dim_384 as number[],
+    );
+    // The user's identity survives; the row now belongs to the local agent.
+    expect(user?.memory.entityId).toBe(USER_ENTITY as UUID);
+    expect(user?.memory.agentId).toBe(LOCAL_AGENT);
+    expect(user?.memory.roomId).toBe(ROOM as UUID);
+    expect(user?.memory.worldId).toBe(WORLD as UUID);
+    // Assistant-authored rows remap entity_id: the source agent has no entity
+    // row here, and recall attributes agent speech by the local agent id.
+    expect(assistant?.memory.entityId).toBe(LOCAL_AGENT);
+  });
+
+  test("ensures scaffolding with transferred ids before any memory insert", async () => {
+    const state = recorderRuntime();
+    await importTransferredMemories(state.runtime, [transferItem()]);
+
+    expect(state.worlds).toEqual([
+      expect.objectContaining({ id: WORLD, agentId: LOCAL_AGENT }),
+    ]);
+    expect(state.rooms).toEqual([
+      expect.objectContaining({
+        id: ROOM,
+        worldId: WORLD,
+        source: "shared-runtime-transfer",
+      }),
+    ]);
+    expect(state.entities).toEqual([
+      expect.objectContaining({ id: USER_ENTITY, agentId: LOCAL_AGENT }),
+    ]);
+  });
+
+  test("re-importing the same batch is a no-op reported as skippedExisting", async () => {
+    const state = recorderRuntime();
+    const item = transferItem();
+    state.existingMemoryIds.add(item.memory.id);
+    state.existingEntityIds.add(USER_ENTITY);
+
+    const result = await importTransferredMemories(state.runtime, [item]);
+
+    expect(result.imported).toBe(0);
+    expect(result.skippedExisting).toBe(1);
+    expect(state.createdMemories).toHaveLength(0);
+    expect(state.entities).toHaveLength(0);
+  });
+
+  test("vector-less rows import without an embedding", async () => {
+    const state = recorderRuntime();
+    const item = transferItem();
+    const vectorless: MemoryImportItem = { memory: item.memory };
+
+    const result = await importTransferredMemories(state.runtime, [vectorless]);
+
+    expect(result.embeddingsWritten).toBe(0);
+    expect(state.createdMemories[0]?.memory.embedding).toBeUndefined();
+  });
+
+  test("schema rejects wrong-width vectors, bad uuids, and oversized batches", () => {
+    const item = transferItem();
+    expect(
+      PostMemoryImportRequestSchema.safeParse({
+        exports: [
+          {
+            memory: item.memory,
+            embedding: { memory_id: item.memory.id, dim_384: [1, 2, 3] },
+          },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      PostMemoryImportRequestSchema.safeParse({
+        exports: [{ memory: { ...item.memory, id: "not-a-uuid" } }],
+      }).success,
+    ).toBe(false);
+    expect(
+      PostMemoryImportRequestSchema.safeParse({
+        exports: Array.from({ length: 501 }, () => ({ memory: item.memory })),
+      }).success,
+    ).toBe(false);
+    expect(
+      PostMemoryImportRequestSchema.safeParse({
+        exports: [{ memory: item.memory }],
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/packages/agent/src/api/memory-import.ts
+++ b/packages/agent/src/api/memory-import.ts
@@ -1,0 +1,237 @@
+/**
+ * Bulk lossless import of transferred memory rows into this agent's database —
+ * the container-side landing half of a Shared→Dedicated cutover. The cloud
+ * control plane exports `shared_agent_memories` rows through its fidelity
+ * transform and POSTs them here once the container is reachable; the wire shape
+ * mirrors that transform's output (snake_case core `memories` row + optional
+ * `dim_384` embedding leg).
+ *
+ * Fidelity invariants: memory ids, `created_at`, `content`, `metadata`,
+ * `unique`, and vectors are persisted verbatim, so writes go through
+ * `runtime.adapter.createMemory` directly — the runtime wrapper's secret
+ * redaction and fact dedupe would mutate transferred history. Two identities
+ * are deliberately remapped: every row's `agent_id`, and the `entity_id` of
+ * rows authored by the source agent, become THIS runtime's agent id — the
+ * source agent id has no entity/agent row here (FK), and recall scopes by the
+ * local agent id. Referenced worlds/rooms/entities are upserted first with
+ * their transferred ids so foreign keys hold and cross-row identity survives.
+ * Re-POSTing a batch is a no-op per already-present id (adapter conflict
+ * skip + a pre-check that reports `skippedExisting` honestly).
+ */
+
+import {
+  type AgentRuntime,
+  ChannelType,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import { z } from "zod";
+import type { MemoryRouteContext } from "./memory-routes.ts";
+
+export const MEMORY_IMPORT_SOURCE = "shared-runtime-transfer";
+export const MEMORY_IMPORT_MAX_BATCH = 500;
+/** Vectored rows are ~4KB each; 500 rows plus content fits well inside this. */
+export const MEMORY_IMPORT_MAX_BODY_BYTES = 16 * 1024 * 1024;
+
+const UuidSchema = z.uuid();
+
+const ImportMemorySchema = z.object({
+  id: UuidSchema,
+  type: z.string().trim().min(1).max(64),
+  created_at: z.iso.datetime(),
+  content: z.record(z.string(), z.unknown()),
+  entity_id: UuidSchema.nullable(),
+  agent_id: UuidSchema,
+  room_id: UuidSchema.nullable(),
+  world_id: UuidSchema.nullable(),
+  unique: z.boolean(),
+  metadata: z.record(z.string(), z.unknown()),
+});
+
+const ImportEmbeddingSchema = z.object({
+  memory_id: UuidSchema,
+  dim_384: z.array(z.number().finite()).length(384),
+});
+
+const ImportItemSchema = z.object({
+  memory: ImportMemorySchema,
+  embedding: ImportEmbeddingSchema.optional(),
+});
+
+export const PostMemoryImportRequestSchema = z.object({
+  exports: z.array(ImportItemSchema).min(1).max(MEMORY_IMPORT_MAX_BATCH),
+});
+
+export type MemoryImportItem = z.infer<typeof ImportItemSchema>;
+
+export interface MemoryImportResult {
+  ok: true;
+  requested: number;
+  imported: number;
+  skippedExisting: number;
+  embeddingsWritten: number;
+  remappedAgentRows: number;
+}
+
+function transferWorldId(runtime: AgentRuntime): UUID {
+  // Deterministic per agent so retries and later batches converge on one world.
+  return `${runtime.agentId}` as UUID;
+}
+
+async function ensureScaffolding(
+  runtime: AgentRuntime,
+  items: MemoryImportItem[],
+): Promise<Map<string, UUID>> {
+  const sourceAgentIds = new Set(items.map((item) => item.memory.agent_id));
+
+  const worldIds = new Set<string>();
+  for (const item of items) {
+    if (item.memory.world_id) worldIds.add(item.memory.world_id);
+    else if (item.memory.room_id) worldIds.add(transferWorldId(runtime));
+  }
+  for (const worldId of worldIds) {
+    await runtime.ensureWorldExists({
+      id: worldId as UUID,
+      name: "Transferred shared history",
+      agentId: runtime.agentId,
+      metadata: { type: MEMORY_IMPORT_SOURCE },
+    });
+  }
+
+  // room id → effective world id, preserving the transferred pairing.
+  const roomWorlds = new Map<string, UUID>();
+  for (const item of items) {
+    if (!item.memory.room_id) continue;
+    const worldId = (item.memory.world_id ?? transferWorldId(runtime)) as UUID;
+    roomWorlds.set(item.memory.room_id, worldId);
+  }
+  for (const [roomId, worldId] of roomWorlds) {
+    await runtime.ensureRoomExists({
+      id: roomId as UUID,
+      name: "Transferred shared history",
+      source: MEMORY_IMPORT_SOURCE,
+      type: ChannelType.DM,
+      worldId,
+      metadata: { type: MEMORY_IMPORT_SOURCE },
+    });
+  }
+
+  const entityIds = new Set<string>();
+  for (const item of items) {
+    const entityId = item.memory.entity_id;
+    if (entityId && !sourceAgentIds.has(entityId)) entityIds.add(entityId);
+  }
+  for (const entityId of entityIds) {
+    const existing = await runtime.getEntityById(entityId as UUID);
+    if (existing) continue;
+    await runtime.createEntity({
+      id: entityId as UUID,
+      names: ["Transferred user"],
+      agentId: runtime.agentId,
+      metadata: { type: MEMORY_IMPORT_SOURCE },
+    });
+  }
+
+  return roomWorlds;
+}
+
+export async function importTransferredMemories(
+  runtime: AgentRuntime,
+  items: MemoryImportItem[],
+): Promise<MemoryImportResult> {
+  const sourceAgentIds = new Set(items.map((item) => item.memory.agent_id));
+  const roomWorlds = await ensureScaffolding(runtime, items);
+
+  let imported = 0;
+  let skippedExisting = 0;
+  let embeddingsWritten = 0;
+  let remappedAgentRows = 0;
+
+  for (const item of items) {
+    const row = item.memory;
+    const existing = await runtime.getMemoryById(row.id as UUID);
+    if (existing) {
+      skippedExisting += 1;
+      continue;
+    }
+
+    const authoredBySourceAgent =
+      row.entity_id !== null && sourceAgentIds.has(row.entity_id);
+    if (authoredBySourceAgent) remappedAgentRows += 1;
+
+    const memory: Memory = {
+      id: row.id as UUID,
+      agentId: runtime.agentId,
+      entityId: (authoredBySourceAgent
+        ? runtime.agentId
+        : (row.entity_id ?? runtime.agentId)) as UUID,
+      roomId: (row.room_id ?? undefined) as UUID,
+      worldId: row.room_id
+        ? roomWorlds.get(row.room_id)
+        : ((row.world_id ?? undefined) as UUID | undefined),
+      content: row.content as Memory["content"],
+      metadata: row.metadata as Memory["metadata"],
+      unique: row.unique,
+      createdAt: Date.parse(row.created_at),
+      ...(item.embedding ? { embedding: item.embedding.dim_384 } : {}),
+    };
+
+    // Adapter-direct on purpose: preserves id/createdAt/unique verbatim,
+    // skips the runtime wrapper's content redaction and fact dedupe, and is
+    // idempotent via the memories-table conflict skip.
+    await runtime.adapter.createMemories([
+      { memory, tableName: row.type, unique: row.unique },
+    ]);
+    imported += 1;
+    if (item.embedding) embeddingsWritten += 1;
+  }
+
+  return {
+    ok: true,
+    requested: items.length,
+    imported,
+    skippedExisting,
+    embeddingsWritten,
+    remappedAgentRows,
+  };
+}
+
+/** POST /api/memories/import — validates the batch and lands it losslessly. */
+export async function handleMemoryImportRoute(
+  ctx: MemoryRouteContext,
+): Promise<boolean> {
+  const { req, res, runtime, json, error, readJsonBody } = ctx;
+  if (!runtime) {
+    error(res, "Agent runtime is not available", 503);
+    return true;
+  }
+
+  const raw = await readJsonBody<Record<string, unknown>>(req, res, {
+    maxBytes: MEMORY_IMPORT_MAX_BODY_BYTES,
+  });
+  if (raw === null) return true;
+
+  const parsed = PostMemoryImportRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const path = issue?.path.length ? ` at ${issue.path.join(".")}` : "";
+    error(res, `${issue?.message ?? "Invalid import payload"}${path}`, 400);
+    return true;
+  }
+
+  const mismatched = parsed.data.exports.find(
+    (item) => item.embedding && item.embedding.memory_id !== item.memory.id,
+  );
+  if (mismatched) {
+    error(
+      res,
+      `embedding.memory_id does not match memory.id for ${mismatched.memory.id}`,
+      400,
+    );
+    return true;
+  }
+
+  const result = await importTransferredMemories(runtime, parsed.data.exports);
+  json(res, result);
+  return true;
+}

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -440,6 +440,13 @@ export async function handleMemoryRoutes(
     return true;
   }
 
+  // Dispatched before ensureMemoryConnection: a transfer import must not
+  // create the client-chat room, and it manages its own scaffolding rows.
+  if (method === "POST" && pathname === "/api/memories/import") {
+    const { handleMemoryImportRoute } = await import("./memory-import.ts");
+    return handleMemoryImportRoute(ctx);
+  }
+
   const resolvedAgentName = resolveAgentName(runtime, agentName);
   const { roomId, entityId } = await ensureMemoryConnection(
     runtime,

--- a/packages/cloud/shared/src/db/repositories/shared-agent-memories.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-agent-memories.integration.test.ts
@@ -325,3 +325,72 @@ describe("SharedAgentMemoriesReader.searchByEmbedding (real PGlite + pgvector)",
     expect(hits).toEqual([]);
   });
 });
+
+describe("SharedAgentMemoriesReader.listOldestByScope (real PGlite)", () => {
+  test("keyset pages walk the tenant's full history oldest-first without leaks", async () => {
+    for (let i = 0; i < 5; i++) {
+      await sharedAgentMemoriesWriter.insertMemory({
+        id: `cccccccc-cccc-4ccc-8ccc-00000000000${i}`,
+        scope: scopeA,
+        roomId: ROOM_A,
+        type: "messages",
+        content: { text: `a${i}` },
+      });
+    }
+    await sharedAgentMemoriesWriter.insertMemory({
+      scope: scopeB,
+      roomId: ROOM_B,
+      type: "messages",
+      content: { text: "other tenant" },
+    });
+
+    const seen: string[] = [];
+    let after: { createdAt: Date; id: string } | undefined;
+    for (;;) {
+      const page = await sharedAgentMemoriesReader.listOldestByScope(scopeA, 2, after);
+      if (page.length === 0) break;
+      for (const row of page) {
+        expect(row.organization_id).toBe(ORG_A);
+        seen.push((row.content as { text: string }).text);
+      }
+      const last = page[page.length - 1];
+      after = { createdAt: last?.created_at as Date, id: last?.id as string };
+      if (page.length < 2) break;
+    }
+    expect(seen).toEqual(["a0", "a1", "a2", "a3", "a4"]);
+  });
+
+  test("same-timestamp rows are disambiguated by the id leg of the cursor", async () => {
+    const ids = [
+      "dddddddd-dddd-4ddd-8ddd-000000000001",
+      "dddddddd-dddd-4ddd-8ddd-000000000002",
+      "dddddddd-dddd-4ddd-8ddd-000000000003",
+    ];
+    for (const id of ids) {
+      await sharedAgentMemoriesWriter.insertMemory({
+        id,
+        scope: scopeA,
+        roomId: ROOM_A,
+        type: "messages",
+        content: { text: id.slice(-1) },
+      });
+    }
+    const stamp = new Date("2026-08-17T00:00:00.000Z");
+    await dbWrite
+      .update(sharedAgentMemories)
+      .set({ created_at: stamp })
+      .where(
+        sql`${sharedAgentMemories.id} = ANY(ARRAY[${sql.join(
+          ids.map((id) => sql`${id}::uuid`),
+          sql`, `,
+        )}])`,
+      );
+
+    const first = await sharedAgentMemoriesReader.listOldestByScope(scopeA, 2);
+    const rest = await sharedAgentMemoriesReader.listOldestByScope(scopeA, 2, {
+      createdAt: first[first.length - 1]?.created_at as Date,
+      id: first[first.length - 1]?.id as string,
+    });
+    expect([...first, ...rest].map((row) => row.id)).toEqual(ids);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/shared-agent-memories.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-agent-memories.ts
@@ -273,6 +273,35 @@ export class SharedAgentMemoriesReader {
   }
 
   /**
+   * Oldest-first keyset page over the whole tenant scope, for full-history
+   * export (Shared→Dedicated transfer). Ascending (created_at, id) ordering
+   * makes pagination stable while new turns keep appending, and a resumed
+   * transfer re-walks from its cursor without skipping or duplicating rows.
+   */
+  async listOldestByScope(
+    scope: SharedAgentMemoryScope,
+    limit: number,
+    after?: { createdAt: Date; id: string },
+  ): Promise<SharedAgentMemoryRow[]> {
+    requiredScope(scope);
+    assertLimit(limit);
+    const pins = and(
+      ...tenantPins(scope),
+      ...(after
+        ? [
+            sql`(${sharedAgentMemories.created_at}, ${sharedAgentMemories.id}) > (${after.createdAt}, ${after.id}::uuid)`,
+          ]
+        : []),
+    );
+    return await dbRead
+      .select()
+      .from(sharedAgentMemories)
+      .where(pins)
+      .orderBy(asc(sharedAgentMemories.created_at), asc(sharedAgentMemories.id))
+      .limit(limit);
+  }
+
+  /**
    * Exact cosine-distance search over the tenant's most recent embedded rows
    * (bounded window; see module header). Only rows whose stored vector has the
    * query's dimensionality participate, so mixed-model histories cannot fail

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Deterministic contract tests for the cloud-side Shared→Dedicated memory
+ * push: scope derivation matches the turn-path writer, keyset pagination walks
+ * the full history without skips, batches carry the wire shape the container
+ * route validates, counts aggregate honestly, and a rejected batch fails the
+ * transfer with a typed error instead of reporting success. Reader and fetch
+ * are recorder doubles; no network or DB.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { stringToUuid } from "@elizaos/core/edge";
+import type { SharedAgentMemoryRow } from "../../../db/schemas/shared-agent-memories";
+import {
+  SHARED_MEMORY_TRANSFER_PAGE,
+  type SharedMemoryTransferReader,
+  sharedMemoryScopeForAgent,
+  transferSharedMemoriesToDedicated,
+} from "./shared-memory-transfer";
+
+const AGENT = {
+  id: "personal:327fd128-cb80-5f3a-aedd-47b3c465c805",
+  organization_id: "75ae457b-801f-43e1-9d95-5585147655cd",
+  user_id: "f210269b-8148-428b-8c24-91da4c95c727",
+};
+const TARGET = { baseUrl: "http://agent.tailnet.test:2138/", apiToken: "tok" };
+
+function row(index: number, overrides: Partial<SharedAgentMemoryRow> = {}): SharedAgentMemoryRow {
+  return {
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+    organization_id: AGENT.organization_id,
+    user_id: AGENT.user_id,
+    agent_id: sharedMemoryScopeForAgent(AGENT).agentId,
+    entity_id: "3a0731c4-5a3c-4a3f-9d6e-0f6f10a4c111",
+    room_id: "9610511b-dff2-5ca3-989a-8e1004ff44b1",
+    world_id: "022a61e3-2968-4c5a-a510-ac7bac458464",
+    type: "messages",
+    content: { text: `m${index}` },
+    embedding: Array.from({ length: 384 }, () => 0.5),
+    embedding_model: "bge-small-en-v1.5",
+    created_at: new Date(1755400000000 + index * 1000),
+    ...overrides,
+  } as SharedAgentMemoryRow;
+}
+
+function pagedReader(rows: SharedAgentMemoryRow[]): SharedMemoryTransferReader & {
+  calls: Array<{ after?: { createdAt: Date; id: string } }>;
+} {
+  const calls: Array<{ after?: { createdAt: Date; id: string } }> = [];
+  return {
+    calls,
+    async listOldestByScope(_scope, limit, after) {
+      calls.push({ after });
+      const start = after ? rows.findIndex((r) => r.id === after.id) + 1 : 0;
+      return rows.slice(start, start + limit);
+    },
+  };
+}
+
+function recordingFetch(status = 200) {
+  const bodies: Array<Record<string, unknown>> = [];
+  const urls: string[] = [];
+  const headers: Array<Record<string, string>> = [];
+  const impl = (async (url: RequestInfo | URL, init?: RequestInit) => {
+    urls.push(String(url));
+    headers.push({ ...((init?.headers ?? {}) as Record<string, string>) });
+    const body = JSON.parse(String(init?.body)) as { exports: unknown[] };
+    bodies.push(body);
+    if (status !== 200) return new Response("nope", { status });
+    return Response.json({
+      ok: true,
+      imported: body.exports.length,
+      skippedExisting: 0,
+      embeddingsWritten: body.exports.length,
+    });
+  }) as typeof fetch;
+  return { impl, bodies, urls, headers };
+}
+
+describe("shared→dedicated memory transfer", () => {
+  test("scope matches the turn-path writer derivation exactly", () => {
+    const scope = sharedMemoryScopeForAgent(AGENT);
+    expect(scope.organizationId).toBe(AGENT.organization_id);
+    expect(scope.userId).toBe(AGENT.user_id);
+    expect(scope.agentId).toBe(stringToUuid(`shared-todos:agent:${AGENT.id}`));
+  });
+
+  test("walks every page oldest-first and posts the wire shape the route validates", async () => {
+    const rows = Array.from({ length: SHARED_MEMORY_TRANSFER_PAGE + 3 }, (_, i) => row(i));
+    const reader = pagedReader(rows);
+    const net = recordingFetch();
+
+    const result = await transferSharedMemoriesToDedicated(AGENT, TARGET, {
+      reader,
+      fetchImpl: net.impl,
+    });
+
+    expect(result.rows).toBe(rows.length);
+    expect(result.imported).toBe(rows.length);
+    expect(result.embeddingsWritten).toBe(rows.length);
+    expect(result.droppedEmbeddings).toBe(0);
+    // 203 rows at page size 200: one full page, then the short terminal page.
+    expect(reader.calls.length).toBe(2);
+    expect(reader.calls[1]?.after?.id).toBe(rows[SHARED_MEMORY_TRANSFER_PAGE - 1]?.id);
+    expect(net.urls[0]).toBe("http://agent.tailnet.test:2138/api/memories/import");
+    expect(net.headers[0]?.Authorization).toBe("Bearer tok");
+
+    const first = (net.bodies[0]?.exports as Array<Record<string, unknown>>)[0] as {
+      memory: Record<string, unknown>;
+      embedding?: { dim_384: number[] };
+    };
+    expect(first.memory.id).toBe(rows[0]?.id);
+    expect(first.memory.created_at).toBe(rows[0]?.created_at.toISOString());
+    expect(first.memory.content).toEqual(rows[0]?.content as Record<string, unknown>);
+    expect(first.embedding?.dim_384).toHaveLength(384);
+  });
+
+  test("aggregates container counts and surfaces dropped anomalous vectors", async () => {
+    const rows = [row(0), row(1, { embedding: Array.from({ length: 768 }, () => 0.1) })];
+    const net = recordingFetch();
+
+    const result = await transferSharedMemoriesToDedicated(AGENT, TARGET, {
+      reader: pagedReader(rows),
+      fetchImpl: net.impl,
+    });
+
+    expect(result.rows).toBe(2);
+    expect(result.droppedEmbeddings).toBe(1);
+    const batch = net.bodies[0]?.exports as Array<{ embedding?: unknown }>;
+    expect(batch[0]?.embedding).toBeDefined();
+    expect(batch[1]?.embedding).toBeUndefined();
+  });
+
+  test("a rejected batch throws typed and never reports success", async () => {
+    const net = recordingFetch(503);
+    await expect(
+      transferSharedMemoriesToDedicated(AGENT, TARGET, {
+        reader: pagedReader([row(0)]),
+        fetchImpl: net.impl,
+      }),
+    ).rejects.toMatchObject({ code: "SHARED_MEMORY_TRANSFER_FAILED" });
+  });
+
+  test("an empty history transfers as a zero-count no-op without network calls", async () => {
+    const net = recordingFetch();
+    const result = await transferSharedMemoriesToDedicated(AGENT, TARGET, {
+      reader: pagedReader([]),
+      fetchImpl: net.impl,
+    });
+    expect(result).toEqual({
+      rows: 0,
+      batches: 0,
+      imported: 0,
+      skippedExisting: 0,
+      embeddingsWritten: 0,
+      droppedEmbeddings: 0,
+    });
+    expect(net.urls).toHaveLength(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.ts
@@ -1,0 +1,175 @@
+/**
+ * Cloud-side push of a tenant's Shared memory history into a Dedicated
+ * container — the delivery leg of the Shared→Dedicated cutover. Reads the
+ * agent's `shared_agent_memories` under the exact scope the Shared turn path
+ * writes (organization/user plus the derived storage agent id), converts rows
+ * through the lossless fidelity transform, and POSTs bounded batches to the
+ * container's `/api/memories/import` route with its own API token.
+ *
+ * Ordering and resumability: pages walk oldest-first by (created_at, id)
+ * keyset, and the container route is idempotent per memory id, so a retried or
+ * resumed transfer converges without duplicating or skipping rows. Any batch
+ * the container rejects fails the transfer with a typed error — a partial
+ * import is safe to re-run, never silently reported as complete.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import type { SharedAgentMemoryScope } from "../../../db/repositories/shared-agent-memories";
+import { sharedAgentMemoriesReader } from "../../../db/repositories/shared-agent-memories";
+import type { SharedAgentMemoryRow } from "../../../db/schemas/shared-agent-memories";
+import {
+  type DedicatedMemoryExport,
+  toDedicatedMemoryExports,
+} from "./shared-memory-dedicated-export";
+import { sharedTodoStorageScope } from "./shared-runtime-storage-identity";
+
+export const SHARED_MEMORY_TRANSFER_BATCH = 500;
+export const SHARED_MEMORY_TRANSFER_PAGE = 200;
+export const SHARED_MEMORY_TRANSFER_FAILED = "SHARED_MEMORY_TRANSFER_FAILED";
+
+/** The identity triple of the agent whose Shared history is being moved. */
+export interface SharedMemoryTransferAgent {
+  id: string;
+  organization_id: string;
+  user_id: string;
+}
+
+/** Container ingress: tailnet-reachable base URL plus its ELIZA_API_TOKEN. */
+export interface SharedMemoryTransferTarget {
+  baseUrl: string;
+  apiToken: string;
+}
+
+export interface SharedMemoryTransferResult {
+  rows: number;
+  batches: number;
+  imported: number;
+  skippedExisting: number;
+  embeddingsWritten: number;
+  droppedEmbeddings: number;
+}
+
+interface ImportRouteResponse {
+  ok: boolean;
+  imported: number;
+  skippedExisting: number;
+  embeddingsWritten: number;
+}
+
+export interface SharedMemoryTransferReader {
+  listOldestByScope(
+    scope: SharedAgentMemoryScope,
+    limit: number,
+    after?: { createdAt: Date; id: string },
+  ): Promise<SharedAgentMemoryRow[]>;
+}
+
+/**
+ * The DB scope the Shared turn path writes this agent's memories under.
+ * Mirrors `sharedTurnMemoryStore` in shared-runtime-chat: the row's agent_id
+ * is the todo-storage derivation of the serving agent id, not the raw id.
+ */
+export function sharedMemoryScopeForAgent(
+  agent: SharedMemoryTransferAgent,
+): SharedAgentMemoryScope {
+  return {
+    organizationId: agent.organization_id,
+    userId: agent.user_id,
+    agentId: sharedTodoStorageScope({
+      sourceAgentId: agent.id,
+      ownerId: agent.user_id,
+    }).agentId,
+  };
+}
+
+function wireExport(item: DedicatedMemoryExport): Record<string, unknown> {
+  return {
+    memory: {
+      ...item.memory,
+      created_at: item.memory.created_at.toISOString(),
+    },
+    ...(item.embedding ? { embedding: item.embedding } : {}),
+  };
+}
+
+async function postBatch(
+  target: SharedMemoryTransferTarget,
+  batch: DedicatedMemoryExport[],
+  fetchImpl: typeof fetch,
+): Promise<ImportRouteResponse> {
+  const response = await fetchImpl(`${target.baseUrl.replace(/\/+$/, "")}/api/memories/import`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${target.apiToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ exports: batch.map(wireExport) }),
+  });
+  if (!response.ok) {
+    const detail = (await response.text().catch(() => "")).slice(0, 300);
+    throw new ElizaError("Dedicated container rejected a memory import batch", {
+      code: SHARED_MEMORY_TRANSFER_FAILED,
+      context: { status: response.status, detail, batchSize: batch.length },
+    });
+  }
+  return (await response.json()) as ImportRouteResponse;
+}
+
+/**
+ * Push the agent's complete Shared history into its Dedicated container.
+ * Safe to re-run: already-present rows are counted as `skippedExisting`.
+ */
+export async function transferSharedMemoriesToDedicated(
+  agent: SharedMemoryTransferAgent,
+  target: SharedMemoryTransferTarget,
+  options: {
+    reader?: SharedMemoryTransferReader;
+    fetchImpl?: typeof fetch;
+  } = {},
+): Promise<SharedMemoryTransferResult> {
+  const reader = options.reader ?? sharedAgentMemoriesReader;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const scope = sharedMemoryScopeForAgent(agent);
+
+  const result: SharedMemoryTransferResult = {
+    rows: 0,
+    batches: 0,
+    imported: 0,
+    skippedExisting: 0,
+    embeddingsWritten: 0,
+    droppedEmbeddings: 0,
+  };
+
+  let after: { createdAt: Date; id: string } | undefined;
+  let pending: DedicatedMemoryExport[] = [];
+
+  const flush = async () => {
+    if (pending.length === 0) return;
+    const response = await postBatch(target, pending, fetchImpl);
+    result.batches += 1;
+    result.imported += response.imported;
+    result.skippedExisting += response.skippedExisting;
+    result.embeddingsWritten += response.embeddingsWritten;
+    pending = [];
+  };
+
+  for (;;) {
+    const page = await reader.listOldestByScope(scope, SHARED_MEMORY_TRANSFER_PAGE, after);
+    if (page.length === 0) break;
+    const last = page[page.length - 1] as SharedAgentMemoryRow;
+    after = { createdAt: last.created_at, id: last.id };
+
+    for (const item of toDedicatedMemoryExports(page)) {
+      result.rows += 1;
+      if (item.droppedEmbeddingDimension !== undefined) {
+        result.droppedEmbeddings += 1;
+      }
+      pending.push(item);
+      if (pending.length >= SHARED_MEMORY_TRANSFER_BATCH) await flush();
+    }
+    if (page.length < SHARED_MEMORY_TRANSFER_PAGE) break;
+  }
+  await flush();
+
+  return result;
+}


### PR DESCRIPTION
Part 3 of the Shared→Dedicated memory transfer (P2.5): the cloud-side push. Composes the fidelity transform (#20861) with the container import route (#20897). The provisioning-hook call site (fire on first `bridge_url` handoff) plus the real promotion-path proof are the final follow-up — this service ships dark until then.

## What

- `SharedAgentMemoriesReader.listOldestByScope(scope, limit, after?)`: oldest-first keyset page over the whole tenant scope — ascending `(created_at, id)` tuple comparison, so pagination stays stable while new turns append and a resumed transfer re-walks from its cursor without skips or duplicates.
- `shared-memory-transfer.ts`:
  - `sharedMemoryScopeForAgent(agent)` — derives the exact DB scope the Shared turn path writes under (org/user + the todo-storage agent-id derivation `sharedTurnMemoryStore` uses), so export reads the same rows the writer produced; pinned by test against `stringToUuid("shared-todos:agent:<id>")`.
  - `transferSharedMemoriesToDedicated(agent, target)` — pages the full history, converts via `toDedicatedMemoryExports`, POSTs ≤500-item batches to the container's `/api/memories/import` with its `ELIZA_API_TOKEN`, aggregates the route's honest counts (`imported` / `skippedExisting` / `embeddingsWritten`) plus `droppedEmbeddings` for anomalous vectors. A rejected batch throws `ElizaError(SHARED_MEMORY_TRANSFER_FAILED)` — a partial import is re-runnable, never reported as complete.

## Evidence

- Unit (deterministic recorder doubles): 5/5 — scope derivation pinned, multi-page walk with cursor handoff, wire shape (`created_at` ISO, embedding leg presence) exactly what the #20897 route validates, count aggregation incl. dropped anomalous vectors, typed failure on container rejection, zero-count no-op without network.
- Real PGlite integration: 11/11 (2 new) — keyset walk covers the full tenant history oldest-first with no cross-tenant leakage, and same-timestamp rows are disambiguated by the id leg of the cursor (the raw tuple-comparison SQL proven on real rows).
- cloud/shared typecheck clean on touched files; Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)