### PR TITLE
fix(ios): fail closed when HealthKit entitlement is absent

### DIFF
--- a/packages/app-core/scripts/mobile/ios-plist.mjs
+++ b/packages/app-core/scripts/mobile/ios-plist.mjs
@@ -30,6 +30,7 @@ const IOS_BG_TASK_IDENTIFIERS = [
   "ai.eliza.tasks.processing",
 ];
 export const IOS_APNS_ENABLED_KEY = "ELIZA_APNS_ENABLED";
+export const IOS_HEALTHKIT_ENABLED_KEY = "ELIZA_HEALTHKIT_ENABLED";
 
 /** Parse the one exact build flag shared by the renderer and native plist. */
 export function readIosApnsBuildFlag(raw) {
@@ -37,6 +38,15 @@ export function readIosApnsBuildFlag(raw) {
   if (raw === "1") return true;
   throw new Error(
     `VITE_ELIZA_APNS_ENABLED must be "0" or "1", received ${JSON.stringify(raw)}`,
+  );
+}
+
+/** Parse the explicit native HealthKit entitlement build flag. */
+export function readIosHealthKitBuildFlag(raw) {
+  if (raw === undefined || raw === "" || raw === "0") return false;
+  if (raw === "1") return true;
+  throw new Error(
+    `ELIZA_IOS_HEALTHKIT_ENABLED must be "0" or "1", received ${JSON.stringify(raw)}`,
   );
 }
 
@@ -85,7 +95,7 @@ export function resolveIosPermissionKeys({ appName }) {
   ];
 }
 
-/** Set (or insert before `</dict>`) a `<key>`/`<string>` pair in a plist. */
+/** Set or insert a root `<key>`/`<string>` pair in a plist. */
 export function replaceOrInsertPlistString(content, key, value) {
   const escapedValue = escapeXmlText(value);
   const keyRe = escapeRegExp(key);
@@ -98,8 +108,8 @@ export function replaceOrInsertPlistString(content, key, value) {
   if (new RegExp(`<key>${keyRe}</key>`).test(content)) {
     throw new Error(`Info.plist: ${key} must be a string`);
   }
-  return content.replace(
-    "</dict>",
+  return insertBeforeRootPlistDictClose(
+    content,
     `\t<key>${key}</key>\n\t<string>${escapedValue}</string>\n</dict>`,
   );
 }
@@ -110,7 +120,10 @@ export function ensurePlistTrueBool(content, key) {
   if (new RegExp(`<key>${keyRe}</key>`).test(content)) {
     return content;
   }
-  return content.replace("</dict>", `\t<key>${key}</key>\n\t<true/>\n</dict>`);
+  return insertBeforeRootPlistDictClose(
+    content,
+    `\t<key>${key}</key>\n\t<true/>\n</dict>`,
+  );
 }
 
 /** Ensure a plist `<array>` under `key` contains every value in `values`. */
@@ -178,13 +191,14 @@ export function mergeIosInfoPlist(
     urlScheme,
     displayName = "$(ELIZA_DISPLAY_NAME)",
     apnsEnabled = false,
+    healthKitEnabled = false,
   },
 ) {
   let nextContent = content;
   for (const [key, desc] of resolveIosPermissionKeys({ appName })) {
     if (!nextContent.includes(key)) {
-      nextContent = nextContent.replace(
-        "</dict>",
+      nextContent = insertBeforeRootPlistDictClose(
+        nextContent,
         `\t<key>${key}</key>\n\t<string>${desc}</string>\n</dict>`,
       );
     }
@@ -216,6 +230,11 @@ export function mergeIosInfoPlist(
     nextContent,
     IOS_APNS_ENABLED_KEY,
     apnsEnabled ? "1" : "0",
+  );
+  nextContent = replaceOrInsertPlistString(
+    nextContent,
+    IOS_HEALTHKIT_ENABLED_KEY,
+    healthKitEnabled ? "1" : "0",
   );
   return {
     changed: nextContent !== content,

--- a/packages/app-core/scripts/mobile/ios-plist.test.mjs
+++ b/packages/app-core/scripts/mobile/ios-plist.test.mjs
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { escapeRegExp, escapeXmlText } from "./escape.mjs";
 import {
   ensurePlistArrayStrings,
+  ensurePlistTrueBool,
   insertBeforeRootPlistDictClose,
   removePbxListEntries,
   replaceIosAppGroupPlaceholders,
@@ -56,6 +57,21 @@ describe("replaceOrInsertPlistString", () => {
     expect(out).toContain("<string>NewValue</string>");
   });
 
+  it("inserts a missing string at the plist root rather than a nested dictionary", () => {
+    const nested = PLIST.replace(
+      "\t<key>CFBundleName</key>",
+      "\t<key>CFBundleIcons</key>\n\t<dict>\n\t\t<key>CFBundlePrimaryIcon</key>\n\t\t<dict>\n\t\t</dict>\n\t</dict>\n\t<key>CFBundleName</key>",
+    );
+    const out = replaceOrInsertPlistString(nested, "NewKey", "NewValue");
+
+    expect(out.indexOf("<key>NewKey</key>")).toBeGreaterThan(
+      out.lastIndexOf("\t</dict>"),
+    );
+    expect(out).toMatch(
+      /<\/dict>\n\t<key>CFBundleName<\/key>[\s\S]*<key>NewKey<\/key>/,
+    );
+  });
+
   it("escapes the inserted value", () => {
     const out = replaceOrInsertPlistString(PLIST, "CFBundleName", "A & B");
     expect(out).toContain("<string>A &amp; B</string>");
@@ -66,6 +82,20 @@ describe("replaceOrInsertPlistString", () => {
     expect(() =>
       replaceOrInsertPlistString(malformed, "CFBundleName", "Eliza"),
     ).toThrow(/CFBundleName must be a string/);
+  });
+});
+
+describe("ensurePlistTrueBool", () => {
+  it("inserts a missing boolean at the plist root rather than a nested dictionary", () => {
+    const nested = PLIST.replace(
+      "\t<key>CFBundleName</key>",
+      "\t<key>Inner</key>\n\t<dict>\n\t</dict>\n\t<key>CFBundleName</key>",
+    );
+    const out = ensurePlistTrueBool(nested, "RootFlag");
+
+    expect(out).toMatch(
+      /<\/dict>\n\t<key>CFBundleName<\/key>[\s\S]*<key>RootFlag<\/key>/,
+    );
   });
 });
 

--- a/packages/app-core/scripts/run-mobile-build-ios-plist.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-ios-plist.test.mjs
@@ -4,8 +4,10 @@ import { describe, expect, it } from "vitest";
 import {
   ensurePlistArrayStrings,
   IOS_APNS_ENABLED_KEY,
+  IOS_HEALTHKIT_ENABLED_KEY,
   mergeIosInfoPlist,
   readIosApnsBuildFlag,
+  readIosHealthKitBuildFlag,
   replaceOrInsertPlistString,
   resolveIosPermissionKeys,
 } from "./mobile/ios-plist.mjs";
@@ -13,6 +15,20 @@ import {
 const minimalPlist = `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
+</dict>
+</plist>`;
+
+const nestedPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>CFBundleIcons</key>
+\t<dict>
+\t\t<key>CFBundlePrimaryIcon</key>
+\t\t<dict>
+\t\t\t<key>CFBundleIconName</key>
+\t\t\t<string>AppIcon</string>
+\t\t</dict>
+\t</dict>
 </dict>
 </plist>`;
 
@@ -48,6 +64,37 @@ describe("iOS Info.plist overlay helpers", () => {
     expect(merged.content).toMatch(
       new RegExp(`<key>${IOS_APNS_ENABLED_KEY}</key>\\s*<string>0</string>`),
     );
+    expect(merged.content).toMatch(
+      new RegExp(
+        `<key>${IOS_HEALTHKIT_ENABLED_KEY}</key>\\s*<string>0</string>`,
+      ),
+    );
+  });
+
+  it("keeps every missing overlay key out of nested plist dictionaries", () => {
+    const merged = mergeIosInfoPlist(nestedPlist, {
+      appName: "Eliza",
+      urlScheme: "eliza",
+      healthKitEnabled: true,
+    }).content;
+    const firstRootOverlayKey = merged.indexOf(
+      "<key>NSCameraUsageDescription</key>",
+    );
+    const nestedIconSection = merged.slice(0, firstRootOverlayKey);
+
+    expect(firstRootOverlayKey).toBeGreaterThan(
+      merged.indexOf("<key>CFBundleIconName</key>"),
+    );
+    expect(nestedIconSection).toContain("<key>CFBundleIconName</key>");
+    expect(nestedIconSection).not.toContain("UsageDescription");
+    expect(nestedIconSection).not.toContain("NSSupportsLiveActivities");
+    expect(nestedIconSection).not.toContain(IOS_APNS_ENABLED_KEY);
+    expect(nestedIconSection).not.toContain(IOS_HEALTHKIT_ENABLED_KEY);
+    expect(merged).toMatch(
+      new RegExp(
+        `<key>${IOS_HEALTHKIT_ENABLED_KEY}</key>\\s*<string>1</string>\\s*</dict>\\s*</plist>$`,
+      ),
+    );
   });
 
   it("writes the native APNs gate from the canonical build option", () => {
@@ -78,6 +125,44 @@ describe("iOS Info.plist overlay helpers", () => {
     expect(readIosApnsBuildFlag("1")).toBe(true);
     expect(() => readIosApnsBuildFlag(" 1 ")).toThrow(/must be "0" or "1"/);
     expect(() => readIosApnsBuildFlag("true")).toThrow(/must be "0" or "1"/);
+  });
+
+  it("writes HealthKit availability only from the exact native build flag", () => {
+    const enabled = mergeIosInfoPlist(minimalPlist, {
+      appName: "Eliza",
+      urlScheme: "eliza",
+      healthKitEnabled: true,
+    });
+
+    expect(enabled.content).toMatch(
+      new RegExp(
+        `<key>${IOS_HEALTHKIT_ENABLED_KEY}</key>\\s*<string>1</string>`,
+      ),
+    );
+    expect(
+      mergeIosInfoPlist(enabled.content, {
+        appName: "Eliza",
+        urlScheme: "eliza",
+        healthKitEnabled: false,
+      }).content,
+    ).toMatch(
+      new RegExp(
+        `<key>${IOS_HEALTHKIT_ENABLED_KEY}</key>\\s*<string>0</string>`,
+      ),
+    );
+  });
+
+  it("accepts only the exact HealthKit build flag", () => {
+    expect(readIosHealthKitBuildFlag(undefined)).toBe(false);
+    expect(readIosHealthKitBuildFlag("")).toBe(false);
+    expect(readIosHealthKitBuildFlag("0")).toBe(false);
+    expect(readIosHealthKitBuildFlag("1")).toBe(true);
+    expect(() => readIosHealthKitBuildFlag(" 1 ")).toThrow(
+      /must be "0" or "1"/,
+    );
+    expect(() => readIosHealthKitBuildFlag("true")).toThrow(
+      /must be "0" or "1"/,
+    );
   });
 
   it("is idempotent after the first merge", () => {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -144,6 +144,7 @@ import { escapeRegExp, escapeXmlText } from "./mobile/escape.mjs";
 import {
   mergeIosInfoPlist,
   readIosApnsBuildFlag,
+  readIosHealthKitBuildFlag,
   removePbxListEntries,
   replaceIosAppGroupPlaceholders,
 } from "./mobile/ios-plist.mjs";
@@ -3708,6 +3709,9 @@ function overlayIos() {
       appName: APP.appName,
       urlScheme: APP.urlScheme,
       apnsEnabled: readIosApnsBuildFlag(process.env.VITE_ELIZA_APNS_ENABLED),
+      healthKitEnabled: readIosHealthKitBuildFlag(
+        process.env.ELIZA_IOS_HEALTHKIT_ENABLED,
+      ),
     });
     if (nextPlist.changed) {
       plist = nextPlist.content;

--- a/plugins/plugin-native-mobile-signals/AGENTS.md
+++ b/plugins/plugin-native-mobile-signals/AGENTS.md
@@ -75,12 +75,23 @@ bun run --cwd plugins/plugin-native-mobile-signals validate:ios-screen-time  # n
 
 | Variable | Required | Description |
 |---|---|---|
+| `ELIZA_IOS_HEALTHKIT_ENABLED` | No | Exact `"1"` tells the canonical iOS build to publish `ELIZA_HEALTHKIT_ENABLED=1` in the final native plist. Missing, empty, or `"0"` disables HealthKit; every other value fails the build. Use only when the signed app actually carries the HealthKit capability. |
 | `MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE` | No | Path to the `.mobileprovision` file used by `validate:ios-screen-time` to verify Screen Time entitlements in the provisioning profile. |
 | `MOBILE_SIGNALS_REQUIRE_IOS_PROVISIONING_PROFILE` | No | Set to `"1"` to make `validate:ios-screen-time` fail if no provisioning profile is supplied. |
 
-No runtime environment variables are read by the plugin itself. Permission state and capabilities are determined at runtime by querying native APIs.
+No runtime environment variables are read by the plugin itself. The native
+HealthKit boundary reads the canonical build marker from the final app plist
+before calling protected APIs; permission state is queried only when that
+marker explicitly enables the capability.
 
 ## iOS requirements
+
+HealthKit calls are default-off. The canonical app build accepts only
+`ELIZA_IOS_HEALTHKIT_ENABLED=1` and mirrors that decision into the final native
+plist. Disabled or malformed markers expose a truthful unavailable state and
+must not call HealthKit authorization, status, query, or background-delivery
+APIs. Enabling the flag without a matching Apple signing entitlement is a
+build/release configuration error, not a runtime fallback.
 
 Screen Time / DeviceActivity features require additional entitlements and Xcode targets. The `validate:ios-screen-time` script checks:
 

--- a/plugins/plugin-native-mobile-signals/CLAUDE.md
+++ b/plugins/plugin-native-mobile-signals/CLAUDE.md
@@ -75,12 +75,23 @@ bun run --cwd plugins/plugin-native-mobile-signals validate:ios-screen-time  # n
 
 | Variable | Required | Description |
 |---|---|---|
+| `ELIZA_IOS_HEALTHKIT_ENABLED` | No | Exact `"1"` tells the canonical iOS build to publish `ELIZA_HEALTHKIT_ENABLED=1` in the final native plist. Missing, empty, or `"0"` disables HealthKit; every other value fails the build. Use only when the signed app actually carries the HealthKit capability. |
 | `MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE` | No | Path to the `.mobileprovision` file used by `validate:ios-screen-time` to verify Screen Time entitlements in the provisioning profile. |
 | `MOBILE_SIGNALS_REQUIRE_IOS_PROVISIONING_PROFILE` | No | Set to `"1"` to make `validate:ios-screen-time` fail if no provisioning profile is supplied. |
 
-No runtime environment variables are read by the plugin itself. Permission state and capabilities are determined at runtime by querying native APIs.
+No runtime environment variables are read by the plugin itself. The native
+HealthKit boundary reads the canonical build marker from the final app plist
+before calling protected APIs; permission state is queried only when that
+marker explicitly enables the capability.
 
 ## iOS requirements
+
+HealthKit calls are default-off. The canonical app build accepts only
+`ELIZA_IOS_HEALTHKIT_ENABLED=1` and mirrors that decision into the final native
+plist. Disabled or malformed markers expose a truthful unavailable state and
+must not call HealthKit authorization, status, query, or background-delivery
+APIs. Enabling the flag without a matching Apple signing entitlement is a
+build/release configuration error, not a runtime fallback.
 
 Screen Time / DeviceActivity features require additional entitlements and Xcode targets. The `validate:ios-screen-time` script checks:
 

--- a/plugins/plugin-native-mobile-signals/README.md
+++ b/plugins/plugin-native-mobile-signals/README.md
@@ -70,6 +70,13 @@ await MobileSignals.stopMonitoring();
 
 ### iOS
 
+HealthKit is disabled by default in local, unsigned, and Simulator builds. A
+signed build that includes the HealthKit capability must set the exact build
+flag `ELIZA_IOS_HEALTHKIT_ENABLED=1`; the canonical mobile build writes the
+matching `ELIZA_HEALTHKIT_ENABLED=1` marker into the final app `Info.plist`.
+Any missing, disabled, or malformed marker fails closed before the plugin calls
+HealthKit authorization, status, query, or background-delivery APIs.
+
 Add to `Info.plist`:
 
 ```xml
@@ -108,13 +115,13 @@ await MobileSignals.openSettings({ target: "usageAccess" });
 
 | Variable | Description |
 |---|---|
+| `ELIZA_IOS_HEALTHKIT_ENABLED` | Exact `"1"` enables HealthKit in a correctly signed iOS build; missing, empty, or `"0"` keeps it unavailable. Any other value fails the build. |
 | `MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE` | Path to a `.mobileprovision` to inspect for Screen Time entitlements during `validate:ios-screen-time`. |
 | `MOBILE_SIGNALS_REQUIRE_IOS_PROVISIONING_PROFILE` | Set to `"1"` to fail validation when no provisioning profile is supplied. |
 
 ## Platform notes
 
 - **Node (desktop):** No native integration. The web fallback applies.
-- **iOS:** Full support. Requires Xcode target with correct entitlements for screen time features.
+- **iOS:** HealthKit is available only in an explicitly enabled, correctly signed build. Screen Time requires its separately approved entitlements and targets.
 - **Android:** Full support for device state and Health Connect. Usage stats require manual user grant via settings.
 - **Web:** Graceful fallback only. Health and screen-time capabilities are unavailable.
-

--- a/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsHealthContract/HealthEntitlementGate.swift
+++ b/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsHealthContract/HealthEntitlementGate.swift
@@ -1,0 +1,46 @@
+/**
+ * Resolves the canonical native build marker that authorizes HealthKit calls.
+ *
+ * The app build writes this marker only when its signed configuration is
+ * expected to include HealthKit. Disabled or malformed values fail closed so
+ * unsigned Simulator and development builds never probe protected APIs.
+ */
+import Foundation
+
+public enum HealthEntitlementGate {
+    public static let infoPlistKey = "ELIZA_HEALTHKIT_ENABLED"
+
+    public enum Access: Equatable {
+        case enabled
+        case disabled
+        case malformed
+
+        public var allowsHealthKitCalls: Bool {
+            self == .enabled
+        }
+
+        public var unavailableReason: String? {
+            switch self {
+            case .enabled:
+                return nil
+            case .disabled:
+                return "HealthKit is unavailable because this app build does not enable the HealthKit capability."
+            case .malformed:
+                return "HealthKit is unavailable because this app build has an invalid HealthKit capability marker."
+            }
+        }
+    }
+
+    public static func resolve(plistValue: Any?) -> Access {
+        guard let plistValue else { return .disabled }
+        guard let value = plistValue as? String else { return .malformed }
+        switch value {
+        case "1":
+            return .enabled
+        case "", "0":
+            return .disabled
+        default:
+            return .malformed
+        }
+    }
+}

--- a/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsPlugin/MobileSignalsPlugin.swift
+++ b/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsPlugin/MobileSignalsPlugin.swift
@@ -1,3 +1,9 @@
+/**
+ * Bridges iOS device, permission, Screen Time, notification, and health state
+ * into the Capacitor MobileSignals contract. Protected HealthKit APIs remain
+ * unreachable unless the canonical native build marker explicitly enables
+ * the capability.
+ */
 import Foundation
 import Capacitor
 import HealthKit
@@ -39,6 +45,24 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
     private var observers: [NSObjectProtocol] = []
     private let healthStore = HKHealthStore()
     private let healthQueue = DispatchQueue(label: "ai.eliza.mobile-signals.health", qos: .utility)
+    private lazy var healthEntitlementAccess = HealthEntitlementGate.resolve(
+        plistValue: Bundle.main.object(
+            forInfoDictionaryKey: HealthEntitlementGate.infoPlistKey
+        )
+    )
+
+    private var healthUnavailableReason: String? {
+        if let reason = healthEntitlementAccess.unavailableReason {
+            return reason
+        }
+        return HKHealthStore.isHealthDataAvailable()
+            ? nil
+            : "HealthKit is not available on this device."
+    }
+
+    private var healthKitAvailable: Bool {
+        healthUnavailableReason == nil
+    }
 
     public override func load() {
         UIDevice.current.isBatteryMonitoringEnabled = true
@@ -108,6 +132,17 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         let shouldRequestScreenTime = target != "health"
+        if let unavailableReason = healthUnavailableReason {
+            resolvePermissionResult(
+                call,
+                status: "not-applicable",
+                canRequest: false,
+                reason: unavailableReason,
+                requestScreenTime: shouldRequestScreenTime
+            )
+            return
+        }
+
         let types = requestedHealthTypes()
         guard !types.isEmpty else {
             resolvePermissionResult(
@@ -154,16 +189,12 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
     /// background delivery is not user-actionable; the foreground monitoring
     /// path already works. We log and move on.
     ///
-    /// Entitlement probe: iOS exposes no public API to read the running
-    /// binary's code-signing entitlements, so the first sample type doubles as
-    /// the capability probe. When the binary is not signed with
-    /// `com.apple.developer.healthkit` (simulator lanes built with code
-    /// signing disabled, sideload/dev builds signed without the capability)
-    /// EVERY call fails identically with "Missing
-    /// com.apple.developer.healthkit entitlement" — so the probe failing that
-    /// way means the remaining registrations are skipped behind a single info
-    /// line instead of one warning per type.
+    /// The canonical native build marker blocks this entire path for builds
+    /// that do not carry HealthKit. The first sample remains a defensive probe
+    /// for a signed-build mismatch, so one entitlement diagnostic replaces a
+    /// warning for every sample type.
     private func enableHealthBackgroundDelivery() {
+        guard healthEntitlementAccess.allowsHealthKitCalls else { return }
         guard HKHealthStore.isHealthDataAvailable() else { return }
         let sampleTypes = backgroundDeliverySampleTypes()
         guard let probeType = sampleTypes.first else { return }
@@ -457,7 +488,7 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
         notification: NotificationPermissionCapture
     ) -> [String: Any] {
         let screenTimeStatus = ScreenTimeSupport.buildStatus()
-        guard HKHealthStore.isHealthDataAvailable() else {
+        if let unavailableReason = healthUnavailableReason {
             return [
                 "status": overrideStatus ?? "not-applicable",
                 "canRequest": overrideCanRequest ?? false,
@@ -465,7 +496,7 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
                 "settingsTarget": "app",
                 "engine": "healthkit-screen-time",
                 "capabilities": mobileSignalsCapabilities(),
-                "reason": overrideReason ?? "HealthKit is not available on this device.",
+                "reason": overrideReason ?? unavailableReason,
                 "permissions": [
                     "sleep": false,
                     "biometrics": false,
@@ -474,6 +505,7 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
                 "setupActions": buildSetupActions(
                     healthStatus: overrideStatus ?? "not-applicable",
                     healthCanRequest: overrideCanRequest ?? false,
+                    healthUnavailableReason: unavailableReason,
                     screenTimeStatus: screenTimeStatus,
                     notification: notification
                 ),
@@ -520,6 +552,7 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
             "setupActions": buildSetupActions(
                 healthStatus: status,
                 healthCanRequest: overrideCanRequest ?? (status != "granted" && hasRequestedTypes),
+                healthUnavailableReason: nil,
                 screenTimeStatus: screenTimeStatus,
                 notification: notification
             ),
@@ -532,7 +565,7 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func mobileSignalsCapabilities() -> [String: Any] {
         [
-            "health": HKHealthStore.isHealthDataAvailable(),
+            "health": healthKitAvailable,
             "screenTime": true,
             "notifications": true,
             "settings": true,
@@ -594,10 +627,15 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
     private func buildSetupActions(
         healthStatus: String,
         healthCanRequest: Bool,
+        healthUnavailableReason: String?,
         screenTimeStatus: [String: Any],
         notification: NotificationPermissionCapture
     ) -> [[String: Any]] {
         let healthReady = healthStatus == "granted"
+        let healthAvailableInBuild = healthUnavailableReason == nil
+        let healthSettingsTarget: Any = healthAvailableInBuild
+            ? "health"
+            : NSNull()
         let authorization = screenTimeStatus["authorization"] as? [String: Any] ?? [:]
         let screenTimeAuthStatus = authorization["status"] as? String ?? "unavailable"
         let screenTimeCanRequest = authorization["canRequest"] as? Bool ?? false
@@ -613,12 +651,12 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
                 "status": healthReady
                     ? "ready"
                     : (healthStatus == "not-applicable" ? "unavailable" : "needs-action"),
-                "canRequest": healthCanRequest,
-                "canOpenSettings": true,
-                "settingsTarget": "health",
+                "canRequest": healthAvailableInBuild && healthCanRequest,
+                "canOpenSettings": healthAvailableInBuild,
+                "settingsTarget": healthSettingsTarget,
                 "reason": healthReady
                     ? NSNull()
-                    : "Grant Health read access for sleep, heart rate, HRV, respiratory rate, and oxygen saturation.",
+                    : (healthUnavailableReason ?? "Grant Health read access for sleep, heart rate, HRV, respiratory rate, and oxygen saturation."),
             ],
             [
                 "id": "screen_time_authorization",
@@ -734,7 +772,7 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
         reason: String,
         completion: @escaping ([String: Any]) -> Void
     ) {
-        guard HKHealthStore.isHealthDataAvailable() else {
+        if let unavailableReason = healthUnavailableReason {
             completion(makeHealthSnapshot(
                 reason: reason,
                 capture: HealthCapture(
@@ -757,7 +795,7 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
                         "respiratoryRate": NSNull(),
                         "bloodOxygenPercent": NSNull(),
                     ],
-                    warnings: ["HealthKit is not available on this device"]
+                    warnings: [unavailableReason]
                 )
             ))
             return

--- a/plugins/plugin-native-mobile-signals/ios/Tests/MobileSignalsHealthContractTests/HealthEntitlementGateTests.swift
+++ b/plugins/plugin-native-mobile-signals/ios/Tests/MobileSignalsHealthContractTests/HealthEntitlementGateTests.swift
@@ -1,0 +1,32 @@
+/**
+ * Verifies that only the exact canonical plist marker authorizes HealthKit.
+ */
+import XCTest
+@testable import MobileSignalsHealthContract
+
+final class HealthEntitlementGateTests: XCTestCase {
+    func testMissingEmptyAndZeroMarkersDisableHealthKit() {
+        for value: Any? in [nil, "", "0"] {
+            let access = HealthEntitlementGate.resolve(plistValue: value)
+            XCTAssertEqual(access, .disabled)
+            XCTAssertFalse(access.allowsHealthKitCalls)
+            XCTAssertNotNil(access.unavailableReason)
+        }
+    }
+
+    func testOnlyExactOneEnablesHealthKit() {
+        let access = HealthEntitlementGate.resolve(plistValue: "1")
+        XCTAssertEqual(access, .enabled)
+        XCTAssertTrue(access.allowsHealthKitCalls)
+        XCTAssertNil(access.unavailableReason)
+    }
+
+    func testWhitespaceAndBooleanLikeValuesFailClosed() {
+        for value: Any in [" 1 ", "true", "yes", "01", true, 1] {
+            let access = HealthEntitlementGate.resolve(plistValue: value)
+            XCTAssertEqual(access, .malformed)
+            XCTAssertFalse(access.allowsHealthKitCalls)
+            XCTAssertNotNil(access.unavailableReason)
+        }
+    }
+}


### PR DESCRIPTION
Closes #20924

## Contract

HealthKit is now a build-time, default-off iOS capability. Only the exact raw value `ELIZA_IOS_HEALTHKIT_ENABLED=1` enables it. The canonical mobile build mirrors that decision into the final native Info.plist as `ELIZA_HEALTHKIT_ENABLED`; missing, malformed, whitespace-padded, or false-like values fail closed before authorization, queries, snapshots, or background delivery.

Screen Time and notifications remain independent. Android behavior is unchanged.

## Why

Unsigned and Simulator builds previously entered HealthKit APIs despite lacking the entitlement. That generated misleading capability status plus entitlement/query errors at boot and background transition.

## Exact revision

- head: `0a97c7b9807258caa60273299cfb52d8be5f08ee`
- tree: `f3d846a4bde4c0d4a6b6a4e8d197db49ab18cca2`
- base: `9a77fc0b50b1c89d674d5dcdcca8c192b8a34f30`
- stable patch-id: `9ae27aa528f55d07f7c3c6b8ee60c9ceb152877b`

## Verification

- plist/build Vitest: 24/24
- Swift entitlement/background contract: 13/13
- app-core typecheck: PASS
- plugin typecheck + lint: PASS
- Biome: PASS
- CLAUDE/AGENTS parity: PASS
- diff-check: PASS
- canonical default-off Simulator build/install/launch/background: PASS; final and staged plist both `ELIZA_HEALTHKIT_ENABLED=0`; no HealthKit entitlement/query diagnostics
- canonical enabled generic-device build: PASS unsigned; final and staged plist both `ELIZA_HEALTHKIT_ENABLED=1`; renderer manifest matches source; arm64 artifact produced

Local evidence bundle: `/private/tmp/ios-healthkit-d8904f5/` (hashes and logs recorded on #20924).

## Honest boundary

This PR proves build authority, native fail-closed behavior, and Simulator/default-off behavior. It does not claim physical HealthKit or APNs delivery. This Mac currently has zero valid Apple code-signing identities and no provisioning profiles. Real-device proof requires a valid Apple identity/profile with the HealthKit entitlements.

## Scope

10 paths only under `packages/app-core` mobile build tooling and `plugin-native-mobile-signals`. No shared UI, macOS, Worker/gateway, staging, production, billing, credential, or provider changes.

AI provider/model: OpenAI / Codex
Client / agent tooling: Codex Desktop
Attribution status: self-reported; no signed contribution receipt claimed.
