### PR TITLE
fix(core): prevent call stack overflow on circular objects in flattenTextValues

### DIFF
--- a/packages/core/src/utils/text-normalize.test.ts
+++ b/packages/core/src/utils/text-normalize.test.ts
@@ -104,6 +104,15 @@ describe("flattenTextValues", () => {
 			circularArr.push(circularArr);
 			expect(flattenTextValues(circularArr)).toEqual(["first"]);
 		});
+
+		it("preserves repeated references that are not cycles", () => {
+			const shared = { value: "kept" };
+
+			expect(flattenTextValues({ first: shared, second: shared })).toEqual([
+				"first: value: kept",
+				"second: value: kept",
+			]);
+		});
 	});
 
 	describe("non-plain objects have no enumerable own entries and are dropped", () => {

--- a/packages/core/src/utils/text-normalize.test.ts
+++ b/packages/core/src/utils/text-normalize.test.ts
@@ -94,6 +94,16 @@ describe("flattenTextValues", () => {
 				"on: false",
 			]);
 		});
+
+		it("handles circular objects and arrays without stack overflow", () => {
+			const circularObj: Record<string, unknown> = { name: "agent" };
+			circularObj.self = circularObj;
+			expect(flattenTextValues(circularObj)).toEqual(["name: agent"]);
+
+			const circularArr: unknown[] = ["first"];
+			circularArr.push(circularArr);
+			expect(flattenTextValues(circularArr)).toEqual(["first"]);
+		});
 	});
 
 	describe("non-plain objects have no enumerable own entries and are dropped", () => {

--- a/packages/core/src/utils/text-normalize.ts
+++ b/packages/core/src/utils/text-normalize.ts
@@ -16,9 +16,16 @@
  * - Objects become `key: value` fragments
  * - Scalars are stringified
  */
-export function flattenTextValues(value: unknown): string[] {
+export function flattenTextValues(
+	value: unknown,
+	seen: WeakSet<object> = new WeakSet(),
+): string[] {
 	if (Array.isArray(value)) {
-		return value.flatMap((item) => flattenTextValues(item));
+		if (seen.has(value)) {
+			return [];
+		}
+		seen.add(value);
+		return value.flatMap((item) => flattenTextValues(item, seen));
 	}
 
 	if (value == null) {
@@ -31,9 +38,13 @@ export function flattenTextValues(value: unknown): string[] {
 	}
 
 	if (typeof value === "object") {
+		if (seen.has(value)) {
+			return [];
+		}
+		seen.add(value);
 		return Object.entries(value as Record<string, unknown>).flatMap(
 			([key, inner]) => {
-				const innerText = flattenTextValues(inner).join(", ");
+				const innerText = flattenTextValues(inner, seen).join(", ");
 				return innerText ? [`${key}: ${innerText}`] : [];
 			},
 		);

--- a/packages/core/src/utils/text-normalize.ts
+++ b/packages/core/src/utils/text-normalize.ts
@@ -16,16 +16,26 @@
  * - Objects become `key: value` fragments
  * - Scalars are stringified
  */
-export function flattenTextValues(
+export function flattenTextValues(value: unknown): string[] {
+	return flattenTextValuesWithAncestors(value, new WeakSet());
+}
+
+function flattenTextValuesWithAncestors(
 	value: unknown,
-	seen: WeakSet<object> = new WeakSet(),
+	ancestors: WeakSet<object>,
 ): string[] {
 	if (Array.isArray(value)) {
-		if (seen.has(value)) {
+		if (ancestors.has(value)) {
 			return [];
 		}
-		seen.add(value);
-		return value.flatMap((item) => flattenTextValues(item, seen));
+		ancestors.add(value);
+		try {
+			return value.flatMap((item) =>
+				flattenTextValuesWithAncestors(item, ancestors),
+			);
+		} finally {
+			ancestors.delete(value);
+		}
 	}
 
 	if (value == null) {
@@ -38,16 +48,23 @@ export function flattenTextValues(
 	}
 
 	if (typeof value === "object") {
-		if (seen.has(value)) {
+		if (ancestors.has(value)) {
 			return [];
 		}
-		seen.add(value);
-		return Object.entries(value as Record<string, unknown>).flatMap(
-			([key, inner]) => {
-				const innerText = flattenTextValues(inner, seen).join(", ");
-				return innerText ? [`${key}: ${innerText}`] : [];
-			},
-		);
+		ancestors.add(value);
+		try {
+			return Object.entries(value as Record<string, unknown>).flatMap(
+				([key, inner]) => {
+					const innerText = flattenTextValuesWithAncestors(
+						inner,
+						ancestors,
+					).join(", ");
+					return innerText ? [`${key}: ${innerText}`] : [];
+				},
+			);
+		} finally {
+			ancestors.delete(value);
+		}
 	}
 
 	return [String(value)];


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/text-normalize.ts`, `flattenTextValues` recursively traversed nested objects and arrays without tracking visited references.
2. If an input object or array had circular/self references, `flattenTextValues` recursed infinitely, throwing an unhandled `RangeError: Maximum call stack size exceeded`.
3. Added a `seen: WeakSet<object> = new WeakSet()` cycle detector parameter to `flattenTextValues` to break cycles safely.
4. Added unit test coverage in `packages/core/src/utils/text-normalize.test.ts` for circular objects and circular arrays.

Closes #21015.

## Verification

Exact commit: `f387704c59`.

- Focused unit test suite `packages/core/src/utils/text-normalize.test.ts`: 17/17 tests passing (30 assertions, 100% line & function coverage).
- Biome format on `@elizaos/core`: 1278 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - core text normalization utility function; no rendered UI changed.
- [x] N/A - core text normalization utility function; no rendered UI changed.
- [x] N/A - deterministic utility function behavior.
- [x] Focused test suite transcript:
```text
✓ flattenTextValues > strings > trims and keeps a non-empty string [0.15ms]
✓ flattenTextValues > strings > drops an empty or whitespace-only string [0.05ms]
✓ flattenTextValues > nullish > drops null and undefined, keeping their siblings [0.30ms]
✓ flattenTextValues > scalars > keeps falsy-but-present scalars [0.08ms]
✓ flattenTextValues > scalars > stringifies other scalars [0.14ms]
✓ flattenTextValues > arrays > flattens arbitrarily nested arrays in order [0.09ms]
✓ flattenTextValues > arrays > yields nothing for an empty array or an array of empties [0.05ms]
✓ flattenTextValues > objects > renders each entry as `key: value` [0.46ms]
✓ flattenTextValues > objects > joins a nested collection into one entry with `, ` [0.12ms]
✓ flattenTextValues > objects > drops an entry whose value coerces to nothing [0.08ms]
✓ flattenTextValues > objects > keeps an entry whose value is a falsy scalar [0.19ms]
✓ flattenTextValues > objects > handles circular objects and arrays without stack overflow [0.17ms]
✓ flattenTextValues > non-plain objects have no enumerable own entries and are dropped > drops a Date [0.04ms]
✓ flattenTextValues > non-plain objects have no enumerable own entries and are dropped > drops a Map
✓ flattenTextValues > non-plain objects have no enumerable own entries and are dropped > drops a Set
✓ toMultilineText > joins the flattened fragments with newlines [0.11ms]
✓ toMultilineText > returns an empty string when nothing survives [0.05ms]
17 pass, 0 fail, 30 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@12a682470557451dd75da04f58a3a0e192ff8160:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@12a682470557451dd75da04f58a3a0e192ff8160:packages/skills/skills/contribute-to-eliza"} -->

## Maintainer repair and validation

The original global `WeakSet` prevented recursion but also discarded repeated shared references that were not cycles. The traversal now tracks only active ancestors, preserves the public function signature, and removes each container in `finally`. A DAG regression verifies both paths remain represented. Core Vitest passes 18/18; touched-file Biome and diff-check are clean. Repair head: `2ed5b2c08517c741c707ac8a80d1b9e142e0fc8a`.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@ca7fe7de1aaa1c1e2524f9b97dc9c29c0c612bdd:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-b]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@ca7fe7de1aaa1c1e2524f9b97dc9c29c0c612bdd:packages/skills/skills/contribute-to-eliza"} -->