### PR TITLE
test(cloud): isolate Discord timing wrapper coverage

### DIFF
--- a/packages/cloud/api/internal/discord/eliza-app/messages/route.test.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/messages/route.test.ts
@@ -2,6 +2,36 @@
 
 import { expect, mock, test } from "bun:test";
 
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: () => Response.json({ success: false }, { status: 500 }),
+}));
+mock.module("@/lib/services/agent-gateway-router", () => ({
+  agentGatewayRouterService: {
+    routeDiscordMessage: mock(async () => ({
+      handled: false,
+      reason: "not_linked",
+    })),
+  },
+}));
+mock.module("@/lib/services/managed-discord-guild-voice", () => ({
+  authorizeManagedDiscordGuildVoice: mock(async () => ({ allowed: false })),
+  runManagedDiscordGuildTextTurn: mock(async () => ({ replyText: "" })),
+}));
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  resolveSharedRuntimeWorkerRequestContext: mock(() => ({
+    error: "unused",
+    code: "service_unavailable",
+    retryable: true,
+    status: 503,
+  })),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(() => undefined) },
+}));
+mock.module("../../../_auth", () => ({
+  requireInternalAuth: mock(async () => ({ service: "discord-gateway" })),
+}));
+
 const personalSharedRequest = mock(
   async () =>
     new Response(


### PR DESCRIPTION
Follow-up to #20990. Part of #20313 and #16079.

## Summary

- isolate the Discord timing wrapper unit test from unused Cloud router, database, and runtime collaborators
- preserve the real wrapper request/response behavior under test
- prevent the new test from leaving imported service handles alive after its assertion passes
- no production source or runtime behavior changes

## Reproduction and repair

Merged #20990 commit `634e21328458d0526317576fb7dbfa567c8dbb3b` adds a wrapper test that reports its assertion as passed but does not terminate after more than 90 seconds; it required SIGINT. The test imported the complete gateway/router dependency graph even though the DM timing path does not call those collaborators.

This follow-up mocks those unused boundaries before importing the wrapper. The same header assertion now completes normally in 1.4 seconds.

## Exact revision

- Head: `c3bd0d7e47a169fa01c1d843170625354624ef4c`
- Base: `634e21328458d0526317576fb7dbfa567c8dbb3b`

## Validation

- Discord wrapper test: 1/1 passed, 3 assertions, process exited normally in 1.4 seconds
- Biome on the changed test: passed
- `git diff --check origin/develop...HEAD`: passed
- Cloud API typecheck is blocked on the unchanged current base by `training/vertex/assignments/route.scope.test.ts:43,56` (`TS2352` and `TS2493`); this one-file test-isolation change does not touch that surface
- No workflow dispatch, deploy, secret mutation, or production state change was performed

## Evidence matrix

- Backend logs: `N/A - test-process isolation only; no runtime source changed`.
- Frontend screenshots/video: `N/A - no UI surface changed`.
- Real-model trajectory: `N/A - no model, prompt, or action behavior changed`.
- Domain artifact: the repaired exact-head Bun test exits normally after preserving the exact `Server-Timing` assertion.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@c3bd0d7e47a169fa01c1d843170625354624ef4c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

— [codex]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@c3bd0d7e47a169fa01c1d843170625354624ef4c:packages/skills/skills/contribute-to-eliza"} -->
