### PR TITLE
fix(cloud): reject unknown analytics requests view

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/analytics/requests/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/requests/route.ts
@@ -50,6 +50,38 @@ async function handleGET(
     }
     const { startDate, endDate } = dateRange;
 
+    // Request-analytics view identity, not leftover Life Ops views
+    // viewType or analytics-periods tax. The prior `|| "stats"` then
+    // switch-default mapped LOGS / STATS / foo onto the stats
+    // dashboard, so operators asking for logs or a timeline received
+    // aggregates. Missing / empty still means stats. Garbage 400s
+    // before getById and the view sinks. period= is untouched.
+    const ANALYTICS_VIEWS = [
+      "logs",
+      "stats",
+      "visitors",
+      "timeline",
+      "sessions",
+    ] as const;
+    const requestedView = searchParams.get("view");
+    if (
+      requestedView !== null &&
+      requestedView !== "" &&
+      !ANALYTICS_VIEWS.includes(
+        requestedView as (typeof ANALYTICS_VIEWS)[number],
+      )
+    ) {
+      return Response.json(
+        {
+          success: false,
+          error: "invalid_view",
+          message:
+            'view must be "logs", "stats", "visitors", "timeline", or "sessions".',
+        },
+        { status: 400 },
+      );
+    }
+
     const existingApp = await appsService.getById(id);
 
     if (!existingApp) {
@@ -72,7 +104,7 @@ async function handleGET(
       );
     }
 
-    const view = searchParams.get("view") || "stats";
+    const view = requestedView || "stats";
     const requestType = searchParams.get("request_type") || undefined;
     const source = searchParams.get("source") || undefined;
 

--- a/packages/cloud/api/v1/apps/[id]/analytics/requests/route.view.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/requests/route.view.test.ts
@@ -1,0 +1,162 @@
+/**
+ * GET /api/v1/apps/:id/analytics/requests `view` is request-analytics
+ * view identity, not leftover Life Ops views viewType or analytics
+ * periods tax. Stock develop defaulted unknown tokens to stats, so
+ * `view=LOGS` / `STATS` / `foo` returned the stats dashboard.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_c: unknown, err: unknown) => {
+    throw err;
+  },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(() => undefined) },
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { AGGRESSIVE: {}, STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+const ORG_A = "11111111-1111-4111-8111-111111111111";
+const APP_ID = "99999999-9999-4999-8999-000000000001";
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+const getById = mock(async (id: string) =>
+  id === APP_ID ? { id: APP_ID, organization_id: ORG_A } : null,
+);
+const getRecentRequests = mock(async () => ({ requests: [], total: 0 }));
+const getTopVisitors = mock(async () => []);
+const getRequestsOverTime = mock(async () => []);
+const getRequestStats = mock(async () => ({ hits: 1 }));
+const getSessionAnalytics = mock(async () => ({
+  summary: { totalSessions: 0 },
+  sessions: [],
+  funnel: { totalEntrants: 0, steps: [] },
+}));
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: { organization_id: ORG_A },
+    apiKey: null,
+  }),
+}));
+mock.module("@/lib/auth/app-key-scope", () => ({
+  isAppKeyOutOfScope: async () => false,
+}));
+mock.module("@/lib/services/apps", () => ({
+  appsService: {
+    getById,
+    getRecentRequests,
+    getTopVisitors,
+    getRequestsOverTime,
+    getRequestStats,
+  },
+}));
+mock.module("@/lib/services/app-analytics", () => ({
+  appAnalyticsService: { getSessionAnalytics },
+}));
+mock.module("@/lib/api/date-range-params", () => ({
+  parseDateRangeParams: () => ({
+    success: true,
+    startDate: undefined,
+    endDate: undefined,
+  }),
+}));
+
+const { default: analyticsRoute } = await import("./route");
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.route("/api/v1/apps/:id/analytics/requests", analyticsRoute);
+  return app;
+}
+
+function request(query = "") {
+  return buildApp().request(
+    `/api/v1/apps/${APP_ID}/analytics/requests${query}`,
+    {},
+    ENV,
+  );
+}
+
+describe("GET /api/v1/apps/:id/analytics/requests view identity", () => {
+  beforeEach(() => {
+    getById.mockClear();
+    getRecentRequests.mockClear();
+    getTopVisitors.mockClear();
+    getRequestsOverTime.mockClear();
+    getRequestStats.mockClear();
+    getSessionAnalytics.mockClear();
+  });
+
+  test.each(["", "?view="])("accepts %s as stats", async (query) => {
+    const response = await request(query);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { success: boolean; stats: unknown };
+    expect(body.success).toBe(true);
+    expect(body.stats).toEqual({ hits: 1 });
+    expect(getRequestStats).toHaveBeenCalledTimes(1);
+    expect(getRecentRequests).not.toHaveBeenCalled();
+    expect(getTopVisitors).not.toHaveBeenCalled();
+    expect(getRequestsOverTime).not.toHaveBeenCalled();
+    expect(getSessionAnalytics).not.toHaveBeenCalled();
+  });
+
+  test("accepts view=logs as the request log", async () => {
+    const response = await request("?view=logs");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { success: boolean; requests: unknown };
+    expect(body.success).toBe(true);
+    expect(body.requests).toEqual([]);
+    expect(getRecentRequests).toHaveBeenCalledTimes(1);
+    expect(getRequestStats).not.toHaveBeenCalled();
+  });
+
+  test("accepts view=stats as the stats dashboard", async () => {
+    const response = await request("?view=stats");
+    expect(response.status).toBe(200);
+    expect(getRequestStats).toHaveBeenCalledTimes(1);
+    expect(getRecentRequests).not.toHaveBeenCalled();
+  });
+
+  test("accepts view=visitors as top visitors", async () => {
+    const response = await request("?view=visitors");
+    expect(response.status).toBe(200);
+    expect(getTopVisitors).toHaveBeenCalledTimes(1);
+    expect(getRequestStats).not.toHaveBeenCalled();
+  });
+
+  test("accepts view=timeline as the request timeline", async () => {
+    const response = await request("?view=timeline");
+    expect(response.status).toBe(200);
+    expect(getRequestsOverTime).toHaveBeenCalledTimes(1);
+    expect(getRequestStats).not.toHaveBeenCalled();
+  });
+
+  test("accepts view=sessions as session analytics", async () => {
+    const response = await request("?view=sessions");
+    expect(response.status).toBe(200);
+    expect(getSessionAnalytics).toHaveBeenCalledTimes(1);
+    expect(getRequestStats).not.toHaveBeenCalled();
+  });
+
+  test.each(["LOGS", "STATS", "Timeline", "foo", "1e2"])(
+    "rejects view=%s before any view sink",
+    async (token) => {
+      const response = await request(`?view=${token}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_view");
+      expect(getById).not.toHaveBeenCalled();
+      expect(getRecentRequests).not.toHaveBeenCalled();
+      expect(getTopVisitors).not.toHaveBeenCalled();
+      expect(getRequestsOverTime).not.toHaveBeenCalled();
+      expect(getRequestStats).not.toHaveBeenCalled();
+      expect(getSessionAnalytics).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/apps/[id]/analytics/requests/route.view.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/requests/route.view.test.ts
@@ -96,7 +96,10 @@ describe("GET /api/v1/apps/:id/analytics/requests view identity", () => {
   test.each(["", "?view="])("accepts %s as stats", async (query) => {
     const response = await request(query);
     expect(response.status).toBe(200);
-    const body = (await response.json()) as { success: boolean; stats: unknown };
+    const body = (await response.json()) as {
+      success: boolean;
+      stats: unknown;
+    };
     expect(body.success).toBe(true);
     expect(body.stats).toEqual({ hits: 1 });
     expect(getRequestStats).toHaveBeenCalledTimes(1);
@@ -109,7 +112,10 @@ describe("GET /api/v1/apps/:id/analytics/requests view identity", () => {
   test("accepts view=logs as the request log", async () => {
     const response = await request("?view=logs");
     expect(response.status).toBe(200);
-    const body = (await response.json()) as { success: boolean; requests: unknown };
+    const body = (await response.json()) as {
+      success: boolean;
+      requests: unknown;
+    };
     expect(body.success).toBe(true);
     expect(body.requests).toEqual([]);
     expect(getRecentRequests).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on app analytics requests view
identity. Request-analytics view class, not leftover tax on influencer bookings
party, payment-request public, X connectionRole, my-agents sortBy, logs
since, analytics periods, analytics export type, admin redemption status,
share-ingest consume, Life Ops inbox bools, views viewType, relationships
scope, commands surface, approvals state, database-rows sort/page,
memory-viewer type, VFS encoding, models catalogOnly/refresh, Cloud
JSON-400, prefix-coerced limit, percent-encoded paths, SIWS chainId,
orchestrator lines, provisioning-worker env ints, invites-accept,
cli-auth, redemption quote, compat agent-logs, avatar, ingress-map format,
or promote-assets platform. `period=` leftover untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `view` only on `/api/v1/apps/:id/analytics/requests`. Omitted/empty
still returns stats. Exact `logs` / `stats` / `visitors` / `timeline` /
`sessions` still bind that view. Unknown tokens 400 before getById and the
view sinks. Timeline `period` is unchanged.

# Background

## What does this PR do?

`GET /api/v1/apps/:id/analytics/requests` treated every unknown `view` token
as the stats dashboard. `view=LOGS` / `STATS` / `foo` silently called
`getRequestStats` instead of the advertised logs/timeline/sessions views.

- omitted / empty → **200** stats (today's default)
- exact `logs` / `stats` / `visitors` / `timeline` / `sessions` → **200** that view
- `LOGS` / `STATS` / `Timeline` / `foo` / `1e2` → **400** before getById and
  the view sinks

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The route documents `view=logs|stats|visitors|timeline|sessions`. A common
`view=LOGS` must not silently return aggregates. This is request-analytics
view identity, not leftover tax on Life Ops views viewType or analytics
periods.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/apps/[id]/analytics/requests/route.view.test.ts` —
omitted still returns stats; exact views still call the matching sink;
garbage 400s with no view sink called.

## Test commands

```bash
cd packages/cloud/api && bun test v1/apps/[id]/analytics/requests/route.view.test.ts
```

12 passed at the evidence head. Stock develop was 7 passed / 5 failed on the
same table (`view=LOGS` returned 200 stats).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; analytics-requests `view` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; analytics-requests `view` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; analytics-requests `view` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real `view` token and assert 400 before view sinks; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no analytics export; illegal `view` 400 before the view sinks.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal `view`
tokens reject; omitted/canonical still bind the matching view.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file analytics-requests `view`
parse with a green focused suite (12 tests). Full monorepo verify is unrelated
to this query grammar and was skipped to keep the proof tied to the changed
path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6c86b6863989698fbba416b112022b948e963bcb -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
