### PR TITLE
fix(workflow): reject malformed trigger route encoding

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/trigger-routes.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/trigger-routes.test.ts
@@ -1,0 +1,148 @@
+/** Exercises malformed and valid dynamic segments through the production trigger route handler. */
+
+import { describe, expect, test } from 'bun:test';
+import type http from 'node:http';
+import type { IAgentRuntime, Task, TriggerConfig } from '@elizaos/core';
+import { handleTriggerRoutes, type TriggerRouteContext } from '../../src/trigger-routes';
+
+function createHarness(
+  method: string,
+  pathname: string
+): {
+  calls: string[];
+  context: TriggerRouteContext;
+  response: { body?: unknown; status?: number };
+} {
+  const calls: string[] = [];
+  const response: { body?: unknown; status?: number } = {};
+  const req = {} as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  const runtime = {
+    createTask: async () => {
+      calls.push('createTask');
+      return 'created-task';
+    },
+    deleteTask: async () => {
+      calls.push('deleteTask');
+    },
+    getTask: async () => {
+      calls.push('getTask');
+      return null;
+    },
+  } as unknown as IAgentRuntime;
+  const context = {
+    method,
+    pathname,
+    req,
+    res,
+    runtime,
+    readJsonBody: async () => {
+      calls.push('readJsonBody');
+      return {};
+    },
+    json: (_res: http.ServerResponse, body: unknown, status?: number) => {
+      response.body = body;
+      response.status = status;
+    },
+    error: (_res: http.ServerResponse, message: string, status: number) => {
+      response.body = { error: message };
+      response.status = status;
+    },
+    executeTriggerTask: async () => {
+      calls.push('executeTriggerTask');
+      return { status: 'success', taskDeleted: false };
+    },
+    getTriggerHealthSnapshot: async () => {
+      calls.push('getTriggerHealthSnapshot');
+      return {
+        triggersEnabled: true,
+        activeTriggers: 0,
+        disabledTriggers: 0,
+        totalExecutions: 0,
+        totalFailures: 0,
+        totalSkipped: 0,
+      };
+    },
+    getTriggerLimit: () => 10,
+    listTriggerTasks: async () => {
+      calls.push('listTriggerTasks');
+      return [];
+    },
+    readTriggerConfig: () => null,
+    readTriggerRuns: () => [],
+    taskToTriggerSummary: () => null,
+    triggersFeatureEnabled: () => true,
+    buildTriggerConfig: () => ({}) as TriggerConfig,
+    buildTriggerMetadata: () => null,
+    normalizeTriggerDraft: () => ({ error: 'unused' }),
+    DISABLED_TRIGGER_INTERVAL_MS: 60_000,
+    TRIGGER_TASK_NAME: 'trigger',
+    TRIGGER_TASK_TAGS: ['trigger'],
+  } as unknown as TriggerRouteContext;
+
+  return { calls, context, response };
+}
+
+describe('trigger route path decoding', () => {
+  test('rejects malformed trigger IDs and event kinds before downstream work', async () => {
+    for (const { method, pathname, message } of [
+      {
+        method: 'GET',
+        pathname: '/api/triggers/%/runs',
+        message: 'Invalid trigger ID: malformed URL encoding',
+      },
+      {
+        method: 'POST',
+        pathname: '/api/triggers/%2/execute',
+        message: 'Invalid trigger ID: malformed URL encoding',
+      },
+      {
+        method: 'POST',
+        pathname: '/api/triggers/events/%ZZ',
+        message: 'Invalid event kind: malformed URL encoding',
+      },
+      {
+        method: 'GET',
+        pathname: '/api/triggers/%E0%A4',
+        message: 'Invalid trigger ID: malformed URL encoding',
+      },
+    ]) {
+      const { calls, context, response } = createHarness(method, pathname);
+
+      await expect(handleTriggerRoutes(context)).resolves.toBe(true);
+
+      expect(response).toEqual({ body: { error: message }, status: 400 });
+      expect(calls).toEqual([]);
+    }
+  });
+
+  test('preserves valid encoded trigger IDs and event kinds', async () => {
+    const runs = createHarness('GET', '/api/triggers/trigger%2Dprod/runs');
+    const task = { id: 'task-id' } as Task;
+    runs.context.listTriggerTasks = async () => {
+      runs.calls.push('listTriggerTasks');
+      return [task];
+    };
+    runs.context.readTriggerConfig = () => ({ triggerId: 'trigger-prod' }) as TriggerConfig;
+
+    await expect(handleTriggerRoutes(runs.context)).resolves.toBe(true);
+
+    expect(runs.calls).toEqual(['listTriggerTasks']);
+    expect(runs.response).toEqual({ body: { runs: [] }, status: undefined });
+
+    const event = createHarness('POST', '/api/triggers/events/order%2Ecreated');
+
+    await expect(handleTriggerRoutes(event.context)).resolves.toBe(true);
+
+    expect(event.calls).toEqual(['readJsonBody', 'listTriggerTasks']);
+    expect(event.response).toEqual({
+      body: {
+        ok: true,
+        eventKind: 'order.created',
+        matched: 0,
+        results: [],
+      },
+      status: undefined,
+    });
+  });
+});

--- a/plugins/plugin-workflow/src/trigger-routes.ts
+++ b/plugins/plugin-workflow/src/trigger-routes.ts
@@ -212,6 +212,16 @@ function parseEventPayload(value: unknown): Record<string, unknown> {
     : {};
 }
 
+function decodePathComponent(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — malformed path encoding is
+    // reported by the trigger route boundary instead of escaping as URIError.
+    return null;
+  }
+}
+
 async function findTask(
   runtime: IAgentRuntime,
   id: string,
@@ -420,12 +430,12 @@ export async function handleTriggerRoutes(ctx: TriggerRouteContext): Promise<boo
 
   const runsMatch = /^\/api\/triggers\/([^/]+)\/runs$/.exec(pathname);
   if (method === 'GET' && runsMatch) {
-    const task = await findTask(
-      runtime,
-      decodeURIComponent(runsMatch[1]),
-      listTriggerTasks,
-      readTriggerConfig
-    );
+    const triggerId = decodePathComponent(runsMatch[1]);
+    if (triggerId === null) {
+      error(res, 'Invalid trigger ID: malformed URL encoding', 400);
+      return true;
+    }
+    const task = await findTask(runtime, triggerId, listTriggerTasks, readTriggerConfig);
     if (!task) {
       error(res, 'Trigger not found', 404);
       return true;
@@ -436,12 +446,12 @@ export async function handleTriggerRoutes(ctx: TriggerRouteContext): Promise<boo
 
   const execMatch = /^\/api\/triggers\/([^/]+)\/execute$/.exec(pathname);
   if (method === 'POST' && execMatch) {
-    const task = await findTask(
-      runtime,
-      decodeURIComponent(execMatch[1]),
-      listTriggerTasks,
-      readTriggerConfig
-    );
+    const triggerId = decodePathComponent(execMatch[1]);
+    if (triggerId === null) {
+      error(res, 'Invalid trigger ID: malformed URL encoding', 400);
+      return true;
+    }
+    const task = await findTask(runtime, triggerId, listTriggerTasks, readTriggerConfig);
     if (!task) {
       error(res, 'Trigger not found', 404);
       return true;
@@ -458,7 +468,12 @@ export async function handleTriggerRoutes(ctx: TriggerRouteContext): Promise<boo
 
   const eventMatch = /^\/api\/triggers\/events\/([^/]+)$/.exec(pathname);
   if (method === 'POST' && eventMatch) {
-    const eventKind = decodeURIComponent(eventMatch[1] ?? '').trim();
+    const decodedEventKind = decodePathComponent(eventMatch[1] ?? '');
+    if (decodedEventKind === null) {
+      error(res, 'Invalid event kind: malformed URL encoding', 400);
+      return true;
+    }
+    const eventKind = decodedEventKind.trim();
     if (!eventKind) {
       error(res, 'event kind is required', 400);
       return true;
@@ -504,7 +519,11 @@ export async function handleTriggerRoutes(ctx: TriggerRouteContext): Promise<boo
 
   const itemMatch = /^\/api\/triggers\/([^/]+)$/.exec(pathname);
   if (!itemMatch) return false;
-  const triggerId = decodeURIComponent(itemMatch[1]);
+  const triggerId = decodePathComponent(itemMatch[1]);
+  if (triggerId === null) {
+    error(res, 'Invalid trigger ID: malformed URL encoding', 400);
+    return true;
+  }
 
   if (method === 'GET') {
     const task = await findTask(runtime, triggerId, listTriggerTasks, readTriggerConfig);


### PR DESCRIPTION
# Relates to

Fixes #20995

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and was rebased onto the synchronized `origin/develop` snapshot below with zero conflicts.
- [x] Frozen install, focused tests, affected typechecks/lint/builds, and root verification were run after sync.
- [x] Exact-head production-handler evidence is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@f3fc142b6d71827455e404ca6b451eef5f5c4082`; zero conflicts.
- [x] `bun run verify` was run post-sync; the unrelated portable-toolchain blocker is documented below.

# Risks

Low. Only malformed percent-encoding at workflow-trigger HTTP boundaries changes. Valid encoded IDs/event kinds retain existing dispatch. Scheduling, execution, persistence, feature gates, and the workflow engine are unchanged.

# Background

## What does this PR do?

- Converts malformed dynamic trigger IDs to handled 400 responses for item, runs, and execute routes.
- Converts malformed event kinds to handled 400 before body parsing or trigger enumeration.
- Proves invalid inputs perform zero downstream work while valid encoded IDs/event kinds preserve dispatch.

## What kind of change is this?

Bug fix (non-breaking HTTP-boundary correction).

# Documentation changes needed?

No. Public configuration and workflow formats remain unchanged.

# Testing

## Where should a reviewer start?

`plugins/plugin-workflow/__tests__/unit/trigger-routes.test.ts`

## Detailed testing steps

Using repository-pinned Bun 1.3.14 and Node 24.15.0:

```text
$ bun install --frozen-lockfile --ignore-scripts
Frozen install completed after retrying two transient Windows package links

$ bun test --isolate __tests__/unit/trigger-routes.test.ts
2 pass, 0 fail, 18 expect() calls

$ bun run --cwd plugins/plugin-workflow typecheck
exit 0

$ bunx @biomejs/biome check plugins/plugin-workflow
Checked 43 files. No fixes applied.

$ bun run --cwd plugins/plugin-workflow build
exit 0

$ bun run --cwd packages/agent typecheck
exit 0

$ bun run --cwd packages/agent build
[rewrite-dist-relative-imports] rewrote 194 file(s)
exit 0
```

The exact-head matrix proves `%`, `%2`, `%ZZ`, and invalid UTF-8 `%E0%A4` are handled as 400 before task listing, body reads, execution, or mutation. It also proves `trigger%2Dprod` and `order%2Ecreated` decode and dispatch normally.

# Evidence Gate

<!-- evidence-head:736717f1435c44d12abaf3d408fee066b895f53c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend plugin dispatcher only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend plugin dispatcher only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic HTTP boundary with no user interface.
<!-- evidence-row:backend-logs -->
- [x] Exact-head production-handler transcript is included above: 2/2 tests and 18 assertions.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action, prompt, provider, model, or LLM path changed.
<!-- evidence-row:domain-artifacts -->
- [x] The malformed/valid route matrix above is the applicable domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - URL decoding is deterministic and invokes no LLM.

## Backend + frontend logs

Backend evidence is the focused production-handler transcript above. Frontend logs are N/A.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- `bun run verify` passes repository preflights through workspace resolution, then Turbo stops with `Unable to find package manager binary: cannot find binary path` under the pinned portable Windows Bun/Node toolchain. Workflow typecheck/build/lint/tests and Agent typecheck/build pass.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@f3fc142b6d71827455e404ca6b451eef5f5c4082:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-workflow-trigger-decoder]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@f3fc142b6d71827455e404ca6b451eef5f5c4082:packages/skills/skills/contribute-to-eliza"} -->
