### PR TITLE
fix(core): reject non-number types in describeRelativeTime

### DIFF
--- a/packages/core/src/utils/time-format.test.ts
+++ b/packages/core/src/utils/time-format.test.ts
@@ -125,6 +125,19 @@ describe("formatTimestamp (verbose)", () => {
 const MAX_REPRESENTABLE_MS = 8_640_000_000_000_000;
 
 describe("invalid and unrepresentable timestamps", () => {
+	it("fails closed to 'just now' for non-number inputs", () => {
+		expect(formatRelativeTime(null as unknown as number)).toBe("just now");
+		expect(formatRelativeTime(undefined as unknown as number)).toBe("just now");
+		expect(formatRelativeTime(false as unknown as number)).toBe("just now");
+		expect(formatRelativeTime(true as unknown as number)).toBe("just now");
+		expect(formatRelativeTime([] as unknown as number)).toBe("just now");
+		expect(formatRelativeTime({} as unknown as number)).toBe("just now");
+		expect(formatTimestamp(null as unknown as number)).toBe("just now");
+		expect(formatTimestamp(undefined as unknown as number)).toBe("just now");
+		expect(formatTimestamp(false as unknown as number)).toBe("just now");
+		expect(formatTimestamp(true as unknown as number)).toBe("just now");
+	});
+
 	it("fails closed to 'just now' for non-finite inputs", () => {
 		expect(formatRelativeTime(Number.NaN)).toBe("just now");
 		expect(formatRelativeTime(Number.POSITIVE_INFINITY)).toBe("just now");

--- a/packages/core/src/utils/time-format.ts
+++ b/packages/core/src/utils/time-format.ts
@@ -4,6 +4,10 @@ function describeRelativeTime(
 	timestamp: number,
 	style: "compact" | "verbose",
 ): string {
+	if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+		return "just now";
+	}
+
 	// Match packages/ui formatRelativeTime: construct the Date first and
 	// require a finite getTime(). That rejects NaN/±Infinity and finite
 	// values outside the ±8.64e15 Date range (which still pass


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/time-format.ts`, `describeRelativeTime` initialized `const time = new Date(timestamp).getTime()` without checking `typeof timestamp === "number"`.
2. When passed non-number values such as `null`, `false`, or `[]`, `new Date(...)` coerced them to `0` (Jan 1, 1970 UTC), formatting them as an absolute date 56 years ago (e.g. `"Jan 1"`) rather than failing closed to `"just now"`.
3. Guarded `describeRelativeTime` with `if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) return "just now"`.
4. Added unit test coverage in `packages/core/src/utils/time-format.test.ts` for non-number inputs (`null`, `undefined`, `false`, `true`, `[]`, `{}`).

Closes #21011.

## Verification

Exact commit: `4211401464`.

- Focused unit test suite `packages/core/src/utils/time-format.test.ts`: 15/15 tests passing.
- Biome format on `@elizaos/core`: 1278 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - core time formatting utility function; no rendered UI changed.
- [x] N/A - core time formatting utility function; no rendered UI changed.
- [x] N/A - deterministic utility function behavior.
- [x] Focused test suite transcript:
```text
RUN  v4.1.5 /home/deepanshu/os/eliza
Test Files  1 passed (1)
     Tests  15 passed (15)
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@634e213284050f2aa747db8b7ff71db64670c5e7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@634e213284050f2aa747db8b7ff71db64670c5e7:packages/skills/skills/contribute-to-eliza"} -->