### PR TITLE
fix(cloud): reject unknown promote-assets platform

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/promote/assets/route.platform.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/assets/route.platform.test.ts
@@ -1,0 +1,121 @@
+/**
+ * GET /api/v1/apps/:id/promote/assets `platform` is catalog-platform
+ * identity, not leftover my-agents sortBy tax. Stock develop cast the
+ * token and `getRecommendedSizes` fell through to Twitter cards, so
+ * `platform=META` / `facebook` listed Twitter sizes.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+  user: { id: "user-1", organization_id: "org-1" },
+  apiKey: null,
+}));
+const getById = mock(async () => ({
+  id: "app-1",
+  organization_id: "org-1",
+  name: "Demo",
+}));
+const isAppKeyOutOfScope = mock(async () => false);
+const getRecommendedSizes = mock((platform: string) => {
+  const recommendations: Record<string, string[]> = {
+    meta: ["facebook_feed"],
+    google: ["google_display_leaderboard"],
+    twitter: ["twitter_card"],
+    linkedin: ["linkedin_post"],
+  };
+  return recommendations[platform] || ["twitter_card"];
+});
+const AD_SIZES = {
+  facebook_feed: { width: 1200, height: 628 },
+  twitter_card: { width: 800, height: 418 },
+  linkedin_post: { width: 1200, height: 627 },
+  google_display_leaderboard: { width: 728, height: 90 },
+};
+
+mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
+mock.module("@/lib/auth/app-key-scope", () => ({ isAppKeyOutOfScope }));
+mock.module("@/lib/services/apps", () => ({
+  appsService: { getById, update: mock(async () => undefined) },
+}));
+mock.module("@/lib/services/app-promotion-assets", () => ({
+  AD_SIZES,
+  appPromotionAssetsService: {
+    getRecommendedSizes,
+    generateAssetBundle: mock(async () => ({
+      assets: [],
+      copy: null,
+      errors: [],
+    })),
+  },
+}));
+mock.module("@/lib/promotion-pricing", () => ({
+  AD_COPY_GENERATION_COST: 1,
+  PROMO_IMAGE_COST: 2,
+  estimateAssetGenerationCost: () => ({ total: 5, display: "5" }),
+}));
+mock.module("@/lib/services/credits", () => ({
+  creditsService: {
+    deductCredits: mock(async () => ({ success: true })),
+    refundCredits: mock(async () => undefined),
+  },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: mock(() => undefined), error: mock(() => undefined) },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id/promote/assets", route);
+
+describe("GET /api/v1/apps/:id/promote/assets platform identity", () => {
+  beforeEach(() => {
+    requireAuthOrApiKeyWithOrg.mockClear();
+    getById.mockClear();
+    isAppKeyOutOfScope.mockClear();
+    getRecommendedSizes.mockClear();
+    getById.mockResolvedValue({
+      id: "app-1",
+      organization_id: "org-1",
+      name: "Demo",
+    });
+  });
+
+  test.each(["", "?platform="])(
+    "accepts %s as the full size catalog",
+    async (query) => {
+      const response = await app.request(`/app-1/promote/assets${query}`);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { recommendedSizes: string[] };
+      expect(body.recommendedSizes).toEqual(Object.keys(AD_SIZES));
+      expect(getRecommendedSizes).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    ["meta", "facebook_feed"],
+    ["google", "google_display_leaderboard"],
+    ["twitter", "twitter_card"],
+    ["linkedin", "linkedin_post"],
+  ] as const)("accepts platform=%s as that catalog", async (token, size) => {
+    const response = await app.request(
+      `/app-1/promote/assets?platform=${token}`,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { recommendedSizes: string[] };
+    expect(body.recommendedSizes).toEqual([size]);
+    expect(getRecommendedSizes).toHaveBeenCalledWith(token);
+  });
+
+  test.each(["META", "Google", "facebook", "foo", "1e2"])(
+    "rejects platform=%s before getRecommendedSizes",
+    async (token) => {
+      const response = await app.request(
+        `/app-1/promote/assets?platform=${token}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_platform");
+      expect(getRecommendedSizes).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
@@ -170,12 +170,33 @@ async function __hono_GET(
   }
 
   const url = new URL(request.url);
-  const platform = url.searchParams.get("platform") as
-    | "meta"
-    | "google"
-    | "twitter"
-    | "linkedin"
-    | null;
+  // Catalog-platform identity, not leftover my-agents sortBy tax. The
+  // service fallback `|| ["twitter_card"]` mapped META / facebook / foo
+  // onto Twitter sizes. Missing / empty still means the full AD_SIZES
+  // catalog. Garbage 400s before getRecommendedSizes.
+  const requestedPlatform = url.searchParams.get("platform");
+  const PROMOTE_PLATFORMS = ["meta", "google", "twitter", "linkedin"] as const;
+  type PromotePlatform = (typeof PROMOTE_PLATFORMS)[number];
+  if (
+    requestedPlatform !== null &&
+    requestedPlatform !== "" &&
+    !PROMOTE_PLATFORMS.includes(requestedPlatform as PromotePlatform)
+  ) {
+    return Response.json(
+      {
+        error: "invalid_platform",
+        message: 'platform must be "meta", "google", "twitter", or "linkedin".',
+      },
+      { status: 400 },
+    );
+  }
+  const platform =
+    requestedPlatform === "meta" ||
+    requestedPlatform === "google" ||
+    requestedPlatform === "twitter" ||
+    requestedPlatform === "linkedin"
+      ? requestedPlatform
+      : null;
 
   const recommendedSizes = platform
     ? appPromotionAssetsService.getRecommendedSizes(platform)


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on promote-assets platform
identity. Catalog-platform class, not leftover tax on influencer bookings
party, payment-request public, X connectionRole, my-agents sortBy, logs
since, analytics periods, analytics export type, admin redemption status,
share-ingest consume, Life Ops inbox bools, views viewType, relationships
scope, commands surface, approvals state, database-rows sort/page,
memory-viewer type, VFS encoding, models catalogOnly/refresh, Cloud
JSON-400, prefix-coerced limit, percent-encoded paths, SIWS chainId,
orchestrator lines, provisioning-worker env ints, invites-accept,
cli-auth, redemption quote, compat agent-logs, or avatar. Disjoint from
admin ingress-map `format`. POST generate / credit parsers untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `platform` only on `/api/v1/apps/:id/promote/assets`. Omitted/empty
still returns the full AD_SIZES catalog. Exact `meta` / `google` / `twitter` /
`linkedin` still return that catalog. Unknown tokens 400 before
`getRecommendedSizes`.

# Background

## What does this PR do?

`GET /api/v1/apps/:id/promote/assets` cast unknown `platform` tokens. The
service fallback `|| ["twitter_card"]` mapped `platform=META` / `facebook` /
`foo` onto Twitter sizes instead of the advertised Meta/Google catalogs.

- omitted / empty → **200** full AD_SIZES catalog (today's default)
- exact `meta` / `google` / `twitter` / `linkedin` → **200** that catalog
- `META` / `Google` / `facebook` / `foo` / `1e2` → **400** before
  `getRecommendedSizes`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The promote UI documents `platform=meta|google|twitter|linkedin`. A common
`platform=META` must not silently recommend Twitter cards. This is
catalog-platform identity, not leftover tax on my-agents sortBy.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/apps/[id]/promote/assets/route.platform.test.ts` —
omitted still returns all sizes; exact platforms still call
`getRecommendedSizes`; garbage 400s with `getRecommendedSizes` never called.

## Test commands

```bash
cd packages/cloud/api && bun test v1/apps/[id]/promote/assets/route.platform.test.ts
```

11 passed at the evidence head. Stock develop was 6 passed / 5 failed on the
same table (`platform=META` returned 200 Twitter sizes).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; promote-assets `platform` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; promote-assets `platform` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; promote-assets `platform` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real `platform` token and assert 400 before getRecommendedSizes; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no asset generation; illegal `platform` 400 before the size catalog.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal `platform`
tokens reject; omitted/canonical still bind the matching catalog.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file promote-assets `platform`
parse with a green focused suite (11 tests). Full monorepo verify is unrelated
to this query grammar and was skipped to keep the proof tied to the changed
path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d61ae90dfedd10f9a6943c6f1c730ae3830ad7e3 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
