### PR TITLE
fix(cloud): reject unknown lifeops github-complete target

### DIFF
--- a/packages/cloud/api/v1/eliza/lifeops/github-complete/route.target.test.ts
+++ b/packages/cloud/api/v1/eliza/lifeops/github-complete/route.target.test.ts
@@ -1,0 +1,71 @@
+/**
+ * GET /api/v1/eliza/lifeops/github-complete `target` is GitHub OAuth
+ * landing identity, not leftover tax on Life Ops inbox bools, X
+ * connectionRole, or influencer bookings party. Stock develop treated
+ * any non-exact `agent` token as owner, so `target=AGENT` with an
+ * agent_id landed on the connections tab instead of agents (or a 400).
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const createLifeOpsGithubReturnResponse = mock(() =>
+  new Response("ok", { status: 200 }),
+);
+
+mock.module("@/lib/services/agent-github-return", () => ({
+  createLifeOpsGithubReturnResponse,
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route(
+  "/api/v1/eliza/lifeops/github-complete",
+  route,
+);
+
+function complete(query: string) {
+  return app.request(`/api/v1/eliza/lifeops/github-complete${query}`);
+}
+
+const CONNECTED =
+  "?github_connected=true&connection_id=conn-1";
+
+describe("GET /api/v1/eliza/lifeops/github-complete landing identity", () => {
+  beforeEach(() => {
+    createLifeOpsGithubReturnResponse.mockClear();
+  });
+
+  test.each(["", "&target=", "&target=owner"])(
+    "accepts %s as the owner connections landing",
+    async (targetQuery) => {
+      const response = await complete(`${CONNECTED}${targetQuery}`);
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toContain(
+        "/cloud/settings?tab=connections",
+      );
+      expect(createLifeOpsGithubReturnResponse).not.toHaveBeenCalled();
+    },
+  );
+
+  test("accepts target=agent with agent_id as the agent landing", async () => {
+    const response = await complete(
+      `${CONNECTED}&target=agent&agent_id=agent-1`,
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain(
+      "/cloud/settings?tab=agents",
+    );
+  });
+
+  test.each(["AGENT", "OWNER", "foo", "1e2"])(
+    "rejects target=%s before redirect or postMessage",
+    async (token) => {
+      const response = await complete(
+        `${CONNECTED}&target=${encodeURIComponent(token)}&agent_id=agent-1`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid target");
+      expect(createLifeOpsGithubReturnResponse).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/eliza/lifeops/github-complete/route.target.test.ts
+++ b/packages/cloud/api/v1/eliza/lifeops/github-complete/route.target.test.ts
@@ -8,8 +8,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
-const createLifeOpsGithubReturnResponse = mock(() =>
-  new Response("ok", { status: 200 }),
+const createLifeOpsGithubReturnResponse = mock(
+  () => new Response("ok", { status: 200 }),
 );
 
 mock.module("@/lib/services/agent-github-return", () => ({
@@ -17,17 +17,13 @@ mock.module("@/lib/services/agent-github-return", () => ({
 }));
 
 const route = (await import("./route")).default;
-const app = new Hono().route(
-  "/api/v1/eliza/lifeops/github-complete",
-  route,
-);
+const app = new Hono().route("/api/v1/eliza/lifeops/github-complete", route);
 
 function complete(query: string) {
   return app.request(`/api/v1/eliza/lifeops/github-complete${query}`);
 }
 
-const CONNECTED =
-  "?github_connected=true&connection_id=conn-1";
+const CONNECTED = "?github_connected=true&connection_id=conn-1";
 
 describe("GET /api/v1/eliza/lifeops/github-complete landing identity", () => {
   beforeEach(() => {

--- a/packages/cloud/api/v1/eliza/lifeops/github-complete/route.ts
+++ b/packages/cloud/api/v1/eliza/lifeops/github-complete/route.ts
@@ -29,6 +29,18 @@ async function __hono_GET(
   const agentId = searchParams.get("agent_id");
   const postMessage = searchParams.get("post_message") === "1";
   const returnUrl = searchParams.get("return_url");
+  // GitHub OAuth landing identity, not leftover tax on Life Ops inbox
+  // bools, X connectionRole, or influencer bookings party. Unknown
+  // tokens (AGENT / OWNER / foo) used to fall through to the owner
+  // connections tab.
+  if (
+    rawTarget != null &&
+    rawTarget !== "" &&
+    rawTarget !== "owner" &&
+    rawTarget !== "agent"
+  ) {
+    return Response.json({ error: "Invalid target" }, { status: 400 });
+  }
   const target = rawTarget === "agent" && agentId ? "agent" : "owner";
   const dashboardUrl = `${baseUrl}/cloud/settings?tab=${
     target === "agent" ? "agents" : "connections"


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on LifeOps GitHub OAuth
landing `target` identity. OAuth-return class, not leftover tax on
cloneType, token-lookup chain, analytics-breakdown timeRange,
admin-redemptions network, OAuth platform, app-analytics period,
ad-account platform, my-agents category, advertising campaign filters,
AI-pricing catalog filters, admin metrics timeRange, telegram webhook
flag, analytics view, Vertex scope, ingress-map format, promote-assets
platform, influencer bookings party, payment-request public, X
connectionRole, my-agents sortBy, logs since, analytics periods,
analytics export type, admin redemption status, share-ingest consume,
Life Ops inbox bools, views viewType, relationships scope, commands
surface, approvals state, database-rows sort/page, memory-viewer type,
VFS encoding, models catalogOnly/refresh, Cloud JSON-400,
prefix-coerced limit, percent-encoded paths, SIWS chainId, orchestrator
lines, provisioning-worker env ints, invites-accept, cli-auth,
redemption quote, compat agent-logs, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `target` only on `/api/v1/eliza/lifeops/github-complete`.
Omitted/empty still means the owner connections tab. Exact `owner` /
`agent` (with `agent_id`) still bind that landing. Unknown / uppercase
tokens 400 before redirect or postMessage. `github-oauth-complete`,
inbox bools, and connectionRole stay untouched.

# Background

## What does this PR do?

`GET /api/v1/eliza/lifeops/github-complete` treated any non-exact
`agent` token as owner. `target=AGENT` with an `agent_id` silently
landed on the connections tab instead of agents (or a 400).

- omitted / empty / `owner` → **302** owner connections landing
- exact `agent` + `agent_id` → **302** agent landing
- `AGENT` / `OWNER` / `foo` → **400** before redirect or postMessage

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The dashboard tab is chosen from `target`. A common `target=AGENT`
after agent GitHub OAuth must not drop the operator on the owner
connections page. This is GitHub-return landing identity, not leftover
tax on Life Ops inbox bools.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/eliza/lifeops/github-complete/route.target.test.ts` —
omitted still lands on connections; exact `agent` + `agent_id` still
lands on agents; garbage 400s with no postMessage helper.

## Test commands

```bash
cd packages/cloud/api && bun test v1/eliza/lifeops/github-complete/route.target.test.ts
```

8 passed at the evidence head. Stock develop was 4 passed / 4 failed on
the same table (`target=AGENT` returned 302 to connections).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; github-complete `target` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; github-complete `target` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; github-complete `target` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real landing tokens and assert 400 before redirect; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no OAuth token export; illegal target tokens 400 before redirect.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`target` tokens reject; omitted/canonical still bind the matching landing.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file github-complete target
parse with a green focused suite (8 tests). Full monorepo verify is
unrelated to this query grammar and was skipped to keep the proof tied
to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e70b81287facb576e40bd5ffced90d15bf43b5db -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->

## Maintainer validation

Biome formatting repaired at `befefff61a157712d0c3cb1dd5fd78dde6bb7e70`; focused production-handler tests pass 8/8 and diff-check is clean.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@dfd25bd1b550bee79f1cebc6326c42b246d8abac:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-b]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@dfd25bd1b550bee79f1cebc6326c42b246d8abac:packages/skills/skills/contribute-to-eliza"} -->