### PR TITLE
fix(cloud): reject non-canonical public token-lookup chain

### DIFF
--- a/packages/cloud/api/v1/agents/by-token/route.chain.test.ts
+++ b/packages/cloud/api/v1/agents/by-token/route.chain.test.ts
@@ -1,0 +1,125 @@
+/**
+ * GET /api/v1/agents/by-token `chain` is public token-rail identity,
+ * not leftover tax on SIWS/SIWE chainId or admin-redemption network.
+ * Stock develop passed unknown tokens into an exact `token_chain`
+ * compare, so `chain=SOLANA` / `ETH` silently 404'd a linked public
+ * agent instead of resolving that rail (or a 400).
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const SOLANA_TOKEN = "So11111111111111111111111111111111111111112";
+const EVM_TOKEN = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+function publicAgent(overrides: {
+  id: string;
+  token_address: string;
+  token_chain: string;
+}) {
+  return {
+    id: overrides.id,
+    name: "Linked agent",
+    username: "linked",
+    avatar_url: null,
+    bio: "public",
+    is_public: true,
+    token_address: overrides.token_address,
+    token_chain: overrides.token_chain,
+    token_name: "Tok",
+    token_ticker: "TOK",
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+const findByTokenAddress = mock(async () =>
+  publicAgent({
+    id: "char-sol",
+    token_address: SOLANA_TOKEN,
+    token_chain: "solana",
+  }),
+);
+
+mock.module("@/db/repositories/characters", () => ({
+  userCharactersRepository: { findByTokenAddress },
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>
+    c.json({ success: false, error: "internal_error" }, 500),
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/v1/agents/by-token", route);
+
+function lookup(query: string) {
+  return app.request(`/api/v1/agents/by-token${query}`);
+}
+
+describe("GET /api/v1/agents/by-token token-rail identity", () => {
+  beforeEach(() => {
+    findByTokenAddress.mockClear();
+    findByTokenAddress.mockResolvedValue(
+      publicAgent({
+        id: "char-sol",
+        token_address: SOLANA_TOKEN,
+        token_chain: "solana",
+      }),
+    );
+  });
+
+  test.each(["", "&chain="])(
+    "accepts %s as the unfiltered public token lookup",
+    async (chainQuery) => {
+      const response = await lookup(`?address=${SOLANA_TOKEN}${chainQuery}`);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success: boolean;
+        data: { id: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data.id).toBe("char-sol");
+      expect(findByTokenAddress).toHaveBeenCalledTimes(1);
+      expect(findByTokenAddress.mock.calls[0][1]).toBeUndefined();
+    },
+  );
+
+  test("accepts chain=solana as the Solana public token rail", async () => {
+    const response = await lookup(
+      `?address=${SOLANA_TOKEN}&chain=solana`,
+    );
+    expect(response.status).toBe(200);
+    expect(findByTokenAddress).toHaveBeenCalledTimes(1);
+    expect(findByTokenAddress.mock.calls[0][1]).toBe("solana");
+  });
+
+  test("accepts chain=eth as the documented public token-rail alias", async () => {
+    findByTokenAddress.mockResolvedValueOnce(
+      publicAgent({
+        id: "char-eth",
+        token_address: EVM_TOKEN,
+        token_chain: "eth",
+      }),
+    );
+    const response = await lookup(`?address=${EVM_TOKEN}&chain=eth`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { data: { id: string } };
+    expect(body.data.id).toBe("char-eth");
+    expect(findByTokenAddress.mock.calls[0][1]).toBe("eth");
+  });
+
+  test.each(["SOLANA", "ETH", "Ethereum", "foo!", "1e2"])(
+    "rejects chain=%s before findByTokenAddress",
+    async (token) => {
+      const response = await lookup(
+        `?address=${SOLANA_TOKEN}&chain=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as {
+        success: boolean;
+        error: string;
+      };
+      expect(body.success).toBe(false);
+      expect(body.error).toContain("Invalid chain");
+      expect(findByTokenAddress).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/agents/by-token/route.chain.test.ts
+++ b/packages/cloud/api/v1/agents/by-token/route.chain.test.ts
@@ -83,9 +83,7 @@ describe("GET /api/v1/agents/by-token token-rail identity", () => {
   );
 
   test("accepts chain=solana as the Solana public token rail", async () => {
-    const response = await lookup(
-      `?address=${SOLANA_TOKEN}&chain=solana`,
-    );
+    const response = await lookup(`?address=${SOLANA_TOKEN}&chain=solana`);
     expect(response.status).toBe(200);
     expect(findByTokenAddress).toHaveBeenCalledTimes(1);
     expect(findByTokenAddress.mock.calls[0][1]).toBe("solana");
@@ -104,6 +102,13 @@ describe("GET /api/v1/agents/by-token token-rail identity", () => {
     const body = (await response.json()) as { data: { id: string } };
     expect(body.data.id).toBe("char-eth");
     expect(findByTokenAddress.mock.calls[0][1]).toBe("eth");
+  });
+
+  test("accepts an extensible canonical lowercase chain id", async () => {
+    const response = await lookup(`?address=${EVM_TOKEN}&chain=arbitrum`);
+
+    expect(response.status).toBe(200);
+    expect(findByTokenAddress.mock.calls[0][1]).toBe("arbitrum");
   });
 
   test.each(["SOLANA", "ETH", "Ethereum", "foo!", "1e2"])(

--- a/packages/cloud/api/v1/agents/by-token/route.ts
+++ b/packages/cloud/api/v1/agents/by-token/route.ts
@@ -13,10 +13,20 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
+const TOKEN_LOOKUP_CHAIN = /^[a-z][a-z0-9_-]{0,49}$/;
+
+function parseTokenLookupChain(
+  raw: string | undefined,
+): string | undefined | null {
+  if (!raw) return undefined;
+  if (TOKEN_LOOKUP_CHAIN.test(raw)) return raw;
+  return null;
+}
+
 app.get("/", async (c) => {
   try {
     const address = c.req.query("address");
-    const chain = c.req.query("chain") || undefined;
+    const chain = parseTokenLookupChain(c.req.query("chain") || undefined);
 
     if (!address) {
       return c.json(
@@ -33,11 +43,12 @@ app.get("/", async (c) => {
         400,
       );
     }
-    if (chain && chain.length > 50) {
+    if (chain === null) {
       return c.json(
         {
           success: false,
-          error: "chain parameter exceeds maximum length (50)",
+          error:
+            "Invalid chain. Use a canonical lowercase token-rail id (e.g. solana, eth, ethereum, base, bsc).",
         },
         400,
       );


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on public token-lookup chain
identity. Public token-rail class, not leftover tax on SIWS/SIWE chainId,
admin-redemptions network, analytics-breakdown timeRange, OAuth platform,
app-analytics period, ad-account platform, my-agents category, advertising
campaign filters, AI-pricing catalog filters, admin metrics timeRange,
telegram webhook flag, analytics view, Vertex scope, ingress-map format,
promote-assets platform, influencer bookings party, payment-request public,
X connectionRole, my-agents sortBy, logs since, analytics periods,
analytics export type, admin redemption status, share-ingest consume,
Life Ops inbox bools, views viewType, relationships scope, commands
surface, approvals state, database-rows sort/page, memory-viewer type,
VFS encoding, models catalogOnly/refresh, Cloud JSON-400,
prefix-coerced limit, percent-encoded paths, orchestrator lines,
provisioning-worker env ints, invites-accept, cli-auth, redemption
quote, compat agent-logs, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `chain` only on `/api/v1/agents/by-token`. Omitted/empty still
means no rail filter. Canonical lowercase ids (`solana`, `eth`,
`ethereum`, `base`, `bsc`) still bind that rail. Unknown / uppercase
tokens 400 before findByTokenAddress. Address length / missing-address
checks stay untouched. Existing e2e `chain=eth` → 404-on-unknown-address
is preserved.

# Background

## What does this PR do?

`GET /api/v1/agents/by-token` passed unknown `chain` tokens into an
exact `token_chain` compare. `chain=SOLANA` silently 404'd a linked
public agent instead of a 400.

- omitted / empty → **200/404** unfiltered public lookup (today's default)
- exact canonical lowercase id (`solana`, `eth`, …) → **200/404** that rail
- `SOLANA` / `ETH` / `Ethereum` / `foo!` → **400** before findByTokenAddress

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

`token_chain` equality is case-sensitive. A common `chain=SOLANA` must
not silently miss a `solana` row. This is public token-rail identity,
not leftover tax on SIWS chainId or admin-redemption network.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/agents/by-token/route.chain.test.ts` —
omitted still looks up without a rail; exact `solana` / `eth` still
bind that rail; garbage 400s with no repository call.

## Test commands

```bash
cd packages/cloud/api && bun test v1/agents/by-token/route.chain.test.ts
```

9 passed at the evidence head. Stock develop was 4 passed / 5 failed on
the same table (`chain=SOLANA` returned 200 and called
findByTokenAddress).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; public token-lookup `chain` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; public token-lookup `chain` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; public token-lookup `chain` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real rail tokens and assert 400 before findByTokenAddress; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no token export; illegal chain tokens 400 before findByTokenAddress.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`chain` tokens reject; omitted/canonical still bind the matching rail.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file public token-lookup
chain parse with a green focused suite (9 tests). Full monorepo verify is
unrelated to this query grammar and was skipped to keep the proof tied
to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f1fa6fa3f49124667529dbde66d91f2e80929e45 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->

## Maintainer repair and validation

Formatting was repaired and the test contract now proves canonical lowercase chain ids remain extensible, matching the open `token_chain` text schema and agent-creation contract. Focused production-handler tests pass 10/10; Biome and diff-check are clean. Repair head: `f44f0f49b1eed9cc3f481c7b0ac18008ff19ea4a`.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@ebbcfc87704659e5f4b68babcbd66256055ceb61:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-b]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@ebbcfc87704659e5f4b68babcbd66256055ceb61:packages/skills/skills/contribute-to-eliza"} -->