### PR TITLE
fix(core): sanitize count and add accessors and unit tests in Semaphore

### DIFF
--- a/packages/core/src/utils/batch-queue/semaphore.test.ts
+++ b/packages/core/src/utils/batch-queue/semaphore.test.ts
@@ -1,6 +1,4 @@
-/**
- * Unit tests for Semaphore in packages/core/src/utils/batch-queue/semaphore.ts.
- */
+/** Deterministic unit coverage for Semaphore capacity and waiter handoff. */
 
 import { describe, expect, it } from "vitest";
 import { Semaphore } from "./semaphore";
@@ -15,6 +13,8 @@ describe("Semaphore", () => {
 	it("sanitizes non-finite, negative, or non-numeric counts to minimum 1", () => {
 		const semNaN = new Semaphore(Number.NaN);
 		expect(semNaN.availablePermits).toBe(1);
+		expect(new Semaphore(Number.POSITIVE_INFINITY).availablePermits).toBe(1);
+		expect(new Semaphore(Number.NEGATIVE_INFINITY).availablePermits).toBe(1);
 
 		const semNeg = new Semaphore(-5);
 		expect(semNeg.availablePermits).toBe(1);

--- a/packages/core/src/utils/batch-queue/semaphore.test.ts
+++ b/packages/core/src/utils/batch-queue/semaphore.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for Semaphore in packages/core/src/utils/batch-queue/semaphore.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+import { Semaphore } from "./semaphore";
+
+describe("Semaphore", () => {
+	it("initializes with valid count and tracks available permits", () => {
+		const sem = new Semaphore(3);
+		expect(sem.availablePermits).toBe(3);
+		expect(sem.queueLength).toBe(0);
+	});
+
+	it("sanitizes non-finite, negative, or non-numeric counts to minimum 1", () => {
+		const semNaN = new Semaphore(Number.NaN);
+		expect(semNaN.availablePermits).toBe(1);
+
+		const semNeg = new Semaphore(-5);
+		expect(semNeg.availablePermits).toBe(1);
+
+		const semZero = new Semaphore(0);
+		expect(semZero.availablePermits).toBe(1);
+
+		const semFloat = new Semaphore(2.7);
+		expect(semFloat.availablePermits).toBe(2);
+	});
+
+	it("acquires and releases permits correctly", async () => {
+		const sem = new Semaphore(2);
+
+		await sem.acquire();
+		expect(sem.availablePermits).toBe(1);
+
+		await sem.acquire();
+		expect(sem.availablePermits).toBe(0);
+
+		sem.release();
+		expect(sem.availablePermits).toBe(1);
+
+		sem.release();
+		expect(sem.availablePermits).toBe(2);
+	});
+
+	it("queues waiters when permits are exhausted and resumes them on release", async () => {
+		const sem = new Semaphore(1);
+		await sem.acquire();
+		expect(sem.availablePermits).toBe(0);
+
+		let taskCompleted = false;
+		const waitingTask = (async () => {
+			await sem.acquire();
+			taskCompleted = true;
+			sem.release();
+		})();
+
+		expect(sem.queueLength).toBe(1);
+		expect(taskCompleted).toBe(false);
+
+		sem.release();
+		await waitingTask;
+
+		expect(taskCompleted).toBe(true);
+		expect(sem.queueLength).toBe(0);
+		expect(sem.availablePermits).toBe(1);
+	});
+});

--- a/packages/core/src/utils/batch-queue/semaphore.ts
+++ b/packages/core/src/utils/batch-queue/semaphore.ts
@@ -13,7 +13,20 @@ export class Semaphore {
 	private waiters: Array<() => void> = [];
 
 	constructor(count: number) {
-		this.permits = Math.max(1, count);
+		this.permits =
+			typeof count === "number" && Number.isFinite(count)
+				? Math.max(1, Math.floor(count))
+				: 1;
+	}
+
+	/** Number of currently available permits. */
+	get availablePermits(): number {
+		return this.permits;
+	}
+
+	/** Number of tasks currently queued waiting for a permit. */
+	get queueLength(): number {
+		return this.waiters.length;
 	}
 
 	async acquire(): Promise<void> {


### PR DESCRIPTION
# Summary

Closes #21072. Semaphore capacity is normalized to a finite positive integer, preventing `NaN` from making every acquire wait forever and preventing fractional permit state. Adds read-only available-permit and queue-length accessors plus deterministic acquire/release/waiter coverage.

# Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash, openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity, Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9399e4596142e429470ba00b3db39a27f43d1686:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Verification

Exact head `f8dfc60e37001176c6a7ab6fb50875a4eac8b533` on `9399e4596142e429470ba00b3db39a27f43d1686`. Pinned Bun 1.3.14: 4/4 tests; core typecheck passed; Biome and diff-check clean. Review added both infinity cases and verified real waiter handoff and restored capacity.

# Evidence Gate
<!-- evidence-head:f8dfc60e37001176c6a7ab6fb50875a4eac8b533 -->
<!-- evidence-row:before-screenshots -->
- [x] `N/A - core concurrency utility; no UI`.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - core concurrency utility; no UI`.
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI workflow`.
<!-- evidence-row:backend-logs -->
- [x]
  ```text
  Test Files 1 passed (1); Tests 4 passed (4)
  packages/core typecheck: exit 0
  Biome: Checked 2 files. No fixes applied; diff-check clean
  ```
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend path`.
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model behavior`.
<!-- evidence-row:domain-artifacts -->
- [x]
  ```text
  NaN/+Infinity/-Infinity/zero/negative capacity => one permit
  2.7 capacity => two permits
  exhausted semaphore queues one waiter; release hands it off and capacity returns to one
  ```
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered surface`.

---
— [codex-root/pr-21075-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@9399e4596142e429470ba00b3db39a27f43d1686:packages/skills/skills/contribute-to-eliza"} -->
