### PR TITLE
fix(plugin-sql): handle Date, BigInt, and non-finite numbers in sanitizeJsonObject

### DIFF
--- a/plugins/plugin-sql/src/__tests__/unit/sanitize-json.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/sanitize-json.test.ts
@@ -58,6 +58,23 @@ describe("sanitizeJsonObject", () => {
     expect(sanitizeJsonObject(false)).toBe(false);
   });
 
+  it("handles Date instances, BigInt primitives, and non-finite numbers", () => {
+    const date = new Date("2026-08-17T00:00:00.000Z");
+    expect(sanitizeJsonObject(date)).toBe("2026-08-17T00:00:00.000Z");
+
+    const invalidDate = new Date("invalid-date");
+    expect(sanitizeJsonObject(invalidDate)).toBeNull();
+
+    expect(sanitizeJsonObject(100n)).toBe("100");
+    expect(sanitizeJsonObject({ block: 12345678901234567890n })).toEqual({
+      block: "12345678901234567890",
+    });
+
+    expect(sanitizeJsonObject(Number.NaN)).toBeNull();
+    expect(sanitizeJsonObject(Number.POSITIVE_INFINITY)).toBeNull();
+    expect(sanitizeJsonObject(Number.NEGATIVE_INFINITY)).toBeNull();
+  });
+
   it("recurses into arrays and objects", () => {
     const input = { list: ["C:\\tmp", { inner: "\\q" }] };
     expect(sanitizeJsonObject(input)).toEqual(input);

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -3021,6 +3021,18 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
     }
 
+    if (typeof value === "bigint") {
+      return value.toString();
+    }
+
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? value : null;
+    }
+
+    if (value instanceof Date) {
+      return Number.isFinite(value.getTime()) ? value.toISOString() : null;
+    }
+
     if (typeof value === "object") {
       if (seen.has(value as object)) {
         return null;

--- a/plugins/plugin-sql/src/utils.browser.ts
+++ b/plugins/plugin-sql/src/utils.browser.ts
@@ -30,6 +30,18 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
     return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
   }
 
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value.toISOString() : null;
+  }
+
   if (typeof value === "object") {
     if (seen.has(value as object)) {
       return null;

--- a/plugins/plugin-sql/src/utils.node.ts
+++ b/plugins/plugin-sql/src/utils.node.ts
@@ -78,6 +78,18 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
     return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
   }
 
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value.toISOString() : null;
+  }
+
   if (typeof value === "object") {
     if (seen.has(value as object)) {
       return null;

--- a/plugins/plugin-sql/src/utils.ts
+++ b/plugins/plugin-sql/src/utils.ts
@@ -80,6 +80,18 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
     return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
   }
 
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value.toISOString() : null;
+  }
+
   if (typeof value === "object") {
     if (seen.has(value as object)) {
       return null;


### PR DESCRIPTION
## Summary

1. In `@elizaos/plugin-sql` (`utils.ts`, `utils.node.ts`, `utils.browser.ts`, and `base.ts`), `sanitizeJsonObject` sanitized JSONB database payloads before storing them in PostgreSQL/PGlite.
2. When passed a `Date` instance, it treated it as a generic object, causing `Object.entries(date)` to evaluate to `[]` and serialize into an empty object `{}` rather than preserving its timestamp. Added `value instanceof Date` conversion to `value.toISOString()`.
3. When passed a `bigint` primitive, it returned it un-coerced, which caused `JSON.stringify` to throw a `TypeError`. Added `typeof value === "bigint"` conversion to `value.toString()`.
4. When passed non-finite numbers (`NaN`, `+Infinity`, `-Infinity`), normalized them to `null` to match valid JSON standards.
5. Added unit regression test coverage in `plugins/plugin-sql/src/__tests__/unit/sanitize-json.test.ts`.

Closes #21033.

## Verification

Exact commit: `cd79bda625`.

- Focused unit test suite `plugins/plugin-sql/src/__tests__/unit/sanitize-json.test.ts`: 8/8 tests passing (22 assertions).
- Full `@elizaos/plugin-sql` vitest suite: 21 test files, 128 tests passing.
- Biome format on `@elizaos/plugin-sql`: 203 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - plugin-sql JSON utility and database adapter helper; no rendered UI changed.
- [x] N/A - plugin-sql JSON utility and database adapter helper; no rendered UI changed.
- [x] N/A - deterministic utility function behavior.
- [x] Focused test suite transcript:
```text
✓ sanitizeJsonObject > preserves backslashes exactly (no double-escaping) [2.28ms]
✓ sanitizeJsonObject > preserves literal \u sequences that are not 4-hex escapes [0.26ms]
✓ sanitizeJsonObject > round-trips through JSON.stringify/JSON.parse unchanged [0.40ms]
✓ sanitizeJsonObject > strips NUL characters from string values and object keys [0.08ms]
✓ sanitizeJsonObject > passes through null, undefined, numbers, and booleans [0.05ms]
✓ sanitizeJsonObject > handles Date instances, BigInt primitives, and non-finite numbers [0.11ms]
✓ sanitizeJsonObject > recurses into arrays and objects [0.07ms]
✓ sanitizeJsonObject > breaks circular references by replacing the repeated object with null [0.12ms]
8 pass, 0 fail, 22 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database schema migration needed; improves runtime JSONB column serialization safety.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@e47b9cdacfa43354cb72f6db475c40ee5535df2a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@e47b9cdacfa43354cb72f6db475c40ee5535df2a:packages/skills/skills/contribute-to-eliza"} -->