### PR TITLE
fix(shared): reject empty and non-string keys in rate-limiter check and peek

### DIFF
--- a/packages/shared/src/utils/rate-limiter.test.ts
+++ b/packages/shared/src/utils/rate-limiter.test.ts
@@ -41,6 +41,20 @@ describe("createRateLimiter", () => {
     ).toThrow(RangeError);
   });
 
+  it("rejects non-string or whitespace-only keys in check and peek", () => {
+    limiter = createRateLimiter({ windowMs: 5000 });
+
+    expect(() => limiter?.check("")).toThrow(TypeError);
+    expect(() => limiter?.check("   ")).toThrow(TypeError);
+    expect(() => limiter?.check(null as unknown as string)).toThrow(TypeError);
+    expect(() => limiter?.check(undefined as unknown as string)).toThrow(
+      TypeError,
+    );
+    expect(() => limiter?.peek("")).toThrow(TypeError);
+    expect(() => limiter?.peek("   ")).toThrow(TypeError);
+    expect(() => limiter?.peek(123 as unknown as string)).toThrow(TypeError);
+  });
+
   it("caps the derived sweep interval at the maximum timer delay", () => {
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
 

--- a/packages/shared/src/utils/rate-limiter.ts
+++ b/packages/shared/src/utils/rate-limiter.ts
@@ -72,7 +72,14 @@ export function createRateLimiter(opts: RateLimiterOptions): RateLimiter {
     (sweepTimer as NodeJS.Timeout).unref();
   }
 
+  function assertKey(key: string): void {
+    if (typeof key !== "string" || key.trim().length === 0) {
+      throw new TypeError("rate-limiter: key must be a non-empty string");
+    }
+  }
+
   function peekImpl(key: string): RateLimitCheck {
+    assertKey(key);
     const last = map.get(key);
     if (last === undefined) return { allowed: true, retryAfterSeconds: 0 };
     const elapsed = Date.now() - last;


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/rate-limiter.ts`, added `assertKey(key)` validation to reject empty, whitespace-only, `null`, `undefined`, and non-string key arguments with `TypeError("rate-limiter: key must be a non-empty string")`.
2. Prevents unvalidated key inputs from polluting the internal tracking Map and causing false-positive rate limit collisions across calls with missing keys.
3. Added unit regression test coverage in `packages/shared/src/utils/rate-limiter.test.ts`.

Closes #21025.

## Verification

Exact commit: `2a77be4ede`.

- Focused unit test suite `packages/shared/src/utils/rate-limiter.test.ts`: 10/10 tests passing (42 assertions, 100% line & function coverage).
- Biome format on `@elizaos/shared`: 397 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - shared in-memory rate limiter utility; no rendered UI changed.
- [x] N/A - shared in-memory rate limiter utility; no rendered UI changed.
- [x] N/A - deterministic utility function behavior.
- [x] Focused test suite transcript:
```text
✓ createRateLimiter > validates windowMs and sweepIntervalMs options [0.57ms]
✓ createRateLimiter > rejects non-string or whitespace-only keys in check and peek [0.39ms]
✓ createRateLimiter > caps the derived sweep interval at the maximum timer delay [0.19ms]
✓ createRateLimiter > allows initial action and blocks subsequent actions within windowMs [0.13ms]
✓ createRateLimiter > allows actions after windowMs has elapsed [0.07ms]
✓ createRateLimiter > peek checks rate limit state without recording an action [0.05ms]
✓ createRateLimiter > ensures retryAfterSeconds is at least 1 when blocked [0.06ms]
✓ createRateLimiter > clears tracked keys [0.08ms]
✓ createRateLimiter > disposes resources and is safe for multiple dispose calls [0.09ms]
✓ createRateLimiter > sweeps stale entries beyond 2x windowMs [0.20ms]
10 pass, 0 fail, 42 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@c7c4b5f7a637d57c8d9df2499d3e8bf3e7b764b8:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@c7c4b5f7a637d57c8d9df2499d3e8bf3e7b764b8:packages/skills/skills/contribute-to-eliza"} -->