### PR TITLE
fix(ios): align APNs registration with build authority

### DIFF
--- a/packages/app-core/scripts/lib/mobile-lane-stamp.mjs
+++ b/packages/app-core/scripts/lib/mobile-lane-stamp.mjs
@@ -5,7 +5,9 @@
  * The renderer bundle carries a machine-readable build stamp
  * (`dist/eliza-renderer-build.json`, written by the vite
  * `renderer-build-manifest` plugin) with `variant`, `capacitorTarget`, and
- * `runtimeMode`. Issue #11030's root operational cause: a cloud/store renderer
+ * `runtimeMode`. iOS stamps also carry the compiled APNs transport gate so a
+ * concurrent build cannot swap in a renderer with the opposite push policy.
+ * Issue #11030's root operational cause: a cloud/store renderer
  * left in `packages/app/dist` by one lane was cap-synced into a DIFFERENT lane
  * (`build:ios:local`), so the device booted a cloud-mode bundle with no agent
  * endpoint and hung at "Booting up…".
@@ -43,7 +45,8 @@
  *           iosRuntimeMode: string|null, androidRuntimeMode: string|null,
  *           runtimeExecutionMode: string|null },
  *           env?: Record<string, string|undefined> }} opts
- * @returns {{ variant: string, capacitorTarget: string|null, runtimeMode: string|null }}
+ * @returns {{ variant: string, capacitorTarget: string|null,
+ *             runtimeMode: string|null, iosApnsEnabled: boolean|null }}
  */
 export function resolveExpectedRendererStamp({ policy, env = {} }) {
   if (!policy || typeof policy !== "object") {
@@ -69,7 +72,9 @@ export function resolveExpectedRendererStamp({ policy, env = {} }) {
       : env.ELIZA_RUNTIME_MODE;
   const runtimeMode =
     viteIosRuntimeMode ?? viteAndroidRuntimeMode ?? executionMode ?? null;
-  return { variant, capacitorTarget, runtimeMode };
+  const iosApnsEnabled =
+    capacitorTarget === "ios" ? env.VITE_ELIZA_APNS_ENABLED === "1" : null;
+  return { variant, capacitorTarget, runtimeMode, iosApnsEnabled };
 }
 
 function normalizeEnvMode(value) {
@@ -150,9 +155,9 @@ function describeStampValue(value) {
  * carries exactly the stamp this lane should bake.
  *
  * @param {{ variant?: string|null, capacitorTarget?: string|null,
- *           runtimeMode?: string|null } | null} manifest
+ *           runtimeMode?: string|null, iosApnsEnabled?: boolean|null } | null} manifest
  * @param {{ variant: string|null, capacitorTarget: string|null,
- *           runtimeMode: string|null }} expected
+ *           runtimeMode: string|null, iosApnsEnabled?: boolean|null }} expected
  * @returns {string[]}
  */
 export function rendererLaneStampMismatches(manifest, expected) {
@@ -166,6 +171,7 @@ export function rendererLaneStampMismatches(manifest, expected) {
     ["variant", "variant"],
     ["capacitorTarget", "capacitor target"],
     ["runtimeMode", "runtime mode"],
+    ["iosApnsEnabled", "iOS APNs gate"],
   ];
   for (const [key, label] of fields) {
     const actual = manifest[key] ?? null;

--- a/packages/app-core/scripts/lib/mobile-lane-stamp.test.mts
+++ b/packages/app-core/scripts/lib/mobile-lane-stamp.test.mts
@@ -72,6 +72,7 @@ describe("resolveExpectedRendererStamp", () => {
       variant: "direct",
       capacitorTarget: "ios",
       runtimeMode: "local",
+      iosApnsEnabled: false,
     });
   });
 
@@ -82,7 +83,29 @@ describe("resolveExpectedRendererStamp", () => {
       variant: "store",
       capacitorTarget: "ios",
       runtimeMode: "cloud-hybrid",
+      iosApnsEnabled: false,
     });
+  });
+
+  it("stamps the exact iOS APNs renderer gate", () => {
+    expect(
+      resolveExpectedRendererStamp({
+        policy: POLICIES.ios,
+        env: { VITE_ELIZA_APNS_ENABLED: "1" },
+      }).iosApnsEnabled,
+    ).toBe(true);
+    expect(
+      resolveExpectedRendererStamp({
+        policy: POLICIES.ios,
+        env: { VITE_ELIZA_APNS_ENABLED: "true" },
+      }).iosApnsEnabled,
+    ).toBe(false);
+    expect(
+      resolveExpectedRendererStamp({
+        policy: POLICIES.android,
+        env: { VITE_ELIZA_APNS_ENABLED: "1" },
+      }).iosApnsEnabled,
+    ).toBeNull();
   });
 
   it("a pre-set VITE_ELIZA_IOS_RUNTIME_MODE wins over the iOS policy default (mirrors buildWeb)", () => {
@@ -122,6 +145,7 @@ describe("resolveExpectedRendererStamp", () => {
       variant: "direct",
       capacitorTarget: "android",
       runtimeMode: "cloud-hybrid",
+      iosApnsEnabled: null,
     });
   });
 
@@ -234,12 +258,18 @@ describe("rendererLaneStampMismatches", () => {
     variant: "direct",
     capacitorTarget: "ios",
     runtimeMode: "local",
+    iosApnsEnabled: false,
   };
 
   it("returns no mismatches for an exact match", () => {
     expect(
       rendererLaneStampMismatches(
-        { variant: "direct", capacitorTarget: "ios", runtimeMode: "local" },
+        {
+          variant: "direct",
+          capacitorTarget: "ios",
+          runtimeMode: "local",
+          iosApnsEnabled: false,
+        },
         expected,
       ),
     ).toEqual([]);
@@ -257,6 +287,7 @@ describe("rendererLaneStampMismatches", () => {
         variant: "store",
         capacitorTarget: "ios",
         runtimeMode: "cloud-hybrid",
+        iosApnsEnabled: false,
       },
       expected,
     );
@@ -268,12 +299,40 @@ describe("rendererLaneStampMismatches", () => {
 
   it("flags a manifest with no runtime mode when the lane bakes one", () => {
     const mismatches = rendererLaneStampMismatches(
-      { variant: "direct", capacitorTarget: "ios" },
+      {
+        variant: "direct",
+        capacitorTarget: "ios",
+        iosApnsEnabled: false,
+      },
       expected,
     );
     expect(mismatches).toEqual([
       "dist runtime mode is (unset) but this lane bakes 'local'",
     ]);
+  });
+
+  it("rejects a renderer compiled with the opposite or unstamped APNs gate", () => {
+    expect(
+      rendererLaneStampMismatches(
+        {
+          variant: "direct",
+          capacitorTarget: "ios",
+          runtimeMode: "local",
+          iosApnsEnabled: true,
+        },
+        expected,
+      ),
+    ).toEqual(["dist iOS APNs gate is 'true' but this lane bakes 'false'"]);
+    expect(
+      rendererLaneStampMismatches(
+        {
+          variant: "direct",
+          capacitorTarget: "ios",
+          runtimeMode: "local",
+        },
+        expected,
+      ),
+    ).toEqual(["dist iOS APNs gate is (unset) but this lane bakes 'false'"]);
   });
 
   it("treats null and missing as equal when the lane bakes no mode", () => {
@@ -288,7 +347,12 @@ describe("rendererLaneStampMismatches", () => {
   it("flags a wrong capacitor target", () => {
     expect(
       rendererLaneStampMismatches(
-        { variant: "direct", capacitorTarget: "android", runtimeMode: "local" },
+        {
+          variant: "direct",
+          capacitorTarget: "android",
+          runtimeMode: "local",
+          iosApnsEnabled: false,
+        },
         expected,
       ),
     ).toEqual(["dist capacitor target is 'android' but this lane bakes 'ios'"]);

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -1,9 +1,10 @@
 /**
  * Resolves renderer feature flags and cache policy for mobile build lanes.
  * Local iOS artifacts expose the existing runtime chooser so a sideload can
- * select its bundled agent without Cloud authentication. LP3 debug artifacts
- * enable the realtime voice client, while lanes with optional flags start from
- * a fresh renderer because the current stamp does not encode those flags.
+ * select its bundled agent without Cloud authentication. Every iOS renderer
+ * also compiles the optional APNs transport gate. LP3 debug artifacts enable
+ * the realtime voice client. Lanes with these optional flags start from a fresh
+ * renderer because the current stamp does not encode their values.
  */
 
 const ANDROID_CLOUD_DEBUG = "android-cloud-debug";
@@ -29,5 +30,5 @@ export function mobileRendererRequiresFreshBuild({ platform } = {}) {
   if (typeof platform !== "string" || platform.length === 0) {
     throw new Error("mobileRendererRequiresFreshBuild: platform is required");
   }
-  return platform === ANDROID_CLOUD_DEBUG || platform === "ios-local";
+  return platform === ANDROID_CLOUD_DEBUG || platform.startsWith("ios");
 }

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -30,12 +30,9 @@ export function mobileRendererRequiresFreshBuild({ platform } = {}) {
   if (typeof platform !== "string" || platform.length === 0) {
     throw new Error("mobileRendererRequiresFreshBuild: platform is required");
   }
-  return platform === ANDROID_CLOUD_DEBUG || platform.startsWith("ios");
-}
-
-/** Explain why a cached renderer cannot prove an unstamped feature value. */
-export function mobileRendererUnstampedFeatureProblem({ platform } = {}) {
-  return mobileRendererRequiresFreshBuild({ platform })
-    ? `dist cannot prove the lane-specific renderer feature flags for '${platform}' because they are not stamped`
-    : null;
+  return (
+    platform === ANDROID_CLOUD_DEBUG ||
+    platform === "ios" ||
+    platform === "ios-local"
+  );
 }

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -32,3 +32,10 @@ export function mobileRendererRequiresFreshBuild({ platform } = {}) {
   }
   return platform === ANDROID_CLOUD_DEBUG || platform.startsWith("ios");
 }
+
+/** Explain why a cached renderer cannot prove an unstamped feature value. */
+export function mobileRendererUnstampedFeatureProblem({ platform } = {}) {
+  return mobileRendererRequiresFreshBuild({ platform })
+    ? `dist cannot prove the lane-specific renderer feature flags for '${platform}' because they are not stamped`
+    : null;
+}

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -2,9 +2,10 @@
  * Resolves renderer feature flags and cache policy for mobile build lanes.
  * Local iOS artifacts expose the existing runtime chooser so a sideload can
  * select its bundled agent without Cloud authentication. Every iOS renderer
- * also compiles the optional APNs transport gate. LP3 debug artifacts enable
- * the realtime voice client. Lanes with these optional flags start from a fresh
- * renderer because the current stamp does not encode their values.
+ * also compiles the optional APNs transport gate, which is recorded in the
+ * renderer manifest. LP3 debug artifacts enable the realtime voice client.
+ * Lanes with feature values that remain unstamped start from a fresh renderer,
+ * and explicit reuse requires a stale-risk acknowledgement.
  */
 
 const ANDROID_CLOUD_DEBUG = "android-cloud-debug";
@@ -35,4 +36,20 @@ export function mobileRendererRequiresFreshBuild({ platform } = {}) {
     platform === "ios" ||
     platform === "ios-local"
   );
+}
+
+/** Explain why a cached renderer cannot prove a still-unstamped feature. */
+export function mobileRendererUnstampedFeatureProblem({ platform } = {}) {
+  if (typeof platform !== "string" || platform.length === 0) {
+    throw new Error(
+      "mobileRendererUnstampedFeatureProblem: platform is required",
+    );
+  }
+  if (platform === "ios-local") {
+    return "dist cannot prove the iOS local runtime chooser because it is not stamped";
+  }
+  if (platform === ANDROID_CLOUD_DEBUG) {
+    return "dist cannot prove the Android cloud-debug realtime voice flags because they are not stamped";
+  }
+  return null;
 }

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   mobileRendererRequiresFreshBuild,
+  mobileRendererUnstampedFeatureProblem,
   resolveMobileRendererFeatureEnv,
 } from "./mobile-renderer-feature-env.mjs";
 
@@ -53,6 +54,22 @@ describe("resolveMobileRendererFeatureEnv", () => {
     expect(() => resolveMobileRendererFeatureEnv()).toThrow(
       /platform is required/,
     );
+  });
+
+  it("requires the explicit stale-risk override before reusing unstamped lanes", () => {
+    for (const platform of [
+      "ios",
+      "ios-local",
+      "ios-overlay",
+      "android-cloud-debug",
+    ]) {
+      expect(mobileRendererUnstampedFeatureProblem({ platform })).toContain(
+        "not stamped",
+      );
+    }
+    expect(
+      mobileRendererUnstampedFeatureProblem({ platform: "android" }),
+    ).toBeNull();
   });
 });
 

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -61,10 +61,10 @@ describe("mobileRendererRequiresFreshBuild", () => {
     expect(
       mobileRendererRequiresFreshBuild({ platform: "android-cloud-debug" }),
     ).toBe(true);
-    expect(mobileRendererRequiresFreshBuild({ platform: "ios-local" })).toBe(
-      true,
-    );
-    for (const platform of ["android", "android-cloud", "ios"]) {
+    for (const platform of ["ios", "ios-local", "ios-overlay"]) {
+      expect(mobileRendererRequiresFreshBuild({ platform })).toBe(true);
+    }
+    for (const platform of ["android", "android-cloud"]) {
       expect(mobileRendererRequiresFreshBuild({ platform })).toBe(false);
     }
   });

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -5,7 +5,6 @@
 import { describe, expect, it } from "vitest";
 import {
   mobileRendererRequiresFreshBuild,
-  mobileRendererUnstampedFeatureProblem,
   resolveMobileRendererFeatureEnv,
 } from "./mobile-renderer-feature-env.mjs";
 
@@ -55,22 +54,6 @@ describe("resolveMobileRendererFeatureEnv", () => {
       /platform is required/,
     );
   });
-
-  it("requires the explicit stale-risk override before reusing unstamped lanes", () => {
-    for (const platform of [
-      "ios",
-      "ios-local",
-      "ios-overlay",
-      "android-cloud-debug",
-    ]) {
-      expect(mobileRendererUnstampedFeatureProblem({ platform })).toContain(
-        "not stamped",
-      );
-    }
-    expect(
-      mobileRendererUnstampedFeatureProblem({ platform: "android" }),
-    ).toBeNull();
-  });
 });
 
 describe("mobileRendererRequiresFreshBuild", () => {
@@ -78,10 +61,10 @@ describe("mobileRendererRequiresFreshBuild", () => {
     expect(
       mobileRendererRequiresFreshBuild({ platform: "android-cloud-debug" }),
     ).toBe(true);
-    for (const platform of ["ios", "ios-local", "ios-overlay"]) {
+    for (const platform of ["ios", "ios-local"]) {
       expect(mobileRendererRequiresFreshBuild({ platform })).toBe(true);
     }
-    for (const platform of ["android", "android-cloud"]) {
+    for (const platform of ["android", "android-cloud", "ios-overlay"]) {
       expect(mobileRendererRequiresFreshBuild({ platform })).toBe(false);
     }
   });

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   mobileRendererRequiresFreshBuild,
+  mobileRendererUnstampedFeatureProblem,
   resolveMobileRendererFeatureEnv,
 } from "./mobile-renderer-feature-env.mjs";
 
@@ -67,5 +68,27 @@ describe("mobileRendererRequiresFreshBuild", () => {
     for (const platform of ["android", "android-cloud", "ios-overlay"]) {
       expect(mobileRendererRequiresFreshBuild({ platform })).toBe(false);
     }
+  });
+});
+
+describe("mobileRendererUnstampedFeatureProblem", () => {
+  it("requires explicit risk acknowledgement only for features absent from the stamp", () => {
+    expect(
+      mobileRendererUnstampedFeatureProblem({ platform: "ios-local" }),
+    ).toContain("runtime chooser");
+    expect(
+      mobileRendererUnstampedFeatureProblem({
+        platform: "android-cloud-debug",
+      }),
+    ).toContain("realtime voice flags");
+    for (const platform of ["ios", "ios-overlay", "android", "android-cloud"]) {
+      expect(mobileRendererUnstampedFeatureProblem({ platform })).toBeNull();
+    }
+  });
+
+  it("rejects a missing platform", () => {
+    expect(() => mobileRendererUnstampedFeatureProblem()).toThrow(
+      /platform is required/,
+    );
   });
 });

--- a/packages/app-core/scripts/lib/mobile-web-build-reuse.mjs
+++ b/packages/app-core/scripts/lib/mobile-web-build-reuse.mjs
@@ -1,7 +1,7 @@
 /**
  * Decides whether a mobile lane can reuse the existing Vite renderer dist by
- * checking the renderer build manifest's variant, target, and runtime mode
- * against what the lane expects.
+ * checking the renderer build manifest's variant, target, runtime mode, and
+ * lane-specific feature flags against what the lane expects.
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -30,6 +30,7 @@ export function mobileWebDistReuseStatus({
   expectedVariant,
   expectedTarget,
   expectedRuntimeMode,
+  expectedIosApnsEnabled,
   readManifest = readRendererBuildManifest,
   buildNeeded = viteRendererBuildNeeded,
 } = {}) {
@@ -83,6 +84,17 @@ export function mobileWebDistReuseStatus({
           manifestRuntimeMode == null
             ? `dist manifest is missing runtime mode; this build targets ${wantedLabel}`
             : `dist built for runtime mode '${manifestRuntimeMode}' but this build targets ${wantedLabel}`,
+        );
+      }
+    }
+    if (expectedIosApnsEnabled !== undefined) {
+      const manifestIosApnsEnabled = manifest.iosApnsEnabled ?? null;
+      const wantedIosApnsEnabled = expectedIosApnsEnabled ?? null;
+      if (manifestIosApnsEnabled !== wantedIosApnsEnabled) {
+        problems.push(
+          manifest.iosApnsEnabled == null
+            ? `dist manifest is missing iOS APNs gate; this build targets '${wantedIosApnsEnabled ? "enabled" : "disabled"}'`
+            : `dist built with iOS APNs gate '${manifestIosApnsEnabled ? "enabled" : "disabled"}' but this build targets '${wantedIosApnsEnabled ? "enabled" : "disabled"}'`,
         );
       }
     }

--- a/packages/app-core/scripts/lib/mobile-web-build-reuse.test.mts
+++ b/packages/app-core/scripts/lib/mobile-web-build-reuse.test.mts
@@ -40,6 +40,7 @@ function makeAppDist(
     variant?: string;
     capacitorTarget?: string;
     runtimeMode?: string;
+    iosApnsEnabled?: boolean;
     playwrightTestAuth?: boolean;
   } = {},
 ) {
@@ -248,6 +249,51 @@ describe("mobileWebDistReuseStatus", () => {
     expect(status.reusable).toBe(false);
     expect(status.problems).toContain(
       "dist built for runtime mode 'cloud-hybrid' but this build targets an unset runtime mode",
+    );
+  });
+
+  it("does not reuse an iOS dist built with the opposite APNs gate", () => {
+    const { appDir } = makeAppDist({
+      variant: "direct",
+      capacitorTarget: "ios",
+      runtimeMode: "cloud-hybrid",
+      iosApnsEnabled: true,
+    });
+
+    const status = mobileWebDistReuseStatus({
+      appDir,
+      repoRoot: tmp,
+      expectedVariant: "direct",
+      expectedTarget: "ios",
+      expectedRuntimeMode: "cloud-hybrid",
+      expectedIosApnsEnabled: false,
+    });
+
+    expect(status.reusable).toBe(false);
+    expect(status.problems).toContain(
+      "dist built with iOS APNs gate 'enabled' but this build targets 'disabled'",
+    );
+  });
+
+  it("does not reuse a legacy iOS dist with no APNs provenance", () => {
+    const { appDir } = makeAppDist({
+      variant: "direct",
+      capacitorTarget: "ios",
+      runtimeMode: "cloud-hybrid",
+    });
+
+    const status = mobileWebDistReuseStatus({
+      appDir,
+      repoRoot: tmp,
+      expectedVariant: "direct",
+      expectedTarget: "ios",
+      expectedRuntimeMode: "cloud-hybrid",
+      expectedIosApnsEnabled: true,
+    });
+
+    expect(status.reusable).toBe(false);
+    expect(status.problems).toContain(
+      "dist manifest is missing iOS APNs gate; this build targets 'enabled'",
     );
   });
 

--- a/packages/app-core/scripts/lib/renderer-build-manifest.d.mts
+++ b/packages/app-core/scripts/lib/renderer-build-manifest.d.mts
@@ -18,6 +18,7 @@ export interface RendererBuildManifest {
   capacitorTarget: string | null;
   runtimeMode: string | null;
   playwrightTestAuth: boolean | null;
+  iosApnsEnabled: boolean | null;
 }
 
 export interface RendererBuildManifestMeta {
@@ -27,6 +28,7 @@ export interface RendererBuildManifestMeta {
   capacitorTarget?: string | null;
   runtimeMode?: string | null;
   playwrightTestAuth?: boolean | null;
+  iosApnsEnabled?: boolean | null;
 }
 
 export function computeRendererFingerprint(distDir: string): {

--- a/packages/app-core/scripts/lib/renderer-build-manifest.mjs
+++ b/packages/app-core/scripts/lib/renderer-build-manifest.mjs
@@ -75,7 +75,8 @@ export function computeRendererFingerprint(distDir) {
  * @param {string} distDir
  * @param {{ builtAt?: string, commit?: string|null, variant?: string|null,
  *           capacitorTarget?: string|null, runtimeMode?: string|null,
- *           playwrightTestAuth?: boolean|null }} [meta]
+ *           playwrightTestAuth?: boolean|null,
+ *           iosApnsEnabled?: boolean|null }} [meta]
  */
 export function buildRendererManifest(distDir, meta = {}) {
   const fingerprint = computeRendererFingerprint(distDir);
@@ -90,6 +91,7 @@ export function buildRendererManifest(distDir, meta = {}) {
     capacitorTarget: meta.capacitorTarget ?? null,
     runtimeMode: meta.runtimeMode ?? null,
     playwrightTestAuth: meta.playwrightTestAuth ?? null,
+    iosApnsEnabled: meta.iosApnsEnabled ?? null,
   };
 }
 
@@ -158,7 +160,10 @@ export function rendererBuildManifestMatchesDist(distDir, manifest) {
     !isNullableString(manifest.capacitorTarget) ||
     !isNullableString(manifest.runtimeMode) ||
     (manifest.playwrightTestAuth !== null &&
-      typeof manifest.playwrightTestAuth !== "boolean")
+      typeof manifest.playwrightTestAuth !== "boolean") ||
+    (manifest.iosApnsEnabled !== undefined &&
+      manifest.iosApnsEnabled !== null &&
+      typeof manifest.iosApnsEnabled !== "boolean")
   ) {
     return false;
   }

--- a/packages/app-core/scripts/lib/renderer-build-manifest.test.mts
+++ b/packages/app-core/scripts/lib/renderer-build-manifest.test.mts
@@ -293,5 +293,6 @@ describe("buildRendererManifest", () => {
     expect(manifest.variant).toBeNull();
     expect(manifest.capacitorTarget).toBeNull();
     expect(manifest.playwrightTestAuth).toBeNull();
+    expect(manifest.iosApnsEnabled).toBeNull();
   });
 });

--- a/packages/app-core/scripts/mobile/ios-plist.mjs
+++ b/packages/app-core/scripts/mobile/ios-plist.mjs
@@ -29,6 +29,16 @@ const IOS_BG_TASK_IDENTIFIERS = [
   "ai.eliza.tasks.refresh",
   "ai.eliza.tasks.processing",
 ];
+export const IOS_APNS_ENABLED_KEY = "ELIZA_APNS_ENABLED";
+
+/** Parse the one exact build flag shared by the renderer and native plist. */
+export function readIosApnsBuildFlag(raw) {
+  if (raw === undefined || raw === "" || raw === "0") return false;
+  if (raw === "1") return true;
+  throw new Error(
+    `VITE_ELIZA_APNS_ENABLED must be "0" or "1", received ${JSON.stringify(raw)}`,
+  );
+}
 
 export function resolveIosPermissionKeys({ appName }) {
   return [
@@ -85,6 +95,9 @@ export function replaceOrInsertPlistString(content, key, value) {
   if (existingRe.test(content)) {
     return content.replace(existingRe, `$1${escapedValue}$2`);
   }
+  if (new RegExp(`<key>${keyRe}</key>`).test(content)) {
+    throw new Error(`Info.plist: ${key} must be a string`);
+  }
   return content.replace(
     "</dict>",
     `\t<key>${key}</key>\n\t<string>${escapedValue}</string>\n</dict>`,
@@ -97,10 +110,7 @@ export function ensurePlistTrueBool(content, key) {
   if (new RegExp(`<key>${keyRe}</key>`).test(content)) {
     return content;
   }
-  return content.replace(
-    "</dict>",
-    `\t<key>${key}</key>\n\t<true/>\n</dict>`,
-  );
+  return content.replace("</dict>", `\t<key>${key}</key>\n\t<true/>\n</dict>`);
 }
 
 /** Ensure a plist `<array>` under `key` contains every value in `values`. */
@@ -163,7 +173,12 @@ export function removePbxListEntries(content, ids) {
 
 export function mergeIosInfoPlist(
   content,
-  { appName, urlScheme, displayName = "$(ELIZA_DISPLAY_NAME)" },
+  {
+    appName,
+    urlScheme,
+    displayName = "$(ELIZA_DISPLAY_NAME)",
+    apnsEnabled = false,
+  },
 ) {
   let nextContent = content;
   for (const [key, desc] of resolveIosPermissionKeys({ appName })) {
@@ -197,6 +212,11 @@ export function mergeIosInfoPlist(
   // Live Activities (voice/dictation session on Lock Screen + Dynamic Island,
   // #12185) require this opt-in in the app Info.plist.
   nextContent = ensurePlistTrueBool(nextContent, "NSSupportsLiveActivities");
+  nextContent = replaceOrInsertPlistString(
+    nextContent,
+    IOS_APNS_ENABLED_KEY,
+    apnsEnabled ? "1" : "0",
+  );
   return {
     changed: nextContent !== content,
     content: nextContent,

--- a/packages/app-core/scripts/mobile/ios-plist.test.mjs
+++ b/packages/app-core/scripts/mobile/ios-plist.test.mjs
@@ -60,6 +60,13 @@ describe("replaceOrInsertPlistString", () => {
     const out = replaceOrInsertPlistString(PLIST, "CFBundleName", "A & B");
     expect(out).toContain("<string>A &amp; B</string>");
   });
+
+  it("rejects an existing key with a non-string plist value", () => {
+    const malformed = PLIST.replace("<string>Eliza</string>", "<false/>");
+    expect(() =>
+      replaceOrInsertPlistString(malformed, "CFBundleName", "Eliza"),
+    ).toThrow(/CFBundleName must be a string/);
+  });
 });
 
 describe("ensurePlistArrayStrings", () => {

--- a/packages/app-core/scripts/run-mobile-build-ios-plist.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-ios-plist.test.mjs
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   ensurePlistArrayStrings,
+  IOS_APNS_ENABLED_KEY,
   mergeIosInfoPlist,
+  readIosApnsBuildFlag,
   replaceOrInsertPlistString,
   resolveIosPermissionKeys,
 } from "./mobile/ios-plist.mjs";
@@ -43,6 +45,39 @@ describe("iOS Info.plist overlay helpers", () => {
     expect(merged.content).toContain("<string>ai.eliza.tasks.refresh</string>");
     expect(merged.content).toContain("<key>CFBundleURLTypes</key>");
     expect(merged.content).toContain("<string>eliza</string>");
+    expect(merged.content).toMatch(
+      new RegExp(`<key>${IOS_APNS_ENABLED_KEY}</key>\\s*<string>0</string>`),
+    );
+  });
+
+  it("writes the native APNs gate from the canonical build option", () => {
+    const enabled = mergeIosInfoPlist(minimalPlist, {
+      appName: "Eliza",
+      urlScheme: "eliza",
+      apnsEnabled: true,
+    });
+
+    expect(enabled.content).toMatch(
+      new RegExp(`<key>${IOS_APNS_ENABLED_KEY}</key>\\s*<string>1</string>`),
+    );
+    expect(
+      mergeIosInfoPlist(enabled.content, {
+        appName: "Eliza",
+        urlScheme: "eliza",
+        apnsEnabled: false,
+      }).content,
+    ).toMatch(
+      new RegExp(`<key>${IOS_APNS_ENABLED_KEY}</key>\\s*<string>0</string>`),
+    );
+  });
+
+  it("accepts only the exact renderer-compatible APNs build flag", () => {
+    expect(readIosApnsBuildFlag(undefined)).toBe(false);
+    expect(readIosApnsBuildFlag("")).toBe(false);
+    expect(readIosApnsBuildFlag("0")).toBe(false);
+    expect(readIosApnsBuildFlag("1")).toBe(true);
+    expect(() => readIosApnsBuildFlag(" 1 ")).toThrow(/must be "0" or "1"/);
+    expect(() => readIosApnsBuildFlag("true")).toThrow(/must be "0" or "1"/);
   });
 
   it("is idempotent after the first merge", () => {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -103,7 +103,6 @@ import {
 } from "./lib/mobile-lane-stamp.mjs";
 import {
   mobileRendererRequiresFreshBuild,
-  mobileRendererUnstampedFeatureProblem,
   resolveMobileRendererFeatureEnv,
 } from "./lib/mobile-renderer-feature-env.mjs";
 import {
@@ -1151,6 +1150,7 @@ async function buildWeb(platform) {
       // bundle left behind by an ios cloud build) must never be reused into
       // this lane — it falls through to a fresh rebuild instead (#11030).
       expectedRuntimeMode: laneExpected.runtimeMode,
+      expectedIosApnsEnabled: laneExpected.iosApnsEnabled,
     });
     if (autoStatus.reusable) {
       console.log(
@@ -1175,6 +1175,7 @@ async function buildWeb(platform) {
       expectedVariant: laneExpected.variant,
       expectedTarget: laneExpected.capacitorTarget,
       expectedRuntimeMode: laneExpected.runtimeMode,
+      expectedIosApnsEnabled: laneExpected.iosApnsEnabled,
     });
     if (!fs.existsSync(status.indexPath)) {
       throw new Error(
@@ -1188,13 +1189,8 @@ async function buildWeb(platform) {
     // forced with ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE=1.
     const allowStale =
       process.env.ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE === "1";
-    const reuseProblems = [...status.problems];
-    const unstampedFeatureProblem = mobileRendererUnstampedFeatureProblem({
-      platform,
-    });
-    if (unstampedFeatureProblem) reuseProblems.push(unstampedFeatureProblem);
-    if (reuseProblems.length > 0) {
-      const detail = formatMobileWebDistProblems(reuseProblems);
+    if (status.problems.length > 0) {
+      const detail = formatMobileWebDistProblems(status.problems);
       if (!allowStale) {
         throw new Error(
           `[mobile-build] ELIZA_MOBILE_SKIP_WEB_BUILD=1 refused — the existing web build is stale or mismatched:\n${detail}\n` +
@@ -1228,6 +1224,13 @@ async function buildWeb(platform) {
     ELIZA_BUILD_VARIANT: process.env.ELIZA_BUILD_VARIANT || buildVariant,
     ELIZA_RELEASE_AUTHORITY:
       process.env.ELIZA_RELEASE_AUTHORITY || releaseAuthority,
+    ...(capacitorTarget === "ios"
+      ? {
+          // Give Vite an explicit normalized value so its `.env*` loading
+          // cannot compile a different gate than the native plist overlay.
+          VITE_ELIZA_APNS_ENABLED: laneExpected.iosApnsEnabled ? "1" : "0",
+        }
+      : {}),
     ...(androidRuntimeMode
       ? {
           VITE_ELIZA_ANDROID_RUNTIME_MODE: androidRuntimeMode,

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -103,6 +103,7 @@ import {
 } from "./lib/mobile-lane-stamp.mjs";
 import {
   mobileRendererRequiresFreshBuild,
+  mobileRendererUnstampedFeatureProblem,
   resolveMobileRendererFeatureEnv,
 } from "./lib/mobile-renderer-feature-env.mjs";
 import {
@@ -1189,8 +1190,13 @@ async function buildWeb(platform) {
     // forced with ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE=1.
     const allowStale =
       process.env.ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE === "1";
-    if (status.problems.length > 0) {
-      const detail = formatMobileWebDistProblems(status.problems);
+    const reuseProblems = [...status.problems];
+    const unstampedFeatureProblem = mobileRendererUnstampedFeatureProblem({
+      platform,
+    });
+    if (unstampedFeatureProblem) reuseProblems.push(unstampedFeatureProblem);
+    if (reuseProblems.length > 0) {
+      const detail = formatMobileWebDistProblems(reuseProblems);
       if (!allowStale) {
         throw new Error(
           `[mobile-build] ELIZA_MOBILE_SKIP_WEB_BUILD=1 refused — the existing web build is stale or mismatched:\n${detail}\n` +

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -142,6 +142,7 @@ import {
 import { escapeRegExp, escapeXmlText } from "./mobile/escape.mjs";
 import {
   mergeIosInfoPlist,
+  readIosApnsBuildFlag,
   removePbxListEntries,
   replaceIosAppGroupPlaceholders,
 } from "./mobile/ios-plist.mjs";
@@ -3691,6 +3692,7 @@ function overlayIos() {
     const nextPlist = mergeIosInfoPlist(plist, {
       appName: APP.appName,
       urlScheme: APP.urlScheme,
+      apnsEnabled: readIosApnsBuildFlag(process.env.VITE_ELIZA_APNS_ENABLED),
     });
     if (nextPlist.changed) {
       plist = nextPlist.content;

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -103,6 +103,7 @@ import {
 } from "./lib/mobile-lane-stamp.mjs";
 import {
   mobileRendererRequiresFreshBuild,
+  mobileRendererUnstampedFeatureProblem,
   resolveMobileRendererFeatureEnv,
 } from "./lib/mobile-renderer-feature-env.mjs";
 import {
@@ -1187,8 +1188,13 @@ async function buildWeb(platform) {
     // forced with ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE=1.
     const allowStale =
       process.env.ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE === "1";
-    if (status.problems.length > 0) {
-      const detail = formatMobileWebDistProblems(status.problems);
+    const reuseProblems = [...status.problems];
+    const unstampedFeatureProblem = mobileRendererUnstampedFeatureProblem({
+      platform,
+    });
+    if (unstampedFeatureProblem) reuseProblems.push(unstampedFeatureProblem);
+    if (reuseProblems.length > 0) {
+      const detail = formatMobileWebDistProblems(reuseProblems);
       if (!allowStale) {
         throw new Error(
           `[mobile-build] ELIZA_MOBILE_SKIP_WEB_BUILD=1 refused — the existing web build is stale or mismatched:\n${detail}\n` +

--- a/packages/app/scripts/patch-ios-plist.mjs
+++ b/packages/app/scripts/patch-ios-plist.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Patches the Capacitor-generated iOS Info.plist for continuous-chat
-// support (R10 §6.1).
+// support (R10 §6.1) and the explicit iOS remote-push build gate.
 //
 // Capacitor regenerates ios/App/App/Info.plist on `cap sync`; this script
 // runs after `cap sync ios` and idempotently inserts the keys the voice
@@ -32,6 +32,7 @@ const APP_DIR = resolve(__dirname, "..");
 const MIC_PURPOSE = "Eliza listens when you talk to your agent.";
 const SPEECH_PURPOSE =
   "Eliza transcribes your speech so you can talk to the agent.";
+const APNS_ENABLED_KEY = "ELIZA_APNS_ENABLED";
 
 const KEYS =
   /** @type {Array<{ key: string; value: string | string[] | boolean }>} */ ([
@@ -110,10 +111,42 @@ function ensureArrayStringValue(xml, key, value) {
   };
 }
 
-function patchPlist(xml, urlScheme) {
+function ensureStringValue(xml, key, value) {
+  const keyPattern = `<key>${escapeKey(key)}</key>`;
+  const valuePattern = new RegExp(
+    `(${keyPattern}\\s*<string>)([\\s\\S]*?)(</string>)`,
+  );
+  const match = xml.match(valuePattern);
+  if (!match) {
+    if (hasKey(xml, key)) {
+      throw new Error(`Info.plist: ${key} must be a string`);
+    }
+    return { next: xml, changed: false };
+  }
+  if (match[2] === value) return { next: xml, changed: false };
+  return {
+    next: xml.replace(valuePattern, `$1${escapeXml(value)}$3`),
+    changed: true,
+  };
+}
+
+function readApnsBuildFlag(raw = process.env.VITE_ELIZA_APNS_ENABLED) {
+  const value = raw?.trim() ?? "";
+  if (value === "" || value === "0") return false;
+  if (value === "1") return true;
+  throw new Error(
+    `VITE_ELIZA_APNS_ENABLED must be "0" or "1", received ${JSON.stringify(value)}`,
+  );
+}
+
+function patchPlist(xml, urlScheme, { apnsEnabled = false } = {}) {
   let changed = false;
   let next = xml;
-  for (const entry of KEYS) {
+  const entries = [
+    ...KEYS,
+    { key: APNS_ENABLED_KEY, value: apnsEnabled ? "1" : "0" },
+  ];
+  for (const entry of entries) {
     if (hasKey(next, entry.key)) {
       if (Array.isArray(entry.value)) {
         for (const value of entry.value) {
@@ -121,6 +154,10 @@ function patchPlist(xml, urlScheme) {
           next = result.next;
           changed = changed || result.changed;
         }
+      } else if (entry.key === APNS_ENABLED_KEY) {
+        const result = ensureStringValue(next, entry.key, entry.value);
+        next = result.next;
+        changed = changed || result.changed;
       }
       continue;
     }
@@ -149,14 +186,16 @@ function main() {
   }
   const original = readFileSync(TARGET_PATH, "utf8");
   const { urlScheme } = readAppIdentity(APP_DIR);
-  const { next, changed } = patchPlist(original, urlScheme);
+  const { next, changed } = patchPlist(original, urlScheme, {
+    apnsEnabled: readApnsBuildFlag(),
+  });
   if (!changed) {
     console.log("[patch-ios-plist] all keys already present — no changes.");
     return;
   }
   writeFileSync(TARGET_PATH, next);
   console.log(
-    "[patch-ios-plist] patched UIBackgroundModes, microphone/speech usage descriptions, and URL scheme.",
+    "[patch-ios-plist] patched iOS background, permission, APNs, and URL-scheme configuration.",
   );
 }
 
@@ -169,13 +208,18 @@ if (checkOnly) {
   }
   const xml = readFileSync(TARGET_PATH, "utf8");
   const { urlScheme } = readAppIdentity(APP_DIR);
-  const patched = patchPlist(xml, urlScheme);
+  const apnsEnabled = readApnsBuildFlag();
+  const patched = patchPlist(xml, urlScheme, { apnsEnabled });
   const missingUrlScheme = ensurePlistUrlScheme(xml, urlScheme) !== xml;
   if (!patched.changed && !missingUrlScheme) {
     console.log("[patch-ios-plist] OK — all required keys present.");
     process.exit(0);
   }
   const missing = KEYS.filter((k) => !hasKey(xml, k.key));
+  const expectedApnsValue = apnsEnabled ? "1" : "0";
+  const apnsMismatch =
+    !hasKey(xml, APNS_ENABLED_KEY) ||
+    ensureStringValue(xml, APNS_ENABLED_KEY, expectedApnsValue).changed;
   const incompleteArrays = KEYS.flatMap((entry) => {
     if (!Array.isArray(entry.value) || !hasKey(xml, entry.key)) return [];
     return entry.value
@@ -186,6 +230,7 @@ if (checkOnly) {
     `[patch-ios-plist] missing keys: ${[
       ...missing.map((k) => k.key),
       ...incompleteArrays,
+      ...(apnsMismatch ? [`${APNS_ENABLED_KEY}:${expectedApnsValue}`] : []),
       ...(missingUrlScheme ? [`CFBundleURLTypes:${urlScheme}`] : []),
     ].join(", ")}`,
   );
@@ -195,4 +240,11 @@ if (checkOnly) {
 main();
 
 // Exports for tests.
-export { findInsertionPoint, hasKey, KEYS, patchPlist };
+export {
+  APNS_ENABLED_KEY,
+  findInsertionPoint,
+  hasKey,
+  KEYS,
+  patchPlist,
+  readApnsBuildFlag,
+};

--- a/packages/app/scripts/patch-ios-plist.mjs
+++ b/packages/app/scripts/patch-ios-plist.mjs
@@ -25,6 +25,10 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ensurePlistUrlScheme } from "../../app-core/scripts/lib/ios-plist-url-scheme.mjs";
 import { readAppIdentity } from "../../app-core/scripts/lib/read-app-identity.mjs";
+import {
+  IOS_APNS_ENABLED_KEY,
+  readIosApnsBuildFlag,
+} from "../../app-core/scripts/mobile/ios-plist.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const APP_DIR = resolve(__dirname, "..");
@@ -32,7 +36,7 @@ const APP_DIR = resolve(__dirname, "..");
 const MIC_PURPOSE = "Eliza listens when you talk to your agent.";
 const SPEECH_PURPOSE =
   "Eliza transcribes your speech so you can talk to the agent.";
-const APNS_ENABLED_KEY = "ELIZA_APNS_ENABLED";
+const APNS_ENABLED_KEY = IOS_APNS_ENABLED_KEY;
 
 const KEYS =
   /** @type {Array<{ key: string; value: string | string[] | boolean }>} */ ([
@@ -131,12 +135,7 @@ function ensureStringValue(xml, key, value) {
 }
 
 function readApnsBuildFlag(raw = process.env.VITE_ELIZA_APNS_ENABLED) {
-  const value = raw?.trim() ?? "";
-  if (value === "" || value === "0") return false;
-  if (value === "1") return true;
-  throw new Error(
-    `VITE_ELIZA_APNS_ENABLED must be "0" or "1", received ${JSON.stringify(value)}`,
-  );
+  return readIosApnsBuildFlag(raw);
 }
 
 function patchPlist(xml, urlScheme, { apnsEnabled = false } = {}) {

--- a/packages/app/scripts/patch-ios-plist.test.mjs
+++ b/packages/app/scripts/patch-ios-plist.test.mjs
@@ -5,7 +5,13 @@
 import { describe, expect, it } from "vitest";
 
 import { ensurePlistUrlScheme } from "../../app-core/scripts/lib/ios-plist-url-scheme.mjs";
-import { hasKey, KEYS, patchPlist } from "./patch-ios-plist.mjs";
+import {
+  APNS_ENABLED_KEY,
+  hasKey,
+  KEYS,
+  patchPlist,
+  readApnsBuildFlag,
+} from "./patch-ios-plist.mjs";
 
 const MINIMAL_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -29,6 +35,47 @@ describe("patch-ios-plist", () => {
     expect(next).toContain("<string>audio</string>");
     expect(next).toContain("NSMicrophoneUsageDescription");
     expect(next).toContain("NSSpeechRecognitionUsageDescription");
+    expect(next).toMatch(
+      /<key>ELIZA_APNS_ENABLED<\/key>\s*<string>0<\/string>/,
+    );
+  });
+
+  it("enables native APNs only when the same explicit build flag is on", () => {
+    const disabled = patchPlist(MINIMAL_PLIST, "elizaos").next;
+    const enabled = patchPlist(disabled, "elizaos", {
+      apnsEnabled: true,
+    });
+
+    expect(enabled.changed).toBe(true);
+    expect(enabled.next).toMatch(
+      /<key>ELIZA_APNS_ENABLED<\/key>\s*<string>1<\/string>/,
+    );
+    expect(hasKey(enabled.next, APNS_ENABLED_KEY)).toBe(true);
+
+    const disabledAgain = patchPlist(enabled.next, "elizaos");
+    expect(disabledAgain.changed).toBe(true);
+    expect(disabledAgain.next).toMatch(
+      /<key>ELIZA_APNS_ENABLED<\/key>\s*<string>0<\/string>/,
+    );
+  });
+
+  it("accepts only an explicit 0 or 1 APNs build flag", () => {
+    expect(readApnsBuildFlag(undefined)).toBe(false);
+    expect(readApnsBuildFlag("")).toBe(false);
+    expect(readApnsBuildFlag("0")).toBe(false);
+    expect(readApnsBuildFlag("1")).toBe(true);
+    expect(() => readApnsBuildFlag("true")).toThrow(/must be "0" or "1"/);
+  });
+
+  it("rejects an existing APNs key with the wrong plist value type", () => {
+    const malformed = MINIMAL_PLIST.replace(
+      "</dict>",
+      "\t<key>ELIZA_APNS_ENABLED</key>\n\t<false/>\n</dict>",
+    );
+
+    expect(() => patchPlist(malformed, "elizaos")).toThrow(
+      /ELIZA_APNS_ENABLED must be a string/,
+    );
   });
 
   it("is idempotent — no changes on the second patch", () => {

--- a/packages/app/scripts/patch-ios-plist.test.mjs
+++ b/packages/app/scripts/patch-ios-plist.test.mjs
@@ -64,6 +64,7 @@ describe("patch-ios-plist", () => {
     expect(readApnsBuildFlag("")).toBe(false);
     expect(readApnsBuildFlag("0")).toBe(false);
     expect(readApnsBuildFlag("1")).toBe(true);
+    expect(() => readApnsBuildFlag(" 1 ")).toThrow(/must be "0" or "1"/);
     expect(() => readApnsBuildFlag("true")).toThrow(/must be "0" or "1"/);
   });
 

--- a/packages/app/src/renderer-build-manifest-plugin.test.ts
+++ b/packages/app/src/renderer-build-manifest-plugin.test.ts
@@ -1,6 +1,6 @@
 /**
- * Proves the renderer manifest records the same Playwright test-auth value
- * that Vite loads from env files and compiles into the browser bundle.
+ * Proves the renderer manifest records the same build flags that Vite loads
+ * and compiles into the browser bundle.
  */
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
@@ -18,11 +18,17 @@ const cleanupHelperScript = path.resolve(
 
 let tmp: string;
 let previousPlaywrightTestAuth: string | undefined;
+let previousCapacitorTarget: string | undefined;
+let previousApnsEnabled: string | undefined;
 
 beforeEach(() => {
   tmp = fs.mkdtempSync(path.join(os.tmpdir(), "renderer-manifest-plugin-"));
   previousPlaywrightTestAuth = process.env.VITE_PLAYWRIGHT_TEST_AUTH;
+  previousCapacitorTarget = process.env.ELIZA_CAPACITOR_BUILD_TARGET;
+  previousApnsEnabled = process.env.VITE_ELIZA_APNS_ENABLED;
   delete process.env.VITE_PLAYWRIGHT_TEST_AUTH;
+  delete process.env.ELIZA_CAPACITOR_BUILD_TARGET;
+  delete process.env.VITE_ELIZA_APNS_ENABLED;
 });
 
 afterEach(() => {
@@ -30,6 +36,16 @@ afterEach(() => {
     delete process.env.VITE_PLAYWRIGHT_TEST_AUTH;
   } else {
     process.env.VITE_PLAYWRIGHT_TEST_AUTH = previousPlaywrightTestAuth;
+  }
+  if (previousCapacitorTarget === undefined) {
+    delete process.env.ELIZA_CAPACITOR_BUILD_TARGET;
+  } else {
+    process.env.ELIZA_CAPACITOR_BUILD_TARGET = previousCapacitorTarget;
+  }
+  if (previousApnsEnabled === undefined) {
+    delete process.env.VITE_ELIZA_APNS_ENABLED;
+  } else {
+    process.env.VITE_ELIZA_APNS_ENABLED = previousApnsEnabled;
   }
   execFileSync(process.execPath, [cleanupHelperScript, tmp], {
     stdio: "inherit",
@@ -67,5 +83,41 @@ describe("rendererBuildManifestPlugin", () => {
       .join("\n");
     expect(bundleSource).toMatch(/globalThis\.testAuth\s*=\s*["']true["']/);
     expect(readRendererBuildManifest(outDir)?.playwrightTestAuth).toBe(true);
+  });
+
+  it("records the authoritative APNs value compiled into an iOS renderer", async () => {
+    const outDir = path.join(tmp, "dist");
+    process.env.ELIZA_CAPACITOR_BUILD_TARGET = "ios";
+    // buildWeb supplies the native build authority through process env. Vite
+    // must prefer it to a conflicting mode file and stamp that exact value.
+    process.env.VITE_ELIZA_APNS_ENABLED = "1";
+    fs.writeFileSync(
+      path.join(tmp, "index.html"),
+      '<script type="module" src="/main.js"></script>',
+    );
+    fs.writeFileSync(
+      path.join(tmp, "main.js"),
+      "globalThis.apnsEnabled = import.meta.env.VITE_ELIZA_APNS_ENABLED;",
+    );
+    fs.writeFileSync(
+      path.join(tmp, ".env.production"),
+      "VITE_ELIZA_APNS_ENABLED=0\n",
+    );
+
+    await build({
+      root: tmp,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [rendererBuildManifestPlugin()],
+      build: { outDir, minify: false },
+    });
+
+    const bundleSource = fs
+      .readdirSync(path.join(outDir, "assets"))
+      .filter((name) => name.endsWith(".js"))
+      .map((name) => fs.readFileSync(path.join(outDir, "assets", name), "utf8"))
+      .join("\n");
+    expect(bundleSource).toMatch(/globalThis\.apnsEnabled\s*=\s*["']1["']/);
+    expect(readRendererBuildManifest(outDir)?.iosApnsEnabled).toBe(true);
   });
 });

--- a/packages/app/vite/renderer-build-manifest-plugin.ts
+++ b/packages/app/vite/renderer-build-manifest-plugin.ts
@@ -39,6 +39,7 @@ function resolveCommit(): string | null {
 export function rendererBuildManifestPlugin(): Plugin {
   let outDir = "dist";
   let playwrightTestAuth = false;
+  let iosApnsEnabled: boolean | null = null;
   return {
     name: "renderer-build-manifest",
     apply: "build",
@@ -47,6 +48,10 @@ export function rendererBuildManifestPlugin(): Plugin {
       // Use Vite's resolved env so values loaded from `.env*` match the
       // `import.meta.env` value compiled into the renderer.
       playwrightTestAuth = config.env.VITE_PLAYWRIGHT_TEST_AUTH === "true";
+      iosApnsEnabled =
+        process.env.ELIZA_CAPACITOR_BUILD_TARGET === "ios"
+          ? config.env.VITE_ELIZA_APNS_ENABLED === "1"
+          : null;
     },
     closeBundle() {
       // Model-tester and other secondary single-file builds emit no index.html;
@@ -62,6 +67,7 @@ export function rendererBuildManifestPlugin(): Plugin {
             process.env.ELIZA_RUNTIME_MODE ??
             null,
           playwrightTestAuth,
+          iosApnsEnabled,
         });
         this.info?.(
           `[renderer-build-manifest] wrote ${RENDERER_BUILD_MANIFEST_FILENAME} buildId=${manifest.buildId.slice(0, 12)} (${manifest.assetCount} assets)`,

--- a/packages/ui/src/state/notifications/push-registration.test.ts
+++ b/packages/ui/src/state/notifications/push-registration.test.ts
@@ -2,7 +2,8 @@
  * Drives the real push-registration flow through a fake Capacitor
  * PushNotifications plugin (the OS boundary): permission gate → register() →
  * `registration` event → token POST, tapped-push → deep-link, and idempotency.
- * Only the four injected seams (plugin, platform, client, navigate) are faked;
+ * Only the five injected seams (plugin, platform, build gate, client, navigate)
+ * are faked;
  * the registration logic under test is the production module.
  */
 import type { PluginListenerHandle } from "@capacitor/core";
@@ -17,6 +18,7 @@ import type { FrontendPlatform } from "../../platform/platform-guards";
 import {
   __resetPushRegistrationForTests,
   initPushRegistration,
+  isRemotePushTransportEnabled,
   type PushRegistrationDeps,
   unregisterPushToken,
 } from "./push-registration";
@@ -60,9 +62,11 @@ function makePlugin(
 function makeDeps(
   plugin: FakePlugin,
   platform: FrontendPlatform,
+  remotePushEnabled = true,
 ): PushRegistrationDeps {
   return {
     getPlatform: () => platform,
+    isRemotePushEnabled: () => remotePushEnabled,
     getPlugin: () => plugin,
     registerToken: vi.fn(async () => ({ ok: true })),
     unregisterToken: vi.fn(async () => ({ ok: true })),
@@ -114,6 +118,30 @@ describe("initPushRegistration", () => {
     await flush();
 
     expect(deps.registerToken).toHaveBeenCalledWith("android", "fcm-token");
+  });
+
+  it("does not touch the iOS plugin when the APNs build gate is disabled", async () => {
+    const plugin = makePlugin("granted");
+    const deps = makeDeps(plugin, "ios", false);
+    plugin.checkPermissions = vi.fn(plugin.checkPermissions);
+
+    await initPushRegistration(deps);
+
+    expect(plugin.checkPermissions).not.toHaveBeenCalled();
+    expect(plugin.__registerCalls).toBe(0);
+    expect(plugin.__listeners.registration).toHaveLength(0);
+    expect(plugin.__listeners.registrationError).toHaveLength(0);
+    expect(plugin.__listeners.pushNotificationActionPerformed).toHaveLength(0);
+    expect(deps.registerToken).not.toHaveBeenCalled();
+  });
+
+  it("keeps Android registration enabled independently of the iOS APNs flag", async () => {
+    const plugin = makePlugin("granted");
+    const deps = makeDeps(plugin, "android", true);
+
+    await initPushRegistration(deps);
+
+    expect(plugin.__registerCalls).toBe(1);
   });
 
   it("does not re-POST an unchanged token when registration re-fires", async () => {
@@ -230,5 +258,19 @@ describe("initPushRegistration", () => {
 
     await unregisterPushToken(deps);
     expect(deps.unregisterToken).toHaveBeenCalledWith("tok-to-drop");
+  });
+});
+
+describe("isRemotePushTransportEnabled", () => {
+  it("fails closed for iOS unless the build flag is exactly 1", () => {
+    expect(isRemotePushTransportEnabled("ios", undefined)).toBe(false);
+    expect(isRemotePushTransportEnabled("ios", "0")).toBe(false);
+    expect(isRemotePushTransportEnabled("ios", "true")).toBe(false);
+    expect(isRemotePushTransportEnabled("ios", "1")).toBe(true);
+  });
+
+  it("keeps Android FCM enabled independently of the APNs flag", () => {
+    expect(isRemotePushTransportEnabled("android", undefined)).toBe(true);
+    expect(isRemotePushTransportEnabled("android", "0")).toBe(true);
   });
 });

--- a/packages/ui/src/state/notifications/push-registration.test.ts
+++ b/packages/ui/src/state/notifications/push-registration.test.ts
@@ -266,6 +266,7 @@ describe("isRemotePushTransportEnabled", () => {
     expect(isRemotePushTransportEnabled("ios", undefined)).toBe(false);
     expect(isRemotePushTransportEnabled("ios", "0")).toBe(false);
     expect(isRemotePushTransportEnabled("ios", "true")).toBe(false);
+    expect(isRemotePushTransportEnabled("ios", " 1 ")).toBe(false);
     expect(isRemotePushTransportEnabled("ios", "1")).toBe(true);
   });
 

--- a/packages/ui/src/state/notifications/push-registration.ts
+++ b/packages/ui/src/state/notifications/push-registration.ts
@@ -7,15 +7,18 @@
  * stack is a dead pipeline.
  *
  * Flow (native only — a no-op on web/desktop where the plugin is absent):
- *   1. Gate on a *granted* notification permission. Registration never prompts;
+ *   1. On iOS, require the same build-time APNs flag that patches the native
+ *      Info.plist. Direct/simulator builds default off because they do not carry
+ *      the `aps-environment` entitlement. Android remains enabled.
+ *   2. Gate on a *granted* notification permission. Registration never prompts;
  *      the ask is primed elsewhere (the onboarding permission modal). We only
  *      register once the user has already said yes, so an unregistered token is
  *      the honest signal "permission not granted", not a swallowed failure.
- *   2. Attach the `registration` listener, then call `register()`. The OS mints
+ *   3. Attach the `registration` listener, then call `register()`. The OS mints
  *      the token asynchronously and fires the listener; we POST it. iOS routes
  *      the APNs token through the AppDelegate → Capacitor bridge; Android reads
  *      the FCM token directly.
- *   3. Attach `pushNotificationActionPerformed` so a tapped push deep-links via
+ *   4. Attach `pushNotificationActionPerformed` so a tapped push deep-links via
  *      the same scheme-checked `navigateDeepLink` the in-app center uses.
  *
  * The listeners live for the app's lifetime; `initPushRegistration` is
@@ -40,12 +43,13 @@ import { navigateDeepLink } from "./navigate-deep-link";
 
 /**
  * Injectable boundaries. The Capacitor push plugin, the platform detector, the
- * HTTP client, and the deep-link navigator are the four seams to the outside
+ * build gate, HTTP client, and deep-link navigator are the five seams to the outside
  * world; injecting them lets the registration flow be driven end-to-end in a
  * test without a real device, while production wires the real singletons.
  */
 export interface PushRegistrationDeps {
   getPlatform: () => FrontendPlatform;
+  isRemotePushEnabled: (platform: "ios" | "android") => boolean;
   getPlugin: () => PushNotificationsPluginLike;
   registerToken: (
     platform: "ios" | "android",
@@ -57,6 +61,7 @@ export interface PushRegistrationDeps {
 
 const defaultDeps: PushRegistrationDeps = {
   getPlatform: getFrontendPlatform,
+  isRemotePushEnabled: isRemotePushTransportEnabled,
   getPlugin: getPushNotificationsPlugin,
   registerToken: (platform, token) => client.registerPushToken(platform, token),
   unregisterToken: (token) => client.unregisterPushToken(token),
@@ -71,6 +76,18 @@ let registeredToken: string | null = null;
 /** Only the native mobile platforms carry a remote-push transport. */
 function pushPlatform(platform: FrontendPlatform): "ios" | "android" | null {
   return platform === "ios" || platform === "android" ? platform : null;
+}
+
+/**
+ * Resolve the build-time remote-push transport gate. iOS is fail-closed unless
+ * the native plist patcher receives the same explicit `1`; Android continues
+ * to use FCM without depending on the APNs-only flag.
+ */
+export function isRemotePushTransportEnabled(
+  platform: "ios" | "android",
+  iosApnsFlag = import.meta.env?.VITE_ELIZA_APNS_ENABLED,
+): boolean {
+  return platform === "android" || iosApnsFlag === "1";
 }
 
 /**
@@ -123,6 +140,7 @@ async function startPushRegistration(
 ): Promise<boolean> {
   const platform = pushPlatform(deps.getPlatform());
   if (!platform) return false;
+  if (!deps.isRemotePushEnabled(platform)) return false;
 
   const plugin = deps.getPlugin();
   if (


### PR DESCRIPTION
Closes #20876.

## What changed

- keep iOS remote push registration default-off unless the build explicitly sets exact `VITE_ELIZA_APNS_ENABLED=1`
- parse that value through the canonical app-core mobile-build authority; whitespace, booleans, and other values fail closed
- carry the verified value into the final merged native Info.plist rather than an app-local post-sync path
- record the exact compiled iOS APNs boolean in the renderer manifest and reject missing/opposite provenance during automatic reuse, explicit reuse, and the pre-sync lane assertion
- normalize the APNs value passed into Vite so `.env*` files cannot diverge from native build authority
- keep Android behavior unchanged and keep registration gating ahead of plugin loading, permission requests, listener registration, APNs registration, and token upload
- retain fresh-build and explicit stale-risk acknowledgement for optional renderer features that remain unstamped

## Exact reviewed revision

- Head: `97f8ada6d6a33d1009f5e6dc361c93509e139dd2`
- Tree: `301d6c7b7dcdb9d1b5025f00ed2e9c8fc3a82e17`
- Base: `07e891e37a99dfc216e0f76f4731fe01c1256096`
- Rebased commits: `d3060e853fc86f1dd7d1a05c8a3c16614a25625c`, `f2ef244212c10645089df63f93315e37c1a57f87`, `85cd5943f201a7c28f8d51d5dd67781c072480f6`, `cdf4a219ff097e5c2f4b42d46c6a04d44aa865d4`, `d8b34593a36612832f590ec143238421a1f85298`, `97f8ada6d6a33d1009f5e6dc361c93509e139dd2`
- New provenance-stamp commit reviewed against prior validated `8f76ede5fb8e0652ec59927de43160578cbf2564`: original `0b8effe8bc0bfd6774197223eca15f96a1d4d957`, now rebased as `d8b34593a36612832f590ec143238421a1f85298`

## Independent review findings and repairs

The original implementation could reuse a renderer compiled with the opposite APNs flag. Earlier repairs forced fresh output and required `ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE=1` before explicitly reusing an unprovable renderer.

The APNs provenance commit correctly stamps the compiled boolean, treats missing/opposite APNs provenance as a mismatch, and preserves the explicit stale override for genuine mismatches. Re-audit found one regression: it removed the acknowledgement for all unstamped feature flags even though the iOS-local runtime chooser and Android cloud-debug realtime voice flags remain absent from the manifest. An explicit skip could therefore reuse those unprovable features without the established stale-risk acknowledgement. The final repair restores acknowledgement only for those remaining unstamped features; APNs-proven iOS overlay reuse is not falsely classified as stale.

## Validation on the exact head

- focused Vitest: 6 files / 83 tests PASS
- app-core, app, and UI typechecks PASS
- exact 12-file Biome PASS
- `git diff --check origin/develop...HEAD` PASS
- GitHub reports the PR CLEAN and MERGEABLE with no remote checks configured

## Native evidence status

The earlier author revision produced an unsigned enabled build with `ELIZA_APNS_ENABLED=1`, but that artifact predates the final rebases, provenance work, and acknowledgement repair and is not exact-head release evidence.

Still required for issue acceptance:

- a current-head default-off Simulator build/reinstall and unified-log capture proving no remote APNs registration attempt
- a current-head enabled native artifact receipt showing the renderer manifest and final built Info.plist both use the enabled gate

This Mac has no valid Apple code-signing identity or matching provisioning profile carrying `aps-environment`. Simulator and unsigned builds cannot prove physical APNs delivery, so this PR does not claim physical banner/token delivery evidence. The PR remains draft.

No macOS/shared overlay, Worker/gateway, staging, production, provider, credential, secret, or agent-lifecycle state was changed. No deployment was performed.

## Contribution provenance

- AI provider/model: OpenAI / GPT-5
- Client / agent tooling: Codex Desktop
- Contribution skill revision: `elizaOS/eliza@7d61167afa23da76e10e8c541401be8d901eeb1e:packages/skills/skills/contribute-to-eliza`
- Attribution status: self-reported

— [codex/ios-acceptance]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@7d61167afa23da76e10e8c541401be8d901eeb1e:packages/skills/skills/contribute-to-eliza"} -->