### PR TITLE
fix(orchestrator): require completed deterministic evidence

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
@@ -9,6 +9,7 @@ import { generateDefaultAcceptanceCriteria } from "../services/acceptance-criter
 import {
   capabilitiesForBackend,
   deterministicLedgerVerdict,
+  isCompletedToolEvidence,
   isGreenCheckOutput,
   isPubliclyReachableUrl,
   renderDeterministicVerdict,
@@ -204,6 +205,22 @@ describe("deterministicLedgerVerdict", () => {
     expect(verdict.allMet).toBe(true);
   });
 
+  test("behavior words inside a matching URL path do not change its claim", () => {
+    const url = "https://example.com/status/get-and-delete/";
+    expect(
+      deterministicLedgerVerdict([`${url} is reachable`], {
+        ...quickAppFacts,
+        verifiedPublicUrls: [url],
+      }).allMet,
+    ).toBe(true);
+    expect(
+      deterministicLedgerVerdict([`${url} returns HTTP 200`], {
+        ...quickAppFacts,
+        verifiedPublicUrls: [url],
+      }).allMet,
+    ).toBe(false);
+  });
+
   test("empty criteria never auto-pass", () => {
     expect(deterministicLedgerVerdict([], quickAppFacts).allMet).toBe(false);
   });
@@ -253,6 +270,25 @@ describe("green check output", () => {
 
   test("accepts an explicit zero-failure summary", () => {
     expect(isGreenCheckOutput("12 passed, 0 failed")).toBe(true);
+  });
+});
+
+describe("deterministic tool-result admission", () => {
+  test.each(["running", "in_progress", "failed", "error", ""])(
+    "rejects %s tool events",
+    (status) => {
+      expect(isCompletedToolEvidence({ status })).toBe(false);
+    },
+  );
+
+  test("accepts only an explicit completed transition", () => {
+    expect(isCompletedToolEvidence({ status: "completed" })).toBe(true);
+    expect(isCompletedToolEvidence({ status: " COMPLETED " })).toBe(true);
+  });
+
+  test("rejects pass-looking output from a non-zero process", () => {
+    expect(isGreenCheckOutput("PASS\n$ bun test → exit 1")).toBe(false);
+    expect(isGreenCheckOutput("ok\nexit_code: 2")).toBe(false);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -187,6 +187,7 @@ import {
   capabilitiesForBackend,
   DETERMINISTIC_LEDGER_VERIFIER_NAME,
   deterministicLedgerVerdict,
+  isCompletedToolEvidence,
   isGreenCheckOutput,
   isPubliclyReachableUrl,
   renderDeterministicVerdict,
@@ -2466,6 +2467,7 @@ export class OrchestratorTaskService extends Service {
    *  carries the command/title so {@link classifyToolOutput} can class it. */
   private extractToolSignals(
     events: OrchestratorTaskDocument["events"],
+    completedOnly = false,
   ): EvidenceSignal[] {
     const signals: EvidenceSignal[] = [];
     for (const event of events) {
@@ -2477,6 +2479,7 @@ export class OrchestratorTaskService extends Service {
       const toolCall = isRecord(event.data.toolCall)
         ? event.data.toolCall
         : event.data;
+      if (completedOnly && !isCompletedToolEvidence(toolCall)) continue;
       const output = str(toolCall.output) ?? str(event.data.output);
       if (!output) continue;
       const rawInput = isRecord(toolCall.rawInput) ? toolCall.rawInput : {};
@@ -4062,6 +4065,7 @@ export class OrchestratorTaskService extends Service {
               (event) =>
                 event.sessionId === sessionId || event.sessionId === undefined,
             ),
+            true,
           ),
         );
         const detVerdict = deterministicLedgerVerdict(acceptanceCriteria, {

--- a/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
@@ -133,6 +133,12 @@ const URL_BEHAVIOR_CRITERION_RE =
   /\b(?:[1-5]\d{2}|status|response|body|json|xml|auth(?:entication|orization)?|unauthorized|forbidden|token|header|payload|method|redirect|error|returns?|responds?|contains?|matches?|accepts?|rejects?|requires?|allows?|denies?|get|post|put|patch|delete)\b/i;
 const IMPLICIT_REACHABILITY_CRITERION_RE =
   /\b(?:live\s+url|public\s+url|(?:url|page|site|app|deployment)\s+(?:is\s+)?(?:live|reachable|available|served)|deployed\s+(?:app|page|site))\b/i;
+const EXPLICIT_REACHABILITY_ASSERTION_RE =
+  /^\s*(?:is\s+)?(?:live|reachable|available|served)[.!]?\s*$/i;
+
+function withoutExplicitHttpUrls(value: string): string {
+  return value.replace(EXPLICIT_HTTP_URL_RE, " ");
+}
 
 function normalizeExplicitHttpUrl(value: string): string | undefined {
   const candidate = value.replace(/[),.;!?]+$/, "");
@@ -157,7 +163,8 @@ function urlCriterionBasis(
   const verified = facts.verifiedPublicUrls
     .map(normalizeExplicitHttpUrl)
     .filter((url): url is string => Boolean(url));
-  if (URL_BEHAVIOR_CRITERION_RE.test(criterion)) return undefined;
+  const assertion = withoutExplicitHttpUrls(criterion);
+  if (URL_BEHAVIOR_CRITERION_RE.test(assertion)) return undefined;
   if (
     demandedUrls.length === 0 &&
     !IMPLICIT_REACHABILITY_CRITERION_RE.test(criterion)
@@ -230,18 +237,21 @@ export function deterministicCriterionCheck(
   criterion: string,
   facts: DeterministicEvidenceFacts,
 ): DeterministicCriterionResult {
+  const assertion = withoutExplicitHttpUrls(criterion);
   if (SCREENSHOT_CRITERION_RE.test(criterion)) {
     return { criterion, status: "undetermined" };
   }
   // One deterministic fact can satisfy only a single-fact evidence assertion.
   // A reachable URL proves liveness, not its content or behavior, and a green
   // existing test run does not prove that a requested new test was added.
-  if (COMPOSITE_CRITERION_RE.test(criterion)) {
+  if (COMPOSITE_CRITERION_RE.test(assertion)) {
     return { criterion, status: "undetermined" };
   }
   if (
-    URL_LIVENESS_CRITERION_RE.test(criterion) &&
-    !CONTENT_OR_BEHAVIOR_RE.test(criterion)
+    (URL_LIVENESS_CRITERION_RE.test(criterion) ||
+      (assertion !== criterion &&
+        EXPLICIT_REACHABILITY_ASSERTION_RE.test(assertion))) &&
+    !CONTENT_OR_BEHAVIOR_RE.test(assertion)
   ) {
     const basis = urlCriterionBasis(criterion, facts);
     return basis
@@ -337,6 +347,22 @@ export function isPubliclyReachableUrl(value: string): boolean {
 
 const GREEN_MARKER_RE = /\bpass(?:ed|ing)?\b|✓|✔|\bPASS\b|\bok\b|0 fail/i;
 const RED_MARKER_RE = /\bnot\s+ok\b|\bfail(?:ed|ing|ure)?\b|✗|✖|\berrors?\b/i;
+const NONZERO_EXIT_RE =
+  /\b(?:exit(?:ed)?(?:\s+with)?|exit[_ -]?code)\s*(?:[:=]|->|→)?\s*[1-9]\d*\b/i;
+
+/**
+ * Deterministic check evidence must come from an explicitly successful tool
+ * transition. Running, failed, errored, or statusless events remain useful to
+ * the model judge, but cannot promote a coding task without judgment.
+ */
+export function isCompletedToolEvidence(
+  toolCall: Record<string, unknown>,
+): boolean {
+  return (
+    typeof toolCall.status === "string" &&
+    toolCall.status.trim().toLowerCase() === "completed"
+  );
+}
 
 /**
  * Whether mined tool output constitutes GREEN evidence for a check class:
@@ -347,7 +373,9 @@ export function isGreenCheckOutput(output: string | undefined | null): boolean {
   if (typeof output !== "string" || output.trim().length === 0) return false;
   const withoutZeroFailures = output.replace(/\b0\s+fail(?:ed|ures?)?\b/gi, "");
   return (
-    GREEN_MARKER_RE.test(output) && !RED_MARKER_RE.test(withoutZeroFailures)
+    GREEN_MARKER_RE.test(output) &&
+    !RED_MARKER_RE.test(withoutZeroFailures) &&
+    !NONZERO_EXIT_RE.test(output)
   );
 }
 


### PR DESCRIPTION
## Summary
- accept deterministic tool evidence only from explicit completed transitions
- reject pass-looking command output with nonzero exit codes
- recognize explicit URL reachability criteria without letting URL path words become behavior claims
- add adversarial coverage for running, failed, statusless, nonzero-exit, and URL-path cases

This is the post-merge hardening follow-up for #21022 and #21038.

## Validation
- bun test src/__tests__/producible-evidence.test.ts — 45 passed
- bunx vitest run --config vitest.config.ts --testTimeout=20000 src/__tests__/auto-goal-verify.test.ts — 46 passed
- package typecheck passed
- Biome and git diff checks passed

Closes #20794
Closes #21002