### PR TITLE
fix(app): resolve @elizaos/app-core/desktop-shell in source mode for entrypoint tests

### DIFF
--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -49,6 +49,13 @@ export default defineConfig({
         ),
       },
       {
+        // Same source-mode rule for the desktop-shell subpath the entrypoint
+        // tests import (runIosFullBunSmokeIfRequested): the export maps to
+        // app-core's dist, which the changed-test lane never builds.
+        find: /^@elizaos\/app-core\/desktop-shell$/,
+        replacement: path.join(here, "../app-core/src/desktop-shell.ts"),
+      },
+      {
         // main.tsx imports "@elizaos/ui/styles"; the ui package otherwise
         // resolves to its built dist, whose externalized styles.js makes Node
         // load raw .css. Aliasing to source keeps the stylesheet inside vite's


### PR DESCRIPTION
## Summary

`bun run --cwd packages/app test` has 4 failed files on develop tip: every `src/main.*-entrypoint.test.ts` fails to collect with

```
Error: Failed to resolve import "@elizaos/app-core/desktop-shell" from "src/main.web-entrypoint.test.ts".
```

**Cause:** the tests import `runIosFullBunSmokeIfRequested` from `@elizaos/app-core/desktop-shell`, whose `exports` entry maps to app-core's **dist** — which the changed-test lane intentionally never builds. The vitest config already solves exactly this for `@elizaos/app-core/api/ios-local-agent-transport` with a source-mode alias; the desktop-shell subpath (added in the `353574037` no-CI merge) was never given one.

**Fix:** mirror the existing alias — `@elizaos/app-core/desktop-shell` → `../app-core/src/desktop-shell.ts`.

## Verification (exact head)

```
npx vitest run src/main.{web,android,ios-full-bun,ios-interactive}-entrypoint.test.ts: 4 passed (was: 4 failed to collect)
biome check: clean
```

With this fix plus the pinned Node 24 present, the full app lane runs 775/775 vitest tests green locally (remaining script-suite reds on my host are environment-only: gosu is container-only, and two script tests require node24-on-PATH which CI provides).

Final sibling in the zero-CI-merge lane-greening series: #20843 (core), #20853 (cloud/shared, merged), #20882 (app-core), #20903 (agent), #20951 (ui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)