### PR TITLE
fix(cloud): make Discord Railway bundle reproducible

### DIFF
--- a/packages/cloud/services/gateway-discord/scripts/deploy-railway.sh
+++ b/packages/cloud/services/gateway-discord/scripts/deploy-railway.sh
@@ -14,7 +14,7 @@
 # runs this script from the package directory:
 #
 #   railway link --project eliza-cloud --service gateway-discord --environment production
-#   bun run scripts/deploy-railway.sh
+#   bun run deploy:railway
 #
 # zlib-sync is intentionally omitted: it is an optional native dep of the Discord
 # WS lib (lazy require -> graceful fallback to no compression).
@@ -30,6 +30,7 @@ trap cleanup_stage EXIT
 
 echo "[deploy] building self-contained bundle from $HERE ..."
 ( cd "$HERE" && bun build src/index.ts --outdir "$STAGE/dist" --target node \
+  --conditions eliza-source \
   --external zlib-sync \
   --external @discordjs/voice \
   --external @discordjs/opus \
@@ -73,6 +74,11 @@ CMD ["bun", "run", "dist/index.js"]
 DOCKER
 
 cp "$HERE/railway.toml" "$STAGE/railway.toml" 2>/dev/null || true
+
+if [ "${GATEWAY_DISCORD_DEPLOY_BUILD_ONLY:-0}" = "1" ]; then
+  echo "[deploy] build-only proof passed"
+  exit 0
+fi
 
 echo "[deploy] railway up from staged bundle ..."
 (

--- a/packages/cloud/services/gateway-discord/tests/deploy-railway.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/deploy-railway.test.ts
@@ -1,0 +1,25 @@
+/** Exercises the package-owned Railway bundle boundary without contacting Railway. */
+
+import { expect, test } from "bun:test";
+
+test("the Railway deploy script builds the source-form workspace bundle", async () => {
+  const process = Bun.spawn(["bash", "scripts/deploy-railway.sh"], {
+    cwd: `${import.meta.dir}/..`,
+    env: {
+      ...Bun.env,
+      GATEWAY_DISCORD_DEPLOY_BUILD_ONLY: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+
+  if (exitCode !== 0) {
+    throw new Error(`Railway bundle proof failed:\n${stderr}`);
+  }
+  expect(stdout).toContain("[deploy] build-only proof passed");
+});


### PR DESCRIPTION
Fixes #21010.

The package-owned Railway deploy script now builds gateway-discord with the same eliza-source export condition used by package build and protected CI. A build-only mode drives the real script through bundle creation while stopping before Railway, so clean-runner CI proves the deploy boundary itself rather than a copied command.

Evidence:
- exact head 097a6075fb1c2d16879e2c263f049b2b5a463ce5
- tree 7d15c1b0f1398bf9a0cdee00fd1caa5b40821591
- base 12a6824705a178197181cfe24c34dca98c1842f9
- full gateway suite 118/118, 356 assertions
- build-only Railway boundary 1/1
- gateway-discord typecheck PASS after canonical shared build prerequisite
- bash syntax, Biome, diff-check PASS
- real pre-fix clean-worktree failure: Could not resolve @elizaos/shared/discord-dm-policy

No Railway, staging, provider, credential, or production mutation occurred from this branch.