### PR TITLE
fix(orchestrator): restore Agent typecheck compatibility for Smithers response recovery

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-integration.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-integration.test.ts
@@ -73,14 +73,19 @@ describe("runDurableTask", () => {
   );
 
   it(
-    "recovers a completed response without another ACP prompt after restart",
+    "recovers the newest completed response without another ACP prompt after restart",
     async () => {
       const session = uniqueSession();
       const durableResponse = `durable-${"x".repeat(128 * 1024)}-tail`;
-      const sendPrompt = vi.fn(async () => ({
-        stopReason: "end_turn",
-        finalText: durableResponse,
-      }));
+      const responses = [
+        { stopReason: "max_tokens", finalText: "older partial response" },
+        { stopReason: "end_turn", finalText: durableResponse },
+      ];
+      const sendPrompt = vi.fn(async () => {
+        const response = responses.shift();
+        if (!response) throw new Error("unexpected extra ACP prompt");
+        return response;
+      });
       const service: AcpTaskService = {
         sendPrompt,
         cancelSession: cancellation(),
@@ -88,17 +93,21 @@ describe("runDurableTask", () => {
 
       const first = await runDurableTask(service, session, "do it once", {
         tenantId,
+        maxTurns: 2,
       });
       expect(first.lastResponse).toBe(durableResponse);
-      expect(sendPrompt).toHaveBeenCalledTimes(1);
+      expect(first.turns).toBe(2);
+      expect(sendPrompt).toHaveBeenCalledTimes(2);
 
       sendPrompt.mockClear();
       const resumed = await runDurableTask(service, session, "do it once", {
         tenantId,
+        maxTurns: 2,
       });
       expect(sendPrompt).not.toHaveBeenCalled();
       expect(resumed.lastResponse).toBe(durableResponse);
       expect(resumed.status).toBe("completed");
+      expect(resumed.turns).toBe(2);
     },
     TIMEOUT,
   );

--- a/plugins/plugin-agent-orchestrator/src/services/smithers-task-integration.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/smithers-task-integration.ts
@@ -56,6 +56,16 @@ function nonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function findLastNonEmptyString(
+  values: readonly unknown[],
+): string | undefined {
+  for (let index = values.length - 1; index >= 0; index -= 1) {
+    const value = values[index];
+    if (nonEmptyString(value)) return value;
+  }
+  return undefined;
+}
+
 function approvalPreset(value: unknown): ApprovalPreset | undefined {
   return value === "readonly" ||
     value === "standard" ||
@@ -253,12 +263,11 @@ export async function runDurableTask(
       severity: "ephemeral",
     });
   }
-  const recoveredResponse = collectDurableTaskTurns(result.execution)
-    .map((turn) => turn.output?.finalText)
-    .findLast(
-      (value): value is string =>
-        typeof value === "string" && value.trim().length > 0,
-    );
+  const recoveredResponse = findLastNonEmptyString(
+    collectDurableTaskTurns(result.execution).map(
+      (turn) => turn.output?.finalText,
+    ),
+  );
   const lastResponse = executor.lastResponse ?? recoveredResponse;
   if (typeof lastResponse !== "string" || lastResponse.trim().length === 0) {
     throw new ElizaError("Durable task completed without a response", {


### PR DESCRIPTION
# Relates to

Fixes #20977

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and was rebased onto the synchronized `origin/develop` snapshot below with zero conflicts.
- [x] Frozen install, focused tests, affected typechecks/lint/builds, and root verification were run after sync.
- [x] Exact-head evidence is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@f3fc142b6d71827455e404ca6b451eef5f5c4082`; zero conflicts.
- [x] `bun run verify` was run post-sync; the unrelated portable-toolchain blocker is documented below.

# Risks

Low. The patch replaces one ES2023 array method with an explicit reverse scan while preserving the newest-non-empty-string predicate. Smithers persistence, task lifecycle, ACP transport, public APIs, and runtime targets are unchanged.

# Background

## What does this PR do?

- Removes the `Array.prototype.findLast` dependency from completed-turn response recovery, restoring Agent package typecheck compatibility.
- Preserves newest-to-oldest recovery and blank-output filtering.
- Strengthens restart coverage with two persisted turns and proves no ACP prompt is replayed after recovery.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. Runtime behavior and public configuration remain unchanged.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-integration.test.ts`

## Detailed testing steps

Using repository-pinned Bun 1.3.14 and Node 24.15.0:

```text
$ bun install --frozen-lockfile --ignore-scripts
Frozen install completed after retrying two transient Windows package links

$ bunx vitest run --config vitest.config.ts __tests__/unit/smithers-task-integration.test.ts --coverage.enabled=false
Test Files  1 passed (1)
Tests       10 passed (10)

$ bun run --cwd plugins/plugin-agent-orchestrator typecheck
exit 0

$ bun run --cwd packages/agent typecheck
exit 0

$ bunx @biomejs/biome check plugins/plugin-agent-orchestrator --no-errors-on-unmatched
Checked 406 files. No fixes applied.

$ bun run --cwd plugins/plugin-agent-orchestrator build
Node ESM, CJS, and TypeScript declarations built successfully

$ bun run --cwd packages/agent build
[rewrite-dist-relative-imports] rewrote 194 file(s)
exit 0
```

The production-service test persists an older partial output followed by the newest completed output, then a fresh executor recovers the newest response with zero additional ACP prompts.

# Evidence Gate

<!-- evidence-head:fc46190ff8685393f426c9d7b3b5e21b113a5164 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - TypeScript service compatibility fix; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - TypeScript service compatibility fix; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic durable-run recovery with no user interface.
<!-- evidence-row:backend-logs -->
- [x] Exact-head 10/10 service transcript and both consuming-package typechecks are included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic ACP stubs; no prompt/provider/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The persisted two-turn execution and restart/no-replay transcript is the applicable domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this is compatibility-only lookup of already persisted deterministic Smithers output.

## Backend + frontend logs

Backend evidence is the exact-head transcript and successful typechecks above. Frontend logs are N/A.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- `bun run verify` passes repository preflights through workspace resolution, then Turbo stops with `Unable to find package manager binary: cannot find binary path` under the pinned portable Windows Bun/Node toolchain. Both affected package typechecks, builds, lint, and focused tests pass.
- The package `lint:check` script delegates to a nested `bunx` that the portable child process did not locate; its exact Biome command was run directly and passes all 406 files.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@f3fc142b6d71827455e404ca6b451eef5f5c4082:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-smithers-response-compat]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@f3fc142b6d71827455e404ca6b451eef5f5c4082:packages/skills/skills/contribute-to-eliza"} -->
