### PR TITLE
fix(cloud): type route contract mocks

### DIFF
--- a/packages/cloud/api/v1/agents/by-token/route.chain.test.ts
+++ b/packages/cloud/api/v1/agents/by-token/route.chain.test.ts
@@ -31,12 +31,13 @@ function publicAgent(overrides: {
   };
 }
 
-const findByTokenAddress = mock(async () =>
-  publicAgent({
-    id: "char-sol",
-    token_address: SOLANA_TOKEN,
-    token_chain: "solana",
-  }),
+const findByTokenAddress = mock(
+  async (_tokenAddress: string, _tokenChain?: string) =>
+    publicAgent({
+      id: "char-sol",
+      token_address: SOLANA_TOKEN,
+      token_chain: "solana",
+    }),
 );
 
 mock.module("@/db/repositories/characters", () => ({

--- a/packages/cloud/api/v1/apps/[id]/analytics/route.period.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/route.period.test.ts
@@ -20,7 +20,14 @@ const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
 const getById = mock(async (id: string) =>
   id === APP_ID ? { id: APP_ID, organization_id: ORG_A } : null,
 );
-const getAnalytics = mock(async () => []);
+const getAnalytics = mock(
+  async (
+    _appId: string,
+    _periodType: "hourly" | "daily" | "monthly",
+    _startDate: Date,
+    _endDate: Date,
+  ) => [],
+);
 const getTotalStats = mock(async () => ({
   totalRequests: 0,
   totalUsers: 0,

--- a/packages/cloud/api/v1/oauth/connections/route.platform.test.ts
+++ b/packages/cloud/api/v1/oauth/connections/route.platform.test.ts
@@ -103,7 +103,8 @@ describe("GET /api/v1/oauth/connections catalog platform identity", () => {
     const response = await request("?platform=google");
 
     expect(response.status).toBe(500);
-    expect(await response.json()).toEqual({
+    const body = (await response.json()) as { error: string };
+    expect(body).toEqual({
       error: "Failed to list OAuth connections",
     });
     expect(loggerError).toHaveBeenCalledWith(

--- a/packages/cloud/api/v1/voice/list/route.clonetype.test.ts
+++ b/packages/cloud/api/v1/voice/list/route.clonetype.test.ts
@@ -28,13 +28,23 @@ function voiceRow(cloneType: "instant" | "professional") {
   };
 }
 
-const listByOrganization = mock(async () => ({
-  voices: [voiceRow("instant"), voiceRow("professional")],
-  total: 2,
-  limit: 50,
-  offset: 0,
-  hasMore: false,
-}));
+const listByOrganization = mock(
+  async (
+    _organizationId: string,
+    _options: {
+      includeInactive?: boolean;
+      cloneType?: "instant" | "professional";
+      limit?: number;
+      offset?: number;
+    },
+  ) => ({
+    voices: [voiceRow("instant"), voiceRow("professional")],
+    total: 2,
+    limit: 50,
+    offset: 0,
+    hasMore: false,
+  }),
+);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg: async () => ({


### PR DESCRIPTION
Follow-up to #21020, #21021, #21047, and #21048.

## Root cause

The four route regression suites declared Bun mocks with zero-argument implementations even though their assertions inspect repository/service call arguments. Bun's current mock typing therefore inferred `mock.calls` as zero-length tuples. The OAuth failure response also left `response.json()` at its default undefined/unknown expectation type. Runtime assertions passed, but the complete Cloud API TypeScript lane failed.

## Repair

- Give the analytics, token lookup, and voice-list mocks the real argument shapes exercised by their routes.
- Type the OAuth error response body at the JSON boundary before asserting its shape.
- No runtime or production behavior changes.

## Exact provenance

- Base: `bdd76405c14110100883d808d0299920be70025c`
- Head: `8afc2705b958d8531c36f02a58fe42c15da17bba`
- Tree: `4ee516b3a645d0d94f2686b54b8ea77837c128fb`

## Validation

- `bun test v1/agents/by-token/route.chain.test.ts 'v1/apps/[id]/analytics/route.period.test.ts' v1/oauth/connections/route.platform.test.ts v1/voice/list/route.clonetype.test.ts` — 34 pass, 0 fail.
- `bun run --cwd packages/cloud/api typecheck` — PASS, including the production Wrangler dry bundle (`--dry-run`; no deployment).
- Biome on all four changed files — PASS.
- `git diff --check origin/develop...HEAD` — PASS.
- Range-diff after rebase onto the exact base above — identical.

## Evidence

- Evidence head: `8afc2705b958d8531c36f02a58fe42c15da17bba`
- Before screenshots: N/A — test-harness typing only; no UI changed.
- After screenshots: N/A — test-harness typing only; no UI changed.
- Walkthrough video: N/A — no user-facing interaction changed.
- Backend logs: N/A — no runtime backend behavior changed; focused tests and full package typecheck are the relevant artifact.
- Frontend logs: N/A — no frontend changed.
- LLM trajectory: N/A — no agent/model behavior changed.
- Domain artifacts: N/A — no domain state or external integration changed.

No deployment, workflow rerun, or live traffic was performed.

<!-- evidence-head:8afc2705b958d8531c36f02a58fe42c15da17bba -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-harness typing only; no UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-harness typing only; no UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing interaction changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - no runtime backend behavior changed; focused tests and complete package typecheck are the relevant evidence

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain state or external integration changed

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or visual assets changed

