### PR TITLE
fix(cloud): reject unknown admin redemption status

### DIFF
--- a/packages/cloud/api/admin/redemptions/route.status.test.ts
+++ b/packages/cloud/api/admin/redemptions/route.status.test.ts
@@ -68,15 +68,12 @@ describe("GET /api/admin/redemptions status identity", () => {
     expect(listForAdmin).toHaveBeenCalledWith(["pending"], 50);
   });
 
-  test.each([...ALL_STATUSES])(
-    "status=%s lists that queue",
-    async (status) => {
-      const response = await listRedemptions(`?status=${status}`);
+  test.each([...ALL_STATUSES])("status=%s lists that queue", async (status) => {
+    const response = await listRedemptions(`?status=${status}`);
 
-      expect(response.status).toBe(200);
-      expect(listForAdmin).toHaveBeenCalledWith([status], 50);
-    },
-  );
+    expect(response.status).toBe(200);
+    expect(listForAdmin).toHaveBeenCalledWith([status], 50);
+  });
 
   test("status=all lists every known queue", async () => {
     const response = await listRedemptions("?status=all");

--- a/packages/cloud/api/admin/redemptions/route.status.test.ts
+++ b/packages/cloud/api/admin/redemptions/route.status.test.ts
@@ -1,0 +1,109 @@
+/**
+ * GET /api/admin/redemptions status identity.
+ *
+ * Stock develop treated unknown `status` tokens as the pending payout queue.
+ * `status=complete` (missing d) and `status=Pending` silently listed pending
+ * redemptions instead of 400. Canonical UI tokens and the `all` / `review`
+ * aliases must keep working. Network / limit / search parsers stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const listForAdmin = mock(async () => []);
+const countByStatusForAdmin = mock(async () => []);
+const requireAdmin = mock(async () => ({
+  user: { id: "admin-1" },
+  role: "super_admin",
+}));
+
+mock.module("@/db/repositories/token-redemptions", () => ({
+  tokenRedemptionsRepository: { listForAdmin, countByStatusForAdmin },
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({ requireAdmin }));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {}, STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>
+    c.json({ success: false, error: "internal_error" }, 500),
+}));
+mock.module("@/lib/services/token-redemption-secure", () => ({
+  secureTokenRedemptionService: {},
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: () => undefined, error: () => undefined },
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/admin/redemptions", route);
+
+function listRedemptions(query = "") {
+  return app.request(`/api/admin/redemptions${query}`);
+}
+
+const ALL_STATUSES = [
+  "pending",
+  "approved",
+  "processing",
+  "completed",
+  "failed",
+  "rejected",
+  "expired",
+] as const;
+
+describe("GET /api/admin/redemptions status identity", () => {
+  beforeEach(() => {
+    requireAdmin.mockClear();
+    listForAdmin.mockClear();
+    countByStatusForAdmin.mockClear();
+    listForAdmin.mockResolvedValue([]);
+    countByStatusForAdmin.mockResolvedValue([]);
+  });
+
+  test("omitted status still lists the pending payout queue", async () => {
+    const response = await listRedemptions();
+
+    expect(response.status).toBe(200);
+    expect(listForAdmin).toHaveBeenCalledWith(["pending"], 50);
+  });
+
+  test.each([...ALL_STATUSES])(
+    "status=%s lists that queue",
+    async (status) => {
+      const response = await listRedemptions(`?status=${status}`);
+
+      expect(response.status).toBe(200);
+      expect(listForAdmin).toHaveBeenCalledWith([status], 50);
+    },
+  );
+
+  test("status=all lists every known queue", async () => {
+    const response = await listRedemptions("?status=all");
+
+    expect(response.status).toBe(200);
+    expect(listForAdmin).toHaveBeenCalledWith([...ALL_STATUSES], 50);
+  });
+
+  test("status=review keeps the pending-review alias", async () => {
+    const response = await listRedemptions("?status=review");
+
+    expect(response.status).toBe(200);
+    expect(listForAdmin).toHaveBeenCalledWith(["pending"], 50);
+  });
+
+  test.each(["complete", "Pending", "cancelled", "foo", "1e2"])(
+    "rejects status=%s before listForAdmin",
+    async (status) => {
+      const response = await listRedemptions(
+        `?status=${encodeURIComponent(status)}`,
+      );
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toContain("Invalid status");
+      expect(listForAdmin).not.toHaveBeenCalled();
+      expect(countByStatusForAdmin).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/admin/redemptions/route.ts
+++ b/packages/cloud/api/admin/redemptions/route.ts
@@ -28,6 +28,30 @@ const AdminActionSchema = z.object({
   reason: z.string().max(1000).optional(),
 });
 
+const ADMIN_REDEMPTION_STATUSES: TokenRedemptionStatus[] = [
+  "pending",
+  "approved",
+  "processing",
+  "completed",
+  "failed",
+  "rejected",
+  "expired",
+];
+
+function parseAdminRedemptionStatusFilter(
+  raw: string | undefined,
+): TokenRedemptionStatus[] | null {
+  const statusFilter = raw || "pending";
+  if (statusFilter === "all") return ADMIN_REDEMPTION_STATUSES;
+  if (statusFilter === "review") return ["pending"];
+  if (
+    (ADMIN_REDEMPTION_STATUSES as readonly string[]).includes(statusFilter)
+  ) {
+    return [statusFilter as TokenRedemptionStatus];
+  }
+  return null;
+}
+
 const app = new Hono<AppEnv>();
 
 app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
@@ -35,28 +59,20 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
     const { user: adminUser } = await requireAdmin(c);
 
     const statusFilter = c.req.query("status") || "pending";
+    const statusArray = parseAdminRedemptionStatusFilter(c.req.query("status"));
+    if (statusArray === null) {
+      return c.json(
+        {
+          success: false,
+          error: `Invalid status: ${statusFilter}. Must be one of: pending, approved, processing, completed, failed, rejected, expired, all, review`,
+        },
+        400,
+      );
+    }
     const networkFilter = c.req.query("network") || "all";
     const searchQuery = c.req.query("search")?.trim().toLowerCase() || "";
     const limitParam = c.req.query("limit");
     const limit = parseClampedLimit(limitParam, 50);
-
-    const allowedStatuses: TokenRedemptionStatus[] = [
-      "pending",
-      "approved",
-      "processing",
-      "completed",
-      "failed",
-      "rejected",
-      "expired",
-    ];
-    const statusArray: TokenRedemptionStatus[] =
-      statusFilter === "all"
-        ? allowedStatuses
-        : statusFilter === "review"
-          ? ["pending"]
-          : allowedStatuses.includes(statusFilter as TokenRedemptionStatus)
-            ? [statusFilter as TokenRedemptionStatus]
-            : ["pending"];
 
     const [allRedemptions, counts] = await Promise.all([
       tokenRedemptionsRepository.listForAdmin(statusArray, limit),

--- a/packages/cloud/api/admin/redemptions/route.ts
+++ b/packages/cloud/api/admin/redemptions/route.ts
@@ -44,9 +44,7 @@ function parseAdminRedemptionStatusFilter(
   const statusFilter = raw || "pending";
   if (statusFilter === "all") return ADMIN_REDEMPTION_STATUSES;
   if (statusFilter === "review") return ["pending"];
-  if (
-    (ADMIN_REDEMPTION_STATUSES as readonly string[]).includes(statusFilter)
-  ) {
+  if ((ADMIN_REDEMPTION_STATUSES as readonly string[]).includes(statusFilter)) {
     return [statusFilter as TokenRedemptionStatus];
   }
   return null;


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on admin redemption payout-queue
identity. Queue-identity class, not leftover tax on share-ingest consume,
Life Ops inbox bools, views viewType, relationships scope, commands surface,
approvals state, database-rows sort/page, memory-viewer type, VFS encoding,
models catalogOnly/refresh, Cloud JSON-400, prefix-coerced limit,
percent-encoded paths, SIWS chainId, orchestrator lines, provisioning-worker
env ints, invites-accept, cli-auth, redemption quote, compat agent-logs, or
avatar. Disjoint from analytics export type. Network / limit / search parsers
untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `status` only on `/api/admin/redemptions`. Omitted status still lists
pending. Canonical UI tokens plus `all` / `review` still filter that queue.
Unknown tokens 400 before `listForAdmin`. Network / limit / POST approve-reject
untouched.

# Background

## What does this PR do?

`GET /api/admin/redemptions` compared `status` to known payout states, then
fell through to `["pending"]`. `status=complete` (missing d) and
`status=Pending` silently listed the pending payout queue.

- omitted / empty → **200** pending queue (today's default)
- exact `pending` / `approved` / `processing` / `completed` / `failed` /
  `rejected` / `expired` → **200** that queue
- `all` → **200** every known queue
- `review` → **200** pending (existing alias)
- `complete` / `Pending` / `cancelled` / `foo` / `1e2` → **400**
  `Invalid status` before `listForAdmin`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Admins review live payouts from this queue. A typo must not silently show
pending redemptions. This is payout-queue identity, not leftover tax on
approval-request `state`.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/admin/redemptions/route.status.test.ts` — omitted still
lists pending; canonical tokens and `all` / `review` keep working; garbage
400s with `listForAdmin` never called.

## Detailed testing steps

```bash
cd packages/cloud/api && bun test admin/redemptions/route.status.test.ts
```

15 passed at the evidence head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; admin redemption status query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; admin redemption status query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; admin redemption status query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real status token and assert 400 before `listForAdmin`; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no payout write; illegal status 400 before `listForAdmin`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal status
tokens reject; omitted/canonical/`all`/`review` still list the matching queue.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file admin redemption status parse
with a green focused suite (15 tests). Full monorepo verify is unrelated to
this query grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7b49aa7f225ed296c84ec4c2a32bc3c86ccadfd1 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
