### PR TITLE
fix(cloud): reject unknown admin-redemption network filter

### DIFF
--- a/packages/cloud/api/admin/redemptions/route.network.test.ts
+++ b/packages/cloud/api/admin/redemptions/route.network.test.ts
@@ -99,7 +99,10 @@ describe("GET /api/admin/redemptions payout-rail identity", () => {
       const response = await listRedemptions(query);
       expect(response.status).toBe(200);
       const body = (await response.json()) as { redemptions: { id: string }[] };
-      expect(body.redemptions.map((row) => row.id)).toEqual(["r-sol", "r-base"]);
+      expect(body.redemptions.map((row) => row.id)).toEqual([
+        "r-sol",
+        "r-base",
+      ]);
       expect(listForAdmin).toHaveBeenCalledTimes(1);
     },
   );

--- a/packages/cloud/api/admin/redemptions/route.network.test.ts
+++ b/packages/cloud/api/admin/redemptions/route.network.test.ts
@@ -1,0 +1,145 @@
+/**
+ * GET /api/admin/redemptions `network` is admin-redemption payout-rail
+ * identity, not leftover tax on admin redemption status (already
+ * fail-closed) or redemption quote pointsAmount. Stock develop passed
+ * unknown tokens into `r.network !== networkFilter`, so
+ * `network=SOLANA` / `ETH` silently returned an empty payout queue.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+function redemptionRow(overrides: {
+  id: string;
+  network: string;
+  user_id?: string;
+  payout_address?: string;
+  user_email?: string;
+}) {
+  return {
+    id: overrides.id,
+    network: overrides.network,
+    user_id: overrides.user_id ?? "u1",
+    payout_address: overrides.payout_address ?? "0xabc",
+    user_email: overrides.user_email ?? "a@example.com",
+    app_id: null,
+    app_name: null,
+    points_amount: "0",
+    usd_value: "0",
+    eliza_amount: "0",
+    eliza_price_usd: "0",
+    status: "pending",
+    requires_review: false,
+    tx_hash: null,
+    failure_reason: null,
+    retry_count: 0,
+    reviewed_by: null,
+    reviewed_at: null,
+    review_notes: null,
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    completed_at: null,
+    metadata: null,
+  };
+}
+
+const listForAdmin = mock(async () => [
+  redemptionRow({
+    id: "r-sol",
+    network: "solana",
+    payout_address: "So11111111111111111111111111111111111111112",
+  }),
+  redemptionRow({
+    id: "r-base",
+    network: "base",
+    user_id: "u2",
+    user_email: "b@example.com",
+  }),
+]);
+const countByStatusForAdmin = mock(async () => []);
+const requireAdmin = mock(async () => ({
+  user: { id: "admin-1" },
+  role: "super_admin",
+}));
+
+mock.module("@/db/repositories/token-redemptions", () => ({
+  tokenRedemptionsRepository: { listForAdmin, countByStatusForAdmin },
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({ requireAdmin }));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {}, STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>
+    c.json({ success: false, error: "internal_error" }, 500),
+}));
+mock.module("@/lib/services/token-redemption-secure", () => ({
+  secureTokenRedemptionService: {},
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: () => undefined, error: () => undefined },
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/admin/redemptions", route);
+
+function listRedemptions(query = "") {
+  return app.request(`/api/admin/redemptions${query}`);
+}
+
+describe("GET /api/admin/redemptions payout-rail identity", () => {
+  beforeEach(() => {
+    requireAdmin.mockClear();
+    listForAdmin.mockClear();
+    countByStatusForAdmin.mockClear();
+  });
+
+  test.each(["", "?network="])(
+    "accepts %s as the unfiltered payout-rail catalog",
+    async (query) => {
+      const response = await listRedemptions(query);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { redemptions: { id: string }[] };
+      expect(body.redemptions.map((row) => row.id)).toEqual(["r-sol", "r-base"]);
+      expect(listForAdmin).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test("accepts network=solana as the Solana payout-rail catalog", async () => {
+    const response = await listRedemptions("?network=solana");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { redemptions: { id: string }[] };
+    expect(body.redemptions.map((row) => row.id)).toEqual(["r-sol"]);
+    expect(listForAdmin).toHaveBeenCalledTimes(1);
+  });
+
+  test("accepts network=bsc as the BNB payout-rail alias", async () => {
+    listForAdmin.mockResolvedValueOnce([
+      redemptionRow({
+        id: "r-bnb",
+        network: "bnb",
+        user_id: "u3",
+        payout_address: "0xbnb",
+        user_email: "c@example.com",
+      }),
+    ]);
+    const response = await listRedemptions("?network=bsc");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { redemptions: { id: string }[] };
+    expect(body.redemptions.map((row) => row.id)).toEqual(["r-bnb"]);
+    expect(listForAdmin).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["SOLANA", "ETH", "polygon", "foo", "1e2"])(
+    "rejects network=%s before listForAdmin",
+    async (token) => {
+      const response = await listRedemptions(
+        `?network=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toContain("Invalid network");
+      expect(listForAdmin).not.toHaveBeenCalled();
+      expect(countByStatusForAdmin).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/admin/redemptions/route.ts
+++ b/packages/cloud/api/admin/redemptions/route.ts
@@ -50,6 +50,26 @@ function parseAdminRedemptionStatusFilter(
   return null;
 }
 
+const ADMIN_REDEMPTION_NETWORKS = [
+  "ethereum",
+  "base",
+  "bnb",
+  "solana",
+] as const;
+type AdminRedemptionNetwork = (typeof ADMIN_REDEMPTION_NETWORKS)[number];
+
+function parseAdminRedemptionNetworkFilter(
+  raw: string | undefined,
+): AdminRedemptionNetwork | "all" | null {
+  const networkFilter = raw || "all";
+  if (networkFilter === "all") return "all";
+  if (networkFilter === "bsc") return "bnb";
+  if ((ADMIN_REDEMPTION_NETWORKS as readonly string[]).includes(networkFilter)) {
+    return networkFilter as AdminRedemptionNetwork;
+  }
+  return null;
+}
+
 const app = new Hono<AppEnv>();
 
 app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
@@ -67,7 +87,17 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
         400,
       );
     }
-    const networkFilter = c.req.query("network") || "all";
+    const networkRaw = c.req.query("network") || "all";
+    const networkFilter = parseAdminRedemptionNetworkFilter(c.req.query("network"));
+    if (networkFilter === null) {
+      return c.json(
+        {
+          success: false,
+          error: `Invalid network: ${networkRaw}. Must be one of: ethereum, base, bnb, solana, bsc, all`,
+        },
+        400,
+      );
+    }
     const searchQuery = c.req.query("search")?.trim().toLowerCase() || "";
     const limitParam = c.req.query("limit");
     const limit = parseClampedLimit(limitParam, 50);

--- a/packages/cloud/api/admin/redemptions/route.ts
+++ b/packages/cloud/api/admin/redemptions/route.ts
@@ -64,7 +64,9 @@ function parseAdminRedemptionNetworkFilter(
   const networkFilter = raw || "all";
   if (networkFilter === "all") return "all";
   if (networkFilter === "bsc") return "bnb";
-  if ((ADMIN_REDEMPTION_NETWORKS as readonly string[]).includes(networkFilter)) {
+  if (
+    (ADMIN_REDEMPTION_NETWORKS as readonly string[]).includes(networkFilter)
+  ) {
     return networkFilter as AdminRedemptionNetwork;
   }
   return null;
@@ -88,7 +90,9 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
       );
     }
     const networkRaw = c.req.query("network") || "all";
-    const networkFilter = parseAdminRedemptionNetworkFilter(c.req.query("network"));
+    const networkFilter = parseAdminRedemptionNetworkFilter(
+      c.req.query("network"),
+    );
     if (networkFilter === null) {
       return c.json(
         {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on admin-redemption network
filter identity. Admin-redemption payout-rail class, not leftover tax on
admin redemption status, redemption quote pointsAmount, app-analytics
period, analytics projections periods, analytics export type, admin
metrics timeRange, ad-account platform, my-agents category, advertising
campaign filters, AI-pricing catalog filters, telegram webhook flag,
analytics view, Vertex scope, ingress-map format, promote-assets
platform, influencer bookings party, payment-request public, X
connectionRole, my-agents sortBy, logs since, share-ingest consume,
Life Ops inbox bools, views viewType, relationships scope, commands
surface, approvals state, database-rows sort/page, memory-viewer type,
VFS encoding, models catalogOnly/refresh, Cloud JSON-400,
prefix-coerced limit, percent-encoded paths, SIWS chainId, orchestrator
lines, provisioning-worker env ints, invites-accept, cli-auth, compat
agent-logs, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `network` only on `/api/admin/redemptions`. Omitted/empty still
means all rails. Exact ethereum/base/bnb/solana still filter that rail.
`bsc` still aliases to `bnb`. Unknown tokens 400 before listForAdmin /
countByStatusForAdmin. Status / limit / search / POST stay untouched.

# Background

## What does this PR do?

`GET /api/admin/redemptions` passed unknown `network` tokens into an
in-memory `r.network !== networkFilter` compare. `network=SOLANA`
silently returned an empty payout queue instead of a 400.

- omitted / empty → **200** unfiltered rails (today's default)
- exact `ethereum` / `base` / `bnb` / `solana` → **200** that rail
- `bsc` → **200** BNB rail (same alias as the public redemption quote)
- `SOLANA` / `ETH` / `polygon` / `foo` → **400** before listForAdmin

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Status already fail-closes. Network did not. A common `network=SOLANA`
must not silently empty the admin payout queue. This is payout-rail
identity, not leftover tax on admin redemption status.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/admin/redemptions/route.network.test.ts` —
omitted still lists every rail; exact `solana` still filters that rail;
`bsc` still aliases to `bnb`; garbage 400s with no repository call.
Existing `route.status.test.ts` stays green.

## Test commands

```bash
cd packages/cloud/api && bun test admin/redemptions/route.network.test.ts admin/redemptions/route.status.test.ts
```

24 passed at the evidence head (9 network + 15 status). Stock develop
was 3 passed / 6 failed on the network table (`network=SOLANA` returned
200 and called listForAdmin).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; admin-redemptions `network` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; admin-redemptions `network` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; admin-redemptions `network` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real rail tokens and assert 400 before listForAdmin; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no payout export; illegal network tokens 400 before listForAdmin.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`network` tokens reject; omitted/canonical still bind the matching rail.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file admin-redemption
network parse with a green focused suite (9 network tests; 15 existing
status tests still pass). Full monorepo verify is unrelated to this
query grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:36651c33d3ac914ea3b3407954391661f1715fde -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->

## Maintainer validation

Biome formatting repaired at `09bf0ecad411c63d905cbaa2bfaf4a02d1d7ab03`; focused production-handler tests pass 9/9 and diff-check is clean.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@f7e27e4a882fa31dc88ae3d693a530370ef23eeb:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-b]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@f7e27e4a882fa31dc88ae3d693a530370ef23eeb:packages/skills/skills/contribute-to-eliza"} -->