### PR TITLE
fix(cloud): account avatar uploads against storage quota

### DIFF
--- a/packages/cloud/api/__tests__/avatar-storage-quota.test.ts
+++ b/packages/cloud/api/__tests__/avatar-storage-quota.test.ts
@@ -1,0 +1,751 @@
+/**
+ * Avatar upload quota contract tests for #20950.
+ *
+ * These tests drive both real Hono route modules and the real
+ * `putPublicObject` helper. Only request authentication, rate limiting, the
+ * quota repository, and the user-avatar database boundary are replaced with
+ * hermetic boundaries. The in-memory BLOB binding therefore proves the route
+ * ordering and compensation behavior without reaching live R2 or Postgres.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as loggerActual from "@/lib/utils/logger";
+import type { Bindings } from "@/types/cloud-worker-env";
+
+const ORGANIZATION_ID = "00000000-0000-4000-8000-0000000000aa";
+const USER_ID = "00000000-0000-4000-8000-0000000000bb";
+const PUBLIC_HOST = "blob.test";
+const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
+const VALID_AVATAR_CONTENT = "avatar";
+const VALID_AVATAR_BYTES = BigInt(VALID_AVATAR_CONTENT.length);
+const SENSITIVE_UUID = "3f10dc7c-9824-4ba6-aa10-c9a63429b055";
+const SENSITIVE_URL = `https://private.example.test/avatar/${SENSITIVE_UUID}?token=do-not-log`;
+const SENSITIVE_SQL_PARAMS =
+  'SQL params: ["tenant-private", "avatar-private", 5242880]';
+const operations: string[] = [];
+
+const loggerWarn = mock((..._args: unknown[]): void => undefined);
+mock.module("@/lib/utils/logger", () => ({
+  ...loggerActual,
+  logger: {
+    ...loggerActual.logger,
+    warn: loggerWarn,
+    redact: loggerActual.redact,
+  },
+}));
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: USER_ID,
+  organization_id: ORGANIZATION_ID,
+  organization: {
+    id: ORGANIZATION_ID,
+    name: "Quota Test Organization",
+    is_active: true,
+  },
+  is_active: true,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_context: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+const tryReserveBytes = mock(
+  async (_organizationId: string, bytes: bigint): Promise<bigint | null> => {
+    operations.push("reserve");
+    return bytes;
+  },
+);
+const releaseBytes = mock(
+  async (_organizationId: string, _bytes: bigint): Promise<void> => {
+    operations.push("release");
+  },
+);
+
+mock.module("@/db/repositories/org-storage-quota", () => ({
+  orgStorageQuotaRepository: { tryReserveBytes, releaseBytes },
+}));
+
+const databaseReturning = mock(async (): Promise<Array<{ id: string }>> => {
+  operations.push("database");
+  return [{ id: USER_ID }];
+});
+const databaseWhere = mock((_predicate: unknown) => ({
+  returning: databaseReturning,
+}));
+let capturedAvatarUrl: string | undefined;
+const databaseSet = mock((values: Record<string, unknown>) => {
+  capturedAvatarUrl =
+    typeof values.avatar === "string" ? values.avatar : undefined;
+  return { where: databaseWhere };
+});
+const databaseUpdate = mock((_table: unknown) => ({ set: databaseSet }));
+const databaseFindFirst = mock(
+  async (_query: unknown): Promise<{ avatar: string | null } | null> => {
+    operations.push("readback");
+    return null;
+  },
+);
+
+mock.module("@/db/helpers", () => ({
+  dbWrite: {
+    update: databaseUpdate,
+    query: { users: { findFirst: databaseFindFirst } },
+  },
+}));
+
+const [characterAvatarRoute, userAvatarRoute] = await Promise.all([
+  import("../my-agents/characters/avatar/route").then(
+    (module) => module.default,
+  ),
+  import("../v1/user/avatar/route").then((module) => module.default),
+]);
+
+type BlobOptions = Parameters<Bindings["BLOB"]["put"]>[2];
+
+interface MemoryBlobOptions {
+  putError?: Error;
+  commitBeforePutError?: boolean;
+  deleteError?: Error;
+}
+
+function copyBytes(
+  value: string | ArrayBuffer | ArrayBufferView | Blob | null,
+): Promise<Uint8Array> | Uint8Array {
+  if (typeof value === "string") {
+    return new TextEncoder().encode(value);
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value).slice();
+  }
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(
+      value.buffer,
+      value.byteOffset,
+      value.byteLength,
+    ).slice();
+  }
+  if (value instanceof Blob) {
+    return value.arrayBuffer().then((buffer) => new Uint8Array(buffer));
+  }
+  return new Uint8Array();
+}
+
+function makeMemoryBlob(options: MemoryBlobOptions = {}) {
+  const objects = new Map<string, Uint8Array>();
+  const put = mock(
+    async (
+      key: string,
+      value: string | ArrayBuffer | ArrayBufferView | Blob | null,
+      _putOptions?: BlobOptions,
+    ): Promise<void> => {
+      operations.push("put");
+      if (!options.putError || options.commitBeforePutError) {
+        objects.set(key, await copyBytes(value));
+      }
+      if (options.putError) throw options.putError;
+    },
+  );
+  const remove = mock(async (key: string): Promise<void> => {
+    operations.push("delete");
+    if (options.deleteError) throw options.deleteError;
+    objects.delete(key);
+  });
+  const binding = {
+    get: async (key: string) => {
+      const value = objects.get(key);
+      if (!value) return null;
+      return {
+        text: async () => new TextDecoder().decode(value),
+        arrayBuffer: async () => value.slice().buffer,
+      };
+    },
+    put,
+    delete: remove,
+  } satisfies Bindings["BLOB"];
+
+  return { binding, objects, put, remove };
+}
+
+function makeEnv(blob: Bindings["BLOB"]): Bindings {
+  return {
+    DATABASE_URL: "postgresql://test.invalid/avatar-quota",
+    BLOB: blob,
+    R2_PUBLIC_HOST: PUBLIC_HOST,
+  };
+}
+
+function avatarFile(
+  content: BlobPart = VALID_AVATAR_CONTENT,
+  type = "image/png",
+  name = "avatar.png",
+): File {
+  return new File([content], name, { type });
+}
+
+function uploadAvatar(
+  route: typeof characterAvatarRoute,
+  file: File,
+  blob: Bindings["BLOB"],
+): Response | Promise<Response> {
+  const form = new FormData();
+  form.set("file", file);
+  return route.request(
+    "/",
+    {
+      method: "POST",
+      body: form,
+    },
+    makeEnv(blob),
+  );
+}
+
+function sensitiveErrorMessage(label: string): string {
+  return `${label}; tenant=${SENSITIVE_UUID}; url=${SENSITIVE_URL}; ${SENSITIVE_SQL_PARAMS}`;
+}
+
+async function expectPrivateInternalError(response: Response): Promise<void> {
+  expect(response.status).toBe(500);
+  const body = await response.text();
+  expect(body).toBe(
+    JSON.stringify({
+      success: false,
+      error: "An unexpected error occurred",
+      code: "internal_error",
+    }),
+  );
+  expect(body).not.toContain(SENSITIVE_UUID);
+  expect(body).not.toContain(SENSITIVE_URL);
+  expect(body).not.toContain(SENSITIVE_SQL_PARAMS);
+}
+
+function expectSafeAvatarWarning(
+  stage:
+    | "r2_put_compensation"
+    | "avatar_persistence_compensation"
+    | "avatar_persistence_ack_readback",
+  reason:
+    | "object_delete_failed"
+    | "quota_release_failed"
+    | "readback_failed"
+    | "avatar_not_confirmed",
+  rawMessages: readonly string[],
+): void {
+  expect(loggerWarn).toHaveBeenCalledTimes(1);
+  const warning = loggerWarn.mock.calls.at(-1);
+  if (!warning) throw new Error("Expected a captured avatar warning");
+  const serialized = JSON.stringify(warning);
+  if (typeof serialized !== "string") {
+    throw new Error("Expected avatar warning arguments to serialize");
+  }
+
+  expect(serialized).not.toContain(SENSITIVE_UUID);
+  expect(serialized).not.toContain(SENSITIVE_URL);
+  expect(serialized).not.toContain(SENSITIVE_SQL_PARAMS);
+  for (const rawMessage of rawMessages) {
+    expect(serialized).not.toContain(rawMessage);
+  }
+  expect(serialized).not.toContain(ORGANIZATION_ID);
+  expect(serialized).not.toContain(USER_ID);
+  expect(serialized).toContain(loggerActual.redact.orgId(ORGANIZATION_ID));
+  expect(serialized).toContain(loggerActual.redact.userId(USER_ID));
+  expect(serialized).toContain(`"reservedBytes":"${VALID_AVATAR_BYTES}"`);
+  expect(serialized).toContain(`"stage":"${stage}"`);
+  expect(serialized).toContain(`"reason":"${reason}"`);
+}
+
+beforeEach(() => {
+  operations.length = 0;
+  capturedAvatarUrl = undefined;
+  loggerWarn.mockClear();
+  requireUserOrApiKeyWithOrg.mockClear();
+  tryReserveBytes.mockReset();
+  tryReserveBytes.mockImplementation(async (_organizationId, bytes) => {
+    operations.push("reserve");
+    return bytes;
+  });
+  releaseBytes.mockReset();
+  releaseBytes.mockImplementation(async () => {
+    operations.push("release");
+  });
+  databaseReturning.mockReset();
+  databaseReturning.mockImplementation(async () => {
+    operations.push("database");
+    return [{ id: USER_ID }];
+  });
+  databaseFindFirst.mockReset();
+  databaseFindFirst.mockImplementation(async () => {
+    operations.push("readback");
+    return null;
+  });
+  databaseWhere.mockClear();
+  databaseSet.mockClear();
+  databaseUpdate.mockClear();
+});
+
+const routeCases = [
+  {
+    name: "character avatar",
+    route: characterAvatarRoute,
+    persistsUser: false,
+  },
+  { name: "user avatar", route: userAvatarRoute, persistsUser: true },
+] as const;
+
+for (const routeCase of routeCases) {
+  describe(routeCase.name, () => {
+    test("rejects an unsupported MIME type before reserving quota", async () => {
+      const blob = makeMemoryBlob();
+
+      const response = await uploadAvatar(
+        routeCase.route,
+        avatarFile("plain text", "text/plain", "avatar.txt"),
+        blob.binding,
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe(
+        JSON.stringify({
+          success: false,
+          error: "Unsupported image type",
+        }),
+      );
+      expect(tryReserveBytes).not.toHaveBeenCalled();
+      expect(blob.put).not.toHaveBeenCalled();
+      expect(databaseUpdate).not.toHaveBeenCalled();
+    });
+
+    test("rejects an oversized image before reserving quota", async () => {
+      const blob = makeMemoryBlob();
+
+      const response = await uploadAvatar(
+        routeCase.route,
+        avatarFile(new ArrayBuffer(MAX_AVATAR_BYTES + 1)),
+        blob.binding,
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe(
+        JSON.stringify({
+          success: false,
+          error: "File too large (max 5MB)",
+        }),
+      );
+      expect(tryReserveBytes).not.toHaveBeenCalled();
+      expect(blob.put).not.toHaveBeenCalled();
+      expect(databaseUpdate).not.toHaveBeenCalled();
+    });
+
+    test("returns the exact 413 contract without R2 or DB work when quota is full", async () => {
+      const blob = makeMemoryBlob();
+      tryReserveBytes.mockImplementationOnce(async () => {
+        operations.push("reserve");
+        return null;
+      });
+
+      const response = await uploadAvatar(
+        routeCase.route,
+        avatarFile(),
+        blob.binding,
+      );
+
+      expect(response.status).toBe(413);
+      expect(await response.text()).toBe(
+        JSON.stringify({
+          success: false,
+          error: "Storage quota exceeded for this organization",
+        }),
+      );
+      expect(tryReserveBytes).toHaveBeenCalledTimes(1);
+      expect(tryReserveBytes).toHaveBeenCalledWith(
+        ORGANIZATION_ID,
+        VALID_AVATAR_BYTES,
+      );
+      expect(blob.put).not.toHaveBeenCalled();
+      expect(blob.remove).not.toHaveBeenCalled();
+      expect(databaseUpdate).not.toHaveBeenCalled();
+      expect(releaseBytes).not.toHaveBeenCalled();
+    });
+
+    test("releases the exact reservation once when the R2 put rejects", async () => {
+      const blob = makeMemoryBlob({
+        putError: new Error("R2 put failed"),
+        commitBeforePutError: true,
+      });
+
+      const response = await uploadAvatar(
+        routeCase.route,
+        avatarFile(),
+        blob.binding,
+      );
+
+      expect(response.status).toBe(500);
+      expect(tryReserveBytes).toHaveBeenCalledWith(
+        ORGANIZATION_ID,
+        VALID_AVATAR_BYTES,
+      );
+      expect(blob.put).toHaveBeenCalledTimes(1);
+      expect(blob.remove).toHaveBeenCalledTimes(1);
+      expect(releaseBytes).toHaveBeenCalledTimes(1);
+      expect(releaseBytes).toHaveBeenCalledWith(
+        ORGANIZATION_ID,
+        VALID_AVATAR_BYTES,
+      );
+      expect(databaseUpdate).not.toHaveBeenCalled();
+      expect(operations).toEqual(["reserve", "put", "delete", "release"]);
+      expect(blob.objects.size).toBe(0);
+    });
+
+    test("preserves the R2 put error when compensating quota release rejects", async () => {
+      const putErrorMessage = sensitiveErrorMessage("original R2 put failure");
+      const releaseErrorMessage = sensitiveErrorMessage(
+        "quota release failure",
+      );
+      const originalError = new Error(putErrorMessage);
+      const blob = makeMemoryBlob({
+        putError: originalError,
+        commitBeforePutError: true,
+      });
+      releaseBytes.mockImplementationOnce(async () => {
+        operations.push("release");
+        throw new Error(releaseErrorMessage);
+      });
+
+      const response = await uploadAvatar(
+        routeCase.route,
+        avatarFile(),
+        blob.binding,
+      );
+
+      await expectPrivateInternalError(response);
+      expect(blob.put).toHaveBeenCalledTimes(1);
+      expect(blob.remove).toHaveBeenCalledTimes(1);
+      expect(releaseBytes).toHaveBeenCalledTimes(1);
+      expect(releaseBytes).toHaveBeenCalledWith(
+        ORGANIZATION_ID,
+        VALID_AVATAR_BYTES,
+      );
+      expect(databaseUpdate).not.toHaveBeenCalled();
+      expect(operations).toEqual(["reserve", "put", "delete", "release"]);
+      expect(blob.objects.size).toBe(0);
+      expectSafeAvatarWarning("r2_put_compensation", "quota_release_failed", [
+        putErrorMessage,
+        releaseErrorMessage,
+      ]);
+    });
+
+    test("retains the reservation when cleanup after an R2 put error cannot delete", async () => {
+      const putErrorMessage = sensitiveErrorMessage("original R2 put failure");
+      const deleteErrorMessage = sensitiveErrorMessage("R2 delete failure");
+      const originalError = new Error(putErrorMessage);
+      const blob = makeMemoryBlob({
+        putError: originalError,
+        commitBeforePutError: true,
+        deleteError: new Error(deleteErrorMessage),
+      });
+
+      const response = await uploadAvatar(
+        routeCase.route,
+        avatarFile(),
+        blob.binding,
+      );
+
+      await expectPrivateInternalError(response);
+      expect(blob.put).toHaveBeenCalledTimes(1);
+      expect(blob.remove).toHaveBeenCalledTimes(1);
+      expect(releaseBytes).not.toHaveBeenCalled();
+      expect(databaseUpdate).not.toHaveBeenCalled();
+      expect(operations).toEqual(["reserve", "put", "delete"]);
+      expect(blob.objects.size).toBe(1);
+      expectSafeAvatarWarning("r2_put_compensation", "object_delete_failed", [
+        putErrorMessage,
+        deleteErrorMessage,
+      ]);
+    });
+
+    test("reserves the exact bytes and keeps the reservation after a successful upload", async () => {
+      const blob = makeMemoryBlob();
+
+      const response = await uploadAvatar(
+        routeCase.route,
+        avatarFile(),
+        blob.binding,
+      );
+
+      expect(response.status).toBe(200);
+      expect(tryReserveBytes).toHaveBeenCalledTimes(1);
+      expect(tryReserveBytes).toHaveBeenCalledWith(
+        ORGANIZATION_ID,
+        VALID_AVATAR_BYTES,
+      );
+      expect(blob.put).toHaveBeenCalledTimes(1);
+      expect(blob.objects.size).toBe(1);
+      expect([...blob.objects.values()][0]).toEqual(
+        new TextEncoder().encode(VALID_AVATAR_CONTENT),
+      );
+      expect(releaseBytes).not.toHaveBeenCalled();
+
+      if (routeCase.persistsUser) {
+        expect(databaseUpdate).toHaveBeenCalledTimes(1);
+        expect(operations).toEqual(["reserve", "put", "database"]);
+      } else {
+        expect(databaseUpdate).not.toHaveBeenCalled();
+        expect(operations).toEqual(["reserve", "put"]);
+      }
+    });
+  });
+}
+
+describe("user avatar database compensation", () => {
+  test("accepts an ambiguous update as committed when readback matches the new avatar", async () => {
+    const originalError = new Error("ambiguous avatar database failure");
+    databaseReturning.mockImplementationOnce(async () => {
+      operations.push("database");
+      throw originalError;
+    });
+    databaseFindFirst.mockImplementationOnce(async () => {
+      operations.push("readback");
+      return capturedAvatarUrl === undefined
+        ? null
+        : { avatar: capturedAvatarUrl };
+    });
+    const blob = makeMemoryBlob();
+
+    const response = await uploadAvatar(
+      userAvatarRoute,
+      avatarFile(),
+      blob.binding,
+    );
+
+    const avatarUrl = capturedAvatarUrl;
+    if (avatarUrl === undefined) {
+      throw new Error("Expected the avatar update mock to capture its URL");
+    }
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(
+      JSON.stringify({
+        success: true,
+        avatarUrl,
+        message: "Avatar uploaded successfully",
+      }),
+    );
+    expect(databaseSet).toHaveBeenCalledWith({ avatar: avatarUrl });
+    expect(databaseFindFirst).toHaveBeenCalledTimes(1);
+    expect(blob.remove).not.toHaveBeenCalled();
+    expect(releaseBytes).not.toHaveBeenCalled();
+    expect(operations).toEqual(["reserve", "put", "database", "readback"]);
+    expect(blob.objects.size).toBe(1);
+    expect(loggerWarn).not.toHaveBeenCalled();
+  });
+
+  const inconclusiveReadbacks = [
+    {
+      name: "a different avatar",
+      value: { avatar: "https://blob.test/avatars/users/existing.png" },
+    },
+    { name: "no user", value: null },
+  ] as const;
+
+  for (const readback of inconclusiveReadbacks) {
+    test(`preserves an ambiguous update error and uploaded object when readback finds ${readback.name}`, async () => {
+      const updateErrorMessage = sensitiveErrorMessage(
+        "original ambiguous avatar database failure",
+      );
+      const originalError = new Error(updateErrorMessage);
+      databaseReturning.mockImplementationOnce(async () => {
+        operations.push("database");
+        throw originalError;
+      });
+      databaseFindFirst.mockImplementationOnce(async () => {
+        operations.push("readback");
+        return readback.value;
+      });
+      const blob = makeMemoryBlob();
+
+      const response = await uploadAvatar(
+        userAvatarRoute,
+        avatarFile(),
+        blob.binding,
+      );
+
+      await expectPrivateInternalError(response);
+      expect(databaseFindFirst).toHaveBeenCalledTimes(1);
+      expect(blob.remove).not.toHaveBeenCalled();
+      expect(releaseBytes).not.toHaveBeenCalled();
+      expect(operations).toEqual(["reserve", "put", "database", "readback"]);
+      expect(blob.objects.size).toBe(1);
+      expectSafeAvatarWarning(
+        "avatar_persistence_ack_readback",
+        "avatar_not_confirmed",
+        [updateErrorMessage],
+      );
+    });
+  }
+
+  test("preserves the update error and uploaded object when readback also fails", async () => {
+    const updateErrorMessage = sensitiveErrorMessage(
+      "original ambiguous avatar database failure",
+    );
+    const readbackErrorMessage = sensitiveErrorMessage(
+      "avatar database readback failure",
+    );
+    const originalError = new Error(updateErrorMessage);
+    databaseReturning.mockImplementationOnce(async () => {
+      operations.push("database");
+      throw originalError;
+    });
+    databaseFindFirst.mockImplementationOnce(async () => {
+      operations.push("readback");
+      throw new Error(readbackErrorMessage);
+    });
+    const blob = makeMemoryBlob();
+
+    const response = await uploadAvatar(
+      userAvatarRoute,
+      avatarFile(),
+      blob.binding,
+    );
+
+    await expectPrivateInternalError(response);
+    expect(databaseFindFirst).toHaveBeenCalledTimes(1);
+    expect(blob.remove).not.toHaveBeenCalled();
+    expect(releaseBytes).not.toHaveBeenCalled();
+    expect(operations).toEqual(["reserve", "put", "database", "readback"]);
+    expect(blob.objects.size).toBe(1);
+    expectSafeAvatarWarning(
+      "avatar_persistence_ack_readback",
+      "readback_failed",
+      [updateErrorMessage, readbackErrorMessage],
+    );
+  });
+
+  test("does not release quota when compensating R2 deletion fails", async () => {
+    const deleteErrorMessage = sensitiveErrorMessage("R2 delete failure");
+    databaseReturning.mockImplementationOnce(async () => {
+      operations.push("database");
+      return [];
+    });
+    const blob = makeMemoryBlob({
+      deleteError: new Error(deleteErrorMessage),
+    });
+
+    const response = await uploadAvatar(
+      userAvatarRoute,
+      avatarFile(),
+      blob.binding,
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe(
+      JSON.stringify({
+        success: false,
+        error: "User not found",
+        code: "resource_not_found",
+      }),
+    );
+    expect(databaseFindFirst).not.toHaveBeenCalled();
+    expect(blob.remove).toHaveBeenCalledTimes(1);
+    expect(releaseBytes).not.toHaveBeenCalled();
+    expect(operations).toEqual(["reserve", "put", "database", "delete"]);
+    expect(blob.objects.size).toBe(1);
+    expectSafeAvatarWarning(
+      "avatar_persistence_compensation",
+      "object_delete_failed",
+      [deleteErrorMessage],
+    );
+  });
+
+  test("keeps the object deleted while preserving the not-found error when quota release fails", async () => {
+    const releaseErrorMessage = sensitiveErrorMessage("quota release failure");
+    databaseReturning.mockImplementationOnce(async () => {
+      operations.push("database");
+      return [];
+    });
+    releaseBytes.mockImplementationOnce(async () => {
+      operations.push("release");
+      throw new Error(releaseErrorMessage);
+    });
+    const blob = makeMemoryBlob();
+
+    const response = await uploadAvatar(
+      userAvatarRoute,
+      avatarFile(),
+      blob.binding,
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe(
+      JSON.stringify({
+        success: false,
+        error: "User not found",
+        code: "resource_not_found",
+      }),
+    );
+    expect(databaseFindFirst).not.toHaveBeenCalled();
+    expect(blob.remove).toHaveBeenCalledTimes(1);
+    expect(releaseBytes).toHaveBeenCalledTimes(1);
+    expect(releaseBytes).toHaveBeenCalledWith(
+      ORGANIZATION_ID,
+      VALID_AVATAR_BYTES,
+    );
+    expect(operations).toEqual([
+      "reserve",
+      "put",
+      "database",
+      "delete",
+      "release",
+    ]);
+    expect(blob.objects.size).toBe(0);
+    expectSafeAvatarWarning(
+      "avatar_persistence_compensation",
+      "quota_release_failed",
+      [releaseErrorMessage],
+    );
+  });
+
+  test("compensates a tenant-scoped avatar update that returns no user", async () => {
+    databaseReturning.mockImplementationOnce(async () => {
+      operations.push("database");
+      return [];
+    });
+    const blob = makeMemoryBlob();
+
+    const response = await uploadAvatar(
+      userAvatarRoute,
+      avatarFile(),
+      blob.binding,
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe(
+      JSON.stringify({
+        success: false,
+        error: "User not found",
+        code: "resource_not_found",
+      }),
+    );
+    expect(databaseReturning).toHaveBeenCalledTimes(1);
+    expect(databaseFindFirst).not.toHaveBeenCalled();
+    expect(blob.remove).toHaveBeenCalledTimes(1);
+    expect(releaseBytes).toHaveBeenCalledTimes(1);
+    expect(releaseBytes).toHaveBeenCalledWith(
+      ORGANIZATION_ID,
+      VALID_AVATAR_BYTES,
+    );
+    expect(operations).toEqual([
+      "reserve",
+      "put",
+      "database",
+      "delete",
+      "release",
+    ]);
+    expect(blob.objects.size).toBe(0);
+  });
+});

--- a/packages/cloud/api/my-agents/characters/avatar/route.ts
+++ b/packages/cloud/api/my-agents/characters/avatar/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { Hono } from "hono";
+import { orgStorageQuotaRepository } from "@/db/repositories/org-storage-quota";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
@@ -12,6 +13,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { putPublicObject } from "@/lib/storage/r2-public-object";
+import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const MAX_BYTES = 5 * 1024 * 1024;
@@ -71,19 +73,77 @@ app.post("/", async (c) => {
 
     const key = `avatars/characters/${authed.organization_id}/${authed.id}/${crypto.randomUUID()}.${ext}`;
     const buf = await entry.arrayBuffer();
+    const sizeBytes = BigInt(buf.byteLength);
 
-    const { url } = await putPublicObject(c.env, {
-      key,
-      body: buf,
-      contentType: mime,
-      customMetadata: {
-        userId: authed.id,
-        organizationId: authed.organization_id,
-      },
-    });
+    const reserved = await orgStorageQuotaRepository.tryReserveBytes(
+      authed.organization_id,
+      sizeBytes,
+    );
+    if (reserved === null) {
+      return c.json(
+        {
+          success: false,
+          error: "Storage quota exceeded for this organization",
+        },
+        413,
+      );
+    }
+
+    let url: string;
+    try {
+      ({ url } = await putPublicObject(c.env, {
+        key,
+        body: buf,
+        contentType: mime,
+        customMetadata: {
+          userId: authed.id,
+          organizationId: authed.organization_id,
+        },
+      }));
+    } catch (error) {
+      // error-policy:J6 a rejected provider write is ambiguous, so confirm
+      // object teardown before releasing quota and rethrowing the original error.
+      try {
+        await c.env.BLOB.delete(key);
+      } catch {
+        // error-policy:J6 retain the reservation when deletion cannot confirm
+        // whether the rejected write committed, and preserve the put failure.
+        logger.warn("[Character Avatar] Failed to delete ambiguous R2 upload", {
+          organizationId: logger.redact.orgId(authed.organization_id),
+          userId: logger.redact.userId(authed.id),
+          reservedBytes: sizeBytes.toString(),
+          stage: "r2_put_compensation",
+          reason: "object_delete_failed",
+        });
+        throw error;
+      }
+
+      try {
+        await orgStorageQuotaRepository.releaseBytes(
+          authed.organization_id,
+          sizeBytes,
+        );
+      } catch {
+        // error-policy:J6 object deletion is confirmed, but a failed quota
+        // release is logged without replacing the original put failure.
+        logger.warn(
+          "[Character Avatar] Failed to release quota after R2 upload cleanup",
+          {
+            organizationId: logger.redact.orgId(authed.organization_id),
+            userId: logger.redact.userId(authed.id),
+            reservedBytes: sizeBytes.toString(),
+            stage: "r2_put_compensation",
+            reason: "quota_release_failed",
+          },
+        );
+      }
+      throw error;
+    }
 
     return c.json({ success: true, url });
   } catch (error) {
+    // error-policy:J1 the route boundary translates authentication, quota,
+    // and object-storage failures through the canonical API error response.
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/api/v1/user/avatar/route.ts
+++ b/packages/cloud/api/v1/user/avatar/route.ts
@@ -4,17 +4,19 @@
  * Uploads a user profile image to R2 and updates `users.avatar`.
  */
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { dbWrite } from "@/db/helpers";
+import { orgStorageQuotaRepository } from "@/db/repositories/org-storage-quota";
 import { users } from "@/db/schemas/users";
-import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { failureResponse, NotFoundError } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { putPublicObject } from "@/lib/storage/r2-public-object";
+import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const MAX_BYTES = 5 * 1024 * 1024;
@@ -74,21 +76,173 @@ app.post("/", async (c) => {
 
     const key = `avatars/users/${authed.organization_id}/${authed.id}/${crypto.randomUUID()}.${ext}`;
     const buf = await entry.arrayBuffer();
+    const sizeBytes = BigInt(buf.byteLength);
 
-    const { url } = await putPublicObject(c.env, {
-      key,
-      body: buf,
-      contentType: mime,
-      customMetadata: {
-        userId: authed.id,
-        organizationId: authed.organization_id,
-      },
-    });
+    const reserved = await orgStorageQuotaRepository.tryReserveBytes(
+      authed.organization_id,
+      sizeBytes,
+    );
+    if (reserved === null) {
+      return c.json(
+        {
+          success: false,
+          error: "Storage quota exceeded for this organization",
+        },
+        413,
+      );
+    }
 
-    await dbWrite
-      .update(users)
-      .set({ avatar: url })
-      .where(eq(users.id, authed.id));
+    let url: string;
+    try {
+      ({ url } = await putPublicObject(c.env, {
+        key,
+        body: buf,
+        contentType: mime,
+        customMetadata: {
+          userId: authed.id,
+          organizationId: authed.organization_id,
+        },
+      }));
+    } catch (error) {
+      // error-policy:J6 a rejected provider write is ambiguous, so confirm
+      // object teardown before releasing quota and rethrowing the original error.
+      try {
+        await c.env.BLOB.delete(key);
+      } catch {
+        // error-policy:J6 retain the reservation when deletion cannot confirm
+        // whether the rejected write committed, and preserve the put failure.
+        logger.warn("[User Avatar] Failed to delete ambiguous R2 upload", {
+          organizationId: logger.redact.orgId(authed.organization_id),
+          userId: logger.redact.userId(authed.id),
+          reservedBytes: sizeBytes.toString(),
+          stage: "r2_put_compensation",
+          reason: "object_delete_failed",
+        });
+        throw error;
+      }
+
+      try {
+        await orgStorageQuotaRepository.releaseBytes(
+          authed.organization_id,
+          sizeBytes,
+        );
+      } catch {
+        // error-policy:J6 object deletion is confirmed, but a failed quota
+        // release is logged without replacing the original put failure.
+        logger.warn(
+          "[User Avatar] Failed to release quota after R2 upload cleanup",
+          {
+            organizationId: logger.redact.orgId(authed.organization_id),
+            userId: logger.redact.userId(authed.id),
+            reservedBytes: sizeBytes.toString(),
+            stage: "r2_put_compensation",
+            reason: "quota_release_failed",
+          },
+        );
+      }
+      throw error;
+    }
+
+    const cleanupDefinitivePersistenceMiss = async (): Promise<void> => {
+      try {
+        await c.env.BLOB.delete(key);
+      } catch {
+        // error-policy:J6 retain the reservation when object deletion fails;
+        // the caller preserves the canonical not-found persistence result.
+        logger.warn(
+          "[User Avatar] Failed to delete R2 object after definitive persistence miss",
+          {
+            organizationId: logger.redact.orgId(authed.organization_id),
+            userId: logger.redact.userId(authed.id),
+            reservedBytes: sizeBytes.toString(),
+            stage: "avatar_persistence_compensation",
+            reason: "object_delete_failed",
+          },
+        );
+        return;
+      }
+
+      try {
+        await orgStorageQuotaRepository.releaseBytes(
+          authed.organization_id,
+          sizeBytes,
+        );
+      } catch {
+        // error-policy:J6 the object is gone, but a failed quota release is
+        // logged without replacing the canonical not-found persistence result.
+        logger.warn(
+          "[User Avatar] Failed to release quota after definitive persistence miss",
+          {
+            organizationId: logger.redact.orgId(authed.organization_id),
+            userId: logger.redact.userId(authed.id),
+            reservedBytes: sizeBytes.toString(),
+            stage: "avatar_persistence_compensation",
+            reason: "quota_release_failed",
+          },
+        );
+      }
+    };
+
+    let updateRowCount: number | undefined;
+    try {
+      const updated = await dbWrite
+        .update(users)
+        .set({ avatar: url })
+        .where(
+          and(
+            eq(users.id, authed.id),
+            eq(users.organization_id, authed.organization_id),
+          ),
+        )
+        .returning({ id: users.id });
+      updateRowCount = updated.length;
+    } catch (updateError) {
+      // error-policy:J1 an UPDATE rejection has an ambiguous acknowledgement;
+      // primary readback decides whether the HTTP boundary can report success.
+      let persistedUser: { avatar: string | null } | undefined;
+      try {
+        persistedUser = await dbWrite.query.users.findFirst({
+          columns: { avatar: true },
+          where: and(
+            eq(users.id, authed.id),
+            eq(users.organization_id, authed.organization_id),
+          ),
+        });
+      } catch {
+        // error-policy:J1 an unavailable primary readback cannot disprove a
+        // late commit, so retain storage accounting and rethrow the UPDATE error.
+        logger.warn(
+          "[User Avatar] Avatar update acknowledgement readback failed",
+          {
+            organizationId: logger.redact.orgId(authed.organization_id),
+            userId: logger.redact.userId(authed.id),
+            reservedBytes: sizeBytes.toString(),
+            stage: "avatar_persistence_ack_readback",
+            reason: "readback_failed",
+          },
+        );
+        throw updateError;
+      }
+
+      if (persistedUser?.avatar !== url) {
+        logger.warn(
+          "[User Avatar] Avatar update was not confirmed by readback",
+          {
+            organizationId: logger.redact.orgId(authed.organization_id),
+            userId: logger.redact.userId(authed.id),
+            reservedBytes: sizeBytes.toString(),
+            stage: "avatar_persistence_ack_readback",
+            reason: "avatar_not_confirmed",
+          },
+        );
+        throw updateError;
+      }
+    }
+
+    if (updateRowCount !== undefined && updateRowCount !== 1) {
+      await cleanupDefinitivePersistenceMiss();
+      throw NotFoundError("User not found");
+    }
 
     return c.json({
       success: true,
@@ -96,6 +250,8 @@ app.post("/", async (c) => {
       message: "Avatar uploaded successfully",
     });
   } catch (error) {
+    // error-policy:J1 the route boundary translates authentication, quota,
+    // object-storage, and persistence failures through the canonical response.
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/shared/src/db/repositories/__tests__/org-storage-quota.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/org-storage-quota.pglite.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Exercises organization storage reservations through the real repository,
+ * schema, and quota migration on isolated in-process PGlite. The harness
+ * installs only the prerequisite organization shape and quota DDL, so bigint
+ * arithmetic and concurrent admission run without repository mocks.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { sql } from "drizzle-orm";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORGANIZATION_ID = "00000000-0000-4000-8000-000000002950";
+const PGLITE_TIMEOUT_MS = 60_000;
+const QUOTA_MIGRATION_PATH = join(
+  import.meta.dir,
+  "../../migrations/0102_add_org_storage_quota.sql",
+);
+
+let closeDatabaseConnectionsForTests:
+  | typeof import("../../client").closeDatabaseConnectionsForTests
+  | null = null;
+let dbWrite: typeof import("../../client").dbWrite;
+let orgStorageQuota: typeof import("../../schemas/org-storage-quota").orgStorageQuota;
+let repository: typeof import("../org-storage-quota").orgStorageQuotaRepository;
+
+beforeAll(async () => {
+  ({ closeDatabaseConnectionsForTests, dbWrite } = await import("../../client"));
+  ({ orgStorageQuota } = await import("../../schemas/org-storage-quota"));
+
+  await dbWrite.execute(
+    sql.raw(`
+    CREATE TABLE organizations (
+      id uuid PRIMARY KEY
+    )
+  `),
+  );
+
+  const migration = readFileSync(QUOTA_MIGRATION_PATH, "utf8");
+  const pricingMarker = "-- Pricing entries for the storage proxy.";
+  const markerIndex = migration.indexOf(pricingMarker);
+  if (markerIndex === -1) {
+    throw new Error("Quota migration is missing its pricing-section marker");
+  }
+  const quotaDdl = migration
+    .slice(0, markerIndex)
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("--"))
+    .join("\n");
+  for (const statement of quotaDdl.split(";")) {
+    const trimmed = statement.trim();
+    if (trimmed.length > 0) {
+      await dbWrite.execute(sql.raw(trimmed));
+    }
+  }
+
+  ({ orgStorageQuotaRepository: repository } = await import("../org-storage-quota"));
+}, PGLITE_TIMEOUT_MS);
+
+beforeEach(async () => {
+  await dbWrite.delete(orgStorageQuota);
+  await dbWrite.execute(sql`DELETE FROM organizations`);
+  await dbWrite.execute(sql`INSERT INTO organizations (id) VALUES (${ORGANIZATION_ID})`);
+});
+
+afterAll(async () => {
+  if (closeDatabaseConnectionsForTests !== null) {
+    await closeDatabaseConnectionsForTests();
+  }
+});
+
+describe("OrgStorageQuotaRepository", () => {
+  test("reserves and releases bigint byte counts exactly, clamping releases at zero", async () => {
+    const exactBytes = 9_007_199_254_740_993n;
+    await repository.setBytesLimit(ORGANIZATION_ID, exactBytes + 10n);
+
+    expect(await repository.tryReserveBytes(ORGANIZATION_ID, exactBytes)).toBe(exactBytes);
+
+    await repository.releaseBytes(ORGANIZATION_ID, 2n);
+    const afterExactRelease = await repository.findByOrganization(ORGANIZATION_ID);
+    expect(afterExactRelease?.bytes_used).toBe(exactBytes - 2n);
+
+    await repository.releaseBytes(ORGANIZATION_ID, exactBytes + 100n);
+    const afterOversizedRelease = await repository.findByOrganization(ORGANIZATION_ID);
+    expect(afterOversizedRelease?.bytes_used).toBe(0n);
+  });
+
+  test("rejects a reservation that would exceed the configured quota", async () => {
+    await repository.setBytesLimit(ORGANIZATION_ID, 10n);
+
+    expect(await repository.tryReserveBytes(ORGANIZATION_ID, 10n)).toBe(10n);
+    expect(await repository.tryReserveBytes(ORGANIZATION_ID, 1n)).toBeNull();
+
+    const stored = await repository.findByOrganization(ORGANIZATION_ID);
+    expect(stored?.bytes_used).toBe(10n);
+    expect(stored?.bytes_limit).toBe(10n);
+  });
+
+  test("keeps concurrent reservations within the configured quota", async () => {
+    const bytesLimit = 10n;
+    const bytesPerReservation = 3n;
+    await repository.setBytesLimit(ORGANIZATION_ID, bytesLimit);
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        repository.tryReserveBytes(ORGANIZATION_ID, bytesPerReservation),
+      ),
+    );
+    const accepted = results.filter((result) => result !== null);
+
+    expect(accepted).toHaveLength(3);
+    expect(accepted.every((bytesUsed) => bytesUsed <= bytesLimit)).toBe(true);
+
+    const stored = await repository.findByOrganization(ORGANIZATION_ID);
+    expect(stored?.bytes_used).toBe(9n);
+    expect(stored?.bytes_limit).toBe(bytesLimit);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/org-storage-quota.ts
+++ b/packages/cloud/shared/src/db/repositories/org-storage-quota.ts
@@ -19,10 +19,10 @@ export const DEFAULT_ORG_STORAGE_BYTES_LIMIT = 5n * 1024n * 1024n * 1024n;
 /**
  * Repository for per-organization attachment storage quotas.
  *
- * Only the route handler in `apps/api/v1/apis/storage` calls this. Reads
- * use the read-intent connection; writes use the primary. There is no soft limit:
+ * Storage proxy and direct object-upload routes call this boundary. Reads use
+ * the read-intent connection; writes use the primary. There is no soft limit:
  * `tryReserveBytes` returns `null` when the requested write would push the
- * org above its `bytes_limit`, and the caller surfaces a 413.
+ * organization above its `bytes_limit`, and the caller surfaces a 413.
  */
 export class OrgStorageQuotaRepository {
   async findByOrganization(organizationId: string): Promise<OrgStorageQuota | undefined> {
@@ -73,8 +73,7 @@ export class OrgStorageQuotaRepository {
 
   /**
    * Atomically releases `bytes` back to an organization's quota. Clamped at
-   * zero so a double-decrement (e.g. delete-after-failed-put) cannot drive
-   * the counter negative.
+   * zero so a repeated compensating release cannot drive the counter negative.
    */
   async releaseBytes(organizationId: string, bytes: bigint): Promise<void> {
     if (bytes <= 0n) {


### PR DESCRIPTION
# Relates to

Relates to #20950

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the changed behavior from the evidence and hermetic route receipts below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@00c18c6cedfab51d9c7dd8e8445314286d1d1ec5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@9a77fc0b50b1c89d674d5dcdcca8c192b8a34f30`; zero conflicts.
- [x] The unchanged stable patch passed `bun run verify`: 356/356 Turbo tasks and all root audits. Final-head focused tests and diff/Biome checks were repeated after the conflict-free rebase.

# Risks

Medium. This changes accounting and compensation around two authenticated public-R2 upload routes. Both paths reserve exact bytes before storage, reject exhaustion before R2, and retain accounting whenever object deletion or database acknowledgement cannot be proven. That intentionally prefers bounded overcounting over an untracked object or a dangling persisted avatar URL. No schema, quota limit, public URL, format, or rate-limit behavior changes.

# Background

## What does this PR do?

- Charges character-avatar and user-avatar objects against the existing organization storage quota before writing R2.
- Returns the stable 413 contract with no R2 or user-database side effects when the reservation is denied.
- Treats a rejected R2 write as outcome-ambiguous: it deletes the fresh UUID key before releasing bytes and retains the reservation when deletion cannot be confirmed.
- Makes user-avatar persistence tenant-scoped and requires exactly one returned user row.
- Reconciles an ambiguous database acknowledgement against the primary row. An exact new URL is accepted; an unprovable outcome retains the object and reservation instead of risking a dangling URL after a late commit.
- Keeps cleanup warnings structured and free of raw provider or SQL error messages.
- Adds real Hono route receipts plus a real-repository PGlite quota suite.

## What kind of change is this?

Bug fix and storage-accounting reliability hardening (non-breaking).

# Documentation changes needed?

No project documentation change is required. The existing quota repository documentation was updated to describe its direct-upload consumers.

# Testing

## Where should a reviewer start?

1. `packages/cloud/api/__tests__/avatar-storage-quota.test.ts`
2. `packages/cloud/api/v1/user/avatar/route.ts`
3. `packages/cloud/api/my-agents/characters/avatar/route.ts`
4. `packages/cloud/shared/src/db/repositories/__tests__/org-storage-quota.pglite.test.ts`

## Detailed testing steps

Exact head: `00c18c6cedfab51d9c7dd8e8445314286d1d1ec5`

Run the API and PGlite files in separate Bun processes because Bun module mocks are process-global:

```bash
mise exec bun@1.3.14 node@24.15.0 -- bun test \
  packages/cloud/api/__tests__/avatar-storage-quota.test.ts \
  --timeout 120000 --coverage-reporter=lcov --coverage-dir=/tmp/avatar-quota-api-lcov

mise exec bun@1.3.14 node@24.15.0 -- bun --conditions=eliza-source test \
  packages/cloud/shared/src/db/repositories/__tests__/org-storage-quota.pglite.test.ts \
  --timeout 120000 --coverage-reporter=lcov --coverage-dir=/tmp/avatar-quota-pglite-lcov

mise exec bun@1.3.14 node@24.15.0 -- bun --conditions=eliza-source test \
  packages/cloud/api/__tests__/cloud-files-route.test.ts \
  --timeout 120000 --coverage-reporter=lcov --coverage-dir=/tmp/avatar-quota-files-route-lcov

mise exec bun@1.3.14 node@24.15.0 -- bun --conditions=eliza-source test \
  packages/cloud/shared/src/lib/services/cloud-files.test.ts \
  --timeout 120000 --coverage-reporter=lcov --coverage-dir=/tmp/avatar-quota-files-service-lcov
```

Result across the unchanged stable patch: 40 passed, 0 failed, 371 assertions. On the final rebased head, the avatar and real PGlite suites passed 24/24 with 305 assertions.

The Cloudflare Worker production dry-run also passed (25,899.43 KiB; gzip 6,337.08 KiB), along with the Cloud API and shared TypeScript checks and targeted Biome.

```bash
mise exec bun@1.3.14 node@24.15.0 -- bun run verify
```

Patch-identical pre-final-rebase result: 356/356 Turbo tasks passed (0 cached), followed by all root audits passing.

Two independent reviews returned GO. The final review is checksum-bound to this exact head and reports 0 blockers, 0 P1 findings, and 0 P2 findings. Stable patch ID across rebases: `9307d6402126e5f97509f588ec7290f057a40973`.

# Evidence Gate

<!-- evidence-head:00c18c6cedfab51d9c7dd8e8445314286d1d1ec5 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only route and repository change; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only route and repository change; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change with no visual user flow
<!-- evidence-row:backend-logs -->
- [x] [20994-PR20994_REVIEW_RECEIPT_00c18c6cedf.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20994-PR20994_REVIEW_RECEIPT_00c18c6cedf.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no live R2 object or production database row was created; hermetic R2 and PGlite receipts are in the backend artifact
<!-- evidence-row:ocr-review -->
- [ ] N/A - backend-only change with no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changed.

## Backend + frontend logs

The exact-head receipt will record quota exhaustion with zero downstream work; committed-then-rejected R2 cleanup; delete/release failure ordering; tenant-scoped zero-row persistence compensation; database acknowledgement readback; safe error redaction; real-repository PGlite bigint/concurrent admission; Cloud Files regressions; typechecks; root verification; and independent review.

## Screenshots (before / after) + video walkthrough

N/A - backend-only route and repository change; no rendered UI surface.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- No live R2 bucket or production database was touched. The in-memory R2 binding deliberately commits bytes before rejecting so the ambiguous provider outcome and delete-before-release invariant are observable.
- One Cloud Files route run passed all 11 assertions and then hit Bun's coverage-output `WriteFailed`; the identical isolated command with output redirected to a temporary file exited 0. This was a runner output-sink artifact, not a test failure.
- PGlite runs the real repository and conditional SQL, but its in-process `Promise.all` is not evidence of multi-session PostgreSQL lock contention. Production admission safety comes from the repository's single conditional `UPDATE`.
- The existing quota model has no reservation identifier. A committed reservation whose acknowledgement is lost can cause safe overcounting until future reconciliation; it cannot create unaccounted storage. Reservation-ledger redesign and full DB/R2 reconciliation are outside this route-local PR.
- Previous-avatar garbage collection and historical-object backfill are unchanged and outside scope.
- Generated image, music, and sound-effect quota policy remains human-gated in #20956 because byte size is known only after billable provider execution.
- This PR does not deploy or mutate production infrastructure.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@00c18c6cedfab51d9c7dd8e8445314286d1d1ec5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-avatar-storage-quota]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@00c18c6cedfab51d9c7dd8e8445314286d1d1ec5:packages/skills/skills/contribute-to-eliza"} -->


