### PR TITLE
fix(orchestrator): preserve contained route workdirs

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/resolve-spawn-workdir.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/resolve-spawn-workdir.test.ts
@@ -381,6 +381,7 @@ describe("route identity follows the directory (#20794 stamp gap)", () => {
     );
     expect(result.workdir).toBe(appDir);
     expect(result.route?.id).toBe("agent-home");
+    expect(result.route?.workdir).toBe(fs.realpathSync(appDir));
   });
 
   it("a locked workdir inside the route tree carries the route while honoring the lock", () => {
@@ -471,5 +472,79 @@ describe("route identity follows the directory (#20794 stamp gap)", () => {
     );
     expect(result.workdir).toBe(fs.realpathSync(routeRoot));
     expect(result.route?.id).toBe("agent-home");
+  });
+
+  it("selects the closest containing route regardless of configuration order", () => {
+    const runtime = {
+      getSetting: (key: string) =>
+        key === "TASK_AGENT_WORKDIR_ROUTES"
+          ? JSON.stringify([
+              {
+                id: "broad",
+                workdir: routeRoot,
+                matchAny: ["never-broad"],
+              },
+              {
+                id: "app",
+                workdir: path.dirname(appDir),
+                matchAny: ["never-app"],
+              },
+            ])
+          : undefined,
+    } as never;
+
+    const result = resolveSpawnWorkdir(
+      runtime,
+      NO_ROUTE_TASK,
+      NO_ROUTE_TASK,
+      appDir,
+    );
+
+    expect(result.route?.id).toBe("app");
+    expect(result.route?.workdir).toBe(fs.realpathSync(appDir));
+  });
+
+  it("does not inherit a broad shared route across a nested repository boundary", () => {
+    fs.writeFileSync(path.join(appDir, ".git"), "gitdir: elsewhere\n");
+
+    const result = resolveSpawnWorkdir(
+      runtimeWithRoutes(),
+      NO_ROUTE_TASK,
+      NO_ROUTE_TASK,
+      appDir,
+    );
+
+    expect(result.route).toBeUndefined();
+  });
+
+  it("allows a route configured at a nested repository root", () => {
+    fs.writeFileSync(path.join(appDir, ".git"), "gitdir: elsewhere\n");
+    const runtime = {
+      getSetting: (key: string) =>
+        key === "TASK_AGENT_WORKDIR_ROUTES"
+          ? JSON.stringify([
+              {
+                id: "broad",
+                workdir: routeRoot,
+                matchAny: ["never-broad"],
+              },
+              {
+                id: "nested-repository",
+                workdir: appDir,
+                matchAny: ["never-nested"],
+              },
+            ])
+          : undefined,
+    } as never;
+
+    const result = resolveSpawnWorkdir(
+      runtime,
+      NO_ROUTE_TASK,
+      NO_ROUTE_TASK,
+      appDir,
+    );
+
+    expect(result.route?.id).toBe("nested-repository");
+    expect(result.route?.workdir).toBe(fs.realpathSync(appDir));
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
@@ -2,6 +2,9 @@
  * Verifies TASKS:spawn_agent.
  * Deterministic unit test with a stubbed runtime; no live model.
  */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { promoteSubactionsToActions } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 // SPAWN_AGENT is `TASKS { action: "spawn_agent" }`.
@@ -396,6 +399,52 @@ describe("TASKS:spawn_agent", () => {
     } finally {
       if (oldRoutes === undefined) delete process.env.TASK_AGENT_WORKDIR_ROUTES;
       else process.env.TASK_AGENT_WORKDIR_ROUTES = oldRoutes;
+    }
+  });
+
+  it("keeps an explicit nested workdir when reverse lookup attaches its route", async () => {
+    const oldRoutes = process.env.TASK_AGENT_WORKDIR_ROUTES;
+    const routeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "spawn-route-"));
+    const appDir = path.join(routeRoot, "data", "apps", "wind-chimes");
+    fs.mkdirSync(appDir, { recursive: true });
+    process.env.TASK_AGENT_WORKDIR_ROUTES = JSON.stringify([
+      {
+        id: "agent-home",
+        workdir: routeRoot,
+        matchAny: ["wording-that-does-not-match"],
+      },
+    ]);
+    try {
+      const svc = serviceMock();
+      const result = await spawnAgentAction.handler(
+        runtimeWith(svc),
+        memory({
+          task: "Polish the chimes.",
+          agentType: "opencode",
+          workdir: appDir,
+        }),
+        state,
+        spawnOptions,
+        callback(),
+      );
+
+      expect(result?.success).toBe(true);
+      const call = svc.spawnSession.mock.calls[0]?.[0] as {
+        initialTask?: string;
+        metadata?: Record<string, unknown>;
+        workdir?: string;
+      };
+      expect(call.workdir).toBe(fs.realpathSync(appDir));
+      expect(call.metadata?.workdirRouteId).toBe("agent-home");
+      expect(call.metadata?.workdirRoute).toMatchObject({
+        id: "agent-home",
+        workdir: fs.realpathSync(appDir),
+      });
+      expect(call.initialTask).toContain(`workdir: ${fs.realpathSync(appDir)}`);
+    } finally {
+      if (oldRoutes === undefined) delete process.env.TASK_AGENT_WORKDIR_ROUTES;
+      else process.env.TASK_AGENT_WORKDIR_ROUTES = oldRoutes;
+      fs.rmSync(routeRoot, { recursive: true, force: true });
     }
   });
 

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
@@ -319,6 +319,10 @@ export function resolveRouteForWorkdir(
     // directory. Callers will retain their normal route-less fallback.
     return undefined;
   }
+  const candidates: Array<{
+    route: WorkdirRoute;
+    canonicalRouteRoot: string;
+  }> = [];
   for (const route of configuredWorkdirRoutes(runtime)) {
     const expanded = expandHomePath(route.workdir);
     let canonicalRouteRoot: string;
@@ -333,10 +337,40 @@ export function resolveRouteForWorkdir(
     const contained =
       relative === "" ||
       (!relative.startsWith("..") && !path.isAbsolute(relative));
-    if (!contained) continue;
+    if (contained) candidates.push({ route, canonicalRouteRoot });
+  }
+  // A route table may intentionally contain a broad checkout plus narrower
+  // project routes. Directory ownership belongs to the closest configured
+  // ancestor, independent of JSON ordering.
+  candidates.sort(
+    (left, right) =>
+      right.canonicalRouteRoot.length - left.canonicalRouteRoot.length,
+  );
+  for (const { route, canonicalRouteRoot } of candidates) {
+    // Do not let a broad shared-checkout route cross into a nested repository
+    // or worktree. Its residuals exemption would otherwise suppress the nested
+    // repository's own uncommitted/unpushed work. A route configured at the
+    // nested repository root remains eligible because its own .git marker is
+    // the boundary, not something crossed beneath it.
+    let cursor = target;
+    let crossesNestedRepository = false;
+    while (cursor !== canonicalRouteRoot) {
+      if (fs.existsSync(path.join(cursor, ".git"))) {
+        crossesNestedRepository = true;
+        break;
+      }
+      const parent = path.dirname(cursor);
+      if (parent === cursor) break;
+      cursor = parent;
+    }
+    if (crossesNestedRepository) continue;
     return {
       id: route.id,
-      workdir: canonicalRouteRoot,
+      // ResolvedWorkdirRoute is persisted and inherited by later sub-agent
+      // turns, so it must carry the session's actual directory rather than the
+      // configured ancestor. Otherwise TASKS:spawn_agent relocates the session
+      // through `effectiveRoute.workdir` after resolution.
+      workdir: target,
       instructions: route.instructions,
       urlMappings: route.urlMappings,
     };


### PR DESCRIPTION
Follow-up repair for #20969; related to #20794.

## Root defect

The merged reverse lookup attached a containing route with the configured route root in `route.workdir`. `TASKS:spawn_agent` subsequently selects `effectiveRoute.workdir`, so an explicit nested app workdir was silently relocated to the route root. The resolver-only test did not exercise that action boundary.

The same lookup also selected the first containing route by JSON order and could apply a broad shared-route residuals exemption across a nested Git repository/worktree boundary.

## Repair

- Persist the actual canonical session directory in the resolved route so the initial spawn and inherited follow-up turns stay in the chosen directory.
- Select the closest containing configured route independent of route-table order.
- Do not inherit a broad shared-checkout route across a nested `.git` boundary; an explicitly configured nested repository route remains eligible.
- Add action-level coverage for the exact nested explicit-workdir spawn path and resolver coverage for nested routes/repositories.

## Exact provenance

- Merged source PR: #20969
- Merged source commit: `0b60149e2e9908cc4e4179e34745c4cc0df60e25`
- Current base used for this follow-up: `158bec60d05df82a1d0ff95e34f02a3dd8cd5fc9`
- Exact follow-up head: `0ae63146c6caa356a694e120271235c4f8e56783`
- Provenance: bounded post-merge repair from independent exact-head review of #20969.

## Validation at exact head

- Focused Vitest: 2 files, 55 tests passed.
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`: passed.
- Biome check on all 3 touched files: passed.
- `git diff --check origin/develop...HEAD`: passed.

## Evidence boundary

These deterministic tests exercise the real resolver and TASKS action-to-session handoff. No live box/dist rebuild or wind-chimes connector rerun was performed, so this is not live integration or deployment evidence. No deploy is included.