### PR TITLE
feat(core): add connected helper, size getter, and unit test suite for UnionFind

### DIFF
--- a/packages/core/src/utils/union-find.test.ts
+++ b/packages/core/src/utils/union-find.test.ts
@@ -22,6 +22,7 @@ describe("UnionFind", () => {
 	it("merges disjoint sets and reports connectivity accurately", () => {
 		const uf = new UnionFind<string>();
 		expect(uf.connected("a", "b")).toBe(false);
+		expect(uf.size).toBe(0);
 
 		uf.union("a", "b");
 		expect(uf.connected("a", "b")).toBe(true);
@@ -64,5 +65,6 @@ describe("UnionFind", () => {
 		uf.clear();
 		expect(uf.size).toBe(0);
 		expect(uf.has("x")).toBe(false);
+		expect(uf.groups()).toEqual(new Map());
 	});
 });

--- a/packages/core/src/utils/union-find.test.ts
+++ b/packages/core/src/utils/union-find.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for UnionFind in packages/core/src/utils/union-find.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+import { UnionFind } from "./union-find";
+
+describe("UnionFind", () => {
+	it("initializes with elements and supports add/has/size", () => {
+		const uf = new UnionFind(["a", "b", "c"]);
+		expect(uf.size).toBe(3);
+		expect(uf.has("a")).toBe(true);
+		expect(uf.has("b")).toBe(true);
+		expect(uf.has("c")).toBe(true);
+		expect(uf.has("d")).toBe(false);
+
+		uf.add("d");
+		expect(uf.has("d")).toBe(true);
+		expect(uf.size).toBe(4);
+	});
+
+	it("merges disjoint sets and reports connectivity accurately", () => {
+		const uf = new UnionFind<string>();
+		expect(uf.connected("a", "b")).toBe(false);
+
+		uf.union("a", "b");
+		expect(uf.connected("a", "b")).toBe(true);
+		expect(uf.connected("a", "c")).toBe(false);
+
+		uf.union("b", "c");
+		expect(uf.connected("a", "c")).toBe(true);
+
+		uf.union("d", "e");
+		expect(uf.connected("d", "e")).toBe(true);
+		expect(uf.connected("a", "d")).toBe(false);
+
+		uf.union("c", "d");
+		expect(uf.connected("a", "e")).toBe(true);
+	});
+
+	it("computes groups and component members", () => {
+		const uf = new UnionFind<string>();
+		uf.union("entity1", "entity2");
+		uf.union("entity2", "entity3");
+		uf.union("other1", "other2");
+
+		const comp1 = uf.componentOf("entity1");
+		expect(comp1.sort()).toEqual(["entity1", "entity2", "entity3"].sort());
+
+		const comp2 = uf.componentOf("other1");
+		expect(comp2.sort()).toEqual(["other1", "other2"].sort());
+
+		const standalone = uf.componentOf("unregistered");
+		expect(standalone).toEqual(["unregistered"]);
+
+		const groups = uf.groups();
+		expect(groups.size).toBe(2);
+	});
+
+	it("clears elements and resets structure", () => {
+		const uf = new UnionFind(["x", "y", "z"]);
+		expect(uf.size).toBe(3);
+
+		uf.clear();
+		expect(uf.size).toBe(0);
+		expect(uf.has("x")).toBe(false);
+	});
+});

--- a/packages/core/src/utils/union-find.ts
+++ b/packages/core/src/utils/union-find.ts
@@ -57,6 +57,9 @@ export class UnionFind<T> {
 
 	/** True if `left` and `right` belong to the same connected component. */
 	connected(left: T, right: T): boolean {
+		if (!this.has(left) || !this.has(right)) {
+			return false;
+		}
 		return this.find(left) === this.find(right);
 	}
 

--- a/packages/core/src/utils/union-find.ts
+++ b/packages/core/src/utils/union-find.ts
@@ -55,6 +55,21 @@ export class UnionFind<T> {
 		}
 	}
 
+	/** True if `left` and `right` belong to the same connected component. */
+	connected(left: T, right: T): boolean {
+		return this.find(left) === this.find(right);
+	}
+
+	/** Total number of registered elements in the structure. */
+	get size(): number {
+		return this.parent.size;
+	}
+
+	/** Clear all elements and reset the structure. */
+	clear(): void {
+		this.parent.clear();
+	}
+
 	/** Return all components as arrays of members keyed by root. */
 	groups(): Map<T, T[]> {
 		const grouped = new Map<T, T[]>();


### PR DESCRIPTION
# Summary

Closes #21064. Adds `connected`, `size`, and `clear` to the shared identity-clustering `UnionFind`, plus its first focused suite. Review made `connected` a read-only query: checking unknown identities returns false without silently registering them.

# Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash, openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity, Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5247ca44633078db60498012a2ceb0faffb8d2a1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Verification

Exact head `bf82d67b040d78b81774a99814e2d98d12365231` on `5247ca44633078db60498012a2ceb0faffb8d2a1`. Pinned Bun 1.3.14: 4/4 tests; core typecheck passed; Biome and diff-check clean. Tests cover initialization, transitive unions, groups/components, unknown connectivity without mutation, size, and full clear/reset.

# Evidence Gate
<!-- evidence-head:bf82d67b040d78b81774a99814e2d98d12365231 -->
<!-- evidence-row:before-screenshots -->
- [x] `N/A - core data structure; no UI`.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - core data structure; no UI`.
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI workflow`.
<!-- evidence-row:backend-logs -->
- [x]
  ```text
  Test Files 1 passed (1); Tests 4 passed (4)
  packages/core typecheck: exit 0
  Biome: Checked 2 files. No fixes applied; diff-check clean
  ```
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend path`.
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model behavior`.
<!-- evidence-row:domain-artifacts -->
- [x]
  ```text
  connected(unknown, unknown) => false and size remains 0
  transitive unions report connected; groups return two expected components
  clear => size 0, has false, and empty groups map
  ```
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered surface`.

---
— [codex-root/pr-21067-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@5247ca44633078db60498012a2ceb0faffb8d2a1:packages/skills/skills/contribute-to-eliza"} -->
