### PR TITLE
fix(agent): 400 malformed percent-encoded registry plugin names, custom action IDs, and agent event IDs

### DIFF
--- a/packages/agent/src/api/misc-routes.agent-event.test.ts
+++ b/packages/agent/src/api/misc-routes.agent-event.test.ts
@@ -119,4 +119,23 @@ describe("handleMiscRoutes agent events", () => {
       vi.useRealTimers();
     }
   });
+
+  it("rejects malformed percent-encoded agent id on POST /api/agents/:agentId/event with 400", async () => {
+    const ctx = makeAgentEventContext({
+      type: "ping",
+      userId: "u-1",
+      payload: {},
+    });
+    ctx.pathname = "/api/agents/%/event";
+    ctx.url = new URL("http://localhost/api/agents/%/event");
+
+    const handled = await handleMiscRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.json).toHaveBeenCalledWith(
+      ctx.res,
+      { error: "Invalid agent id" },
+      400,
+    );
+  });
 });

--- a/packages/agent/src/api/misc-routes.agent-event.test.ts
+++ b/packages/agent/src/api/misc-routes.agent-event.test.ts
@@ -12,7 +12,10 @@ function makeAgentEventContext(
   body: Record<string, unknown>,
 ): MiscRouteContext {
   const req = { url: "/api/agent/event" } as http.IncomingMessage;
-  const res = {} as http.ServerResponse;
+  const res = {
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  } as unknown as http.ServerResponse;
   const broadcastWs = vi.fn();
 
   return {
@@ -132,10 +135,26 @@ describe("handleMiscRoutes agent events", () => {
     const handled = await handleMiscRoutes(ctx);
 
     expect(handled).toBe(true);
+    expect(ctx.res.statusCode).toBe(400);
+    expect(ctx.res.end).toHaveBeenCalledWith(
+      JSON.stringify({ error: "Invalid agent id: malformed URL encoding" }),
+    );
+    expect(ctx.json).not.toHaveBeenCalled();
+    expect(ctx.state.broadcastWs).not.toHaveBeenCalled();
+  });
+
+  it("rejects a decoded non-UUID agent id before event dispatch", async () => {
+    const ctx = makeAgentEventContext({ type: "ping", payload: {} });
+    ctx.pathname = "/api/agents/not%2Da%2Duuid/event";
+    ctx.url = new URL("http://localhost/api/agents/not%2Da%2Duuid/event");
+
+    expect(await handleMiscRoutes(ctx)).toBe(true);
+
     expect(ctx.json).toHaveBeenCalledWith(
       ctx.res,
       { error: "Invalid agent id" },
       400,
     );
+    expect(ctx.state.broadcastWs).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/api/misc-routes.custom-actions.test.ts
+++ b/packages/agent/src/api/misc-routes.custom-actions.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for custom-action route handlers in `handleMiscRoutes`.
+ * Deterministic: validates that malformed percent-encoding in custom-action URLs
+ * fails closed with 400 Bad Request per Error Policy J3.
+ */
+import type http from "node:http";
+import type { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleMiscRoutes, type MiscRouteContext } from "./misc-routes";
+import { AGENT_EVENT_ALLOWED_STREAMS } from "./plugin-discovery-helpers";
+
+function makeCustomActionContext(
+  method: string,
+  pathname: string,
+  body: Record<string, unknown> = {},
+): {
+  ctx: MiscRouteContext;
+  json: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+} {
+  const req = { url: pathname } as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  const json = vi.fn();
+  const error = vi.fn();
+
+  const ctx: MiscRouteContext = {
+    req,
+    res,
+    method,
+    pathname,
+    url: new URL(`http://localhost${pathname}`),
+    state: {
+      config: {} as MiscRouteContext["state"]["config"],
+      runtime: {
+        agentId: "00000000-0000-0000-0000-0000000000aa",
+      } as AgentRuntime,
+      agentState: "running",
+      agentName: "Eliza",
+      shellEnabled: true,
+      broadcastWs: vi.fn(),
+      broadcastWsToClientId: vi.fn(),
+      nextEventId: 1,
+      eventBuffer: [],
+      shareIngestQueue: [],
+      startup: { phase: "running", attempt: 0 },
+      broadcastStatus: vi.fn(),
+      pendingRestartReasons: [],
+    },
+    json,
+    error,
+    readJsonBody: vi.fn().mockResolvedValue(body),
+    AGENT_EVENT_ALLOWED_STREAMS,
+    resolveTerminalRunRejection: vi.fn().mockReturnValue(null),
+    resolveTerminalRunClientId: vi.fn().mockReturnValue(null),
+    isSharedTerminalClientId: vi.fn().mockReturnValue(false),
+    activeTerminalRunCount: 0,
+    setActiveTerminalRunCount: vi.fn(),
+  };
+
+  return { ctx, json, error };
+}
+
+describe("handleMiscRoutes custom actions encoding", () => {
+  it("rejects malformed percent-encoding on POST /api/custom-actions/:id/test with 400", async () => {
+    const { ctx, error } = makeCustomActionContext(
+      "POST",
+      "/api/custom-actions/%/test",
+      { params: {} },
+    );
+
+    const handled = await handleMiscRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid action id encoding",
+      400,
+    );
+  });
+
+  it("rejects malformed percent-encoding on PUT /api/custom-actions/:id with 400", async () => {
+    const { ctx, error } = makeCustomActionContext(
+      "PUT",
+      "/api/custom-actions/%",
+      { name: "TEST_ACTION" },
+    );
+
+    const handled = await handleMiscRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid action id encoding",
+      400,
+    );
+  });
+
+  it("rejects malformed percent-encoding on DELETE /api/custom-actions/:id with 400", async () => {
+    const { ctx, error } = makeCustomActionContext(
+      "DELETE",
+      "/api/custom-actions/%",
+    );
+
+    const handled = await handleMiscRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid action id encoding",
+      400,
+    );
+  });
+});

--- a/packages/agent/src/api/misc-routes.custom-actions.test.ts
+++ b/packages/agent/src/api/misc-routes.custom-actions.test.ts
@@ -17,9 +17,14 @@ function makeCustomActionContext(
   ctx: MiscRouteContext;
   json: ReturnType<typeof vi.fn>;
   error: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
 } {
   const req = { url: pathname } as http.IncomingMessage;
-  const res = {} as http.ServerResponse;
+  const end = vi.fn();
+  const res = {
+    setHeader: vi.fn(),
+    end,
+  } as unknown as http.ServerResponse;
   const json = vi.fn();
   const error = vi.fn();
 
@@ -57,12 +62,12 @@ function makeCustomActionContext(
     setActiveTerminalRunCount: vi.fn(),
   };
 
-  return { ctx, json, error };
+  return { ctx, json, error, end };
 }
 
 describe("handleMiscRoutes custom actions encoding", () => {
   it("rejects malformed percent-encoding on POST /api/custom-actions/:id/test with 400", async () => {
-    const { ctx, error } = makeCustomActionContext(
+    const { ctx, end, error } = makeCustomActionContext(
       "POST",
       "/api/custom-actions/%/test",
       { params: {} },
@@ -71,15 +76,17 @@ describe("handleMiscRoutes custom actions encoding", () => {
     const handled = await handleMiscRoutes(ctx);
 
     expect(handled).toBe(true);
-    expect(error).toHaveBeenCalledWith(
-      ctx.res,
-      "Invalid action id encoding",
-      400,
+    expect(ctx.res.statusCode).toBe(400);
+    expect(end).toHaveBeenCalledWith(
+      JSON.stringify({
+        error: "Invalid custom action id: malformed URL encoding",
+      }),
     );
+    expect(error).not.toHaveBeenCalled();
   });
 
   it("rejects malformed percent-encoding on PUT /api/custom-actions/:id with 400", async () => {
-    const { ctx, error } = makeCustomActionContext(
+    const { ctx, end, error } = makeCustomActionContext(
       "PUT",
       "/api/custom-actions/%",
       { name: "TEST_ACTION" },
@@ -88,15 +95,17 @@ describe("handleMiscRoutes custom actions encoding", () => {
     const handled = await handleMiscRoutes(ctx);
 
     expect(handled).toBe(true);
-    expect(error).toHaveBeenCalledWith(
-      ctx.res,
-      "Invalid action id encoding",
-      400,
+    expect(ctx.res.statusCode).toBe(400);
+    expect(end).toHaveBeenCalledWith(
+      JSON.stringify({
+        error: "Invalid custom action id: malformed URL encoding",
+      }),
     );
+    expect(error).not.toHaveBeenCalled();
   });
 
   it("rejects malformed percent-encoding on DELETE /api/custom-actions/:id with 400", async () => {
-    const { ctx, error } = makeCustomActionContext(
+    const { ctx, end, error } = makeCustomActionContext(
       "DELETE",
       "/api/custom-actions/%",
     );
@@ -104,9 +113,29 @@ describe("handleMiscRoutes custom actions encoding", () => {
     const handled = await handleMiscRoutes(ctx);
 
     expect(handled).toBe(true);
+    expect(ctx.res.statusCode).toBe(400);
+    expect(end).toHaveBeenCalledWith(
+      JSON.stringify({
+        error: "Invalid custom action id: malformed URL encoding",
+      }),
+    );
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["POST", "/api/custom-actions/not%2Da%2Duuid/test"],
+    ["PUT", "/api/custom-actions/not%2Da%2Duuid"],
+    ["DELETE", "/api/custom-actions/not%2Da%2Duuid"],
+  ])("rejects a decoded non-UUID on %s %s", async (method, pathname) => {
+    const { ctx, error } = makeCustomActionContext(method, pathname, {
+      params: {},
+    });
+
+    expect(await handleMiscRoutes(ctx)).toBe(true);
+
     expect(error).toHaveBeenCalledWith(
       ctx.res,
-      "Invalid action id encoding",
+      "Invalid custom action id",
       400,
     );
   });

--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -336,7 +336,14 @@ export async function handleMiscRoutes(
     if (rawEvent === null) return true;
     const agentEventMatch = pathname.match(/^\/api\/agents\/([^/]+)\/event$/);
     if (agentEventMatch) {
-      const routeAgentId = decodeURIComponent(agentEventMatch[1] ?? "").trim();
+      let routeAgentId: string;
+      try {
+        routeAgentId = decodeURIComponent(agentEventMatch[1] ?? "").trim();
+      } catch {
+        // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
+        json(res, { error: "Invalid agent id" }, 400);
+        return true;
+      }
       if (state.runtime?.agentId && state.runtime.agentId !== routeAgentId) {
         json(res, { error: "Agent not found" }, 404);
         return true;
@@ -722,7 +729,14 @@ export async function handleMiscRoutes(
   );
 
   if (method === "POST" && customActionTestMatch) {
-    const actionId = decodeURIComponent(customActionTestMatch[1]);
+    let actionId: string;
+    try {
+      actionId = decodeURIComponent(customActionTestMatch[1]);
+    } catch {
+      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
+      error(res, "Invalid action id encoding", 400);
+      return true;
+    }
     const rawTest = await readJsonBody<Record<string, unknown>>(req, res);
     if (rawTest === null) return true;
     const parsedTest = PostCustomActionTestRequestSchema.safeParse(rawTest);
@@ -780,7 +794,14 @@ export async function handleMiscRoutes(
   }
 
   if (method === "PUT" && customActionMatch) {
-    const actionId = decodeURIComponent(customActionMatch[1]);
+    let actionId: string;
+    try {
+      actionId = decodeURIComponent(customActionMatch[1]);
+    } catch {
+      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
+      error(res, "Invalid action id encoding", 400);
+      return true;
+    }
     const rawUpdate = await readJsonBody<Record<string, unknown>>(req, res);
     if (rawUpdate === null) return true;
     const parsedUpdate = PutCustomActionRequestSchema.safeParse(rawUpdate);
@@ -844,7 +865,14 @@ export async function handleMiscRoutes(
   }
 
   if (method === "DELETE" && customActionMatch) {
-    const actionId = decodeURIComponent(customActionMatch[1]);
+    let actionId: string;
+    try {
+      actionId = decodeURIComponent(customActionMatch[1]);
+    } catch {
+      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
+      error(res, "Invalid action id encoding", 400);
+      return true;
+    }
 
     const config = loadElizaConfig();
     const actions = config.customActions ?? [];

--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -20,6 +20,7 @@ import {
   logger,
   ModelType,
   parseBooleanValue,
+  validateUuid,
 } from "@elizaos/core";
 import type { ReadJsonBodyOptions, StreamEventEnvelope } from "@elizaos/shared";
 import {
@@ -39,6 +40,7 @@ import {
   registerCustomActionLive,
 } from "../runtime/custom-actions.ts";
 import { runShell } from "../services/shell-execution-router.ts";
+import { decodePathComponent } from "./server-helpers.ts";
 import type { ServerState } from "./server-types.ts";
 import { resolveTerminalRunLimits } from "./terminal-run-limits.ts";
 
@@ -336,11 +338,14 @@ export async function handleMiscRoutes(
     if (rawEvent === null) return true;
     const agentEventMatch = pathname.match(/^\/api\/agents\/([^/]+)\/event$/);
     if (agentEventMatch) {
-      let routeAgentId: string;
-      try {
-        routeAgentId = decodeURIComponent(agentEventMatch[1] ?? "").trim();
-      } catch {
-        // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
+      const decodedAgentId = decodePathComponent(
+        agentEventMatch[1] ?? "",
+        res,
+        "agent id",
+      );
+      if (decodedAgentId === null) return true;
+      const routeAgentId = validateUuid(decodedAgentId.trim());
+      if (!routeAgentId) {
         json(res, { error: "Invalid agent id" }, 400);
         return true;
       }
@@ -729,12 +734,15 @@ export async function handleMiscRoutes(
   );
 
   if (method === "POST" && customActionTestMatch) {
-    let actionId: string;
-    try {
-      actionId = decodeURIComponent(customActionTestMatch[1]);
-    } catch {
-      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
-      error(res, "Invalid action id encoding", 400);
+    const decodedActionId = decodePathComponent(
+      customActionTestMatch[1],
+      res,
+      "custom action id",
+    );
+    if (decodedActionId === null) return true;
+    const actionId = validateUuid(decodedActionId);
+    if (!actionId) {
+      error(res, "Invalid custom action id", 400);
       return true;
     }
     const rawTest = await readJsonBody<Record<string, unknown>>(req, res);
@@ -794,12 +802,15 @@ export async function handleMiscRoutes(
   }
 
   if (method === "PUT" && customActionMatch) {
-    let actionId: string;
-    try {
-      actionId = decodeURIComponent(customActionMatch[1]);
-    } catch {
-      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
-      error(res, "Invalid action id encoding", 400);
+    const decodedActionId = decodePathComponent(
+      customActionMatch[1],
+      res,
+      "custom action id",
+    );
+    if (decodedActionId === null) return true;
+    const actionId = validateUuid(decodedActionId);
+    if (!actionId) {
+      error(res, "Invalid custom action id", 400);
       return true;
     }
     const rawUpdate = await readJsonBody<Record<string, unknown>>(req, res);
@@ -865,12 +876,15 @@ export async function handleMiscRoutes(
   }
 
   if (method === "DELETE" && customActionMatch) {
-    let actionId: string;
-    try {
-      actionId = decodeURIComponent(customActionMatch[1]);
-    } catch {
-      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
-      error(res, "Invalid action id encoding", 400);
+    const decodedActionId = decodePathComponent(
+      customActionMatch[1],
+      res,
+      "custom action id",
+    );
+    if (decodedActionId === null) return true;
+    const actionId = validateUuid(decodedActionId);
+    if (!actionId) {
+      error(res, "Invalid custom action id", 400);
       return true;
     }
 

--- a/packages/agent/src/api/registry-routes.test.ts
+++ b/packages/agent/src/api/registry-routes.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for `handleRegistryRoutes` path encoding validation and registry lookup.
+ * Deterministic: asserts malformed percent-escapes fail closed with 400 Bad Request
+ * per Error Policy J3, and valid percent-encoded plugin names are correctly decoded.
+ */
+import type http from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleRegistryRoutes,
+  type RegistryRouteContext,
+} from "./registry-routes";
+
+function createRegistryContext(
+  method: string,
+  pathname: string,
+  overrides: Partial<RegistryRouteContext> = {},
+): {
+  ctx: RegistryRouteContext;
+  json: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  getRegistryPlugin: ReturnType<typeof vi.fn>;
+} {
+  const req = { method, url: pathname } as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  const json = vi.fn();
+  const error = vi.fn();
+  const getRegistryPlugin = vi.fn().mockResolvedValue({
+    name: "@elizaos/plugin-test",
+    description: "test plugin",
+  });
+
+  const ctx: RegistryRouteContext = {
+    req,
+    res,
+    method,
+    pathname,
+    url: new URL(`http://localhost${pathname}`),
+    json,
+    error,
+    getPluginManager: () => ({
+      refreshRegistry: vi.fn().mockResolvedValue(new Map()),
+      listInstalledPlugins: vi.fn().mockResolvedValue([]),
+      getRegistryPlugin,
+      searchRegistry: vi.fn().mockResolvedValue([]),
+    }),
+    getLoadedPluginNames: () => [],
+    getBundledPluginIds: () => new Set(),
+    classifyRegistryPluginRelease: () => ({ status: "compatible" }),
+    ...overrides,
+  };
+
+  return { ctx, json, error, getRegistryPlugin };
+}
+
+describe("handleRegistryRoutes path encoding validation", () => {
+  it("rejects malformed percent-encoding on GET /api/registry/plugins/:name with 400", async () => {
+    const { ctx, error, getRegistryPlugin } = createRegistryContext(
+      "GET",
+      "/api/registry/plugins/%",
+    );
+
+    const handled = await handleRegistryRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid plugin name encoding",
+      400,
+    );
+    expect(getRegistryPlugin).not.toHaveBeenCalled();
+  });
+
+  it("decodes valid percent-encoded plugin name on GET /api/registry/plugins/:name", async () => {
+    const { ctx, json, getRegistryPlugin } = createRegistryContext(
+      "GET",
+      "/api/registry/plugins/%40elizaos%2Fplugin-test",
+    );
+
+    const handled = await handleRegistryRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(getRegistryPlugin).toHaveBeenCalledWith("@elizaos/plugin-test");
+    expect(json).toHaveBeenCalledWith(ctx.res, {
+      plugin: {
+        name: "@elizaos/plugin-test",
+        description: "test plugin",
+      },
+    });
+  });
+});

--- a/packages/agent/src/api/registry-routes.test.ts
+++ b/packages/agent/src/api/registry-routes.test.ts
@@ -19,9 +19,14 @@ function createRegistryContext(
   json: ReturnType<typeof vi.fn>;
   error: ReturnType<typeof vi.fn>;
   getRegistryPlugin: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
 } {
   const req = { method, url: pathname } as http.IncomingMessage;
-  const res = {} as http.ServerResponse;
+  const end = vi.fn();
+  const res = {
+    setHeader: vi.fn(),
+    end,
+  } as unknown as http.ServerResponse;
   const json = vi.fn();
   const error = vi.fn();
   const getRegistryPlugin = vi.fn().mockResolvedValue({
@@ -49,12 +54,12 @@ function createRegistryContext(
     ...overrides,
   };
 
-  return { ctx, json, error, getRegistryPlugin };
+  return { ctx, json, error, getRegistryPlugin, end };
 }
 
 describe("handleRegistryRoutes path encoding validation", () => {
   it("rejects malformed percent-encoding on GET /api/registry/plugins/:name with 400", async () => {
-    const { ctx, error, getRegistryPlugin } = createRegistryContext(
+    const { ctx, end, error, getRegistryPlugin } = createRegistryContext(
       "GET",
       "/api/registry/plugins/%",
     );
@@ -62,11 +67,11 @@ describe("handleRegistryRoutes path encoding validation", () => {
     const handled = await handleRegistryRoutes(ctx);
 
     expect(handled).toBe(true);
-    expect(error).toHaveBeenCalledWith(
-      ctx.res,
-      "Invalid plugin name encoding",
-      400,
+    expect(ctx.res.statusCode).toBe(400);
+    expect(end).toHaveBeenCalledWith(
+      JSON.stringify({ error: "Invalid plugin name: malformed URL encoding" }),
     );
+    expect(error).not.toHaveBeenCalled();
     expect(getRegistryPlugin).not.toHaveBeenCalled();
   });
 

--- a/packages/agent/src/api/registry-routes.ts
+++ b/packages/agent/src/api/registry-routes.ts
@@ -12,6 +12,7 @@ import type {
   RegistryPluginInfo,
   RegistrySearchResult,
 } from "../services/plugin-manager-types.ts";
+import { decodePathComponent } from "./server-helpers.ts";
 
 interface InstalledRegistryPluginLike {
   name: string;
@@ -116,16 +117,12 @@ export async function handleRegistryRoutes(
     pathname.startsWith("/api/registry/plugins/") &&
     pathname.length > "/api/registry/plugins/".length
   ) {
-    let name: string;
-    try {
-      name = decodeURIComponent(
-        pathname.slice("/api/registry/plugins/".length),
-      );
-    } catch {
-      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
-      error(res, "Invalid plugin name encoding", 400);
-      return true;
-    }
+    const name = decodePathComponent(
+      pathname.slice("/api/registry/plugins/".length),
+      res,
+      "plugin name",
+    );
+    if (name === null) return true;
     try {
       const pluginManager = getPluginManager();
       const info = await pluginManager.getRegistryPlugin(name);

--- a/packages/agent/src/api/registry-routes.ts
+++ b/packages/agent/src/api/registry-routes.ts
@@ -116,9 +116,16 @@ export async function handleRegistryRoutes(
     pathname.startsWith("/api/registry/plugins/") &&
     pathname.length > "/api/registry/plugins/".length
   ) {
-    const name = decodeURIComponent(
-      pathname.slice("/api/registry/plugins/".length),
-    );
+    let name: string;
+    try {
+      name = decodeURIComponent(
+        pathname.slice("/api/registry/plugins/".length),
+      );
+    } catch {
+      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
+      error(res, "Invalid plugin name encoding", 400);
+      return true;
+    }
     try {
       const pluginManager = getPluginManager();
       const info = await pluginManager.getRegistryPlugin(name);


### PR DESCRIPTION
## Summary

Fails closed with `400 Bad Request` for malformed percent-encoded path segments across registry plugin lookup, agent event ingestion, and custom-action routes. The routes now reuse the agent server's canonical `decodePathComponent` response policy. UUID-bound agent and custom-action identifiers are validated after decoding and before event dispatch, config loading, or action lookup.

Routes covered:
- `GET /api/registry/plugins/:name`
- `POST /api/agents/:agentId/event`
- `POST /api/custom-actions/:id/test`
- `PUT|DELETE /api/custom-actions/:id`

Closes #20959.

## Verification

Exact reviewed head: `ce60fd6f9edfd429c6cb6582362c41774df48dd4`.

- Production route suites: 13/13 tests passing.
- Tests exercise the real shared decoder's wire response.
- Tests cover percent-decoded non-UUID agent/action IDs and prove they are rejected before dispatch or lookup.
- Biome check on all five changed files: clean.
- `git diff --check`: clean.
- Agent typecheck remains limited by the sparse review checkout's missing optional workspace packages; the same environment produced no changed-file diagnostic on the adjacent encoding repairs.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only route validation; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only route validation; no rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic HTTP boundary behavior has no visual flow.
<!-- evidence-row:backend-logs -->
- [x] Focused production-handler transcript:

```text
RUN v4.1.5 packages/agent
Test Files 3 passed (3)
Tests 13 passed (13); malformed escapes and decoded non-UUIDs return 400 before event/config collaborators
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action-planning, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - invalid requests are rejected before event dispatch or config mutation.

---
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@a24e5fbd8da932200836cdb0d78c0fc0a1b788fa:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ce60fd6f9edfd429c6cb6582362c41774df48dd4 -->

AI assistance: yes
AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@a24e5fbd8da932200836cdb0d78c0fc0a1b788fa:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@a24e5fbd8da932200836cdb0d78c0fc0a1b788fa:packages/skills/skills/contribute-to-eliza"} -->
