### PR TITLE
fix(app): stabilize zero-key settings walkthrough

### DIFF
--- a/packages/app/test/ui-smoke/walkthrough/journey.ts
+++ b/packages/app/test/ui-smoke/walkthrough/journey.ts
@@ -32,6 +32,10 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import {
+  DEFAULT_NETWORK_POLICY_PREFERENCES,
+  VOICE_MODEL_VERSIONS,
+} from "@elizaos/shared";
 import type { AccountsListResponse } from "@elizaos/ui/api/client-agent";
 import { expect, type Page, type Route, type TestInfo } from "@playwright/test";
 import {
@@ -47,6 +51,17 @@ export type Lane = "mock" | "live";
 export const WALKTHROUGH_ACCOUNTS_RESPONSE = {
   providers: [],
 } satisfies AccountsListResponse;
+
+const WALKTHROUGH_VOICE_MODEL_INSTALLATIONS = Array.from(
+  new Set(VOICE_MODEL_VERSIONS.map((version) => version.id)),
+)
+  .sort()
+  .map((id) => ({
+    id,
+    installedVersion: null,
+    pinned: false,
+    lastError: null,
+  }));
 
 export interface ViewportProfile {
   id: "desktop" | "mobile";
@@ -681,17 +696,14 @@ async function installMockLaneWrites(page: Page): Promise<void> {
     if (route.request().method() === "GET") {
       const pathname = new URL(route.request().url()).pathname;
       if (pathname === "/api/local-inference/voice-models") {
-        await fulfillJson(route, 200, { installations: [] });
+        await fulfillJson(route, 200, {
+          installations: WALKTHROUGH_VOICE_MODEL_INSTALLATIONS,
+        });
         return;
       }
       if (pathname === "/api/local-inference/voice-models/preferences") {
         await fulfillJson(route, 200, {
-          preferences: {
-            autoUpdateOnWifi: true,
-            autoUpdateOnCellular: false,
-            autoUpdateOnMetered: false,
-            quietHours: [{ start: "22:00", end: "08:00" }],
-          },
+          preferences: DEFAULT_NETWORK_POLICY_PREFERENCES,
         });
         return;
       }

--- a/packages/app/test/ui-smoke/walkthrough/journey.ts
+++ b/packages/app/test/ui-smoke/walkthrough/journey.ts
@@ -659,7 +659,7 @@ async function installMockLaneWrites(page: Page): Promise<void> {
       await route.fulfill({
         status: 200,
         contentType: "text/event-stream",
-        body: `data: ${JSON.stringify({
+        body: `retry: 60000\ndata: ${JSON.stringify({
           type: "status",
           status: {
             connected: false,
@@ -680,21 +680,21 @@ async function installMockLaneWrites(page: Page): Promise<void> {
   await page.route("**/api/local-inference/voice-models**", async (route) => {
     if (route.request().method() === "GET") {
       const pathname = new URL(route.request().url()).pathname;
-      await fulfillJson(
-        route,
-        200,
-        pathname.endsWith("/preferences")
-          ? {
-              preferences: {
-                autoUpdateOnWifi: true,
-                autoUpdateOnCellular: false,
-                autoUpdateOnMetered: false,
-                quietHours: [{ start: "22:00", end: "08:00" }],
-              },
-            }
-          : { installations: [] },
-      );
-      return;
+      if (pathname === "/api/local-inference/voice-models") {
+        await fulfillJson(route, 200, { installations: [] });
+        return;
+      }
+      if (pathname === "/api/local-inference/voice-models/preferences") {
+        await fulfillJson(route, 200, {
+          preferences: {
+            autoUpdateOnWifi: true,
+            autoUpdateOnCellular: false,
+            autoUpdateOnMetered: false,
+            quietHours: [{ start: "22:00", end: "08:00" }],
+          },
+        });
+        return;
+      }
     }
     await route.fallback();
   });

--- a/packages/app/test/ui-smoke/walkthrough/journey.ts
+++ b/packages/app/test/ui-smoke/walkthrough/journey.ts
@@ -649,6 +649,62 @@ async function installMockLaneWrites(page: Page): Promise<void> {
     }
     await route.fallback();
   });
+  // Settings mounts local-device, voice-update, and consumer-key panels in
+  // parallel. They are optional on a fresh zero-key runtime, but the fallback
+  // server's 501 responses are real diagnostics failures. Return each route's
+  // canonical empty/default contract so the walkthrough still exercises the
+  // panels' designed zero states instead of hiding errors in the gate.
+  await page.route("**/api/local-inference/device/stream**", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body: `data: ${JSON.stringify({
+          type: "status",
+          status: {
+            connected: false,
+            devices: [],
+            primaryDeviceId: null,
+            pendingRequests: 0,
+            deviceId: null,
+            capabilities: null,
+            loadedPath: null,
+            connectedSince: null,
+          },
+        })}\n\n`,
+      });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.route("**/api/local-inference/voice-models**", async (route) => {
+    if (route.request().method() === "GET") {
+      const pathname = new URL(route.request().url()).pathname;
+      await fulfillJson(
+        route,
+        200,
+        pathname.endsWith("/preferences")
+          ? {
+              preferences: {
+                autoUpdateOnWifi: true,
+                autoUpdateOnCellular: false,
+                autoUpdateOnMetered: false,
+                quietHours: [{ start: "22:00", end: "08:00" }],
+              },
+            }
+          : { installations: [] },
+      );
+      return;
+    }
+    await route.fallback();
+  });
+  await page.route("**/api/accounts/consumer-keys", async (route) => {
+    if (route.request().method() === "GET") {
+      await fulfillJson(route, 200, { keys: [] });
+      return;
+    }
+    await route.fallback();
+  });
   // Chat collapse/reopen fires a best-effort turn abort; ack it so the gate
   // sees no 5xx on a write the mock lane cannot execute.
   await page.route("**/api/turns/*/abort", async (route) => {


### PR DESCRIPTION
## Summary

- model the optional device-status SSE stream in the keyless walkthrough
- return the real voice-model list/preferences zero-state contracts
- return the real consumer-key empty-list contract
- keep the page diagnostics gate strict; no 5xx filtering or allowlist

Closes #20957.

## Root cause

Scenario E2E run 31998429262 completed all walkthrough interactions, but Settings mounted four optional panels whose requests fell through to the deterministic server and returned 501. Both desktop and mobile therefore failed the strict diagnostics gate despite producing every step capture.

## Verification

- `bunx biome check packages/app/test/ui-smoke/walkthrough/journey.ts`
- `bun run --cwd packages/app test:e2e:walkthrough -- --skip-review`
  - 2/2 Playwright journeys passed
  - 25/25 desktop and 25/25 mobile steps
  - zero page/console errors
  - zero server errors
  - desktop/mobile MP4s and contact sheets generated
- `bun run --cwd packages/app audit:app`
  - 219/219 capture tests
  - 0 broken, 0 needs-work
  - 0 minimalism, hover, or density regressions
  - OCR: 0 broken
- `bun run verify`
  - 356/356 workspace tasks
  - 8,448 test files scanned; 0 focused or orphaned skips

## Evidence

Failing baseline: Scenario E2E run 31998429262, job 95294362290. The downloaded gate reports contained the same four 501s on desktop and mobile. The repaired local artifact reports `gate.ok: true` for both viewports.