### PR TITLE
fix(cloud): make storage presign GET-only

### DIFF
--- a/packages/cloud/api/__tests__/storage-presign-contract.test.ts
+++ b/packages/cloud/api/__tests__/storage-presign-contract.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Exercises the storage presign route through its real Hono boundary with
+ * deterministic authentication, billing, and storage collaborators. The suite
+ * protects the GET-only contract and verifies that rejected requests cannot
+ * initialize storage or create billing and provider side effects.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
+import { Hono } from "hono";
+
+const ORGANIZATION_ID = "00000000-0000-4000-8000-000000021009";
+const FIXED_NOW = new Date("2026-08-17T12:00:00.000Z");
+const COST = 0.00005;
+const SIGNED_URL = "https://r2.example.test/signed-object";
+const ROUTE_PATH = "/api/v1/apis/storage/presign";
+
+const requireUserOrApiKeyWithOrg = mock();
+const getR2StorageAdapter = mock();
+const getServiceMethodCost = mock();
+const deductCredits = mock();
+const presignGet = mock();
+const failureResponse = mock();
+const loggerError = mock();
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/storage/r2-storage-adapter", () => ({
+  getR2StorageAdapter,
+}));
+
+mock.module("@/lib/services/proxy/pricing", () => ({
+  getServiceMethodCost,
+}));
+
+mock.module("@/lib/services/credits", () => ({
+  creditsService: { deductCredits },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: loggerError },
+}));
+
+const presignRoute = (await import("../v1/apis/storage/presign/route")).default;
+const app = new Hono();
+app.route(ROUTE_PATH, presignRoute);
+
+function post(body: unknown): Response | Promise<Response> {
+  return app.request(ROUTE_PATH, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  setSystemTime(FIXED_NOW);
+  requireUserOrApiKeyWithOrg.mockReset();
+  getR2StorageAdapter.mockReset();
+  getServiceMethodCost.mockReset();
+  deductCredits.mockReset();
+  presignGet.mockReset();
+  failureResponse.mockReset();
+  loggerError.mockReset();
+
+  requireUserOrApiKeyWithOrg.mockResolvedValue({
+    organization_id: ORGANIZATION_ID,
+  });
+  getR2StorageAdapter.mockReturnValue({ presignGet });
+  getServiceMethodCost.mockResolvedValue(COST);
+  deductCredits.mockResolvedValue({ success: true });
+  presignGet.mockResolvedValue(SIGNED_URL);
+});
+
+afterEach(() => {
+  setSystemTime();
+});
+
+describe("POST /api/v1/apis/storage/presign", () => {
+  test("rejects PUT after authentication and before storage or billing side effects", async () => {
+    const response = await post({
+      key: "voice/message.ogg",
+      operation: "put",
+      expiresIn: 600,
+    });
+
+    expect(response.status).toBe(400);
+    const responseBody: unknown = await response.json();
+    expect(responseBody).toMatchObject({
+      error: "Invalid presign request",
+    });
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+    expect(getR2StorageAdapter).not.toHaveBeenCalled();
+    expect(getServiceMethodCost).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(presignGet).not.toHaveBeenCalled();
+  });
+
+  test("presigns GET with the scoped key, explicit TTL, and exact debit metadata", async () => {
+    const response = await post({
+      key: "/voice/message.ogg/",
+      operation: "get",
+      expiresIn: 600,
+    });
+
+    expect(response.status).toBe(200);
+    const responseBody: unknown = await response.json();
+    expect(responseBody).toEqual({
+      url: SIGNED_URL,
+      expiresAt: "2026-08-17T12:10:00.000Z",
+    });
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+    expect(getR2StorageAdapter).toHaveBeenCalledTimes(1);
+    expect(getServiceMethodCost).toHaveBeenCalledTimes(1);
+    expect(getServiceMethodCost).toHaveBeenCalledWith("storage", "presign");
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(deductCredits).toHaveBeenCalledWith({
+      organizationId: ORGANIZATION_ID,
+      amount: COST,
+      description: "API proxy: storage — presign (get)",
+      metadata: {
+        type: "proxy_storage",
+        service: "storage",
+        method: "presign",
+        operation: "get",
+      },
+    });
+    expect(presignGet).toHaveBeenCalledTimes(1);
+    expect(presignGet).toHaveBeenCalledWith(
+      `org/${ORGANIZATION_ID}/voice/message.ogg`,
+      600,
+    );
+  });
+
+  test("uses the one-hour default TTL without charging when the catalog cost is zero", async () => {
+    getServiceMethodCost.mockResolvedValueOnce(0);
+
+    const response = await post({
+      key: "avatars/profile.png",
+      operation: "get",
+    });
+
+    expect(response.status).toBe(200);
+    const responseBody: unknown = await response.json();
+    expect(responseBody).toEqual({
+      url: SIGNED_URL,
+      expiresAt: "2026-08-17T13:00:00.000Z",
+    });
+    expect(getServiceMethodCost).toHaveBeenCalledWith("storage", "presign");
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(presignGet).toHaveBeenCalledWith(
+      `org/${ORGANIZATION_ID}/avatars/profile.png`,
+      3600,
+    );
+  });
+
+  test("does not presign when the organization has insufficient credits", async () => {
+    deductCredits.mockResolvedValueOnce({ success: false });
+
+    const response = await post({
+      key: "voice/message.ogg",
+      operation: "get",
+      expiresIn: 300,
+    });
+
+    expect(response.status).toBe(402);
+    const responseBody: unknown = await response.json();
+    expect(responseBody).toEqual({
+      error: "Insufficient credits",
+      topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
+    });
+    expect(getR2StorageAdapter).toHaveBeenCalledTimes(1);
+    expect(getServiceMethodCost).toHaveBeenCalledTimes(1);
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(presignGet).not.toHaveBeenCalled();
+  });
+
+  test("rejects traversal keys before storage initialization or billing", async () => {
+    const response = await post({
+      key: "voice/../secret.txt",
+      operation: "get",
+    });
+
+    expect(response.status).toBe(400);
+    const responseBody: unknown = await response.json();
+    expect(responseBody).toEqual({ error: "Invalid object key" });
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+    expect(getR2StorageAdapter).not.toHaveBeenCalled();
+    expect(getServiceMethodCost).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(presignGet).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/apis/storage/presign/route.ts
+++ b/packages/cloud/api/v1/apis/storage/presign/route.ts
@@ -2,16 +2,15 @@
  * Mints a short-lived signed URL for a single attachment object.
  *
  * Routes:
- *   POST /api/v1/apis/storage/presign  { key, operation, expiresIn? }
+ *   POST /api/v1/apis/storage/presign  { key, operation: "get", expiresIn? }
  *                                      → { url, expiresAt }
  *
  * Auth: requireUserOrApiKeyWithOrg.
  * Pricing: flat per-request charge against the `storage:presign` row.
  *
- * The URL is a direct R2 S3 signed URL — clients hit R2 directly with it,
- * NOT this proxy. Presign for `put` is supported but the signed URL bypasses
- * the proxy's quota enforcement; clients SHOULD prefer `PUT /objects/{key+}`
- * for writes that should count against the org quota.
+ * The URL grants direct, temporary GET access through the R2 S3 endpoint;
+ * clients hit R2 directly rather than this proxy. Writes continue through
+ * `PUT /objects/{key+}` so organization quota enforcement remains authoritative.
  */
 
 import { Hono } from "hono";
@@ -29,7 +28,7 @@ const MAX_OBJECT_KEY_LENGTH = 1024;
 
 const presignRequestSchema = z.object({
   key: z.string().min(1).max(MAX_OBJECT_KEY_LENGTH),
-  operation: z.enum(["get", "put"]),
+  operation: z.literal("get"),
   expiresIn: z.number().int().min(60).max(3600).optional(),
 });
 
@@ -40,19 +39,10 @@ app.post("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const { organization_id } = user;
 
-    const adapter = getR2StorageAdapter(c.env);
-    if (!adapter) {
-      logger.error("[storage proxy] R2_* env vars not set; presign rejected");
-      return c.json(
-        {
-          error:
-            "Attachment storage proxy not available — server misconfigured",
-        },
-        503,
-      );
-    }
-
-    const rawBody = await c.req.json().catch(() => null);
+    const rawBody = await c.req.json().catch(() => {
+      // error-policy:J3 malformed JSON remains an explicit invalid request.
+      return null;
+    });
     const parsed = presignRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       return c.json(
@@ -67,6 +57,18 @@ app.post("/", async (c) => {
       trimmedKey.split("/").some((s) => s === "..")
     ) {
       return c.json({ error: "Invalid object key" }, 400);
+    }
+
+    const adapter = getR2StorageAdapter(c.env);
+    if (!adapter) {
+      logger.error("[storage proxy] R2_* env vars not set; presign rejected");
+      return c.json(
+        {
+          error:
+            "Attachment storage proxy not available — server misconfigured",
+        },
+        503,
+      );
     }
 
     const cost = await getServiceMethodCost(STORAGE_SERVICE_ID, "presign");
@@ -95,11 +97,13 @@ app.post("/", async (c) => {
 
     const ttlSeconds = expiresIn ?? 3600;
     const scopedKey = `org/${organization_id}/${trimmedKey}`;
-    const url = await adapter.presign(scopedKey, ttlSeconds);
+    const url = await adapter.presignGet(scopedKey, ttlSeconds);
     const expiresAt = new Date(Date.now() + ttlSeconds * 1000).toISOString();
 
     return c.json({ url, expiresAt });
   } catch (error) {
+    // error-policy:J1 the route boundary translates authentication, pricing,
+    // debit, configuration, and signing failures into the canonical response.
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/shared/src/lib/services/storage/r2-storage-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/storage/r2-storage-adapter.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Verifies the typed R2 adapter against a real Brighter S3 storage instance.
+ * The upstream signing method is spied so the test remains deterministic and
+ * network-free while preserving the dependency's concrete interface.
+ */
+
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Storage } from "@brighter/storage-adapter-s3";
+import { R2StorageAdapter } from "./r2-storage-adapter";
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("R2StorageAdapter.presignGet", () => {
+  test("delegates the key and TTL to the upstream GET presign operation", async () => {
+    const storage = Storage(
+      { path: "test-bucket" },
+      {
+        region: "auto",
+        endpoint: "https://example.r2.cloudflarestorage.com",
+        credentials: {
+          accessKeyId: "test-access-key",
+          secretAccessKey: "test-secret-key",
+        },
+        forcePathStyle: true,
+      },
+    );
+    const upstreamPresign = spyOn(storage, "presign").mockResolvedValue(
+      "https://r2.example.test/signed-object",
+    );
+    const adapter = new R2StorageAdapter(storage);
+
+    await expect(adapter.presignGet("org/org-1/voice/message.ogg", 600)).resolves.toBe(
+      "https://r2.example.test/signed-object",
+    );
+    expect(upstreamPresign).toHaveBeenCalledTimes(1);
+    expect(upstreamPresign).toHaveBeenCalledWith("org/org-1/voice/message.ogg", { expiresIn: 600 });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/storage/r2-storage-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/storage/r2-storage-adapter.ts
@@ -80,7 +80,8 @@ export class R2StorageAdapter {
     });
   }
 
-  async presign(key: string, expiresIn: number): Promise<string> {
+  /** Creates a short-lived URL authorizing GET access to one object. */
+  async presignGet(key: string, expiresIn: number): Promise<string> {
     return this.storage.presign(key, { expiresIn });
   }
 }


### PR DESCRIPTION
# Relates to

Relates to #21009

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the changed behavior from the evidence and hermetic route receipts below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7cdb599ecebf7f762a616ba56f60f64c8b27d873:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@bdd76405c14110100883d808d0299920be70025c`; zero conflicts.
- [x] `bun run verify` passes post-sync: 356/356 Turbo tasks, followed by all root audits passing.

# Risks

Low to medium. This narrows one authenticated storage endpoint to the only presign operation its installed provider actually implements. Unsupported write-presign requests now receive a deterministic 400 before provider initialization or monetary work. Existing GET key scoping, TTL, pricing, insufficient-credit behavior, response shape, and the Discord voice caller are unchanged. This does not enable or deploy production GET signing.

# Background

## What does this PR do?

- Makes the storage presign request schema explicitly GET-only.
- Keeps authentication first, then validates the request and object key before storage initialization, pricing, credit deduction, or URL generation.
- Renames the local adapter method to `presignGet` so the code surface cannot imply write-signing support.
- Adds a real Hono route contract suite and a real-package adapter delegation test.

## What kind of change is this?

Bug fix and billing-side-effect hardening for an unsupported API operation.

# Documentation changes needed?

No separate project documentation change is required. Route and adapter documentation now describe the GET-only contract. Production Worker GET-presign availability is intentionally tracked outside this bounded PR.

# Testing

## Where should a reviewer start?

1. `packages/cloud/api/__tests__/storage-presign-contract.test.ts`
2. `packages/cloud/api/v1/apis/storage/presign/route.ts`
3. `packages/cloud/shared/src/lib/services/storage/r2-storage-adapter.test.ts`
4. `packages/cloud/shared/src/lib/services/storage/r2-storage-adapter.ts`

## Detailed testing steps

Exact head: `dba1d0803ca026b7dc00d0e534b730eae17f348d`

Run the focused suites in their package directories:

```bash
cd packages/cloud/api
mise exec bun@1.3.14 node@24.15.0 -- bun test __tests__/storage-presign-contract.test.ts

cd ../shared
mise exec bun@1.3.14 node@24.15.0 -- bun test src/lib/services/storage/r2-storage-adapter.test.ts

cd ../services/gateway-discord
mise exec bun@1.3.14 node@24.15.0 -- bun test tests/voice-message-handler.test.ts
```

Result: 9 passed, 0 failed, 45 assertions.

The Cloud API and shared TypeScript checks, targeted Biome, and the Cloudflare Worker production dry-run also passed. Worker dry-run size: 25,963.96 KiB; gzip: 6,354.72 KiB (identical stable patch on the immediately preceding rebase). 

```bash
mise exec bun@1.3.14 node@24.15.0 -- bun run verify
```

Result: 356/356 Turbo tasks passed (0 cached), followed by all root audits passing.

The independent exact-head review returned GO with 0 blockers, 0 P1 findings, and 0 P2 findings. Stable patch ID across rebases: `bb6f535772ccfd96ef2b15b078a3ddcc66692c55`.

# Evidence Gate

<!-- evidence-head:dba1d0803ca026b7dc00d0e534b730eae17f348d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only route and adapter contract change; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only route and adapter contract change; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change with no visual user flow
<!-- evidence-row:backend-logs -->
- [x] [21034-PR21034_REVIEW_DBA1D080.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21034-PR21034_REVIEW_DBA1D080.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no live R2 object, provider request, or production credit mutation was created; hermetic receipts are in the backend artifact
<!-- evidence-row:ocr-review -->
- [ ] N/A - backend-only change with no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changed.

## Backend + frontend logs

The exact-head receipt records unsupported PUT rejection after authentication and before adapter/pricing/debit work; preserved GET scoping, TTL, billing metadata, insufficient-credit behavior, and response shape; real-package GET delegation; the Discord voice caller regression; typechecks; Worker dry-run; root verification; and independent review.

## Screenshots (before / after) + video walkthrough

N/A - backend-only route and adapter contract change; no rendered UI surface.

## Audio / voice walkthrough

N/A - the Discord voice storage caller is covered by a hermetic regression test; no audio, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- No live R2 bucket, provider, production environment, deployment, secret, or credit balance was touched.
- This PR does not establish production GET-presign availability. The deployed Worker currently substitutes the S3 adapter with an unavailable stub while exposing native R2, so Worker-native signing architecture remains separate work.
- Provider failure after a successful credit deduction is not reconciled by this bounded contract fix and must be addressed with the production signing architecture.
- Direct PUT presigning remains intentionally unsupported. A correct implementation requires quota reservation, byte reconciliation, and billing lifecycle semantics rather than a URL-only change.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@7cdb599ecebf7f762a616ba56f60f64c8b27d873:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-storage-presign-contract]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@7cdb599ecebf7f762a616ba56f60f64c8b27d873:packages/skills/skills/contribute-to-eliza"} -->


