### PR TITLE
fix(orchestrator): do not auto-pass behavioral URL criteria from reachability alone

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
@@ -104,7 +104,7 @@ describe("deterministicLedgerVerdict", () => {
   test("the live quick-app incident shape passes deterministically", () => {
     const verdict = deterministicLedgerVerdict(
       [
-        "the live URL returns HTTP 200",
+        "the deployed app is reachable at its public URL",
         "the deliverable file exists in the workdir",
         "the change is summarized in the diff",
       ],
@@ -118,11 +118,52 @@ describe("deterministicLedgerVerdict", () => {
 
   test("an unsatisfied check criterion stays undetermined and blocks allMet", () => {
     const verdict = deterministicLedgerVerdict(
-      ["the live URL returns HTTP 200", "tests pass"],
+      ["the deployed app is reachable at its public URL", "tests pass"],
       quickAppFacts,
     );
     expect(verdict.allMet).toBe(false);
     expect(verdict.undetermined).toEqual(["tests pass"]);
+  });
+
+  test("behavioral URL criteria stay undetermined on reachability alone (#21002)", () => {
+    // A probe answering cannot prove HTTP status, auth, error, content, or
+    // method behavior — so each of these must NOT auto-pass from a verified
+    // URL, even when the criterion contains URL/API vocabulary.
+    const behavioral = [
+      "the API returns 401 for an invalid token",
+      "the endpoint responds with HTTP 200",
+      "the deployed URL requires authentication",
+      "a GET request to the endpoint returns JSON",
+      "the API rejects a malformed request body with an error",
+    ];
+    for (const criterion of behavioral) {
+      const verdict = deterministicLedgerVerdict([criterion], quickAppFacts);
+      expect(verdict.allMet).toBe(false);
+      expect(verdict.undetermined).toEqual([criterion]);
+      expect(verdict.results[0]?.basis).toBeUndefined();
+    }
+  });
+
+  test("a named+verified URL still cannot prove behavior (#21002)", () => {
+    // Even when the exact probed URL is named, reachability does not prove the
+    // asserted 401 response — the criterion must defer to model judgment.
+    const verdict = deterministicLedgerVerdict(
+      [
+        "https://nubilio.org/apps/canon-clock/ returns HTTP 401 for a bad token",
+      ],
+      quickAppFacts,
+    );
+    expect(verdict.allMet).toBe(false);
+    expect(verdict.undetermined).toHaveLength(1);
+  });
+
+  test("a plain reachability criterion still passes with any verified URL (#21002)", () => {
+    const verdict = deterministicLedgerVerdict(
+      ["the deployed app is reachable and serves at a public URL"],
+      quickAppFacts,
+    );
+    expect(verdict.allMet).toBe(true);
+    expect(verdict.results[0]?.basis).toContain("nubilio.org");
   });
 
   test("green mined output satisfies test/build/lint criteria", () => {
@@ -152,12 +193,17 @@ describe("deterministicLedgerVerdict", () => {
     expect(verdict.allMet).toBe(false);
   });
 
-  test("a criterion naming a specific URL must match the probed URL", () => {
+  test("an unrelated verified URL does not satisfy a demanded explicit URL", () => {
+    // The demanded URL was never probed; a different verified URL must not
+    // stand in for it even for a plain reachability assertion (#21002).
     const verdict = deterministicLedgerVerdict(
-      ["https://nubilio.org/apps/other/ returns HTTP 200"],
+      ["https://nubilio.org/apps/other/ is reachable"],
       quickAppFacts,
     );
     expect(verdict.allMet).toBe(false);
+    expect(verdict.undetermined).toEqual([
+      "https://nubilio.org/apps/other/ is reachable",
+    ]);
   });
 
   test("empty criteria never auto-pass", () => {
@@ -167,11 +213,13 @@ describe("deterministicLedgerVerdict", () => {
   test("renders met bases and undetermined markers", () => {
     const rendered = renderDeterministicVerdict(
       deterministicLedgerVerdict(
-        ["the live URL returns HTTP 200", "tests pass"],
+        ["the deployed app is reachable at its public URL", "tests pass"],
         quickAppFacts,
       ),
     );
-    expect(rendered).toContain("MET: the live URL returns HTTP 200");
+    expect(rendered).toContain(
+      "MET: the deployed app is reachable at its public URL",
+    );
     expect(rendered).toContain("undetermined (needs judgment): tests pass");
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
@@ -135,6 +135,22 @@ const LINT_CRITERION_RE = /\b(lint|biome|eslint|format)\b/i;
 const SCREENSHOT_CRITERION_RE = /\b(screenshot|screen\s*capture)\b/i;
 const EXPLICIT_HTTP_URL_RE = /https?:\/\/[^\s`"'<>]+/gi;
 
+/**
+ * Detects when a URL/API criterion asserts endpoint BEHAVIOR — an HTTP status,
+ * a response body/content shape, authentication/authorization, an error
+ * response, or a specific HTTP method — rather than mere reachability (#21002).
+ * Router probes only prove that *a* URL answered; they cannot prove *how* it
+ * answered. A behavioral assertion therefore can never be satisfied by
+ * reachability evidence alone, even when a matching URL is named and verified,
+ * so it must fall through to model judgment instead of auto-passing.
+ *
+ * Kept deliberately conservative: the vocabulary is chosen to leave plain
+ * "is reachable / serves / deployed at a public URL" phrasings untouched, and
+ * over-matching only ever removes a false auto-pass (never creates one).
+ */
+const BEHAVIORAL_URL_RE =
+  /\b(status|returns?|respond(?:s|ing)?|response|body|content|payload|json|header|auth|authenticated|authentication|authoriz(?:e|ed|ation)|token|login|logged|unauthorized|forbidden|error|errors|fails?|failure|reject(?:s|ed)?|invalid|redirects?|GET|POST|PUT|DELETE|PATCH)\b|\b[1-5]\d\d\b/i;
+
 function normalizeExplicitHttpUrl(value: string): string | undefined {
   const candidate = value.replace(/[),.;!?]+$/, "");
   try {
@@ -229,6 +245,13 @@ export function deterministicCriterionCheck(
     return { criterion, status: "undetermined" };
   }
   if (URL_CRITERION_RE.test(criterion)) {
+    // Reachability evidence (a probed URL answered) cannot prove endpoint
+    // behavior. A behavioral assertion — HTTP status, response content, auth,
+    // an error response, or an HTTP method — stays undetermined and defers to
+    // model judgment even when a matching URL was named and verified (#21002).
+    if (BEHAVIORAL_URL_RE.test(criterion)) {
+      return { criterion, status: "undetermined" };
+    }
     const basis = urlCriterionBasis(criterion, facts);
     return basis
       ? { criterion, status: "met", basis }


### PR DESCRIPTION
# Relates to

Closes #21002

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and focused package gates were run after sync; unrelated `bun run verify` limits on this constrained Raspberry Pi host are recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm (autonomous)`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@12a6824705a178197181cfe24c34dca98c1842f9:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused package tests, typecheck, and Biome pass post-sync (see Evidence). Full `bun run verify` is not completable on this constrained host — see **Known gaps / failures**.

# Risks

Low. The change only tightens a deterministic auto-pass heuristic (fewer criteria auto-pass; none newly auto-pass). Over-classifying a criterion as behavioral only defers it to model judgment — the pre-existing safe fallback — and can never manufacture a false success.

# Background

## What does this PR do?

The deterministic evidence prepass in `plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts` classified any URL/API acceptance criterion as `met` whenever a single probed public URL answered. Reachability (a URL answered) cannot prove *how* an endpoint answers: HTTP status, response body/content, authentication, error responses, or HTTP method behavior. A criterion like `API returns 401 for an invalid token` therefore falsely auto-passed on an unrelated verified URL, and when every criterion was similarly misclassified `deterministicLedgerVerdict` reported `allMet: true`, promoting an incomplete task with no model review.

This PR adds `BEHAVIORAL_URL_RE` and, in `deterministicCriterionCheck`, keeps any URL criterion that asserts endpoint behavior `undetermined` — even when a matching explicit URL was named and verified — so it defers to model judgment. Plain reachability criteria still resolve to `met` with any verified URL.

- Generic reachability criteria are satisfied only by (a) a matching explicitly named+verified URL, or (b) any verified URL when no stronger behavioral assertion is made.
- Criteria asserting HTTP status, response content, auth, errors, or HTTP methods stay `undetermined` from reachability evidence, even with a named+verified URL.
- Existing quick-app plain reachability behavior is preserved.

## What kind of change is this?

Bug fix (non-breaking change which fixes a false-success path).

# Documentation changes needed?

My changes do not require a change to the project documentation. The behavior is documented inline via the `BEHAVIORAL_URL_RE` header comment and the error-policy conventions already in the file.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts` — the new `#21002` cases in the `deterministicLedgerVerdict` block prove both the rejection paths and the preserved reachability path.

## Detailed testing steps

Automated tests are sufficient. From the repo root:

```bash
cd plugins/plugin-agent-orchestrator
bunx vitest run --config vitest.config.ts src/__tests__/producible-evidence.test.ts
bunx tsc --noEmit -p tsconfig.json
bunx @biomejs/biome check src/services/producible-evidence.ts src/__tests__/producible-evidence.test.ts
```

# Evidence Gate

<!-- evidence-head:745699ab1ca92bb03d540c96c5a1691df93007f1 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no UI surface; this is a pure deterministic function in a Node-only orchestrator service.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no UI surface (Node-only service logic).`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; behavior is a headless classifier verified by unit tests and a reproduction script.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - text logs are inline under 'Backend + frontend logs' and 'Focused test output'; immutable release-asset upload requires write access to the upstream pr-evidence release, which this fork contributor identity lacks (upload returns HTTP 404).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - this change removes a deterministic auto-pass and defers to the existing model path; it introduces no new prompt/model/agent behavior to trace.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the failing-then-passing reproduction (verdict classification) is inline in the PR body; immutable release-asset hosting is unavailable to this fork identity (upstream release upload returns HTTP 404).
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change. The change only narrows a deterministic pre-model heuristic.`

## Backend + frontend logs

Reproduction using the built module (`bun --conditions=eliza-source`), showing the before/after contract for a behavioral criterion, a named+verified behavioral criterion, and a plain reachability criterion against a single verified public URL:

```text
UNDETERMINED | API returns 401 for an invalid token
UNDETERMINED | https://nubilio.org/apps/canon-clock/ returns HTTP 200
MET          | the deployed app is reachable at its public URL  [probed URL answered: https://nubilio.org/apps/canon-clock/]
```

Before this fix, both `UNDETERMINED` rows above were classified `MET` (basis `probed URL answered`), which is the false-success path #21002 describes.

Frontend logs: `N/A - no frontend involved.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no user-facing flow.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Focused test output

```text
✓ deterministicLedgerVerdict > the live quick-app incident shape passes deterministically
✓ deterministicLedgerVerdict > an unsatisfied check criterion stays undetermined and blocks allMet
✓ deterministicLedgerVerdict > behavioral URL criteria stay undetermined on reachability alone (#21002)
✓ deterministicLedgerVerdict > a named+verified URL still cannot prove behavior (#21002)
✓ deterministicLedgerVerdict > a plain reachability criterion still passes with any verified URL (#21002)
✓ deterministicLedgerVerdict > an unrelated verified URL does not satisfy a demanded explicit URL
✓ deterministicLedgerVerdict > renders met bases and undetermined markers

 Test Files  1 passed (1)
      Tests  32 passed (32)
```

Typecheck (`bunx tsc --noEmit -p tsconfig.json`): clean (exit 0) after building the `@elizaos/core` and `@elizaos/vault` peer artifacts this package's project references depend on.

Biome (`bunx @biomejs/biome check` on the two changed files): `Checked 2 files. No fixes applied.` (exit 0).

## Known gaps / failures

- Full repo-root `bun run verify` is not completable on this constrained Raspberry Pi host (it drives the full Turbo build/lint/type graph across every workspace). The owning-package gates — focused Vitest (32 passing), `tsc --noEmit`, and Biome on the changed files — all pass and are attached above. The diff is confined to two files in a single Node-only service with no cross-package surface change.
- `bun install` succeeded under the host's `minimumReleaseAge` install policy without modifying any tracked file.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@12a6824705a178197181cfe24c34dca98c1842f9:packages/skills/skills/contribute-to-eliza"} -->

