### PR TITLE
fix(shell): close auth and native lifecycle races

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -1,4 +1,5 @@
 /** Exercises desktop window behavior with deterministic app-core test fixtures. */
+import { Screen } from "electrobun/bun";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DesktopManager, resetDesktopManagerForTesting } from "./desktop";
 
@@ -338,6 +339,10 @@ describe("DesktopManager main window controls", () => {
   beforeEach(() => {
     resetDesktopManagerForTesting();
     electrobunMock.reset();
+    vi.mocked(Screen.getPrimaryDisplay).mockReset();
+    vi.mocked(Screen.getPrimaryDisplay).mockReturnValue({
+      workArea: { x: 100, y: 50, width: 900, height: 700 },
+    } as never);
     delete process.env.ELIZAOS_CLOSE_MINIMIZES_TO_TRAY;
   });
 
@@ -412,6 +417,63 @@ describe("DesktopManager main window controls", () => {
     await manager.setBottomBarExpanded({ expanded: false, chip: true });
     expect(window.setFrame).toHaveBeenLastCalledWith(430, 694, 240, 56);
     await manager.dispose();
+  });
+
+  it("applies a chip frame requested before the native window becomes available", async () => {
+    vi.useFakeTimers();
+    try {
+      const manager = new DesktopManager();
+      manager.enableBottomBarReanchor();
+      await manager.setBottomBarExpanded({ expanded: false, chip: true });
+
+      const window = new FakeBrowserWindow();
+      manager.setMainWindow(window as never);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(window.setFrame).toHaveBeenLastCalledWith(430, 694, 240, 56);
+      await manager.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries an unapplied frame after a transient setFrame failure", async () => {
+    vi.useFakeTimers();
+    try {
+      const { manager, window } = createManagerWithWindow();
+      manager.enableBottomBarReanchor();
+      window.setFrame.mockImplementationOnce(() => {
+        throw new Error("native frame unavailable");
+      });
+
+      await expect(
+        manager.setBottomBarExpanded({ expanded: false, chip: true }),
+      ).rejects.toThrow("native frame unavailable");
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(window.setFrame).toHaveBeenLastCalledWith(430, 694, 240, 56);
+      expect(window.setFrame).toHaveBeenCalledTimes(2);
+      await manager.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retains a desired chip frame while the display work area is unavailable", async () => {
+    vi.useFakeTimers();
+    try {
+      const { manager, window } = createManagerWithWindow();
+      manager.enableBottomBarReanchor();
+      vi.mocked(Screen.getPrimaryDisplay).mockReturnValueOnce(null as never);
+      await manager.setBottomBarExpanded({ expanded: false, chip: true });
+      expect(window.setFrame).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(window.setFrame).toHaveBeenLastCalledWith(430, 694, 240, 56);
+      await manager.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns safe fallback states when no main window is present", async () => {

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -377,6 +377,7 @@ export class DesktopManager {
   private bottomBarWorkArea: ScreenWorkArea | null = null;
   private bottomBarPoller: ReturnType<typeof setInterval> | null = null;
   private bottomBarSize = resolveBottomBarFrameSize({ expanded: false });
+  private bottomBarFrameDirty = false;
 
   // Callback to open the settings window (set by index.ts)
   private openSettingsCallback: ((tabHint?: string) => void) | null = null;
@@ -1542,14 +1543,18 @@ X-GNOME-Autostart-enabled=true
     expanded: boolean;
     chip?: boolean;
   }): Promise<void> {
+    // Record desired presentation before consulting transient native state. A
+    // missing window/display must not lose a 96↔240↔600 transition.
+    this.bottomBarSize = resolveBottomBarFrameSize(options);
+    this.bottomBarFrameDirty = true;
     if (!this.bottomBarReanchorEnabled) return;
     const win = this.mainWindow;
     const workArea = this.readPrimaryWorkArea();
     if (!win || !workArea) return;
-    this.bottomBarSize = resolveBottomBarFrameSize(options);
     const frame = computeBottomBarFrame(workArea, this.bottomBarSize);
     win.setFrame(frame.x, frame.y, frame.width, frame.height);
     this.bottomBarWorkArea = workArea;
+    this.bottomBarFrameDirty = false;
   }
 
   private readPrimaryWorkArea(): ScreenWorkArea | null {
@@ -1576,14 +1581,24 @@ X-GNOME-Autostart-enabled=true
     const nextWorkArea = this.readPrimaryWorkArea();
     if (!nextWorkArea) return;
     if (
+      !this.bottomBarFrameDirty &&
       this.bottomBarWorkArea &&
       !shouldReanchorBottomBar(this.bottomBarWorkArea, nextWorkArea)
     ) {
       return;
     }
     const frame = computeBottomBarFrame(nextWorkArea, this.bottomBarSize);
-    win.setFrame(frame.x, frame.y, frame.width, frame.height);
-    this.bottomBarWorkArea = nextWorkArea;
+    try {
+      win.setFrame(frame.x, frame.y, frame.width, frame.height);
+      this.bottomBarWorkArea = nextWorkArea;
+      this.bottomBarFrameDirty = false;
+    } catch (err) {
+      // error-policy:J1 The periodic native callback keeps the desired frame
+      // dirty for its next bounded retry instead of crashing the timer loop.
+      logger.warn(
+        `[Desktop] bottom-bar frame retry failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private _startFocusPoller(): void {

--- a/packages/app-core/platforms/electrobun/src/shell-sync-relay.ts
+++ b/packages/app-core/platforms/electrobun/src/shell-sync-relay.ts
@@ -10,7 +10,7 @@ import { logger } from "./logger";
 
 import type { SendToWebview } from "./types";
 
-export const SHELL_SYNC_PROTOCOL_VERSION = "2";
+export const SHELL_SYNC_PROTOCOL_VERSION = "3";
 export const SHELL_AUTHORITY_STATE_MESSAGE = "shellControllerAuthorityState";
 export const SHELL_AUTHORITY_COMMAND_MESSAGE =
   "shellControllerAuthorityCommand";

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -219,7 +219,9 @@ export function HomePill({
   const chipExpanded =
     phase === "listening" || phase === "processing" || needsAuth;
   const label = needsAuth
-    ? signInLabel
+    ? signingIn
+      ? `Signing in to ${appName}`
+      : signInLabel
     : phase === "listening"
       ? `${appName} is listening — release to send`
       : phase === "processing"
@@ -234,7 +236,8 @@ export function HomePill({
     <Button
       variant="ghost"
       aria-label={label}
-      aria-pressed={isOpen}
+      aria-busy={needsAuth && signingIn ? true : undefined}
+      aria-pressed={needsAuth ? undefined : isOpen}
       data-phase={phase}
       data-speaking={speaking || undefined}
       data-testid="shell-home-pill"

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -192,6 +192,7 @@ describe("HomePill", () => {
     );
     const btn = screen.getByRole("button", { name: /sign in to eliza/i });
     expect(btn.getAttribute("data-phase")).toBe("needs-auth");
+    expect(btn.hasAttribute("aria-pressed")).toBe(false);
     expect(screen.getByTestId("shell-home-pill-sign-in").textContent).toBe(
       "Sign in to Eliza",
     );
@@ -215,6 +216,9 @@ describe("HomePill", () => {
     expect(screen.getByTestId("shell-home-pill-mark").className).toContain(
       "animate-pulse",
     );
+    const btn = screen.getByRole("button", { name: /signing in to eliza/i });
+    expect(btn.getAttribute("aria-busy")).toBe("true");
+    expect(btn.hasAttribute("aria-pressed")).toBe(false);
   });
 
   it("stays available while booting and opens on click", () => {

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -252,15 +252,20 @@ vi.mock("../../../voice/voice-capture-factory", () => ({
 // no `navigator.permissions.microphone`), so the common engage path stays
 // synchronous and proceeds exactly as before. Keeps the rest of the module
 // real (WAV/silence helpers used elsewhere).
-const micPermissionMock = vi.hoisted(() => ({
-  state: "unknown" as "granted" | "denied" | "prompt" | "unknown",
-}));
+const micPermissionMock = vi.hoisted(() => {
+  const holder = {
+    state: "unknown" as "granted" | "denied" | "prompt" | "unknown",
+    query: vi.fn<() => Promise<"granted" | "denied" | "prompt" | "unknown">>(),
+  };
+  holder.query.mockImplementation(async () => holder.state);
+  return holder;
+});
 vi.mock("../../../voice/local-asr-capture", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../../../voice/local-asr-capture")>();
   return {
     ...actual,
-    queryMicrophonePermission: vi.fn(async () => micPermissionMock.state),
+    queryMicrophonePermission: micPermissionMock.query,
   };
 });
 
@@ -296,10 +301,12 @@ vi.mock("../useShellVoiceOutput", () => ({
 // real native subscription never runs in jsdom.
 const wakeListenMock = vi.hoisted(() => ({
   lastEnabled: undefined as boolean | undefined,
+  onOpen: undefined as (() => void) | undefined,
 }));
 vi.mock("../../../voice/useWakeListenWindow", () => ({
-  useWakeListenWindow: (opts: { enabled: boolean }) => {
+  useWakeListenWindow: (opts: { enabled: boolean; onOpen: () => void }) => {
     wakeListenMock.lastEnabled = opts.enabled;
+    wakeListenMock.onOpen = opts.onOpen;
     return { phase: "idle" as const };
   },
 }));
@@ -342,6 +349,11 @@ afterEach(() => {
   voiceOutputMock.lastTurnVoiceSeen = undefined;
   voiceOutputMock.cloudConnectedSeen = undefined;
   wakeListenMock.lastEnabled = undefined;
+  wakeListenMock.onOpen = undefined;
+  micPermissionMock.query.mockReset();
+  micPermissionMock.query.mockImplementation(
+    async () => micPermissionMock.state,
+  );
   realtimeVoiceMock.enabled = false;
   realtimeVoiceMock.options = null;
   realtimeVoiceMock.startOutcome = { kind: "live" };
@@ -2480,6 +2492,14 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
 });
 
 describe("useShellController cloud-only auth gate", () => {
+  beforeEach(() => {
+    lastCaptureOpts = null;
+    captureHandles = [];
+    createVoiceCaptureMock.mockReset();
+    installFakeCapture();
+    micPermissionMock.state = "unknown";
+  });
+
   it("stays booting while the auth probe is checking, even when the proxy is ready", () => {
     authGateMock.value = { gated: true, phase: "checking" };
     const { result } = renderHook(() => useShellController());
@@ -2537,6 +2557,7 @@ describe("useShellController cloud-only auth gate", () => {
       act(() => rerender());
       expect(result.current.handsFree).toBe(false);
       expect(result.current.recording).toBe(false);
+      expect(result.current.isOpen).toBe(false);
       expect(
         window.localStorage.getItem("eliza:voice:continuous-chat-mode"),
       ).not.toBe("always-on");
@@ -2612,5 +2633,83 @@ describe("useShellController cloud-only auth gate", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("sign-out invalidates a transcription handoff waiting on recorder drain", async () => {
+    let resolveStop: (() => void) | undefined;
+    const { result, rerender } = renderHook(() => useShellController());
+    act(() => result.current.toggleHandsFree());
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+    captureHandles[0]?.stop.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStop = resolve;
+        }),
+    );
+
+    let transition: Promise<void> | undefined;
+    act(() => {
+      transition = Promise.resolve(result.current.toggleTranscriptionMode());
+    });
+    expect(result.current.transcriptionMode).toBe(true);
+
+    authGateMock.value = { gated: true, phase: "needs-auth" };
+    act(() => rerender());
+    expect(result.current.transcriptionMode).toBe(false);
+    expect(result.current.handsFree).toBe(false);
+    expect(result.current.isOpen).toBe(false);
+
+    await act(async () => {
+      resolveStop?.();
+      await transition;
+    });
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+    expect(result.current.recording).toBe(false);
+  });
+
+  it("keeps queued wake and server voice-control events inert while gated", () => {
+    authGateMock.value = { gated: true, phase: "needs-auth" };
+    const { result } = renderHook(() => useShellController());
+    expect(wakeListenMock.lastEnabled).toBe(false);
+
+    act(() => {
+      wakeListenMock.onOpen?.();
+      window.dispatchEvent(
+        new CustomEvent("eliza:voice-control", {
+          detail: { command: "start" },
+        }),
+      );
+    });
+
+    expect(result.current.handsFree).toBe(false);
+    expect(result.current.transcriptionMode).toBe(false);
+    expect(result.current.isOpen).toBe(false);
+    expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+  });
+
+  it("does not restore persisted always-on after auth gates during permission probe", async () => {
+    window.localStorage.setItem(
+      "eliza:voice:continuous-chat-mode",
+      "always-on",
+    );
+    let resolvePermission: ((state: "granted") => void) | undefined;
+    micPermissionMock.query.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePermission = resolve;
+        }),
+    );
+    const { result, rerender } = renderHook(() => useShellController());
+
+    authGateMock.value = { gated: true, phase: "needs-auth" };
+    act(() => rerender());
+    await act(async () => {
+      resolvePermission?.("granted");
+      await Promise.resolve();
+    });
+
+    expect(result.current.handsFree).toBe(false);
+    expect(result.current.isOpen).toBe(false);
+    expect(createVoiceCaptureMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/apply-command.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/apply-command.test.ts
@@ -9,6 +9,8 @@ describe("applyShellControllerCommand", () => {
     const c = makeFakeShellController();
     applyShellControllerCommand(c, { kind: "open" });
     expect(c.open).toHaveBeenCalledTimes(1);
+    applyShellControllerCommand(c, { kind: "requestSignIn" });
+    expect(c.requestSignIn).toHaveBeenCalledTimes(1);
 
     applyShellControllerCommand(c, {
       kind: "send",

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/fixtures.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/fixtures.ts
@@ -24,6 +24,8 @@ export function baseSnapshot(
 ): ShellControllerSnapshot {
   return {
     phase: "idle",
+    authGate: { gated: false, phase: "clear" },
+    signingIn: false,
     responding: false,
     turnStatus: null,
     messages: EMPTY_MESSAGES,

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/follower-controller.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/follower-controller.test.ts
@@ -38,10 +38,14 @@ describe("buildFollowerController reads", () => {
       recording: true,
       transcript: "live",
       handsFree: true,
+      authGate: { gated: true, phase: "needs-auth" },
+      signingIn: true,
     });
     expect(controller.recording).toBe(true);
     expect(controller.transcript).toBe("live");
     expect(controller.handsFree).toBe(true);
+    expect(controller.authGate).toEqual({ gated: true, phase: "needs-auth" });
+    expect(controller.signingIn).toBe(true);
     expect(controller.analyser).toBeNull();
   });
 });
@@ -61,12 +65,14 @@ describe("buildFollowerController commands", () => {
   it("forwards voice + nav controls", () => {
     const { controller, dispatch } = build();
     controller.startRecording("dictate");
+    controller.requestSignIn();
     controller.toggleHandsFree();
     controller.conversationNav.goNext();
     expect(dispatch).toHaveBeenCalledWith({
       kind: "startRecording",
       intent: "dictate",
     });
+    expect(dispatch).toHaveBeenCalledWith({ kind: "requestSignIn" });
     expect(dispatch).toHaveBeenCalledWith({ kind: "toggleHandsFree" });
     expect(dispatch).toHaveBeenCalledWith({
       kind: "navConversation",

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/snapshot.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/snapshot.test.ts
@@ -9,9 +9,13 @@ describe("deriveShellControllerSnapshot", () => {
     const controller = makeFakeShellController();
     controller.recording = true;
     controller.transcript = "hi";
+    controller.authGate = { gated: true, phase: "needs-auth" };
+    controller.signingIn = true;
     const snap = deriveShellControllerSnapshot(controller);
     expect(snap.recording).toBe(true);
     expect(snap.transcript).toBe("hi");
+    expect(snap.authGate).toEqual({ gated: true, phase: "needs-auth" });
+    expect(snap.signingIn).toBe(true);
     expect("analyser" in snap).toBe(false);
     expect(snap.conversationNav).toEqual({
       hasPrev: false,
@@ -27,6 +31,9 @@ describe("snapshotsEqual", () => {
     expect(snapshotsEqual(baseSnapshot(), baseSnapshot())).toBe(true);
     expect(
       snapshotsEqual(baseSnapshot(), baseSnapshot({ recording: true })),
+    ).toBe(false);
+    expect(
+      snapshotsEqual(baseSnapshot(), baseSnapshot({ signingIn: true })),
     ).toBe(false);
   });
   it("compares messages by reference (identity-preserving projection)", () => {

--- a/packages/ui/src/components/shell/shell-controller-sync/apply-command.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/apply-command.ts
@@ -18,6 +18,8 @@ export function applyShellControllerCommand(
   switch (command.kind) {
     case "open":
       return Promise.resolve(controller.open());
+    case "requestSignIn":
+      return Promise.resolve(controller.requestSignIn());
     case "close":
       return Promise.resolve(controller.close());
     case "send":

--- a/packages/ui/src/components/shell/shell-controller-sync/follower-controller.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/follower-controller.ts
@@ -55,12 +55,9 @@ export function buildFollowerController(
 
   return {
     phase: snapshot.phase,
-    authGate:
-      snapshot.phase === "needs-auth"
-        ? { gated: true, phase: "needs-auth" }
-        : { gated: false, phase: "clear" },
-    requestSignIn: () => fire({ kind: "open" }),
-    signingIn: false,
+    authGate: snapshot.authGate,
+    requestSignIn: () => fire({ kind: "requestSignIn" }),
+    signingIn: snapshot.signingIn,
     bootProgressSignal: snapshot.bootProgressSignal,
     responding: snapshot.responding,
     turnStatus: snapshot.turnStatus,

--- a/packages/ui/src/components/shell/shell-controller-sync/protocol.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/protocol.ts
@@ -22,7 +22,7 @@ import { decodeOsIntent } from "../../../os-intent/decode";
  * The native authority rejects a renderer whose version differs rather than
  * trusting a field that may have moved.
  */
-export const SHELL_SYNC_PROTOCOL_VERSION = "2";
+export const SHELL_SYNC_PROTOCOL_VERSION = "3";
 
 export type ShellWindowRole = "owner" | "follower";
 
@@ -30,6 +30,7 @@ export type ShellWindowRole = "owner" | "follower";
  *  owner switches exhaustively so a new command cannot be silently dropped. */
 export type ShellControllerCommand =
   | { kind: "open" }
+  | { kind: "requestSignIn" }
   | { kind: "close" }
   | {
       kind: "send";
@@ -127,6 +128,7 @@ function isImageAttachment(value: unknown): value is ImageAttachment {
 
 const NO_ARG_COMMANDS: ReadonlySet<ShellControllerCommandKind> = new Set([
   "open",
+  "requestSignIn",
   "close",
   "captureVision",
   "toggleRecording",

--- a/packages/ui/src/components/shell/shell-controller-sync/snapshot.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/snapshot.ts
@@ -14,6 +14,7 @@
 import type { ChatTurnStatus } from "../../../api/client-types-chat";
 import type { HomeModelStatus } from "../../../services/local-inference/home-model-status";
 import type { MicrophonePermissionState } from "../../../voice/local-asr-capture";
+import type { ShellAuthGate } from "../shell-auth-gate";
 import {
   isShellPhase,
   type ShellMessage,
@@ -32,6 +33,8 @@ export interface ShellConversationNavSnapshot {
 
 export interface ShellControllerSnapshot {
   phase: ShellPhase;
+  authGate: ShellAuthGate;
+  signingIn: boolean;
   responding: boolean;
   turnStatus: ChatTurnStatus | null;
   messages: readonly ShellMessage[];
@@ -70,8 +73,18 @@ export function parseShellControllerSnapshot(
   const nav = value.conversationNav;
   const model = value.modelStatus;
   const messages = value.messages;
+  const authGate = value.authGate;
   if (
     !isShellPhase(phase) ||
+    !isRecord(authGate) ||
+    typeof authGate.gated !== "boolean" ||
+    !(
+      authGate.phase === "checking" ||
+      authGate.phase === "needs-auth" ||
+      authGate.phase === "clear"
+    ) ||
+    authGate.gated !== (authGate.phase !== "clear") ||
+    typeof value.signingIn !== "boolean" ||
     typeof value.responding !== "boolean" ||
     (value.turnStatus !== null && !isRecord(value.turnStatus)) ||
     !Array.isArray(messages) ||
@@ -127,6 +140,8 @@ export function deriveShellControllerSnapshot(
 ): ShellControllerSnapshot {
   return {
     phase: controller.phase,
+    authGate: controller.authGate,
+    signingIn: controller.signingIn,
     responding: controller.responding,
     turnStatus: controller.turnStatus,
     messages: controller.messages,
@@ -197,6 +212,9 @@ export function snapshotsEqual(
 ): boolean {
   return (
     a.phase === b.phase &&
+    a.authGate.gated === b.authGate.gated &&
+    a.authGate.phase === b.authGate.phase &&
+    a.signingIn === b.signingIn &&
     a.responding === b.responding &&
     a.turnStatus === b.turnStatus &&
     a.messages === b.messages &&

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -479,8 +479,9 @@ export function useShellController(): ShellController {
     handleInteractiveCloudLogin,
   } = useAppSelectorShallow(selectShellController);
   const authGate = useShellAuthGate();
-  // Ref mirror for async continuations (permission probes, timers) that must
-  // read the gate as it is at fire time, not as it was when they were armed.
+  // Async voice transitions must read the current auth boundary, not the render
+  // that created their callback. Permission probes, recorder drains, and
+  // conversation creation can all outlive a sign-out render.
   const authGateRef = React.useRef(authGate);
   authGateRef.current = authGate;
   const [signingIn, setSigningIn] = React.useState(false);
@@ -1210,7 +1211,7 @@ export function useShellController(): ShellController {
       // Cloud-only, signed out: refuse capture. User-initiated paths call
       // requestSignIn themselves; auto-engage must not pop a login from an
       // effect (that would lose the gesture and fall into same-tab).
-      if (authGate.gated) return;
+      if (authGateRef.current.gated) return;
       // Cartesia realtime owns conversational Talk end to end. Every legacy
       // boot/re-listen/wake path converges here, so this guard is the hard
       // boundary that prevents an effect from silently reopening batch Cloud
@@ -1521,7 +1522,6 @@ export function useShellController(): ShellController {
         });
     },
     [
-      authGate.gated,
       realtimeVoiceEnabled,
       send,
       stopCapture,
@@ -1625,7 +1625,7 @@ export function useShellController(): ShellController {
         }
         // Recovered (or now-unknown): guard against a capture that opened via
         // another path during the await, then open the mic.
-        if (captureRef.current) return;
+        if (authGateRef.current.gated || captureRef.current) return;
         onProceed();
       });
     },
@@ -1698,8 +1698,13 @@ export function useShellController(): ShellController {
       // double-opened / overridden. The auth gate is re-read through the ref —
       // sign-out during the await must not light hands-free or summon the
       // overlay against a startCapture that will refuse.
-      if (authGateRef.current.gated) return;
-      if (captureRef.current || handsFreeRef.current) return;
+      if (
+        authGateRef.current.gated ||
+        captureRef.current ||
+        handsFreeRef.current
+      ) {
+        return;
+      }
       setHandsFree(true);
       setIsOpen(true);
       startCapture("converse");
@@ -1942,7 +1947,7 @@ export function useShellController(): ShellController {
   }, [stopCapture, voiceOutput.stopSpeaking]);
 
   const startRealtimeVoice = React.useCallback(async () => {
-    if (authGate.gated) return;
+    if (authGateRef.current.gated) return;
     if (!realtimeVoiceEnabled) return;
     if (
       realtimeVoiceWantedRef.current ||
@@ -1966,7 +1971,7 @@ export function useShellController(): ShellController {
     let conversationId = activeConversationIdRef.current?.trim() || null;
     if (!conversationId) {
       conversationId = await ensureActiveConversationForVoice();
-      if (!realtimeVoiceWantedRef.current) return;
+      if (authGateRef.current.gated || !realtimeVoiceWantedRef.current) return;
     }
     if (!conversationId) {
       const message =
@@ -1980,6 +1985,7 @@ export function useShellController(): ShellController {
       return;
     }
 
+    if (authGateRef.current.gated) return;
     const outcome = await realtimeVoiceRef.current.start();
     if (!realtimeVoiceWantedRef.current) {
       if (outcome.kind === "live") void realtimeVoiceRef.current.stop();
@@ -2002,7 +2008,6 @@ export function useShellController(): ShellController {
     }
     setActionNotice(message, "error", 6000);
   }, [
-    authGate.gated,
     ensureActiveConversationForVoice,
     realtimeVoiceEnabled,
     setActionNotice,
@@ -2154,6 +2159,7 @@ export function useShellController(): ShellController {
         const payload = event.payload as VoiceSettingsApplyPayload;
         const continuous = readAppliedContinuousMode(payload.continuous);
         if (!continuous) return;
+        if (authGateRef.current.gated) return;
         saveContinuousChatMode(continuous);
 
         if (continuous === "always-on") {
@@ -2206,11 +2212,14 @@ export function useShellController(): ShellController {
   // native subscription, no mic effect).
   const wakeWordEnabled = loadWakeWordEnabled();
   useWakeListenWindow({
-    enabled: wakeWordEnabled,
+    enabled: wakeWordEnabled && !authGate.gated,
     alwaysOn: wakeAlreadyAlwaysOn,
     agentBusy: responding,
     characterName: wakeCharacterName,
     onOpen: React.useCallback(() => {
+      // A native wake notification may already be queued when sign-out disables
+      // the subscription. The callback itself is the final boundary.
+      if (authGateRef.current.gated) return;
       setIsOpen(true);
       if (realtimeVoiceEnabled) {
         startRealtimeVoiceRef.current();
@@ -2241,6 +2250,10 @@ export function useShellController(): ShellController {
   // phrase) finalizes the session, which drops the transcript into the composer
   // as an attachment the user sends with their next message.
   const toggleTranscriptionMode = React.useCallback(async () => {
+    if (authGateRef.current.gated) {
+      requestSignIn();
+      return;
+    }
     if (transcriptionModeRef.current) {
       setTranscriptionMode(false);
       transcriptionModeRef.current = false;
@@ -2283,6 +2296,7 @@ export function useShellController(): ShellController {
       // both captures reach ASR in order and the old handle cannot dispose the
       // new capture's state.
       if (captureRef.current) await stopCaptureAndDrain();
+      if (authGateRef.current.gated || !transcriptionModeRef.current) return;
       startCapture("transcription");
     }
   }, [
@@ -2292,6 +2306,7 @@ export function useShellController(): ShellController {
     beginTranscriptSession,
     finalizeTranscriptSession,
     realtimeVoiceEnabled,
+    requestSignIn,
   ]);
 
   // The mic button while transcribing: turn the mic (and thus transcript) fully
@@ -2319,6 +2334,7 @@ export function useShellController(): ShellController {
   // "stop" while idle) is a no-op.
   React.useEffect(() => {
     const onVoiceControl = (e: Event) => {
+      if (authGateRef.current.gated) return;
       const detail = (e as CustomEvent<VoiceControlEventDetail>).detail;
       if (!detail) return;
       if (detail.command === "start" && !transcriptionModeRef.current) {
@@ -2392,6 +2408,7 @@ export function useShellController(): ShellController {
     const timer = window.setTimeout(() => {
       if (
         transcriptionModeRef.current &&
+        !authGateRef.current.gated &&
         !captureRef.current &&
         !chatSending &&
         !voiceOutput.speaking
@@ -2432,6 +2449,7 @@ export function useShellController(): ShellController {
     const timer = window.setTimeout(() => {
       if (
         handsFreeRef.current &&
+        !authGateRef.current.gated &&
         !captureRef.current &&
         !chatSending &&
         !voiceOutput.speaking &&
@@ -2582,19 +2600,20 @@ export function useShellController(): ShellController {
   // a later sign-in clears the gate — without a fresh voice gesture.
   React.useEffect(() => {
     if (!authGate.gated) return;
+    // Authentication is a terminal boundary for every voice loop. Discard the
+    // partial transcription session instead of finalizing it into a healthy
+    // attachment after its authenticated owner has disappeared.
+    setTranscriptionMode(false);
+    transcriptionModeRef.current = false;
+    transcriptSessionRef.current = null;
+    transcriptSessionStartRef.current = 0;
+    resumeHandsFreeAfterTranscriptRef.current = false;
+    recordReplyIntoTranscriptRef.current = false;
+    wasCapturingAtSuspendRef.current = false;
+    autoEngagedHandsFreeRef.current = true;
     if (captureRef.current) cancelCapture();
     if (isOpen) setIsOpen(false);
     stopRealtimeVoiceRef.current();
-    if (handsFreeRef.current) {
-      saveContinuousChatMode(priorContinuousModeRef.current);
-      setHandsFree(false);
-      handsFreeRef.current = false;
-    }
-    resumeHandsFreeAfterTranscriptRef.current = false;
-    if (transcriptionModeRef.current) {
-      setTranscriptionMode(false);
-      transcriptionModeRef.current = false;
-    }
   }, [authGate.gated, cancelCapture, isOpen]);
 
   const startRecording = React.useCallback(


### PR DESCRIPTION
## Summary

Follow-up to merged #20705. Makes the Cloud authentication boundary terminal across every voice loop and deferred continuation, synchronizes auth state to follower windows, fixes the sign-in action semantics, and makes native bottom-bar frame changes recover after transient platform failures.

Fixes #21066.

## Correctness changes

- Re-read the live auth gate before capture, realtime setup, permission-probe, recorder-drain, and re-listen continuations.
- Tear down transcription session/refs, resume flags, hands-free, realtime, capture, and overlay state on sign-out.
- Disable queued wake and server voice-control activation while gated.
- Synchronize `authGate` and `signingIn` to shell followers and add an explicit `requestSignIn` command (protocol v3).
- Expose the sign-in chip as an action rather than an ARIA toggle; announce in-flight login with `aria-busy` and an updated label.
- Persist desired native bottom-bar size before platform availability checks and retry failed frame application.

## Validation

Exact current-base commit: `2866db55041`.

- UI auth transition/race suite: 9 passed (83 unrelated skipped).
- HomePill + follower/snapshot/command suites: 44 passed.
- Electrobun native sizing/relay suites: 53 passed.
- UI typecheck: passed.
- UI lint: passed with 8 pre-existing cookie warnings.
- Electrobun lint: passed.
- Root `bun run verify`: 208/210 tasks completed; stopped only by unrelated existing Cloud API type errors in `training/vertex/assignments/route.scope.test.ts` (tuple index/cast at lines 43 and 56).
- App audit capture: attempted; its duplicate cold UI declaration build was stopped after >10 minutes to allow root verification to complete. No audit verdict is claimed.

## Evidence

- Desktop/mobile screenshots: pending; the visible delta is limited to the in-flight sign-in label/ARIA state.
- MP4: N/A for the voice/privacy race fix; behavior is exercised deterministically with deferred promises and transition tests.
- Native recovery: deterministic tests cover missing window, missing work area, `setFrame` throw, and subsequent retry.
- Windows/Linux packaged proof: unavailable from this macOS review host.

## Contribution provenance

- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex desktop / multi-agent
- Human review: self-reviewed against exact current `develop`; focused runtime contracts independently exercised
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent"} -->