### PR TITLE
fix(ci): restore valid workflow concurrency

### DIFF
--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -129,7 +129,6 @@ jobs:
     concurrency:
       group: cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}
       cancel-in-progress: false
-      queue: max
     env:
       REQUESTED_ENVIRONMENT: ${{ inputs.environment }}
       TARGET_ENVIRONMENT: ${{ inputs.environment == 'production' && 'production' || 'staging' }}

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -371,15 +371,12 @@ jobs:
     name: Mutate and verify Cloud CF release
     needs: [validate-deploy-source, admit-staging, validate-staging-certification, authorize-production]
     if: ${{ always() && github.event_name != 'pull_request' && (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && needs.authorize-production.result == 'success' || !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.admit-staging.outputs.should_deploy == 'true') }}
-    # One critical section for migrate + API + Pages + routing proof.
-    # `queue: max` is GitHub's production-deploy contract: up to 100 approved
-    # releases wait instead of the default one-pending eviction. FIFO is by
-    # wait-start, not dispatch; ordering is not guaranteed. Incompatible with
-    # cancel-in-progress: true (#18092).
+    # One critical section for migrate + API + Pages + routing proof. Native
+    # GitHub concurrency preserves the active release but retains at most one
+    # pending release; a later arrival replaces the previous pending run.
     concurrency:
       group: cloud-cf-release-v6-${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
       cancel-in-progress: false
-      queue: max
     uses: ./.github/workflows/cloud-cf-release.yml
     secrets: inherit
     with:

--- a/.github/workflows/deploy-aasa.yml
+++ b/.github/workflows/deploy-aasa.yml
@@ -81,7 +81,6 @@ jobs:
     concurrency:
       group: deploy-aasa-edge-mutate
       cancel-in-progress: false
-      queue: max
     environment: production
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -118,7 +118,6 @@ jobs:
     concurrency:
       group: deploy-eliza-provisioning-worker-mutate-${{ needs.determine-env.outputs.environment }}
       cancel-in-progress: false
-      queue: max
     environment: ${{ needs.determine-env.outputs.environment }}
     # The three bounded remote phases (5m prerequisites, 40m deploy including
     # a possible wait for an orphaned prior SSH process, 5m health) can each

--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -37,7 +37,6 @@ jobs:
     concurrency:
       group: cloud-cf-release-v6-${{ inputs.environment }}
       cancel-in-progress: false
-      queue: max
     env:
       TARGET_ENVIRONMENT: ${{ inputs.environment }}
       DEPLOY_BRANCH: ${{ inputs.environment == 'production' && 'main' || 'develop' }}

--- a/packages/cloud/scripts/production-deploy-admission-lock.mjs
+++ b/packages/cloud/scripts/production-deploy-admission-lock.mjs
@@ -2,32 +2,26 @@
  * #18092 release lock model.
  *
  * GitHub's concurrency contract (docs.github.com control-workflow-concurrency):
- * at most one running member per group. Default `queue: single` keeps at most
- * one pending member and evicts the previous waiter. `queue: max` keeps up
- * to 100 pending members and processes them FIFO by wait-start (not dispatch);
- * ordering is not guaranteed. `queue: max` cannot combine with
- * `cancel-in-progress: true`.
+ * at most one running and one pending member per group. A new pending member
+ * evicts the previous waiter; `cancel-in-progress: false` preserves only the
+ * active member.
  *
  * Admission groups must be unique per non-PR run so two dispatches of the
  * same SHA both create jobs. Mutation is one holder for the whole
- * migrate/API/Pages/verify (or publish/CDN) lifecycle, with `queue: max` so
- * a third approved release waits instead of cancelling the second.
+ * migrate/API/Pages/verify (or publish/CDN) lifecycle. Callers must account
+ * for GitHub replacing an existing pending release when a third one arrives.
  */
-
-const MAX_PENDING = 100;
 
 export function admissionGroup({ eventName, prNumber, runId }) {
   if (eventName === "pull_request") {
     return {
       group: `pr-${prNumber}`,
       cancelInProgress: true,
-      queue: "single",
     };
   }
   return {
     group: `run-${runId}`,
     cancelInProgress: false,
-    queue: "single",
   };
 }
 
@@ -35,24 +29,14 @@ export function releaseGroup(environment) {
   return {
     group: `release-${environment}`,
     cancelInProgress: false,
-    queue: "max",
   };
 }
 
-export function createConcurrencyGroup({
-  cancelInProgress = false,
-  queue = "single",
-} = {}) {
-  if (cancelInProgress && queue === "max") {
-    throw new Error(
-      "The combination of queue: max and cancel-in-progress: true is not allowed",
-    );
-  }
+export function createConcurrencyGroup({ cancelInProgress = false } = {}) {
   return {
     active: null,
     pending: [],
     cancelInProgress,
-    queue,
     cancelled: new Set(),
   };
 }
@@ -68,15 +52,6 @@ export function requestConcurrency(group, id) {
     group.active = id;
     group.pending = [];
     return "active";
-  }
-  if (group.queue === "max") {
-    if (group.pending.includes(id)) return "pending";
-    if (group.pending.length >= MAX_PENDING) {
-      group.cancelled.add(id);
-      return "cancelled";
-    }
-    group.pending.push(id);
-    return "pending";
   }
   const current = group.pending[0];
   if (current && current !== id) group.cancelled.add(current);

--- a/packages/cloud/scripts/production-deploy-admission-lock.test.mjs
+++ b/packages/cloud/scripts/production-deploy-admission-lock.test.mjs
@@ -100,8 +100,8 @@ describe("GitHub concurrency state model", () => {
     expect(lock.pending).toEqual([]);
   });
 
-  test("default queue:single evicts the pending member, not the active one", () => {
-    const lock = createConcurrencyGroup({ cancelInProgress: false });
+  test("a third approved release evicts the pending member, not the active one", () => {
+    const lock = createConcurrencyGroup(releaseGroup("production"));
     requestConcurrency(lock, "A");
     requestConcurrency(lock, "B");
     requestConcurrency(lock, "C");
@@ -109,45 +109,6 @@ describe("GitHub concurrency state model", () => {
     expect(lock.pending).toEqual(["C"]);
     expect(lock.cancelled.has("B")).toBe(true);
     expect(lock.cancelled.has("A")).toBe(false);
-  });
-
-  test("queue:max keeps every approved waiter and promotes FIFO by wait-start", () => {
-    const lock = createConcurrencyGroup(releaseGroup("production"));
-    expect(lock.queue).toBe("max");
-    requestConcurrency(lock, "A");
-    requestConcurrency(lock, "B");
-    requestConcurrency(lock, "C");
-    expect(lock.active).toBe("A");
-    expect(lock.pending).toEqual(["B", "C"]);
-    expect(lock.cancelled.size).toBe(0);
-    completeConcurrency(lock, "A");
-    expect(lock.active).toBe("B");
-    expect(lock.pending).toEqual(["C"]);
-    completeConcurrency(lock, "B");
-    expect(lock.active).toBe("C");
-    expect(lock.pending).toEqual([]);
-  });
-
-  test("queue:max cannot combine with cancel-in-progress", () => {
-    expect(() =>
-      createConcurrencyGroup({ cancelInProgress: true, queue: "max" }),
-    ).toThrow(/queue: max/);
-  });
-
-  test("queue:max cancels arrivals after 100 pending members", () => {
-    const lock = createConcurrencyGroup({
-      cancelInProgress: false,
-      queue: "max",
-    });
-    requestConcurrency(lock, "active");
-    for (let i = 0; i < 100; i += 1) {
-      expect(requestConcurrency(lock, `p${i}`)).toBe("pending");
-    }
-    expect(requestConcurrency(lock, "overflow")).toBe("cancelled");
-    expect(lock.active).toBe("active");
-    expect(lock.pending).toHaveLength(100);
-    expect(lock.cancelled.has("overflow")).toBe(true);
-    expect(lock.cancelled.has("p0")).toBe(false);
   });
 
   test("the former three-group design allows B to migrate while A deploys API", () => {
@@ -202,7 +163,7 @@ describe("committed Cloud CF workflow matches the policy", () => {
       "format('pr-{0}', github.event.pull_request.number)",
     );
     expect(block).not.toContain("github.sha");
-    expect(block).not.toContain("queue: max");
+    expect(block).not.toContain("queue:");
     expect(cloudCf).not.toContain("cloud-cf-deploy-v5-");
   });
 
@@ -214,7 +175,7 @@ describe("committed Cloud CF workflow matches the policy", () => {
     expect(release).toContain("uses: ./.github/workflows/cloud-cf-release.yml");
     expect(release).toContain("group: cloud-cf-release-v6-");
     expect(release).toContain("cancel-in-progress: false");
-    expect(release).toContain("queue: max");
+    expect(release).not.toContain("queue:");
     expect(release).not.toMatch(/^ {4}environment:/m);
   });
 
@@ -249,7 +210,7 @@ describe("committed AASA and provisioning workflows match the policy", () => {
     expect(determine).not.toContain("concurrency:");
     expect(deploy).toContain("group: deploy-eliza-provisioning-worker-mutate-");
     expect(deploy).toContain("cancel-in-progress: false");
-    expect(deploy).toContain("queue: max");
+    expect(deploy).not.toContain("queue:");
   });
 
   test("AASA admission is per run and CDN proof stays inside the mutate job", () => {
@@ -262,6 +223,6 @@ describe("committed AASA and provisioning workflows match the policy", () => {
     expect(publish).toContain("group: deploy-aasa-edge-mutate");
     expect(publish).toContain("apple-cdn-live");
     expect(publish).toContain("cancel-in-progress: false");
-    expect(publish).toContain("queue: max");
+    expect(publish).not.toContain("queue:");
   });
 });

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -408,7 +408,6 @@ describe("Personal Shared Telegram edge deploy", () => {
       "cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}",
     );
     expect(job?.concurrency?.["cancel-in-progress"]).toBe(false);
-    expect(job?.concurrency?.queue).toBe("max");
     expect(job?.env?.REQUESTED_ENVIRONMENT).toBe("${{ inputs.environment }}");
     expect(job?.env?.TARGET_ENVIRONMENT).toBe(
       "${{ inputs.environment == 'production' && 'production' || 'staging' }}",

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -40,7 +40,6 @@ interface WorkflowJob {
   concurrency?: {
     "cancel-in-progress"?: boolean;
     group?: string;
-    queue?: string;
   };
   env?: Record<string, string>;
   environment?: string;
@@ -209,7 +208,6 @@ describe("protected gateway-webhook deployment workflow", () => {
       ["cloud-cf-release-v6-", githubExpression("inputs.environment")].join(""),
     );
     expect(deploy?.concurrency?.["cancel-in-progress"]).toBe(false);
-    expect(deploy?.concurrency?.queue).toBe("max");
 
     expect(deploy?.env).toEqual(expectedJobEnvironment);
     expect(() => assertExactProtectedRouting(deploy)).not.toThrow();


### PR DESCRIPTION
Urgent follow-up to merged #20896 and the inherited production workflow concurrency contract.

## Summary

- remove every unsupported `concurrency.queue: max` key from the five affected GitHub workflows
- remove the self-affirming activation/gateway assertions that encoded the invalid key
- correct the production deploy lock model and contract tests to GitHub's actual one-running/one-pending semantics
- retain `cancel-in-progress: false`, shared mutation groups, and authorization-before-lock ordering

## Root cause and behavior

GitHub Actions concurrency accepts only `group` and `cancel-in-progress`. The merged keys make the affected workflow YAML invalid; pinned `actionlint` reports `unexpected key "queue"`.

GitHub natively retains at most one running and one pending member per group. With `cancel-in-progress: false`, the active release is preserved, but a third arrival replaces the existing pending release. The repaired simulator and workflow comments now state and test that real consequence instead of modeling a nonexistent 100-member FIFO queue.

Affected workflows:

- Personal Shared Telegram edge activation
- gateway-webhook deployment
- Cloudflare production/staging release
- AASA edge publication
- Eliza provisioning Worker deployment

## Exact revision

- Head: `643c0469f96d6b0bab912461945b04b52edb435e`
- Base: `c7c4b5f7a61bf0bbea2e130e941c297b476ba401`

## Validation

- pinned `actionlint` across all five affected workflows: passed
- focused workflow and concurrency-model tests: 27/27 passed, 306 assertions
- production deploy lock model coverage: 100% functions and lines
- Biome on all changed script/test sources: zero errors; 15 existing workflow-expression fixture warnings
- repo-wide scan: no remaining `queue: max`, typed concurrency `queue`, or self-affirming queue assertions in workflow/script sources
- `git diff --check origin/develop...HEAD`: passed
- No workflow dispatch, deployment, environment approval, secret mutation, or production state change was performed

## Evidence matrix

- Backend/runtime logs: `N/A - workflow schema and contract-model repair; no run was dispatched`.
- Frontend screenshots/video: `N/A - no UI surface changed`.
- Real-model trajectory: `N/A - no model behavior changed`.
- Domain artifact: exact-head actionlint plus the 27 focused contract tests above.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@643c0469f96d6b0bab912461945b04b52edb435e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

— [codex]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@643c0469f96d6b0bab912461945b04b52edb435e:packages/skills/skills/contribute-to-eliza"} -->
