### PR TITLE
fix(plugin-personal-assistant): reject non-boolean lifeops inbox flags

### DIFF
--- a/plugins/plugin-personal-assistant/src/routes/lifeops-inbox-boolean-query.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-inbox-boolean-query.test.ts
@@ -1,0 +1,164 @@
+/**
+ * GET /api/lifeops/inbox boolean-identity leftovers.
+ *
+ * `forceSync` / `replyNeededOnly` already use parseBooleanQuery. Inbox
+ * `groupByThread`, `missedOnly`, and `sortByPriority` still compared against
+ * the exact token `true`, so `groupByThread=1` silently returned a flat list
+ * and garbage tokens were treated as false. Channels / cacheMode / limit
+ * parsers are untouched.
+ */
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import type { AgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LifeOpsRouteContext } from "./lifeops-routes.js";
+
+const getInbox = vi.hoisted(() =>
+  vi.fn(async () => ({ items: [{ id: "m1" }] })),
+);
+
+vi.mock("@elizaos/plugin-calendar/routes/calendar-routes", () => ({
+  handleCalendarRoutes: vi.fn(async () => false),
+}));
+
+vi.mock("../lifeops/service.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lifeops/service.js")>();
+  return {
+    ...actual,
+    LifeOpsService: class MockLifeOpsService {
+      getInbox = getInbox;
+    },
+  };
+});
+
+const { handleLifeOpsRoutes } = await import("./lifeops-routes.js");
+
+interface CapturedResponse {
+  statusCode?: number;
+  body?: string;
+  ended: boolean;
+}
+
+function buildCtx(search = ""): {
+  ctx: LifeOpsRouteContext;
+  res: CapturedResponse;
+} {
+  const res: CapturedResponse = { ended: false };
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  const httpReq = new IncomingMessage(socket);
+  httpReq.method = "GET";
+  const httpRes = new ServerResponse(httpReq);
+  httpRes.statusCode = 0;
+  httpRes.end = function end(
+    this: ServerResponse,
+    chunk?: unknown,
+    encodingOrCallback?: BufferEncoding | (() => void),
+    callback?: () => void,
+  ): ServerResponse {
+    res.ended = true;
+    res.body = typeof chunk === "string" ? chunk : "";
+    res.statusCode = this.statusCode;
+    const done =
+      typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+    done?.();
+    return this;
+  };
+
+  const ctx: LifeOpsRouteContext = {
+    req: httpReq,
+    res: httpRes,
+    method: "GET",
+    pathname: "/api/lifeops/inbox",
+    url: new URL(`http://localhost/api/lifeops/inbox${search}`),
+    state: {
+      runtime: { agentId: "agent-1" } as unknown as AgentRuntime,
+      adminEntityId: null,
+    },
+    json(r, data, status = 200) {
+      r.statusCode = status;
+      r.setHeader?.("content-type", "application/json");
+      r.end?.(JSON.stringify(data));
+    },
+    error(r, message, status = 400) {
+      r.statusCode = status;
+      r.setHeader?.("content-type", "application/json");
+      r.end?.(JSON.stringify({ error: message }));
+    },
+    async readJsonBody<T extends object>(): Promise<T | null> {
+      return null;
+    },
+    decodePathComponent(raw) {
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return null;
+      }
+    },
+  };
+  return { ctx, res };
+}
+
+describe("GET /api/lifeops/inbox boolean query identity", () => {
+  beforeEach(() => {
+    getInbox.mockClear();
+  });
+
+  it("omitted flags still load the inbox", async () => {
+    const { ctx, res } = buildCtx();
+    await handleLifeOpsRoutes(ctx);
+    expect(res.statusCode).toBe(200);
+    expect(getInbox).toHaveBeenCalledWith({
+      limit: undefined,
+      channels: undefined,
+      groupByThread: undefined,
+      chatTypeFilter: undefined,
+      maxParticipants: undefined,
+      gmailAccountId: undefined,
+      phoneAccountIds: undefined,
+      missedOnly: undefined,
+      sortByPriority: undefined,
+      cacheMode: undefined,
+      cacheLimit: undefined,
+    });
+  });
+
+  it("accepts groupByThread=1 the same as groupByThread=true", async () => {
+    const { ctx, res } = buildCtx("?groupByThread=1");
+    await handleLifeOpsRoutes(ctx);
+    expect(res.statusCode).toBe(200);
+    expect(getInbox).toHaveBeenCalledWith(
+      expect.objectContaining({ groupByThread: true }),
+    );
+  });
+
+  it("accepts missedOnly=true and sortByPriority=1 together", async () => {
+    const { ctx, res } = buildCtx("?missedOnly=true&sortByPriority=1");
+    await handleLifeOpsRoutes(ctx);
+    expect(res.statusCode).toBe(200);
+    expect(getInbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        missedOnly: true,
+        sortByPriority: true,
+      }),
+    );
+  });
+
+  it.each([
+    ["groupByThread", "maybe"],
+    ["groupByThread", "1e2"],
+    ["missedOnly", "truee"],
+    ["sortByPriority", "12px"],
+  ])("rejects non-boolean %s=%s before getInbox", async (field, token) => {
+    const { ctx, res } = buildCtx(`?${field}=${token}`);
+    await handleLifeOpsRoutes(ctx);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body ?? "")).toEqual({
+      error: `${field} must be a boolean`,
+    });
+    expect(getInbox).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
@@ -1509,7 +1509,10 @@ export async function handleLifeOpsRoutes(
         }
         channels = parsedChannels;
       }
-      const groupByThread = url.searchParams.get("groupByThread") === "true";
+      const groupByThread = parseBooleanQuery(
+        url.searchParams.get("groupByThread"),
+        "groupByThread",
+      );
       const rawChatTypeFilter = url.searchParams.get("chatTypeFilter");
       let chatTypeFilter: Array<"dm" | "group" | "channel"> | undefined;
       if (rawChatTypeFilter !== null && rawChatTypeFilter.trim().length > 0) {
@@ -1544,8 +1547,14 @@ export async function handleLifeOpsRoutes(
         ?.split(",")
         .map((value) => value.trim())
         .filter(Boolean);
-      const missedOnly = url.searchParams.get("missedOnly") === "true";
-      const sortByPriority = url.searchParams.get("sortByPriority") === "true";
+      const missedOnly = parseBooleanQuery(
+        url.searchParams.get("missedOnly"),
+        "missedOnly",
+      );
+      const sortByPriority = parseBooleanQuery(
+        url.searchParams.get("sortByPriority"),
+        "sortByPriority",
+      );
       const rawCacheMode = url.searchParams.get("cacheMode");
       let cacheMode: GetLifeOpsInboxRequest["cacheMode"];
       if (rawCacheMode !== null && rawCacheMode.trim().length > 0) {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on Life Ops inbox boolean flags.
Boolean-identity class, not leftover tax on views viewType, relationships scope,
commands surface, approvals state, database-rows sort/page, memory-viewer type,
VFS encoding, models catalogOnly/refresh, Cloud JSON-400, prefix-coerced limit,
percent-encoded paths, SIWS chainId, orchestrator lines, provisioning-worker env
ints, invites-accept, cli-auth, redemption quote, compat agent-logs, or avatar.
Disjoint from share-ingest `consume`. Inbox `channels` / `cacheMode` / `limit`
parsers untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET flags only on `/api/lifeops/inbox`. Omitted flags still load the inbox.
Canonical `true` / `1` still set `groupByThread` / `missedOnly` /
`sortByPriority`. Unknown tokens 400 before `getInbox`. Sibling Gmail
`forceSync` helper reused; no new parser.

# Background

## What does this PR do?

`GET /api/lifeops/inbox` compared `groupByThread`, `missedOnly`, and
`sortByPriority` to the exact token `true`. `groupByThread=1` silently returned
a flat list. Garbage tokens were treated as false. The same file already
fail-closes `forceSync` / `replyNeededOnly` through `parseBooleanQuery`.

- omitted → **200** inbox with those flags unset (today's default)
- `true` / `1` → **200** that flag set
- `false` / `0` → **200** flag unset (same as today)
- `maybe` / `1e2` / `truee` / `12px` → **400**
  `<field> must be a boolean` before `getInbox`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The merged Life Ops inbox is supposed to group threads and surface missed /
priority slices when asked. Canonical boolean identities must apply. Unknown
tokens must not silently flatten the inbox.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-personal-assistant/src/routes/lifeops-inbox-boolean-query.test.ts`
— omitted still loads; `groupByThread=1` matches `true`; garbage 400s with
`getInbox` never called.

## Detailed testing steps

```bash
cd plugins/plugin-personal-assistant && bunx vitest run --config vitest.config.ts \
  src/routes/lifeops-inbox-boolean-query.test.ts --coverage.enabled=false
```

7 passed at the evidence head. Sibling calendar-route-ownership suite still green (2).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; Life Ops inbox boolean query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; Life Ops inbox boolean query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; Life Ops inbox boolean query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused parser tests drive the real inbox flags and assert 400 before `getInbox`; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no inbox write; illegal flags 400 before `getInbox`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal inbox
boolean tokens reject; omitted/`true`/`1` still parse.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file Life Ops inbox boolean parse
with a green focused suite (7 tests). Full monorepo verify is unrelated to
this query grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c07bdaee9beb8baa913556b05f184fad3e2631ee -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
