### PR TITLE
fix(agent): reject malformed dynamic app route slug encoding

### DIFF
--- a/packages/agent/src/api/app-package-routes.test.ts
+++ b/packages/agent/src/api/app-package-routes.test.ts
@@ -15,17 +15,45 @@ vi.mock("../services/app-package-modules.ts", () => ({
   importAppRouteModule: importAppRouteModuleMock,
 }));
 
+// Keep this focused dispatcher test independent of the broad server-helper
+// module graph while preserving the decoder's real response contract.
+vi.mock("./server-helpers.ts", () => ({
+  decodePathComponent(
+    raw: string,
+    res: http.ServerResponse,
+    fieldName: string,
+  ): string | null {
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "application/json");
+      res.end(
+        JSON.stringify({
+          error: `Invalid ${fieldName}: malformed URL encoding`,
+        }),
+      );
+      return null;
+    }
+  },
+}));
+
 import { handleAppPackageRoutes } from "./app-package-routes.ts";
 
 function createContext(pathname: string): {
   context: AppPackageRouteDispatchContext;
   error: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
   readJsonBody: ReturnType<typeof vi.fn>;
   req: http.IncomingMessage;
   res: http.ServerResponse;
 } {
   const req = {} as http.IncomingMessage;
-  const res = {} as http.ServerResponse;
+  const end = vi.fn();
+  const res = {
+    setHeader: vi.fn(),
+    end,
+  } as unknown as http.ServerResponse;
   const error = vi.fn();
   const readJsonBody = vi.fn(async () => ({ ok: true }));
   const context = {
@@ -40,7 +68,7 @@ function createContext(pathname: string): {
     readJsonBody,
   } as unknown as AppPackageRouteDispatchContext;
 
-  return { context, error, readJsonBody, req, res };
+  return { context, error, end, readJsonBody, req, res };
 }
 
 describe("dynamic app-package route dispatch", () => {
@@ -51,18 +79,23 @@ describe("dynamic app-package route dispatch", () => {
   it.each(["%", "%2", "%ZZ", "%E0%A4"])(
     "handles malformed app slug encoding %s as a 400",
     async (encodedSlug) => {
-      const { context, error, res } = createContext(
+      const { context, end, error, res } = createContext(
         `/api/apps/${encodedSlug}/run`,
       );
 
       await expect(handleAppPackageRoutes(context)).resolves.toBe(true);
 
-      expect(error).toHaveBeenCalledOnce();
-      expect(error).toHaveBeenCalledWith(
-        res,
-        "Invalid app slug: malformed URL encoding",
-        400,
+      expect(res.statusCode).toBe(400);
+      expect(res.setHeader).toHaveBeenCalledWith(
+        "Content-Type",
+        "application/json",
       );
+      expect(end).toHaveBeenCalledWith(
+        JSON.stringify({
+          error: "Invalid app slug: malformed URL encoding",
+        }),
+      );
+      expect(error).not.toHaveBeenCalled();
       expect(importAppRouteModuleMock).not.toHaveBeenCalled();
     },
   );

--- a/packages/agent/src/api/app-package-routes.test.ts
+++ b/packages/agent/src/api/app-package-routes.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Exercises the production dynamic app-package dispatcher with mocked package
+ * loading so URL-boundary failures and valid handler delegation remain
+ * deterministic and side-effect free.
+ */
+import type http from "node:http";
+import type { AppPackageRouteDispatchContext } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { importAppRouteModuleMock } = vi.hoisted(() => ({
+  importAppRouteModuleMock: vi.fn(),
+}));
+
+vi.mock("../services/app-package-modules.ts", () => ({
+  importAppRouteModule: importAppRouteModuleMock,
+}));
+
+import { handleAppPackageRoutes } from "./app-package-routes.ts";
+
+function createContext(pathname: string): {
+  context: AppPackageRouteDispatchContext;
+  error: ReturnType<typeof vi.fn>;
+  readJsonBody: ReturnType<typeof vi.fn>;
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+} {
+  const req = {} as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  const error = vi.fn();
+  const readJsonBody = vi.fn(async () => ({ ok: true }));
+  const context = {
+    req,
+    res,
+    method: "GET",
+    pathname,
+    url: new URL("http://localhost/"),
+    runtime: null,
+    json: vi.fn(),
+    error,
+    readJsonBody,
+  } as unknown as AppPackageRouteDispatchContext;
+
+  return { context, error, readJsonBody, req, res };
+}
+
+describe("dynamic app-package route dispatch", () => {
+  beforeEach(() => {
+    importAppRouteModuleMock.mockReset();
+  });
+
+  it.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "handles malformed app slug encoding %s as a 400",
+    async (encodedSlug) => {
+      const { context, error, res } = createContext(
+        `/api/apps/${encodedSlug}/run`,
+      );
+
+      await expect(handleAppPackageRoutes(context)).resolves.toBe(true);
+
+      expect(error).toHaveBeenCalledOnce();
+      expect(error).toHaveBeenCalledWith(
+        res,
+        "Invalid app slug: malformed URL encoding",
+        400,
+      );
+      expect(importAppRouteModuleMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["/api/commands", "/api/apps/info", "/api/apps/%69nfo"])(
+    "leaves unmatched or reserved route %s for the next dispatcher",
+    async (pathname) => {
+      const { context, error } = createContext(pathname);
+
+      await expect(handleAppPackageRoutes(context)).resolves.toBe(false);
+
+      expect(error).not.toHaveBeenCalled();
+      expect(importAppRouteModuleMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("dispatches a valid encoded slug with a request-bound body reader", async () => {
+    const { context, error, readJsonBody, req, res } = createContext(
+      "/api/apps/example%2Dapp/run",
+    );
+    const routeHandler = vi.fn(async (appContext) => {
+      await appContext.readJsonBody({ maxBytes: 1_024 });
+      return true;
+    });
+    importAppRouteModuleMock.mockResolvedValue({
+      handleAppRoutes: routeHandler,
+    });
+
+    await expect(handleAppPackageRoutes(context)).resolves.toBe(true);
+
+    expect(importAppRouteModuleMock).toHaveBeenCalledWith("example-app");
+    expect(routeHandler).toHaveBeenCalledOnce();
+    expect(readJsonBody).toHaveBeenCalledWith(req, res, { maxBytes: 1_024 });
+    expect(error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/api/app-package-routes.ts
+++ b/packages/agent/src/api/app-package-routes.ts
@@ -27,14 +27,28 @@ const RESERVED_APP_ROUTE_SLUGS = new Set([
   "stop",
 ]);
 
-function extractAppSlug(pathname: string): string | null {
+type AppSlugParseResult =
+  | { kind: "unmatched" }
+  | { kind: "invalid" }
+  | { kind: "slug"; value: string };
+
+function parseAppSlug(pathname: string): AppSlugParseResult {
   const match = pathname.match(/^\/api\/apps\/([^/]+)(?:\/|$)/);
-  if (!match?.[1]) return null;
-  const slug = decodeURIComponent(match[1]).trim();
-  if (!slug || RESERVED_APP_ROUTE_SLUGS.has(slug)) {
-    return null;
+  if (!match?.[1]) return { kind: "unmatched" };
+
+  let slug: string;
+  try {
+    slug = decodeURIComponent(match[1]).trim();
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — malformed path encoding is
+    // reported by the route boundary instead of escaping as URIError.
+    return { kind: "invalid" };
   }
-  return slug;
+
+  if (!slug || RESERVED_APP_ROUTE_SLUGS.has(slug)) {
+    return { kind: "unmatched" };
+  }
+  return { kind: "slug", value: slug };
 }
 
 function toLegacyHandlerName(slug: string): string {
@@ -65,8 +79,13 @@ function resolveAppRouteHandler(
 export async function handleAppPackageRoutes(
   ctx: AppPackageRouteDispatchContext,
 ): Promise<boolean> {
-  const slug = extractAppSlug(ctx.pathname);
-  if (!slug) return false;
+  const parsedSlug = parseAppSlug(ctx.pathname);
+  if (parsedSlug.kind === "unmatched") return false;
+  if (parsedSlug.kind === "invalid") {
+    ctx.error(ctx.res, "Invalid app slug: malformed URL encoding", 400);
+    return true;
+  }
+  const slug = parsedSlug.value;
 
   const routeModule = await importAppRouteModule(slug);
   if (!routeModule) return false;

--- a/packages/agent/src/api/app-package-routes.ts
+++ b/packages/agent/src/api/app-package-routes.ts
@@ -14,6 +14,7 @@ import {
   type AppRouteModule,
   importAppRouteModule,
 } from "../services/app-package-modules.ts";
+import { decodePathComponent } from "./server-helpers.ts";
 
 const RESERVED_APP_ROUTE_SLUGS = new Set([
   "",
@@ -27,28 +28,9 @@ const RESERVED_APP_ROUTE_SLUGS = new Set([
   "stop",
 ]);
 
-type AppSlugParseResult =
-  | { kind: "unmatched" }
-  | { kind: "invalid" }
-  | { kind: "slug"; value: string };
-
-function parseAppSlug(pathname: string): AppSlugParseResult {
+function extractEncodedAppSlug(pathname: string): string | null {
   const match = pathname.match(/^\/api\/apps\/([^/]+)(?:\/|$)/);
-  if (!match?.[1]) return { kind: "unmatched" };
-
-  let slug: string;
-  try {
-    slug = decodeURIComponent(match[1]).trim();
-  } catch {
-    // error-policy:J3 untrusted-input sanitizing — malformed path encoding is
-    // reported by the route boundary instead of escaping as URIError.
-    return { kind: "invalid" };
-  }
-
-  if (!slug || RESERVED_APP_ROUTE_SLUGS.has(slug)) {
-    return { kind: "unmatched" };
-  }
-  return { kind: "slug", value: slug };
+  return match?.[1] ?? null;
 }
 
 function toLegacyHandlerName(slug: string): string {
@@ -79,13 +61,16 @@ function resolveAppRouteHandler(
 export async function handleAppPackageRoutes(
   ctx: AppPackageRouteDispatchContext,
 ): Promise<boolean> {
-  const parsedSlug = parseAppSlug(ctx.pathname);
-  if (parsedSlug.kind === "unmatched") return false;
-  if (parsedSlug.kind === "invalid") {
-    ctx.error(ctx.res, "Invalid app slug: malformed URL encoding", 400);
-    return true;
-  }
-  const slug = parsedSlug.value;
+  const encodedSlug = extractEncodedAppSlug(ctx.pathname);
+  if (encodedSlug === null) return false;
+
+  // error-policy:J3 untrusted-input sanitizing — the shared HTTP boundary
+  // decoder writes the explicit 400 response for malformed percent encoding.
+  const decodedSlug = decodePathComponent(encodedSlug, ctx.res, "app slug");
+  if (decodedSlug === null) return true;
+
+  const slug = decodedSlug.trim();
+  if (!slug || RESERVED_APP_ROUTE_SLUGS.has(slug)) return false;
 
   const routeModule = await importAppRouteModule(slug);
   if (!routeModule) return false;


### PR DESCRIPTION
# Relates to

Fixes #20943

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the unrelated verifier/toolchain blockers are recorded below.
- [x] A reviewer can confirm the change works without reading the code from the focused production-handler transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@f3fc142b6d71827455e404ca6b451eef5f5c4082`; zero conflicts.
- [x] `bun run verify` was run post-sync; its unrelated Windows portable-toolchain blocker is documented below.

# Risks

Low. The change is confined to the dynamic `/api/apps/<slug>` package dispatcher. Valid encoded slugs retain their existing import and delegation behavior; unmatched and reserved routes still fall through. Malformed percent-encoding now terminates at the HTTP boundary with a deterministic 400 instead of escaping as `URIError`.

# Background

## What does this PR do?

- Parses the dynamic app slug into explicit unmatched, invalid, and valid outcomes.
- Converts malformed percent-encoding to a handled HTTP 400 without importing an app package or falling through to another dispatcher.
- Adds production-handler regressions for truncated, non-hex, and invalid UTF-8 escapes, reserved-route fallthrough, and valid encoded-slug delegation.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. This is an HTTP error-boundary correction with no new public configuration or user workflow.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/app-package-routes.test.ts`

## Detailed testing steps

Using the repository-pinned Bun 1.3.14 and Node 24.15.0:

```text
$ bun install --frozen-lockfile --ignore-scripts
Frozen install completed after retrying two transient Windows package links

$ bunx vitest run packages/agent/src/api/app-package-routes.test.ts --coverage.enabled=false
Test Files  1 passed (1)
Tests       8 passed (8)

$ bunx @biomejs/biome check packages/agent/src/api/app-package-routes.ts packages/agent/src/api/app-package-routes.test.ts
Checked 2 files. No fixes applied.

$ bun run --cwd packages/agent build
[rewrite-dist-relative-imports] rewrote 194 file(s)
exit 0

$ bun run --cwd packages/agent typecheck
exit 0
```

The focused matrix proves:

- `%`, `%2`, `%ZZ`, and invalid UTF-8 `%E0%A4` each return handled 400 and perform zero package imports.
- unmatched and decoded-reserved routes remain unhandled for the next dispatcher.
- `/api/apps/example%2Dapp/run` still imports `example-app`, invokes the production handler, and preserves the request-bound JSON body reader.

# Evidence Gate

<!-- evidence-head:50caa99666aca7f5e1cf2ccf433c0d1cce77105b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend HTTP dispatcher only; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend HTTP dispatcher only; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic request-boundary behavior with no user interface.
<!-- evidence-row:backend-logs -->
- [x] Focused production-handler transcript is included above: 8/8 cases pass, including exact handled 400 and zero-import assertions.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, state, console, or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, prompt, provider, model, or LLM path changed.
<!-- evidence-row:domain-artifacts -->
- [x] The 8-case deterministic route matrix above is the applicable domain artifact; it exercises the production dispatcher with package loading mocked at the external boundary.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - the patch changes URL decoding at an HTTP route boundary and never invokes an LLM.

## Backend + frontend logs

Backend evidence is the focused production-handler transcript in **Testing**. Frontend logs are N/A because no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- `bun run verify` passes AGENTS/CLAUDE parity, Biome-version consistency, i18n, Bun-version, workspace-dependency, plugin-convention, and alias-read guards. It then reaches Turbo and stops with `Unable to find package manager binary: cannot find binary path` under the pinned portable Windows Bun/Node toolchain. This is environment/toolchain resolution after all diff-relevant preflights, not a failure in the changed dispatcher or tests.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@8c3d35e16e52058190a9102f5e35fc616cc1e224:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-agent-app-route-decoder]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@f3fc142b6d71827455e404ca6b451eef5f5c4082:packages/skills/skills/contribute-to-eliza"} -->
