### PR TITLE
test(cloud): type Vertex assignment scope mock

### DIFF
--- a/packages/cloud/api/training/vertex/assignments/route.scope.test.ts
+++ b/packages/cloud/api/training/vertex/assignments/route.scope.test.ts
@@ -6,8 +6,15 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import type { VertexModelRegistryService } from "@/lib/services/vertex-model-registry";
 
-const listVisibleAssignments = mock(async () => [{ id: "asg-1" }]);
+type ListVisibleAssignmentsArgs = Parameters<
+  VertexModelRegistryService["listVisibleAssignments"]
+>;
+
+const listVisibleAssignments = mock(
+  async (..._args: ListVisibleAssignmentsArgs) => [{ id: "asg-1" }],
+);
 
 mock.module("@/lib/auth", () => ({
   requireAuthOrApiKeyWithOrg: async () => ({
@@ -40,10 +47,8 @@ describe("GET /api/training/vertex/assignments scope identity", () => {
       const body = (await response.json()) as { assignments: { id: string }[] };
       expect(body.assignments).toEqual([{ id: "asg-1" }]);
       expect(listVisibleAssignments).toHaveBeenCalledTimes(1);
-      const filter = listVisibleAssignments.mock.calls[0][1] as {
-        scope?: string;
-      };
-      expect(filter.scope).toBeUndefined();
+      const filter = listVisibleAssignments.mock.calls[0]?.[1];
+      expect(filter?.scope).toBeUndefined();
     },
   );
 
@@ -53,10 +58,8 @@ describe("GET /api/training/vertex/assignments scope identity", () => {
       const response = await app.request(`/?scope=${token}`);
       expect(response.status).toBe(200);
       expect(listVisibleAssignments).toHaveBeenCalledTimes(1);
-      const filter = listVisibleAssignments.mock.calls[0][1] as {
-        scope?: string;
-      };
-      expect(filter.scope).toBe(token);
+      const filter = listVisibleAssignments.mock.calls[0]?.[1];
+      expect(filter?.scope).toBe(token);
     },
   );
 


### PR DESCRIPTION
Follow-up to the current `develop` Cloud API typecheck regression.

## Summary

- bind the Vertex assignments scope mock to the real `listVisibleAssignments` argument signature
- read the recorded filter argument without casting an impossible zero-argument mock tuple
- leave the production route and its tenant-scope behavior unchanged

## Root cause

The test declared `listVisibleAssignments` as `async () => ...`, so TypeScript correctly inferred every recorded mock call as an empty tuple. The test then indexed argument 1 at lines 43 and 56, producing `TS2352` and `TS2493` in the Cloud API typecheck.

## Exact revision

- Head: `1f23c1a172bbdb42f62292c3cac7494157ec9899`
- Base: `12a6824705a178197181cfe24c34dca98c1842f9`

## Validation

- Vertex assignments scope tests: 10/10 passed, 32 assertions
- Cloud API typecheck: passed
- production Worker dry bundle: passed, 25,897.51 KiB / 6,296.53 KiB gzip
- Biome on the changed test: passed
- `git diff --check origin/develop...HEAD`: passed
- No workflow dispatch, deployment, secret mutation, or production state change was performed

## Evidence matrix

- Backend/runtime evidence: `N/A - test typing only; no production source changed`.
- Frontend screenshots/video: `N/A - no UI surface changed`.
- Real-model trajectory: `N/A - no model behavior changed`.
- Domain artifact: exact-head Cloud API typecheck and Worker dry bundle above.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@1f23c1a172bbdb42f62292c3cac7494157ec9899:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

— [codex]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@1f23c1a172bbdb42f62292c3cac7494157ec9899:packages/skills/skills/contribute-to-eliza"} -->
