### PR TITLE
feat(core): export readJsonFileSync and add test suite in atomic-json

### DIFF
--- a/packages/core/src/utils/atomic-json.test.ts
+++ b/packages/core/src/utils/atomic-json.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for atomic-json read/write helpers in packages/core/src/utils/atomic-json.ts.
+ * Exercises async/sync atomic write, async/sync json reading, ENOENT handling, and malformed JSON errors.
+ */
+
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	readJsonFile,
+	readJsonFileSync,
+	writeJsonAtomic,
+	writeJsonAtomicSync,
+} from "./atomic-json";
+
+describe("atomic-json", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "atomic-json-test-"));
+	});
+
+	afterEach(async () => {
+		await fsp.rm(tempDir, { recursive: true, force: true });
+	});
+
+	describe("writeJsonAtomic & readJsonFile (async)", () => {
+		it("writes and reads json data atomically", async () => {
+			const target = path.join(tempDir, "nested", "data.json");
+			const payload = { hello: "world", count: 42, flag: true };
+
+			await writeJsonAtomic(target, payload);
+			const readBack = await readJsonFile<typeof payload>(target);
+
+			expect(readBack).toEqual(payload);
+		});
+
+		it("returns null for non-existent files (ENOENT)", async () => {
+			const missing = path.join(tempDir, "non-existent.json");
+			const result = await readJsonFile(missing);
+			expect(result).toBeNull();
+		});
+
+		it("throws for malformed JSON", async () => {
+			const broken = path.join(tempDir, "broken.json");
+			await fsp.writeFile(broken, "{ invalid json", "utf-8");
+
+			await expect(readJsonFile(broken)).rejects.toThrow(SyntaxError);
+		});
+
+		it("supports custom formatting options like trailingNewline and indent", async () => {
+			const target = path.join(tempDir, "formatted.json");
+			await writeJsonAtomic(
+				target,
+				{ a: 1 },
+				{ trailingNewline: true, indent: 4 },
+			);
+
+			const raw = await fsp.readFile(target, "utf-8");
+			expect(raw).toBe('{\n    "a": 1\n}\n');
+		});
+	});
+
+	describe("writeJsonAtomicSync & readJsonFileSync (sync)", () => {
+		it("writes and reads json data synchronously", () => {
+			const target = path.join(tempDir, "sync-nested", "data.json");
+			const payload = { name: "eliza", items: [1, 2, 3] };
+
+			writeJsonAtomicSync(target, payload);
+			const readBack = readJsonFileSync<typeof payload>(target);
+
+			expect(readBack).toEqual(payload);
+		});
+
+		it("returns null for non-existent files (ENOENT)", () => {
+			const missing = path.join(tempDir, "missing-sync.json");
+			const result = readJsonFileSync(missing);
+			expect(result).toBeNull();
+		});
+
+		it("throws for malformed JSON", () => {
+			const broken = path.join(tempDir, "broken-sync.json");
+			fs.writeFileSync(broken, "not valid json {", "utf-8");
+
+			expect(() => readJsonFileSync(broken)).toThrow(SyntaxError);
+		});
+
+		it("supports custom formatting options synchronously", () => {
+			const target = path.join(tempDir, "sync-formatted.json");
+			writeJsonAtomicSync(
+				target,
+				{ b: 2 },
+				{ trailingNewline: true, indent: 0 },
+			);
+
+			const raw = fs.readFileSync(target, "utf-8");
+			expect(raw).toBe('{"b":2}\n');
+		});
+	});
+});

--- a/packages/core/src/utils/atomic-json.ts
+++ b/packages/core/src/utils/atomic-json.ts
@@ -149,3 +149,21 @@ export async function readJsonFile<T>(filePath: string): Promise<T | null> {
 		throw error;
 	}
 }
+
+/**
+ * Synchronous read and parse JSON. Only a genuinely absent file returns `null`;
+ * malformed JSON and filesystem failures surface to the caller.
+ */
+export function readJsonFileSync<T>(filePath: string): T | null {
+	try {
+		const raw = fs.readFileSync(filePath, "utf-8");
+		return JSON.parse(raw) as T;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			// error-policy:J4 an absent optional JSON file is an explicit not-found
+			// state; parse and other filesystem failures still propagate.
+			return null;
+		}
+		throw error;
+	}
+}


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/atomic-json.ts`, exported `readJsonFileSync<T>(filePath: string): T | null` matching the asynchronous `readJsonFile` contract (ENOENT returns `null`, while malformed JSON throws a `SyntaxError`).
2. Added dedicated unit test coverage in `packages/core/src/utils/atomic-json.test.ts` covering `writeJsonAtomic`, `writeJsonAtomicSync`, `readJsonFile`, and `readJsonFileSync`.

Closes #21018.

## Verification

Exact commit: `e1995b7e60`.

- Focused unit test suite `packages/core/src/utils/atomic-json.test.ts`: 8/8 tests passing (8 assertions).
- Biome format on `@elizaos/core`: 1279 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - core atomic JSON I/O utility function; no rendered UI changed.
- [x] N/A - core atomic JSON I/O utility function; no rendered UI changed.
- [x] N/A - deterministic utility function behavior.
- [x] Focused test suite transcript:
```text
RUN  v4.1.5 /home/deepanshu/os/eliza
Test Files  1 passed (1)
     Tests  8 passed (8)
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@1803d6113524dbf4d89617d5830ca8f44ff531e2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@1803d6113524dbf4d89617d5830ca8f44ff531e2:packages/skills/skills/contribute-to-eliza"} -->