### PR TITLE
fix(cloud): reject unknown app-analytics period grain

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/analytics/route.period.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/route.period.test.ts
@@ -1,0 +1,107 @@
+/**
+ * GET /api/v1/apps/:id/analytics `period` is app-analytics grain
+ * identity, not leftover tax on analytics projections periods,
+ * analytics requests view, or admin metrics timeRange. Stock develop
+ * cast unknown tokens and date_trunc'd them as day, so
+ * `period=MONTHLY` / `HOURLY` silently returned daily buckets.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(() => undefined) },
+}));
+
+const ORG_A = "11111111-1111-4111-8111-111111111111";
+const APP_ID = "99999999-9999-4999-8999-000000000001";
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+const getById = mock(async (id: string) =>
+  id === APP_ID ? { id: APP_ID, organization_id: ORG_A } : null,
+);
+const getAnalytics = mock(async () => []);
+const getTotalStats = mock(async () => ({
+  totalRequests: 0,
+  totalUsers: 0,
+  totalCreditsUsed: "0.00",
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: ORG_A,
+  }),
+}));
+mock.module("@/lib/auth/app-key-scope", () => ({
+  isAppKeyOutOfScope: async () => false,
+}));
+mock.module("@/lib/services/apps", () => ({
+  appsService: { getById, getAnalytics, getTotalStats },
+}));
+mock.module("@/lib/api/date-range-params", () => ({
+  parseDateRangeParams: () => ({
+    success: true,
+    startDate: undefined,
+    endDate: undefined,
+  }),
+}));
+
+const { default: analyticsRoute } = await import("./route");
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.route("/api/v1/apps/:id/analytics", analyticsRoute);
+  return app;
+}
+
+function request(query = "") {
+  return buildApp().request(
+    `/api/v1/apps/${APP_ID}/analytics${query}`,
+    {},
+    ENV,
+  );
+}
+
+describe("GET /api/v1/apps/:id/analytics grain identity", () => {
+  beforeEach(() => {
+    getById.mockClear();
+    getAnalytics.mockClear();
+    getTotalStats.mockClear();
+  });
+
+  test.each(["", "?period="])(
+    "accepts %s as the daily app-analytics grain",
+    async (query) => {
+      const response = await request(query);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success: boolean;
+        period: { type: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.period.type).toBe("daily");
+      expect(getAnalytics).toHaveBeenCalledTimes(1);
+      expect(getAnalytics.mock.calls[0][1]).toBe("daily");
+    },
+  );
+
+  test("accepts period=monthly as the monthly app-analytics grain", async () => {
+    const response = await request("?period=monthly");
+    expect(response.status).toBe(200);
+    expect(getAnalytics).toHaveBeenCalledTimes(1);
+    expect(getAnalytics.mock.calls[0][1]).toBe("monthly");
+  });
+
+  test.each(["MONTHLY", "HOURLY", "week", "foo"])(
+    "rejects period=%s before getAnalytics",
+    async (token) => {
+      const response = await request(`?period=${token}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_period");
+      expect(getAnalytics).not.toHaveBeenCalled();
+      expect(getById).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/apps/[id]/analytics/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/route.ts
@@ -35,9 +35,7 @@ app.get("/", async (c) => {
     if (
       requestedPeriod != null &&
       requestedPeriod !== "" &&
-      !APP_PERIODS.includes(
-        requestedPeriod as (typeof APP_PERIODS)[number],
-      )
+      !APP_PERIODS.includes(requestedPeriod as (typeof APP_PERIODS)[number])
     ) {
       return c.json(
         {

--- a/packages/cloud/api/v1/apps/[id]/analytics/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/route.ts
@@ -23,7 +23,32 @@ app.get("/", async (c) => {
     if (!id) return c.json({ success: false, error: "Missing app id" }, 400);
     const { searchParams } = new URL(c.req.url);
 
-    const periodType = (searchParams.get("period") || "daily") as
+    // App-analytics grain identity, not leftover tax on analytics
+    // projections periods, analytics requests view, or admin metrics
+    // timeRange. The prior `as "hourly" | "daily" | "monthly"` cast
+    // plus date_trunc fallback mapped MONTHLY / HOURLY / week onto
+    // daily buckets, so operators asking for a month of grain received
+    // days. Missing / empty still means daily. Garbage 400s before
+    // getById / getAnalytics. Date-range parsing is untouched.
+    const APP_PERIODS = ["hourly", "daily", "monthly"] as const;
+    const requestedPeriod = searchParams.get("period");
+    if (
+      requestedPeriod != null &&
+      requestedPeriod !== "" &&
+      !APP_PERIODS.includes(
+        requestedPeriod as (typeof APP_PERIODS)[number],
+      )
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: "invalid_period",
+          message: 'period must be "hourly", "daily", or "monthly".',
+        },
+        400,
+      );
+    }
+    const periodType = (requestedPeriod || "daily") as
       | "hourly"
       | "daily"
       | "monthly";


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on app-analytics period
grain identity. App-analytics grain class, not leftover tax on
ad-account platform, my-agents category, advertising campaign filters,
AI-pricing catalog filters, admin metrics timeRange, telegram webhook
flag, analytics view, Vertex scope, ingress-map format, promote-assets
platform, influencer bookings party, payment-request public, X
connectionRole, my-agents sortBy, logs since, analytics periods,
analytics export type, admin redemption status, share-ingest consume,
Life Ops inbox bools, views viewType, relationships scope, commands
surface, approvals state, database-rows sort/page, memory-viewer type,
VFS encoding, models catalogOnly/refresh, Cloud JSON-400,
prefix-coerced limit, percent-encoded paths, SIWS chainId, orchestrator
lines, provisioning-worker env ints, invites-accept, cli-auth,
redemption quote, compat agent-logs, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `period` only on `/api/v1/apps/:id/analytics`. Omitted/empty
still means daily. Exact hourly/daily/monthly still bind that grain.
Unknown tokens 400 before getById/getAnalytics. Date-range parsing and
the requests-view sibling are unchanged.

# Background

## What does this PR do?

`GET /api/v1/apps/:id/analytics` cast unknown `period` tokens and
`date_trunc`'d them as day. `period=MONTHLY` silently returned daily
buckets instead of monthly grain (or a 400).

- omitted / empty → **200** daily grain (today's default)
- exact `hourly` / `daily` / `monthly` → **200** that grain
- `MONTHLY` / `HOURLY` / `week` / `foo` → **400** before getById/getAnalytics

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Repository `getAnalytics` maps only lowercase `hourly`/`monthly` and
falls through everything else to `day`. A common `period=MONTHLY` must
not silently chart days. This is app-analytics grain identity, not
leftover tax on analytics projections periods or analytics requests view.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/apps/[id]/analytics/route.period.test.ts` —
omitted still uses daily; exact `monthly` still calls getAnalytics with
that grain; garbage 400s with no repository call.

## Test commands

```bash
cd packages/cloud/api && bun test v1/apps/[id]/analytics/route.period.test.ts
```

7 passed at the evidence head. Stock develop was 3 passed / 4 failed on
the same table (`period=MONTHLY` returned 200 and called getAnalytics).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; app-analytics `period` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; app-analytics `period` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; app-analytics `period` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real grain tokens and assert 400 before getAnalytics; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no analytics export; illegal period tokens 400 before getAnalytics.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`period` tokens reject; omitted/canonical still bind the matching grain.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file app-analytics period
parse with a green focused suite (7 tests). Full monorepo verify is
unrelated to this query grammar and was skipped to keep the proof tied
to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8169494e22578f83b0d4812729459ee1793dfb85 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->

## Maintainer repair and validation

Biome formatting was repaired at `8169494e22578f83b0d4812729459ee1793dfb85`. Focused production-handler tests pass 7/7; touched-file Biome and diff-check are clean.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@8cb45410bf2720f07053b6d11e563f37f3b31c96:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-b]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@8cb45410bf2720f07053b6d11e563f37f3b31c96:packages/skills/skills/contribute-to-eliza"} -->