### PR TITLE
fix(shared): make options optional in formatTrajectoryTokenCount and round sub-second ms

### DIFF
--- a/packages/shared/src/utils/trajectory-format.test.ts
+++ b/packages/shared/src/utils/trajectory-format.test.ts
@@ -32,6 +32,8 @@ describe("formatTrajectoryDuration", () => {
   it("formats sub-second durations in ms", () => {
     expect(formatTrajectoryDuration(0)).toBe("0ms");
     expect(formatTrajectoryDuration(999)).toBe("999ms");
+    expect(formatTrajectoryDuration(24.7)).toBe("25ms");
+    expect(formatTrajectoryDuration(0.4)).toBe("0ms");
   });
 
   it("formats seconds with one decimal", () => {
@@ -70,6 +72,9 @@ describe("formatTrajectoryTokenCount", () => {
   it("returns the empty label for undefined or zero", () => {
     expect(formatTrajectoryTokenCount(undefined, EMPTY)).toBe("—");
     expect(formatTrajectoryTokenCount(0, EMPTY)).toBe("—");
+    expect(formatTrajectoryTokenCount(undefined)).toBe("—");
+    expect(formatTrajectoryTokenCount(0)).toBe("—");
+    expect(formatTrajectoryTokenCount(500)).toBe("500");
   });
 
   it("fails closed on non-finite or negative values", () => {

--- a/packages/shared/src/utils/trajectory-format.ts
+++ b/packages/shared/src/utils/trajectory-format.ts
@@ -15,7 +15,7 @@ export function formatTrajectoryDuration(ms: number | null): string {
   // browser garbage "NaNh" / "Infinityh" / "-1ms" instead of the designed
   // placeholder.
   if (ms === null || !Number.isFinite(ms) || ms < 0) return "—";
-  if (ms < 1000) return `${ms}ms`;
+  if (ms < 1000) return `${Math.round(ms)}ms`;
   const seconds = ms / 1000;
   if (seconds < 60) {
     const rounded = Math.round(seconds * 10) / 10;
@@ -40,8 +40,9 @@ export function formatTrajectoryDuration(ms: number | null): string {
  */
 export function formatTrajectoryTokenCount(
   count: number | undefined,
-  options: { emptyLabel: string },
+  options?: { emptyLabel?: string },
 ): string {
+  const emptyLabel = options?.emptyLabel ?? "—";
   // Fail closed on non-finite or negative values: NaN / Infinity / negative
   // counts render as emptyLabel rather than "NaNM" / "InfinityM". Aligns with
   // the non-negative contract of formatByteSize in format.ts.
@@ -51,7 +52,7 @@ export function formatTrajectoryTokenCount(
     !Number.isFinite(count) ||
     count < 0
   ) {
-    return options.emptyLabel;
+    return emptyLabel;
   }
   if (count < 1000) return String(count);
   const thousands = count / 1000;


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/trajectory-format.ts`, `formatTrajectoryTokenCount` required a non-optional `options: { emptyLabel: string }` argument, throwing a `TypeError` if callers invoked it without options. Made `options?: { emptyLabel?: string }` optional with default `{ emptyLabel: "—" }`.
2. In `formatTrajectoryDuration`, sub-second durations (`ms < 1000`) now apply `Math.round(ms)` to avoid printing raw unrounded floating-point fractions (e.g. `24.718ms`).
3. Added unit regression test coverage in `packages/shared/src/utils/trajectory-format.test.ts`.

Closes #21023.

## Verification

Exact commit: `576ee2c66d`.

- Focused unit test suite `packages/shared/src/utils/trajectory-format.test.ts`: 19/19 tests passing (51 assertions, 100% line & function coverage).
- Biome format on `@elizaos/shared`: 397 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - shared trajectory formatter utility function; no rendered UI changed.
- [x] N/A - shared trajectory formatter utility function; no rendered UI changed.
- [x] N/A - deterministic utility function behavior.
- [x] Focused test suite transcript:
```text
✓ formatTrajectoryDuration > formats null as the placeholder [0.21ms]
✓ formatTrajectoryDuration > fails closed on non-finite values [0.05ms]
✓ formatTrajectoryDuration > fails closed on negative durations while preserving 0ms [0.04ms]
✓ formatTrajectoryDuration > formats sub-second durations in ms [0.03ms]
✓ formatTrajectoryDuration > formats seconds with one decimal [0.04ms]
✓ formatTrajectoryDuration > rolls over to minutes when rounding crosses the 60s boundary [0.02ms]
✓ formatTrajectoryDuration > formats minutes with one decimal [0.02ms]
✓ formatTrajectoryDuration > rolls over to hours when rounding crosses the 60m boundary [0.02ms]
✓ formatTrajectoryDuration > formats hours with one decimal [0.02ms]
✓ formatTrajectoryTokenCount > returns the empty label for undefined or zero [0.09ms]
✓ formatTrajectoryTokenCount > fails closed on non-finite or negative values [0.04ms]
✓ formatTrajectoryTokenCount > formats raw counts below 1000 without a suffix [0.02ms]
✓ formatTrajectoryTokenCount > formats thousands with one decimal [0.03ms]
✓ formatTrajectoryTokenCount > promotes to M when rounding crosses the 1000k boundary [0.02ms]
✓ formatTrajectoryTokenCount > formats millions with one decimal [0.03ms]
✓ formatTrajectoryTimestamp > fails closed on empty or unparseable timestamps [0.11ms]
✓ formatTrajectoryTimestamp > formats today in smart mode as a local time [3.26ms]
✓ formatTrajectoryTimestamp > formats non-today dates with a short month and day [0.70ms]
✓ formatTrajectoryTimestamp > formats detailed mode with seconds [0.46ms]
19 pass, 0 fail, 51 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@07e891e37a28e573a6a9ff44b62db40d517c5b36:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@07e891e37a28e573a6a9ff44b62db40d517c5b36:packages/skills/skills/contribute-to-eliza"} -->