### PR TITLE
fix(core): sanitize non-positive and non-finite ttlMs in requireConfirmation

### DIFF
--- a/packages/core/src/__tests__/confirmation.test.ts
+++ b/packages/core/src/__tests__/confirmation.test.ts
@@ -140,4 +140,39 @@ describe("requireConfirmation", () => {
 			});
 		},
 	);
+
+	it.each([
+		0,
+		-1000,
+		Number.NaN,
+		Number.POSITIVE_INFINITY,
+		"5000" as unknown as number,
+	])(
+		"sanitizes invalid or non-positive ttlMs (%j) to DEFAULT_TTL_MS",
+		async (invalidTtl) => {
+			const runtime = createRuntimeStub();
+			const args = {
+				runtime,
+				actionName: "DELETE_RESOURCE",
+				pendingKey: "res:1",
+				prompt: "Delete res 1?",
+				ttlMs: invalidTtl,
+			};
+
+			await expect(
+				requireConfirmation({
+					...args,
+					message: message("delete res 1"),
+				}),
+			).resolves.toEqual({ status: "pending" });
+
+			// Should successfully confirm on the second turn rather than being immediately expired
+			await expect(
+				requireConfirmation({
+					...args,
+					message: message("yes"),
+				}),
+			).resolves.toEqual({ status: "confirmed", metadata: undefined });
+		},
+	);
 });

--- a/packages/core/src/utils/confirmation.ts
+++ b/packages/core/src/utils/confirmation.ts
@@ -124,7 +124,12 @@ function readUserText(message: Memory): string {
 export async function requireConfirmation(
 	args: RequireConfirmationArgs,
 ): Promise<ConfirmationDecision> {
-	const ttlMs = args.ttlMs ?? DEFAULT_TTL_MS;
+	const ttlMs =
+		typeof args.ttlMs === "number" &&
+		Number.isFinite(args.ttlMs) &&
+		args.ttlMs > 0
+			? args.ttlMs
+			: DEFAULT_TTL_MS;
 	const confirmRegex = args.confirmRegex ?? DEFAULT_CONFIRM_REGEX;
 	const userId = String(args.message.entityId);
 	const cacheKey = buildCacheKey(userId, args.actionName, args.pendingKey);


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/confirmation.ts`, `requireConfirmation` evaluated `args.ttlMs ?? DEFAULT_TTL_MS`, which allowed non-positive (<= 0), non-finite, and NaN values to be passed into `PendingConfirmation.ttlMs`.
2. A non-positive TTL caused the cache entry to be treated as expired immediately on the confirmation reply, looping the pending prompt endlessly; a NaN TTL caused the cache entry to never expire.
3. Sanitized `ttlMs` to ensure it falls back to `DEFAULT_TTL_MS` (5 minutes) when `args.ttlMs` is not a positive finite number.
4. Added unit test regression coverage in `packages/core/src/__tests__/confirmation.test.ts`.

Closes #21031.

## Verification

Exact commit: `ee048665d5`.

- Focused unit test suite `packages/core/src/__tests__/confirmation.test.ts`: 24/24 tests passing (48 assertions).
- Biome format on `@elizaos/core`: 1281 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - core confirmation helper; no rendered UI changed.
- [x] N/A - core confirmation helper; no rendered UI changed.
- [x] N/A - deterministic utility function behavior.
- [x] Focused test suite transcript:
```text
✓ requireConfirmation > confirms wrapped external follow-up text by evaluating the payload [1.91ms]
✓ requireConfirmation > does not treat marker-shaped user text as wrapped without metadata [0.29ms]
✓ requireConfirmation > confirms the multilingual follow-up "sí" [0.27ms]
✓ requireConfirmation > confirms the multilingual follow-up "SÍ!" [0.03ms]
✓ requireConfirmation > confirms the multilingual follow-up "はい" [0.45ms]
✓ requireConfirmation > confirms the multilingual follow-up "はい。" [0.23ms]
✓ requireConfirmation > confirms the multilingual follow-up "はい！" [0.03ms]
✓ requireConfirmation > confirms the multilingual follow-up "はい？" [0.03ms]
✓ requireConfirmation > confirms the multilingual follow-up "はい、分かりました" [0.03ms]
✓ requireConfirmation > confirms the multilingual follow-up "「はい」" [0.02ms]
✓ requireConfirmation > confirms the multilingual follow-up "确认" [0.02ms]
✓ requireConfirmation > confirms the multilingual follow-up "确认，请继续" [0.03ms]
✓ requireConfirmation > confirms the multilingual follow-up "確認。" [0.02ms]
✓ requireConfirmation > confirms the multilingual follow-up "확인" [0.02ms]
✓ requireConfirmation > confirms the multilingual follow-up "확인 했습니다" [0.03ms]
✓ requireConfirmation > rejects a longer word beginning with a confirmation token: "sígueme" [0.18ms]
✓ requireConfirmation > rejects a longer word beginning with a confirmation token: "确认了" [0.28ms]
✓ requireConfirmation > rejects a longer word beginning with a confirmation token: "はいはい" [0.07ms]
✓ requireConfirmation > rejects a longer word beginning with a confirmation token: "확인했습니다" [0.09ms]
✓ requireConfirmation > sanitizes invalid or non-positive ttlMs (0) to DEFAULT_TTL_MS [0.30ms]
✓ requireConfirmation > sanitizes invalid or non-positive ttlMs (-1000) to DEFAULT_TTL_MS [0.03ms]
✓ requireConfirmation > sanitizes invalid or non-positive ttlMs (null) to DEFAULT_TTL_MS [0.02ms]
✓ requireConfirmation > sanitizes invalid or non-positive ttlMs (null) to DEFAULT_TTL_MS [0.02ms]
✓ requireConfirmation > sanitizes invalid or non-positive ttlMs ("5000") to DEFAULT_TTL_MS [0.01ms]
24 pass, 0 fail, 48 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@f3fc142b6d194fc8949826f0761e0bb43c683b54:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@f3fc142b6d194fc8949826f0761e0bb43c683b54:packages/skills/skills/contribute-to-eliza"} -->