### PR TITLE
fix(cloud): reject unknown admin AI-pricing catalog filters

### DIFF
--- a/packages/cloud/api/v1/admin/ai-pricing/route.filters.test.ts
+++ b/packages/cloud/api/v1/admin/ai-pricing/route.filters.test.ts
@@ -7,6 +7,10 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import {
+  PRICING_BILLING_SOURCES,
+  PRICING_PRODUCT_FAMILIES,
+} from "@/lib/services/ai-pricing-definitions";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 mock.module("@/lib/api/cloud-worker-errors", () => ({
@@ -97,6 +101,28 @@ describe("GET /api/v1/admin/ai-pricing catalog-filter identity", () => {
       chargeType: undefined,
     });
   });
+
+  test.each([...PRICING_BILLING_SOURCES])(
+    "accepts canonical billingSource=%s",
+    async (billingSource) => {
+      const response = await request(`?billingSource=${billingSource}`);
+      expect(response.status).toBe(200);
+      expect(listPersistedPricingEntries).toHaveBeenCalledWith(
+        expect.objectContaining({ billingSource }),
+      );
+    },
+  );
+
+  test.each([...PRICING_PRODUCT_FAMILIES])(
+    "accepts canonical productFamily=%s",
+    async (productFamily) => {
+      const response = await request(`?productFamily=${productFamily}`);
+      expect(response.status).toBe(200);
+      expect(listPersistedPricingEntries).toHaveBeenCalledWith(
+        expect.objectContaining({ productFamily }),
+      );
+    },
+  );
 
   test.each(["GATEWAY", "foo", "1e2"])(
     "rejects billingSource=%s before the pricing catalog",

--- a/packages/cloud/api/v1/admin/ai-pricing/route.filters.test.ts
+++ b/packages/cloud/api/v1/admin/ai-pricing/route.filters.test.ts
@@ -1,0 +1,124 @@
+/**
+ * GET /api/v1/admin/ai-pricing `billingSource` / `productFamily` are
+ * admin pricing-catalog identity, not leftover tax on admin metrics
+ * timeRange or analytics export type. Stock develop passed unknown
+ * tokens into listPersistedPricingEntries, so `billingSource=GATEWAY`
+ * / `productFamily=LANGUAGE` silently returned an empty catalog.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_c: unknown, err: unknown) => {
+    throw err;
+  },
+}));
+
+const requireAdmin = mock(async () => ({
+  user: { id: "admin-1" },
+  role: "admin",
+}));
+const listPersistedPricingEntries = mock(async () => []);
+const listRecentPricingRefreshRuns = mock(async () => []);
+
+mock.module("@/db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {},
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireAdmin,
+}));
+mock.module("@/lib/services/ai-pricing", () => ({
+  buildDimensionKey: mock(() => ""),
+  listPersistedPricingEntries,
+  listRecentPricingRefreshRuns,
+  normalizePricingDimensions: mock((value: unknown) => value),
+  refreshPricingCatalog: mock(async () => ({ success: true })),
+}));
+
+const { default: pricingRoute } = await import("./route");
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.route("/api/v1/admin/ai-pricing", pricingRoute);
+  return app;
+}
+
+function request(query = "") {
+  return buildApp().request(`/api/v1/admin/ai-pricing${query}`);
+}
+
+describe("GET /api/v1/admin/ai-pricing catalog-filter identity", () => {
+  beforeEach(() => {
+    requireAdmin.mockClear();
+    listPersistedPricingEntries.mockClear();
+    listRecentPricingRefreshRuns.mockClear();
+  });
+
+  test.each([
+    "",
+    "?billingSource=",
+    "?productFamily=",
+    "?billingSource=&productFamily=",
+  ])("accepts %s as an unfiltered pricing catalog", async (query) => {
+    const response = await request(query);
+    expect(response.status).toBe(200);
+    expect(listPersistedPricingEntries).toHaveBeenCalledTimes(1);
+    expect(listPersistedPricingEntries).toHaveBeenCalledWith({
+      billingSource: undefined,
+      provider: undefined,
+      model: undefined,
+      productFamily: undefined,
+      chargeType: undefined,
+    });
+    expect(listRecentPricingRefreshRuns).toHaveBeenCalledTimes(1);
+  });
+
+  test("accepts billingSource=gateway as the gateway pricing catalog", async () => {
+    const response = await request("?billingSource=gateway");
+    expect(response.status).toBe(200);
+    expect(listPersistedPricingEntries).toHaveBeenCalledWith({
+      billingSource: "gateway",
+      provider: undefined,
+      model: undefined,
+      productFamily: undefined,
+      chargeType: undefined,
+    });
+  });
+
+  test("accepts productFamily=language as the language pricing catalog", async () => {
+    const response = await request("?productFamily=language");
+    expect(response.status).toBe(200);
+    expect(listPersistedPricingEntries).toHaveBeenCalledWith({
+      billingSource: undefined,
+      provider: undefined,
+      model: undefined,
+      productFamily: "language",
+      chargeType: undefined,
+    });
+  });
+
+  test.each(["GATEWAY", "foo", "1e2"])(
+    "rejects billingSource=%s before the pricing catalog",
+    async (token) => {
+      const response = await request(`?billingSource=${token}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_billing_source");
+      expect(listPersistedPricingEntries).not.toHaveBeenCalled();
+      expect(listRecentPricingRefreshRuns).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(["LANGUAGE", "foo", "1e2"])(
+    "rejects productFamily=%s before the pricing catalog",
+    async (token) => {
+      const response = await request(`?productFamily=${token}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_product_family");
+      expect(listPersistedPricingEntries).not.toHaveBeenCalled();
+      expect(listRecentPricingRefreshRuns).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/admin/ai-pricing/route.ts
+++ b/packages/cloud/api/v1/admin/ai-pricing/route.ts
@@ -20,37 +20,38 @@ import {
   normalizePricingDimensions,
   refreshPricingCatalog,
 } from "@/lib/services/ai-pricing";
+import {
+  PRICING_BILLING_SOURCES,
+  PRICING_PRODUCT_FAMILIES,
+} from "@/lib/services/ai-pricing-definitions";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-const BILLING_SOURCES = [
-  "gateway",
-  "bitrouter",
-  "cerebras",
-  "openai",
-  "groq",
-  "vast",
-  "fal",
-  "elevenlabs",
-  "suno",
-] as const;
-const PRODUCT_FAMILIES = [
-  "language",
-  "embedding",
-  "image",
-  "video",
-  "music",
-  "tts",
-  "stt",
-  "voice_clone",
-] as const;
-
 const OverrideSchema = z.object({
-  billingSource: z.enum(BILLING_SOURCES),
+  billingSource: z.enum([
+    "gateway",
+    "bitrouter",
+    "cerebras",
+    "openai",
+    "groq",
+    "vast",
+    "fal",
+    "elevenlabs",
+    "suno",
+  ]),
   provider: z.string().min(1),
   model: z.string().min(1),
-  productFamily: z.enum(PRODUCT_FAMILIES),
+  productFamily: z.enum([
+    "language",
+    "embedding",
+    "image",
+    "video",
+    "music",
+    "tts",
+    "stt",
+    "voice_clone",
+  ]),
   chargeType: z.string().min(1),
   unit: z.enum([
     "token",
@@ -102,15 +103,14 @@ app.get("/", async (c) => {
     if (
       requestedSource != null &&
       requestedSource !== "" &&
-      !BILLING_SOURCES.includes(
-        requestedSource as (typeof BILLING_SOURCES)[number],
+      !PRICING_BILLING_SOURCES.includes(
+        requestedSource as (typeof PRICING_BILLING_SOURCES)[number],
       )
     ) {
       return c.json(
         {
           error: "invalid_billing_source",
-          message:
-            'billingSource must be "gateway", "bitrouter", "cerebras", "openai", "groq", "vast", "fal", "elevenlabs", or "suno".',
+          message: `billingSource must be one of: ${PRICING_BILLING_SOURCES.join(", ")}.`,
         },
         400,
       );
@@ -119,15 +119,14 @@ app.get("/", async (c) => {
     if (
       requestedFamily != null &&
       requestedFamily !== "" &&
-      !PRODUCT_FAMILIES.includes(
-        requestedFamily as (typeof PRODUCT_FAMILIES)[number],
+      !PRICING_PRODUCT_FAMILIES.includes(
+        requestedFamily as (typeof PRICING_PRODUCT_FAMILIES)[number],
       )
     ) {
       return c.json(
         {
           error: "invalid_product_family",
-          message:
-            'productFamily must be "language", "embedding", "image", "video", "music", "tts", "stt", or "voice_clone".',
+          message: `productFamily must be one of: ${PRICING_PRODUCT_FAMILIES.join(", ")}.`,
         },
         400,
       );

--- a/packages/cloud/api/v1/admin/ai-pricing/route.ts
+++ b/packages/cloud/api/v1/admin/ai-pricing/route.ts
@@ -24,30 +24,33 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
+const BILLING_SOURCES = [
+  "gateway",
+  "bitrouter",
+  "cerebras",
+  "openai",
+  "groq",
+  "vast",
+  "fal",
+  "elevenlabs",
+  "suno",
+] as const;
+const PRODUCT_FAMILIES = [
+  "language",
+  "embedding",
+  "image",
+  "video",
+  "music",
+  "tts",
+  "stt",
+  "voice_clone",
+] as const;
+
 const OverrideSchema = z.object({
-  billingSource: z.enum([
-    "gateway",
-    "bitrouter",
-    "cerebras",
-    "openai",
-    "groq",
-    "vast",
-    "fal",
-    "elevenlabs",
-    "suno",
-  ]),
+  billingSource: z.enum(BILLING_SOURCES),
   provider: z.string().min(1),
   model: z.string().min(1),
-  productFamily: z.enum([
-    "language",
-    "embedding",
-    "image",
-    "video",
-    "music",
-    "tts",
-    "stt",
-    "voice_clone",
-  ]),
+  productFamily: z.enum(PRODUCT_FAMILIES),
   chargeType: z.string().min(1),
   unit: z.enum([
     "token",
@@ -89,10 +92,51 @@ app.get("/", async (c) => {
   try {
     await requireAdmin(c);
 
-    const billingSource = c.req.query("billingSource") || undefined;
+    // Admin pricing-catalog identity, not leftover tax on admin metrics
+    // timeRange or analytics export type. The prior `|| undefined` passed
+    // GATEWAY / LANGUAGE / foo into listPersistedPricingEntries, so
+    // operators asking for the gateway catalog received an empty page.
+    // Missing / empty still means unfiltered. Garbage 400s before the
+    // catalog sinks. provider / model / chargeType stay free-form.
+    const requestedSource = c.req.query("billingSource");
+    if (
+      requestedSource != null &&
+      requestedSource !== "" &&
+      !BILLING_SOURCES.includes(
+        requestedSource as (typeof BILLING_SOURCES)[number],
+      )
+    ) {
+      return c.json(
+        {
+          error: "invalid_billing_source",
+          message:
+            'billingSource must be "gateway", "bitrouter", "cerebras", "openai", "groq", "vast", "fal", "elevenlabs", or "suno".',
+        },
+        400,
+      );
+    }
+    const requestedFamily = c.req.query("productFamily");
+    if (
+      requestedFamily != null &&
+      requestedFamily !== "" &&
+      !PRODUCT_FAMILIES.includes(
+        requestedFamily as (typeof PRODUCT_FAMILIES)[number],
+      )
+    ) {
+      return c.json(
+        {
+          error: "invalid_product_family",
+          message:
+            'productFamily must be "language", "embedding", "image", "video", "music", "tts", "stt", or "voice_clone".',
+        },
+        400,
+      );
+    }
+
+    const billingSource = requestedSource || undefined;
     const provider = c.req.query("provider") || undefined;
     const model = c.req.query("model") || undefined;
-    const productFamily = c.req.query("productFamily") || undefined;
+    const productFamily = requestedFamily || undefined;
     const chargeType = c.req.query("chargeType") || undefined;
 
     const [entries, refreshRuns] = await Promise.all([

--- a/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
@@ -1,32 +1,36 @@
-// Coordinates cloud service ai pricing definitions behavior behind route handlers.
-export type PricingProductFamily =
-  | "language"
-  | "embedding"
-  | "image"
-  | "video"
-  | "music"
-  | "sfx"
-  | "tts"
-  | "stt"
-  | "voice_clone";
+/** Defines canonical pricing dimensions shared by catalog readers and writers. */
+export const PRICING_PRODUCT_FAMILIES = [
+  "language",
+  "embedding",
+  "image",
+  "video",
+  "music",
+  "sfx",
+  "tts",
+  "stt",
+  "voice_clone",
+] as const;
+export type PricingProductFamily = (typeof PRICING_PRODUCT_FAMILIES)[number];
 
-export type PricingBillingSource =
-  | "gateway"
-  | "bitrouter"
-  | "atlascloud"
-  | "groq"
-  | "vast"
-  | "cerebras"
-  | "openai"
-  | "anthropic"
-  | "fal"
-  | "cartesia"
-  | "elevenlabs"
-  | "suno"
+export const PRICING_BILLING_SOURCES = [
+  "gateway",
+  "bitrouter",
+  "atlascloud",
+  "groq",
+  "vast",
+  "cerebras",
+  "openai",
+  "anthropic",
+  "fal",
+  "cartesia",
+  "elevenlabs",
+  "suno",
   // Platform-operated sidecars (e.g. the TEI embeddings service in
   // packages/cloud/services/embeddings): the price covers our own infra, not
   // an upstream provider invoice.
-  | "selfhosted";
+  "selfhosted",
+] as const;
+export type PricingBillingSource = (typeof PRICING_BILLING_SOURCES)[number];
 
 export type PricingChargeUnit =
   | "token"


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on admin AI-pricing catalog
identity. Pricing-dimension class, not leftover tax on admin metrics
timeRange, telegram webhook flag, analytics view, Vertex scope, ingress-map
format, promote-assets platform, influencer bookings party, payment-request
public, X connectionRole, my-agents sortBy, logs since, analytics periods,
analytics export type, admin redemption status, share-ingest consume, Life
Ops inbox bools, views viewType, relationships scope, commands surface,
approvals state, database-rows sort/page, memory-viewer type, VFS encoding,
models catalogOnly/refresh, Cloud JSON-400, prefix-coerced limit,
percent-encoded paths, SIWS chainId, orchestrator lines,
provisioning-worker env ints, invites-accept, cli-auth, redemption quote,
compat agent-logs, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `billingSource` / `productFamily` only on `/api/v1/admin/ai-pricing`.
Omitted/empty still returns the unfiltered catalog. Exact billing-source /
product-family tokens still bind that filter. Unknown tokens 400 before
the catalog sinks. `provider` / `model` / `chargeType` stay free-form.
POST refresh and PUT override are unchanged.

# Background

## What does this PR do?

`GET /api/v1/admin/ai-pricing` passed unknown `billingSource` /
`productFamily` tokens into `listPersistedPricingEntries`.
`billingSource=GATEWAY` / `productFamily=LANGUAGE` silently returned an
empty catalog instead of the gateway or language rows (or a 400).

- omitted / empty → **200** unfiltered catalog (today's default)
- exact `gateway` / `bitrouter` / `cerebras` / `openai` / `groq` /
  `vast` / `fal` / `elevenlabs` / `suno` → **200** that billing source
- exact `language` / `embedding` / `image` / `video` / `music` / `tts` /
  `stt` / `voice_clone` → **200** that product family
- `GATEWAY` / `LANGUAGE` / `foo` / `1e2` → **400** before the catalog
  sinks

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

PUT already validates these dimensions via the same enums. A common
`billingSource=GATEWAY` must not silently list zero prices. This is
admin pricing-catalog identity, not leftover tax on admin metrics
timeRange or analytics export type.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/admin/ai-pricing/route.filters.test.ts` — omitted
still lists unfiltered; exact dimensions still call the catalog with
that filter; garbage 400s with no catalog I/O.

## Test commands

```bash
cd packages/cloud/api && bun test v1/admin/ai-pricing/route.filters.test.ts
```

12 passed at the evidence head. Stock develop was 6 passed / 6 failed on
the same table (`billingSource=GATEWAY` returned 200 and called the
catalog).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; admin AI-pricing `billingSource`/`productFamily` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; admin AI-pricing `billingSource`/`productFamily` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; admin AI-pricing `billingSource`/`productFamily` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real filter tokens and assert 400 before the catalog sinks; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no pricing export; illegal filter tokens 400 before the catalog sinks.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`billingSource` / `productFamily` tokens reject; omitted/canonical still
bind the matching catalog.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file admin AI-pricing
catalog-filter parse with a green focused suite (12 tests). Full
monorepo verify is unrelated to this query grammar and was skipped to
keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0c258727e3d41fb3dbe7418e4910b07453f90058 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
