### PR TITLE
perf(cloud): preserve Discord Shared timing split

### DIFF
--- a/packages/cloud/api/internal/discord/eliza-app/messages/route.test.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/messages/route.test.ts
@@ -1,0 +1,66 @@
+/** Verifies that the Discord service wrapper preserves Personal Shared timing. */
+
+import { expect, mock, test } from "bun:test";
+
+const personalSharedRequest = mock(
+  async () =>
+    new Response(
+      JSON.stringify({
+        success: true,
+        data: {
+          identity: { id: "11111111-1111-4111-8111-111111111111" },
+          account: {
+            userId: "22222222-2222-4222-8222-222222222222",
+            organizationId: "33333333-3333-4333-8333-333333333333",
+          },
+          reply: "ready",
+        },
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Server-Timing":
+            'account;dur=14.2;desc="sender-projection-hit", prewarm;dur=1.1, shared;dur=472.8',
+        },
+      },
+    ),
+);
+
+mock.module("../../../eliza-app/personal-shared/messages/route", () => ({
+  default: { request: personalSharedRequest },
+}));
+
+const { default: app } = await import("./route");
+const executionCtx = {
+  waitUntil() {},
+  passThroughOnException() {},
+  props: {},
+};
+
+test("forwards the Personal Shared account, prewarm, and runtime split", async () => {
+  const response = await app.request(
+    "http://localhost/",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-secret",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        channelId: "444444444444444444",
+        messageId: "555555555555555555",
+        content: "hello",
+        sender: { id: "666666666666666666", username: "tester" },
+      }),
+    },
+    { INTERNAL_SECRET: "test-secret" } as never,
+    executionCtx as never,
+  );
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("Server-Timing")).toBe(
+    'account;dur=14.2;desc="sender-projection-hit", prewarm;dur=1.1, shared;dur=472.8',
+  );
+  expect(personalSharedRequest).toHaveBeenCalledTimes(1);
+});

--- a/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
@@ -107,6 +107,12 @@ app.post("/", async (c) => {
       c.env,
       c.executionCtx,
     );
+    const personalSharedTiming = response.headers.get("Server-Timing");
+    if (personalSharedTiming) {
+      // The Discord gateway cannot optimize a slow turn if the internal
+      // wrapper erases the account, prewarm, and Shared runtime split.
+      c.header("Server-Timing", personalSharedTiming);
+    }
     const payload = (await response.json()) as {
       success?: boolean;
       error?: string;

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -2621,6 +2621,12 @@ export class GatewayManager {
         elapsedMs: Date.now() - startedAt,
         attempts: outcome.attempts,
         ok: outcome.ok,
+        ...(outcome.ok
+          ? {
+              traceId: outcome.traceId,
+              serverTiming: outcome.serverTiming,
+            }
+          : {}),
       });
 
       if (!outcome.ok) {

--- a/packages/cloud/services/gateway-discord/src/managed-message-egress.ts
+++ b/packages/cloud/services/gateway-discord/src/managed-message-egress.ts
@@ -29,7 +29,13 @@ function isRoutedManagedReply(value: unknown): value is RoutedManagedReply {
 }
 
 export type ManagedRouteOutcome =
-  | { ok: true; routed: RoutedManagedReply; attempts: number }
+  | {
+      ok: true;
+      routed: RoutedManagedReply;
+      attempts: number;
+      traceId: string | null;
+      serverTiming: string | null;
+    }
   | {
       ok: false;
       attempts: number;
@@ -141,13 +147,21 @@ export async function postManagedAgentMessageWithRetry(options: {
     if (response) {
       if (response.ok) {
         try {
+          const traceId = response.headers.get("X-Eliza-Trace-Id");
+          const serverTiming = response.headers.get("Server-Timing");
           const routed: unknown = await response.json();
           if (!isRoutedManagedReply(routed)) {
             throw new TypeError(
               "managed route returned an invalid reply object",
             );
           }
-          return { ok: true, routed, attempts: attempt };
+          return {
+            ok: true,
+            routed,
+            attempts: attempt,
+            traceId,
+            serverTiming,
+          };
         } catch (error) {
           // error-policy:J4 A malformed success response is not delivered as a
           // healthy reply; expose it and retry the idempotent upstream turn.

--- a/packages/cloud/services/gateway-discord/tests/managed-message-egress.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/managed-message-egress.test.ts
@@ -209,6 +209,30 @@ describe("postManagedAgentMessageWithRetry", () => {
     expect(slept).toBe(false);
     expect(refreshed).toBe(false);
   });
+
+  test("preserves the successful Cloud trace and inner timing split", async () => {
+    const outcome = await postManagedAgentMessageWithRetry({
+      doPost: async () =>
+        new Response(JSON.stringify({ handled: true, replyText: "ready" }), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "X-Eliza-Trace-Id": "trace-discord-1",
+            "Server-Timing":
+              'account;dur=14.2;desc="sender-projection-hit", prewarm;dur=1.1, shared;dur=472.8',
+          },
+        }),
+      sleep: noSleep,
+    });
+
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.traceId).toBe("trace-discord-1");
+      expect(outcome.serverTiming).toBe(
+        'account;dur=14.2;desc="sender-projection-hit", prewarm;dur=1.1, shared;dur=472.8',
+      );
+    }
+  });
 });
 
 describe("isRetryableRouteStatus", () => {


### PR DESCRIPTION
## Summary
- preserve Personal Shared `account / prewarm / shared` Server-Timing through the internal Discord wrapper
- bind the successful Cloud trace and timing split to the gateway's existing per-turn completion log
- leave routing, authentication, retry, typing, reply, and delivery behavior unchanged

Part of #20313
Part of #16079

## Real staging defect
Exact serving Worker `78bd11ff6c23234edf5c6ed712ef694661a1645a` / version `c4c5d095-ca7e-4706-b2ca-b0839f43013a`; gateway-discord deployment `84631d9d-22ba-476c-a3d6-9153bf667df1`.

Three authenticated Eliza Dev DM turns were correct, single-attempt, and slow:
- 15,551ms
- 15,768ms
- 9,629ms

The final Cloud route alone took 7,775ms under trace `3ec761d6-b702-4307-ae33-51573297730f`, while an adjacent Shared Cerebras inference span was 471ms. The wrapper discarded the existing inner Server-Timing, so account resolution, prewarm, and Shared runtime could not be separated in the gateway log.

Live receipt: https://github.com/elizaOS/eliza/issues/20313#issuecomment-5312645168
Fleet checkpoint: https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18047933

## Verification
Exact head `9fce48fce047e134319d082c6eadfc762236b9fe` on base `0b60149e2e9908cc4e4179e34745c4cc0df60e25`.

- gateway managed egress: 20/20, 65 assertions
- internal Discord wrapper: 1/1, 3 assertions
- Personal Shared route regression: 26/26, 115 assertions
- gateway-discord typecheck: PASS
- Cloud API typecheck: PASS
- production Worker dry bundle: PASS, 25,895.45 KiB / 6,296.05 KiB gzip
- Biome exact five paths: PASS
- `git diff --check`: PASS

## Evidence matrix
- Real model trajectory: N/A — this patch does not change model/action/prompt behavior; the live inference timing receipt above is the measured input to the change.
- Backend logs: attached inline above via exact trace/timing receipt.
- Frontend screenshots/video: N/A — no UI behavior changes.
- Domain artifacts: the post-deploy acceptance artifact is one gateway completion log carrying exact trace plus `account / prewarm / shared / cloud_worker` timing. Protected staging proof follows legitimate review/merge.
- Production: untouched.
