### PR TITLE
feat(core): implement flush on PassthroughExtractor and add streaming test suite

### DIFF
--- a/packages/core/src/utils/streaming.test.ts
+++ b/packages/core/src/utils/streaming.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for streaming utilities in packages/core/src/utils/streaming.ts.
+ * Tests PassthroughExtractor, MarkableExtractor, StreamError, createStreamingRetryState, and createStreamingContext.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+	MarkableExtractor,
+	PassthroughExtractor,
+	StreamError,
+	createStreamingContext,
+	createStreamingRetryState,
+} from "./streaming";
+
+describe("StreamError", () => {
+	it("constructs and identifies StreamError instances", () => {
+		const error = new StreamError("CHUNK_TOO_LARGE", "Chunk too big", {
+			chunkSize: 2000,
+		});
+
+		expect(error.name).toBe("StreamError");
+		expect(error.code).toBe("CHUNK_TOO_LARGE");
+		expect(error.message).toBe("Chunk too big");
+		expect(error.details).toEqual({ chunkSize: 2000 });
+		expect(StreamError.isStreamError(error)).toBe(true);
+		expect(StreamError.isStreamError(new Error("generic"))).toBe(false);
+	});
+});
+
+describe("PassthroughExtractor", () => {
+	it("passes chunks through unchanged and implements IStreamExtractor lifecycle", () => {
+		const extractor = new PassthroughExtractor();
+		expect(extractor.done).toBe(false);
+
+		expect(extractor.push("hello")).toBe("hello");
+		expect(extractor.push(" world")).toBe(" world");
+		expect(extractor.flush()).toBe("");
+
+		extractor.reset();
+		expect(extractor.done).toBe(false);
+	});
+
+	it("throws StreamError when chunk exceeds MAX_CHUNK_SIZE", () => {
+		const extractor = new PassthroughExtractor();
+		const oversized = "x".repeat(1024 * 1024 + 1);
+
+		expect(() => extractor.push(oversized)).toThrow(StreamError);
+	});
+});
+
+describe("MarkableExtractor", () => {
+	it("passes through chunks and marks complete on demand", () => {
+		const extractor = new MarkableExtractor();
+		expect(extractor.done).toBe(false);
+
+		expect(extractor.push("chunk-1")).toBe("chunk-1");
+		expect(extractor.flush()).toBe("");
+		expect(extractor.done).toBe(false);
+
+		extractor.markComplete();
+		expect(extractor.done).toBe(true);
+
+		extractor.reset();
+		expect(extractor.done).toBe(false);
+	});
+});
+
+describe("createStreamingRetryState", () => {
+	it("tracks streamed text and handles reset", () => {
+		const extractor = new PassthroughExtractor();
+		const retryState = createStreamingRetryState(extractor);
+
+		expect(retryState.isComplete()).toBe(false);
+		expect(retryState.getStreamedText()).toBe("");
+
+		retryState.appendText("token1 ");
+		retryState.appendText("token2");
+		expect(retryState.getStreamedText()).toBe("token1 token2");
+
+		retryState.reset();
+		expect(retryState.getStreamedText()).toBe("");
+	});
+});
+
+describe("createStreamingContext", () => {
+	it("routes streaming chunks through extractor to callback and records text", async () => {
+		const extractor = new MarkableExtractor();
+		const receivedChunks: string[] = [];
+		const callback = vi.fn(async (chunk: string) => {
+			receivedChunks.push(chunk);
+		});
+
+		const context = createStreamingContext(extractor, callback, "msg-123");
+		expect(context.messageId).toBe("msg-123");
+		expect(context.isComplete()).toBe(false);
+
+		await context.onStreamChunk("first ");
+		await context.onStreamChunk("second");
+
+		expect(receivedChunks).toEqual(["first ", "second"]);
+		expect(context.getStreamedText()).toBe("first second");
+
+		extractor.markComplete();
+		expect(context.isComplete()).toBe(true);
+
+		// When complete, further chunks are ignored
+		await context.onStreamChunk("ignored");
+		expect(receivedChunks).toEqual(["first ", "second"]);
+	});
+});

--- a/packages/core/src/utils/streaming.test.ts
+++ b/packages/core/src/utils/streaming.test.ts
@@ -5,11 +5,11 @@
 
 import { describe, expect, it, vi } from "vitest";
 import {
+	createStreamingContext,
+	createStreamingRetryState,
 	MarkableExtractor,
 	PassthroughExtractor,
 	StreamError,
-	createStreamingContext,
-	createStreamingRetryState,
 } from "./streaming";
 
 describe("StreamError", () => {
@@ -45,6 +45,12 @@ describe("PassthroughExtractor", () => {
 		const oversized = "x".repeat(1024 * 1024 + 1);
 
 		expect(() => extractor.push(oversized)).toThrow(StreamError);
+	});
+
+	it("rejects non-string chunks at the runtime boundary", () => {
+		const extractor = new PassthroughExtractor();
+
+		expect(() => extractor.push(42 as never)).toThrow(TypeError);
 	});
 });
 

--- a/packages/core/src/utils/streaming.ts
+++ b/packages/core/src/utils/streaming.ts
@@ -65,7 +65,7 @@ const MAX_CHUNK_SIZE = 1024 * 1024;
  */
 function validateChunkSize(chunk: string): void {
 	if (typeof chunk !== "string") {
-		return;
+		throw new TypeError("Stream chunk must be a string");
 	}
 	if (chunk.length > MAX_CHUNK_SIZE) {
 		throw new StreamError(

--- a/packages/core/src/utils/streaming.ts
+++ b/packages/core/src/utils/streaming.ts
@@ -64,6 +64,9 @@ const MAX_CHUNK_SIZE = 1024 * 1024;
  * @throws StreamError if chunk exceeds maximum size
  */
 function validateChunkSize(chunk: string): void {
+	if (typeof chunk !== "string") {
+		return;
+	}
 	if (chunk.length > MAX_CHUNK_SIZE) {
 		throw new StreamError(
 			"CHUNK_TOO_LARGE",
@@ -92,6 +95,10 @@ export class PassthroughExtractor implements IStreamExtractor {
 	push(chunk: string): string {
 		validateChunkSize(chunk);
 		return chunk; // Pass through everything
+	}
+
+	flush(): string {
+		return "";
 	}
 
 	reset(): void {


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/streaming.ts`, added `flush(): string { return ""; }` to `PassthroughExtractor` to ensure complete contract parity with `IStreamExtractor` and `MarkableExtractor`.
2. Added `typeof chunk === "string"` type guard to `validateChunkSize`.
3. Created dedicated unit test suite in `packages/core/src/utils/streaming.test.ts` exercising `PassthroughExtractor`, `MarkableExtractor`, `StreamError`, `createStreamingRetryState`, and `createStreamingContext`.

Closes #21040.

## Verification

Exact commit: `3f1b7ee9dc`.

- Focused unit test suite `packages/core/src/utils/streaming.test.ts`: 6/6 tests passing (28 assertions).
- Biome format on `@elizaos/core`: 1283 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - core streaming utility function; no rendered UI changed.
- [x] N/A - core streaming utility function; no rendered UI changed.
- [x] N/A - deterministic utility function behavior.
- [x] Focused test suite transcript:
```text
✓ StreamError > constructs and identifies StreamError instances [0.18ms]
✓ PassthroughExtractor > passes chunks through unchanged and implements IStreamExtractor lifecycle [0.15ms]
✓ PassthroughExtractor > throws StreamError when chunk exceeds MAX_CHUNK_SIZE [0.61ms]
✓ MarkableExtractor > passes through chunks and marks complete on demand [0.15ms]
✓ createStreamingRetryState > tracks streamed text and handles reset [0.16ms]
✓ createStreamingContext > routes streaming chunks through extractor to callback and records text [0.41ms]
6 pass, 0 fail, 28 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.


## Maintainer repair validation

The original non-string guard silently returned and then allowed `push()` to return a non-string despite its contract. The repaired head fails fast with `TypeError` and adds a real regression. Exact-head validation: 7/7 tests (29 assertions), core typecheck, Biome, and diff-check clean.

<!-- evidence-head:3e05c6435b34ec16cd21e10e0c913a374da78ee5 -->

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash; OpenAI / gpt-5.6-sol
Client / agent tooling: Antigravity; Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@eca8c9701670ede52e04260c875a03fe3f778f89:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@eca8c9701670ede52e04260c875a03fe3f778f89:packages/skills/skills/contribute-to-eliza"} -->