### PR TITLE
fix(core): harden computer-use contracts

### DIFF
--- a/packages/core/src/contracts/computer-use.test.ts
+++ b/packages/core/src/contracts/computer-use.test.ts
@@ -23,6 +23,7 @@ import {
 	type InteractionOutcomeStatus,
 	type InteractionSession,
 	type InteractionSurfaceRef,
+	interactionActionDigest,
 	normalizeInteractionActionResult,
 	normalizeInteractionCapabilitySet,
 	normalizeInteractionConfirmationPreview,
@@ -175,7 +176,7 @@ function resultFor(input: InteractionAction): InteractionActionResult {
 					destination: "https://recipient.test",
 					disclosures: ["draft text"],
 					consequence: "Sends a message to the configured recipient.",
-					actionDigest: "sha256:confirmation-digest",
+					actionDigest: interactionActionDigest(input),
 					requestedAt: now,
 					expiresAt: "2026-01-01T00:05:00.000Z",
 				}
@@ -214,7 +215,12 @@ const adapter: InteractionAdapter = {
 	id: adapterId,
 	capabilities: async () => capabilities,
 	observe: async () => observation,
-	execute: async (input) => resultFor(input),
+	execute: async (input) => {
+		if (input.actionId === "case-invalid_payload") {
+			return { invalid: true } as unknown as InteractionActionResult;
+		}
+		return resultFor(input);
+	},
 };
 
 describe("computer-use interaction contracts", () => {
@@ -287,10 +293,14 @@ describe("computer-use interaction contracts", () => {
 	});
 
 	it("reuses canonical effect receipts in successful action results", () => {
-		const normalized = normalizeInteractionActionResult({
-			...resultFor(action("case-success")),
-			ignored: "discard me",
-		});
+		const succeededAction = action("case-success");
+		const normalized = normalizeInteractionActionResult(
+			{
+				...resultFor(succeededAction),
+				ignored: "discard me",
+			},
+			succeededAction,
+		);
 		expect(normalized.status).toBe("SUCCEEDED");
 		expect(normalized.effectReceipts).toHaveLength(1);
 		expect(normalized.effectReceipts[0]?.outcome).toBe("applied");
@@ -298,12 +308,16 @@ describe("computer-use interaction contracts", () => {
 	});
 
 	it("forbids automatic retry after an uncertain effect", () => {
-		const uncertain = resultFor(action("case-uncertain_effect"));
+		const uncertainAction = action("case-uncertain_effect");
+		const uncertain = resultFor(uncertainAction);
 		expect(() =>
-			normalizeInteractionActionResult({
-				...uncertain,
-				error: { ...uncertain.error, retryable: true },
-			}),
+			normalizeInteractionActionResult(
+				{
+					...uncertain,
+					error: { ...uncertain.error, retryable: true },
+				},
+				uncertainAction,
+			),
 		).toThrowError(
 			expect.objectContaining({ code: "INVALID_INTERACTION_CONTRACT" }),
 		);
@@ -318,7 +332,7 @@ describe("computer-use interaction contracts", () => {
 			destination: "https://merchant.test/checkout",
 			disclosures: ["shipping address"],
 			consequence: "Places the order.",
-			actionDigest: "sha256:action",
+			actionDigest: `sha256:${"a".repeat(64)}`,
 			requestedAt: now,
 			expiresAt: later,
 		});
@@ -343,7 +357,7 @@ describe("computer-use interaction contracts", () => {
 				destination: null,
 				disclosures: [],
 				consequence: "Places the order.",
-				actionDigest: "sha256:action",
+				actionDigest: `sha256:${"a".repeat(64)}`,
 				requestedAt: "2026-02-30T00:00:00.000Z",
 				expiresAt: later,
 			}),
@@ -353,28 +367,67 @@ describe("computer-use interaction contracts", () => {
 	});
 
 	it("binds confirmation and observation evidence to the result action", () => {
-		const confirmationResult = resultFor(action("case-confirmation"));
+		const confirmationAction = action("case-confirmation");
+		const confirmationResult = resultFor(confirmationAction);
 		expect(() =>
-			normalizeInteractionActionResult({
-				...confirmationResult,
-				confirmation: {
-					...confirmationResult.confirmation,
-					actionId: "another-action",
+			normalizeInteractionActionResult(
+				{
+					...confirmationResult,
+					confirmation: {
+						...confirmationResult.confirmation,
+						actionId: "another-action",
+					},
 				},
-			}),
+				confirmationAction,
+			),
+		).toThrowError(
+			expect.objectContaining({ code: "INVALID_INTERACTION_CONTRACT" }),
+		);
+		expect(() =>
+			normalizeInteractionActionResult(
+				{
+					...confirmationResult,
+					confirmation: {
+						...confirmationResult.confirmation,
+						actionDigest: `sha256:${"b".repeat(64)}`,
+					},
+				},
+				confirmationAction,
+			),
 		).toThrowError(
 			expect.objectContaining({ code: "INVALID_INTERACTION_CONTRACT" }),
 		);
 
 		const succeeded = resultFor(action("case-success"));
+		const succeededAction = action("case-success");
 		expect(() =>
-			normalizeInteractionActionResult({
-				...succeeded,
-				evidence: {
-					...succeeded.evidence,
-					afterObservationId: "another-observation",
+			normalizeInteractionActionResult(
+				{
+					...succeeded,
+					evidence: {
+						...succeeded.evidence,
+						afterObservationId: "another-observation",
+					},
 				},
-			}),
+				succeededAction,
+			),
+		).toThrowError(
+			expect.objectContaining({ code: "INVALID_INTERACTION_CONTRACT" }),
+		);
+	});
+
+	it("rejects committed effect proof on non-success outcomes", () => {
+		const failedAction = action("case-failed_no_effect");
+		const failed = resultFor(failedAction);
+		const applied = resultFor(action("case-success")).effectReceipts;
+		expect(() =>
+			normalizeInteractionActionResult(
+				{
+					...failed,
+					effectReceipts: applied,
+				},
+				failedAction,
+			),
 		).toThrowError(
 			expect.objectContaining({ code: "INVALID_INTERACTION_CONTRACT" }),
 		);
@@ -398,6 +451,14 @@ describe("computer-use interaction contracts", () => {
 			expect.objectContaining({
 				code: "INTERACTION_CROSS_SESSION_REFERENCE",
 			}),
+		);
+		expect(() =>
+			assertInteractionSurfaceCurrent(session, {
+				...surface,
+				parentSurfaceId: "forged-parent",
+			}),
+		).toThrowError(
+			expect.objectContaining({ code: "INTERACTION_SURFACE_NOT_FOUND" }),
 		);
 	});
 
@@ -440,6 +501,19 @@ describe("computer-use interaction contracts", () => {
 			ttlMs: 100,
 		});
 		expect(coordinator.release(second)).toBe(true);
+		expect(() =>
+			coordinator.acquire({
+				leaseId: "lease-overflow",
+				sessionId,
+				ownerId: "owner-1",
+				resourceKind: "clipboard",
+				resourceId: "overflow",
+				generation: 1,
+				ttlMs: Number.MAX_VALUE,
+			}),
+		).toThrowError(
+			expect.objectContaining({ code: "INVALID_INTERACTION_CONTRACT" }),
+		);
 	});
 });
 

--- a/packages/core/src/contracts/computer-use.ts
+++ b/packages/core/src/contracts/computer-use.ts
@@ -5,11 +5,13 @@
  * that reuse the runtime's existing effect receipts as mutation proof.
  */
 
+import { sha256 } from "@noble/hashes/sha2.js";
 import { ElizaError } from "../errors.ts";
 import {
 	type EffectReceipt,
 	normalizeEffectReceipts,
 } from "../types/effects.ts";
+import { stableStringify } from "../utils/deterministic.ts";
 
 export const INTERACTION_CONTRACT_VERSION = 1 as const;
 
@@ -325,6 +327,12 @@ export interface InteractionConfirmationPreview {
 	actionDigest: string;
 	requestedAt: string;
 	expiresAt: string;
+}
+
+/** Return the canonical digest a confirmation preview must bind to. */
+export function interactionActionDigest(action: InteractionAction): string {
+	const digest = sha256(new TextEncoder().encode(stableStringify(action)));
+	return `sha256:${Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
 }
 
 export interface InteractionActionError {
@@ -928,6 +936,17 @@ export function normalizeInteractionConfirmationPreview(
 			context,
 		);
 	}
+	const actionDigest = nonEmptyString(
+		raw.actionDigest,
+		"actionDigest",
+		context,
+	);
+	if (!/^sha256:[0-9a-f]{64}$/i.test(actionDigest)) {
+		return invalid(
+			"Interaction confirmation actionDigest must be a SHA-256 digest.",
+			context,
+		);
+	}
 	return Object.freeze({
 		confirmationId,
 		actionId: nonEmptyString(raw.actionId, "actionId", context),
@@ -936,7 +955,7 @@ export function normalizeInteractionConfirmationPreview(
 		destination: nullableString(raw.destination, "destination", context),
 		disclosures: stringArray(raw.disclosures, "disclosures", context),
 		consequence: nonEmptyString(raw.consequence, "consequence", context),
-		actionDigest: nonEmptyString(raw.actionDigest, "actionDigest", context),
+		actionDigest: actionDigest.toLowerCase(),
 		requestedAt,
 		expiresAt,
 	});
@@ -944,6 +963,7 @@ export function normalizeInteractionConfirmationPreview(
 
 export function normalizeInteractionActionResult(
 	value: unknown,
+	expectedAction: InteractionAction,
 ): InteractionActionResult {
 	const raw = asRecord(value);
 	if (!raw) return invalid("Interaction action result must be an object.");
@@ -1007,6 +1027,26 @@ export function normalizeInteractionActionResult(
 			context,
 		);
 	}
+	if (
+		confirmation &&
+		(Date.parse(confirmation.requestedAt) < Date.parse(startedAt) ||
+			Date.parse(confirmation.requestedAt) > Date.parse(completedAt) ||
+			Date.parse(confirmation.expiresAt) <= Date.parse(completedAt))
+	) {
+		return invalid(
+			"Interaction confirmation must be requested during execution and remain unexpired after the result.",
+			context,
+		);
+	}
+	if (
+		confirmation &&
+		confirmation.actionDigest !== interactionActionDigest(expectedAction)
+	) {
+		return invalid(
+			"Interaction confirmation does not authorize the exact requested action.",
+			context,
+		);
+	}
 	if (status === "NEEDS_CONFIRMATION" && error) {
 		return invalid(
 			"NEEDS_CONFIRMATION results cannot also carry an execution error.",
@@ -1063,6 +1103,41 @@ export function normalizeInteractionActionResult(
 			context,
 		);
 	}
+	const effectReceipts = normalizeEffectReceipts(raw.effectReceipts);
+	const hasCommittedEffect = effectReceipts.some(
+		(receipt) =>
+			receipt.outcome === "applied" ||
+			(receipt.outcome === "noop" && receipt.idempotency.replayed),
+	);
+	if (status !== "SUCCEEDED" && hasCommittedEffect) {
+		return invalid(
+			`Interaction result '${status}' cannot carry committed mutation proof.`,
+			context,
+		);
+	}
+	if (
+		actionId !== expectedAction.actionId ||
+		sessionId !== expectedAction.sessionId ||
+		adapterId !== expectedAction.adapterId
+	) {
+		return invalid(
+			"Interaction result does not belong to the requested action.",
+			context,
+		);
+	}
+	if (
+		observation &&
+		(observation.surface.surfaceId !== expectedAction.surface.surfaceId ||
+			observation.surface.kind !== expectedAction.surface.kind ||
+			observation.surface.generation !== expectedAction.surface.generation ||
+			observation.surface.parentSurfaceId !==
+				expectedAction.surface.parentSurfaceId)
+	) {
+		return invalid(
+			"Interaction result observation escaped the requested action surface.",
+			context,
+		);
+	}
 	return Object.freeze({
 		contractVersion: INTERACTION_CONTRACT_VERSION,
 		actionId,
@@ -1095,7 +1170,7 @@ export function normalizeInteractionActionResult(
 				context,
 			),
 		}),
-		effectReceipts: normalizeEffectReceipts(raw.effectReceipts),
+		effectReceipts,
 		observation,
 	});
 }
@@ -1139,7 +1214,8 @@ export function assertInteractionSurfaceCurrent(
 		(candidate) =>
 			candidate.surfaceId === surface.surfaceId &&
 			candidate.kind === surface.kind &&
-			candidate.generation === surface.generation,
+			candidate.generation === surface.generation &&
+			candidate.parentSurfaceId === surface.parentSurfaceId,
 	);
 	if (!registered) {
 		throw new ElizaError(
@@ -1168,11 +1244,20 @@ export class InteractionLeaseCoordinator {
 
 	acquire(request: AcquireInteractionLeaseRequest): InteractionLease {
 		const now = this.clock();
+		if (!Number.isFinite(now)) {
+			return invalid("Interaction lease clock must return a finite timestamp.");
+		}
 		if (!Number.isInteger(request.generation) || request.generation < 0) {
 			return invalid("Interaction lease generation must be non-negative.");
 		}
 		if (!Number.isFinite(request.ttlMs) || request.ttlMs <= 0) {
 			return invalid("Interaction lease ttlMs must be positive.");
+		}
+		const expiresAt = now + request.ttlMs;
+		if (!Number.isFinite(expiresAt) || expiresAt > 8.64e15) {
+			return invalid(
+				"Interaction lease expiry exceeds the supported date range.",
+			);
 		}
 		for (const field of [
 			"leaseId",
@@ -1215,7 +1300,7 @@ export class InteractionLeaseCoordinator {
 			resourceId: request.resourceId,
 			generation: request.generation,
 			acquiredAt: new Date(now).toISOString(),
-			expiresAt: new Date(now + request.ttlMs).toISOString(),
+			expiresAt: new Date(expiresAt).toISOString(),
 		});
 		this.leases.set(key, lease);
 		return lease;

--- a/packages/core/src/testing/computer-use-conformance.ts
+++ b/packages/core/src/testing/computer-use-conformance.ts
@@ -30,13 +30,17 @@ export const REQUIRED_INTERACTION_CONFORMANCE_CASES = [
 	"unsupported",
 	"stale_observation",
 	"lease_conflict",
+	"invalid_payload",
 ] as const;
 
 export type InteractionConformanceCaseName =
 	(typeof REQUIRED_INTERACTION_CONFORMANCE_CASES)[number];
 
 const EXPECTED_STATUS: Readonly<
-	Record<InteractionConformanceCaseName, InteractionOutcomeStatus>
+	Record<
+		Exclude<InteractionConformanceCaseName, "invalid_payload">,
+		InteractionOutcomeStatus
+	>
 > = Object.freeze({
 	success: "SUCCEEDED",
 	failed_no_effect: "FAILED_NO_EFFECT",
@@ -93,7 +97,9 @@ function ensureActionIdentity(
 		action.surface.sessionId !== surface.sessionId ||
 		action.surface.adapterId !== surface.adapterId ||
 		action.surface.surfaceId !== surface.surfaceId ||
-		action.surface.generation !== surface.generation
+		action.surface.kind !== surface.kind ||
+		action.surface.generation !== surface.generation ||
+		action.surface.parentSurfaceId !== surface.parentSurfaceId
 	) {
 		fail("Conformance action does not target the supplied session surface.", {
 			actionId: action.actionId,
@@ -176,12 +182,33 @@ export async function runInteractionAdapterConformance(
 			surfaceKind: surface.kind,
 		});
 	}
+	const assertAdvertisedObservationChannels = (
+		channels: readonly string[],
+		observationId: string,
+	) => {
+		const advertised = new Set<string>(capabilities.observationChannels);
+		const unadvertised = channels.filter((channel) => !advertised.has(channel));
+		if (unadvertised.length > 0) {
+			return fail(
+				"Adapter emitted observation channels it did not advertise.",
+				{
+					adapterId: adapter.id,
+					observationId,
+					unadvertised,
+				},
+			);
+		}
+	};
 
 	const rawObservation = await adapter.observe(session, surface);
 	const observation = normalizeAdapterPayload(
 		"observation",
 		() => normalizeInteractionObservation(rawObservation),
 		{ adapterId: adapter.id },
+	);
+	assertAdvertisedObservationChannels(
+		observation.channels,
+		observation.observationId,
 	);
 	assertInteractionSurfaceCurrent(session, observation.surface);
 	if (
@@ -212,7 +239,6 @@ export async function runInteractionAdapterConformance(
 		const fixture = fixtureByName.get(name);
 		if (!fixture) return fail(`Missing conformance fixture '${name}'.`);
 		ensureActionIdentity(fixture.action, session, surface);
-		const expectedStatus = EXPECTED_STATUS[name];
 		if (
 			name === "unsupported" &&
 			capabilities.actionKinds.includes(fixture.action.kind)
@@ -238,9 +264,42 @@ export async function runInteractionAdapterConformance(
 			);
 		}
 		const rawResult = await adapter.execute(fixture.action);
+		if (name === "invalid_payload") {
+			let rejected = false;
+			try {
+				normalizeAdapterPayload(
+					"action result",
+					() => normalizeInteractionActionResult(rawResult, fixture.action),
+					{
+						adapterId: adapter.id,
+						actionId: fixture.action.actionId,
+						case: name,
+					},
+				);
+			} catch (error) {
+				rejected =
+					error instanceof ElizaError &&
+					error.code === "INTERACTION_ADAPTER_CONFORMANCE_FAILED";
+				if (!rejected) throw error;
+			}
+			if (!rejected) {
+				return fail("The invalid_payload fixture returned a valid result.", {
+					adapterId: adapter.id,
+					actionId: fixture.action.actionId,
+				});
+			}
+			checks.push({
+				name,
+				passed: true,
+				detail:
+					"Malformed adapter output was rejected at the contract boundary.",
+			});
+			continue;
+		}
+		const expectedStatus = EXPECTED_STATUS[name];
 		const result = normalizeAdapterPayload(
 			"action result",
-			() => normalizeInteractionActionResult(rawResult),
+			() => normalizeInteractionActionResult(rawResult, fixture.action),
 			{ adapterId: adapter.id, actionId: fixture.action.actionId, case: name },
 		);
 		if (
@@ -262,6 +321,10 @@ export async function runInteractionAdapterConformance(
 		}
 		if (result.observation) {
 			assertInteractionSurfaceCurrent(session, result.observation.surface);
+			assertAdvertisedObservationChannels(
+				result.observation.channels,
+				result.observation.observationId,
+			);
 		}
 		checks.push({
 			name,


### PR DESCRIPTION
## Summary
- bind confirmation receipts to the canonical action digest and execution window
- require exact action, adapter, session, surface kind, generation, and parent identity
- reject committed effect receipts on every non-success outcome
- verify observation channels were advertised by the adapter
- add the required invalid-payload conformance case and typed lease timestamp/range failures

This is the post-merge hardening follow-up for #20975.

## Validation
- bun test packages/core/src/contracts/computer-use.test.ts — 18 passed
- package typecheck passed
- Node, browser, edge, and testing bundles plus declarations built successfully
- Biome and git diff checks passed

Closes #20942