### PR TITLE
fix(cloud): reject unknown payment-request public flag

### DIFF
--- a/packages/cloud/api/v1/payment-requests/[id]/route.public-query.test.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/route.public-query.test.ts
@@ -1,0 +1,130 @@
+/**
+ * GET /api/v1/payment-requests/:id `public` is checkout-visibility identity,
+ * not leftover Life Ops inbox bool tax. Stock develop treated only the exact
+ * token `1` as the unauthenticated checkout DTO; `public=true` / `public=yes`
+ * silently took the authenticated creator path.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { PaymentRequestRow } from "@/lib/services/payment-requests";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+const getMock = mock(
+  async (
+    _id: string,
+    _organizationId: string,
+  ): Promise<PaymentRequestRow | null> => null,
+);
+const getPublicMock = mock(
+  async (_id: string): Promise<PaymentRequestRow | null> => null,
+);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/services/payment-requests-default", () => ({
+  getPaymentRequestsService: () => ({
+    get: getMock,
+    getPublic: getPublicMock,
+  }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: "standard" },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (
+    c: { json: (body: unknown, status: number) => Response },
+    _error: unknown,
+  ) => c.json({ success: false, error: "internal error" }, 500),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(() => undefined) },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id", route);
+
+const paymentRequest: PaymentRequestRow = {
+  id: "pr-1",
+  organizationId: "org-1",
+  agentId: "agent-1",
+  appId: "app-1",
+  provider: "stripe" as const,
+  amountCents: 2500,
+  currency: "USD",
+  reason: "Premium plan",
+  paymentContext: { kind: "any_payer" as const },
+  payerIdentityId: "payer-identity-1",
+  payerUserId: "payer-user-1",
+  payerOrganizationId: "payer-org-1",
+  status: "pending" as const,
+  hostedUrl: "https://checkout.example.test/session",
+  callbackUrl: "https://merchant.example.test/callback",
+  callbackSecret: "callback-secret",
+  providerIntent: { secretSessionId: "provider-secret" },
+  settledAt: null,
+  settlementTxRef: "provider-tx-ref",
+  settlementProof: { signature: "proof-secret" },
+  expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  metadata: { internal: "do-not-expose" },
+};
+
+function expectNoLookup() {
+  expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+  expect(getMock).not.toHaveBeenCalled();
+  expect(getPublicMock).not.toHaveBeenCalled();
+}
+
+describe("GET /api/v1/payment-requests/:id public checkout identity", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    getMock.mockClear();
+    getPublicMock.mockClear();
+    getMock.mockResolvedValue(paymentRequest);
+    getPublicMock.mockResolvedValue(paymentRequest);
+  });
+
+  test.each(["", "?public="])(
+    "accepts %s as the authenticated creator view",
+    async (query) => {
+      const response = await app.request(`/pr-1${query}`);
+      expect(response.status).toBe(200);
+      expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+      expect(getMock).toHaveBeenCalledWith("pr-1", "org-1");
+      expect(getPublicMock).not.toHaveBeenCalled();
+    },
+  );
+
+  test("accepts public=1 as the unauthenticated checkout DTO", async () => {
+    const response = await app.request("/pr-1?public=1");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      success: boolean;
+      paymentRequest: { id: string; hostedUrl: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.paymentRequest.id).toBe("pr-1");
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+    expect(getPublicMock).toHaveBeenCalledWith("pr-1");
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  test.each(["true", "yes", "TRUE", "0", "foo", "1e2"])(
+    "rejects public=%s before checkout or creator lookup",
+    async (token) => {
+      const response = await app.request(
+        `/pr-1?public=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toMatch(/public/i);
+      expectNoLookup();
+    },
+  );
+});

--- a/packages/cloud/api/v1/payment-requests/[id]/route.public-query.test.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/route.public-query.test.ts
@@ -1,8 +1,7 @@
 /**
- * GET /api/v1/payment-requests/:id `public` is checkout-visibility identity,
- * not leftover Life Ops inbox bool tax. Stock develop treated only the exact
- * token `1` as the unauthenticated checkout DTO; `public=true` / `public=yes`
- * silently took the authenticated creator path.
+ * Deterministic route tests for the payment-request detail visibility query.
+ * Mocked authentication and storage boundaries prove selection happens before
+ * either collaborator is invoked.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";

--- a/packages/cloud/api/v1/payment-requests/[id]/route.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/route.ts
@@ -31,7 +31,27 @@ app.get("/", async (c) => {
       );
     }
 
-    const isPublic = c.req.query("public") === "1";
+    // Checkout-visibility identity, not leftover inbox-bool tax. Only the
+    // exact token `1` is the allowlisted unauthenticated DTO. `public=true`
+    // / `public=yes` previously fell through to the authenticated creator
+    // path. Missing/empty still means creator view. Garbage 400s before
+    // auth or either lookup.
+    const requestedPublic = c.req.query("public");
+    if (
+      requestedPublic !== undefined &&
+      requestedPublic !== "" &&
+      requestedPublic !== "1"
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: "invalid_public",
+          message: 'public must be "1" for the checkout view.',
+        },
+        400,
+      );
+    }
+    const isPublic = requestedPublic === "1";
     const service = getPaymentRequestsService(c.env);
 
     if (isPublic) {

--- a/packages/cloud/api/v1/payment-requests/[id]/route.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/route.ts
@@ -31,11 +31,9 @@ app.get("/", async (c) => {
       );
     }
 
-    // Checkout-visibility identity, not leftover inbox-bool tax. Only the
-    // exact token `1` is the allowlisted unauthenticated DTO. `public=true`
-    // / `public=yes` previously fell through to the authenticated creator
-    // path. Missing/empty still means creator view. Garbage 400s before
-    // auth or either lookup.
+    // Only the exact token `1` selects the unauthenticated, redacted checkout
+    // DTO. Missing or empty selects the authenticated creator view; any other
+    // token is ambiguous and must fail before authentication or lookup.
     const requestedPublic = c.req.query("public");
     if (
       requestedPublic !== undefined &&


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on payment-request checkout
visibility identity. Checkout-visibility class, not leftover tax on X
connectionRole, my-agents sortBy, logs since, analytics periods,
analytics export type, admin redemption status, share-ingest consume,
Life Ops inbox bools, views viewType, relationships scope, commands
surface, approvals state, database-rows sort/page, memory-viewer type,
VFS encoding, models catalogOnly/refresh, Cloud JSON-400, prefix-coerced
limit, percent-encoded paths, SIWS chainId, orchestrator lines,
provisioning-worker env ints, invites-accept, cli-auth, redemption
quote, compat agent-logs, or avatar. Disjoint from influencer bookings
`as`. List / create parsers untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; exact-head evidence is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync at the exact reviewed head.

# Risks

Low. GET `public` only on `/api/v1/payment-requests/:id`. Omitted/empty still
returns the authenticated creator row. Exact `1` still returns the public
checkout DTO without auth. Unknown tokens 400 before auth or either lookup.

# Background

## What does this PR do?

`GET /api/v1/payment-requests/:id` treated only the exact token `1` as the
allowlisted unauthenticated checkout DTO. `public=true` / `public=yes` /
`public=TRUE` silently took the authenticated creator path.

- omitted / empty → **200** authenticated creator row (today's default)
- exact `1` → **200** public checkout DTO, no auth
- `true` / `yes` / `TRUE` / `0` / `foo` / `1e2` → **400** before auth or lookup

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The checkout page documents `?public=1` as the unauthenticated DTO. A
common `public=true` must not silently switch to the creator path. This is
checkout-visibility identity, not leftover tax on Life Ops inbox bools.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/payment-requests/[id]/route.public-query.test.ts` —
omitted still authenticates; `public=1` still returns the DTO; garbage 400s
with auth / `get` / `getPublic` never called. Existing
`route.test.ts` still passes.

## Test commands

```bash
cd packages/cloud/api && bun test v1/payment-requests/[id]/route.public-query.test.ts
```

9 passed at the evidence head. Existing `route.test.ts` 6 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; payment-request `public` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; payment-request `public` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; payment-request `public` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real `public` token and assert 400 before auth or lookup; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no payment write; illegal `public` 400 before checkout or creator lookup.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal `public`
tokens reject; omitted/canonical still bind the matching view.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

Reviewer repair and exact-head proof at `2bc5660d6d09e8c2e25df2d2062d370758202cca`:
- New public-query contract: 9/9.
- Existing payment-request resource contract: 6/6.
- Global anonymous-detail auth-boundary integration: 2/2.
- Cloud API typecheck and production Worker dry-run: pass.
- Biome, diff, and comment-only token gate: pass.
- `TURBO_FORCE=true bun run verify`: 356/356, 0 cached, all audits; anti-larp 8,449 files with 0 focused and 0 orphaned skips.

The first combined focused invocation was intentionally discarded because Bun process-global module mocks from the auth-boundary suite conflict with the route suites. Each authoritative file passes in a fresh process, matching repository lane isolation.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2bc5660d6d09e8c2e25df2d2062d370758202cca -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->

