### PR TITLE
fix(cloud): reject unknown market-trades tx_type

### DIFF
--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
@@ -61,8 +61,29 @@ async function __hono_GET(
   const offset = searchParams.get("offset");
   if (offset) requestParams.offset = offset;
 
-  const txType = searchParams.get("tx_type");
-  if (txType) requestParams.tx_type = txType;
+  // Token-trade type identity, not leftover tax on market-candles
+  // OHLCV type. Unknown tokens (SWAP / buy / 1e2) used to be
+  // forwarded to the paid market-data provider.
+  const TX_TYPES = ["swap", "add", "remove", "all"] as const;
+  const requestedTxType = searchParams.get("tx_type");
+  if (
+    requestedTxType != null &&
+    requestedTxType !== "" &&
+    !TX_TYPES.includes(requestedTxType as (typeof TX_TYPES)[number])
+  ) {
+    return applyCorsHeaders(
+      Response.json(
+        {
+          error: "Invalid tx_type",
+          details:
+            "tx_type must be a canonical Birdeye trade type (swap, add, remove, all).",
+        },
+        { status: 400 },
+      ),
+      CORS_METHODS,
+    );
+  }
+  if (requestedTxType) requestParams.tx_type = requestedTxType;
 
   const body = {
     method: "getTokenTrades",

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
@@ -1,0 +1,100 @@
+/**
+ * GET /api/v1/market/trades/:chain/:address `tx_type` is token-trade
+ * type identity, not leftover tax on market-candles OHLCV type.
+ * Stock develop forwarded unknown tokens to the paid market-data
+ * provider, so `tx_type=SWAP` / `buy` / `1e2` billed a wrong (or
+ * empty) trade series instead of a 400.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const SOLANA_TOKEN = "So11111111111111111111111111111111111111112";
+
+const executeWithBody = mock(async () => Response.json({ success: true }));
+
+mock.module("@/lib/services/proxy/engine", () => ({
+  executeWithBody,
+}));
+mock.module("@/lib/services/proxy/cors", () => ({
+  applyCorsHeaders: (response: Response) => response,
+  handleCorsOptions: () => new Response(null, { status: 204 }),
+}));
+mock.module("@/lib/services/proxy/services/address-validation", () => ({
+  isValidChain: () => true,
+  isValidAddress: () => true,
+}));
+mock.module("@/lib/services/proxy/services/market-data", () => ({
+  marketDataConfig: { id: "market-data" },
+  marketDataHandler: {},
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route(
+  "/api/v1/market/trades/:chain/:address",
+  route,
+);
+
+function trades(query = "") {
+  return app.request(
+    `/api/v1/market/trades/solana/${SOLANA_TOKEN}${query}`,
+  );
+}
+
+describe("GET /api/v1/market/trades token-trade type identity", () => {
+  beforeEach(() => {
+    executeWithBody.mockClear();
+  });
+
+  test.each(["", "?tx_type="])(
+    "accepts %s as the provider-default trade type",
+    async (query) => {
+      const response = await trades(query);
+      expect(response.status).toBe(200);
+      expect(executeWithBody).toHaveBeenCalledTimes(1);
+      const body = executeWithBody.mock.calls[0][3] as {
+        method: string;
+        params: Record<string, string>;
+      };
+      expect(body.method).toBe("getTokenTrades");
+      expect(body.params.address).toBe(SOLANA_TOKEN);
+      expect(body.params.tx_type).toBeUndefined();
+    },
+  );
+
+  test("accepts tx_type=swap as the swap trade series", async () => {
+    const response = await trades("?tx_type=swap");
+    expect(response.status).toBe(200);
+    expect(executeWithBody).toHaveBeenCalledTimes(1);
+    const body = executeWithBody.mock.calls[0][3] as {
+      params: Record<string, string>;
+    };
+    expect(body.params.tx_type).toBe("swap");
+  });
+
+  test("accepts tx_type=add as the add-liquidity series", async () => {
+    const response = await trades("?tx_type=add");
+    expect(response.status).toBe(200);
+    expect(executeWithBody.mock.calls[0][3]).toMatchObject({
+      params: { tx_type: "add" },
+    });
+  });
+
+  test("accepts tx_type=all as the unfiltered trade series", async () => {
+    const response = await trades("?tx_type=all");
+    expect(response.status).toBe(200);
+    expect(executeWithBody.mock.calls[0][3]).toMatchObject({
+      params: { tx_type: "all" },
+    });
+  });
+
+  test.each(["SWAP", "buy", "sell", "foo", "1e2"])(
+    "rejects tx_type=%s before executeWithBody",
+    async (token) => {
+      const response = await trades(`?tx_type=${encodeURIComponent(token)}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid tx_type");
+      expect(executeWithBody).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
@@ -29,15 +29,10 @@ mock.module("@/lib/services/proxy/services/market-data", () => ({
 }));
 
 const route = (await import("./route")).default;
-const app = new Hono().route(
-  "/api/v1/market/trades/:chain/:address",
-  route,
-);
+const app = new Hono().route("/api/v1/market/trades/:chain/:address", route);
 
 function trades(query = "") {
-  return app.request(
-    `/api/v1/market/trades/solana/${SOLANA_TOKEN}${query}`,
-  );
+  return app.request(`/api/v1/market/trades/solana/${SOLANA_TOKEN}${query}`);
 }
 
 describe("GET /api/v1/market/trades token-trade type identity", () => {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on market-trades
`tx_type` identity. Paid trade-series class, not leftover tax on
market-candles type, cloneType, token-lookup chain, analytics-breakdown
timeRange, admin-redemptions network, OAuth platform, app-analytics
period, ad-account platform, my-agents category, advertising campaign
filters, AI-pricing catalog filters, admin metrics timeRange, telegram
webhook flag, analytics view, Vertex scope, ingress-map format,
promote-assets platform, influencer bookings party, payment-request
public, X connectionRole, my-agents sortBy, logs since, analytics
periods, analytics export type, admin redemption status, share-ingest
consume, Life Ops inbox bools, views viewType, relationships scope,
commands surface, approvals state, database-rows sort/page,
memory-viewer type, VFS encoding, models catalogOnly/refresh, Cloud
JSON-400, prefix-coerced limit, percent-encoded paths, SIWS chainId,
orchestrator lines, provisioning-worker env ints, invites-accept,
cli-auth, redemption quote, compat agent-logs, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `tx_type` only on `/api/v1/market/trades/:chain/:address`.
Omitted/empty still means the provider-default series. Exact `swap` /
`add` / `remove` / `all` still bind that series. Unknown / uppercase
tokens 400 before executeWithBody. `limit` / `offset` and market-candles
`type` stay untouched.

# Background

## What does this PR do?

`GET /api/v1/market/trades/:chain/:address` forwarded unknown `tx_type`
tokens to the paid market-data provider. `tx_type=SWAP` / `buy` silently
billed a wrong (or empty) trade series instead of a 400.

- omitted / empty → **200** provider-default trade series
- exact `swap` / `add` / `remove` / `all` → **200** that series
- `SWAP` / `buy` / `sell` / `foo` / `1e2` → **400** before executeWithBody

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The billed Birdeye trade series is chosen from `tx_type`. A common
`tx_type=SWAP` or `buy` after a UI uppercases the filter must not spend
credits on an empty or default swap page. This is token-trade type
identity, not leftover tax on market-candles OHLCV type.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts` —
omitted still bills the provider default; exact `swap` / `add` / `all`
still bind that series; garbage 400s with no executeWithBody.

## Test commands

```bash
cd packages/cloud/api && bun test v1/market/trades/[chain]/[address]/route.tx-type.test.ts
```

10 passed at the evidence head. Stock develop forwarded `tx_type=SWAP`
into executeWithBody (200).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; market-trades `tx_type` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; market-trades `tx_type` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; market-trades `tx_type` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real trade-type tokens and assert 400 before executeWithBody; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no market-data export; illegal trade-type tokens 400 before the paid provider.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`tx_type` tokens reject; omitted/canonical still bind the matching series.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file market-trades tx_type
parse with a green focused suite (10 tests). Full monorepo verify is
unrelated to this query grammar and was skipped to keep the proof tied
to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:895c2a354621d5b17425174fe20cf67c2e53b89b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->

## Maintainer validation

Validated the enum against Birdeye’s current legacy `/defi/txs/token` contract (`swap`, `add`, `remove`, `all`). Biome formatting repaired at `48187bc8e759ae9b31ba432b83e2dba37da8d854`; focused production-handler tests pass 10/10 and diff-check is clean.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@ca70074328146db92a158341860fb4d7adc81b1a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-b]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@ca70074328146db92a158341860fb4d7adc81b1a:packages/skills/skills/contribute-to-eliza"} -->