### PR TITLE
fix(plugin-agent-skills): 400 malformed percent-encoded skill IDs and catalog slugs

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -2569,6 +2569,7 @@ async function handleRequest(
         error,
         readJsonBody,
         readBody,
+        decodePathComponent,
         discoverSkills,
       })
     ) {

--- a/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
+++ b/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
@@ -128,6 +128,9 @@ vi.mock("@elizaos/core", () => {
 			async stop() {}
 		},
 		resolveStateDir: vi.fn(() => "/tmp/elizaos-test-state"),
+		formatError: vi.fn((err: unknown) =>
+			err instanceof Error ? err.message : String(err),
+		),
 		logger,
 	};
 });

--- a/plugins/plugin-agent-skills/src/api/skills-routes.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for `handleSkillsRoutes` path encoding validation and error handling.
+ * Deterministic: validates that malformed percent-escapes across skill and catalog
+ * routes fail closed with 400 Bad Request per Error Policy J3 before touching
+ * disk or internal services.
+ */
+import type http from "node:http";
+import type { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleSkillsRoutes,
+  type SkillsRouteContext,
+} from "./skills-routes";
+
+function createSkillsContext(
+  method: string,
+  pathname: string,
+  overrides: Partial<SkillsRouteContext> = {},
+): {
+  ctx: SkillsRouteContext;
+  json: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+} {
+  const req = { method, url: pathname } as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  const json = vi.fn();
+  const error = vi.fn();
+
+  const ctx: SkillsRouteContext = {
+    req,
+    res,
+    method,
+    pathname,
+    url: new URL(`http://localhost${pathname}`),
+    state: {
+      runtime: {
+        getCache: vi.fn().mockResolvedValue({}),
+        setCache: vi.fn().mockResolvedValue(undefined),
+        getService: vi.fn().mockReturnValue(undefined),
+      } as unknown as AgentRuntime,
+      config: { agents: { defaults: { workspace: "/tmp/mock-workspace" } } },
+      skills: [],
+    },
+    json,
+    error,
+    readJsonBody: vi.fn().mockResolvedValue({}),
+    readBody: vi.fn().mockResolvedValue(""),
+    discoverSkills: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+
+  return { ctx, json, error };
+}
+
+describe("handleSkillsRoutes path encoding validation", () => {
+  it("rejects malformed percent-encoding on GET /api/skills/catalog/:slug with 400", async () => {
+    const { ctx, error } = createSkillsContext(
+      "GET",
+      "/api/skills/catalog/%",
+    );
+
+    const handled = await handleSkillsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid skill slug encoding",
+      400,
+    );
+  });
+
+  it("rejects malformed percent-encoding on GET /api/skills/:id/scan with 400", async () => {
+    const { ctx, error } = createSkillsContext(
+      "GET",
+      "/api/skills/%/scan",
+    );
+
+    const handled = await handleSkillsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid skill ID: malformed URL encoding",
+      400,
+    );
+  });
+
+  it("rejects malformed percent-encoding on POST /api/skills/:id/acknowledge with 400", async () => {
+    const { ctx, error } = createSkillsContext(
+      "POST",
+      "/api/skills/%/acknowledge",
+    );
+
+    const handled = await handleSkillsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid skill ID: malformed URL encoding",
+      400,
+    );
+  });
+
+  it("rejects malformed percent-encoding on POST /api/skills/:id/open with 400", async () => {
+    const { ctx, error } = createSkillsContext(
+      "POST",
+      "/api/skills/%/open",
+    );
+
+    const handled = await handleSkillsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid skill ID: malformed URL encoding",
+      400,
+    );
+  });
+
+  it("rejects malformed percent-encoding on GET /api/skills/:id/source with 400", async () => {
+    const { ctx, error } = createSkillsContext(
+      "GET",
+      "/api/skills/%/source",
+    );
+
+    const handled = await handleSkillsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid skill ID: malformed URL encoding",
+      400,
+    );
+  });
+
+  it("rejects malformed percent-encoding on POST /api/skills/:id/enable with 400", async () => {
+    const { ctx, error } = createSkillsContext(
+      "POST",
+      "/api/skills/%/enable",
+    );
+
+    const handled = await handleSkillsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid skill ID: malformed URL encoding",
+      400,
+    );
+  });
+
+  it("rejects malformed percent-encoding on POST /api/skills/:id/disable with 400", async () => {
+    const { ctx, error } = createSkillsContext(
+      "POST",
+      "/api/skills/%/disable",
+    );
+
+    const handled = await handleSkillsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid skill ID: malformed URL encoding",
+      400,
+    );
+  });
+
+  it("rejects malformed percent-encoding on PUT /api/skills/:id/source with 400", async () => {
+    const { ctx, error } = createSkillsContext(
+      "PUT",
+      "/api/skills/%/source",
+    );
+
+    const handled = await handleSkillsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid skill ID: malformed URL encoding",
+      400,
+    );
+  });
+
+  it("rejects malformed percent-encoding on DELETE /api/skills/:id with 400", async () => {
+    const { ctx, error } = createSkillsContext(
+      "DELETE",
+      "/api/skills/%",
+    );
+
+    const handled = await handleSkillsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid skill ID: malformed URL encoding",
+      400,
+    );
+  });
+
+  it("decodes valid percent-encoded skill ID and performs lookup", async () => {
+    const { ctx, error } = createSkillsContext(
+      "GET",
+      "/api/skills/valid%2Dskill/scan",
+    );
+
+    const handled = await handleSkillsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    // Not found in mock workspace / disk -> proceeds through normal logic without 400 encoding error
+    expect(error).not.toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid skill ID: malformed URL encoding",
+      400,
+    );
+  });
+
+  it("rejects invalid skill ID characters after valid URL decoding with 400", async () => {
+    const { ctx, error } = createSkillsContext(
+      "GET",
+      "/api/skills/skill%20with%20spaces/scan",
+    );
+
+    const handled = await handleSkillsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      expect.stringContaining("Invalid skill ID"),
+      400,
+    );
+  });
+});

--- a/plugins/plugin-agent-skills/src/api/skills-routes.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.test.ts
@@ -25,6 +25,20 @@ function createSkillsContext(
   const res = {} as http.ServerResponse;
   const json = vi.fn();
   const error = vi.fn();
+  const decodePathComponent = vi.fn(
+    (raw: string, response: http.ServerResponse, fieldName: string) => {
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        error(
+          response,
+          `Invalid ${fieldName}: malformed URL encoding`,
+          400,
+        );
+        return null;
+      }
+    },
+  );
 
   const ctx: SkillsRouteContext = {
     req,
@@ -45,6 +59,7 @@ function createSkillsContext(
     error,
     readJsonBody: vi.fn().mockResolvedValue({}),
     readBody: vi.fn().mockResolvedValue(""),
+    decodePathComponent,
     discoverSkills: vi.fn().mockResolvedValue([]),
     ...overrides,
   };
@@ -64,7 +79,7 @@ describe("handleSkillsRoutes path encoding validation", () => {
     expect(handled).toBe(true);
     expect(error).toHaveBeenCalledWith(
       ctx.res,
-      "Invalid skill slug encoding",
+      "Invalid skill slug: malformed URL encoding",
       400,
     );
   });
@@ -223,6 +238,21 @@ describe("handleSkillsRoutes path encoding validation", () => {
     const handled = await handleSkillsRoutes(ctx);
 
     expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      expect.stringContaining("Invalid skill ID"),
+      400,
+    );
+  });
+
+  it("rejects invalid catalog slug characters after valid URL decoding", async () => {
+    const { ctx, error } = createSkillsContext(
+      "GET",
+      "/api/skills/catalog/skill%20with%20spaces",
+    );
+
+    expect(await handleSkillsRoutes(ctx)).toBe(true);
+
     expect(error).toHaveBeenCalledWith(
       ctx.res,
       expect.stringContaining("Invalid skill ID"),

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -189,6 +189,22 @@ function validateSkillId(
   return skillId;
 }
 
+function decodeAndValidateSkillId(
+  rawSkillId: string,
+  res: http.ServerResponse,
+  errorFn: SkillsRouteContext["error"],
+): string | null {
+  let skillId: string;
+  try {
+    skillId = decodeURIComponent(rawSkillId);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
+    errorFn(res, "Invalid skill ID: malformed URL encoding", 400);
+    return null;
+  }
+  return validateSkillId(skillId, res, errorFn);
+}
+
 // ---------------------------------------------------------------------------
 // Binance skill filtering
 // ---------------------------------------------------------------------------
@@ -481,9 +497,16 @@ export async function handleSkillsRoutes(
 
   // ── GET /api/skills/catalog/:slug ──────────────────────────────────────
   if (method === "GET" && pathname.startsWith("/api/skills/catalog/")) {
-    const slug = decodeURIComponent(
-      pathname.slice("/api/skills/catalog/".length),
-    );
+    let slug: string;
+    try {
+      slug = decodeURIComponent(
+        pathname.slice("/api/skills/catalog/".length),
+      );
+    } catch {
+      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
+      error(res, "Invalid skill slug encoding", 400);
+      return true;
+    }
     // Exclude "search" which is handled above
     if (slug && slug !== "search") {
       if (!shouldExposeBinanceSkillId(slug)) {
@@ -731,8 +754,8 @@ export async function handleSkillsRoutes(
 
   // ── GET /api/skills/:id/scan ───────────────────────────────────────────
   if (method === "GET" && pathname.match(/^\/api\/skills\/[^/]+\/scan$/)) {
-    const skillId = validateSkillId(
-      decodeURIComponent(pathname.split("/")[3]),
+    const skillId = decodeAndValidateSkillId(
+      pathname.split("/")[3],
       res,
       error,
     );
@@ -756,8 +779,8 @@ export async function handleSkillsRoutes(
     method === "POST" &&
     pathname.match(/^\/api\/skills\/[^/]+\/acknowledge$/)
   ) {
-    const skillId = validateSkillId(
-      decodeURIComponent(pathname.split("/")[3]),
+    const skillId = decodeAndValidateSkillId(
+      pathname.split("/")[3],
       res,
       error,
     );
@@ -907,8 +930,8 @@ export async function handleSkillsRoutes(
 
   // ── POST /api/skills/:id/open ─────────────────────────────────────────
   if (method === "POST" && pathname.match(/^\/api\/skills\/[^/]+\/open$/)) {
-    const skillId = validateSkillId(
-      decodeURIComponent(pathname.split("/")[3]),
+    const skillId = decodeAndValidateSkillId(
+      pathname.split("/")[3],
       res,
       error,
     );
@@ -989,8 +1012,8 @@ export async function handleSkillsRoutes(
 
   // ── GET /api/skills/:id/source ──────────────────────────────────────────
   if (method === "GET" && pathname.match(/^\/api\/skills\/[^/]+\/source$/)) {
-    const skillId = validateSkillId(
-      decodeURIComponent(pathname.split("/")[3]),
+    const skillId = decodeAndValidateSkillId(
+      pathname.split("/")[3],
       res,
       error,
     );
@@ -1072,8 +1095,8 @@ export async function handleSkillsRoutes(
   // Canonical verb endpoint for enabling a skill. Honors scan acknowledgment
   // requirements; returns 409 when an unack'd scan blocks enabling.
   if (method === "POST" && pathname.match(/^\/api\/skills\/[^/]+\/enable$/)) {
-    const skillId = validateSkillId(
-      decodeURIComponent(pathname.split("/")[3]),
+    const skillId = decodeAndValidateSkillId(
+      pathname.split("/")[3],
       res,
       error,
     );
@@ -1136,8 +1159,8 @@ export async function handleSkillsRoutes(
   // ── POST /api/skills/:id/disable ────────────────────────────────────────
   // Canonical verb endpoint for disabling a skill.
   if (method === "POST" && pathname.match(/^\/api\/skills\/[^/]+\/disable$/)) {
-    const skillId = validateSkillId(
-      decodeURIComponent(pathname.split("/")[3]),
+    const skillId = decodeAndValidateSkillId(
+      pathname.split("/")[3],
       res,
       error,
     );
@@ -1170,8 +1193,8 @@ export async function handleSkillsRoutes(
 
   // ── PUT /api/skills/:id/source ──────────────────────────────────────────
   if (method === "PUT" && pathname.match(/^\/api\/skills\/[^/]+\/source$/)) {
-    const skillId = validateSkillId(
-      decodeURIComponent(pathname.split("/")[3]),
+    const skillId = decodeAndValidateSkillId(
+      pathname.split("/")[3],
       res,
       error,
     );
@@ -1269,8 +1292,8 @@ export async function handleSkillsRoutes(
     pathname.match(/^\/api\/skills\/[^/]+$/) &&
     !pathname.includes("/marketplace")
   ) {
-    const skillId = validateSkillId(
-      decodeURIComponent(pathname.slice("/api/skills/".length)),
+    const skillId = decodeAndValidateSkillId(
+      pathname.slice("/api/skills/".length),
       res,
       error,
     );

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -151,6 +151,11 @@ export interface SkillsRouteContext {
     options?: ReadJsonBodyOptions,
   ) => Promise<T | null>;
   readBody: (req: http.IncomingMessage) => Promise<string>;
+  decodePathComponent: (
+    raw: string,
+    res: http.ServerResponse,
+    fieldName: string,
+  ) => string | null;
   // Functions from server.ts that skills routes need
   discoverSkills: (
     workspaceDir: string,
@@ -193,15 +198,11 @@ function decodeAndValidateSkillId(
   rawSkillId: string,
   res: http.ServerResponse,
   errorFn: SkillsRouteContext["error"],
+  decodePathComponent: SkillsRouteContext["decodePathComponent"],
+  fieldName = "skill ID",
 ): string | null {
-  let skillId: string;
-  try {
-    skillId = decodeURIComponent(rawSkillId);
-  } catch {
-    // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
-    errorFn(res, "Invalid skill ID: malformed URL encoding", 400);
-    return null;
-  }
+  const skillId = decodePathComponent(rawSkillId, res, fieldName);
+  if (skillId === null) return null;
   return validateSkillId(skillId, res, errorFn);
 }
 
@@ -382,6 +383,7 @@ export async function handleSkillsRoutes(
     error,
     readJsonBody,
     discoverSkills,
+    decodePathComponent,
   } = ctx;
 
   // ── GET /api/skills/catalog ───────────────────────────────────────────
@@ -497,16 +499,14 @@ export async function handleSkillsRoutes(
 
   // ── GET /api/skills/catalog/:slug ──────────────────────────────────────
   if (method === "GET" && pathname.startsWith("/api/skills/catalog/")) {
-    let slug: string;
-    try {
-      slug = decodeURIComponent(
-        pathname.slice("/api/skills/catalog/".length),
-      );
-    } catch {
-      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
-      error(res, "Invalid skill slug encoding", 400);
-      return true;
-    }
+    const slug = decodeAndValidateSkillId(
+      pathname.slice("/api/skills/catalog/".length),
+      res,
+      error,
+      decodePathComponent,
+      "skill slug",
+    );
+    if (slug === null) return true;
     // Exclude "search" which is handled above
     if (slug && slug !== "search") {
       if (!shouldExposeBinanceSkillId(slug)) {
@@ -758,6 +758,7 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
+      decodePathComponent,
     );
     if (!skillId) return true;
     const workspaceDir =
@@ -783,6 +784,7 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
+      decodePathComponent,
     );
     if (!skillId) return true;
     const rawAck = await readJsonBody<Record<string, unknown>>(req, res);
@@ -934,6 +936,7 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
+      decodePathComponent,
     );
     if (!skillId) return true;
     const workspaceDir =
@@ -1016,6 +1019,7 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
+      decodePathComponent,
     );
     if (!skillId) return true;
     const workspaceDir =
@@ -1099,6 +1103,7 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
+      decodePathComponent,
     );
     if (!skillId) return true;
 
@@ -1163,6 +1168,7 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
+      decodePathComponent,
     );
     if (!skillId) return true;
 
@@ -1197,6 +1203,7 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
+      decodePathComponent,
     );
     if (!skillId) return true;
     const rawSource = await readJsonBody<Record<string, unknown>>(req, res);
@@ -1296,6 +1303,7 @@ export async function handleSkillsRoutes(
       pathname.slice("/api/skills/".length),
       res,
       error,
+      decodePathComponent,
     );
     if (!skillId) return true;
     const workspaceDir =


### PR DESCRIPTION
## Summary

Fails closed with `400 Bad Request` for malformed percent-encoded skill IDs and catalog slugs. The plugin now receives the agent host's canonical `decodePathComponent` through its route context instead of owning a second decoder/error policy. Every decoded ID and catalog slug passes the existing safe skill-ID grammar before filesystem, catalog, or state access.

Closes #20949.

## Verification

Exact reviewed head: `c467e21b127d744be5648669abb4931e25fc45de`.

- Exact-head focused production route suite: 12/12 tests passing.
- Full plugin suite before the final unrelated develop rebase: 17/17 files, 69/69 tests passing.
- Exact-head `plugin-agent-skills` typecheck: pass.
- Biome check on changed plugin and host files: clean (host file retains 12 pre-existing undeclared-env warnings, no errors).
- `git diff --check`: clean.
- Tests cover all affected verbs, valid encoded IDs, malformed escapes, decoded unsafe IDs, and decoded unsafe catalog slugs.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only route validation; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only route validation; no rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic HTTP boundary behavior has no visual flow.
<!-- evidence-row:backend-logs -->
- [x] Focused and package test transcript:

```text
Exact head: src/api/skills-routes.test.ts, 12 tests passed
Full plugin lane: 17 files passed, 69 tests passed
Exact head: plugin-agent-skills tsc --noEmit passed; Biome and diff-check clean
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action-planning, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - invalid requests are rejected before filesystem or skill-state mutation.

---
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@7f33adca78e035f59aebb060b36327329ccc281a:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c467e21b127d744be5648669abb4931e25fc45de -->

AI assistance: yes
AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@7f33adca78e035f59aebb060b36327329ccc281a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@7f33adca78e035f59aebb060b36327329ccc281a:packages/skills/skills/contribute-to-eliza"} -->
