### PR TITLE
fix(cloud): make Railway build-only proof explicit

### DIFF
--- a/packages/cloud/services/gateway-discord/scripts/deploy-railway.sh
+++ b/packages/cloud/services/gateway-discord/scripts/deploy-railway.sh
@@ -19,6 +19,19 @@
 # zlib-sync is intentionally omitted: it is an optional native dep of the Discord
 # WS lib (lazy require -> graceful fallback to no compression).
 set -euo pipefail
+BUILD_ONLY=0
+case "${1:-}" in
+  "") ;;
+  --build-only) BUILD_ONLY=1 ;;
+  *)
+    echo "usage: $0 [--build-only]" >&2
+    exit 2
+    ;;
+esac
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [--build-only]" >&2
+  exit 2
+fi
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
 PACKAGES_DIR="$(cd "$HERE/../../.." && pwd)"
 CLEANUP_HELPER="$PACKAGES_DIR/scripts/rm-path-recursive.mjs"
@@ -75,7 +88,7 @@ DOCKER
 
 cp "$HERE/railway.toml" "$STAGE/railway.toml" 2>/dev/null || true
 
-if [ "${GATEWAY_DISCORD_DEPLOY_BUILD_ONLY:-0}" = "1" ]; then
+if [ "$BUILD_ONLY" = "1" ]; then
   echo "[deploy] build-only proof passed"
   exit 0
 fi

--- a/packages/cloud/services/gateway-discord/tests/deploy-railway.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/deploy-railway.test.ts
@@ -3,15 +3,14 @@
 import { expect, test } from "bun:test";
 
 test("the Railway deploy script builds the source-form workspace bundle", async () => {
-  const process = Bun.spawn(["bash", "scripts/deploy-railway.sh"], {
-    cwd: `${import.meta.dir}/..`,
-    env: {
-      ...Bun.env,
-      GATEWAY_DISCORD_DEPLOY_BUILD_ONLY: "1",
+  const process = Bun.spawn(
+    ["bash", "scripts/deploy-railway.sh", "--build-only"],
+    {
+      cwd: `${import.meta.dir}/..`,
+      stdout: "pipe",
+      stderr: "pipe",
     },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+  );
   const [exitCode, stdout, stderr] = await Promise.all([
     process.exited,
     new Response(process.stdout).text(),
@@ -22,4 +21,22 @@ test("the Railway deploy script builds the source-form workspace bundle", async 
     throw new Error(`Railway bundle proof failed:\n${stderr}`);
   }
   expect(stdout).toContain("[deploy] build-only proof passed");
+});
+
+test("the Railway deploy script rejects unknown modes before building", async () => {
+  const process = Bun.spawn(
+    ["bash", "scripts/deploy-railway.sh", "--unexpected"],
+    {
+      cwd: `${import.meta.dir}/..`,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const [exitCode, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stderr).text(),
+  ]);
+
+  expect(exitCode).toBe(2);
+  expect(stderr).toContain("usage:");
 });


### PR DESCRIPTION
Closes #21029.

## Summary

- replace the inherited `GATEWAY_DISCORD_DEPLOY_BUILD_ONLY` switch with an explicit `--build-only` argument
- reject unknown or extra arguments before bundling or deployment
- keep the no-argument operator deploy path unchanged

This prevents a stale exported test variable from making a real operator deploy exit successfully without contacting Railway.

## Verification

Exact head `664bbed5dd3267f43a43f3c9547d673362a8a0b8` (before remote push):

- deploy-boundary tests: 2/2
- full gateway-discord suite: 119/119, 358 assertions
- gateway-discord typecheck: PASS
- Bash syntax, Biome, and diff check: PASS
- no Railway, staging, provider, credential, or production mutation performed