### PR TITLE
fix(shared): enforce positive bound in parsePositiveFloat with flooring and unify clamp logic

### DIFF
--- a/packages/shared/src/utils/number-parsing.test.ts
+++ b/packages/shared/src/utils/number-parsing.test.ts
@@ -34,6 +34,8 @@ describe("number parsing utilities", () => {
   it("parses positive floats with optional flooring", () => {
     expect(parsePositiveFloat("1.5")).toBe(1.5);
     expect(parsePositiveFloat("1.9", { floor: true })).toBe(1);
+    expect(parsePositiveFloat("0.5", { floor: true, fallback: 3 })).toBe(3);
+    expect(parsePositiveFloat("0.5", { floor: true })).toBeUndefined();
     expect(parsePositiveFloat("-1", { fallback: 3 })).toBe(3);
     expect(parsePositiveFloat("abc", { fallback: 3 })).toBe(3);
   });

--- a/packages/shared/src/utils/number-parsing.ts
+++ b/packages/shared/src/utils/number-parsing.ts
@@ -86,7 +86,8 @@ export function parsePositiveFloat(
     return normalizeFallback(options?.fallback);
   }
 
-  return options?.floor ? Math.floor(parsed) : parsed;
+  const result = options?.floor ? Math.floor(parsed) : parsed;
+  return result > 0 ? result : normalizeFallback(options?.fallback);
 }
 
 export function parseClampedFloat(
@@ -134,9 +135,7 @@ export function parseClampedInteger(
   const parsed = Number(raw);
   if (!Number.isSafeInteger(parsed)) return normalizeFallback(options.fallback);
 
-  const { min, max } = options;
-  if (min !== undefined && parsed < min) return min;
-  if (max !== undefined && parsed > max) return max;
-
-  return parsed;
+  const min = options.min ?? -Infinity;
+  const max = options.max ?? Infinity;
+  return Math.max(min, Math.min(max, parsed));
 }


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/number-parsing.ts`, `parsePositiveFloat` checks that `parsed > 0`. However, when `options.floor` is `true`, fractional numbers in `(0, 1)` evaluated to `Math.floor(parsed) === 0`. The function previously returned `0`, violating the `parsePositiveFloat` type contract (which requires strictly positive results `> 0`). It now ensures `result > 0`, otherwise returning the normalized fallback or `undefined`.
2. In `parseClampedInteger`, replaces ad-hoc branching with canonical `Math.max(min, Math.min(max, parsed))` clamping, making it consistent with `parseClampedFloat`.

Closes #20978.

## Verification

Exact commit: `4fcc3f529e`.

- Focused unit test suite `packages/shared/src/utils/number-parsing.test.ts`: 7/7 tests passing (29 assertions, 100% line & function coverage).
- Typecheck on `@elizaos/shared`: clean pass.
- Biome check on `@elizaos/shared`: 397 files checked, 0 errors, 0 warnings.
- Biome format on `@elizaos/shared`: 397 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - shared utility math/parsing function; no rendered UI changed.
- [x] N/A - shared utility math/parsing function; no rendered UI changed.
- [x] N/A - deterministic utility function behavior.
- [x] Focused test suite transcript:
```text
✓ number parsing utilities > parses positive integers strictly [0.50ms]
✓ number parsing utilities > parses non-negative integers without accepting alternate syntax [0.26ms]
✓ number parsing utilities > parses positive floats with optional flooring [0.36ms]
✓ number parsing utilities > clamps floats and rejects non-finite values [0.20ms]
✓ number parsing utilities > parses clamped integers without accepting partial strings [0.18ms]
✓ number parsing utilities > rejects malformed clamped integers instead of coercing them [0.07ms]
✓ number parsing utilities > rejects unsafe clamped integers [0.04ms]
7 pass, 0 fail, 29 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@78bd11ff6cf9e30a5cbef64ee8db83be59ba96f0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@78bd11ff6cf9e30a5cbef64ee8db83be59ba96f0:packages/skills/skills/contribute-to-eliza"} -->