### PR TITLE
fix(build): keep generated desktop brand data ephemeral

### DIFF
--- a/packages/app-core/platforms/electrobun/electrobun.config.ts
+++ b/packages/app-core/platforms/electrobun/electrobun.config.ts
@@ -299,7 +299,7 @@ const defaultBrandConfigPath = path.join(
 );
 const generatedBrandConfigPath = path.join(
   electrobunDir,
-  ".generated",
+  "tmp",
   "brand-config.json",
 );
 const libMacWindowEffectsDylib = path.join(

--- a/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
@@ -1,6 +1,9 @@
 /** Exercises electrobun config behavior with deterministic app-core test fixtures. */
+import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  createElectrobunConfig,
   resolveElectrobunCopyMap,
   shouldEmbedRuntimeBundle,
 } from "../electrobun.config";
@@ -75,5 +78,34 @@ describe("Electrobun Store packaging", () => {
       Object.values(copy).some((target) => target.startsWith("eliza-dist/")),
     ).toBe(true);
     expect(Object.values(copy)).toContain("eliza-dist/package.json");
+  });
+
+  it("keeps generated brand overrides outside tracked source", () => {
+    const originalNamespace = process.env.ELIZA_NAMESPACE;
+    const outputPath = path.resolve(
+      import.meta.dirname,
+      "..",
+      "tmp",
+      "brand-config.json",
+    );
+
+    try {
+      process.env.ELIZA_NAMESPACE = "eliza-test";
+      createElectrobunConfig();
+
+      expect(JSON.parse(fs.readFileSync(outputPath, "utf8"))).toMatchObject({
+        appName: "Eliza",
+        appId: "ai.elizaos.app",
+        namespace: "eliza-test",
+        urlScheme: "elizaos",
+      });
+    } finally {
+      if (originalNamespace === undefined) {
+        delete process.env.ELIZA_NAMESPACE;
+      } else {
+        process.env.ELIZA_NAMESPACE = originalNamespace;
+      }
+      fs.rmSync(outputPath, { force: true });
+    }
   });
 });

--- a/packages/docs/action-catalog.md
+++ b/packages/docs/action-catalog.md
@@ -15,7 +15,7 @@ This catalog is generated from `packages/prompts/specs/**` by `bun run --cwd pac
 - **Plugin overlay actions:** 11
 - **Canonical providers:** 23
 - **Core providers:** 23
-- **Registered runtime actions:** 168
+- **Registered runtime actions:** 170
 
 ## Actions
 
@@ -411,6 +411,7 @@ list. Regenerate this document after changing the registered action surface.
 - `GET_APP` — `plugins/plugin-cloud-apps/src/actions/get-app.ts`
 - `GET_APP_DEPLOY_STATUS` — `plugins/plugin-cloud-apps/src/actions/get-app-deploy-status.ts`
 - `GET_APP_EARNINGS` — `plugins/plugin-cloud-apps/src/actions/get-app-earnings.ts`
+- `GET_COMPANION_STATUS` — `plugins/plugin-companion/src/actions.ts`
 - `GET_MEETING_TRANSCRIPT` — `plugins/plugin-meetings/src/actions/get-meeting-transcript.ts`
 - `GITHUB` — `plugins/plugin-github/src/actions/github.ts`
 - `HOUSEHOLD_COORDINATION` — `plugins/plugin-personal-assistant/src/actions/household-coordination.ts`
@@ -485,6 +486,7 @@ list. Regenerate this document after changing the registered action surface.
 - `SECURITY_EVALUATOR` — `packages/core/src/features/trust/evaluators/securityEvaluator.ts`
 - `SEND_MEDIA_TO` — `packages/agent/src/actions/knowledge.ts`
 - `SET_AD_CAMPAIGN_DAYPARTING` — `plugins/plugin-cloud-apps/src/actions/ad-campaigns.ts`
+- `SET_COMPANION_MOOD` — `plugins/plugin-companion/src/actions.ts`
 - `SET_FOLLOWUP_THRESHOLD` — `plugins/plugin-personal-assistant/src/followup/actions/setFollowupThreshold.ts`
 - `SETTINGS` — `packages/agent/src/actions/settings-actions.ts`, `plugins/plugin-app-control/src/actions/settings.ts`
 - `SHARE_TRANSCRIPT` — `plugins/plugin-local-inference/src/actions/transcript-permissioning.ts`


### PR DESCRIPTION
# Relates to

Closes #20987.

- [x] Targets `develop` at exact base `7387bbaf57acd39c7ca7be51aad27cc126b761b5` with zero conflicts.
- [x] Repository `lint`, `build`, and `typecheck` passed on the exact base before this bounded repair; focused post-repair gates are below.
- [x] The generated output and regression test make the behavior independently reviewable.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact parent is current `origin/develop`; zero conflicts.
- [x] Exact base gates: `bun run lint` 134/134, `bun run build` 124/124, `bun run typecheck` 222/222.

# Risks

Low. Electrobun brand overrides move from a tracked source directory to the already ignored build-temp directory. The package copy map still receives the generated file. The action-catalog change is generated documentation only.

# Background

## What does this PR do?

- Prevents normal direct desktop builds from overwriting the tracked cloud-only brand fixture.
- Adds a focused config regression proving override output is generated under `tmp/`.
- Regenerates the runtime action catalog so the two companion actions shipped by #20436 are listed.

## What kind of change is this?

Bug fix and generated documentation refresh.

# Documentation changes needed?

The generated action catalog is updated in this PR.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/electrobun.config.ts` and its focused config test.

## Detailed testing steps

- Focused Electrobun config: 6/6 tests pass.
- Electrobun typecheck passes.
- Exact changed-file Biome passes.
- `git diff --check` passes.

# Evidence Gate

<!-- evidence-head:672cd5362e7639d7f4ce2a1332235dc88b1a7a33 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - build-output hygiene has no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action behavior, or provider changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact; the generated catalog diff and brand-output regression are directly reviewable in the PR.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changes.

# Evidence Details

## Known gaps / failures

No deployment was performed or required. The root build before this repair passed but dirtied the tracked brand fixture; the focused regression proves subsequent config generation uses ignored build output instead.

— [codex/build-generated-contracts]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"Codex Desktop","skill_revision":"N/A"} -->
