### PR TITLE
fix(cloud): reject unknown voice-list cloneType filter

### DIFF
--- a/packages/cloud/api/v1/voice/list/route.clonetype.test.ts
+++ b/packages/cloud/api/v1/voice/list/route.clonetype.test.ts
@@ -1,0 +1,137 @@
+/**
+ * GET /api/v1/voice/list `cloneType` is Voice Studio clone-kind
+ * identity, not leftover tax on models catalogOnly/refresh, Life Ops
+ * inbox bools, or prefix-coerced limit. Stock develop cast unknown
+ * tokens to undefined, so `cloneType=INSTANT` / `PROFESSIONAL`
+ * silently listed every clone instead of that kind (or a 400).
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+function voiceRow(cloneType: "instant" | "professional") {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+  return {
+    id: `voice-${cloneType}`,
+    elevenlabsVoiceId: `el-${cloneType}`,
+    name: `${cloneType} voice`,
+    description: null,
+    cloneType,
+    sampleCount: 1,
+    totalAudioDurationSeconds: 1,
+    audioQualityScore: "1.00",
+    usageCount: 0,
+    lastUsedAt: null,
+    isActive: true,
+    isPublic: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+const listByOrganization = mock(async () => ({
+  voices: [voiceRow("instant"), voiceRow("professional")],
+  total: 2,
+  limit: 50,
+  offset: 0,
+  hasMore: false,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>
+    c.json({ error: "internal_error" }, 500),
+}));
+mock.module("@/db/repositories/user-voices", () => ({
+  userVoicesRepository: { listByOrganization },
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/v1/voice/list", route);
+
+function listVoices(query = "") {
+  return app.request(`/api/v1/voice/list${query}`);
+}
+
+describe("GET /api/v1/voice/list clone-kind identity", () => {
+  beforeEach(() => {
+    listByOrganization.mockClear();
+  });
+
+  test.each(["", "?cloneType="])(
+    "accepts %s as the unfiltered Voice Studio catalog",
+    async (query) => {
+      const response = await listVoices(query);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success: boolean;
+        voices: { cloneType: string }[];
+      };
+      expect(body.success).toBe(true);
+      expect(body.voices.map((row) => row.cloneType)).toEqual([
+        "instant",
+        "professional",
+      ]);
+      expect(listByOrganization).toHaveBeenCalledTimes(1);
+      expect(listByOrganization.mock.calls[0][1]).toMatchObject({
+        cloneType: undefined,
+      });
+    },
+  );
+
+  test("accepts cloneType=instant as the instant Voice Studio catalog", async () => {
+    listByOrganization.mockResolvedValueOnce({
+      voices: [voiceRow("instant")],
+      total: 1,
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+    });
+    const response = await listVoices("?cloneType=instant");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      voices: { cloneType: string }[];
+    };
+    expect(body.voices.map((row) => row.cloneType)).toEqual(["instant"]);
+    expect(listByOrganization).toHaveBeenCalledTimes(1);
+    expect(listByOrganization.mock.calls[0][1]).toMatchObject({
+      cloneType: "instant",
+    });
+  });
+
+  test("accepts cloneType=professional as the professional Voice Studio catalog", async () => {
+    listByOrganization.mockResolvedValueOnce({
+      voices: [voiceRow("professional")],
+      total: 1,
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+    });
+    const response = await listVoices("?cloneType=professional");
+    expect(response.status).toBe(200);
+    expect(listByOrganization.mock.calls[0][1]).toMatchObject({
+      cloneType: "professional",
+    });
+  });
+
+  test.each(["INSTANT", "PROFESSIONAL", "instant-clone", "foo", "1e2"])(
+    "rejects cloneType=%s before listByOrganization",
+    async (token) => {
+      const response = await listVoices(
+        `?cloneType=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid cloneType");
+      expect(listByOrganization).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/voice/list/route.ts
+++ b/packages/cloud/api/v1/voice/list/route.ts
@@ -24,6 +24,16 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const MAX_LIMIT = 100;
 const DEFAULT_LIMIT = 50;
 
+type VoiceCloneType = "instant" | "professional";
+
+function parseVoiceCloneType(
+  raw: string | undefined,
+): VoiceCloneType | undefined | null {
+  if (!raw) return undefined;
+  if (raw === "instant" || raw === "professional") return raw;
+  return null;
+}
+
 interface VoiceListItem {
   id: string;
   elevenlabsVoiceId: string;
@@ -59,11 +69,10 @@ app.get("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
 
     const includeInactive = c.req.query("includeInactive") === "true";
-    const cloneTypeParam = c.req.query("cloneType");
-    const cloneType: "instant" | "professional" | undefined =
-      cloneTypeParam === "instant" || cloneTypeParam === "professional"
-        ? cloneTypeParam
-        : undefined;
+    const cloneType = parseVoiceCloneType(c.req.query("cloneType"));
+    if (cloneType === null) {
+      return c.json({ error: "Invalid cloneType" }, 400);
+    }
 
     const limit = parseClampedLimit(
       c.req.query("limit"),


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on Voice Studio cloneType
identity. Voice-clone-kind class, not leftover tax on analytics-breakdown
timeRange, admin-redemptions network, OAuth platform, app-analytics period,
ad-account platform, my-agents category, advertising campaign filters,
AI-pricing catalog filters, admin metrics timeRange, telegram webhook flag,
analytics view, Vertex scope, ingress-map format, promote-assets platform,
influencer bookings party, payment-request public, X connectionRole,
my-agents sortBy, logs since, analytics periods, analytics export type,
admin redemption status, share-ingest consume, Life Ops inbox bools,
views viewType, relationships scope, commands surface, approvals state,
database-rows sort/page, memory-viewer type, VFS encoding, models
catalogOnly/refresh, Cloud JSON-400, prefix-coerced limit,
percent-encoded paths, SIWS chainId, orchestrator lines,
provisioning-worker env ints, invites-accept, cli-auth, redemption
quote, compat agent-logs, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `cloneType` only on `/api/v1/voice/list`. Omitted/empty still
means the unfiltered Voice Studio catalog. Exact `instant` /
`professional` still bind that kind. Unknown tokens 400 before
listByOrganization. includeInactive / limit / offset / clone POST stay
untouched.

# Background

## What does this PR do?

`GET /api/v1/voice/list` cast unknown `cloneType` tokens to `undefined`.
`cloneType=INSTANT` silently listed every Voice Studio clone instead of
instant clones (or a 400).

- omitted / empty → **200** unfiltered catalog (today's default)
- exact `instant` / `professional` → **200** that kind
- `INSTANT` / `PROFESSIONAL` / `instant-clone` / `foo` → **400** before listByOrganization

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The ElevenLabs sibling and `POST /api/v1/voice/clone` already fail-close
`cloneType`. Voice Studio list did not. A common `cloneType=INSTANT`
must not silently dump the whole catalog. This is Voice Studio
clone-kind identity, not leftover tax on models catalogOnly/refresh or
prefix-coerced limit.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/voice/list/route.clonetype.test.ts` —
omitted still lists unfiltered; exact `instant` / `professional` still
bind that kind; garbage 400s with no repository call.

## Test commands

```bash
cd packages/cloud/api && bun test v1/voice/list/route.clonetype.test.ts
```

9 passed at the evidence head. Stock develop was 4 passed / 5 failed on
the same table (`cloneType=INSTANT` returned 200 and called
listByOrganization).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; voice-list `cloneType` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; voice-list `cloneType` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; voice-list `cloneType` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real clone-kind tokens and assert 400 before listByOrganization; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no voice export; illegal cloneType tokens 400 before listByOrganization.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`cloneType` tokens reject; omitted/canonical still bind the matching kind.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; list filter identity only.

## Known gaps / failures

`bun run verify` was not run. This is a two-file voice-list cloneType
parse with a green focused suite (9 tests). Full monorepo verify is
unrelated to this query grammar and was skipped to keep the proof tied
to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:bfa8470b4f013a463b8c4e4dc0e8203a28697ddb -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
