### PR TITLE
fix(vault): reject whitespace-only keys in assertKey validation helper

### DIFF
--- a/packages/vault/src/internal-utils.ts
+++ b/packages/vault/src/internal-utils.ts
@@ -5,7 +5,7 @@
 import type { SetOptions } from "./vault-types.js";
 
 export function assertKey(key: string): void {
-  if (typeof key !== "string" || key.length === 0) {
+  if (typeof key !== "string" || key.trim().length === 0) {
     throw new TypeError("vault: key must be a non-empty string");
   }
   if (key.length > 256) {

--- a/packages/vault/test/vault.test.ts
+++ b/packages/vault/test/vault.test.ts
@@ -23,6 +23,13 @@ describe("vault — set / get / has / remove", () => {
     expect(await test.vault.get("ui.theme")).toBe("dark");
   });
 
+  it("rejects empty or whitespace-only keys", async () => {
+    await expect(test.vault.set("", "val")).rejects.toThrow(TypeError);
+    await expect(test.vault.set("   ", "val")).rejects.toThrow(TypeError);
+    await expect(test.vault.set("\t\n", "val")).rejects.toThrow(TypeError);
+    await expect(test.vault.get("   ")).rejects.toThrow(TypeError);
+  });
+
   it("atomically preserves one setIfAbsent winner", async () => {
     const outcomes = await Promise.all([
       test.vault.setIfAbsent("system.integrity", "first", {


### PR DESCRIPTION
## Summary

1. In `packages/vault/src/internal-utils.ts`, `assertKey` checked `if (typeof key !== "string" || key.length === 0)`.
2. When passed whitespace-only keys (such as `"   "` or `"\t\n"`), `key.length === 0` evaluated to `false`, allowing blank keys to pass validation and be persisted into storage and audit logs.
3. Updated `assertKey` to check `key.trim().length === 0`.
4. Added unit test coverage in `packages/vault/test/vault.test.ts` for empty, whitespace, and tab/newline keys.

Closes #21003.

## Verification

Exact commit: `de664a6221`.

- Focused unit test suite `packages/vault/test/vault.test.ts`: 30/30 tests passing (100 assertions).
- Vitest suite `packages/vault`: 12/12 files passed, 199/199 tests passed.
- Biome format on `@elizaos/vault`: 35 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - internal vault key validation utility function; no rendered UI changed.
- [x] N/A - internal vault key validation utility function; no rendered UI changed.
- [x] N/A - deterministic utility function behavior.
- [x] Focused test suite transcript:
```text
✓ vault — set / get / has / remove > stores and retrieves a non-sensitive value [1980.17ms]
✓ vault — set / get / has / remove > rejects empty or whitespace-only keys [0.79ms]
✓ vault — set / get / has / remove > atomically preserves one setIfAbsent winner [1452.61ms]
✓ vault — set / get / has / remove > stores and retrieves a sensitive value (encrypted at rest) [1417.65ms]
✓ vault — set / get / has / remove > non-sensitive values are stored as plaintext (by design) [1384.59ms]
✓ vault — set / get / has / remove > has() reports presence without revealing value [1416.54ms]
✓ vault — set / get / has / remove > get() throws VaultMissError for missing keys [1373.43ms]
✓ vault — set / get / has / remove > remove() deletes the entry [1396.13ms]
✓ vault — set / get / has / remove > remove() is idempotent [1353.75ms]
✓ vault — set / get / has / remove > rejects empty / non-string keys [0.67ms]
✓ vault — set / get / has / remove > rejects non-string values [0.27ms]
... (30 passing tests)
30 pass, 0 fail, 100 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@6e7af8b940989f66bb6c4784ae1ceb4859f81eb3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@6e7af8b940989f66bb6c4784ae1ceb4859f81eb3:packages/skills/skills/contribute-to-eliza"} -->