### PR TITLE
fix(cloud): preserve affiliate E2E org during cleanup

### DIFF
--- a/packages/cloud/api/test/e2e/group-c-agents.test.ts
+++ b/packages/cloud/api/test/e2e/group-c-agents.test.ts
@@ -171,14 +171,14 @@ async function seedOwnedCharacter(input: {
 /**
  * Seeds the real "signed-in user chatted with an affiliate character" state
  * the claim-affiliate-characters route reads: an anonymous affiliate owner
- * (own org + @anonymous.elizacloud.ai email), a user_characters row it owns,
- * the eliza runtime rows (agents / entities / rooms) and a participants row
- * linking the claiming user (entity_id = users.id, rooms.agent_id =
+ * in the persistent affiliate fixture organization, a user_characters row it
+ * owns, the eliza runtime rows (agents / entities / rooms) and a participants
+ * row linking the claiming user (entity_id = users.id, rooms.agent_id =
  * user_characters.id — the route's "new architecture" mapping).
  */
 async function seedAffiliateInteraction(input: {
   userId: string;
-}): Promise<{ characterId: string; anonOrgId: string }> {
+}): Promise<{ characterId: string; anonUserId: string }> {
   const databaseUrl = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
   if (!databaseUrl) {
     throw new Error(
@@ -187,7 +187,6 @@ async function seedAffiliateInteraction(input: {
   }
 
   const suffix = crypto.randomUUID().slice(0, 8);
-  const anonOrgId = crypto.randomUUID();
   const anonUserId = crypto.randomUUID();
   const characterId = crypto.randomUUID();
   const roomId = crypto.randomUUID();
@@ -195,10 +194,16 @@ async function seedAffiliateInteraction(input: {
   const client = new Client({ connectionString: databaseUrl });
   await client.connect();
   try {
-    await client.query(
-      `INSERT INTO organizations (id, name, slug) VALUES ($1, $2, $3)`,
-      [anonOrgId, `E2E Anon Org ${suffix}`, `e2e-anon-org-${suffix}`],
+    const affiliateOrganization = await client.query<{ id: string }>(
+      `SELECT id FROM organizations WHERE slug = $1`,
+      ["playwright-e2e-affiliate-org"],
     );
+    const affiliateOrganizationId = affiliateOrganization.rows[0]?.id;
+    if (!affiliateOrganizationId) {
+      throw new Error(
+        "E2E preload must seed the persistent affiliate organization",
+      );
+    }
     await client.query(
       `INSERT INTO users (id, email, steward_user_id, is_anonymous, organization_id)
        VALUES ($1, $2, $3, true, $4)`,
@@ -206,12 +211,12 @@ async function seedAffiliateInteraction(input: {
         anonUserId,
         `e2e-anon-${suffix}@anonymous.elizacloud.ai`,
         `e2e-anon-steward-${suffix}`,
-        anonOrgId,
+        affiliateOrganizationId,
       ],
     );
     await seedOwnedCharacter({
       id: characterId,
-      organizationId: anonOrgId,
+      organizationId: affiliateOrganizationId,
       userId: anonUserId,
       name: `E2E Affiliate ${suffix}`,
     });
@@ -238,10 +243,10 @@ async function seedAffiliateInteraction(input: {
     await client.end();
   }
 
-  return { characterId, anonOrgId };
+  return { characterId, anonUserId };
 }
 
-const seededAnonOrgIds: string[] = [];
+const seededAnonUserIds: string[] = [];
 
 afterAll(async () => {
   if (!serverReachable || !hasTestApiKey) return;
@@ -250,9 +255,10 @@ afterAll(async () => {
       headers: bearerHeaders(),
     });
   }
-  // Remove the affiliate-claim seed rows (agents cascades rooms/participants/
-  // entities; organizations cascades the anonymous owner user).
-  if (seededAnonOrgIds.length > 0) {
+  // The affiliate organization is a durable preload fixture. Keeping it also
+  // exercises the production rule that only a non-final user can be removed
+  // while auto-top-up cutover is paused.
+  if (seededAnonUserIds.length > 0) {
     const databaseUrl =
       process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
     if (databaseUrl) {
@@ -262,10 +268,8 @@ afterAll(async () => {
         for (const id of createdCharacterIds) {
           await client.query(`DELETE FROM agents WHERE id = $1`, [id]);
         }
-        for (const orgId of seededAnonOrgIds) {
-          await client.query(`DELETE FROM organizations WHERE id = $1`, [
-            orgId,
-          ]);
+        for (const userId of seededAnonUserIds) {
+          await client.query(`DELETE FROM users WHERE id = $1`, [userId]);
         }
       } finally {
         await client.end();
@@ -1341,7 +1345,7 @@ describeE2E("/api/my-agents/claim-affiliate-characters", () => {
 
     const seeded = await seedAffiliateInteraction({ userId });
     createdCharacterIds.push(seeded.characterId);
-    seededAnonOrgIds.push(seeded.anonOrgId);
+    seededAnonUserIds.push(seeded.anonUserId);
 
     const sessionCookie = await exchangeApiKeyForSession();
     const res = await api.post(


### PR DESCRIPTION
Closes #21050

## Summary

The Group C affiliate-claim fixture now places its temporary anonymous owner in the persistent affiliate preload organization. Teardown removes the temporary user after agent/runtime cleanup instead of deleting a disposable one-user organization, so the production auto-top-up lifecycle guard remains sealed and unchanged. The test still proves ownership moves from the affiliate fixture organization to the signed-in user and organization.

## Exact evidence

- Head: `c16b68f2a840ebcc74d3fab1f7e0773565107324`
- Tree: `958914e12957b55de465772ac2a281a73741a087`
- Base/current at proof: `1b2f53abf71c32aeaf96764bb8bfa9c7bb47f444`
- Real Worker + fresh PGlite `group-c-agents`: **85 pass / 2 provider-gated skip / 0 fail / 113 assertions**. The formerly failing `afterAll` teardown completed with cutover still paused.
- Production Worker dry bundle: PASS on the byte-identical patch before the final disjoint-base rebase.
- Exact-file Biome and `git diff --check`: PASS on final head.
- Cloud API typecheck: inherited failure only in `v1/apps/[id]/analytics/route.period.test.ts` and `v1/oauth/connections/route.platform.test.ts`; neither path is touched.

## Evidence

- Backend logs: real Worker/PGlite run above, manually inspected through fixture claim, queried ownership assertion, API cleanup, and terminal PASS.
- Domain artifact: test queries and asserts the claimed row has the signed-in `user_id` and `organization_id`; teardown now succeeds without deleting an organization.
- UI screenshots/video: N/A - backend-only E2E fixture correction.
- Live-model trajectory: N/A - no agent/model/prompt/provider behavior changes.

## Safety

No production guard, billing state, staging resource, provider, credential, or user-facing runtime path changes.

## Contribution provenance

- AI assistance: yes
- Provider: OpenAI
- Model: GPT-5
- Client: Codex Desktop
- Exact model identifier: GPT-5

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@1b2f53abf71c32aeaf96764bb8bfa9c7bb47f444:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-root/shared-latency]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@1b2f53abf71c32aeaf96764bb8bfa9c7bb47f444:packages/skills/skills/contribute-to-eliza"} -->