### PR TITLE
fix(ui): reject malformed streaming token payloads at SSE boundary

### DIFF
--- a/packages/ui/src/api/client-base-delta-stream.test.ts
+++ b/packages/ui/src/api/client-base-delta-stream.test.ts
@@ -43,6 +43,44 @@ function parseRequestBody(request: ReturnType<typeof vi.fn>): {
 }
 
 describe("delta-v2 chat stream client reducer", () => {
+  it("ignores malformed non-string token payloads at the SSE boundary", async () => {
+    const { client } = streamFromSse(
+      'data: {"type":"token","text":123}\n\n' +
+        'data: {"type":"token","text":{"value":"spoof"}}\n\n' +
+        'data: {"type":"token","text":false}\n\n' +
+        'data: {"type":"token","text":"valid"}\n\n' +
+        'data: {"type":"done","fullText":"valid","agentName":"Eliza"}\n\n',
+    );
+    const onToken = vi.fn();
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "hi",
+      onToken,
+    );
+
+    expect(onToken).toHaveBeenCalledTimes(1);
+    expect(onToken).toHaveBeenCalledWith("valid", "valid", false);
+    expect(result.text).toBe("valid");
+  });
+
+  it("keeps a valid fullText snapshot when the optional delta is malformed", async () => {
+    const { client } = streamFromSse(
+      'data: {"type":"token","text":{"bad":true},"fullText":"snapshot"}\n\n' +
+        'data: {"type":"done","fullText":"snapshot","agentName":"Eliza"}\n\n',
+    );
+    const onToken = vi.fn();
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "hi",
+      onToken,
+    );
+
+    expect(onToken).toHaveBeenCalledWith("", "snapshot", false);
+    expect(result.text).toBe("snapshot");
+  });
+
   it("appends a repeated multi-char delta instead of dropping it (mergeStreamingText regression)", async () => {
     const { client } = streamFromSse(
       'data: {"type":"token","text":"the "}\n\n' +

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -366,24 +366,31 @@ function applyStreamChatTokenEvent(
     provisional?: boolean,
   ) => void,
 ): boolean {
-  const chunk = parsed.text ?? "";
+  const chunk = typeof parsed.text === "string" ? parsed.text : null;
+  const fullText = typeof parsed.fullText === "string" ? parsed.fullText : null;
+  if (chunk === null && fullText === null) {
+    // error-policy:J3 malformed SSE token frames are ignored at the transport
+    // boundary; they must not become a valid-looking empty text update.
+    return false;
+  }
+  const safeChunk = chunk ?? "";
   const nextFullText =
-    typeof parsed.fullText === "string"
+    fullText !== null
       ? // An explicit snapshot is always authoritative (delta-v2 periodic
         // snapshot AND legacy per-token fullText both land here).
-        parsed.fullText
-      : chunk
+        fullText
+      : safeChunk
         ? // No fullText: a bare delta. Under negotiated delta-v2 the server
           // guarantees pure appends, so bypass mergeStreamingText (its overlap
           // dedupe drops legitimately repeated multi-char deltas). Foreign /
           // un-negotiated streams still ride the merge heuristic.
           state.deltaProtocol
-          ? state.fullText + chunk
-          : mergeStreamingText(state.fullText, chunk)
+          ? state.fullText + safeChunk
+          : mergeStreamingText(state.fullText, safeChunk)
         : state.fullText;
   if (nextFullText === state.fullText) return false;
   state.fullText = nextFullText;
-  onToken(chunk, state.fullText, parsed.provisional === true);
+  onToken(safeChunk, state.fullText, parsed.provisional === true);
   return false;
 }
 


### PR DESCRIPTION
# Relates to

Closes #21056.

# Contribution provenance

<!-- contribution-attribution:v1 -->
AI-assisted. The contributor's original Google Gemini / Antigravity change attempted to coerce invalid values inside typed shared utilities. Maintainer review traced the actual untrusted input to the SSE transport boundary, replaced that approach with boundary validation, added production-client regressions, and independently ran the exact-head gates below using OpenAI Codex (`gpt-5.6-sol`).

<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity`, `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@4a1380f82d25ddf90f9fe76937d1cfe10613bc74:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

Rebased onto `develop` at `4a1380f82d25ddf90f9fe76937d1cfe10613bc74` immediately before exact-head validation.

# Risks

Low. The repair is limited to malformed `type: "token"` SSE frames. Valid string deltas and authoritative string snapshots keep their existing semantics. A frame with neither a string `text` nor a string `fullText` is ignored instead of fabricating an empty update; a valid snapshot is retained even when its optional delta is malformed.

# Background

## What does this PR do?

The original report was valid but the proposed layer was wrong: `mergeStreamingText`, `computeStreamingDelta`, and `resolveStreamingUpdate` are typed internal utilities, and coercing arbitrary values there silently hides boundary failures. The reachable unsafe path was `packages/ui/src/api/client-base.ts`, where parsed SSE JSON used `parsed.text ?? ""` and could pass numbers or objects into the reconciler.

This repaired head validates `text` and `fullText` once in `applyStreamChatTokenEvent`, at the transport boundary. It ignores a wholly malformed token frame, preserves a valid authoritative snapshot when only the optional delta is malformed, and leaves the shared typed utilities unchanged.

## What kind of change is this?

Bug fix and untrusted-input hardening; no public API or schema change.

# Documentation changes needed?

No.

# Testing

Two real `streamChatEndpoint` SSE regressions were added to the existing delta-stream client suite:

- number, object, and boolean token payloads are ignored while a following valid token is delivered exactly once;
- a valid `fullText` snapshot remains authoritative when optional `text` is malformed.

# Evidence Gate

<!-- evidence-head:d9992d1178ed40d36963ead457dbc3b18ab18228 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes; this is transport-boundary validation
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes; this is transport-boundary validation
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic malformed-frame boundary with no visible user flow
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code path changed
<!-- evidence-row:frontend-logs -->
- [x] Exact-head production-client transcript:
```text
Pinned Bun 1.3.14: packages/ui/src/api/client-base-delta-stream.test.ts
8 pass, 0 fail, 18 expect() calls
Malformed number/object/boolean token frames were ignored; valid token and snapshot paths passed.
```
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, evaluator, or provider behavior
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, media, or generated domain artifact
<!-- evidence-row:ocr-review -->
- [x] Exact-head app audit transcript:
```text
App aesthetic audit: 219 passed; broken=0; needs-work=0
OCR triage: 216 views; verified=200; broken=0; needs-eyeball=16
Minimalism, hover, and density ratchets reported zero failures.
```

## Known gaps / failures

`@elizaos/ui` typecheck reached the workspace graph and stopped on the sparse review checkout's absent `@elizaos/plugin-sql` package. No changed-file diagnostic was emitted. Focused Biome and `git diff --check` are clean.

## Maintainer validation

- Exact repaired head: `d9992d1178ed40d36963ead457dbc3b18ab18228`.
- Pinned Bun 1.3.14 production-client suite: 8/8 passed.
- Full app aesthetic audit: 219/219 passed; broken=0, needs-work=0.
- OCR triage: 216 views, broken=0.
- Biome on both changed files: passed.
- `git diff --check`: passed.
- No overlapping open PR found for this transport-boundary repair.

---

Original contributor provenance: Google / gemini-3.7-flash via Antigravity.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@4a1380f82d25ddf90f9fe76937d1cfe10613bc74:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@4a1380f82d25ddf90f9fe76937d1cfe10613bc74:packages/skills/skills/contribute-to-eliza"} -->
