### PR TITLE
fix(core): include trailing closing quotes and brackets in extractFirstSentence

### DIFF
--- a/packages/core/src/utils/text-splitting.test.ts
+++ b/packages/core/src/utils/text-splitting.test.ts
@@ -77,6 +77,11 @@ describe("extractFirstSentence", () => {
 		expect(paren.first).toBe("(This is inside parentheses.)");
 		expect(paren.rest).toBe("Outside text.");
 		expect(paren.complete).toBe(true);
+
+		const nested = extractFirstSentence("She replied, ‘Done.’)] Next step.");
+		expect(nested.first).toBe("She replied, ‘Done.’)]");
+		expect(nested.rest).toBe("Next step.");
+		expect(nested.complete).toBe(true);
 	});
 
 	it("returns the whole text when there is no boundary", () => {

--- a/packages/core/src/utils/text-splitting.test.ts
+++ b/packages/core/src/utils/text-splitting.test.ts
@@ -60,6 +60,25 @@ describe("extractFirstSentence", () => {
 		expect(r.rest).toBe("Next one.");
 	});
 
+	it("includes trailing closing quotes and brackets in the first sentence", () => {
+		const quoted = extractFirstSentence('She said, "Hello." Then she left.');
+		expect(quoted.first).toBe('She said, "Hello."');
+		expect(quoted.rest).toBe("Then she left.");
+		expect(quoted.complete).toBe(true);
+
+		const shouted = extractFirstSentence('He shouted, "Stop!" Everyone froze.');
+		expect(shouted.first).toBe('He shouted, "Stop!"');
+		expect(shouted.rest).toBe("Everyone froze.");
+		expect(shouted.complete).toBe(true);
+
+		const paren = extractFirstSentence(
+			"(This is inside parentheses.) Outside text.",
+		);
+		expect(paren.first).toBe("(This is inside parentheses.)");
+		expect(paren.rest).toBe("Outside text.");
+		expect(paren.complete).toBe(true);
+	});
+
 	it("returns the whole text when there is no boundary", () => {
 		const r = extractFirstSentence("No boundary here");
 		expect(r.first).toBe("No boundary here");

--- a/packages/core/src/utils/text-splitting.ts
+++ b/packages/core/src/utils/text-splitting.ts
@@ -31,13 +31,18 @@ export function extractFirstSentence(text: string): {
 	for (let i = 0; i < text.length; i++) {
 		const char = text[i];
 		if (".?!".includes(char)) {
-			// Check if it's followed by a space or end of string
+			// Check if it's followed by a space, closing delimiter, or end of string
 			const nextChar = text[i + 1];
 			if (
 				nextChar === undefined ||
 				/\s/.test(nextChar) ||
 				nextChar === '"' ||
-				nextChar === "'"
+				nextChar === "'" ||
+				nextChar === "\u201D" ||
+				nextChar === "\u2019" ||
+				nextChar === ")" ||
+				nextChar === "]" ||
+				nextChar === "}"
 			) {
 				// Potential boundary. Check prior context for abbreviations.
 				// We look at the word preceding the punctuation.
@@ -69,6 +74,12 @@ export function extractFirstSentence(text: string): {
 
 				if (!isAbbreviation) {
 					boundaryIndex = i + 1;
+					while (
+						boundaryIndex < text.length &&
+						"\"'\u201D\u2019)]}".includes(text[boundaryIndex])
+					) {
+						boundaryIndex++;
+					}
 					break;
 				}
 			}


### PR DESCRIPTION
# Summary

Closes #20999. `extractFirstSentence` now keeps contiguous closing straight/curly quotes and brackets with the sentence-ending punctuation instead of orphaning them at the start of `rest`.

The implementation remains linear and allocation-light. It preserves abbreviation handling and existing split semantics; only the chosen boundary advances across closing delimiters.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash, openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity, Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ebbcfc87704659e5f4b68babcbd66256055ceb61:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Exact-head verification

- Candidate: `0e00653a343d0695591f0147843787c089337e18`, rebased on `ebbcfc87704659e5f4b68babcbd66256055ceb61`.
- Pinned Bun 1.3.14 focused Vitest: `10 passed, 0 failed`.
- `packages/core` typecheck: exit 0.
- Biome: 2 files checked, no fixes.
- `git diff --check`: clean.
- Added nested straight/curly delimiter regression evidence beyond the original quote and parenthesis cases.

# Evidence Gate

<!-- evidence-head:0e00653a343d0695591f0147843787c089337e18 -->
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - deterministic core text utility; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - deterministic core text utility; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no UI workflow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:

  ```text
  RUN v4.1.5 packages/core
  Test Files 1 passed (1); Tests 10 passed (10)
  packages/core typecheck: exit 0
  Biome: Checked 2 files. No fixes applied.
  ```
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend path changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model, prompt, or agent behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts:

  ```text
  quoted: first='She said, "Hello."'; rest='Then she left.'
  parenthesized: first='(This is inside parentheses.)'; rest='Outside text.'
  nested curly/straight closers: first='She replied, ‘Done.’)]'; rest='Next step.'
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no rendered surface`.

---
— [codex-root/pr-21001-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@ebbcfc87704659e5f4b68babcbd66256055ceb61:packages/skills/skills/contribute-to-eliza"} -->
