### PR TITLE
fix(core): reject non-finite target budgets and clamp invalid item estimates in sliceToFitBudget

### DIFF
--- a/packages/core/src/utils/slice-to-fit-budget.test.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.test.ts
@@ -54,6 +54,7 @@ describe("sliceToFitBudget", () => {
 	it("returns empty for a zero or negative budget", () => {
 		expect(sliceToFitBudget(["a"], byLength, 0)).toEqual([]);
 		expect(sliceToFitBudget(["a"], byLength, -10)).toEqual([]);
+		expect(sliceToFitBudget(["a", "b"], byLength, Number.NaN)).toEqual([]);
 	});
 
 	it("treats a zero budget as no room even for a zero-cost item", () => {
@@ -62,10 +63,17 @@ describe("sliceToFitBudget", () => {
 		// wants nothing back, so the guard is load-bearing rather than cosmetic.
 		expect(sliceToFitBudget([""], byLength, 0)).toEqual([]);
 		expect(sliceToFitBudget([""], byLength, 0, { fromEnd: true })).toEqual([]);
+		expect(sliceToFitBudget([""], byLength, Number.NaN)).toEqual([]);
 	});
 
 	it("keeps zero-cost items when there is any budget at all", () => {
 		expect(sliceToFitBudget(["", "", "a"], byLength, 1)).toEqual(["", "", "a"]);
+	});
+
+	it("sanitizes invalid or negative estimator returns", () => {
+		const items = ["a", "b", "c"];
+		expect(sliceToFitBudget(items, () => Number.NaN, 5)).toEqual(items);
+		expect(sliceToFitBudget(items, () => -10, 5)).toEqual(items);
 	});
 
 	describe("fromEnd", () => {

--- a/packages/core/src/utils/slice-to-fit-budget.test.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.test.ts
@@ -55,6 +55,12 @@ describe("sliceToFitBudget", () => {
 		expect(sliceToFitBudget(["a"], byLength, 0)).toEqual([]);
 		expect(sliceToFitBudget(["a"], byLength, -10)).toEqual([]);
 		expect(sliceToFitBudget(["a", "b"], byLength, Number.NaN)).toEqual([]);
+		expect(
+			sliceToFitBudget(["a", "b"], byLength, Number.POSITIVE_INFINITY),
+		).toEqual([]);
+		expect(
+			sliceToFitBudget(["a", "b"], byLength, Number.NEGATIVE_INFINITY),
+		).toEqual([]);
 	});
 
 	it("treats a zero budget as no room even for a zero-cost item", () => {
@@ -70,10 +76,21 @@ describe("sliceToFitBudget", () => {
 		expect(sliceToFitBudget(["", "", "a"], byLength, 1)).toEqual(["", "", "a"]);
 	});
 
-	it("sanitizes invalid or negative estimator returns", () => {
+	it("rejects invalid or negative estimator returns", () => {
 		const items = ["a", "b", "c"];
-		expect(sliceToFitBudget(items, () => Number.NaN, 5)).toEqual(items);
-		expect(sliceToFitBudget(items, () => -10, 5)).toEqual(items);
+		for (const invalidSize of [
+			Number.NaN,
+			Number.POSITIVE_INFINITY,
+			Number.NEGATIVE_INFINITY,
+			-10,
+		]) {
+			expect(() => sliceToFitBudget(items, () => invalidSize, 5)).toThrow(
+				RangeError,
+			);
+			expect(() =>
+				sliceToFitBudget(items, () => invalidSize, 5, { fromEnd: true }),
+			).toThrow("estimateChars must return a non-negative finite number");
+		}
 	});
 
 	describe("fromEnd", () => {

--- a/packages/core/src/utils/slice-to-fit-budget.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.ts
@@ -5,6 +5,9 @@
  * WHY: Providers often fetch a superset of data, then need to keep prompt size
  * bounded. One fetch + in-memory selection avoids extra DB round trips while
  * still adapting to item size (short items -> more fit, long items -> fewer).
+ *
+ * @throws {RangeError} When `estimateChars` returns a negative or non-finite
+ *   value, because treating a broken estimate as free would violate the budget.
  */
 
 export function sliceToFitBudget<T>(
@@ -24,7 +27,12 @@ export function sliceToFitBudget<T>(
 	// Calculate all sizes upfront to avoid double estimation
 	const sizes = items.map((item) => {
 		const size = estimateChars(item);
-		return Number.isFinite(size) && size > 0 ? size : 0;
+		if (!Number.isFinite(size) || size < 0) {
+			throw new RangeError(
+				"estimateChars must return a non-negative finite number",
+			);
+		}
+		return size;
 	});
 
 	if (fromEnd) {

--- a/packages/core/src/utils/slice-to-fit-budget.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.ts
@@ -14,15 +14,18 @@ export function sliceToFitBudget<T>(
 	options?: { fromEnd?: boolean },
 ): T[] {
 	if (items.length === 0) return [];
-	// Zero or negative budget means no room - return empty array
-	if (targetChars <= 0) return [];
+	// Zero, negative, or non-finite budget means no room - return empty array
+	if (!Number.isFinite(targetChars) || targetChars <= 0) return [];
 
 	const fromEnd = options?.fromEnd ?? false;
 	let total = 0;
 	let count = 0;
 
 	// Calculate all sizes upfront to avoid double estimation
-	const sizes = items.map(estimateChars);
+	const sizes = items.map((item) => {
+		const size = estimateChars(item);
+		return Number.isFinite(size) && size > 0 ? size : 0;
+	});
 
 	if (fromEnd) {
 		for (let index = items.length - 1; index >= 0; index--) {


### PR DESCRIPTION
# Summary

Closes #20984. `sliceToFitBudget` now returns an empty selection for non-finite/non-positive target budgets and rejects invalid estimator output.

The review changed the original invalid-estimator approach: silently converting `NaN`, infinity, or negative estimates to zero would admit those items as free and fabricate a healthy budget result. Because `estimateChars` is an internal contract, the utility now throws `RangeError` for a negative or non-finite estimate. Valid zero-cost items remain supported.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash, openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity, Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@cf868392a3a725f5f05b5285602816bcfa839eca:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Exact-head verification

- Candidate: `08862fd66e2ac303f2f3c51062b59868991f898b`, rebased on `cf868392a3a725f5f05b5285602816bcfa839eca`.
- Pinned Bun 1.3.14 focused Vitest: `17 passed, 0 failed`.
- Tests cover `NaN`, both infinities, negative targets, both iteration directions, invalid estimators, and legitimate zero-cost items.
- `packages/core` typecheck: exit 0.
- Biome: 2 files checked, no fixes; `git diff --check` clean.

# Risks

Low. The single production caller returns finite positive estimates. Invalid estimator output now surfaces a programming error instead of bypassing the prompt-size budget. The estimator is still called exactly once per item, and forward/from-end contiguous selection behavior is unchanged.

# Evidence Gate

<!-- evidence-head:08862fd66e2ac303f2f3c51062b59868991f898b -->
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - deterministic core budgeting utility; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - deterministic core budgeting utility; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no UI workflow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:

  ```text
  RUN v4.1.5 packages/core
  Test Files 1 passed (1); Tests 17 passed (17)
  packages/core typecheck: exit 0
  Biome: Checked 2 files. No fixes applied.
  ```
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend path changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - utility contract only; no model/provider behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts:

  ```text
  NaN/+Infinity/-Infinity/non-positive target => []
  NaN/+Infinity/-Infinity/negative estimate => RangeError in forward and fromEnd modes
  zero estimate with a positive budget remains valid and selected
  one production caller audited: its estimate is an addition of bounded string lengths
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no rendered surface`.

---
— [codex-root/pr-20989-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@cf868392a3a725f5f05b5285602816bcfa839eca:packages/skills/skills/contribute-to-eliza"} -->
