### PR TITLE
fix(cloud): reject unknown app-delete GitHub-repo flag

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/route.delete-github-repo.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.delete-github-repo.test.ts
@@ -1,0 +1,119 @@
+/**
+ * DELETE /api/v1/apps/:id `deleteGitHubRepo` is app-delete GitHub-repo
+ * identity, not leftover tax on telegram webhook flag or share-ingest
+ * consume. Stock develop treated any non-exact `false` token as
+ * delete, so `deleteGitHubRepo=FALSE` still deleted the linked repo.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: mock(() => undefined), error: mock(() => undefined) },
+}));
+
+const ORG_A = "11111111-1111-4111-8111-111111111111";
+const APP_ID = "99999999-9999-4999-8999-000000000001";
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+const getById = mock(async (id: string) =>
+  id === APP_ID
+    ? { id: APP_ID, organization_id: ORG_A, github_repo: "elizaOS-apps/keep" }
+    : null,
+);
+const deleteAppWithCleanup = mock(async () => ({
+  success: true,
+  errors: [],
+  cleaned: {
+    domainsRemoved: 0,
+    githubRepoDeleted: true,
+    secretBindingsRemoved: 0,
+    managedDomainsUnlinked: 0,
+  },
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: ORG_A,
+  }),
+}));
+mock.module("@/lib/auth/app-key-scope", () => ({
+  isAppKeyOutOfScope: async () => false,
+}));
+mock.module("@/lib/services/apps", () => ({
+  appsService: { getById },
+}));
+mock.module("@/lib/services/app-cleanup", () => ({
+  appCleanupService: { deleteAppWithCleanup },
+}));
+mock.module("@/lib/services/app-review", () => ({
+  buildReviewCandidate: () => ({}),
+}));
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: { getById: async () => null },
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_c: unknown, error: unknown) => {
+    throw error;
+  },
+}));
+
+const { default: detailRoute } = await import("./route");
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.route("/api/v1/apps/:id", detailRoute);
+  return app;
+}
+
+function del(query = "") {
+  return buildApp().request(
+    `/api/v1/apps/${APP_ID}${query}`,
+    { method: "DELETE" },
+    ENV,
+  );
+}
+
+describe("DELETE /api/v1/apps/:id GitHub-repo identity", () => {
+  beforeEach(() => {
+    getById.mockClear();
+    deleteAppWithCleanup.mockClear();
+  });
+
+  test.each(["", "?deleteGitHubRepo=", "?deleteGitHubRepo=true"])(
+    "accepts %s as delete the linked GitHub repo",
+    async (query) => {
+      const response = await del(query);
+      expect(response.status).toBe(200);
+      expect(getById).toHaveBeenCalledTimes(1);
+      expect(deleteAppWithCleanup).toHaveBeenCalledTimes(1);
+      expect(deleteAppWithCleanup.mock.calls[0][1]).toMatchObject({
+        deleteGitHubRepo: true,
+      });
+    },
+  );
+
+  test("accepts deleteGitHubRepo=false as keep the linked repo", async () => {
+    const response = await del("?deleteGitHubRepo=false");
+    expect(response.status).toBe(200);
+    expect(deleteAppWithCleanup).toHaveBeenCalledTimes(1);
+    expect(deleteAppWithCleanup.mock.calls[0][1]).toMatchObject({
+      deleteGitHubRepo: false,
+    });
+  });
+
+  test.each(["FALSE", "TRUE", "0", "1", "no", "yes", "foo"])(
+    "rejects deleteGitHubRepo=%s before getById and cleanup",
+    async (token) => {
+      const response = await del(
+        `?deleteGitHubRepo=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid deleteGitHubRepo");
+      expect(getById).not.toHaveBeenCalled();
+      expect(deleteAppWithCleanup).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/apps/[id]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.ts
@@ -194,6 +194,26 @@ app.delete("/", async (c) => {
     const id = c.req.param("id");
     if (!id) return c.json({ success: false, error: "Missing app id" }, 400);
 
+    // App-delete GitHub-repo identity, not leftover tax on telegram
+    // webhook flag or share-ingest consume. deleteGitHubRepo=FALSE
+    // used to still delete the linked repo.
+    const requestedDeleteGitHub = c.req.query("deleteGitHubRepo");
+    if (
+      requestedDeleteGitHub != null &&
+      requestedDeleteGitHub !== "" &&
+      requestedDeleteGitHub !== "true" &&
+      requestedDeleteGitHub !== "false"
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: "Invalid deleteGitHubRepo",
+          message: 'deleteGitHubRepo must be "true" or "false".',
+        },
+        400,
+      );
+    }
+
     const existing = await appsService.getById(id);
     if (!existing)
       return c.json({ success: false, error: "App not found" }, 404);
@@ -205,7 +225,7 @@ app.delete("/", async (c) => {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
 
-    const deleteGitHubRepo = c.req.query("deleteGitHubRepo") !== "false";
+    const deleteGitHubRepo = requestedDeleteGitHub !== "false";
 
     const cleanupResult = await appCleanupService.deleteAppWithCleanup(id, {
       deleteGitHubRepo,


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on app-delete
`deleteGitHubRepo` identity. Destructive GitHub-repo class, not leftover
tax on telegram webhook flag, share-ingest consume, Life Ops inbox
bools, models catalogOnly/refresh, payment-request public, market-candles
type, github-complete target, cloneType, token-lookup chain,
analytics-breakdown timeRange, admin-redemptions network, OAuth
platform, app-analytics period, ad-account platform, my-agents category,
advertising campaign filters, AI-pricing catalog filters, admin metrics
timeRange, analytics view, Vertex scope, ingress-map format,
promote-assets platform, influencer bookings party, X connectionRole,
my-agents sortBy, logs since, analytics periods, analytics export type,
admin redemption status, views viewType, relationships scope, commands
surface, approvals state, database-rows sort/page, memory-viewer type,
VFS encoding, Cloud JSON-400, prefix-coerced limit, percent-encoded
paths, SIWS chainId, orchestrator lines, provisioning-worker env ints,
invites-accept, cli-auth, redemption quote, compat agent-logs, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. DELETE `deleteGitHubRepo` only on `/api/v1/apps/:id`.
Omitted/empty/`true` still deletes the linked repo (today's default).
Exact `false` still keeps it. Unknown / uppercase tokens 400 before
getById and deleteAppWithCleanup. Telegram webhook, share-ingest
consume, and Life Ops inbox bools stay untouched.

# Background

## What does this PR do?

`DELETE /api/v1/apps/:id` treated any non-exact `false` token as delete.
`deleteGitHubRepo=FALSE` silently deleted the linked GitHub repo instead
of a 400.

- omitted / empty / `true` → **200** delete the linked GitHub repo
- exact `false` → **200** keep the linked repo
- `FALSE` / `TRUE` / `0` / `1` / `no` / `yes` / `foo` → **400** before getById and cleanup

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The GitHub-repo cleanup flag is chosen from `deleteGitHubRepo`. A common
`deleteGitHubRepo=FALSE` after a client uppercases the bool must not
destroy the linked repo. This is app-delete GitHub-repo identity, not
leftover tax on telegram webhook flag.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/apps/[id]/route.delete-github-repo.test.ts` —
omitted still deletes the repo; exact `false` still keeps it; garbage
400s with no getById and no cleanup.

## Test commands

```bash
cd packages/cloud/api && bun test v1/apps/[id]/route.delete-github-repo.test.ts
```

11 passed at the evidence head. Stock develop called
deleteAppWithCleanup(`deleteGitHubRepo: true`) for `FALSE`.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; app-delete `deleteGitHubRepo` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; app-delete `deleteGitHubRepo` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; app-delete `deleteGitHubRepo` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real GitHub-repo tokens and assert 400 before cleanup; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no GitHub repo export; illegal tokens 400 before deleteAppWithCleanup.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`deleteGitHubRepo` tokens reject; omitted/canonical still bind the
matching cleanup.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file app-delete GitHub-repo
parse with a green focused suite (11 tests). Full monorepo verify is
unrelated to this query grammar and was skipped to keep the proof tied
to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f71cc46f1dbefe0a86df8c0c1cce7760c8ce1dff -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
