### PR TITLE
fix(cloud): fail close domain purchases on limiter outage

### DIFF
--- a/packages/cloud/api/__tests__/domains-buy-credit-debit.test.ts
+++ b/packages/cloud/api/__tests__/domains-buy-credit-debit.test.ts
@@ -134,6 +134,7 @@ mock.module("@/lib/services/cloudflare-dns", () => ({
 
 mock.module("@/lib/runtime/cloud-bindings", () => ({
   getCloudAwareEnv: () => ({}),
+  getCloudBinding: () => undefined,
 }));
 
 mock.module("@/lib/utils/error-handling", () => ({
@@ -160,6 +161,8 @@ const { default: buyRoute } = await import("../v1/apps/[id]/domains/buy/route");
 const app = new Hono();
 app.route("/api/v1/apps/:id/domains/buy", buyRoute);
 
+const ENV = { NODE_ENV: "test", RATE_LIMIT_DISABLED: "true" };
+
 type DomainBuyResponseBody = {
   success?: unknown;
   code?: unknown;
@@ -167,11 +170,15 @@ type DomainBuyResponseBody = {
 };
 
 function buy(domain = "example.com", appId = "app-1") {
-  return app.request(`/api/v1/apps/${appId}/domains/buy`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ domain }),
-  });
+  return app.request(
+    `/api/v1/apps/${appId}/domains/buy`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ domain }),
+    },
+    ENV,
+  );
 }
 
 async function readDomainBuyResponseBody(

--- a/packages/cloud/api/__tests__/domains-buy-rate-limit.test.ts
+++ b/packages/cloud/api/__tests__/domains-buy-rate-limit.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Domain-purchase rate-limit wiring through the real Hono middleware and route.
+ * The harness replaces Redis and purchase collaborators with deterministic
+ * in-process seams so limiter failures can prove that no money or external
+ * registration side effect begins before the canonical 503 response.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+type RedisMode = "healthy" | "missing" | "throwing";
+
+let redisMode: RedisMode = "healthy";
+
+interface TestRedisPipeline {
+  incr(key: string): TestRedisPipeline;
+  pttl(key: string): TestRedisPipeline;
+  exec(): Promise<unknown[]>;
+}
+
+const redisPipelineExec = mock(async (): Promise<unknown[]> => {
+  if (redisMode === "throwing") {
+    throw new Error("ECONNREFUSED: hermetic Redis outage");
+  }
+  return [1, 300_000];
+});
+
+const redisPipeline: TestRedisPipeline = {
+  incr: mock((_key: string) => redisPipeline),
+  pttl: mock((_key: string) => redisPipeline),
+  exec: redisPipelineExec,
+};
+
+const redisPexpire = mock(async () => 1);
+const redisClient = {
+  pipeline: mock(() => redisPipeline),
+  pexpire: redisPexpire,
+};
+const buildRedisClient = mock(() =>
+  redisMode === "missing" ? null : redisClient,
+);
+
+mock.module("@/lib/cache/redis-factory", () => ({
+  buildRedisClient,
+  hasRedisConfig: () => redisMode !== "missing",
+  isCloudflareWorkerRuntime: () => false,
+}));
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+const isAppKeyOutOfScope = mock(async () => false);
+const getById = mock(async () => ({
+  organization_id: "org-1",
+  app_url: "https://app-1.apps.elizacloud.ai",
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/auth/app-key-scope", () => ({ isAppKeyOutOfScope }));
+mock.module("@/lib/services/apps", () => ({
+  appsService: { getById },
+}));
+
+let dbWrite: Record<string, unknown>;
+const dbWriteInsert = mock<() => Record<string, unknown>>(() => dbWrite);
+const dbWriteValues = mock<() => Record<string, unknown>>(() => dbWrite);
+const dbWriteOnConflictDoNothing = mock<() => Record<string, unknown>>(
+  () => dbWrite,
+);
+const dbWriteReturning = mock(async () => [{ id: "claim-1" }]);
+const dbWriteUpdate = mock<() => Record<string, unknown>>(() => dbWrite);
+const dbWriteSet = mock<() => Record<string, unknown>>(() => dbWrite);
+const dbWriteDelete = mock<() => Record<string, unknown>>(() => dbWrite);
+const dbWriteWhere = mock(async () => undefined);
+
+dbWrite = {
+  insert: dbWriteInsert,
+  values: dbWriteValues,
+  onConflictDoNothing: dbWriteOnConflictDoNothing,
+  returning: dbWriteReturning,
+  update: dbWriteUpdate,
+  set: dbWriteSet,
+  delete: dbWriteDelete,
+  where: dbWriteWhere,
+};
+
+let dbRead: Record<string, unknown>;
+const dbReadSelect = mock<() => Record<string, unknown>>(() => dbRead);
+const dbReadFrom = mock<() => Record<string, unknown>>(() => dbRead);
+const dbReadWhere = mock<() => Record<string, unknown>>(() => dbRead);
+const dbReadLimit = mock(async () => []);
+
+dbRead = {
+  select: dbReadSelect,
+  from: dbReadFrom,
+  where: dbReadWhere,
+  limit: dbReadLimit,
+};
+
+mock.module("@/db/client", () => ({ dbRead, dbWrite }));
+
+const getDomainByName = mock(async () => null);
+const upsertCloudflareRegisteredDomain = mock(async () => ({
+  id: "managed-domain-1",
+  status: "active" as const,
+  verified: true,
+}));
+const assignToResource = mock(async () => ({ id: "app-domain-1" }));
+const hasUnrefundedDomainPurchase = mock(async () => false);
+
+mock.module("@/lib/services/managed-domains", () => ({
+  managedDomainsService: {
+    getDomainByName,
+    upsertCloudflareRegisteredDomain,
+    assignToResource,
+  },
+}));
+mock.module("@/db/repositories/credit-transactions", () => ({
+  creditTransactionsRepository: { hasUnrefundedDomainPurchase },
+}));
+
+const checkAvailability = mock(async () => ({
+  available: true,
+  priceUsdCents: 1_000,
+  renewalUsdCents: 1_000,
+  currency: "USD",
+}));
+const registerDomain = mock(async () => ({ registrationId: "registration-1" }));
+const getRegisteredDomain = mock(async () => ({
+  domain: "example.com",
+  zoneId: "zone-1",
+  expiresAt: "2027-01-01T00:00:00.000Z",
+  autoRenew: true,
+}));
+
+mock.module("@/lib/services/cloudflare-registrar", () => ({
+  cloudflareRegistrarService: {
+    checkAvailability,
+    registerDomain,
+    getRegisteredDomain,
+  },
+}));
+
+const deductCredits = mock(async () => ({
+  success: true as const,
+  newBalance: 85,
+  transaction: { id: "transaction-1" },
+}));
+const refundCredits = mock(async () => ({ success: true }));
+
+mock.module("@/lib/services/credits", () => ({
+  creditsService: { deductCredits, refundCredits },
+}));
+mock.module("@/lib/services/domain-pricing", () => ({
+  computeDomainPrice: () => ({
+    totalUsdCents: 1_495,
+    wholesaleUsdCents: 1_000,
+    marginUsdCents: 495,
+  }),
+}));
+
+const setCustomDomain = mock(async () => undefined);
+mock.module("@/lib/services/app-domains-compat", () => ({
+  appDomainsCompat: { setCustomDomain },
+}));
+
+const listRecords = mock(async () => []);
+const createRecord = mock(async () => ({ id: "dns-record-1" }));
+const updateRecord = mock(async () => ({ id: "dns-record-1" }));
+
+mock.module("@/lib/services/cloudflare-dns", () => ({
+  cloudflareDnsService: { listRecords, createRecord, updateRecord },
+}));
+
+const failureResponse = mock(
+  (c: { json: (body: unknown, status: 500) => Response }) =>
+    c.json({ success: false, error: "unhandled" }, 500),
+);
+mock.module("@/lib/api/cloud-worker-errors", () => ({ failureResponse }));
+
+const logger = {
+  info: mock(() => undefined),
+  warn: mock(() => undefined),
+  error: mock(() => undefined),
+  debug: mock(() => undefined),
+};
+mock.module("@/lib/utils/logger", () => ({ logger }));
+mock.module("@/lib/utils/error-handling", () => ({
+  extractErrorMessage: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+}));
+
+const { _resetHonoRateLimitLeases, _resetRedisUnavailableFallbackBuckets } =
+  await import("@/lib/middleware/rate-limit-hono-cloudflare");
+const { default: buyRoute } = await import("../v1/apps/[id]/domains/buy/route");
+
+const api = new Hono();
+api.route("/api/v1/apps/:id/domains/buy", buyRoute);
+
+const ENV = {
+  NODE_ENV: "production",
+  REDIS_RATE_LIMITING: "true",
+  REDIS_URL: "redis://hermetic.invalid:6379",
+  INFERENCE_HOT_PATH_CACHES: "true",
+};
+
+async function buy(): Promise<Response> {
+  return await api.request(
+    "/api/v1/apps/app-1/domains/buy",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": "eliza_domain_buy_test_key",
+      },
+      body: JSON.stringify({ domain: "example.com" }),
+    },
+    ENV,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readJsonObject(
+  response: Response,
+): Promise<Record<string, unknown>> {
+  const body: unknown = await response.json();
+  if (!isRecord(body)) throw new Error("Expected a JSON object response");
+  return body;
+}
+
+function purchaseSideEffectReceipt(): Record<string, number> {
+  return {
+    authentication: requireUserOrApiKeyWithOrg.mock.calls.length,
+    apiKeyScopeCheck: isAppKeyOutOfScope.mock.calls.length,
+    appLookup: getById.mock.calls.length,
+    idempotencyInsert: dbWriteInsert.mock.calls.length,
+    idempotencyUpdate: dbWriteUpdate.mock.calls.length,
+    idempotencyDelete: dbWriteDelete.mock.calls.length,
+    idempotencyRead: dbReadSelect.mock.calls.length,
+    domainLookup: getDomainByName.mock.calls.length,
+    availabilityCheck: checkAvailability.mock.calls.length,
+    creditDebit: deductCredits.mock.calls.length,
+    creditRefund: refundCredits.mock.calls.length,
+    registrarRegistration: registerDomain.mock.calls.length,
+    registrarLookup: getRegisteredDomain.mock.calls.length,
+    unrefundedPurchaseLookup: hasUnrefundedDomainPurchase.mock.calls.length,
+    domainPersistence: upsertCloudflareRegisteredDomain.mock.calls.length,
+    domainAssignment: assignToResource.mock.calls.length,
+    appDomainPersistence: setCustomDomain.mock.calls.length,
+    dnsList: listRecords.mock.calls.length,
+    dnsCreate: createRecord.mock.calls.length,
+    dnsUpdate: updateRecord.mock.calls.length,
+  };
+}
+
+const ZERO_SIDE_EFFECT_RECEIPT = {
+  authentication: 0,
+  apiKeyScopeCheck: 0,
+  appLookup: 0,
+  idempotencyInsert: 0,
+  idempotencyUpdate: 0,
+  idempotencyDelete: 0,
+  idempotencyRead: 0,
+  domainLookup: 0,
+  availabilityCheck: 0,
+  creditDebit: 0,
+  creditRefund: 0,
+  registrarRegistration: 0,
+  registrarLookup: 0,
+  unrefundedPurchaseLookup: 0,
+  domainPersistence: 0,
+  domainAssignment: 0,
+  appDomainPersistence: 0,
+  dnsList: 0,
+  dnsCreate: 0,
+  dnsUpdate: 0,
+} as const;
+
+const resetMocks = [
+  buildRedisClient,
+  redisClient.pipeline,
+  redisPipelineExec,
+  redisPexpire,
+  requireUserOrApiKeyWithOrg,
+  isAppKeyOutOfScope,
+  getById,
+  dbWriteInsert,
+  dbWriteValues,
+  dbWriteOnConflictDoNothing,
+  dbWriteReturning,
+  dbWriteUpdate,
+  dbWriteSet,
+  dbWriteDelete,
+  dbWriteWhere,
+  dbReadSelect,
+  dbReadFrom,
+  dbReadWhere,
+  dbReadLimit,
+  getDomainByName,
+  upsertCloudflareRegisteredDomain,
+  assignToResource,
+  hasUnrefundedDomainPurchase,
+  checkAvailability,
+  registerDomain,
+  getRegisteredDomain,
+  deductCredits,
+  refundCredits,
+  setCustomDomain,
+  listRecords,
+  createRecord,
+  updateRecord,
+  failureResponse,
+  logger.info,
+  logger.warn,
+  logger.error,
+  logger.debug,
+] as const;
+
+beforeEach(() => {
+  redisMode = "healthy";
+  _resetHonoRateLimitLeases();
+  _resetRedisUnavailableFallbackBuckets();
+  for (const testMock of resetMocks) testMock.mockClear();
+});
+
+describe("POST /apps/:id/domains/buy — fail-closed rate limit", () => {
+  test("GET stays 404 instead of entering the POST-only limiter", async () => {
+    redisMode = "missing";
+
+    const response = await api.request(
+      "/api/v1/apps/app-1/domains/buy",
+      { method: "GET" },
+      ENV,
+    );
+
+    expect(response.status).toBe(404);
+    expect(buildRedisClient).not.toHaveBeenCalled();
+    expect(purchaseSideEffectReceipt()).toEqual(ZERO_SIDE_EFFECT_RECEIPT);
+  });
+
+  for (const mode of ["missing", "throwing"] as const) {
+    test(`${mode} Redis returns 503 before every purchase side effect`, async () => {
+      redisMode = mode;
+
+      const response = await buy();
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get("Retry-After")).toBe("30");
+      expect(await readJsonObject(response)).toEqual({
+        success: false,
+        error: "Service temporarily unavailable",
+        code: "rate_limit_unavailable",
+        message: "Rate limiter backing store is unavailable; request rejected.",
+      });
+      expect(purchaseSideEffectReceipt()).toEqual(ZERO_SIDE_EFFECT_RECEIPT);
+      expect(failureResponse).not.toHaveBeenCalled();
+    });
+  }
+
+  test("healthy Redis reaches the unchanged successful purchase handler", async () => {
+    const response = await buy();
+    const body = await readJsonObject(response);
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ success: true, domain: "example.com" });
+    expect(redisPipelineExec).toHaveBeenCalledTimes(1);
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+    expect(dbWriteInsert).toHaveBeenCalledTimes(1);
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(registerDomain).toHaveBeenCalledTimes(1);
+    expect(upsertCloudflareRegisteredDomain).toHaveBeenCalledTimes(1);
+    expect(assignToResource).toHaveBeenCalledTimes(1);
+    expect(createRecord).toHaveBeenCalledTimes(1);
+    expect(refundCredits).not.toHaveBeenCalled();
+    expect(failureResponse).not.toHaveBeenCalled();
+  });
+
+  test("a warm healthy check cannot lease a purchase through a later Redis outage", async () => {
+    const healthyResponse = await buy();
+    expect(healthyResponse.status).toBe(200);
+    const receiptAfterHealthyPurchase = purchaseSideEffectReceipt();
+
+    redisMode = "throwing";
+    const outageResponse = await buy();
+
+    expect(outageResponse.status).toBe(503);
+    expect(outageResponse.headers.get("Retry-After")).toBe("30");
+    expect(redisPipelineExec).toHaveBeenCalledTimes(2);
+    expect(purchaseSideEffectReceipt()).toEqual(receiptAfterHealthyPurchase);
+  });
+});

--- a/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
@@ -23,6 +23,10 @@ import { domainPurchaseIdempotency } from "@/db/schemas/domain-purchase-idempote
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import {
+  RateLimitPresets,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { getCloudAwareEnv } from "@/lib/runtime/cloud-bindings";
 import { appDomainsCompat } from "@/lib/services/app-domains-compat";
 import { appsService } from "@/lib/services/apps";
@@ -56,7 +60,16 @@ type PurchaseOutcome = {
 
 const app = new Hono<AppEnv>();
 
-app.post("/", async (c) => {
+// A domain registration spends credits and commits an external purchase. If
+// the shared limiter is unavailable, reject before route authentication and
+// before any idempotency, ledger, registrar, persistence, or DNS side effect.
+const domainBuyRateLimit = rateLimit({
+  ...RateLimitPresets.CRITICAL,
+  failClosed: true,
+  localLease: false,
+});
+
+app.post("/", domainBuyRateLimit, async (c) => {
   let idempotencyKey: string | undefined;
   let claimed = false;
   try {

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -20,6 +20,12 @@ export interface RateLimitConfig {
   maxRequests: number;
   keyGenerator?: (c: AppContext) => string;
   /**
+   * Reuse a short-lived in-isolate Redis verdict when hot-path caches are
+   * enabled. Defaults to true. Set false when every request must observe the
+   * shared limiter, including immediately after a healthy check.
+   */
+  localLease?: boolean;
+  /**
    * Use an in-isolate fallback bucket when Redis cannot be constructed or
    * throws at request time.
    * This is weaker than the shared Redis limiter because every Worker isolate
@@ -594,7 +600,7 @@ export function rateLimit(
     let result: CheckResult;
     let policy = "redis";
     let headersConfig = effectiveConfig;
-    const leaseEnabled = isHotPathCachesEnabled(env);
+    const leaseEnabled = effectiveConfig.localLease !== false && isHotPathCachesEnabled(env);
     const leaseKey = honoLeaseKey(key, effectiveConfig);
     const now = Date.now();
     const lease = honoRateLimitLeases.get(leaseKey);

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-lease.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-lease.test.ts
@@ -3,7 +3,8 @@
  * inference gateway hot path. The Redis client is fake, but the Hono middleware
  * and lease accounting are real: flag-off behavior stays authoritative, repeat
  * allowed decisions skip Redis, carried usage flushes into the next Redis
- * check, and denials lease without repeated backend round-trips.
+ * check, denials lease without repeated backend round-trips, and sensitive
+ * routes can opt out while the global hot-path flag stays enabled.
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -107,6 +108,20 @@ describe("Hono rateLimit lease (#15428)", () => {
   test("INFERENCE_HOT_PATH_CACHES off keeps every request authoritative", async () => {
     const app = makeApp({ windowMs: 60_000, maxRequests: 20 });
     const env = { ...BASE_ENV, INFERENCE_HOT_PATH_CACHES: "false" };
+
+    for (let i = 0; i < 4; i++) {
+      const res = await app.fetch(req(), env);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("X-RateLimit-Policy")).toBe("redis");
+    }
+
+    expect(redis.incrCalls).toBe(4);
+    expect(redis.pipelineExecCalls).toBe(4);
+  });
+
+  test("localLease false keeps every request authoritative while the flag is on", async () => {
+    const app = makeApp({ windowMs: 60_000, maxRequests: 20, localLease: false });
+    const env = { ...BASE_ENV, INFERENCE_HOT_PATH_CACHES: "true" };
 
     for (let i = 0; i < 4; i++) {
       const res = await app.fetch(req(), env);


### PR DESCRIPTION
# Relates to

Relates to #20910

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the changed behavior from the evidence and hermetic route receipts below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9c9f2d66678588e7af5cce3f77841c7d7e047345:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@78bd11ff6c23234edf5c6ed712ef694661a1645a`; zero conflicts.
- [x] The stable patch passed `bun run verify` before the conflict-free rebase: 356/356 tasks. Focused validation was repeated on the rebased head.

# Risks

Medium. This changes the admission boundary for an authenticated route that debits Cloud credits and commits an external domain purchase. The limiter is POST-only, uses the existing authenticated identity/API-key keying, fails closed on Redis unavailability, and disables the five-second local lease only for this purchase route so every purchase observes the shared limiter. Existing middleware consumers retain their current default lease behavior.

# Background

## What does this PR do?

- Adds a `CRITICAL` fail-closed limiter to `POST /api/v1/apps/:id/domains/buy` before route authentication and all purchase side effects.
- Adds an optional, behavior-preserving `localLease` middleware setting and disables the lease for this money route.
- Preserves unimplemented GET behavior as 404 by mounting the limiter on POST only.
- Proves missing Redis, runtime Redis failure, and a warm-check-then-outage all return the canonical 503 without app lookup, idempotency, ledger, registrar, persistence, or DNS side effects.
- Retains existing purchase, refund, recovery, and cross-app idempotency behavior.

## What kind of change is this?

Bug fix and reliability hardening (non-breaking).

# Documentation changes needed?

No project documentation change is required. The middleware option is documented inline and is exercised by a shared contract test.

# Testing

## Where should a reviewer start?

1. `packages/cloud/api/__tests__/domains-buy-rate-limit.test.ts`
2. `packages/cloud/api/v1/apps/[id]/domains/buy/route.ts`
3. `packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts`

## Detailed testing steps

Exact head: `9c9f2d66678588e7af5cce3f77841c7d7e047345`

```bash
mise exec bun@1.3.14 node@24.15.0 -- bun test \
  packages/cloud/api/__tests__/domains-buy-rate-limit.test.ts \
  packages/cloud/api/__tests__/domains-buy-credit-debit.test.ts \
  packages/cloud/api/__tests__/domains-buy-cross-app-replay.integration.test.ts \
  packages/cloud/api/v1/topup/topup-rate-limit.test.ts \
  packages/cloud/shared/src/lib/middleware/rate-limit-hono-lease.test.ts \
  packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts \
  --coverage-reporter=lcov --timeout 120000
```

Result: all 33 cases printed PASS on the rebased head. The set includes a real PGlite cross-app purchase replay and real middleware execution with hermetic Redis clients. The prior identical stable patch completed with 0 failures and 191 assertions.

```bash
mise exec bun@1.3.14 node@24.15.0 -- bun run verify
```

Pre-rebase stable-patch result: 356/356 tasks passed, followed by all root audits passing. The rebase had no conflicts or changed-file overlap; focused tests, Biome, and `git diff --check` were repeated on the rebased head.

Independent exact-head review: GO, with 0 blockers, 0 P1 findings, and 0 P2 findings. Stable patch-id across rebases: `fc2f1215a7308a45865c7fcc3dcf23371d477419`.

# Evidence Gate

<!-- evidence-head:9c9f2d66678588e7af5cce3f77841c7d7e047345 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only route and middleware change; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only route and middleware change; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only route and middleware change; no visual user flow
<!-- evidence-row:backend-logs -->
- [x] [20939-PR20939_REBASED_HEAD_RECEIPT.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20939-PR20939_REBASED_HEAD_RECEIPT.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend-only route and middleware change; no frontend code changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no live domain, registrar record, DNS record, database row, or other persistent domain artifact was created; hermetic receipt is linked under backend logs
<!-- evidence-row:ocr-review -->
- [ ] N/A - backend-only change with no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changed.

## Backend + frontend logs

The attached rebased-head receipt records the canonical 503 response, `Retry-After: 30`, zero route-authentication and purchase-side-effect counters, the healthy control path, the warm-lease outage regression, the 33/33 focused result, and the 356/356 root verification result. No live Redis, registrar, domain purchase, staging, or production service was used.

## Screenshots (before / after) + video walkthrough

N/A - backend-only route and middleware change; no rendered UI surface.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- No live Redis outage or registrar purchase was executed. The route uses the real middleware and handler boundary with hermetic Redis/provider dependencies; the cross-app replay regression uses real PGlite.
- The full Cloud API unit runner has eight unrelated failures that reproduce on the clean parent with byte-identical tests and implicated sources. None imports the changed route or reaches the domain-buy code path. The exact focused suites and root verification pass.
- This PR does not deploy or mutate production infrastructure.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@9c9f2d66678588e7af5cce3f77841c7d7e047345:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-domain-buy-rate-limit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@9c9f2d66678588e7af5cce3f77841c7d7e047345:packages/skills/skills/contribute-to-eliza"} -->



