### PR TITLE
fix(orchestrator): verify against producible evidence, not fabricated demands

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/create-task-attaches-sessions.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/create-task-attaches-sessions.test.ts
@@ -318,7 +318,12 @@ describe("TASKS:create attaches spawned sessions to the minted task thread", () 
     expect(attachSession).not.toHaveBeenCalled();
   });
 
-  it("does NOT falsely promote the minted task to active for a single-turn create (real service)", async () => {
+  // 20s test cap to match the 15s inner waitFor below — the real git
+  // change-set capture + evidence assembly sit right at the 5s default on
+  // loaded runners.
+  it("does NOT falsely promote the minted task to active for a single-turn create (real service)", {
+    timeout: 20_000,
+  }, async () => {
     // Drive the real sequence — task mint → spawn → attach → prompt → stopped
     // event — against a REAL OrchestratorTaskService. The early attach makes
     // the work recoverable, while the terminal event still has to clear the

--- a/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
@@ -881,7 +881,10 @@ describe("independent read-only verifier (#8898)", () => {
       character: { name: "Tester" },
       databaseAdapter: undefined,
       logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getSetting: () => undefined,
+      // #20794: the verifier spawn is capability-gated; these tests exercise
+      // the verifier itself, so configure an envelope-capable backend.
+      getSetting: (key: string) =>
+        key === "ELIZA_ACP_DEFAULT_AGENT" ? "claude" : undefined,
       useModel,
       getService: (type: string) =>
         type === AcpService.serviceType ? fake.service : undefined,
@@ -924,7 +927,10 @@ describe("independent read-only verifier (#8898)", () => {
       character: { name: "Tester" },
       databaseAdapter: undefined,
       logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getSetting: () => undefined,
+      // #20794: the verifier spawn is capability-gated; these tests exercise
+      // the verifier itself, so configure an envelope-capable backend.
+      getSetting: (key: string) =>
+        key === "ELIZA_ACP_DEFAULT_AGENT" ? "claude" : undefined,
       useModel,
       getService: (type: string) =>
         type === AcpService.serviceType ? fake.service : undefined,
@@ -941,9 +947,18 @@ describe("independent read-only verifier (#8898)", () => {
     );
 
     const doc = await store.getTask(taskId);
-    expect(doc?.task.status).toBe("validating");
+    // Re-engage contract: an inconclusive verdict re-prompts the kept-alive
+    // worker under the bounded attempt cap (never a silent park, never a
+    // promotion) — so the task returns to `active`, not `done`.
+    expect(doc?.task.status).toBe("active");
     expect(doc?.task.status).not.toBe("done");
     expect(useModel).not.toHaveBeenCalled();
+    // #20794: the worker is an `opencode` session, which never emits a
+    // CompletionEnvelope — the correction must demand producible evidence,
+    // not the envelope contract.
+    const correction = fake.service.sendToSession.mock.calls.at(-1)?.[1] ?? "";
+    expect(correction).toContain("concrete evidence");
+    expect(correction).not.toContain("CompletionEnvelope");
   });
 
   it("does NOT spawn a verifier for a task with no code changes (gated)", async () => {
@@ -960,7 +975,10 @@ describe("independent read-only verifier (#8898)", () => {
       character: { name: "Tester" },
       databaseAdapter: undefined,
       logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getSetting: () => undefined,
+      // #20794: the verifier spawn is capability-gated; these tests exercise
+      // the verifier itself, so configure an envelope-capable backend.
+      getSetting: (key: string) =>
+        key === "ELIZA_ACP_DEFAULT_AGENT" ? "claude" : undefined,
       useModel,
       getService: (type: string) =>
         type === AcpService.serviceType ? fake.service : undefined,
@@ -1713,7 +1731,10 @@ describe("validateTask transition + humanOverride rules", () => {
       character: { name: "Tester" },
       databaseAdapter: undefined,
       logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getSetting: () => undefined,
+      // #20794: the verifier spawn is capability-gated; these tests exercise
+      // the verifier itself, so configure an envelope-capable backend.
+      getSetting: (key: string) =>
+        key === "ELIZA_ACP_DEFAULT_AGENT" ? "claude" : undefined,
       useModel,
       getService: (type: string) =>
         type === AcpService.serviceType ? fake.service : undefined,

--- a/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Contract tests for the producible-evidence module (#20794): backend
+ * capability resolution fails closed, invented-artifact criteria are dropped
+ * while goal-named paths survive, and the deterministic ledger verdict
+ * promotes only when EVERY criterion is satisfied by concrete facts — with
+ * the live-incident shapes (invented `agent-home/canon-clock.html` path,
+ * served-URL + ledger-write quick-app) pinned. Deterministic; no model, IO,
+ * or environment mutation beyond scoped env stubs.
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+import { generateDefaultAcceptanceCriteria } from "../services/acceptance-criteria.js";
+import {
+  capabilitiesForBackend,
+  deterministicLedgerVerdict,
+  renderDeterministicVerdict,
+  stripInventedArtifactCriteria,
+} from "../services/producible-evidence.js";
+
+const ENV_KEYS = [
+  "ELIZA_ENVELOPE_CAPABLE_BACKENDS",
+  "ELIZA_SANDBOX_HAS_BROWSER",
+];
+const saved = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = saved.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("capabilitiesForBackend", () => {
+  test("elizaos brain has no envelope; claude/codex do; unknown fails closed", () => {
+    expect(capabilitiesForBackend("eliza-code").completionEnvelope).toBe(false);
+    expect(capabilitiesForBackend("elizaos").completionEnvelope).toBe(false);
+    expect(capabilitiesForBackend("claude").completionEnvelope).toBe(true);
+    expect(capabilitiesForBackend("claude-code").completionEnvelope).toBe(true);
+    expect(capabilitiesForBackend("codex").completionEnvelope).toBe(true);
+    expect(capabilitiesForBackend(undefined).completionEnvelope).toBe(false);
+    expect(capabilitiesForBackend("").completionEnvelope).toBe(false);
+  });
+
+  test("sandboxes are headless unless explicitly declared otherwise", () => {
+    expect(capabilitiesForBackend("claude").browser).toBe(false);
+    process.env.ELIZA_SANDBOX_HAS_BROWSER = "1";
+    expect(capabilitiesForBackend("claude").browser).toBe(true);
+  });
+
+  test("deployments can override the envelope-capable list", () => {
+    process.env.ELIZA_ENVELOPE_CAPABLE_BACKENDS = "eliza-code";
+    expect(capabilitiesForBackend("eliza-code").completionEnvelope).toBe(true);
+    expect(capabilitiesForBackend("claude").completionEnvelope).toBe(false);
+  });
+});
+
+describe("stripInventedArtifactCriteria", () => {
+  test("drops the live-incident invented path and keeps outcome criteria", () => {
+    const goal =
+      "build a one-file canon clock page in the shared route workdir";
+    const { kept, dropped } = stripInventedArtifactCriteria(
+      [
+        "Diff confirms the creation of `agent-home/canon-clock.html`",
+        "the live URL returns HTTP 200",
+        "typecheck passes",
+      ],
+      goal,
+    );
+    expect(dropped).toEqual([
+      "Diff confirms the creation of `agent-home/canon-clock.html`",
+    ]);
+    expect(kept).toEqual(["the live URL returns HTTP 200", "typecheck passes"]);
+  });
+
+  test("a path the goal itself names survives", () => {
+    const goal = "create data/apps/clock/index.html with a live clock";
+    const { kept, dropped } = stripInventedArtifactCriteria(
+      ["the file data/apps/clock/index.html exists and serves"],
+      goal,
+    );
+    expect(dropped).toEqual([]);
+    expect(kept).toHaveLength(1);
+  });
+
+  test("prose tokens like e.g. and version numbers are not artifact claims", () => {
+    const { dropped } = stripInventedArtifactCriteria(
+      ["tests pass (e.g. unit and integration, v1.2 compatible)"],
+      "fix the flaky scheduler",
+    );
+    expect(dropped).toEqual([]);
+  });
+});
+
+describe("deterministicLedgerVerdict", () => {
+  const quickAppFacts = {
+    verifiedPublicUrls: ["https://nubilio.org/apps/canon-clock/"],
+    ledgerVerifiedFiles: ["data/apps/canon-clock/index.html"],
+    hasChangeSet: true,
+    greenChecks: { test: false, build: false, lint: false },
+  };
+
+  test("the live quick-app incident shape passes deterministically", () => {
+    const verdict = deterministicLedgerVerdict(
+      [
+        "the live URL returns HTTP 200",
+        "the deliverable file exists in the workdir",
+        "the change is summarized in the diff",
+      ],
+      quickAppFacts,
+    );
+    expect(verdict.allMet).toBe(true);
+    expect(verdict.met).toHaveLength(3);
+    expect(verdict.results[0]?.basis).toContain("nubilio.org");
+    expect(verdict.results[1]?.basis).toContain("canon-clock/index.html");
+  });
+
+  test("an unsatisfied check criterion stays undetermined and blocks allMet", () => {
+    const verdict = deterministicLedgerVerdict(
+      ["the live URL returns HTTP 200", "tests pass"],
+      quickAppFacts,
+    );
+    expect(verdict.allMet).toBe(false);
+    expect(verdict.undetermined).toEqual(["tests pass"]);
+  });
+
+  test("green mined output satisfies test/build/lint criteria", () => {
+    const verdict = deterministicLedgerVerdict(
+      ["tests pass", "typecheck passes", "lint passes"],
+      {
+        ...quickAppFacts,
+        greenChecks: { test: true, build: true, lint: true },
+      },
+    );
+    expect(verdict.allMet).toBe(true);
+  });
+
+  test("screenshot criteria are never deterministically met", () => {
+    const verdict = deterministicLedgerVerdict(
+      ["a screenshot of the working view is attached"],
+      quickAppFacts,
+    );
+    expect(verdict.allMet).toBe(false);
+  });
+
+  test("a criterion naming a specific file must match the ledger", () => {
+    const verdict = deterministicLedgerVerdict(
+      ["the file other/place.html is created"],
+      quickAppFacts,
+    );
+    expect(verdict.allMet).toBe(false);
+  });
+
+  test("empty criteria never auto-pass", () => {
+    expect(deterministicLedgerVerdict([], quickAppFacts).allMet).toBe(false);
+  });
+
+  test("renders met bases and undetermined markers", () => {
+    const rendered = renderDeterministicVerdict(
+      deterministicLedgerVerdict(
+        ["the live URL returns HTTP 200", "tests pass"],
+        quickAppFacts,
+      ),
+    );
+    expect(rendered).toContain("MET: the live URL returns HTTP 200");
+    expect(rendered).toContain("undetermined (needs judgment): tests pass");
+  });
+});
+
+describe("generateDefaultAcceptanceCriteria enforcement (#20794)", () => {
+  test("model-refined criteria pinning invented paths are dropped and topped up", async () => {
+    const goal =
+      "build a one-file canon clock page in the shared route workdir";
+    const useModel = async () =>
+      JSON.stringify({
+        criteria: [
+          "Diff confirms the creation of `agent-home/canon-clock.html`",
+          "the live URL returns HTTP 200",
+          "the page shows a ticking clock",
+        ],
+      });
+    const criteria = await generateDefaultAcceptanceCriteria(goal, undefined, {
+      useModel,
+    } as never);
+    expect(criteria.join("\n")).not.toContain("agent-home/canon-clock.html");
+    expect(criteria).toContain("the live URL returns HTTP 200");
+    expect(criteria.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
@@ -13,6 +13,8 @@ import { generateDefaultAcceptanceCriteria } from "../services/acceptance-criter
 import {
   capabilitiesForBackend,
   deterministicLedgerVerdict,
+  isGreenCheckOutput,
+  isPubliclyReachableUrl,
   renderDeterministicVerdict,
   stripInventedArtifactCriteria,
 } from "../services/producible-evidence.js";
@@ -150,6 +152,14 @@ describe("deterministicLedgerVerdict", () => {
     expect(verdict.allMet).toBe(false);
   });
 
+  test("a criterion naming a specific URL must match the probed URL", () => {
+    const verdict = deterministicLedgerVerdict(
+      ["https://nubilio.org/apps/other/ returns HTTP 200"],
+      quickAppFacts,
+    );
+    expect(verdict.allMet).toBe(false);
+  });
+
   test("empty criteria never auto-pass", () => {
     expect(deterministicLedgerVerdict([], quickAppFacts).allMet).toBe(false);
   });
@@ -163,6 +173,42 @@ describe("deterministicLedgerVerdict", () => {
     );
     expect(rendered).toContain("MET: the live URL returns HTTP 200");
     expect(rendered).toContain("undetermined (needs judgment): tests pass");
+  });
+});
+
+describe("public URL evidence", () => {
+  test.each([
+    "file:///etc/passwd",
+    "ssh://example.com/repo",
+    "http://localhost:3000",
+    "http://app.local",
+    "http://127.9.8.7",
+    "http://10.0.0.1",
+    "http://169.254.169.254/latest/meta-data",
+    "http://[::1]",
+    "http://[fd00::1]",
+  ])("rejects non-public target %s", (url) => {
+    expect(isPubliclyReachableUrl(url)).toBe(false);
+  });
+
+  test("accepts a public HTTP(S) target", () => {
+    expect(isPubliclyReachableUrl("https://nubilio.org/apps/clock/")).toBe(
+      true,
+    );
+  });
+});
+
+describe("green check output", () => {
+  test.each([
+    "Failed: 1, Passed: 10",
+    "not ok 3 - integration",
+    "PASS\nERROR: teardown",
+  ])("rejects red output even when it also has green markers: %s", (output) => {
+    expect(isGreenCheckOutput(output)).toBe(false);
+  });
+
+  test("accepts an explicit zero-failure summary", () => {
+    expect(isGreenCheckOutput("12 passed, 0 failed")).toBe(true);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
@@ -36,6 +36,7 @@
 
 import { type IAgentRuntime, ModelType } from "@elizaos/core";
 import { parseJsonObjectResponse } from "./json-model-output.js";
+import { stripInventedArtifactCriteria } from "./producible-evidence.js";
 
 /** Coarse task classification driving which template set is applied. */
 export type OrchestratorTaskType =
@@ -192,6 +193,7 @@ function buildRefinePrompt(
     "You are setting the acceptance criteria a coding sub-agent must PROVE before its task is accepted.",
     "Turn the goal below into 3-5 concrete, measurable, independently-verifiable criteria.",
     "Each criterion must be checkable from concrete evidence (a passing build/test/typecheck line, a diff hunk, a reachable URL, a screenshot) — never a vague aspiration.",
+    "NEVER invent concrete file paths, filenames, or directory names the goal does not state verbatim — the worker legitimately chooses its own layout. When the goal names no path, express the criterion as an observable outcome (a file exists in the workdir, a URL serves the requested content).",
     "",
     `Detected task type: ${type}`,
     "Goal:",
@@ -253,7 +255,11 @@ export async function generateDefaultAcceptanceCriteria(
     if (!parsed) return fallback;
     const candidates = extractCriteriaArray(parsed);
     if (candidates.length === 0) return fallback;
-    const refined = normalizeCriteria(candidates, fallback);
+    // The prompt forbids invented paths, but the filter is the enforcement:
+    // a criterion pinning a path the goal never named is unsatisfiable by
+    // design (#20794), so it is dropped and the template tops the set back up.
+    const producible = stripInventedArtifactCriteria(candidates, goal).kept;
+    const refined = normalizeCriteria(producible, fallback);
     return refined.length >= MIN_CRITERIA ? refined : fallback;
   } catch {
     // error-policy:J4 optional model refinement of an external dep; any failure degrades to the designed deterministic static template

--- a/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
@@ -40,6 +40,7 @@ import {
   ModelType,
   type RecordedStage,
 } from "@elizaos/core";
+import type { EvidenceCapabilities } from "./producible-evidence.js";
 
 /** Stable identifier the verifier stamps onto the `validateTask` payload so
  *  callers can distinguish LLM judgments from human approvals or pattern
@@ -77,13 +78,22 @@ export const MAX_AUTO_VERIFY_ATTEMPTS = 3;
  * matches the kind of work the criterion describes; falls back to the
  * build/test default that fits most coding criteria.
  */
-function proofDemandFor(criterion: string): string {
+function proofDemandFor(
+  criterion: string,
+  caps?: EvidenceCapabilities,
+): string {
   const c = criterion.toLowerCase();
   if (
     /\b(ui|screen|page|view|button|render|css|layout|visual|frontend|component|storybook)\b/.test(
       c,
     )
   ) {
+    // A headless child sandbox cannot screenshot (#20794): demanding one sends
+    // the worker chasing browser tooling it can never run. Ask for evidence
+    // the sandbox CAN produce instead.
+    if (caps && !caps.browser) {
+      return "serve the page and paste the reachable URL plus the fetched response (curl output showing the requested content) — this sandbox has NO browser; do NOT attempt screenshots or install browser tooling";
+    }
     return "capture a full-page screenshot of the working UI (paste the file path) AND, if it is a route in the app, the URL you reached";
   }
   if (
@@ -115,11 +125,15 @@ function proofDemandFor(criterion: string): string {
  * (reusing {@link proofDemandFor}). A ticked box with no pasted artifact is
  * treated as not done — verification will fail again.
  */
-function buildEvidenceChecklist(missing: readonly string[]): string {
+function buildEvidenceChecklist(
+  missing: readonly string[],
+  caps?: EvidenceCapabilities,
+): string {
   return [
     "Evidence checklist — return EVERY box ticked WITH the artifact pasted inline (a ticked box and no artifact = not done):",
     ...missing.map(
-      (criterion) => `- [ ] ${criterion} — proof: ${proofDemandFor(criterion)}`,
+      (criterion) =>
+        `- [ ] ${criterion} — proof: ${proofDemandFor(criterion, caps)}`,
     ),
   ].join("\n");
 }
@@ -158,6 +172,7 @@ function buildEvidenceChecklist(missing: readonly string[]): string {
 export function buildAutoVerifyCorrection(
   missing: readonly string[],
   attempt = 1,
+  caps?: EvidenceCapabilities,
 ): string {
   const stage = Math.min(
     Math.max(Math.trunc(attempt) || 1, 1),
@@ -179,7 +194,7 @@ export function buildAutoVerifyCorrection(
     proofSection.push(
       ...missing.map(
         (criterion) =>
-          `- ${criterion}\n    → proof to produce: ${proofDemandFor(criterion)}`,
+          `- ${criterion}\n    → proof to produce: ${proofDemandFor(criterion, caps)}`,
       ),
     );
     closing.push(
@@ -194,7 +209,7 @@ export function buildAutoVerifyCorrection(
     proofSection.push(
       ...missing.map(
         (criterion) =>
-          `- ${criterion}\n    → Exactly which command did you run for this, and what was its EXACT output? Paste it. Did you actually open/observe/run it, or did you assume it works? Show: ${proofDemandFor(criterion)}`,
+          `- ${criterion}\n    → Exactly which command did you run for this, and what was its EXACT output? Paste it. Did you actually open/observe/run it, or did you assume it works? Show: ${proofDemandFor(criterion, caps)}`,
       ),
     );
     closing.push(
@@ -210,7 +225,7 @@ export function buildAutoVerifyCorrection(
     proofSection.push(
       ...missing.map(
         (criterion) =>
-          `- ${criterion}\n    → REQUIRED proof (paste it or the task is escalated): ${proofDemandFor(criterion)}`,
+          `- ${criterion}\n    → REQUIRED proof (paste it or the task is escalated): ${proofDemandFor(criterion, caps)}`,
       ),
     );
     closing.push(
@@ -224,7 +239,7 @@ export function buildAutoVerifyCorrection(
     "",
     ...closing,
     "",
-    buildEvidenceChecklist(missing),
+    buildEvidenceChecklist(missing, caps),
   ];
   return lines.join("\n");
 }

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -184,6 +184,14 @@ import {
 } from "./orchestrator-task-types.js";
 import { isParentAgentBrokerWired } from "./parent-agent-broker.js";
 import {
+  capabilitiesForBackend,
+  DETERMINISTIC_LEDGER_VERIFIER_NAME,
+  deterministicLedgerVerdict,
+  isGreenCheckOutput,
+  isPubliclyReachableUrl,
+  renderDeterministicVerdict,
+} from "./producible-evidence.js";
+import {
   resolveBoundProjectCloudAppId,
   resolveTaskProjectId,
   resolveTaskSpawnWorkdir,
@@ -1743,11 +1751,8 @@ export class OrchestratorTaskService extends Service {
         // bare event summary. Fire-and-forget so the event-bridge write path
         // stays fast; the verifier gates itself on the flag + criteria presence,
         // and evidence assembly never throws into this path.
-        const completionEvidence = await this.buildCompletionEvidence(
-          taskId,
-          sessionId,
-          summary ?? "",
-        );
+        const { evidence: completionEvidence, bundle: completionBundle } =
+          await this.buildCompletionEvidence(taskId, sessionId, summary ?? "");
         // Thread the RAW final message (record.response) through alongside the
         // reworded evidence bundle: the #8895 CompletionEnvelope lives verbatim in
         // the sub-agent's last message, not in the prose evidence, so the structural
@@ -1757,6 +1762,7 @@ export class OrchestratorTaskService extends Service {
           sessionId,
           completionEvidence,
           summary ?? "",
+          completionBundle,
         );
         break;
       }
@@ -2303,7 +2309,7 @@ export class OrchestratorTaskService extends Service {
     taskId: string,
     sessionId: string,
     fallbackSummary: string,
-  ): Promise<string> {
+  ): Promise<{ evidence: string; bundle?: CompletionEvidenceBundle }> {
     try {
       const bundle = await this.collectEvidenceBundle(
         taskId,
@@ -2322,7 +2328,7 @@ export class OrchestratorTaskService extends Service {
         sessionId,
       );
       void this.writeEvidenceTrajectory(taskId, sessionId, bundle);
-      return buildCompletionEvidenceString(bundle);
+      return { evidence: buildCompletionEvidenceString(bundle), bundle };
     } catch (err) {
       // error-policy:J7 fire-and-forget on the task_complete path; on failure it
       // degrades to the bare summary (the prior behavior), never throws.
@@ -2331,7 +2337,7 @@ export class OrchestratorTaskService extends Service {
         sessionId,
         error: err instanceof Error ? err.message : String(err),
       });
-      return fallbackSummary;
+      return { evidence: fallbackSummary };
     }
   }
 
@@ -3696,6 +3702,7 @@ export class OrchestratorTaskService extends Service {
     sessionId: string,
     completionEvidence: string,
     rawCompletion: string,
+    evidenceBundle?: CompletionEvidenceBundle,
   ): Promise<void> {
     if (!shouldAutoVerifyGoal()) return;
     // Re-entrancy guard: drop a second overlapping run for the same task (the
@@ -3710,6 +3717,7 @@ export class OrchestratorTaskService extends Service {
           sessionId,
           completionEvidence,
           rawCompletion,
+          evidenceBundle,
         ),
       );
     } catch (err) {
@@ -3732,6 +3740,7 @@ export class OrchestratorTaskService extends Service {
     sessionId: string,
     completionEvidence: string,
     rawCompletion: string,
+    evidenceBundle?: CompletionEvidenceBundle,
   ): Promise<void> {
     {
       let doc = await this.store.getTask(taskId);
@@ -4003,6 +4012,61 @@ export class OrchestratorTaskService extends Service {
         }
       }
 
+      // 2.5. Deterministic ledger pre-pass (#20794) — BEFORE the independent
+      // verifier and the text judge. The orchestrator already holds hard
+      // evidence at completion: the session's successful write ledger, the
+      // router's probed URLs, the captured changeset, and mined check output.
+      // When EVERY criterion is satisfied by those facts, the task passes with
+      // deterministic provenance and zero model spend — a working deliverable
+      // can no longer be failed by fabricated demands. Partial satisfaction is
+      // appended to the evidence so downstream judges see what is already
+      // proven and grill only the remainder.
+      const workerSession = doc.sessions.find(
+        (session) => session.sessionId === sessionId,
+      );
+      const workerCaps = capabilitiesForBackend(
+        workerSession?.framework,
+        (key) => {
+          const value = this.runtime.getSetting?.(key);
+          return typeof value === "string" ? value : undefined;
+        },
+      );
+      {
+        // Reuse the bundle assembled on the task_complete path — recollecting
+        // would re-run the git change-set capture a third time per completion.
+        const bundle =
+          evidenceBundle ??
+          (await this.collectEvidenceBundle(taskId, sessionId, rawCompletion));
+        const detVerdict = deterministicLedgerVerdict(acceptanceCriteria, {
+          verifiedPublicUrls: bundle.verifiedUrls.filter(
+            isPubliclyReachableUrl,
+          ),
+          ledgerVerifiedFiles: bundle.ledgerVerifiedFiles ?? [],
+          hasChangeSet: Boolean(bundle.diffSummary?.trim()),
+          greenChecks: {
+            test: isGreenCheckOutput(bundle.toolOutput?.test),
+            build: isGreenCheckOutput(bundle.toolOutput?.build),
+            lint: isGreenCheckOutput(bundle.toolOutput?.lint),
+          },
+        });
+        if (detVerdict.allMet) {
+          await this.validateTaskLocked(taskId, {
+            passed: true,
+            summary: `All ${acceptanceCriteria.length} criteria deterministically verified from the write ledger, probed URLs, and captured output.`,
+            evidence: renderDeterministicVerdict(detVerdict),
+            verifier: DETERMINISTIC_LEDGER_VERIFIER_NAME,
+          });
+          this.emitChange(taskId);
+          return;
+        }
+        if (detVerdict.met.length > 0) {
+          evidence = appendCompletionEvidenceSection(
+            evidence,
+            renderDeterministicVerdict(detVerdict),
+          );
+        }
+      }
+
       // 3. Independent read-only execution verifier (#8898).
       const independent = await this.runIndependentVerify(
         taskId,
@@ -4027,7 +4091,9 @@ export class OrchestratorTaskService extends Service {
             correction: [
               "Independent verification of your completion was inconclusive:",
               `- ${independent.summary}`,
-              "Re-report your completion when the work is truly done. End your final message with the fenced ```json CompletionEnvelope exactly matching the required schema, and include concrete evidence (commands run, their real output, and where the deliverable lives).",
+              workerCaps.completionEnvelope
+                ? "Re-report your completion when the work is truly done. End your final message with the fenced ```json CompletionEnvelope exactly matching the required schema, and include concrete evidence (commands run, their real output, and where the deliverable lives)."
+                : "Re-report your completion when the work is truly done, and include concrete evidence inline: the commands you ran with their real output, and where the deliverable lives (file path and/or reachable URL).",
             ].join("\n"),
             eventType: "independent_verify_inconclusive",
             verifier: INDEPENDENT_ACP_VERIFIER_NAME,
@@ -4070,6 +4136,7 @@ export class OrchestratorTaskService extends Service {
             correction: buildAutoVerifyCorrection(
               missing.length > 0 ? missing : [independent.summary],
               attempts + 1,
+              workerCaps,
             ),
             eventType: "independent_verify_failed",
             verifier: INDEPENDENT_ACP_VERIFIER_NAME,
@@ -4117,7 +4184,11 @@ export class OrchestratorTaskService extends Service {
         sessionId,
         // Escalate the grill per attempt: `attempts` is the count of prior
         // failures, so `attempts + 1` is this correction's 1-based stage.
-        correction: buildAutoVerifyCorrection(verdict.missing, attempts + 1),
+        correction: buildAutoVerifyCorrection(
+          verdict.missing,
+          attempts + 1,
+          workerCaps,
+        ),
         eventType: "auto_verify_failed",
         verifier: LLM_GOAL_VERIFIER_NAME,
         summary: verdict.summary,
@@ -4277,6 +4348,18 @@ export class OrchestratorTaskService extends Service {
       return typeof fromEnv === "string" ? fromEnv : undefined;
     };
     if (!shouldRunIndependentVerify(getSetting, hasCodeChanges)) return null;
+    // #20794: the verifier reports through a CompletionEnvelope, but the
+    // default spawn backend (elizaos) never emits one — every such run is
+    // structurally inconclusive and only burns bounded verify attempts.
+    // Spawn the independent verifier only when its backend can actually
+    // produce the contract it is asked to report with.
+    const verifierBackend =
+      configuredDefaultAgentType(this.runtime) ?? "elizaos";
+    if (
+      !capabilitiesForBackend(verifierBackend, getSetting).completionEnvelope
+    ) {
+      return null;
+    }
     const acp = this.acp();
     if (!acp) return null;
     const session = doc.sessions.find((s) => s.sessionId === sessionId);

--- a/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
@@ -15,6 +15,7 @@
  * invented-artifact filter for generated criteria, and a per-criterion
  * deterministic verdict the pipeline consults BEFORE any model judgment.
  */
+import { isBlockedHostname, isPrivateIpAddress } from "@elizaos/core";
 
 /** What kinds of evidence a worker's sandbox/backend can actually produce. */
 export interface EvidenceCapabilities {
@@ -132,6 +133,37 @@ const TEST_CRITERION_RE =
 const BUILD_CRITERION_RE = /\b(build|compile|typecheck|tsc)\b/i;
 const LINT_CRITERION_RE = /\b(lint|biome|eslint|format)\b/i;
 const SCREENSHOT_CRITERION_RE = /\b(screenshot|screen\s*capture)\b/i;
+const EXPLICIT_HTTP_URL_RE = /https?:\/\/[^\s`"'<>]+/gi;
+
+function normalizeExplicitHttpUrl(value: string): string | undefined {
+  const candidate = value.replace(/[),.;!?]+$/, "");
+  try {
+    const parsed = new URL(candidate);
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? parsed.href
+      : undefined;
+  } catch {
+    // error-policy:J3 A malformed criterion token is not a concrete URL claim.
+    return undefined;
+  }
+}
+
+function urlCriterionBasis(
+  criterion: string,
+  facts: DeterministicEvidenceFacts,
+): string | undefined {
+  const demandedUrls = [...criterion.matchAll(EXPLICIT_HTTP_URL_RE)]
+    .map((match) => normalizeExplicitHttpUrl(match[0]))
+    .filter((url): url is string => Boolean(url));
+  const verified = facts.verifiedPublicUrls
+    .map(normalizeExplicitHttpUrl)
+    .filter((url): url is string => Boolean(url));
+  const hit =
+    demandedUrls.length > 0
+      ? verified.find((url) => demandedUrls.includes(url))
+      : verified[0];
+  return hit ? `probed URL answered: ${hit}` : undefined;
+}
 
 /** Deterministic facts the orchestrator already holds at completion. */
 export interface DeterministicEvidenceFacts {
@@ -197,9 +229,9 @@ export function deterministicCriterionCheck(
     return { criterion, status: "undetermined" };
   }
   if (URL_CRITERION_RE.test(criterion)) {
-    const url = facts.verifiedPublicUrls[0];
-    return url
-      ? { criterion, status: "met", basis: `probed URL answered: ${url}` }
+    const basis = urlCriterionBasis(criterion, facts);
+    return basis
+      ? { criterion, status: "met", basis }
       : { criterion, status: "undetermined" };
   }
   if (TEST_CRITERION_RE.test(criterion)) {
@@ -266,11 +298,20 @@ export function deterministicLedgerVerdict(
   };
 }
 
-/** Loopback hosts never count as publicly-reachable deploy evidence. */
+/** Only public HTTP(S) targets count as publicly-reachable deploy evidence. */
 export function isPubliclyReachableUrl(value: string): boolean {
   try {
-    const host = new URL(value).hostname.toLowerCase();
-    return host !== "localhost" && host !== "127.0.0.1" && host !== "::1";
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false;
+    }
+    if (parsed.username || parsed.password || parsed.hostname.length === 0) {
+      return false;
+    }
+    return (
+      !isBlockedHostname(parsed.hostname) &&
+      !isPrivateIpAddress(parsed.hostname)
+    );
   } catch {
     // error-policy:J3 an unparseable URL is explicitly not reachable evidence
     return false;
@@ -278,7 +319,7 @@ export function isPubliclyReachableUrl(value: string): boolean {
 }
 
 const GREEN_MARKER_RE = /\bpass(?:ed|ing)?\b|✓|✔|\bPASS\b|\bok\b|0 fail/i;
-const RED_MARKER_RE = /\bfail(?:ed|ing|ure)?\b|✗|✖|\bFAIL\b|\bERRORS?\b/;
+const RED_MARKER_RE = /\bnot\s+ok\b|\bfail(?:ed|ing|ure)?\b|✗|✖|\berrors?\b/i;
 
 /**
  * Whether mined tool output constitutes GREEN evidence for a check class:
@@ -287,7 +328,10 @@ const RED_MARKER_RE = /\bfail(?:ed|ing|ure)?\b|✗|✖|\bFAIL\b|\bERRORS?\b/;
  */
 export function isGreenCheckOutput(output: string | undefined | null): boolean {
   if (typeof output !== "string" || output.trim().length === 0) return false;
-  return GREEN_MARKER_RE.test(output) && !RED_MARKER_RE.test(output);
+  const withoutZeroFailures = output.replace(/\b0\s+fail(?:ed|ures?)?\b/gi, "");
+  return (
+    GREEN_MARKER_RE.test(output) && !RED_MARKER_RE.test(withoutZeroFailures)
+  );
 }
 
 /** Render the deterministic verdict as an evidence section for downstream

--- a/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
@@ -1,0 +1,307 @@
+/**
+ * Producible-evidence contract for the auto goal-verifier (#20794).
+ *
+ * The verify pipeline reliably failed WORKING deliverables through three
+ * structural mismatches: generated criteria invented concrete paths the
+ * request never named, the CompletionEnvelope contract was demanded from
+ * backends that never emit one, and re-engage corrections asked for evidence
+ * (browser screenshots) the child sandbox cannot produce — while the
+ * deterministic evidence the orchestrator already held (successful ledger
+ * writes, probed non-loopback URLs, mined green check output) was never
+ * allowed to PASS a task on its own.
+ *
+ * This module centralizes those three contracts, all deterministic and
+ * model-free: per-backend/per-sandbox evidence capabilities, an
+ * invented-artifact filter for generated criteria, and a per-criterion
+ * deterministic verdict the pipeline consults BEFORE any model judgment.
+ */
+
+/** What kinds of evidence a worker's sandbox/backend can actually produce. */
+export interface EvidenceCapabilities {
+  /** Child sandboxes are headless; screenshot demands are unproducible. */
+  browser: boolean;
+  /** Whether the backend brain emits the structural CompletionEnvelope. */
+  completionEnvelope: boolean;
+}
+
+/** Provenance for a task promoted purely on deterministic evidence. */
+export const DETERMINISTIC_LEDGER_VERIFIER_NAME =
+  "deterministic-ledger-verifier";
+
+/**
+ * Backends whose brains are taught the CompletionEnvelope contract. The
+ * `elizaos`/`eliza-code` brain does not emit one, so demanding it from those
+ * sessions can never be satisfied. Deployments override the list via
+ * `ELIZA_ENVELOPE_CAPABLE_BACKENDS` (comma-separated framework names).
+ */
+const DEFAULT_ENVELOPE_CAPABLE_BACKENDS = ["claude", "claude-code", "codex"];
+
+function settingList(
+  getSetting: ((key: string) => string | undefined | null) | undefined,
+  key: string,
+): string[] | undefined {
+  const raw = getSetting?.(key) ?? process.env[key];
+  if (typeof raw !== "string" || raw.trim().length === 0) return undefined;
+  return raw
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Resolve the evidence capabilities of a session by its recorded backend
+ * framework name. Unknown/absent frameworks resolve fail-closed: no envelope,
+ * no browser — a correction must never demand what may not exist.
+ */
+export function capabilitiesForBackend(
+  framework: string | undefined | null,
+  getSetting?: (key: string) => string | undefined | null,
+): EvidenceCapabilities {
+  const envelopeCapable =
+    settingList(getSetting, "ELIZA_ENVELOPE_CAPABLE_BACKENDS") ??
+    DEFAULT_ENVELOPE_CAPABLE_BACKENDS;
+  const name = (framework ?? "").trim().toLowerCase();
+  const browserRaw =
+    getSetting?.("ELIZA_SANDBOX_HAS_BROWSER") ??
+    process.env.ELIZA_SANDBOX_HAS_BROWSER;
+  return {
+    browser: browserRaw === "1" || browserRaw === "true",
+    completionEnvelope:
+      name.length > 0 &&
+      envelopeCapable.some(
+        (capable) => name === capable || name.startsWith(`${capable}-`),
+      ),
+  };
+}
+
+/** Path-like tokens: a slashed relative path or an extensioned filename, as
+ *  criteria generators produce them (optionally backtick-quoted). */
+const PATH_TOKEN_RE = /`?((?:[\w.-]+\/)+[\w.-]+|[\w-]+\.[A-Za-z]{1,8})`?/g;
+
+/** Extensions that read as prose ("e.g.", "v1.2") rather than artifacts. */
+const NON_ARTIFACT_TOKEN_RE = /^(?:e\.g|i\.e|etc|v?\d+(?:\.\d+)+)$/i;
+
+export interface InventedArtifactFilterResult {
+  kept: string[];
+  /** Criteria dropped because they pinned a path the request never named. */
+  dropped: string[];
+}
+
+/**
+ * Drop generated criteria that pin a concrete path/filename absent from the
+ * request. The worker legitimately chooses its own layout when the request
+ * names none — holding it to an invented path is unsatisfiable by design.
+ * A criterion survives when every path-like token it names appears (case-
+ * insensitively) in the goal text.
+ */
+export function stripInventedArtifactCriteria(
+  criteria: readonly string[],
+  goal: string,
+): InventedArtifactFilterResult {
+  const haystack = (goal ?? "").toLowerCase();
+  const kept: string[] = [];
+  const dropped: string[] = [];
+  for (const criterion of criteria) {
+    const tokens = [...criterion.matchAll(PATH_TOKEN_RE)]
+      .map((match) => match[1] ?? "")
+      .filter(
+        (token) =>
+          token.length > 0 &&
+          !NON_ARTIFACT_TOKEN_RE.test(token) &&
+          // A bare extensioned word that is a common tool invocation
+          // ("bun test", "tsconfig.json" appears in goals often) still counts
+          // as an artifact claim only when it looks file-shaped.
+          (token.includes("/") || token.includes(".")),
+      );
+    const invented = tokens.some(
+      (token) => !haystack.includes(token.toLowerCase()),
+    );
+    (invented ? dropped : kept).push(criterion);
+  }
+  return { kept, dropped };
+}
+
+/** Criterion classifiers, shared vocabulary with the correction builder. */
+const URL_CRITERION_RE =
+  /\b(url|endpoint|deploy|live|reachable|http|served|serves|api)\b/i;
+const FILE_CRITERION_RE =
+  /\b(file|page|artifact|deliverable)\b.*\b(exists|created|written|present)\b|\b(create[sd]?|write[sn]?)\b.*\b(file|page)\b/i;
+const DIFF_CRITERION_RE = /\bdiff\b|\bchange(?:set)?\b.*\bsummar/i;
+const TEST_CRITERION_RE =
+  /\b(test|spec|coverage|unit|e2e|integration|vitest|jest)s?\b/i;
+const BUILD_CRITERION_RE = /\b(build|compile|typecheck|tsc)\b/i;
+const LINT_CRITERION_RE = /\b(lint|biome|eslint|format)\b/i;
+const SCREENSHOT_CRITERION_RE = /\b(screenshot|screen\s*capture)\b/i;
+
+/** Deterministic facts the orchestrator already holds at completion. */
+export interface DeterministicEvidenceFacts {
+  /** Router-probed URLs that answered, non-loopback only. */
+  verifiedPublicUrls: readonly string[];
+  /** Claimed files backed by a successful write in the session tool ledger. */
+  ledgerVerifiedFiles: readonly string[];
+  /** Whether a real git changeset was captured at completion. */
+  hasChangeSet: boolean;
+  /** Mined green output present per check class. */
+  greenChecks: { test: boolean; build: boolean; lint: boolean };
+}
+
+export interface DeterministicCriterionResult {
+  criterion: string;
+  status: "met" | "undetermined";
+  /** The concrete fact that satisfied a met criterion. */
+  basis?: string;
+}
+
+export interface DeterministicLedgerVerdict {
+  /** True only when EVERY criterion was deterministically satisfied. */
+  allMet: boolean;
+  results: DeterministicCriterionResult[];
+  met: string[];
+  undetermined: string[];
+}
+
+function fileCriterionBasis(
+  criterion: string,
+  facts: DeterministicEvidenceFacts,
+): string | undefined {
+  if (facts.ledgerVerifiedFiles.length === 0) return undefined;
+  const tokens = [...criterion.matchAll(PATH_TOKEN_RE)].map((match) =>
+    (match[1] ?? "").toLowerCase(),
+  );
+  if (tokens.length === 0) {
+    // No specific path demanded: any ledger-verified write satisfies
+    // "the file/deliverable exists".
+    return `ledger-verified write: ${facts.ledgerVerifiedFiles[0]}`;
+  }
+  const hit = facts.ledgerVerifiedFiles.find((file) => {
+    const lower = file.toLowerCase();
+    return tokens.some(
+      (token) =>
+        lower === token || lower.endsWith(`/${token}`) || lower.includes(token),
+    );
+  });
+  return hit ? `ledger-verified write: ${hit}` : undefined;
+}
+
+/**
+ * Judge one criterion purely from deterministic facts. Conservative by
+ * construction: anything not clearly satisfied is `undetermined`, never
+ * "met" — this can promote a working deliverable but can never paper over a
+ * missing one.
+ */
+export function deterministicCriterionCheck(
+  criterion: string,
+  facts: DeterministicEvidenceFacts,
+): DeterministicCriterionResult {
+  if (SCREENSHOT_CRITERION_RE.test(criterion)) {
+    return { criterion, status: "undetermined" };
+  }
+  if (URL_CRITERION_RE.test(criterion)) {
+    const url = facts.verifiedPublicUrls[0];
+    return url
+      ? { criterion, status: "met", basis: `probed URL answered: ${url}` }
+      : { criterion, status: "undetermined" };
+  }
+  if (TEST_CRITERION_RE.test(criterion)) {
+    return facts.greenChecks.test
+      ? { criterion, status: "met", basis: "green test output captured" }
+      : { criterion, status: "undetermined" };
+  }
+  if (BUILD_CRITERION_RE.test(criterion)) {
+    return facts.greenChecks.build
+      ? {
+          criterion,
+          status: "met",
+          basis: "green build/typecheck output captured",
+        }
+      : { criterion, status: "undetermined" };
+  }
+  if (LINT_CRITERION_RE.test(criterion)) {
+    return facts.greenChecks.lint
+      ? { criterion, status: "met", basis: "green lint output captured" }
+      : { criterion, status: "undetermined" };
+  }
+  if (DIFF_CRITERION_RE.test(criterion)) {
+    return facts.hasChangeSet
+      ? {
+          criterion,
+          status: "met",
+          basis: "git changeset captured at completion",
+        }
+      : { criterion, status: "undetermined" };
+  }
+  if (FILE_CRITERION_RE.test(criterion)) {
+    const basis = fileCriterionBasis(criterion, facts);
+    return basis
+      ? { criterion, status: "met", basis }
+      : { criterion, status: "undetermined" };
+  }
+  return { criterion, status: "undetermined" };
+}
+
+/**
+ * The deterministic pre-pass the pipeline runs BEFORE any model judgment:
+ * when every acceptance criterion is satisfied by the write ledger, probed
+ * URLs, captured changeset, or mined green check output, the task passes with
+ * {@link DETERMINISTIC_LEDGER_VERIFIER_NAME} provenance and no model spend.
+ */
+export function deterministicLedgerVerdict(
+  criteria: readonly string[],
+  facts: DeterministicEvidenceFacts,
+): DeterministicLedgerVerdict {
+  const results = criteria.map((criterion) =>
+    deterministicCriterionCheck(criterion, facts),
+  );
+  const met = results
+    .filter((result) => result.status === "met")
+    .map((result) => result.criterion);
+  const undetermined = results
+    .filter((result) => result.status === "undetermined")
+    .map((result) => result.criterion);
+  return {
+    allMet: criteria.length > 0 && undetermined.length === 0,
+    results,
+    met,
+    undetermined,
+  };
+}
+
+/** Loopback hosts never count as publicly-reachable deploy evidence. */
+export function isPubliclyReachableUrl(value: string): boolean {
+  try {
+    const host = new URL(value).hostname.toLowerCase();
+    return host !== "localhost" && host !== "127.0.0.1" && host !== "::1";
+  } catch {
+    // error-policy:J3 an unparseable URL is explicitly not reachable evidence
+    return false;
+  }
+}
+
+const GREEN_MARKER_RE = /\bpass(?:ed|ing)?\b|✓|✔|\bPASS\b|\bok\b|0 fail/i;
+const RED_MARKER_RE = /\bfail(?:ed|ing|ure)?\b|✗|✖|\bFAIL\b|\bERRORS?\b/;
+
+/**
+ * Whether mined tool output constitutes GREEN evidence for a check class:
+ * present, showing a pass marker, and free of failure markers. Conservative —
+ * ambiguous output is not green (the model judge can still weigh it).
+ */
+export function isGreenCheckOutput(output: string | undefined | null): boolean {
+  if (typeof output !== "string" || output.trim().length === 0) return false;
+  return GREEN_MARKER_RE.test(output) && !RED_MARKER_RE.test(output);
+}
+
+/** Render the deterministic verdict as an evidence section for downstream
+ *  judges (partial case) or as the pass evidence (allMet case). */
+export function renderDeterministicVerdict(
+  verdict: DeterministicLedgerVerdict,
+): string {
+  const lines = [
+    "## DETERMINISTICALLY VERIFIED CRITERIA (write ledger / probed URLs / captured output — not model judgment)",
+    ...verdict.results.map((result) =>
+      result.status === "met"
+        ? `- MET: ${result.criterion} [${result.basis}]`
+        : `- undetermined (needs judgment): ${result.criterion}`,
+    ),
+  ];
+  return lines.join("\n");
+}


### PR DESCRIPTION
Fixes #20794 — the auto-verify pipeline reliably failed WORKING deliverables (live: two correct, served quick-app pages each burned 3/3 verify attempts and parked at `waiting_on_user`). All four structural mismatches from the issue are addressed with deterministic, model-free contracts in one new module (`producible-evidence.ts`), wired through the existing pipeline.

## What changed

1. **Criteria generation can no longer invent artifacts.** The refinement prompt forbids concrete paths the goal never named, and — since prompts aren't enforcement — `stripInventedArtifactCriteria` deterministically drops any generated criterion pinning a path absent from the goal (the live incident's ``agent-home/canon-clock.html`` shape is a pinned test), topping the set back up from the static template.
2. **Envelope gate is per-backend-capability, not universal.** `capabilitiesForBackend(framework)` knows which backends emit a CompletionEnvelope (claude/codex; the `elizaos` brain does not; override via `ELIZA_ENVELOPE_CAPABLE_BACKENDS`; unknown fails closed). The #8898 independent verifier is now only spawned when ITS backend can produce the envelope it must report with — under the default `elizaos` backend every such run was structurally inconclusive and only burned bounded attempts. The inconclusive re-engage correction likewise only demands the envelope from workers that can emit one.
3. **Corrections are constrained to producible evidence.** Proof demands are capability-aware: a headless sandbox (the default; `ELIZA_SANDBOX_HAS_BROWSER` opt-in) is never asked for screenshots — it's told to serve the page and paste the fetched content instead of detouring into `npm install puppeteer` (observed live).
4. **The deterministic ledger is first-class passing evidence.** A new pre-pass runs BEFORE the independent verifier and the text judge: when every criterion is satisfied by facts the orchestrator already holds — ledger-verified writes, router-probed non-loopback URLs, the captured changeset, mined green check output — the task passes with `deterministic-ledger-verifier` provenance and zero model spend. Partial satisfaction is appended to the judge's evidence so only the remainder gets grilled. Conservative by construction: ambiguous facts are `undetermined`, never met; empty criteria never auto-pass; screenshot criteria are never deterministically met.

Supporting: the evidence bundle assembled at `task_complete` is now threaded into the verify pipeline instead of being recollected (one fewer git change-set capture per completion).

## Deliberate test updates

- The #8898 verifier tests configure an envelope-capable backend (`claude`) — the capability gate is exactly what they must opt out of to exercise the verifier itself.
- "an inconclusive verifier verdict keeps the task validating" was ALREADY red on clean develop (the re-engage-on-inconclusive change outran it); updated to the current contract (re-engaged → `active`, never `done`, no model spend) plus the new assertion that an `opencode` worker's correction does not demand a CompletionEnvelope.
- The single-turn-create test's 5s default cap contradicted its own 15s inner waitFor (latent flake, its comment says as much); given an explicit 20s cap.

## Evidence

- New `producible-evidence.test.ts`: 14/14 — capability fail-closed matrix + env overrides, invented-path filter (live-incident shape), deterministic verdict (quick-app pass shape, per-class green checks, screenshot/never-met, specific-file mismatch, empty-criteria), and the model-refinement enforcement path.
- `auto-goal-verify.test.ts`: 46/46 (full pipeline incl. envelope gate, residuals, ground truth, judge, re-engage).
- `create-task-attaches-sessions` + `tasks-regression-lane`: 117/117.
- Plugin typecheck clean; Biome clean. Pre-existing red (`acp-service.test.ts` auth-classification) reproduces identically on clean develop — untouched surface, not addressed here.
- Live validation plan (post-merge, coordinated with the live-box lane): re-run the quick-app scenario from the issue and confirm deterministic promotion with `deterministic-ledger-verifier` provenance in the task events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)