### PR TITLE
fix(cloud): recover Steward binding activation on retry

### DIFF
--- a/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -244,6 +244,20 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
     ]);
   });
 
+  test("Steward identity upsert retry clears a fence left after the row write", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-new",
+    };
+
+    const { usersService } = await import("./users");
+    await usersService.upsertStewardIdentity("u1", "steward-new");
+
+    expect(lifecycleEvents).toEqual(["session-binding:o1:u1:steward-new:true"]);
+  });
+
   test("Steward identity link fences the prior session generation before relinking", async () => {
     userRecord = {
       id: "u1",

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -329,6 +329,9 @@ export class UsersService {
     }
     const result = await usersRepository.update(id, data);
     if (result?.organization_id && typeof data.steward_user_id === "string") {
+      // Repeat the activation even when the row already has this binding. A
+      // prior attempt can commit the database update and then fail while
+      // clearing the durable fence; the retry must finish that recovery.
       await setInferenceSessionBindingActive(
         result.organization_id,
         id,
@@ -363,6 +366,13 @@ export class UsersService {
     const existingIdentity = await usersRepository.findIdentityByUserIdForWrite(userId);
 
     if (existingIdentity?.steward_user_id === stewardUserId) {
+      const user = await usersRepository.findById(userId);
+      if (user?.organization_id) {
+        // The identity row may have committed before a prior attempt failed to
+        // clear the durable binding fence. Make the idempotent retry complete
+        // that activation before returning.
+        await setInferenceSessionBindingActive(user.organization_id, userId, stewardUserId, true);
+      }
       await Promise.all([
         cache.del(CacheKeys.user.byStewardId(stewardUserId)),
         cache.del(CacheKeys.user.byStewardIdWithOrg(stewardUserId)),


### PR DESCRIPTION
## Summary

Follow-up to #20901. If a Steward identity upsert commits its database row and then fails while reopening the durable session-binding fence, the idempotent retry sees the already-current identity and previously returned without repairing the fence. This keeps that user incorrectly denied.

The already-current path now reloads the owning user and reactivates the current binding before cache cleanup. The direct user-update retry behavior merged in #20901 remains unchanged and both retry variants are covered.

Closes #20913

## Verification

Exact head: e8464ef1d9e20f8898a3d3c94c3e25f1e0a2e87c

- inference auth lifecycle: 13/13
- cloud shared typecheck and lint: pass
- Biome and git diff check: pass
- bun run verify: 356/356 workspace tasks pass; all repository audits pass; 8,442 test files scanned with no focused tests or orphaned skips

No deployment, feature-flag activation, credential mutation, or live session action was performed.