### PR TITLE
fix(agent): reject non-boolean share ingest consume

### DIFF
--- a/packages/agent/src/api/misc-routes.share-ingest.test.ts
+++ b/packages/agent/src/api/misc-routes.share-ingest.test.ts
@@ -1,0 +1,121 @@
+/**
+ * GET /api/ingest/share `consume` identity.
+ *
+ * Stock develop treated only the exact token `1` as drain. `consume=true`
+ * (and every other canonical boolean) peeked, so share-sheet items stayed
+ * in the in-memory queue and the next poll duplicated them. Garbage tokens
+ * also peeked. Omitted still peeks. Canonical true identities drain once.
+ */
+import type http from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { handleMiscRoutes, type MiscRouteContext } from "./misc-routes";
+import { AGENT_EVENT_ALLOWED_STREAMS } from "./plugin-discovery-helpers";
+
+function makeShareCtx(search = ""): {
+  ctx: MiscRouteContext;
+  json: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+} {
+  const json = vi.fn();
+  const error = vi.fn();
+  const queued = [
+    {
+      id: "share-1",
+      source: "android-share-sheet",
+      title: "Design doc",
+      receivedAt: 1,
+    },
+  ];
+  const ctx: MiscRouteContext = {
+    req: {} as http.IncomingMessage,
+    res: {} as http.ServerResponse,
+    method: "GET",
+    pathname: "/api/ingest/share",
+    url: new URL(`http://localhost/api/ingest/share${search}`),
+    state: {
+      config: {} as MiscRouteContext["state"]["config"],
+      runtime: null,
+      agentState: "running",
+      agentName: "Eliza",
+      shellEnabled: true,
+      broadcastWs: vi.fn(),
+      broadcastWsToClientId: vi.fn(),
+      nextEventId: 1,
+      eventBuffer: [],
+      shareIngestQueue: queued,
+      startup: { phase: "running", attempt: 0 },
+      broadcastStatus: vi.fn(),
+      pendingRestartReasons: [],
+    },
+    json,
+    error,
+    readJsonBody: vi.fn(),
+    AGENT_EVENT_ALLOWED_STREAMS,
+    resolveTerminalRunRejection: vi.fn().mockReturnValue(null),
+    resolveTerminalRunClientId: vi.fn().mockReturnValue(null),
+    isSharedTerminalClientId: vi.fn().mockReturnValue(false),
+    activeTerminalRunCount: 0,
+    setActiveTerminalRunCount: vi.fn(),
+  };
+  return { ctx, json, error };
+}
+
+describe("GET /api/ingest/share consume identity", () => {
+  it("omitted consume peeks and leaves the queue", async () => {
+    const { ctx, json, error } = makeShareCtx();
+    await expect(handleMiscRoutes(ctx)).resolves.toBe(true);
+    expect(error).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(ctx.res, {
+      items: ctx.state.shareIngestQueue,
+    });
+    expect(ctx.state.shareIngestQueue).toHaveLength(1);
+  });
+
+  it.each(["1", "true", "TRUE", "yes", "on"])(
+    "consume=%s drains the queue once",
+    async (token) => {
+      const { ctx, json, error } = makeShareCtx(`?consume=${token}`);
+      await expect(handleMiscRoutes(ctx)).resolves.toBe(true);
+      expect(error).not.toHaveBeenCalled();
+      expect(json).toHaveBeenCalledWith(ctx.res, {
+        items: [
+          {
+            id: "share-1",
+            source: "android-share-sheet",
+            title: "Design doc",
+            receivedAt: 1,
+          },
+        ],
+      });
+      expect(ctx.state.shareIngestQueue).toHaveLength(0);
+    },
+  );
+
+  it.each(["0", "false", "FALSE", "no", "off"])(
+    "consume=%s peeks without draining",
+    async (token) => {
+      const { ctx, json, error } = makeShareCtx(`?consume=${token}`);
+      await expect(handleMiscRoutes(ctx)).resolves.toBe(true);
+      expect(error).not.toHaveBeenCalled();
+      expect(json).toHaveBeenCalledWith(ctx.res, {
+        items: ctx.state.shareIngestQueue,
+      });
+      expect(ctx.state.shareIngestQueue).toHaveLength(1);
+    },
+  );
+
+  it.each(["truee", "1e2", "12px", "maybe", "2"])(
+    "rejects non-boolean consume=%s before touching the queue",
+    async (token) => {
+      const { ctx, json, error } = makeShareCtx(`?consume=${token}`);
+      await expect(handleMiscRoutes(ctx)).resolves.toBe(true);
+      expect(error).toHaveBeenCalledWith(
+        ctx.res,
+        "consume must be a boolean",
+        400,
+      );
+      expect(json).not.toHaveBeenCalled();
+      expect(ctx.state.shareIngestQueue).toHaveLength(1);
+    },
+  );
+});

--- a/packages/agent/src/api/misc-routes.share-ingest.test.ts
+++ b/packages/agent/src/api/misc-routes.share-ingest.test.ts
@@ -23,6 +23,7 @@ function makeShareCtx(search = ""): {
       id: "share-1",
       source: "android-share-sheet",
       title: "Design doc",
+      suggestedPrompt: "Review the shared design doc",
       receivedAt: 1,
     },
   ];
@@ -83,6 +84,7 @@ describe("GET /api/ingest/share consume identity", () => {
             id: "share-1",
             source: "android-share-sheet",
             title: "Design doc",
+            suggestedPrompt: "Review the shared design doc",
             receivedAt: 1,
           },
         ],

--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -19,6 +19,7 @@ import {
   isLocalCodeExecutionAllowed,
   logger,
   ModelType,
+  parseBooleanValue,
 } from "@elizaos/core";
 import type { ReadJsonBodyOptions, StreamEventEnvelope } from "@elizaos/shared";
 import {
@@ -179,6 +180,15 @@ function resolveTerminalShellCommand(): {
   };
 }
 
+function parseOptionalBooleanQuery(
+  raw: string | null,
+): { ok: true; value?: boolean } | { ok: false } {
+  if (raw === null) return { ok: true };
+  const parsed = parseBooleanValue(raw);
+  if (parsed === undefined) return { ok: false };
+  return { ok: true, value: parsed };
+}
+
 function toTerminalRunRequestBody(
   body: Record<string, unknown>,
 ): TerminalRunRequestBody {
@@ -298,7 +308,14 @@ export async function handleMiscRoutes(
 
   // ── GET /api/ingest/share ────────────────────────────────────────────
   if (method === "GET" && pathname === "/api/ingest/share") {
-    const consume = url.searchParams.get("consume") === "1";
+    const consumeParsed = parseOptionalBooleanQuery(
+      url.searchParams.get("consume"),
+    );
+    if (!consumeParsed.ok) {
+      error(res, "consume must be a boolean", 400);
+      return true;
+    }
+    const consume = consumeParsed.value === true;
     if (consume) {
       const items = [...state.shareIngestQueue];
       state.shareIngestQueue.length = 0;


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on share-ingest `consume` identity.
Boolean-identity class, not leftover tax on views viewType, relationships scope,
commands surface, approvals state, database-rows sort/page, memory-viewer type,
VFS encoding, models catalogOnly/refresh, Cloud JSON-400, prefix-coerced limit,
percent-encoded paths, SIWS chainId, orchestrator lines, provisioning-worker env
ints, invites-accept, cli-auth, redemption quote, compat agent-logs, or avatar.
Disjoint from Life Ops inbox flags. Location / agent-event / terminal parsers
untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `consume` only on `/api/ingest/share`. Omitted `consume` still peeks.
Canonical `1` / `true` / `yes` / `on` still drain once. `false` / `0` / `no` /
`off` still peek. Unknown tokens 400 before the in-memory queue is copied or
cleared. POST ingest and other misc routes unchanged.

# Background

## What does this PR do?

`GET /api/ingest/share?consume=` treated only the exact token `1` as drain.
`consume=true` peeked, so share-sheet items stayed in the queue and the next
poll duplicated them. Garbage tokens also peeked.

- omitted → **200** peek (today's default)
- `1` / `true` / `yes` / `on` → **200** drain once
- `0` / `false` / `no` / `off` → **200** peek
- `truee` / `1e2` / `12px` / `maybe` / `2` → **400**
  `consume must be a boolean` before the queue is touched

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Share-sheet ingest is a destructive consume-or-peek switch. Canonical boolean
identities must drain. Unknown tokens must not silently peek.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/misc-routes.share-ingest.test.ts` — omitted peek;
canonical true identities drain; falsy identities peek; garbage 400s with the
queue left intact.

## Detailed testing steps

```bash
cd packages/agent && bunx vitest run --config vitest.config.ts \
  src/api/misc-routes.share-ingest.test.ts --coverage.enabled=false
```

16 passed at the evidence head. Sibling location + agent-event suites still green (7).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; share-ingest `consume` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; share-ingest `consume` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; share-ingest `consume` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused parser tests drive the real `consume` identity and assert 400 before the queue is copied or cleared; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persist; illegal `consume` 400s before the in-memory queue is mutated.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal `consume`
tokens reject; omitted/`1`/`true` still parse.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file share-ingest `consume` parse
with a green focused suite (16 tests). Full monorepo verify is unrelated to
this query grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:372debe9ca9f6f83c58ba55f47a11dbcca1afe91 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
