### PR TITLE
test(orchestrator): compare canonical workdirs after realpath route hardening

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/originating-request-routing.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/originating-request-routing.test.ts
@@ -230,7 +230,15 @@ describe("route matching uses the originating request, not the planner task", ()
   let originalRoutes: string | undefined;
 
   beforeEach(() => {
-    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "originating-route-"));
+    // Canonicalize the temp root the same way production does: after #20991,
+    // resolveWorkdirRoute resolves a matched route's workdir with
+    // fs.realpathSync, so on macOS it returns /private/var/... while a bare
+    // os.tmpdir() yields the /var symlink. Deriving appsDir from the canonical
+    // root keeps every expected path in the same filesystem identity as the
+    // value production returns; otherwise these assertions fail only on macOS.
+    tmpRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "originating-route-")),
+    );
     appsDir = path.join(tmpRoot, "custom-apps");
     fs.mkdirSync(appsDir, { recursive: true });
     originalRoutes = process.env[ENV_KEY];


### PR DESCRIPTION
# Relates to

Closes #21041

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; owning-package gates run (see Testing). Full-repo `bun run verify` was not run — see **Known gaps / failures** for the exact reason.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@03a217f2eb37d7f02bfbb7692e1573b57bbe8390:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — not run in full; unrelated blocker documented in **Known gaps / failures**.

# Risks

Low. Test-only change to a single unit-test setup helper. No production/`src/` file is modified, so runtime routing behavior is unchanged. The only risk is test correctness, which is covered by the before/after evidence below.

# Background

## What does this PR do?

PR #20991 ("fix(orchestrator): preserve contained route workdirs") hardened symlink containment by canonicalizing route workdirs with `fs.realpathSync`. Production `resolveWorkdirRoute` (in `plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts`) now returns the **canonical** path for a matched route.

`originating-request-routing.test.ts` still built its expected paths **lexically** from `os.tmpdir()`. On macOS `os.tmpdir()` returns `/var/folders/...`, a symlink to `/private/var/folders/...`, so two assertions compared a canonical returned path against a non-canonical expected path and failed **only on macOS**, even though route identity and containment were correct. (On Linux `/tmp` is normally not symlinked, so the suite was green there — which is why #20991's own CI did not catch it. #20991 did update `resolve-spawn-workdir.test.ts` and `spawn-agent.test.ts` to canonicalize with `fs.realpathSync`, but this suite — last touched by an unrelated commit — was missed.)

The fix canonicalizes the temp root once at creation:

```ts
tmpRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "originating-route-")));
```

so every derived expected path (`appsDir`) shares the same filesystem identity production resolves. This does not change what the tests assert (same route id, same containment outcome) — only the filesystem-identity representation of the expected path.

## What kind of change is this?

Bug fixes (test-only: aligns existing macOS assertions to the canonical filesystem identity production returns).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-orchestrator/__tests__/unit/originating-request-routing.test.ts` — the `beforeEach` of the "route matching uses the originating request…" describe block is the only change.

## Detailed testing steps

Run the three affected routing suites:

```
bun test \
  plugins/plugin-agent-orchestrator/__tests__/unit/originating-request-routing.test.ts \
  plugins/plugin-agent-orchestrator/__tests__/unit/resolve-spawn-workdir.test.ts \
  plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
```

Result (Linux):

```
 66 pass
 0 fail
 145 expect() calls
Ran 66 tests across 3 files.
```

Package gates:

```
$ bun run --cwd plugins/plugin-agent-orchestrator lint:check
Checked 406 files in 4s. No fixes applied.

$ bun run --cwd plugins/plugin-agent-orchestrator typecheck   # after building workspace deps
$ tsc --noEmit -p tsconfig.json     # (no errors)
```

# Evidence Gate

<!-- evidence-head:298a5d282a5605095828fbf299bb45a489d90778 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change to a Node unit-test helper; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change to a Node unit-test helper; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; unit test setup only.
<!-- evidence-row:backend-logs -->
- [x] Focused test output — three routing suites (Linux) and the fixed suite under a simulated-macOS symlinked `TMPDIR`. Mirror: [21055-backend-logs.txt](https://github.com/agent-cortex/eliza/releases/download/pr-21055-evidence/21055-backend-logs.txt)

```text
$ bun test originating-request-routing resolve-spawn-workdir spawn-agent
 66 pass
 0 fail
 145 expect() calls
Ran 66 tests across 3 files.

$ TMPDIR=/tmp/linktmp bun test originating-request-routing   # simulated macOS /var -> /private/var
 11 pass
 0 fail
 18 expect() calls
Ran 11 tests across 1 file.
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change; deterministic unit test, no live model.
<!-- evidence-row:domain-artifacts -->
- [x] Failing-then-passing macOS reproduction (simulated on Linux via a symlinked `TMPDIR`, mirroring `/var` -> `/private/var`). Mirror: [21055-domain-artifacts.txt](https://github.com/agent-cortex/eliza/releases/download/pr-21055-evidence/21055-domain-artifacts.txt)

```text
=== BEFORE FIX + simulated macOS: reproduces #21041 ===
error: expect(received).toBe(expected)
Expected: "/tmp/linktmp/originating-route-hR2z68/custom-apps"   # lexical os.tmpdir()
Received: "/tmp/realtmp/originating-route-hR2z68/custom-apps"   # canonical fs.realpathSync
(fail) FAILS-ON-OLD: terse planner task + empty content.text misses, recovered request matches
(fail) recovers from the state window when the action message has no text at all
 9 pass
 2 fail

=== AFTER FIX + simulated macOS ===
 11 pass
 0 fail
Ran 11 tests across 1 file.
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change; the affected tests are deterministic and run against a real temp filesystem with a stubbed runtime and no live model.`

## Backend + frontend logs

Because macOS's `/var → /private/var` symlink is not present on the Linux CI/dev host, I reproduced the exact platform condition by pointing `TMPDIR` at a symlink (`/tmp/linktmp → /tmp/realtmp`) so `os.tmpdir()` returns a non-canonical path, mirroring macOS.

**Before the fix (original test) + simulated macOS symlinked tmp — the reported failure:**

```
$ TMPDIR=/tmp/linktmp bun test .../originating-request-routing.test.ts
error: expect(received).toBe(expected)
Expected: "/tmp/linktmp/originating-route-WSr6dN/custom-apps"
Received: "/tmp/realtmp/originating-route-WSr6dN/custom-apps"
(fail) ... FAILS-ON-OLD: terse planner task + empty content.text misses, recovered request matches
error: expect(received).toBe(expected)
Expected: "/tmp/linktmp/originating-route-RmiOGO/custom-apps"
Received: "/tmp/realtmp/originating-route-RmiOGO/custom-apps"
(fail) ... recovers from the state window when the action message has no text at all
 9 pass
 2 fail
Ran 11 tests across 1 file.
```

The `Received` value is the **canonical** path production returns via `fs.realpathSync`; the `Expected` value is the old lexical `os.tmpdir()`-derived path. This is precisely the macOS-only mismatch #21041 describes.

**After the fix + simulated macOS symlinked tmp:**

```
$ TMPDIR=/tmp/linktmp bun test .../originating-request-routing.test.ts
 11 pass
 0 fail
 18 expect() calls
Ran 11 tests across 1 file.
```

**All three suites, normal Linux run:**

```
 66 pass
 0 fail
 145 expect() calls
Ran 66 tests across 3 files.
```

## Screenshots (before / after) + video walkthrough

`N/A - test-only change, no UI surface.`

## Audio / voice walkthrough

`N/A - not a voice/transcript/TTS/STT change.`

## Known gaps / failures

- **`bun run verify` (full repo gate) was not run.** `bun install` on this machine is subject to a supply-chain `minimumReleaseAge` guard that blocks a few freshly-published locked versions (`viem`, `smthrs`, `kubernetes-fluent-client`) unrelated to this change; the workspace installs and builds fine once the vetted, already-cached locked versions are used. Running the entire `verify` lane (parity, dependency, type, lint, repo audit across all workspaces) is disproportionate to a one-line, test-only diff and prone to timeouts on unrelated packages. Instead, the **owning package's** gates were run and pass: the three affected suites (66 pass), `lint:check` (clean), and `typecheck` (clean after building the workspace dependency `.d.ts`). No production/`src/` file changed, confirmed by `git diff --name-only` listing only the one test file.
- Adversarial symlink-escape coverage in `resolve-spawn-workdir.test.ts` is intentionally left untouched and still passes (part of the 66).

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@03a217f2eb37d7f02bfbb7692e1573b57bbe8390:packages/skills/skills/contribute-to-eliza"} -->
