### PR TITLE
fix(cloud): reject unknown advertising campaign list filters

### DIFF
--- a/packages/cloud/api/v1/advertising/campaigns/route.filters.test.ts
+++ b/packages/cloud/api/v1/advertising/campaigns/route.filters.test.ts
@@ -7,6 +7,10 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import {
+  AdPlatformSchema,
+  CampaignStatusSchema,
+} from "@/lib/services/advertising/schemas";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 mock.module("@/lib/api/cloud-worker-errors", () => ({
@@ -68,29 +72,31 @@ describe("GET /api/v1/advertising/campaigns list-filter identity", () => {
     },
   );
 
-  test("accepts platform=meta as the Meta campaign catalog", async () => {
-    const response = await request("?platform=meta");
-    expect(response.status).toBe(200);
-    expect(listCampaigns).toHaveBeenCalledTimes(1);
-    expect(listCampaigns).toHaveBeenCalledWith("org-1", {
-      adAccountId: undefined,
-      platform: "meta",
-      status: undefined,
-      appId: undefined,
-    });
-  });
+  test.each([...AdPlatformSchema.options])(
+    "accepts platform=%s as a campaign catalog",
+    async (platform) => {
+      const response = await request(`?platform=${platform}`);
+      expect(response.status).toBe(200);
+      expect(listCampaigns).toHaveBeenCalledTimes(1);
+      expect(listCampaigns).toHaveBeenCalledWith(
+        "org-1",
+        expect.objectContaining({ platform }),
+      );
+    },
+  );
 
-  test("accepts status=active as the live campaign catalog", async () => {
-    const response = await request("?status=active");
-    expect(response.status).toBe(200);
-    expect(listCampaigns).toHaveBeenCalledTimes(1);
-    expect(listCampaigns).toHaveBeenCalledWith("org-1", {
-      adAccountId: undefined,
-      platform: undefined,
-      status: "active",
-      appId: undefined,
-    });
-  });
+  test.each([...CampaignStatusSchema.options])(
+    "accepts status=%s as a campaign catalog",
+    async (status) => {
+      const response = await request(`?status=${status}`);
+      expect(response.status).toBe(200);
+      expect(listCampaigns).toHaveBeenCalledTimes(1);
+      expect(listCampaigns).toHaveBeenCalledWith(
+        "org-1",
+        expect.objectContaining({ status }),
+      );
+    },
+  );
 
   test.each(["META", "facebook", "foo", "1e2"])(
     "rejects platform=%s before listCampaigns",

--- a/packages/cloud/api/v1/advertising/campaigns/route.filters.test.ts
+++ b/packages/cloud/api/v1/advertising/campaigns/route.filters.test.ts
@@ -1,0 +1,116 @@
+/**
+ * GET /api/v1/advertising/campaigns `platform` / `status` are ad-campaign
+ * catalog identity, not leftover tax on promote-assets platform (Twitter
+ * card sizes) or admin redemption status. Stock develop cast unknown
+ * tokens as AdPlatform / status and passed them to listCampaigns, so
+ * `platform=META` / `status=ACTIVE` silently returned an empty catalog.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_c: unknown, err: unknown) => {
+    throw err;
+  },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: mock(() => undefined), error: mock(() => undefined) },
+}));
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+const listCampaigns = mock(async () => []);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/services/advertising", () => ({
+  advertisingService: {
+    listCampaigns,
+  },
+}));
+
+const { default: campaignsRoute } = await import("./route");
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.route("/api/v1/advertising/campaigns", campaignsRoute);
+  return app;
+}
+
+function request(query = "") {
+  return buildApp().request(`/api/v1/advertising/campaigns${query}`);
+}
+
+describe("GET /api/v1/advertising/campaigns list-filter identity", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    listCampaigns.mockClear();
+  });
+
+  test.each(["", "?platform=", "?status=", "?platform=&status="])(
+    "accepts %s as an unfiltered campaign catalog",
+    async (query) => {
+      const response = await request(query);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { count: number };
+      expect(body.count).toBe(0);
+      expect(listCampaigns).toHaveBeenCalledTimes(1);
+      expect(listCampaigns).toHaveBeenCalledWith("org-1", {
+        adAccountId: undefined,
+        platform: undefined,
+        status: undefined,
+        appId: undefined,
+      });
+    },
+  );
+
+  test("accepts platform=meta as the Meta campaign catalog", async () => {
+    const response = await request("?platform=meta");
+    expect(response.status).toBe(200);
+    expect(listCampaigns).toHaveBeenCalledTimes(1);
+    expect(listCampaigns).toHaveBeenCalledWith("org-1", {
+      adAccountId: undefined,
+      platform: "meta",
+      status: undefined,
+      appId: undefined,
+    });
+  });
+
+  test("accepts status=active as the live campaign catalog", async () => {
+    const response = await request("?status=active");
+    expect(response.status).toBe(200);
+    expect(listCampaigns).toHaveBeenCalledTimes(1);
+    expect(listCampaigns).toHaveBeenCalledWith("org-1", {
+      adAccountId: undefined,
+      platform: undefined,
+      status: "active",
+      appId: undefined,
+    });
+  });
+
+  test.each(["META", "facebook", "foo", "1e2"])(
+    "rejects platform=%s before listCampaigns",
+    async (token) => {
+      const response = await request(`?platform=${token}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_platform");
+      expect(listCampaigns).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(["ACTIVE", "running", "foo", "1e2"])(
+    "rejects status=%s before listCampaigns",
+    async (token) => {
+      const response = await request(`?status=${token}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_status");
+      expect(listCampaigns).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/advertising/campaigns/route.ts
+++ b/packages/cloud/api/v1/advertising/campaigns/route.ts
@@ -39,17 +39,75 @@ app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
+    // Ad-campaign catalog identity, not leftover tax on promote-assets
+    // platform (Twitter card sizes) or admin redemption status. The
+    // prior `as AdPlatform` cast passed META / facebook / foo into
+    // eq(adCampaigns.platform), so operators asking for Meta received
+    // an empty catalog. Same for status=ACTIVE. Missing / empty still
+    // means unfiltered. Garbage 400s before listCampaigns.
+    const AD_PLATFORMS = [
+      "meta",
+      "google",
+      "tiktok",
+      "snap",
+      "x-twitter",
+      "reddit",
+      "linkedin",
+      "programmatic-dsp",
+    ] as const;
+    const CAMPAIGN_STATUSES = [
+      "draft",
+      "pending",
+      "active",
+      "paused",
+      "completed",
+      "failed",
+      "archived",
+    ] as const;
+    const requestedPlatform = c.req.query("platform");
+    if (
+      requestedPlatform != null &&
+      requestedPlatform !== "" &&
+      !AD_PLATFORMS.includes(
+        requestedPlatform as (typeof AD_PLATFORMS)[number],
+      )
+    ) {
+      return c.json(
+        {
+          error: "invalid_platform",
+          message:
+            'platform must be "meta", "google", "tiktok", "snap", "x-twitter", "reddit", "linkedin", or "programmatic-dsp".',
+        },
+        400,
+      );
+    }
+    const requestedStatus = c.req.query("status");
+    if (
+      requestedStatus != null &&
+      requestedStatus !== "" &&
+      !CAMPAIGN_STATUSES.includes(
+        requestedStatus as (typeof CAMPAIGN_STATUSES)[number],
+      )
+    ) {
+      return c.json(
+        {
+          error: "invalid_status",
+          message:
+            'status must be "draft", "pending", "active", "paused", "completed", "failed", or "archived".',
+        },
+        400,
+      );
+    }
+
     const adAccountId = c.req.query("adAccountId");
-    const platform = c.req.query("platform") as AdPlatform | undefined;
-    const status = c.req.query("status");
     const appId = c.req.query("appId");
 
     const campaigns = await advertisingService.listCampaigns(
       user.organization_id,
       {
         adAccountId: adAccountId || undefined,
-        platform: platform || undefined,
-        status: status || undefined,
+        platform: (requestedPlatform || undefined) as AdPlatform | undefined,
+        status: requestedStatus || undefined,
         appId: appId || undefined,
       },
     );

--- a/packages/cloud/api/v1/advertising/campaigns/route.ts
+++ b/packages/cloud/api/v1/advertising/campaigns/route.ts
@@ -6,11 +6,12 @@
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { advertisingService } from "@/lib/services/advertising";
 import {
-  type AdPlatform,
-  advertisingService,
-} from "@/lib/services/advertising";
-import { CreateCampaignSchema } from "@/lib/services/advertising/schemas";
+  AdPlatformSchema,
+  CampaignStatusSchema,
+  CreateCampaignSchema,
+} from "@/lib/services/advertising/schemas";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -39,61 +40,28 @@ app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    // Ad-campaign catalog identity, not leftover tax on promote-assets
-    // platform (Twitter card sizes) or admin redemption status. The
-    // prior `as AdPlatform` cast passed META / facebook / foo into
-    // eq(adCampaigns.platform), so operators asking for Meta received
-    // an empty catalog. Same for status=ACTIVE. Missing / empty still
-    // means unfiltered. Garbage 400s before listCampaigns.
-    const AD_PLATFORMS = [
-      "meta",
-      "google",
-      "tiktok",
-      "snap",
-      "x-twitter",
-      "reddit",
-      "linkedin",
-      "programmatic-dsp",
-    ] as const;
-    const CAMPAIGN_STATUSES = [
-      "draft",
-      "pending",
-      "active",
-      "paused",
-      "completed",
-      "failed",
-      "archived",
-    ] as const;
     const requestedPlatform = c.req.query("platform");
-    if (
-      requestedPlatform != null &&
-      requestedPlatform !== "" &&
-      !AD_PLATFORMS.includes(
-        requestedPlatform as (typeof AD_PLATFORMS)[number],
-      )
-    ) {
+    const parsedPlatform = requestedPlatform
+      ? AdPlatformSchema.safeParse(requestedPlatform)
+      : null;
+    if (parsedPlatform && !parsedPlatform.success) {
       return c.json(
         {
           error: "invalid_platform",
-          message:
-            'platform must be "meta", "google", "tiktok", "snap", "x-twitter", "reddit", "linkedin", or "programmatic-dsp".',
+          message: `platform must be one of: ${AdPlatformSchema.options.join(", ")}.`,
         },
         400,
       );
     }
     const requestedStatus = c.req.query("status");
-    if (
-      requestedStatus != null &&
-      requestedStatus !== "" &&
-      !CAMPAIGN_STATUSES.includes(
-        requestedStatus as (typeof CAMPAIGN_STATUSES)[number],
-      )
-    ) {
+    const parsedStatus = requestedStatus
+      ? CampaignStatusSchema.safeParse(requestedStatus)
+      : null;
+    if (parsedStatus && !parsedStatus.success) {
       return c.json(
         {
           error: "invalid_status",
-          message:
-            'status must be "draft", "pending", "active", "paused", "completed", "failed", or "archived".',
+          message: `status must be one of: ${CampaignStatusSchema.options.join(", ")}.`,
         },
         400,
       );
@@ -106,8 +74,8 @@ app.get("/", async (c) => {
       user.organization_id,
       {
         adAccountId: adAccountId || undefined,
-        platform: (requestedPlatform || undefined) as AdPlatform | undefined,
-        status: requestedStatus || undefined,
+        platform: parsedPlatform?.data,
+        status: parsedStatus?.data,
         appId: appId || undefined,
       },
     );

--- a/packages/cloud/shared/src/lib/services/advertising/schemas.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/schemas.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service schemas behavior behind route handlers.
+/** Validates advertising service inputs shared by API routes and providers. */
 import { z } from "zod";
 
 export const AdPlatformSchema = z.enum([
@@ -10,6 +10,16 @@ export const AdPlatformSchema = z.enum([
   "reddit",
   "linkedin",
   "programmatic-dsp",
+]);
+
+export const CampaignStatusSchema = z.enum([
+  "draft",
+  "pending",
+  "active",
+  "paused",
+  "completed",
+  "failed",
+  "archived",
 ]);
 
 export const CampaignObjectiveSchema = z.enum([
@@ -296,7 +306,7 @@ export const ListAccountsSchema = z.object({
 export const ListCampaignsSchema = z.object({
   adAccountId: z.string().uuid().optional(),
   platform: AdPlatformSchema.optional(),
-  status: z.string().optional(),
+  status: CampaignStatusSchema.optional(),
   appId: z.string().uuid().optional(),
 });
 


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on advertising campaign
list-filter identity. Ad-catalog class, not leftover tax on admin metrics
timeRange, telegram webhook flag, analytics view, Vertex scope, ingress-map
format, promote-assets platform, influencer bookings party, payment-request
public, X connectionRole, my-agents sortBy, logs since, analytics periods,
analytics export type, admin redemption status, share-ingest consume, Life
Ops inbox bools, views viewType, relationships scope, commands surface,
approvals state, database-rows sort/page, memory-viewer type, VFS encoding,
models catalogOnly/refresh, Cloud JSON-400, prefix-coerced limit,
percent-encoded paths, SIWS chainId, orchestrator lines,
provisioning-worker env ints, invites-accept, cli-auth, redemption quote,
compat agent-logs, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `platform` / `status` only on `/api/v1/advertising/campaigns`.
Omitted/empty still returns the unfiltered catalog. Exact AdPlatform /
CampaignStatus tokens still bind that filter. Unknown tokens 400 before
`listCampaigns`. Create / other advertising routes are unchanged.

# Background

## What does this PR do?

`GET /api/v1/advertising/campaigns` cast unknown `platform` / `status`
tokens and passed them to `listCampaigns`. `platform=META` /
`status=ACTIVE` silently returned an empty catalog instead of Meta or
live campaigns (or a 400).

- omitted / empty → **200** unfiltered catalog (today's default)
- exact `meta` / `google` / `tiktok` / `snap` / `x-twitter` / `reddit` /
  `linkedin` / `programmatic-dsp` → **200** that platform
- exact `draft` / `pending` / `active` / `paused` / `completed` /
  `failed` / `archived` → **200** that status
- `META` / `facebook` / `ACTIVE` / `foo` / `1e2` → **400** before
  `listCampaigns`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The create path already validates `AdPlatform` via zod. A common
`platform=META` must not silently list zero campaigns. This is
ad-campaign catalog identity, not leftover tax on promote-assets
platform (Twitter card sizes) or admin redemption status.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/advertising/campaigns/route.filters.test.ts` —
omitted still lists unfiltered; exact platform/status still call
`listCampaigns` with that filter; garbage 400s with no list call.

## Test commands

```bash
cd packages/cloud/api && bun test v1/advertising/campaigns/route.filters.test.ts
```

14 passed at the evidence head. Stock develop was 6 passed / 8 failed on
the same table (`platform=META` returned 200 and called `listCampaigns`).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; advertising-campaigns `platform`/`status` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; advertising-campaigns `platform`/`status` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; advertising-campaigns `platform`/`status` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real filter tokens and assert 400 before `listCampaigns`; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no campaign export; illegal filter tokens 400 before `listCampaigns`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`platform` / `status` tokens reject; omitted/canonical still bind the
matching catalog.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file advertising-campaigns
list-filter parse with a green focused suite (14 tests). Full monorepo
verify is unrelated to this query grammar and was skipped to keep the
proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f5100f3767c9978cdcd0f3b6fae970e4e0636de2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
