### PR TITLE
fix(shared): reject unsafe integer duration values exceeding MAX_SAFE_INTEGER in parseDurationMs

### DIFF
--- a/packages/shared/src/cli/parse-duration.test.ts
+++ b/packages/shared/src/cli/parse-duration.test.ts
@@ -25,6 +25,9 @@ describe("parseDurationMs", () => {
 
   it("throws on empty / malformed / negative input", () => {
     expect(() => parseDurationMs("")).toThrow();
+    expect(() => parseDurationMs("   ")).toThrow();
+    expect(() => parseDurationMs(null as unknown as string)).toThrow();
+    expect(() => parseDurationMs(undefined as unknown as string)).toThrow();
     expect(() => parseDurationMs("abc")).toThrow();
     expect(() => parseDurationMs("10x")).toThrow();
     expect(() => parseDurationMs("-5s")).toThrow();
@@ -38,6 +41,18 @@ describe("parseDurationMs", () => {
       );
     },
   );
+
+  it("rejects values exceeding MAX_SAFE_INTEGER", () => {
+    expect(() => parseDurationMs("1000000000000000d")).toThrow(
+      "invalid duration",
+    );
+    expect(() => parseDurationMs("10000000000000000ms")).toThrow(
+      "invalid duration",
+    );
+    expect(parseDurationMs(`${Number.MAX_SAFE_INTEGER}ms`)).toBe(
+      Number.MAX_SAFE_INTEGER,
+    );
+  });
 
   it("checks overflow after applying the default unit", () => {
     expect(() =>

--- a/packages/shared/src/cli/parse-duration.ts
+++ b/packages/shared/src/cli/parse-duration.ts
@@ -11,7 +11,10 @@ export function parseDurationMs(
   raw: string,
   opts?: DurationMsParseOptions,
 ): number {
-  const trimmed = String(raw).trim().toLowerCase();
+  if (typeof raw !== "string") {
+    throw new Error("invalid duration (empty)");
+  }
+  const trimmed = raw.trim().toLowerCase();
   if (!trimmed) {
     throw new Error("invalid duration (empty)");
   }
@@ -43,7 +46,10 @@ export function parseDurationMs(
             ? 3_600_000
             : 86_400_000;
   const milliseconds = value * multiplier;
-  if (!Number.isFinite(milliseconds)) {
+  if (
+    !Number.isFinite(milliseconds) ||
+    !Number.isSafeInteger(Math.round(milliseconds))
+  ) {
     throw new Error(`invalid duration: ${raw}`);
   }
   return Math.round(milliseconds);


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/cli/parse-duration.ts`, `parseDurationMs` previously only checked `Number.isFinite(milliseconds)`, allowing very large duration strings (e.g. `1000000000000d` or `1e16ms`) that exceeded `Number.MAX_SAFE_INTEGER`.
2. Added `Number.isSafeInteger(Math.round(milliseconds))` validation to throw `invalid duration: ${raw}` when the computed duration exceeds JavaScript safe integer precision limits.
3. Added `typeof raw !== "string"` validation to reject non-string inputs with `invalid duration (empty)`.
4. Added unit regression test coverage in `packages/shared/src/cli/parse-duration.test.ts`.

Closes #21044.

## Verification

Exact commit: `b27fe9a4fb`.

- Focused unit test suite `packages/shared/src/cli/parse-duration.test.ts`: 9/9 tests passing (24 assertions).
- Biome format on `@elizaos/shared`: 397 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - shared CLI and duration parsing utility function; no rendered UI changed.
- [x] N/A - shared CLI and duration parsing utility function; no rendered UI changed.
- [x] N/A - deterministic utility function behavior.
- [x] Focused test suite transcript:
```text
✓ parseDurationMs > converts each unit suffix to milliseconds [0.63ms]
✓ parseDurationMs > uses the default unit only when no suffix is present [0.09ms]
✓ parseDurationMs > throws on empty / malformed / negative input [0.35ms]
✓ parseDurationMs > throws when s conversion overflows milliseconds [0.13ms]
✓ parseDurationMs > throws when m conversion overflows milliseconds [0.05ms]
✓ parseDurationMs > throws when h conversion overflows milliseconds [0.03ms]
✓ parseDurationMs > throws when d conversion overflows milliseconds [0.01ms]
✓ parseDurationMs > rejects values exceeding MAX_SAFE_INTEGER [0.24ms]
✓ parseDurationMs > checks overflow after applying the default unit [0.08ms]
9 pass, 0 fail, 24 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@9a77fc0b501f2f8149eb0f3fae8bcba14c6225ee:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@9a77fc0b501f2f8149eb0f3fae8bcba14c6225ee:packages/skills/skills/contribute-to-eliza"} -->