### PR TITLE
fix(documents): retain guarded route runtime

### DIFF
--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -777,6 +777,8 @@ export async function handleDocumentsRoutes(
     error(res, "Authentication required", 401);
     return true;
   }
+  // Preserve the runtime guard across the nested async location resolver.
+  const uploadLocationRuntime = runtime;
   const uploadLocationActor = routeActor;
 
   async function resolveUploadLocation(input: {
@@ -814,10 +816,12 @@ export async function handleDocumentsRoutes(
     const roomId = input.roomId.trim() as UUID;
     let room: Awaited<ReturnType<AgentRuntime["getRoom"]>>;
     try {
-      room = await runtime.getRoom(roomId);
+      room = await uploadLocationRuntime.getRoom(roomId);
     } catch (cause) {
       // error-policy:J1 The HTTP boundary reports canonical-room lookup failure as unavailable.
-      runtime.reportError("documents.upload-location", cause, { roomId });
+      uploadLocationRuntime.reportError("documents.upload-location", cause, {
+        roomId,
+      });
       return {
         ok: false,
         status: 503,
@@ -828,7 +832,7 @@ export async function handleDocumentsRoutes(
       return { ok: false, status: 400, error: "roomId does not exist" };
     }
     if (!room.worldId) {
-      runtime.reportError(
+      uploadLocationRuntime.reportError(
         "documents.upload-location",
         new Error("Canonical document room has no worldId"),
         { roomId },


### PR DESCRIPTION
## Summary

- preserve the established non-null runtime guard across the nested async document upload-location resolver
- use that stable runtime collaborator for canonical room lookup and diagnostic reporting
- retain all tenant-scope behavior from #20670 unchanged

## Root cause and attribution

PR #20670 maintainer repair commit `64b8c0110c12d83bb23934d7b18d0d90f6815c88` (merge `e35c0b433fdc756aee7795011221b35240360070`) introduced `resolveUploadLocation` as a nested async function. TypeScript does not retain the outer nullable runtime narrowing inside that closure, causing TS18047 at `routes.ts` lines 817, 820, and 831 on current `develop`.

This follow-up captures the already-guarded runtime as the resolver’s stable collaborator. It does not weaken authentication, room lookup, world matching, or fail-closed error handling.

## Exact revision

- base: `f55a2922333194d67c540d002394d3e751df4406`
- head: `eeda85c9674ec263d69f0e481dbb8f71c5dcc9bb`

## Validation

- `bun run --cwd plugins/plugin-documents typecheck`: pass
- `bun run --cwd plugins/plugin-documents test -- test/routes.test.ts`: 55 passed
- `bunx biome check plugins/plugin-documents/src/routes.ts`: pass
- `git diff --check origin/develop...HEAD`: pass

The local UI package distribution was built first to provide the package exports consumed by plugin typechecking; generated output is not committed.

No deployment, workflow dispatch, or secret mutation was performed.

AI provider/model: OpenAI / GPT-5  
Client / agent tooling: Codex  
Contribution skill revision: `elizaOS/eliza@eeda85c9674ec263d69f0e481dbb8f71c5dcc9bb:packages/skills/skills/contribute-to-eliza`  
Attribution status: self-reported  
— [codex]

<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"GPT-5","client":"Codex","skill":"packages/skills/skills/contribute-to-eliza","revision":"eeda85c9674ec263d69f0e481dbb8f71c5dcc9bb","status":"self-reported"} -->
