### PR TITLE
fix(cloud): reject unknown analytics-breakdown timeRange window

### DIFF
--- a/packages/cloud/api/analytics/breakdown/route.timerange.test.ts
+++ b/packages/cloud/api/analytics/breakdown/route.timerange.test.ts
@@ -1,0 +1,123 @@
+/**
+ * GET /api/analytics/breakdown `timeRange` is analytics-breakdown window
+ * identity, not leftover tax on admin metrics timeRange (7d/30d/90d),
+ * app-analytics period grain, analytics projections periods, analytics
+ * requests view, or analytics export type. Stock develop fell unknown
+ * tokens through to weekly, so `timeRange=MONTHLY` / `DAILY` silently
+ * charted a week instead of a month (or a 400).
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getUsageStats = mock(async () => ({ totalRequests: 0 }));
+const getUsageTimeSeries = mock(async () => []);
+const getCostTrending = mock(async () => ({}));
+const getProviderBreakdown = mock(async () => []);
+const getModelBreakdown = mock(async () => []);
+const getTrendData = mock(async () => ({}));
+const getById = mock(async () => ({ credit_balance: "0" }));
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>
+    c.json({ error: "internal_error" }, 500),
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/services/analytics", () => ({
+  analyticsService: {
+    getUsageStats,
+    getUsageTimeSeries,
+    getCostTrending,
+    getProviderBreakdown,
+    getModelBreakdown,
+    getTrendData,
+  },
+}));
+mock.module("@/lib/services/analytics-derived", () => ({
+  deriveCostTrendingFields: () => ({}),
+  toSuccessRatePercent: (value: number) => value,
+}));
+mock.module("@/lib/services/organizations", () => ({
+  organizationsService: { getById },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: () => undefined },
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/analytics/breakdown", route);
+
+function getBreakdown(query = "") {
+  return app.request(`/api/analytics/breakdown${query}`);
+}
+
+describe("GET /api/analytics/breakdown window identity", () => {
+  beforeEach(() => {
+    getUsageStats.mockClear();
+    getUsageTimeSeries.mockClear();
+    getCostTrending.mockClear();
+    getProviderBreakdown.mockClear();
+    getModelBreakdown.mockClear();
+    getTrendData.mockClear();
+    getById.mockClear();
+  });
+
+  test.each(["", "?timeRange="])(
+    "accepts %s as the weekly analytics-breakdown window",
+    async (query) => {
+      const response = await getBreakdown(query);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success: boolean;
+        data: { filters: { timeRange: string; granularity: string } };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data.filters.timeRange).toBe("weekly");
+      expect(body.data.filters.granularity).toBe("day");
+      expect(getUsageStats).toHaveBeenCalledTimes(1);
+      expect(getById).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test("accepts timeRange=monthly as the monthly analytics-breakdown window", async () => {
+    const response = await getBreakdown("?timeRange=monthly");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: { filters: { timeRange: string } };
+    };
+    expect(body.data.filters.timeRange).toBe("monthly");
+    expect(getUsageStats).toHaveBeenCalledTimes(1);
+  });
+
+  test("accepts timeRange=daily as the daily analytics-breakdown window", async () => {
+    const response = await getBreakdown("?timeRange=daily");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: { filters: { timeRange: string; granularity: string } };
+    };
+    expect(body.data.filters.timeRange).toBe("daily");
+    expect(body.data.filters.granularity).toBe("hour");
+    expect(getUsageStats).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["MONTHLY", "DAILY", "week", "foo", "90d"])(
+    "rejects timeRange=%s before analytics sinks",
+    async (token) => {
+      const response = await getBreakdown(`?timeRange=${token}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid timeRange");
+      expect(getUsageStats).not.toHaveBeenCalled();
+      expect(getUsageTimeSeries).not.toHaveBeenCalled();
+      expect(getById).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/analytics/breakdown/route.ts
+++ b/packages/cloud/api/analytics/breakdown/route.ts
@@ -74,6 +74,9 @@ app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const rawTimeRange = c.req.query("timeRange");
+    if (rawTimeRange && !isTimeRange(rawTimeRange)) {
+      return c.json({ error: "Invalid timeRange" }, 400);
+    }
     const timeRange: TimeRange = isTimeRange(rawTimeRange)
       ? rawTimeRange
       : "weekly";


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on analytics-breakdown
timeRange window identity. Analytics-breakdown window class, not leftover
tax on admin metrics timeRange, app-analytics period, analytics
projections periods, analytics requests view, analytics export type,
ad-account platform, my-agents category, advertising campaign filters,
AI-pricing catalog filters, telegram webhook flag, Vertex scope,
ingress-map format, promote-assets platform, influencer bookings party,
payment-request public, X connectionRole, my-agents sortBy, logs since,
admin redemption status, share-ingest consume, Life Ops inbox bools,
views viewType, relationships scope, commands surface, approvals state,
database-rows sort/page, memory-viewer type, VFS encoding, models
catalogOnly/refresh, Cloud JSON-400, prefix-coerced limit,
percent-encoded paths, SIWS chainId, orchestrator lines,
provisioning-worker env ints, invites-accept, cli-auth, redemption
quote, compat agent-logs, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `timeRange` only on `/api/analytics/breakdown`. Omitted/empty
still means weekly. Exact daily/weekly/monthly still bind that window.
Unknown tokens 400 before getUsageStats / other analytics sinks. Overview
sibling and admin-metrics timeRange stay untouched.

# Background

## What does this PR do?

`GET /api/analytics/breakdown` cast unknown `timeRange` tokens and
resolved them as weekly. `timeRange=MONTHLY` silently charted a week
instead of a month (or a 400).

- omitted / empty → **200** weekly window (today's default)
- exact `daily` / `weekly` / `monthly` → **200** that window
- `MONTHLY` / `DAILY` / `week` / `foo` / `90d` → **400** before analytics sinks

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

`isTimeRange` already knew the three lowercase windows, but unknown
tokens fell through to weekly. A common `timeRange=MONTHLY` must not
silently chart a week. This is analytics-breakdown window identity, not
leftover tax on admin metrics timeRange (`7d`/`30d`/`90d`) or
app-analytics period grain.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/analytics/breakdown/route.timerange.test.ts` —
omitted still uses weekly; exact `monthly` / `daily` still bind that
window; garbage 400s with no analytics sink call.

## Test commands

```bash
cd packages/cloud/api && bun test analytics/breakdown/route.timerange.test.ts
```

9 passed at the evidence head. Stock develop was 4 passed / 5 failed on
the same table (`timeRange=MONTHLY` returned 200 and called getUsageStats).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; analytics-breakdown `timeRange` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; analytics-breakdown `timeRange` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; analytics-breakdown `timeRange` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real window tokens and assert 400 before analytics sinks; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no analytics export; illegal timeRange tokens 400 before getUsageStats.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`timeRange` tokens reject; omitted/canonical still bind the matching window.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file analytics-breakdown
window parse with a green focused suite (9 tests). Full monorepo verify is
unrelated to this query grammar and was skipped to keep the proof tied
to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1cae081388260f29bc6fb8dde136fcb2debfec05 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
