### PR TITLE
fix(cloud): expose setInferenceSessionBindingActive in inference auth test mocks

### DIFF
--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -102,6 +102,7 @@ mock.module("./inference-credential-revocation", () => ({
   revokeInferenceApiKey: async () => undefined,
   revokeInferenceSessionsThrough: async () => undefined,
   setInferenceOrganizationActive: async () => undefined,
+  setInferenceSessionBindingActive: async () => undefined,
   setInferenceSubjectActive: async () => undefined,
 }));
 
@@ -682,6 +683,35 @@ describe("isInferenceAuthContext shape guard", () => {
         admission: ADMISSION,
       }),
     ).toBe(true);
+  });
+});
+
+describe("inference-credential-revocation mock namespace completeness (#20976)", () => {
+  // Regression guard: users.ts (pulled into this suite's transitive import
+  // graph via admin.ts / inference-auth-context.ts) does NAMED imports of the
+  // session-binding collaborators. Bun validates the mocked namespace against
+  // those named imports, so an omitted export aborts the whole batch before
+  // any test in this file runs. Assert every collaborator the production graph
+  // imports by name is present and callable on the mock.
+  test("exposes every session-binding collaborator users.ts imports by name", async () => {
+    const revocation = await import("./inference-credential-revocation");
+    for (const name of [
+      "assertInferenceCredentialActive",
+      "revokeInferenceApiKey",
+      "revokeInferenceSessionsThrough",
+      "setInferenceOrganizationActive",
+      "setInferenceSessionBindingActive",
+      "setInferenceSubjectActive",
+    ] as const) {
+      expect(typeof (revocation as Record<string, unknown>)[name]).toBe("function");
+    }
+  });
+
+  test("setInferenceSessionBindingActive resolves without throwing", async () => {
+    const { setInferenceSessionBindingActive } = await import("./inference-credential-revocation");
+    await expect(
+      setInferenceSessionBindingActive("org-1", "user-1", "steward-1", false),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
@@ -68,6 +68,7 @@ mock.module("./inference-credential-revocation", () => ({
   revokeInferenceApiKey: async () => undefined,
   revokeInferenceSessionsThrough: async () => undefined,
   setInferenceOrganizationActive: async () => undefined,
+  setInferenceSessionBindingActive: async () => undefined,
   setInferenceSubjectActive: async () => undefined,
 }));
 


### PR DESCRIPTION
# Relates to

Closes #20976

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; verification recorded below (root `bun run verify` blocker documented in Known gaps / failures).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@78bd11ff6c23234edf5c6ed712ef694661a1645a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — see Known gaps / failures for the unrelated environment blocker (dependency `minimum-release-age` install policy and un-built workspace `dist`); focused package test + typecheck + lint all pass on this exact head.

# Risks

Low. Test-infrastructure only — two Bun `mock.module(...)` factories are made namespace-complete. No production source, runtime behavior, public export, or type is changed.

# Background

## What does this PR do?

The Cloud Shared full test lane (`bun run --cwd packages/cloud/shared test`) aborted deterministically at batch 25 **before** `inference-auth-context.test.ts` executed, with:

```
SyntaxError: Export named 'setInferenceSessionBindingActive' not found in module .../inference-credential-revocation.ts
```

`inference-auth-context.test.ts` replaces `./inference-credential-revocation` with `mock.module(...)`, but production module `users.ts` (in the suite's transitive import graph via `admin.ts` / `inference-auth-context.ts`) does a **named** import of `setInferenceSessionBindingActive`. Bun validates the mocked namespace against every named import at module-load time, so the omitted export aborts the whole batch before any test runs.

Once batch 25 was repaired, the maintainer's own full-lane follow-up (issue comment) confirmed batch 26 exposed the **identical** missing export in `inference-hot-path-benchmark.test.ts`. This PR completes both mocks — the confirmed scope covering both mocks of the same revocation-module namespace.

Changes:
- `inference-auth-context.test.ts` (batch 25): add `setInferenceSessionBindingActive` to the mock namespace, plus a focused regression guard (`inference-credential-revocation mock namespace completeness (#20976)`) asserting the mock exposes every session-binding collaborator `users.ts` imports by name and that the newly-exposed stub resolves.
- `inference-hot-path-benchmark.test.ts` (batch 26): add the same missing export; it exhibited the identical abort once batch 25 cleared.

The other three suites mocking this module (`inference-auth-lifecycle.test.ts`, `inference-session-auth-context.test.ts` already list the export; `admin-moderation-iac.test.ts` deliberately mocks only `setInferenceSubjectActive` and passes in isolation) need no change.

No production source (`inference-credential-revocation.ts`, `users.ts`, `admin.ts`) is modified.

## What kind of change is this?

Bug fix (non-breaking; repairs the test lane).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/inference-auth-context.test.ts` and `inference-hot-path-benchmark.test.ts` — the two `mock.module("./inference-credential-revocation", ...)` factories.

## Detailed testing steps

Run from repo root on this exact head (`4b8b6d244211736c52909c03e062c02af2c76b1f`):

- `bun test --conditions=eliza-source packages/cloud/shared/src/lib/services/inference-auth-context.test.ts` → 46 pass
- `bun test --conditions=eliza-source packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts` → 3 pass
- `bun run --cwd packages/cloud/shared typecheck` → clean
- Full lane `node packages/cloud/shared/scripts/run-bun-tests.mjs --conditions=eliza-source` → clears batches 25–29 (previously aborted at 25); stops at batch 30 on an unrelated source-resolution artifact (see Known gaps).

# Evidence Gate

<!-- evidence-head:4b8b6d244211736c52909c03e062c02af2c76b1f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend test-infrastructure change; no UI surface exists to screenshot.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend test-infrastructure change; no UI surface exists to screenshot.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend test-infrastructure change; there is no user-facing flow to record.
<!-- evidence-row:backend-logs -->
- [x] Test-lane transcripts (failing-then-passing reproduction + static checks) are pasted below.

<details>
<summary>Backend / test-lane transcript — failing-then-passing reproduction (head 4b8b6d24)</summary>

```
=== 1. PRE-FIX abort reproduced (exact issue SyntaxError) ===
# reproduced by removing the single added setInferenceSessionBindingActive line, then restoring it
$ bun test --conditions=eliza-source src/lib/services/inference-auth-context.test.ts
src/lib/services/inference-auth-context.test.ts:
# Unhandled error between tests
SyntaxError: Export named 'setInferenceSessionBindingActive' not found in module
  '.../packages/cloud/shared/src/lib/services/inference-credential-revocation.ts'.
 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [1431.00ms]

=== 2. POST-FIX inference-auth-context.test.ts (batch 25) ===
$ bun test --conditions=eliza-source src/lib/services/inference-auth-context.test.ts
(pass) resolveInferenceAuthContext > warm hit -> served from cache, no authoritative chain call
(pass) resolveInferenceAuthContext > auth failure propagates (never fail-open)
(pass) namespace-completeness (#20976) > exposes every session-binding collaborator users.ts imports by name
(pass) namespace-completeness (#20976) > setInferenceSessionBindingActive resolves without throwing
 46 pass
 0 fail
 133 expect() calls
Ran 46 tests across 1 file. [1.67s]

=== 3. POST-FIX inference-hot-path-benchmark.test.ts (batch 26) ===
$ bun test --conditions=eliza-source src/lib/services/inference-hot-path-benchmark.test.ts
 3 pass
 0 fail
Ran 3 tests across 1 file. [1495.00ms]

=== 4. Package typecheck (clean) ===
$ bun run --cwd packages/cloud/shared typecheck
> node ../../shared/scripts/generate-keywords.mjs && tsc --noEmit
Done!   (tsc --noEmit produced no ERROR output)

=== 5. Biome lint (clean) ===
$ bunx @biomejs/biome check src/lib/services/inference-hot-path-benchmark.test.ts src/lib/services/inference-auth-context.test.ts
Checked 2 files in 61ms. No fixes applied.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - this change has no frontend; there is no request/response or client state involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = the full-lane batch progression (batch-25 abort → cleared), pasted below.

<details>
<summary>Domain artifact — Cloud Shared full-lane batch progression logs (before vs after)</summary>

```
runner: node packages/cloud/shared/scripts/run-bun-tests.mjs --conditions=eliza-source

=== BEFORE the benchmark fix (only batch-25 file fixed) — lane still aborts at batch 26 ===
[run-bun-tests] ordinary batch 24/184: 16 file(s)
[run-bun-tests] ordinary batch 25/184: 16 file(s)     <- inference-auth-context.test.ts now PASSES
[run-bun-tests] ordinary batch 26/184: 16 file(s)
src/lib/services/inference-hot-path-benchmark.test.ts:
# Unhandled error between tests
SyntaxError: Export named 'setInferenceSessionBindingActive' not found in module '.../inference-credential-revocation.ts'.
[run-bun-tests] ordinary batch 26/184 FAILED (status=1, signal=none); stopping before later batches.

=== AFTER both mocks fixed — lane clears batches 25-29; grep -c "Export named" over the run => 0 ===
[run-bun-tests] ordinary batch 24/184: 16 file(s)
[run-bun-tests] ordinary batch 25/184: 16 file(s)     <- inference-auth-context.test.ts PASSES
[run-bun-tests] ordinary batch 26/184: 16 file(s)     <- inference-hot-path-benchmark.test.ts PASSES
[run-bun-tests] ordinary batch 27/184: 16 file(s)
[run-bun-tests] ordinary batch 28/184: 16 file(s)
[run-bun-tests] ordinary batch 29/184: 16 file(s)
[run-bun-tests] ordinary batch 30/184: 16 file(s)
[run-bun-tests] ordinary batch 30/184 FAILED (status=1, signal=none); stopping before later batches.
# batch-30 stop is UNRELATED: "Cannot find module '@elizaos/core/edge' from
# plugins/plugin-scheduling/src/scheduled-task/due.ts" — a source-condition subpath
# resolution artifact (no dist built on this host), not a namespace abort, not #20976.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; OCR review does not apply to a test-mock change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Frontend: N/A - no frontend involved. Backend/test-lane transcripts are inlined under the Backend logs and Domain artifacts rows above.

## Screenshots (before / after) + video walkthrough

N/A - backend test-infrastructure change; no UI surface.

## Audio / voice walkthrough

N/A - no voice/audio surface.

## Known gaps / failures

- **Root `bun run verify` not completed on this machine.** `bun install` here is gated by a global dependency `minimum-release-age` supply-chain policy (recently-published `viem`/`smthrs`/`kubernetes-fluent-client` are blocked); the install was completed against the committed frozen lockfile (exact pinned versions, no floating resolution). Workspace `@elizaos/*` packages are not built to `dist` here, so full-workspace resolution requires `--conditions=eliza-source`. Neither limitation affects this change: the abort is a module-load-time namespace validation independent of dist-vs-source resolution, and it is reproduced-then-fixed above under identical resolution. Focused package **test**, **typecheck**, and **lint** all pass on the exact head.
- **Full-lane batch-30 stop is unrelated.** Batch 30 fails with `Cannot find module '@elizaos/core/edge' from plugins/plugin-scheduling/src/scheduled-task/due.ts` — a `@elizaos/core/edge` subpath resolution artifact of running the whole lane from source without a built `dist`. It is not a namespace abort and is unrelated to #20976. `message-router/index.test.ts` (also near the batch-26 region) passes 3/3 in isolation.
- **Evidence hosting note.** The fork account (`agent-cortex`) has only `pull` permission on `elizaOS/eliza`, so it cannot upload assets to the `pr-evidence` release. Per CONTRIBUTING.md § Evidence and the root AGENTS.md, the full transcripts are pasted inline in `<details>` blocks above instead of linked artifacts.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@78bd11ff6c23234edf5c6ed712ef694661a1645a:packages/skills/skills/contribute-to-eliza"} -->
