### PR TITLE
fix(cloud): reject unknown influencer bookings party

### DIFF
--- a/packages/cloud/api/v1/marketing/influencers/bookings/route.as-query.test.ts
+++ b/packages/cloud/api/v1/marketing/influencers/bookings/route.as-query.test.ts
@@ -1,0 +1,91 @@
+/**
+ * GET /api/v1/marketing/influencers/bookings `as` is marketplace party
+ * identity, not leftover X connectionRole or catalog-sort tax. Stock develop
+ * treated every non-"influencer" token as the advertiser org list, so
+ * `as=INFLUENCER` / `as=advertiser` silently showed the wrong party's bookings.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const listBookingsForOrg = mock(async (_organizationId: string) => [
+  { id: "org-booking" },
+]);
+const listBookingsForInfluencer = mock(async (_userId: string) => [
+  { id: "influencer-booking" },
+]);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+mock.module("@/lib/services/influencer-marketplace", () => ({
+  influencerMarketplaceService: {
+    listBookingsForOrg,
+    listBookingsForInfluencer,
+  },
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>
+    c.json({ success: false, error: "internal_error" }, 500),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: () => undefined },
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/v1/marketing/influencers/bookings", route);
+
+function listBookings(query = "") {
+  return app.request(`/api/v1/marketing/influencers/bookings${query}`);
+}
+
+function expectNoList() {
+  expect(listBookingsForOrg).not.toHaveBeenCalled();
+  expect(listBookingsForInfluencer).not.toHaveBeenCalled();
+}
+
+describe("GET /api/v1/marketing/influencers/bookings party identity", () => {
+  beforeEach(() => {
+    listBookingsForOrg.mockClear();
+    listBookingsForInfluencer.mockClear();
+  });
+
+  test.each([
+    ["", "org"],
+    ["?as=", "org"],
+    ["?as=advertiser", "org"],
+    ["?as=influencer", "influencer"],
+  ])("accepts %s as %s bookings", async (query, party) => {
+    const response = await listBookings(query);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      success: boolean;
+      bookings: Array<{ id: string }>;
+    };
+    expect(body.success).toBe(true);
+    if (party === "influencer") {
+      expect(listBookingsForInfluencer).toHaveBeenCalledTimes(1);
+      expect(listBookingsForInfluencer).toHaveBeenCalledWith("user-1");
+      expect(listBookingsForOrg).not.toHaveBeenCalled();
+      expect(body.bookings).toEqual([{ id: "influencer-booking" }]);
+    } else {
+      expect(listBookingsForOrg).toHaveBeenCalledTimes(1);
+      expect(listBookingsForOrg).toHaveBeenCalledWith("org-1");
+      expect(listBookingsForInfluencer).not.toHaveBeenCalled();
+      expect(body.bookings).toEqual([{ id: "org-booking" }]);
+    }
+  });
+
+  test.each(["INFLUENCER", "Advertiser", "foo", "1e2", "influencer "])(
+    "rejects as=%s before either booking list",
+    async (token) => {
+      const response = await listBookings(`?as=${encodeURIComponent(token)}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toMatch(/as/i);
+      expectNoList();
+    },
+  );
+});

--- a/packages/cloud/api/v1/marketing/influencers/bookings/route.as-query.test.ts
+++ b/packages/cloud/api/v1/marketing/influencers/bookings/route.as-query.test.ts
@@ -1,8 +1,7 @@
 /**
- * GET /api/v1/marketing/influencers/bookings `as` is marketplace party
- * identity, not leftover X connectionRole or catalog-sort tax. Stock develop
- * treated every non-"influencer" token as the advertiser org list, so
- * `as=INFLUENCER` / `as=advertiser` silently showed the wrong party's bookings.
+ * Deterministic route tests for influencer-booking party selection.
+ * Mocked marketplace lists prove canonical queries select exactly one party
+ * and ambiguous tokens do not read either list.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";

--- a/packages/cloud/api/v1/marketing/influencers/bookings/route.ts
+++ b/packages/cloud/api/v1/marketing/influencers/bookings/route.ts
@@ -27,11 +27,9 @@ const app = new Hono<AppEnv>();
 app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    // Party identity, not leftover X connectionRole tax. The prior ternary
-    // mapped every non-"influencer" token — including INFLUENCER, advertiser
-    // typos, and 1e2 — onto the advertiser org list. Missing/empty still
-    // defaults to advertiser (this route's documented default). Garbage 400s
-    // before either booking list.
+    // The query selects a tenant-facing party view, so only the two documented
+    // identities are accepted. Missing or empty retains the advertiser default;
+    // ambiguous tokens fail before either booking list is read.
     const requestedAs = c.req.query("as");
     if (
       requestedAs !== undefined &&

--- a/packages/cloud/api/v1/marketing/influencers/bookings/route.ts
+++ b/packages/cloud/api/v1/marketing/influencers/bookings/route.ts
@@ -27,8 +27,29 @@ const app = new Hono<AppEnv>();
 app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
+    // Party identity, not leftover X connectionRole tax. The prior ternary
+    // mapped every non-"influencer" token — including INFLUENCER, advertiser
+    // typos, and 1e2 — onto the advertiser org list. Missing/empty still
+    // defaults to advertiser (this route's documented default). Garbage 400s
+    // before either booking list.
+    const requestedAs = c.req.query("as");
+    if (
+      requestedAs !== undefined &&
+      requestedAs !== "" &&
+      requestedAs !== "influencer" &&
+      requestedAs !== "advertiser"
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: "invalid_as",
+          message: 'as must be "influencer" or "advertiser".',
+        },
+        400,
+      );
+    }
     const bookings =
-      c.req.query("as") === "influencer"
+      requestedAs === "influencer"
         ? await influencerMarketplaceService.listBookingsForInfluencer(user.id)
         : await influencerMarketplaceService.listBookingsForOrg(
             user.organization_id,


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on influencer-marketplace
booking party identity. Marketplace-party class, not leftover tax on X
connectionRole, my-agents sortBy, logs since, analytics periods,
analytics export type, admin redemption status, share-ingest consume,
Life Ops inbox bools, views viewType, relationships scope, commands
surface, approvals state, database-rows sort/page, memory-viewer type,
VFS encoding, models catalogOnly/refresh, Cloud JSON-400, prefix-coerced
limit, percent-encoded paths, SIWS chainId, orchestrator lines,
provisioning-worker env ints, invites-accept, cli-auth, redemption
quote, compat agent-logs, or avatar. Disjoint from payment-request
`public`. POST create / accept / reject untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; exact-head evidence is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync at the exact reviewed head.

# Risks

Low. GET `as` only on `/api/v1/marketing/influencers/bookings`. Omitted/empty
still lists advertiser-org bookings. Exact `influencer` / `advertiser` still
select that party. Unknown tokens 400 before either list.

# Background

## What does this PR do?

`GET /api/v1/marketing/influencers/bookings` treated every non-`influencer`
`as` token as the advertiser org list. `as=INFLUENCER` / `as=Advertiser` /
`as=foo` silently showed the caller's org bookings instead of the requested
party.

- omitted / empty → **200** advertiser org list (today's default)
- exact `advertiser` → **200** org list
- exact `influencer` → **200** influencer list
- `INFLUENCER` / `Advertiser` / `foo` / `1e2` → **400** before either list

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The marketplace documents `?as=influencer` for bookings you were booked
for. A typo must not silently swap the party. This is marketplace party
identity, not leftover tax on X status connectionRole.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/marketing/influencers/bookings/route.as-query.test.ts`
— omitted still lists org bookings; canonical tokens keep working; garbage
400s with neither list called.

## Test commands

```bash
cd packages/cloud/api && bun test v1/marketing/influencers/bookings/route.as-query.test.ts
```

9 passed at the evidence head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; influencer bookings `as` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; influencer bookings `as` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; influencer bookings `as` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real `as` token and assert 400 before either booking list; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no booking write; illegal `as` 400 before either list.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal `as`
tokens reject; omitted/canonical still bind the matching party.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

Reviewer repair and exact-head proof at `63d26da95cda4063e2b0bc6b9a054af9ed2c3d7f`:
- Influencer-booking party-selection contract: 9/9.
- Cloud API typecheck and production Worker dry-run: pass within root verification.
- Biome, diff, and comment-only token gate: pass.
- `TURBO_FORCE=true bun run verify`: 356/356, 0 cached, all audits; anti-larp 8,449 files with 0 focused and 0 orphaned skips.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:63d26da95cda4063e2b0bc6b9a054af9ed2c3d7f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


