### PR TITLE
fix(cloud): reject unknown analytics export type

### DIFF
--- a/packages/cloud/api/analytics/export/route.test.ts
+++ b/packages/cloud/api/analytics/export/route.test.ts
@@ -2,6 +2,7 @@
  * Exercises the mounted analytics export Hono route with mocked auth, rate
  * limiting, export formatting, and analytics services. Invalid date queries
  * must fail before service lookups instead of reaching filename serialization.
+ * Unknown `type` tokens must 400 instead of silently exporting timeseries.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
@@ -122,4 +123,42 @@ describe("GET /api/analytics/export date validation", () => {
     expect(body).toEqual({ error: `Invalid ${field}` });
     expectNoServiceLookups();
   });
+});
+
+describe("GET /api/analytics/export type identity", () => {
+  beforeEach(clearServiceMocks);
+
+  test("omitted type still exports the timeseries slice", async () => {
+    const response = await getExport();
+
+    expect(response.status).toBe(200);
+    expect(getUsageTimeSeries).toHaveBeenCalledTimes(1);
+    expect(getUsageByUser).not.toHaveBeenCalled();
+    expect(getModelBreakdown).not.toHaveBeenCalled();
+    expect(getProviderBreakdown).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["timeseries", getUsageTimeSeries],
+    ["users", getUsageByUser],
+    ["providers", getProviderBreakdown],
+    ["models", getModelBreakdown],
+  ] as const)("type=%s selects that catalog", async (type, service) => {
+    const response = await getExport(`?type=${type}`);
+
+    expect(response.status).toBe(200);
+    expect(service).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["user", "model", "provider", "USERS", "foo", "1e2"])(
+    "rejects type=%s before analytics lookups",
+    async (type) => {
+      const response = await getExport(`?type=${encodeURIComponent(type)}`);
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toContain("Invalid type");
+      expectNoServiceLookups();
+    },
+  );
 });

--- a/packages/cloud/api/analytics/export/route.ts
+++ b/packages/cloud/api/analytics/export/route.ts
@@ -45,6 +45,7 @@ const EXPORT_LIMITS = {
   MAX_ROWS_WARNING: 50_000,
 } as const;
 const SUPPORTED_FORMATS = new Set(["csv", "json", "excel", "xlsx"]);
+const SUPPORTED_TYPES = new Set(["timeseries", "users", "providers", "models"]);
 
 const app = new Hono<AppEnv>();
 
@@ -102,6 +103,14 @@ app.get("/", async (c) => {
     }
     const granularity = granularityParam as TimeGranularity;
     const dataType = c.req.query("type") || "timeseries";
+    if (!SUPPORTED_TYPES.has(dataType)) {
+      return c.json(
+        {
+          error: `Invalid type: ${dataType}. Must be one of: timeseries, users, providers, models`,
+        },
+        400,
+      );
+    }
     const includeMetadata = c.req.query("includeMetadata") === "true";
 
     const exportOptions: ExportOptions = {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on analytics export catalog identity.
Export-slice class, not leftover tax on share-ingest consume, Life Ops inbox
bools, views viewType, relationships scope, commands surface, approvals state,
database-rows sort/page, memory-viewer type, VFS encoding, models
catalogOnly/refresh, Cloud JSON-400, prefix-coerced limit, percent-encoded
paths, SIWS chainId, orchestrator lines, provisioning-worker env ints,
invites-accept, cli-auth, redemption quote, compat agent-logs, or avatar.
Disjoint from admin redemption status. Format / date / granularity /
includeMetadata parsers untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `type` only on `/api/analytics/export`. Omitted type still exports
timeseries. Canonical `timeseries` / `users` / `providers` / `models` still
select that catalog. Unknown tokens 400 before analytics lookups. Format and
date contracts unchanged.

# Background

## What does this PR do?

`GET /api/analytics/export` already fail-closes `format` and `granularity`.
`type` fell through to the timeseries exporter. `type=user` (singular) and
`type=USERS` downloaded the usage series instead of the user breakdown.

- omitted / empty → **200** timeseries (today's default)
- `timeseries` / `users` / `providers` / `models` → **200** that catalog
- `user` / `model` / `provider` / `USERS` / `foo` / `1e2` → **400**
  `Invalid type` before `getUsage*`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Org owners download billed usage slices from this route. A typo must not
silently emit the wrong catalog. Format already 400s unknown tokens; type
must match.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/analytics/export/route.test.ts` — omitted still exports
timeseries; canonical types select that service; garbage 400s with no
analytics lookup.

## Detailed testing steps

```bash
cd packages/cloud/api && bun test analytics/export/route.test.ts
```

19 passed at the evidence head (date suite + type identity).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; analytics export type query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; analytics export type query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; analytics export type query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real type token and assert 400 before `getUsage*`; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no export write; illegal type 400 before analytics lookups.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal export
type tokens reject; omitted/`timeseries`/`users`/`providers`/`models` still
select the matching catalog.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file analytics export type parse
with a green focused suite (19 tests). Full monorepo verify is unrelated to
this query grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:509503d5ff8b31c04a3aeeea2d6b00ef048846e2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
