### PR TITLE
fix(ci): restore GitHub concurrency queue support

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,6 +10,12 @@ self-hosted-runner:
 paths:
   .github/workflows/*.yml:
     ignore:
+      # GitHub added concurrency.queue on 2026-05-07, but actionlint v1.7.12
+      # and its current main branch still use the pre-queue schema. The deploy
+      # contract tests validate queue:max and its cancel-in-progress:false
+      # requirement; ignore only actionlint's exact stale-schema diagnostic.
+      # https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/
+      - 'unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"'
       # Keep workflow lint focused on actionable failures. actionlint surfaces
       # shellcheck `info` and `style` diagnostics as errors by default, which
       # makes this repo's workflow lint fail without any workflow syntax,
@@ -17,4 +23,6 @@ paths:
       - "shellcheck reported issue in this script: SC[0-9]+:(info|style):"
   .github/workflows/*.yaml:
     ignore:
+      # Match the same temporary GitHub/actionlint schema gap for .yaml files.
+      - 'unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"'
       - "shellcheck reported issue in this script: SC[0-9]+:(info|style):"

--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -129,6 +129,7 @@ jobs:
     concurrency:
       group: cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}
       cancel-in-progress: false
+      queue: max
     env:
       REQUESTED_ENVIRONMENT: ${{ inputs.environment }}
       TARGET_ENVIRONMENT: ${{ inputs.environment == 'production' && 'production' || 'staging' }}

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -371,12 +371,15 @@ jobs:
     name: Mutate and verify Cloud CF release
     needs: [validate-deploy-source, admit-staging, validate-staging-certification, authorize-production]
     if: ${{ always() && github.event_name != 'pull_request' && (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && needs.authorize-production.result == 'success' || !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.admit-staging.outputs.should_deploy == 'true') }}
-    # One critical section for migrate + API + Pages + routing proof. Native
-    # GitHub concurrency preserves the active release but retains at most one
-    # pending release; a later arrival replaces the previous pending run.
+    # One critical section for migrate + API + Pages + routing proof.
+    # `queue: max` is GitHub's production-deploy contract: up to 100 approved
+    # releases wait instead of the default one-pending eviction. FIFO is by
+    # wait-start, not dispatch; ordering is not guaranteed. Incompatible with
+    # cancel-in-progress: true (#18092).
     concurrency:
       group: cloud-cf-release-v6-${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
       cancel-in-progress: false
+      queue: max
     uses: ./.github/workflows/cloud-cf-release.yml
     secrets: inherit
     with:

--- a/.github/workflows/deploy-aasa.yml
+++ b/.github/workflows/deploy-aasa.yml
@@ -81,6 +81,7 @@ jobs:
     concurrency:
       group: deploy-aasa-edge-mutate
       cancel-in-progress: false
+      queue: max
     environment: production
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -118,6 +118,7 @@ jobs:
     concurrency:
       group: deploy-eliza-provisioning-worker-mutate-${{ needs.determine-env.outputs.environment }}
       cancel-in-progress: false
+      queue: max
     environment: ${{ needs.determine-env.outputs.environment }}
     # The three bounded remote phases (5m prerequisites, 40m deploy including
     # a possible wait for an orphaned prior SSH process, 5m health) can each

--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -37,6 +37,7 @@ jobs:
     concurrency:
       group: cloud-cf-release-v6-${{ inputs.environment }}
       cancel-in-progress: false
+      queue: max
     env:
       TARGET_ENVIRONMENT: ${{ inputs.environment }}
       DEPLOY_BRANCH: ${{ inputs.environment == 'production' && 'main' || 'develop' }}

--- a/packages/cloud/scripts/production-deploy-admission-lock.mjs
+++ b/packages/cloud/scripts/production-deploy-admission-lock.mjs
@@ -2,26 +2,32 @@
  * #18092 release lock model.
  *
  * GitHub's concurrency contract (docs.github.com control-workflow-concurrency):
- * at most one running and one pending member per group. A new pending member
- * evicts the previous waiter; `cancel-in-progress: false` preserves only the
- * active member.
+ * at most one running member per group. Default `queue: single` keeps at most
+ * one pending member and evicts the previous waiter. `queue: max` keeps up
+ * to 100 pending members and processes them FIFO by wait-start (not dispatch);
+ * ordering is not guaranteed. `queue: max` cannot combine with
+ * `cancel-in-progress: true`.
  *
  * Admission groups must be unique per non-PR run so two dispatches of the
  * same SHA both create jobs. Mutation is one holder for the whole
- * migrate/API/Pages/verify (or publish/CDN) lifecycle. Callers must account
- * for GitHub replacing an existing pending release when a third one arrives.
+ * migrate/API/Pages/verify (or publish/CDN) lifecycle, with `queue: max` so
+ * a third approved release waits instead of cancelling the second.
  */
+
+const MAX_PENDING = 100;
 
 export function admissionGroup({ eventName, prNumber, runId }) {
   if (eventName === "pull_request") {
     return {
       group: `pr-${prNumber}`,
       cancelInProgress: true,
+      queue: "single",
     };
   }
   return {
     group: `run-${runId}`,
     cancelInProgress: false,
+    queue: "single",
   };
 }
 
@@ -29,14 +35,24 @@ export function releaseGroup(environment) {
   return {
     group: `release-${environment}`,
     cancelInProgress: false,
+    queue: "max",
   };
 }
 
-export function createConcurrencyGroup({ cancelInProgress = false } = {}) {
+export function createConcurrencyGroup({
+  cancelInProgress = false,
+  queue = "single",
+} = {}) {
+  if (cancelInProgress && queue === "max") {
+    throw new Error(
+      "The combination of queue: max and cancel-in-progress: true is not allowed",
+    );
+  }
   return {
     active: null,
     pending: [],
     cancelInProgress,
+    queue,
     cancelled: new Set(),
   };
 }
@@ -52,6 +68,15 @@ export function requestConcurrency(group, id) {
     group.active = id;
     group.pending = [];
     return "active";
+  }
+  if (group.queue === "max") {
+    if (group.pending.includes(id)) return "pending";
+    if (group.pending.length >= MAX_PENDING) {
+      group.cancelled.add(id);
+      return "cancelled";
+    }
+    group.pending.push(id);
+    return "pending";
   }
   const current = group.pending[0];
   if (current && current !== id) group.cancelled.add(current);

--- a/packages/cloud/scripts/production-deploy-admission-lock.test.mjs
+++ b/packages/cloud/scripts/production-deploy-admission-lock.test.mjs
@@ -100,8 +100,8 @@ describe("GitHub concurrency state model", () => {
     expect(lock.pending).toEqual([]);
   });
 
-  test("a third approved release evicts the pending member, not the active one", () => {
-    const lock = createConcurrencyGroup(releaseGroup("production"));
+  test("default queue:single evicts the pending member, not the active one", () => {
+    const lock = createConcurrencyGroup({ cancelInProgress: false });
     requestConcurrency(lock, "A");
     requestConcurrency(lock, "B");
     requestConcurrency(lock, "C");
@@ -109,6 +109,45 @@ describe("GitHub concurrency state model", () => {
     expect(lock.pending).toEqual(["C"]);
     expect(lock.cancelled.has("B")).toBe(true);
     expect(lock.cancelled.has("A")).toBe(false);
+  });
+
+  test("queue:max keeps every approved waiter and promotes FIFO by wait-start", () => {
+    const lock = createConcurrencyGroup(releaseGroup("production"));
+    expect(lock.queue).toBe("max");
+    requestConcurrency(lock, "A");
+    requestConcurrency(lock, "B");
+    requestConcurrency(lock, "C");
+    expect(lock.active).toBe("A");
+    expect(lock.pending).toEqual(["B", "C"]);
+    expect(lock.cancelled.size).toBe(0);
+    completeConcurrency(lock, "A");
+    expect(lock.active).toBe("B");
+    expect(lock.pending).toEqual(["C"]);
+    completeConcurrency(lock, "B");
+    expect(lock.active).toBe("C");
+    expect(lock.pending).toEqual([]);
+  });
+
+  test("queue:max cannot combine with cancel-in-progress", () => {
+    expect(() =>
+      createConcurrencyGroup({ cancelInProgress: true, queue: "max" }),
+    ).toThrow(/queue: max/);
+  });
+
+  test("queue:max cancels arrivals after 100 pending members", () => {
+    const lock = createConcurrencyGroup({
+      cancelInProgress: false,
+      queue: "max",
+    });
+    requestConcurrency(lock, "active");
+    for (let i = 0; i < 100; i += 1) {
+      expect(requestConcurrency(lock, `p${i}`)).toBe("pending");
+    }
+    expect(requestConcurrency(lock, "overflow")).toBe("cancelled");
+    expect(lock.active).toBe("active");
+    expect(lock.pending).toHaveLength(100);
+    expect(lock.cancelled.has("overflow")).toBe(true);
+    expect(lock.cancelled.has("p0")).toBe(false);
   });
 
   test("the former three-group design allows B to migrate while A deploys API", () => {
@@ -163,7 +202,7 @@ describe("committed Cloud CF workflow matches the policy", () => {
       "format('pr-{0}', github.event.pull_request.number)",
     );
     expect(block).not.toContain("github.sha");
-    expect(block).not.toContain("queue:");
+    expect(block).not.toContain("queue: max");
     expect(cloudCf).not.toContain("cloud-cf-deploy-v5-");
   });
 
@@ -175,7 +214,7 @@ describe("committed Cloud CF workflow matches the policy", () => {
     expect(release).toContain("uses: ./.github/workflows/cloud-cf-release.yml");
     expect(release).toContain("group: cloud-cf-release-v6-");
     expect(release).toContain("cancel-in-progress: false");
-    expect(release).not.toContain("queue:");
+    expect(release).toContain("queue: max");
     expect(release).not.toMatch(/^ {4}environment:/m);
   });
 
@@ -210,7 +249,7 @@ describe("committed AASA and provisioning workflows match the policy", () => {
     expect(determine).not.toContain("concurrency:");
     expect(deploy).toContain("group: deploy-eliza-provisioning-worker-mutate-");
     expect(deploy).toContain("cancel-in-progress: false");
-    expect(deploy).not.toContain("queue:");
+    expect(deploy).toContain("queue: max");
   });
 
   test("AASA admission is per run and CDN proof stays inside the mutate job", () => {
@@ -223,6 +262,6 @@ describe("committed AASA and provisioning workflows match the policy", () => {
     expect(publish).toContain("group: deploy-aasa-edge-mutate");
     expect(publish).toContain("apple-cdn-live");
     expect(publish).toContain("cancel-in-progress: false");
-    expect(publish).not.toContain("queue:");
+    expect(publish).toContain("queue: max");
   });
 });

--- a/packages/scripts/__tests__/actionlint-config.test.ts
+++ b/packages/scripts/__tests__/actionlint-config.test.ts
@@ -1,0 +1,41 @@
+/** Verifies the repository actionlint configuration narrows its GitHub concurrency queue compatibility exception to the stale-schema diagnostic. */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const configPath = join(repoRoot, ".github", "actionlint.yaml");
+
+type ActionlintConfig = {
+  paths?: Record<string, { ignore?: string[] }>;
+};
+
+describe("actionlint concurrency queue compatibility", () => {
+  const config = Bun.YAML.parse(
+    readFileSync(configPath, "utf8"),
+  ) as ActionlintConfig;
+
+  test.each([".github/workflows/*.yml", ".github/workflows/*.yaml"])(
+    "ignores only the stale queue schema error for %s",
+    (workflowGlob) => {
+      const ignorePatterns = config.paths?.[workflowGlob]?.ignore ?? [];
+      const queueDiagnostic =
+        'unexpected key "queue" for "concurrency" section. expected one of "cancel-in-progress", "group"';
+      const unrelatedInvalidKey =
+        'unexpected key "limit" for "concurrency" section. expected one of "cancel-in-progress", "group"';
+
+      expect(
+        ignorePatterns.some((pattern) =>
+          new RegExp(pattern).test(queueDiagnostic),
+        ),
+      ).toBeTrue();
+      expect(
+        ignorePatterns.every(
+          (pattern) => !new RegExp(pattern).test(unrelatedInvalidKey),
+        ),
+      ).toBeTrue();
+    },
+  );
+});

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -408,6 +408,7 @@ describe("Personal Shared Telegram edge deploy", () => {
       "cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}",
     );
     expect(job?.concurrency?.["cancel-in-progress"]).toBe(false);
+    expect(job?.concurrency?.queue).toBe("max");
     expect(job?.env?.REQUESTED_ENVIRONMENT).toBe("${{ inputs.environment }}");
     expect(job?.env?.TARGET_ENVIRONMENT).toBe(
       "${{ inputs.environment == 'production' && 'production' || 'staging' }}",

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -40,6 +40,7 @@ interface WorkflowJob {
   concurrency?: {
     "cancel-in-progress"?: boolean;
     group?: string;
+    queue?: string;
   };
   env?: Record<string, string>;
   environment?: string;
@@ -208,6 +209,7 @@ describe("protected gateway-webhook deployment workflow", () => {
       ["cloud-cf-release-v6-", githubExpression("inputs.environment")].join(""),
     );
     expect(deploy?.concurrency?.["cancel-in-progress"]).toBe(false);
+    expect(deploy?.concurrency?.queue).toBe("max");
 
     expect(deploy?.env).toEqual(expectedJobEnvironment);
     expect(() => assertExactProtectedRouting(deploy)).not.toThrow();


### PR DESCRIPTION
## Summary

- restore `concurrency.queue: max` on all five protected deployment workflows after #21027 incorrectly removed this valid GitHub syntax
- restore the queue model and workflow contract coverage for FIFO waiters, the 100-pending limit, and the required `cancel-in-progress: false` pairing
- narrowly ignore only actionlint v1.7.12’s stale `unexpected key "queue" for "concurrency" section` schema diagnostic; a regression test proves unrelated invalid concurrency keys remain visible

GitHub released `concurrency.queue` on 2026-05-07. `queue: max` preserves up to 100 pending runs when `cancel-in-progress` is false or unset:

- https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/
- https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

The pinned actionlint v1.7.12 schema predates this GitHub feature, so the repository config carries a diagnostic-specific compatibility exception until actionlint supports the key.

## Exact revision

- base: `34a4bdf7166e199e0c930fac060898e74af04839`
- head: `0ee6f99de4f603c65ecfe0d92b3cc8c6d9cb90b6`

## Validation

- `actionlint -config-file .github/actionlint.yaml` on all five affected workflows: pass
- focused Bun tests: 32 passed, 426 assertions
- queue model covers FIFO promotion, incompatible cancellation, and overflow after 100 pending runs
- actionlint config regression covers `.yml` and `.yaml` and proves another invalid key is not ignored
- focused Biome: pass
- `git diff --check origin/develop...HEAD`: pass
- repo-wide scan: exactly five `queue: max` workflow entries restored

No workflow was dispatched and no deployment or secret mutation was performed.

## Attribution

AI provider/model: OpenAI / GPT-5  
Client / agent tooling: Codex  
Contribution skill revision: `elizaOS/eliza@0ee6f99de4f603c65ecfe0d92b3cc8c6d9cb90b6:packages/skills/skills/contribute-to-eliza`  
Attribution status: self-reported  
— [codex]

<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"GPT-5","client":"Codex","skill":"packages/skills/skills/contribute-to-eliza","revision":"0ee6f99de4f603c65ecfe0d92b3cc8c6d9cb90b6","status":"self-reported"} -->

