### PR TITLE
feat(cloud): complete Personal Shared APNs push

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -701,6 +701,32 @@ jobs:
             exit 1
           fi
 
+          apns_config_names=(
+            ELIZA_APNS_KEY
+            ELIZA_APNS_KEY_ID
+            ELIZA_APNS_TEAM_ID
+            ELIZA_APNS_TOPIC
+            ELIZA_APNS_PRODUCTION
+          )
+          apns_configured_count=0
+          for name in "${apns_config_names[@]}"; do
+            has_nonblank_value "${!name:-}" && apns_configured_count=$((apns_configured_count + 1))
+          done
+          if [ "$apns_configured_count" -ne 0 ] && [ "$apns_configured_count" -ne "${#apns_config_names[@]}" ]; then
+            echo "::error::Personal Shared APNs bindings must be configured all-or-none"
+            exit 1
+          fi
+          if [ "$apns_configured_count" -gt 0 ]; then
+            if [ "$ELIZA_APNS_TOPIC" != "ai.elizaos.app" ]; then
+              echo "::error::ELIZA_APNS_TOPIC must match the signed iOS bundle id"
+              exit 1
+            fi
+            if [ "$ELIZA_APNS_PRODUCTION" != "0" ] && [ "$ELIZA_APNS_PRODUCTION" != "1" ]; then
+              echo "::error::ELIZA_APNS_PRODUCTION must be exactly 0 or 1"
+              exit 1
+            fi
+          fi
+
           declare -a worker_secret_names=()
           declare -A queued_worker_secret_names=()
 
@@ -1093,6 +1119,18 @@ jobs:
                 "VOICE_REALTIME_ELIZA_AUTHORIZATION",
                 "VOICE_REALTIME_ELIZA_ENDPOINT",
               );
+            }
+            const apns = [
+              "ELIZA_APNS_KEY",
+              "ELIZA_APNS_KEY_ID",
+              "ELIZA_APNS_TEAM_ID",
+              "ELIZA_APNS_TOPIC",
+              "ELIZA_APNS_PRODUCTION",
+            ];
+            const presentApns = apns.filter((name) => present.has(name));
+            if (presentApns.length !== 0 && presentApns.length !== apns.length) {
+              console.error(`::error::Personal Shared APNs bindings are partial: ${presentApns.join(" ")}`);
+              process.exit(1);
             }
             const missing = required.filter((name) => !present.has(name));
             if (missing.length > 0) {

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -581,6 +581,14 @@ jobs:
           # activation is a separate protected, live-proven rollout.
           ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
           ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
+          # Personal Shared APNs stays dormant unless the complete protected
+          # environment config is present. Topic/environment are explicit so a
+          # signed development build cannot silently receive production pushes.
+          ELIZA_APNS_KEY: ${{ secrets.ELIZA_APNS_KEY }}
+          ELIZA_APNS_KEY_ID: ${{ secrets.ELIZA_APNS_KEY_ID }}
+          ELIZA_APNS_TEAM_ID: ${{ secrets.ELIZA_APNS_TEAM_ID }}
+          ELIZA_APNS_TOPIC: ${{ vars.ELIZA_APNS_TOPIC }}
+          ELIZA_APNS_PRODUCTION: ${{ vars.ELIZA_APNS_PRODUCTION }}
           # Bearer key for the self-hosted TEI embeddings sidecar (#20627); the
           # Worker's local-embeddings routing sends it when LOCAL_EMBEDDINGS_BASE_URL
           # is configured. The sidecar rejects unauthenticated calls (401).
@@ -900,6 +908,11 @@ jobs:
             ELIZA_APP_WEBHOOK_GATEWAY_SECRET \
             ELIZA_APP_TELEGRAM_BOT_TOKEN \
             ELIZA_APP_TELEGRAM_WEBHOOK_SECRET \
+            ELIZA_APNS_KEY \
+            ELIZA_APNS_KEY_ID \
+            ELIZA_APNS_TEAM_ID \
+            ELIZA_APNS_TOPIC \
+            ELIZA_APNS_PRODUCTION \
             LOCAL_EMBEDDINGS_API_KEY
           do
             queue_secret "$name"

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -701,30 +701,14 @@ jobs:
             exit 1
           fi
 
-          apns_config_names=(
-            ELIZA_APNS_KEY
-            ELIZA_APNS_KEY_ID
-            ELIZA_APNS_TEAM_ID
-            ELIZA_APNS_TOPIC
-            ELIZA_APNS_PRODUCTION
-          )
-          apns_configured_count=0
-          for name in "${apns_config_names[@]}"; do
-            has_nonblank_value "${!name:-}" && apns_configured_count=$((apns_configured_count + 1))
-          done
-          if [ "$apns_configured_count" -ne 0 ] && [ "$apns_configured_count" -ne "${#apns_config_names[@]}" ]; then
-            echo "::error::Personal Shared APNs bindings must be configured all-or-none"
+          if has_nonblank_value "$ELIZA_APNS_TOPIC" && [ "$ELIZA_APNS_TOPIC" != "ai.elizaos.app" ]; then
+            echo "::error::ELIZA_APNS_TOPIC must match the signed iOS bundle id"
             exit 1
           fi
-          if [ "$apns_configured_count" -gt 0 ]; then
-            if [ "$ELIZA_APNS_TOPIC" != "ai.elizaos.app" ]; then
-              echo "::error::ELIZA_APNS_TOPIC must match the signed iOS bundle id"
-              exit 1
-            fi
-            if [ "$ELIZA_APNS_PRODUCTION" != "0" ] && [ "$ELIZA_APNS_PRODUCTION" != "1" ]; then
-              echo "::error::ELIZA_APNS_PRODUCTION must be exactly 0 or 1"
-              exit 1
-            fi
+          if has_nonblank_value "$ELIZA_APNS_PRODUCTION" && \
+             [ "$ELIZA_APNS_PRODUCTION" != "0" ] && [ "$ELIZA_APNS_PRODUCTION" != "1" ]; then
+            echo "::error::ELIZA_APNS_PRODUCTION must be exactly 0 or 1"
+            exit 1
           fi
 
           declare -a worker_secret_names=()
@@ -808,6 +792,35 @@ jobs:
                 process.exit(1);
               }
               console.log(`Verified ${required.length} existing or configured production voice binding names; values were not read.`);
+            ' "${worker_secret_names[@]}"
+          }
+
+          verify_apns_binding_candidates() {
+            local secret_inventory
+            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+            printf '%s' "$secret_inventory" | node -e '
+              const fs = require("node:fs");
+              const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
+              const entries = Array.isArray(parsed)
+                ? parsed
+                : Array.isArray(parsed?.result)
+                  ? parsed.result
+                  : [];
+              const available = new Set(entries.map((entry) => entry?.name).filter(Boolean));
+              for (const name of process.argv.slice(1)) available.add(name);
+              const apns = [
+                "ELIZA_APNS_KEY",
+                "ELIZA_APNS_KEY_ID",
+                "ELIZA_APNS_TEAM_ID",
+                "ELIZA_APNS_TOPIC",
+                "ELIZA_APNS_PRODUCTION",
+              ];
+              const present = apns.filter((name) => available.has(name));
+              if (present.length !== 0 && present.length !== apns.length) {
+                console.error(`::error::Personal Shared APNs bindings must be zero-or-complete; partial existing or configured bindings: ${present.join(" ")}`);
+                process.exit(1);
+              }
+              console.log(`Verified ${present.length} existing or configured APNs binding names; values were not read.`);
             ' "${worker_secret_names[@]}"
           }
 
@@ -964,6 +977,10 @@ jobs:
           # active Worker: every required voice name must either already exist
           # or be queued for the atomic version below.
           verify_production_voice_secret_candidates || exit 1
+          # APNs is dormant only when all five names are absent. Merge the live
+          # names-only inventory with this deploy's candidates before mutation
+          # so a stale partial environment cannot receive APNs-enabled source.
+          verify_apns_binding_candidates || exit 1
           # The staging base URL routes live traffic to an authenticated TEI
           # sidecar, so its bearer binding must exist or be committed in the
           # same Worker version. A missing value may never deploy as a healthy

--- a/packages/agent/src/api/push-token-routes.test.ts
+++ b/packages/agent/src/api/push-token-routes.test.ts
@@ -126,6 +126,22 @@ describe("handlePushTokenRoute", () => {
     expect(helpers.error).toHaveBeenCalledWith(res, expect.any(String), 400);
   });
 
+  it("DELETE accepts a body token without exposing it in the request URL", async () => {
+    await registry.register("ios", "private/device-token");
+    const helpers = makeHelpers();
+    helpers.readJsonBody.mockResolvedValue({ token: "private/device-token" });
+    await handlePushTokenRoute(
+      req(PREFIX),
+      res,
+      PREFIX,
+      "DELETE",
+      { runtime },
+      helpers,
+    );
+    expect(helpers.json).toHaveBeenCalledWith(res, { ok: true });
+    expect(await registry.count()).toBe(0);
+  });
+
   it("GET returns count + per-platform breakdown", async () => {
     await registry.register("ios", "i1");
     await registry.register("ios", "i2");

--- a/packages/agent/src/api/push-token-routes.ts
+++ b/packages/agent/src/api/push-token-routes.ts
@@ -13,8 +13,10 @@
  *     Register (upsert) a device token. Body: { platform: "ios"|"android",
  *     token: string }. Returns `{ ok: true }`.
  *
- *   DELETE /api/notifications/push-tokens/:token
- *     Unregister a device token. Returns `{ ok }` (true if it existed).
+ *   DELETE /api/notifications/push-tokens
+ *     Unregister a device token from `{ token }`. The legacy token path remains
+ *     accepted for installed clients, but new clients keep identifiers out of
+ *     request URLs and access logs.
  *
  *   GET    /api/notifications/push-tokens
  *     Diagnostics: `{ count, platforms: { ios, android } }`.
@@ -96,7 +98,23 @@ export async function handlePushTokenRoute(
     return true;
   }
 
-  // ── DELETE /api/notifications/push-tokens/:token ──────────────────
+  // ── DELETE /api/notifications/push-tokens ─────────────────────────
+  if (method === "DELETE" && pathname === PUSH_TOKENS_PREFIX) {
+    const body = await helpers.readJsonBody<Record<string, unknown>>(req, res, {
+      maxBytes: 8 * 1024,
+    });
+    if (body === null) return true;
+    const token = typeof body.token === "string" ? body.token.trim() : "";
+    if (!token) {
+      helpers.error(res, "token is required", 400);
+      return true;
+    }
+    const ok = await registry.unregister(token);
+    helpers.json(res, { ok });
+    return true;
+  }
+
+  // ── Legacy DELETE /api/notifications/push-tokens/:token ───────────
   const tokenMatch = pathname.match(
     /^\/api\/notifications\/push-tokens\/([^/]+)$/,
   );

--- a/packages/agent/src/api/runtime-mode/remote-forwarder.test.ts
+++ b/packages/agent/src/api/runtime-mode/remote-forwarder.test.ts
@@ -47,10 +47,7 @@ describe("shouldForwardToRemoteTarget", () => {
       shouldForwardToRemoteTarget("/api/notifications/push-tokens", "POST"),
     ).toBe(true);
     expect(
-      shouldForwardToRemoteTarget(
-        "/api/notifications/push-tokens/token%2Fwith%2Bslash",
-        "DELETE",
-      ),
+      shouldForwardToRemoteTarget("/api/notifications/push-tokens", "DELETE"),
     ).toBe(true);
     expect(
       shouldForwardToRemoteTarget("/api/notifications/push-tokens", "GET"),

--- a/packages/agent/src/api/runtime-mode/remote-forwarder.test.ts
+++ b/packages/agent/src/api/runtime-mode/remote-forwarder.test.ts
@@ -2,7 +2,7 @@
  * Unit coverage for the remote-mode request forwarder that a local controller
  * uses to relay traffic to its private remote Eliza target.
  * `shouldForwardToRemoteTarget` decides which cloud-auth mutations get forwarded
- * (POST login/disconnect and billing/v1 writes — never GETs or unrelated paths),
+ * (cloud settings and push-token writes — never GETs or unrelated paths),
  * and `buildForwardHeaders` rewrites the outbound header set: preserving
  * multi-valued `set-cookie`, stripping hop-by-hop headers, rewriting Host to the
  * target, and injecting a Bearer token only when a remote access token is set.
@@ -40,6 +40,21 @@ describe("shouldForwardToRemoteTarget", () => {
     expect(shouldForwardToRemoteTarget("/api/cloud/v1/agents", "DELETE")).toBe(
       true,
     );
+  });
+
+  test("forwards push-token registration and revocation mutations", () => {
+    expect(
+      shouldForwardToRemoteTarget("/api/notifications/push-tokens", "POST"),
+    ).toBe(true);
+    expect(
+      shouldForwardToRemoteTarget(
+        "/api/notifications/push-tokens/token%2Fwith%2Bslash",
+        "DELETE",
+      ),
+    ).toBe(true);
+    expect(
+      shouldForwardToRemoteTarget("/api/notifications/push-tokens", "GET"),
+    ).toBe(false);
   });
 
   test("does not forward GET requests", () => {

--- a/packages/agent/src/api/runtime-mode/remote-forwarder.test.ts
+++ b/packages/agent/src/api/runtime-mode/remote-forwarder.test.ts
@@ -10,8 +10,17 @@
 import { describe, expect, test } from "vitest";
 import {
   buildForwardHeaders,
+  redactPushTokenRequestUrl,
   shouldForwardToRemoteTarget,
 } from "./remote-forwarder.ts";
+
+test("legacy push-token URLs are redacted before agent diagnostics", () => {
+  expect(
+    redactPushTokenRequestUrl(
+      "/api/notifications/push-tokens/token%2Fwith%2Bslash?trace=1",
+    ),
+  ).toBe("/api/notifications/push-tokens/[redacted]?trace=1");
+});
 
 describe("shouldForwardToRemoteTarget", () => {
   test("forwards POST /api/cloud/login", () => {
@@ -48,6 +57,12 @@ describe("shouldForwardToRemoteTarget", () => {
     ).toBe(true);
     expect(
       shouldForwardToRemoteTarget("/api/notifications/push-tokens", "DELETE"),
+    ).toBe(true);
+    expect(
+      shouldForwardToRemoteTarget(
+        "/api/notifications/push-tokens/token%2Fwith%2Bslash",
+        "DELETE",
+      ),
     ).toBe(true);
     expect(
       shouldForwardToRemoteTarget("/api/notifications/push-tokens", "GET"),

--- a/packages/agent/src/api/runtime-mode/remote-forwarder.ts
+++ b/packages/agent/src/api/runtime-mode/remote-forwarder.ts
@@ -29,9 +29,17 @@ const REMOTE_FORWARDED_MUTATION_PREFIXES = [
   "/api/cloud/billing/",
   "/api/cloud/v1/",
   "/api/notifications/push-tokens",
+  "/api/notifications/push-tokens/",
 ] as const;
 
 const FORWARDED_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+const LEGACY_PUSH_TOKEN_URL = /(\/api\/notifications\/push-tokens\/)[^/?\s]+/g;
+
+/** Removes legacy device identifiers before the agent boundary can log a URL. */
+export function redactPushTokenRequestUrl(value: string): string {
+  return value.replace(LEGACY_PUSH_TOKEN_URL, "$1[redacted]");
+}
 
 export function shouldForwardToRemoteTarget(
   pathname: string,
@@ -127,6 +135,9 @@ export async function forwardRemoteCloudMutation(
     `${url.pathname}${url.search}`,
     snapshot.remoteApiBase,
   );
+  // The raw target URL above remains authoritative for compatibility, but any
+  // later boundary diagnostic observing this request must not see the token.
+  req.url = redactPushTokenRequestUrl(req.url ?? "/");
 
   const rawBody = FORWARDED_METHODS.has(method)
     ? await readRequestBody(req)

--- a/packages/agent/src/api/runtime-mode/remote-forwarder.ts
+++ b/packages/agent/src/api/runtime-mode/remote-forwarder.ts
@@ -29,7 +29,6 @@ const REMOTE_FORWARDED_MUTATION_PREFIXES = [
   "/api/cloud/billing/",
   "/api/cloud/v1/",
   "/api/notifications/push-tokens",
-  "/api/notifications/push-tokens/",
 ] as const;
 
 const FORWARDED_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);

--- a/packages/agent/src/api/runtime-mode/remote-forwarder.ts
+++ b/packages/agent/src/api/runtime-mode/remote-forwarder.ts
@@ -13,6 +13,8 @@
  *
  * This module does not catch transport errors — a broken target is a
  * 502 surface to the caller, not a silent log-and-continue.
+ * Device push-token mutations follow the same ownership rule: the selected
+ * remote target owns its token registry and sender, never the controller.
  */
 
 import type http from "node:http";
@@ -26,6 +28,8 @@ const REMOTE_FORWARDED_MUTATION_PREFIXES = [
   "/api/cloud/disconnect",
   "/api/cloud/billing/",
   "/api/cloud/v1/",
+  "/api/notifications/push-tokens",
+  "/api/notifications/push-tokens/",
 ] as const;
 
 const FORWARDED_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
@@ -35,8 +39,8 @@ export function shouldForwardToRemoteTarget(
   method: string,
 ): boolean {
   if (!FORWARDED_METHODS.has(method.toUpperCase())) return false;
-  return REMOTE_FORWARDED_MUTATION_PREFIXES.some((p) =>
-    p.endsWith("/") ? pathname.startsWith(p) : pathname === p,
+  return REMOTE_FORWARDED_MUTATION_PREFIXES.some((prefix) =>
+    prefix.endsWith("/") ? pathname.startsWith(prefix) : pathname === prefix,
   );
 }
 

--- a/packages/cloud/api/__tests__/apns-provider.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/apns-provider.miniflare.test.ts
@@ -1,0 +1,65 @@
+/** Bundles the cloud APNs provider and verifies its WebCrypto path in a real Workerd isolate. */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Miniflare } from "miniflare";
+
+describe("Cloud APNs provider Workerd boundary", () => {
+  let buildDirectory: string;
+  let miniflare: Miniflare;
+
+  beforeAll(async () => {
+    buildDirectory = await mkdtemp(join(tmpdir(), "eliza-apns-workerd-"));
+    const entrypoint = fileURLToPath(
+      new URL("../test/fixtures/apns-provider-worker.ts", import.meta.url),
+    );
+    const outputPath = join(buildDirectory, "worker.mjs");
+    const result = await Bun.build({
+      entrypoints: [entrypoint],
+      format: "esm",
+      target: "browser",
+      conditions: ["worker"],
+      minify: true,
+    });
+    if (!result.success) {
+      throw new Error(
+        `Failed to bundle APNs Workerd fixture: ${result.logs.join("\n")}`,
+      );
+    }
+    const output = result.outputs[0];
+    if (!output) throw new Error("APNs Workerd fixture bundle was not emitted");
+    await Bun.write(outputPath, output);
+    miniflare = new Miniflare({
+      compatibilityDate: "2026-04-01",
+      modules: [
+        {
+          type: "ESModule",
+          path: "worker.mjs",
+          contents: await readFile(outputPath, "utf8"),
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await miniflare?.dispose();
+    if (buildDirectory) await rm(buildDirectory, { recursive: true });
+  });
+
+  test("signs, verifies, and reuses one sandbox provider token", async () => {
+    const response = await miniflare.dispatchFetch("https://apns.test/");
+    const body = await response.text();
+    expect(response.status, body).toBe(200);
+    expect(JSON.parse(body)).toEqual({
+      accepted: true,
+      collapseIds: [expect.stringMatching(/^[A-Za-z0-9_-]{43}$/)],
+      jwtHeaders: [expect.stringMatching(/^bearer [^.]+\.[^.]+\.[^.]+$/)],
+      sandbox: true,
+      topic: "ai.elizaos.app",
+      verified: true,
+    });
+  });
+});

--- a/packages/cloud/api/__tests__/shared-agent-cloud-push-route.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-cloud-push-route.test.ts
@@ -1,0 +1,129 @@
+/** Drives the mounted Personal Shared push-token compatibility route with a durable coordinator seam. */
+
+import { afterAll, beforeEach, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import * as realCoordinator from "@/lib/services/shared-runtime/conversation-coordinator";
+import * as realResolver from "@/lib/services/shared-runtime/resolve-shared-agent";
+
+const resolveSharedAgent = mock();
+const coordinateSharedPushList = mock();
+const coordinateSharedPushRegister = mock();
+const coordinateSharedPushUnregister = mock();
+const namespace = { getByName: mock() };
+
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  ...realResolver,
+  resolveSharedAgent,
+  resolveSharedRuntimeWorkerRequestContext: () => ({
+    namespace,
+    executionCtx: { waitUntil: () => undefined },
+  }),
+}));
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  ...realCoordinator,
+  coordinateSharedPushList,
+  coordinateSharedPushRegister,
+  coordinateSharedPushUnregister,
+}));
+
+const route = (await import("../v1/eliza/agents/[agentId]/api/[...path]/route"))
+  .default;
+const app = new Hono();
+app.route("/api/v1/eliza/agents/:agentId/api/:*{.+}", route);
+const agentId = "cc3f37f5-f69a-4b27-9fa1-a4bd3d702136";
+
+function request(path: string, init?: RequestInit) {
+  return app.request(
+    `https://api.elizacloud.ai/api/v1/eliza/agents/${agentId}/api/${path}`,
+    {
+      headers: { "Content-Type": "application/json" },
+      ...init,
+    },
+  );
+}
+
+beforeEach(() => {
+  resolveSharedAgent.mockReset();
+  resolveSharedAgent.mockResolvedValue({
+    agent: { id: agentId, execution_tier: "shared" },
+    agentId,
+    orgId: "org-1",
+    agentName: "Eliza",
+  });
+  coordinateSharedPushList.mockReset();
+  coordinateSharedPushRegister.mockReset();
+  coordinateSharedPushUnregister.mockReset();
+});
+
+afterAll(() => {
+  mock.module(
+    "@/lib/services/shared-runtime/resolve-shared-agent",
+    () => realResolver,
+  );
+  mock.module(
+    "@/lib/services/shared-runtime/conversation-coordinator",
+    () => realCoordinator,
+  );
+});
+
+test("registers through the selected agent's durable coordinator", async () => {
+  coordinateSharedPushRegister.mockResolvedValue(undefined);
+  const response = await request("notifications/push-tokens", {
+    method: "POST",
+    body: JSON.stringify({ platform: "ios", token: "device-token" }),
+  });
+  expect(response.status).toBe(201);
+  await expect(response.json()).resolves.toEqual({ ok: true });
+  expect(coordinateSharedPushRegister).toHaveBeenCalledWith(
+    agentId,
+    { platform: "ios", token: "device-token" },
+    { namespace },
+  );
+});
+
+test("reports platform counts without returning raw tokens", async () => {
+  coordinateSharedPushList.mockResolvedValue([
+    { platform: "ios", token: "secret-ios", createdAt: 1 },
+    { platform: "android", token: "secret-android", createdAt: 2 },
+  ]);
+  const response = await request("notifications/push-tokens");
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body).toEqual({ count: 2, platforms: { ios: 1, android: 1 } });
+  expect(JSON.stringify(body)).not.toContain("secret-ios");
+});
+
+test("unregisters an encoded token through the same agent authority", async () => {
+  coordinateSharedPushUnregister.mockResolvedValue(true);
+  const response = await request(
+    "notifications/push-tokens/tok%2Fwith%2Bslash",
+    {
+      method: "DELETE",
+    },
+  );
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({ ok: true });
+  expect(coordinateSharedPushUnregister).toHaveBeenCalledWith(
+    agentId,
+    "tok/with+slash",
+    { namespace },
+  );
+});
+
+test("rejects invalid registration before durable mutation", async () => {
+  const response = await request("notifications/push-tokens", {
+    method: "POST",
+    body: JSON.stringify({ platform: "web", token: "x" }),
+  });
+  expect(response.status).toBe(400);
+  expect(coordinateSharedPushRegister).not.toHaveBeenCalled();
+});
+
+test("rejects an oversized registration body before parsing or mutation", async () => {
+  const response = await request("notifications/push-tokens", {
+    method: "POST",
+    body: JSON.stringify({ platform: "ios", token: "x".repeat(8_192) }),
+  });
+  expect(response.status).toBe(413);
+  expect(coordinateSharedPushRegister).not.toHaveBeenCalled();
+});

--- a/packages/cloud/api/__tests__/shared-agent-cloud-push-route.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-cloud-push-route.test.ts
@@ -194,6 +194,32 @@ test("rejects a token above the durable registration limit", async () => {
   expect(coordinateSharedPushRegister).not.toHaveBeenCalled();
 });
 
+test("accepts exact-limit registration and body revocation", async () => {
+  const token = "x".repeat(4_096);
+  const registration = await request("notifications/push-tokens", {
+    method: "POST",
+    body: JSON.stringify({ platform: "ios", token }),
+  });
+  expect(registration.status).toBe(201);
+  expect(coordinateSharedPushRegister).toHaveBeenCalledWith(
+    agentId,
+    { platform: "ios", token },
+    expect.anything(),
+  );
+
+  coordinateSharedPushUnregister.mockResolvedValueOnce(true);
+  const revocation = await request("notifications/push-tokens", {
+    method: "DELETE",
+    body: JSON.stringify({ token }),
+  });
+  expect(revocation.status).toBe(200);
+  expect(coordinateSharedPushUnregister).toHaveBeenCalledWith(
+    agentId,
+    token,
+    expect.anything(),
+  );
+});
+
 test("rejects body revocation above the durable token limit", async () => {
   const response = await request("notifications/push-tokens", {
     method: "DELETE",

--- a/packages/cloud/api/__tests__/shared-agent-cloud-push-route.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-cloud-push-route.test.ts
@@ -49,6 +49,8 @@ beforeEach(() => {
     agentId,
     orgId: "org-1",
     agentName: "Eliza",
+    agentKind: "personal",
+    createdAt: new Date(),
   });
   coordinateSharedPushList.mockReset();
   coordinateSharedPushRegister.mockReset();
@@ -93,14 +95,12 @@ test("reports platform counts without returning raw tokens", async () => {
   expect(JSON.stringify(body)).not.toContain("secret-ios");
 });
 
-test("unregisters an encoded token through the same agent authority", async () => {
+test("unregisters a body token without placing the device identifier in the URL", async () => {
   coordinateSharedPushUnregister.mockResolvedValue(true);
-  const response = await request(
-    "notifications/push-tokens/tok%2Fwith%2Bslash",
-    {
-      method: "DELETE",
-    },
-  );
+  const response = await request("notifications/push-tokens", {
+    method: "DELETE",
+    body: JSON.stringify({ token: "tok/with+slash" }),
+  });
   expect(response.status).toBe(200);
   await expect(response.json()).resolves.toEqual({ ok: true });
   expect(coordinateSharedPushUnregister).toHaveBeenCalledWith(
@@ -108,6 +108,30 @@ test("unregisters an encoded token through the same agent authority", async () =
     "tok/with+slash",
     { namespace },
   );
+});
+
+test("rejects Android registration until Shared has an FCM sender", async () => {
+  const response = await request("notifications/push-tokens", {
+    method: "POST",
+    body: JSON.stringify({ platform: "android", token: "fcm-token" }),
+  });
+  expect(response.status).toBe(400);
+  expect(coordinateSharedPushRegister).not.toHaveBeenCalled();
+});
+
+test("does not expose agent-wide push registration on ordinary shared agents", async () => {
+  resolveSharedAgent.mockResolvedValue({
+    agent: { id: agentId, execution_tier: "shared" },
+    agentId,
+    orgId: "org-1",
+    agentName: "Team Eliza",
+  });
+  const response = await request("notifications/push-tokens", {
+    method: "POST",
+    body: JSON.stringify({ platform: "ios", token: "device-token" }),
+  });
+  expect(response.status).toBe(404);
+  expect(coordinateSharedPushRegister).not.toHaveBeenCalled();
 });
 
 test("rejects invalid registration before durable mutation", async () => {

--- a/packages/cloud/api/__tests__/shared-agent-cloud-push-route.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-cloud-push-route.test.ts
@@ -185,6 +185,33 @@ test("rejects invalid registration before durable mutation", async () => {
   expect(coordinateSharedPushRegister).not.toHaveBeenCalled();
 });
 
+test("rejects a token above the durable registration limit", async () => {
+  const response = await request("notifications/push-tokens", {
+    method: "POST",
+    body: JSON.stringify({ platform: "ios", token: "x".repeat(4_097) }),
+  });
+  expect(response.status).toBe(400);
+  expect(coordinateSharedPushRegister).not.toHaveBeenCalled();
+});
+
+test("rejects body revocation above the durable token limit", async () => {
+  const response = await request("notifications/push-tokens", {
+    method: "DELETE",
+    body: JSON.stringify({ token: "x".repeat(4_097) }),
+  });
+  expect(response.status).toBe(400);
+  expect(coordinateSharedPushUnregister).not.toHaveBeenCalled();
+});
+
+test("rejects path revocation above the durable token limit", async () => {
+  const response = await request(
+    `notifications/push-tokens/${"x".repeat(4_097)}`,
+    { method: "DELETE" },
+  );
+  expect(response.status).toBe(400);
+  expect(coordinateSharedPushUnregister).not.toHaveBeenCalled();
+});
+
 test("rejects an oversized registration body before parsing or mutation", async () => {
   const response = await request("notifications/push-tokens", {
     method: "POST",

--- a/packages/cloud/api/__tests__/shared-agent-cloud-push-route.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-cloud-push-route.test.ts
@@ -110,6 +110,34 @@ test("unregisters a body token without placing the device identifier in the URL"
   );
 });
 
+test("a shipped path-based client can register and later revoke its token", async () => {
+  const tokens = new Set<string>();
+  coordinateSharedPushRegister.mockImplementation(
+    async (_agentId: string, registration: { token: string }) => {
+      tokens.add(registration.token);
+    },
+  );
+  coordinateSharedPushUnregister.mockImplementation(
+    async (_agentId: string, token: string) => tokens.delete(token),
+  );
+  const token = "legacy/device+token";
+
+  const registration = await request("notifications/push-tokens", {
+    method: "POST",
+    body: JSON.stringify({ platform: "ios", token }),
+  });
+  expect(registration.status).toBe(201);
+  expect(tokens.has(token)).toBe(true);
+
+  const revocation = await request(
+    `notifications/push-tokens/${encodeURIComponent(token)}`,
+    { method: "DELETE" },
+  );
+  expect(revocation.status).toBe(200);
+  await expect(revocation.json()).resolves.toEqual({ ok: true });
+  expect(tokens.has(token)).toBe(false);
+});
+
 test("rejects Android registration until Shared has an FCM sender", async () => {
   const response = await request("notifications/push-tokens", {
     method: "POST",
@@ -134,6 +162,20 @@ test("does not expose agent-wide push registration on ordinary shared agents", a
   expect(coordinateSharedPushRegister).not.toHaveBeenCalled();
 });
 
+test("does not expose legacy token revocation on ordinary shared agents", async () => {
+  resolveSharedAgent.mockResolvedValue({
+    agent: { id: agentId, execution_tier: "shared" },
+    agentId,
+    orgId: "org-1",
+    agentName: "Team Eliza",
+  });
+  const response = await request("notifications/push-tokens/private-token", {
+    method: "DELETE",
+  });
+  expect(response.status).toBe(404);
+  expect(coordinateSharedPushUnregister).not.toHaveBeenCalled();
+});
+
 test("rejects invalid registration before durable mutation", async () => {
   const response = await request("notifications/push-tokens", {
     method: "POST",
@@ -150,4 +192,26 @@ test("rejects an oversized registration body before parsing or mutation", async 
   });
   expect(response.status).toBe(413);
   expect(coordinateSharedPushRegister).not.toHaveBeenCalled();
+});
+
+test("rejects an oversized body revocation before durable mutation", async () => {
+  const response = await request("notifications/push-tokens", {
+    method: "DELETE",
+    body: JSON.stringify({ token: "x".repeat(8_192) }),
+  });
+  expect(response.status).toBe(413);
+  expect(coordinateSharedPushUnregister).not.toHaveBeenCalled();
+});
+
+test("rejects a declared oversized body revocation before reading JSON", async () => {
+  const response = await request("notifications/push-tokens", {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": "8193",
+    },
+    body: "{}",
+  });
+  expect(response.status).toBe(413);
+  expect(coordinateSharedPushUnregister).not.toHaveBeenCalled();
 });

--- a/packages/cloud/api/src/bootstrap-app.ts
+++ b/packages/cloud/api/src/bootstrap-app.ts
@@ -37,6 +37,7 @@ import oidcDiscoveryRoute from "../.well-known/openid-configuration/route";
 import { handleBlueBubblesWebhook } from "../webhooks/bluebubbles/route";
 import { mountRoutes } from "./_router.generated";
 import { appsDeployTriggerDecision } from "./lib/apps-deploy-gate";
+import { redactSensitiveRequestPath } from "./lib/observability/request-path-redaction";
 import { authMiddleware } from "./middleware/auth";
 import { initAuditDispatcher } from "./services/audit-dispatcher-singleton";
 import { embeddedStewardHandler } from "./steward/embedded";
@@ -327,7 +328,12 @@ export function createApp(): Hono<AppEnv> {
     }
   });
 
-  app.use("*", honoLogger());
+  app.use(
+    "*",
+    honoLogger((message) => {
+      logger.info({ src: "cloud-http" }, redactSensitiveRequestPath(message));
+    }),
+  );
   app.use("*", async (c, next) => {
     c.set("requestId", c.get("requestId") ?? crypto.randomUUID());
     c.set("user", undefined);
@@ -343,7 +349,7 @@ export function createApp(): Hono<AppEnv> {
         id: requestId,
         traceId,
         method: c.req.method,
-        path: new URL(c.req.url).pathname,
+        path: redactSensitiveRequestPath(new URL(c.req.url).pathname),
       },
       async () => {
         await next();

--- a/packages/cloud/api/src/lib/observability/request-path-redaction.test.ts
+++ b/packages/cloud/api/src/lib/observability/request-path-redaction.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Deterministic contracts verify sensitive identifiers are removed before
+ * either plain-text or structured request telemetry receives a path.
+ */
+
+import { expect, test } from "bun:test";
+import { redactSensitiveRequestPath } from "./request-path-redaction";
+
+test("legacy push-token paths are redacted before request logging", () => {
+  const raw =
+    "--> DELETE /api/v1/eliza/agents/personal/api/notifications/push-tokens/device-secret?trace=1";
+  expect(redactSensitiveRequestPath(raw)).toBe(
+    "--> DELETE /api/v1/eliza/agents/personal/api/notifications/push-tokens/[redacted]?trace=1",
+  );
+});
+
+test("exact body-based push-token paths and unrelated paths are unchanged", () => {
+  expect(redactSensitiveRequestPath("/api/notifications/push-tokens")).toBe(
+    "/api/notifications/push-tokens",
+  );
+  expect(redactSensitiveRequestPath("/api/i18n/locale")).toBe(
+    "/api/i18n/locale",
+  );
+});

--- a/packages/cloud/api/src/lib/observability/request-path-redaction.ts
+++ b/packages/cloud/api/src/lib/observability/request-path-redaction.ts
@@ -1,0 +1,12 @@
+/**
+ * Removes sensitive device identifiers from request-path telemetry while
+ * preserving route shape for operational diagnostics.
+ */
+
+const PUSH_TOKEN_PATH_SEGMENT =
+  /(\/api\/notifications\/push-tokens\/)[^/?\s]+/g;
+
+/** Keeps legacy push-token URLs from placing device identifiers in telemetry. */
+export function redactSensitiveRequestPath(value: string): string {
+  return value.replace(PUSH_TOKEN_PATH_SEGMENT, "$1[redacted]");
+}

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -39,6 +39,10 @@ let rehydrateCalls = 0;
 let bridgeFunding: unknown;
 let recoveredCutoverTargetId: string | null = null;
 let lastBridgeAgent: unknown;
+let apnsOutcome: { outcome: string; reason?: string; status?: number } = {
+  outcome: "accepted",
+};
+const apnsSentTokens: string[] = [];
 
 function testMessageIdentity(value: unknown): string {
   const message = value as {
@@ -123,6 +127,10 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
       },
       options: {
         funding?: unknown;
+        mobilePushDispatch?: (message: {
+          title: string;
+          body?: string;
+        }) => Promise<void>;
         historyStore: {
           load(
             agentId: string,
@@ -144,6 +152,12 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
     ) => {
       bridgeFunding = options.funding;
       lastBridgeAgent = agent;
+      if (rpc.id === "push-event") {
+        await options.mobilePushDispatch?.({
+          title: "Reminder",
+          body: "Stand up",
+        });
+      }
       if (rpc.id === "rate-limited") {
         throw new RateLimitError("Organization rate limit exceeded.", 29);
       }
@@ -223,6 +237,16 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
     },
   },
 }));
+mock.module("@/lib/mobile-push/apns-provider", () => ({
+  resolveCloudApnsConfig: (env: { ELIZA_APNS_KEY?: string }) =>
+    env.ELIZA_APNS_KEY ? { configured: true } : null,
+  CloudApnsProvider: class {
+    async send(token: string) {
+      apnsSentTokens.push(token);
+      return apnsOutcome;
+    }
+  },
+}));
 mock.module("@/lib/utils/logger", () => ({
   logger: { warn: mock(() => undefined) },
 }));
@@ -244,6 +268,8 @@ beforeEach(() => {
   bridgeFunding = undefined;
   recoveredCutoverTargetId = null;
   lastBridgeAgent = undefined;
+  apnsOutcome = { outcome: "accepted" };
+  apnsSentTokens.length = 0;
 });
 
 function makeState(data: Map<string, unknown>, background: Promise<unknown>[]) {
@@ -341,6 +367,69 @@ function makeInvoke(object: { fetch(request: Request): Promise<Response> }) {
     return await response.json();
   };
 }
+
+async function pushOperation(
+  object: { fetch(request: Request): Promise<Response> },
+  body: Record<string, unknown>,
+) {
+  return await object.fetch(
+    new Request("https://shared-runtime.internal/mobile-push", {
+      method: "POST",
+      body: JSON.stringify({ agentId: AGENT_FIXTURE.id, ...body }),
+    }),
+  );
+}
+
+test("mobile push registration is durable, idempotent, and removable", async () => {
+  const data = new Map<string, unknown>();
+  const object = new SharedRuntimeConversation(
+    makeState(data, []) as never,
+    {} as never,
+  );
+  for (const platform of ["ios", "ios", "android"] as const) {
+    const response = await pushOperation(object, {
+      operation: "push-register",
+      platform,
+      token: platform === "ios" ? "ios-token" : "android-token",
+    });
+    expect(response.status).toBe(201);
+    await response.arrayBuffer();
+  }
+  const list = await pushOperation(object, { operation: "push-list" });
+  expect(await list.json()).toMatchObject({
+    tokens: [
+      { token: "ios-token", platform: "ios" },
+      { token: "android-token", platform: "android" },
+    ],
+  });
+  const removed = await pushOperation(object, {
+    operation: "push-unregister",
+    token: "ios-token",
+  });
+  expect((await removed.json()) as unknown).toEqual({ removed: true });
+  expect(data.get("mobile-push-tokens")).toEqual([
+    expect.objectContaining({ token: "android-token", platform: "android" }),
+  ]);
+});
+
+test("notification dispatch sends iOS tokens and removes APNs-dead records", async () => {
+  const data = new Map<string, unknown>();
+  const object = new SharedRuntimeConversation(
+    makeState(data, []) as never,
+    { ELIZA_APNS_KEY: "configured" } as never,
+  );
+  await (
+    await pushOperation(object, {
+      operation: "push-register",
+      platform: "ios",
+      token: "dead-token",
+    })
+  ).arrayBuffer();
+  apnsOutcome = { outcome: "unregistered", reason: "BadDeviceToken" };
+  await makeInvoke(object)("push-event");
+  expect(apnsSentTokens).toEqual(["dead-token"]);
+  expect(data.has("mobile-push-tokens")).toBe(false);
+});
 
 test("prewarm joins cold hydration without writing a conversation turn", async () => {
   repositoryReads = 0;

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -667,6 +667,62 @@ test("retry sends only unsettled devices and never logs an APNs token URL", asyn
   ]);
 });
 
+test("partial-failure ledger prunes hashes through repeated token rotation", async () => {
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    { ELIZA_APNS_KEY: "configured" } as never,
+  );
+  const mutateToken = async (
+    operation: "push-register" | "push-unregister",
+    token: string,
+  ) => {
+    await (
+      await pushOperation(object, {
+        operation,
+        ...(operation === "push-register" ? { platform: "ios" } : {}),
+        token,
+      })
+    ).arrayBuffer();
+  };
+  const dispatch = async () => {
+    await (
+      await pushOperation(object, {
+        operation: "push-dispatch",
+        message: {
+          title: "Reminder",
+          collapseKey: "rotation-occurrence",
+        },
+      })
+    ).arrayBuffer();
+    await Promise.all(background.splice(0));
+  };
+  await mutateToken("push-register", "always-failing-token");
+  apnsOutcomes.set("always-failing-token", new Error("offline"));
+
+  let previousRotatedToken: string | undefined;
+  for (let index = 0; index < 40; index++) {
+    if (previousRotatedToken) {
+      await mutateToken("push-unregister", previousRotatedToken);
+    }
+    const rotatedToken = `rotated-token-${index}`;
+    await mutateToken("push-register", rotatedToken);
+    await dispatch();
+    previousRotatedToken = rotatedToken;
+  }
+
+  const ledger = data.get("mobile-push-delivery-ledger") as Record<
+    string,
+    { status: string; acceptedTokens: string[] }
+  >;
+  const entry = Object.values(ledger)[0];
+  expect(entry?.status).toBe("retryable");
+  expect(entry?.acceptedTokens).toHaveLength(1);
+  expect(entry?.acceptedTokens[0]?.length).toBe(64);
+  expect(entry?.acceptedTokens.length).toBeLessThanOrEqual(32);
+});
+
 test("prewarm joins cold hydration without writing a conversation turn", async () => {
   repositoryReads = 0;
   repositoryWrites = 0;

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -426,6 +426,48 @@ test("mobile push registration is durable, idempotent, iOS-only, and removable",
   expect(data.has("mobile-push-tokens")).toBe(false);
 });
 
+test("mobile push register and unregister share exact 4096-character boundaries", async () => {
+  const data = new Map<string, unknown>();
+  const object = new SharedRuntimeConversation(
+    makeState(data, []) as never,
+    {} as never,
+  );
+  const maximumToken = "x".repeat(4_096);
+  const oversizedToken = "x".repeat(4_097);
+
+  const maximumRegistration = await pushOperation(object, {
+    operation: "push-register",
+    platform: "ios",
+    token: maximumToken,
+  });
+  expect(maximumRegistration.status).toBe(201);
+  await maximumRegistration.arrayBuffer();
+
+  const oversizedRegistration = await pushOperation(object, {
+    operation: "push-register",
+    platform: "ios",
+    token: oversizedToken,
+  });
+  expect(oversizedRegistration.status).toBe(400);
+  await oversizedRegistration.arrayBuffer();
+
+  const maximumUnregister = await pushOperation(object, {
+    operation: "push-unregister",
+    token: maximumToken,
+  });
+  expect(maximumUnregister.status).toBe(200);
+  expect((await maximumUnregister.json()) as unknown).toEqual({
+    removed: true,
+  });
+
+  const oversizedUnregister = await pushOperation(object, {
+    operation: "push-unregister",
+    token: oversizedToken,
+  });
+  expect(oversizedUnregister.status).toBe(400);
+  await oversizedUnregister.arrayBuffer();
+});
+
 test("notification dispatch sends iOS tokens and removes APNs-dead records", async () => {
   const data = new Map<string, unknown>();
   const background: Promise<unknown>[] = [];

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -43,6 +43,10 @@ let apnsOutcome: { outcome: string; reason?: string; status?: number } = {
   outcome: "accepted",
 };
 const apnsSentTokens: string[] = [];
+const apnsOutcomes = new Map<
+  string,
+  { outcome: string; reason?: string; status?: number } | Error
+>();
 
 function testMessageIdentity(value: unknown): string {
   const message = value as {
@@ -243,7 +247,9 @@ mock.module("@/lib/mobile-push/apns-provider", () => ({
   CloudApnsProvider: class {
     async send(token: string) {
       apnsSentTokens.push(token);
-      return apnsOutcome;
+      const outcome = apnsOutcomes.get(token) ?? apnsOutcome;
+      if (outcome instanceof Error) throw outcome;
+      return outcome;
     }
   },
 }));
@@ -270,6 +276,7 @@ beforeEach(() => {
   lastBridgeAgent = undefined;
   apnsOutcome = { outcome: "accepted" };
   apnsSentTokens.length = 0;
+  apnsOutcomes.clear();
 });
 
 function makeState(data: Map<string, unknown>, background: Promise<unknown>[]) {
@@ -380,42 +387,45 @@ async function pushOperation(
   );
 }
 
-test("mobile push registration is durable, idempotent, and removable", async () => {
+test("mobile push registration is durable, idempotent, iOS-only, and removable", async () => {
   const data = new Map<string, unknown>();
   const object = new SharedRuntimeConversation(
     makeState(data, []) as never,
     {} as never,
   );
-  for (const platform of ["ios", "ios", "android"] as const) {
+  for (const platform of ["ios", "ios"] as const) {
     const response = await pushOperation(object, {
       operation: "push-register",
       platform,
-      token: platform === "ios" ? "ios-token" : "android-token",
+      token: "ios-token",
     });
     expect(response.status).toBe(201);
     await response.arrayBuffer();
   }
   const list = await pushOperation(object, { operation: "push-list" });
   expect(await list.json()).toMatchObject({
-    tokens: [
-      { token: "ios-token", platform: "ios" },
-      { token: "android-token", platform: "android" },
-    ],
+    tokens: [{ token: "ios-token", platform: "ios" }],
   });
+  const android = await pushOperation(object, {
+    operation: "push-register",
+    platform: "android",
+    token: "android-token",
+  });
+  expect(android.status).toBe(400);
+  await android.arrayBuffer();
   const removed = await pushOperation(object, {
     operation: "push-unregister",
     token: "ios-token",
   });
   expect((await removed.json()) as unknown).toEqual({ removed: true });
-  expect(data.get("mobile-push-tokens")).toEqual([
-    expect.objectContaining({ token: "android-token", platform: "android" }),
-  ]);
+  expect(data.has("mobile-push-tokens")).toBe(false);
 });
 
 test("notification dispatch sends iOS tokens and removes APNs-dead records", async () => {
   const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
   const object = new SharedRuntimeConversation(
-    makeState(data, []) as never,
+    makeState(data, background) as never,
     { ELIZA_APNS_KEY: "configured" } as never,
   );
   await (
@@ -426,9 +436,54 @@ test("notification dispatch sends iOS tokens and removes APNs-dead records", asy
     })
   ).arrayBuffer();
   apnsOutcome = { outcome: "unregistered", reason: "BadDeviceToken" };
-  await makeInvoke(object)("push-event");
+  const dispatched = await pushOperation(object, {
+    operation: "push-dispatch",
+    message: { title: "Reminder", body: "Time to leave" },
+  });
+  expect(dispatched.status).toBe(202);
+  await dispatched.arrayBuffer();
+  await Promise.all(background.splice(0));
   expect(apnsSentTokens).toEqual(["dead-token"]);
   expect(data.has("mobile-push-tokens")).toBe(false);
+});
+
+test("notification dispatch settles every device when one APNs request fails", async () => {
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    { ELIZA_APNS_KEY: "configured" } as never,
+  );
+  for (const token of ["live-token", "dead-token", "network-token"]) {
+    await (
+      await pushOperation(object, {
+        operation: "push-register",
+        platform: "ios",
+        token,
+      })
+    ).arrayBuffer();
+  }
+  apnsOutcomes.set("dead-token", {
+    outcome: "unregistered",
+    reason: "ExpiredToken",
+  });
+  apnsOutcomes.set("network-token", new Error("APNs timeout"));
+
+  const dispatched = await pushOperation(object, {
+    operation: "push-dispatch",
+    message: { title: "Reminder" },
+  });
+  expect(dispatched.status).toBe(202);
+  await dispatched.arrayBuffer();
+  await Promise.all(background.splice(0));
+
+  expect(new Set(apnsSentTokens)).toEqual(
+    new Set(["live-token", "dead-token", "network-token"]),
+  );
+  expect(data.get("mobile-push-tokens")).toEqual([
+    expect.objectContaining({ token: "live-token" }),
+    expect.objectContaining({ token: "network-token" }),
+  ]);
 });
 
 test("prewarm joins cold hydration without writing a conversation turn", async () => {

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -47,6 +47,7 @@ const apnsOutcomes = new Map<
   string,
   { outcome: string; reason?: string; status?: number } | Error
 >();
+const loggerWarn = mock(() => undefined);
 
 function testMessageIdentity(value: unknown): string {
   const message = value as {
@@ -254,11 +255,14 @@ mock.module("@/lib/mobile-push/apns-provider", () => ({
   },
 }));
 mock.module("@/lib/utils/logger", () => ({
-  logger: { warn: mock(() => undefined) },
+  logger: { warn: loggerWarn },
 }));
 
 const { SharedRuntimeConversation } = await import(
   "./shared-runtime-conversation"
+);
+const { coordinateSharedPushDispatch } = await import(
+  "@/lib/services/shared-runtime/conversation-coordinator"
 );
 type SharedRuntimeConversationInstance = InstanceType<
   typeof SharedRuntimeConversation
@@ -277,6 +281,7 @@ beforeEach(() => {
   apnsOutcome = { outcome: "accepted" };
   apnsSentTokens.length = 0;
   apnsOutcomes.clear();
+  loggerWarn.mockClear();
 });
 
 function makeState(data: Map<string, unknown>, background: Promise<unknown>[]) {
@@ -447,6 +452,46 @@ test("notification dispatch sends iOS tokens and removes APNs-dead records", asy
   expect(data.has("mobile-push-tokens")).toBe(false);
 });
 
+test("real coordinator namespace dispatch reaches the durable APNs provider path", async () => {
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    { ELIZA_APNS_KEY: "configured" } as never,
+  );
+  await (
+    await pushOperation(object, {
+      operation: "push-register",
+      platform: "ios",
+      token: "coordinated-token",
+    })
+  ).arrayBuffer();
+  const names: string[] = [];
+  const namespace = {
+    getByName(name: string) {
+      names.push(name);
+      return {
+        fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+          object.fetch(new Request(input, init)),
+      };
+    },
+  };
+
+  await coordinateSharedPushDispatch(
+    AGENT_FIXTURE.id,
+    {
+      title: "Reminder",
+      collapseKey: "scheduled-occurrence",
+      data: { notificationId: "scheduled-occurrence" },
+    },
+    { namespace: namespace as never },
+  );
+  await Promise.all(background.splice(0));
+
+  expect(names).toEqual([`${AGENT_FIXTURE.id}:${AGENT_FIXTURE.id}`]);
+  expect(apnsSentTokens).toEqual(["coordinated-token"]);
+});
+
 test("notification dispatch settles every device when one APNs request fails", async () => {
   const data = new Map<string, unknown>();
   const background: Promise<unknown>[] = [];
@@ -483,6 +528,142 @@ test("notification dispatch settles every device when one APNs request fails", a
   expect(data.get("mobile-push-tokens")).toEqual([
     expect.objectContaining({ token: "live-token" }),
     expect.objectContaining({ token: "network-token" }),
+  ]);
+});
+
+test("accepted occurrence replay is suppressed by the bounded durable ledger", async () => {
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    { ELIZA_APNS_KEY: "configured" } as never,
+  );
+  await (
+    await pushOperation(object, {
+      operation: "push-register",
+      platform: "ios",
+      token: "live-token",
+    })
+  ).arrayBuffer();
+  const dispatch = async () => {
+    await (
+      await pushOperation(object, {
+        operation: "push-dispatch",
+        message: {
+          title: "Reminder",
+          collapseKey: "reminder-occurrence-1",
+        },
+      })
+    ).arrayBuffer();
+    await Promise.all(background.splice(0));
+  };
+
+  await dispatch();
+  await dispatch();
+
+  expect(apnsSentTokens).toEqual(["live-token"]);
+  const ledger = data.get("mobile-push-delivery-ledger") as Record<
+    string,
+    { status: string }
+  >;
+  expect(Object.keys(ledger)).toHaveLength(1);
+  expect(Object.keys(ledger)[0]?.length).toBe(64);
+  expect(Object.values(ledger)[0]?.status).toBe("accepted");
+});
+
+test("concurrent occurrence ledgers merge without storing raw maximum-length tokens", async () => {
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    { ELIZA_APNS_KEY: "configured" } as never,
+  );
+  const token = "sensitive-token-".padEnd(4_096, "x");
+  await (
+    await pushOperation(object, {
+      operation: "push-register",
+      platform: "ios",
+      token,
+    })
+  ).arrayBuffer();
+  const enqueue = async (collapseKey: string) =>
+    await (
+      await pushOperation(object, {
+        operation: "push-dispatch",
+        message: { title: "Reminder", collapseKey },
+      })
+    ).arrayBuffer();
+
+  await Promise.all([enqueue("occurrence-a"), enqueue("occurrence-b")]);
+  await Promise.all(background.splice(0));
+  await Promise.all([enqueue("occurrence-a"), enqueue("occurrence-b")]);
+  await Promise.all(background.splice(0));
+
+  expect(apnsSentTokens).toHaveLength(2);
+  const ledgerJson = JSON.stringify(data.get("mobile-push-delivery-ledger"));
+  expect(ledgerJson).not.toContain("sensitive-token-");
+  expect(new TextEncoder().encode(ledgerJson).length).toBeLessThan(1_024);
+  const ledger = data.get("mobile-push-delivery-ledger") as Record<
+    string,
+    { acceptedTokens: string[] }
+  >;
+  expect(Object.keys(ledger)).toHaveLength(2);
+  for (const entry of Object.values(ledger)) {
+    expect(entry.acceptedTokens).toHaveLength(1);
+    expect(entry.acceptedTokens[0]?.length).toBe(64);
+  }
+});
+
+test("retry sends only unsettled devices and never logs an APNs token URL", async () => {
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    { ELIZA_APNS_KEY: "configured" } as never,
+  );
+  for (const token of ["accepted-token", "private-device-token"]) {
+    await (
+      await pushOperation(object, {
+        operation: "push-register",
+        platform: "ios",
+        token,
+      })
+    ).arrayBuffer();
+  }
+  apnsOutcomes.set(
+    "private-device-token",
+    new Error(
+      "fetch failed https://api.push.apple.com/3/device/private-device-token",
+    ),
+  );
+  const dispatch = async () => {
+    await (
+      await pushOperation(object, {
+        operation: "push-dispatch",
+        message: {
+          title: "Reminder",
+          collapseKey: "reminder-occurrence-2",
+        },
+      })
+    ).arrayBuffer();
+    await Promise.all(background.splice(0));
+  };
+
+  await dispatch();
+  expect(JSON.stringify(loggerWarn.mock.calls)).not.toContain(
+    "private-device-token",
+  );
+  expect(JSON.stringify(loggerWarn.mock.calls)).not.toContain(
+    "api.push.apple.com",
+  );
+  expect(JSON.stringify(loggerWarn.mock.calls)).toContain("1 transport");
+
+  apnsOutcomes.delete("private-device-token");
+  await dispatch();
+  expect(apnsSentTokens).toEqual([
+    "accepted-token",
+    "private-device-token",
+    "private-device-token",
   ]);
 });
 

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -158,6 +158,24 @@ const PROVISIONAL_CONVERGENCE_IMPORT_PREFIX =
 const RETRY_DELAY_MS = 30_000;
 const MOBILE_PUSH_TOKENS_KEY = "mobile-push-tokens";
 const MAX_MOBILE_PUSH_TOKENS = 32;
+const MOBILE_PUSH_DELIVERY_LEDGER_KEY = "mobile-push-delivery-ledger";
+const MAX_MOBILE_PUSH_DELIVERY_LEDGER_ENTRIES = 128;
+const MOBILE_PUSH_PENDING_RETRY_MS = 2 * 60 * 1000;
+
+interface MobilePushDeliveryLedgerEntry {
+  status: "pending" | "retryable" | "accepted";
+  acceptedTokens: string[];
+  updatedAt: number;
+}
+
+async function mobilePushLedgerDigest(value: string): Promise<string> {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value)),
+  );
+  return Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
 
 /**
  * Retention lifecycle (#17006). The single DO alarm is multiplexed across two
@@ -310,7 +328,12 @@ export class SharedRuntimeConversation {
   private queue: Promise<void> = Promise.resolve();
   private mirrorQueue: Promise<void> = Promise.resolve();
   private alarmMutationQueue: Promise<void> = Promise.resolve();
+  private mobilePushLedgerQueue: Promise<void> = Promise.resolve();
   private apnsProvider: CloudApnsProvider | undefined;
+  private readonly activeMobilePushDispatches = new Map<
+    string,
+    Promise<void>
+  >();
   // Instance field rather than a direct constant read so the deterministic
   // unit harness can shorten the stall window without a real two-minute wait.
   private streamStallTimeoutMs = STREAM_STALL_TIMEOUT_MS;
@@ -532,43 +555,146 @@ export class SharedRuntimeConversation {
     else await this.state.storage.delete(MOBILE_PUSH_TOKENS_KEY);
   }
 
-  private async dispatchMobilePush(message: MobilePushMessage): Promise<void> {
+  private async mobilePushDeliveryLedger(): Promise<
+    Record<string, MobilePushDeliveryLedgerEntry>
+  > {
+    return (
+      (await this.state.storage.get<
+        Record<string, MobilePushDeliveryLedgerEntry>
+      >(MOBILE_PUSH_DELIVERY_LEDGER_KEY)) ?? {}
+    );
+  }
+
+  private async saveMobilePushDeliveryLedger(
+    ledger: Record<string, MobilePushDeliveryLedgerEntry>,
+  ): Promise<void> {
+    const bounded = Object.fromEntries(
+      Object.entries(ledger)
+        .sort(([, left], [, right]) => right.updatedAt - left.updatedAt)
+        .slice(0, MAX_MOBILE_PUSH_DELIVERY_LEDGER_ENTRIES),
+    );
+    await this.state.storage.put(MOBILE_PUSH_DELIVERY_LEDGER_KEY, bounded);
+  }
+
+  private async mutateMobilePushDeliveryLedger<T>(
+    operation: (
+      ledger: Record<string, MobilePushDeliveryLedgerEntry>,
+    ) => Promise<T> | T,
+  ): Promise<T> {
+    let release = () => {};
+    const previous = this.mobilePushLedgerQueue;
+    this.mobilePushLedgerQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      const ledger = await this.mobilePushDeliveryLedger();
+      const result = await operation(ledger);
+      await this.saveMobilePushDeliveryLedger(ledger);
+      return result;
+    } finally {
+      release();
+    }
+  }
+
+  private async performMobilePushDispatch(
+    message: MobilePushMessage,
+  ): Promise<void> {
     const config = resolveCloudApnsConfig(this.env);
     if (!config) return;
     this.apnsProvider ??= new CloudApnsProvider(config);
     const provider = this.apnsProvider;
-    const records = (await this.mobilePushTokens()).filter(
+    let records = (await this.mobilePushTokens()).filter(
       (record) => record.platform === "ios",
     );
+    let ledgerId: string | undefined;
+    let acceptedTokenIds = new Set<string>();
+    const recordTokenIds = await Promise.all(
+      records.map((record) => mobilePushLedgerDigest(record.token)),
+    );
+    if (message.collapseKey) {
+      ledgerId = await mobilePushLedgerDigest(message.collapseKey);
+      const claim = await this.mutateMobilePushDeliveryLedger((ledger) => {
+        const existing = ledger[ledgerId!];
+        const now = Date.now();
+        const suppress =
+          existing?.status === "accepted" ||
+          (existing?.status === "pending" &&
+            now - existing.updatedAt < MOBILE_PUSH_PENDING_RETRY_MS);
+        if (suppress) return { suppress: true, acceptedTokenIds: [] };
+        const previouslyAccepted = existing?.acceptedTokens ?? [];
+        ledger[ledgerId!] = {
+          status: "pending",
+          acceptedTokens: previouslyAccepted,
+          updatedAt: now,
+        };
+        return { suppress: false, acceptedTokenIds: previouslyAccepted };
+      });
+      if (claim.suppress) return;
+      acceptedTokenIds = new Set(claim.acceptedTokenIds);
+      records = records.filter(
+        (_record, index) => !acceptedTokenIds.has(recordTokenIds[index]),
+      );
+    }
     const attempts = await Promise.allSettled(
       records.map((record) => provider.send(record.token, message)),
     );
     const staleTokens = new Set<string>();
-    const rejections: string[] = [];
+    const settledTokenIds = new Set(acceptedTokenIds);
+    let transportFailures = 0;
+    let providerRejections = 0;
     for (const [index, attempt] of attempts.entries()) {
       if (attempt.status === "rejected") {
-        rejections.push(
-          attempt.reason instanceof Error
-            ? attempt.reason.message
-            : String(attempt.reason),
-        );
+        transportFailures++;
         continue;
       }
       const result = attempt.value;
       if (result.outcome === "unregistered") {
         staleTokens.add(records[index].token);
+        settledTokenIds.add(await mobilePushLedgerDigest(records[index].token));
+      } else if (result.outcome === "accepted") {
+        settledTokenIds.add(await mobilePushLedgerDigest(records[index].token));
       } else if (result.outcome === "rejected") {
-        rejections.push(
-          `${result.status}${result.reason ? ` ${result.reason}` : ""}`,
-        );
+        providerRejections++;
       }
     }
     await this.unregisterMobilePushTokens(staleTokens);
-    if (rejections.length > 0) {
+    if (ledgerId) {
+      await this.mutateMobilePushDeliveryLedger((ledger) => {
+        const currentAccepted = ledger[ledgerId!]?.acceptedTokens ?? [];
+        ledger[ledgerId!] = {
+          status:
+            transportFailures + providerRejections === 0
+              ? "accepted"
+              : "retryable",
+          acceptedTokens: [
+            ...new Set([...currentAccepted, ...settledTokenIds]),
+          ],
+          updatedAt: Date.now(),
+        };
+      });
+    }
+    if (transportFailures + providerRejections > 0) {
       throw new Error(
-        `[SharedRuntimeConversation] APNs rejected ${rejections.length} notification delivery attempt(s): ${rejections.join(", ")}`,
+        `[SharedRuntimeConversation] APNs delivery failed (${transportFailures} transport, ${providerRejections} provider rejection)`,
       );
     }
+  }
+
+  private async dispatchMobilePush(message: MobilePushMessage): Promise<void> {
+    if (!message.collapseKey)
+      return await this.performMobilePushDispatch(message);
+    const active = this.activeMobilePushDispatches.get(message.collapseKey);
+    if (active) return await active;
+    const dispatch = this.performMobilePushDispatch(message).finally(() => {
+      if (
+        this.activeMobilePushDispatches.get(message.collapseKey!) === dispatch
+      ) {
+        this.activeMobilePushDispatches.delete(message.collapseKey!);
+      }
+    });
+    this.activeMobilePushDispatches.set(message.collapseKey, dispatch);
+    return await dispatch;
   }
 
   private enqueueMobilePush(message: MobilePushMessage): void {

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -10,10 +10,11 @@ import {
   CloudApnsProvider,
   resolveCloudApnsConfig,
 } from "@/lib/mobile-push/apns-provider";
-import type {
-  MobilePushMessage,
-  MobilePushPlatform,
-  MobilePushTokenRecord,
+import {
+  MAX_MOBILE_PUSH_TOKEN_CHARACTERS,
+  type MobilePushMessage,
+  type MobilePushPlatform,
+  type MobilePushTokenRecord,
 } from "@/lib/mobile-push/types";
 import type { BridgeRequest } from "@/lib/services/eliza-sandbox";
 import type { CachedAgentSandbox } from "@/lib/services/shared-runtime/cached-agent-dates";
@@ -1057,7 +1058,11 @@ export class SharedRuntimeConversation {
     }
     if (payload.operation === "push-register") {
       const token = payload.token?.trim();
-      if (payload.platform !== "ios" || !token || token.length > 4096) {
+      if (
+        payload.platform !== "ios" ||
+        !token ||
+        token.length > MAX_MOBILE_PUSH_TOKEN_CHARACTERS
+      ) {
         return Response.json(
           { success: false, error: "Invalid mobile push registration" },
           { status: 400 },
@@ -1068,7 +1073,7 @@ export class SharedRuntimeConversation {
     }
     if (payload.operation === "push-unregister") {
       const token = payload.token?.trim();
-      if (!token) {
+      if (!token || token.length > MAX_MOBILE_PUSH_TOKEN_CHARACTERS) {
         return Response.json(
           { success: false, error: "Invalid mobile push token" },
           { status: 400 },

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -6,6 +6,15 @@
  * and updated asynchronously as a recoverable reporting/backup mirror.
  */
 
+import {
+  CloudApnsProvider,
+  resolveCloudApnsConfig,
+} from "@/lib/mobile-push/apns-provider";
+import type {
+  MobilePushMessage,
+  MobilePushPlatform,
+  MobilePushTokenRecord,
+} from "@/lib/mobile-push/types";
 import type { BridgeRequest } from "@/lib/services/eliza-sandbox";
 import type { CachedAgentSandbox } from "@/lib/services/shared-runtime/cached-agent-dates";
 import type { SharedTurnMessage } from "@/lib/services/shared-runtime/run-shared-agent-turn";
@@ -67,6 +76,14 @@ type ConversationRequest =
       roomId: string;
       event: { id: string; content: string; createdAt: number };
     }
+  | { operation: "push-list"; agentId: string }
+  | {
+      operation: "push-register";
+      agentId: string;
+      platform: MobilePushPlatform;
+      token: string;
+    }
+  | { operation: "push-unregister"; agentId: string; token: string }
   | {
       operation: "cutover-seal";
       agentId: string;
@@ -138,6 +155,8 @@ const PROVISIONAL_CONVERGENCE_ALIAS_KEY =
 const PROVISIONAL_CONVERGENCE_IMPORT_PREFIX =
   "personal-provisional-convergence-import:";
 const RETRY_DELAY_MS = 30_000;
+const MOBILE_PUSH_TOKENS_KEY = "mobile-push-tokens";
+const MAX_MOBILE_PUSH_TOKENS = 32;
 
 /**
  * Retention lifecycle (#17006). The single DO alarm is multiplexed across two
@@ -290,6 +309,7 @@ export class SharedRuntimeConversation {
   private queue: Promise<void> = Promise.resolve();
   private mirrorQueue: Promise<void> = Promise.resolve();
   private alarmMutationQueue: Promise<void> = Promise.resolve();
+  private apnsProvider: CloudApnsProvider | undefined;
   // Instance field rather than a direct constant read so the deterministic
   // unit harness can shorten the stall window without a real two-minute wait.
   private streamStallTimeoutMs = STREAM_STALL_TIMEOUT_MS;
@@ -461,6 +481,66 @@ export class SharedRuntimeConversation {
         DELETION_TOMBSTONE_KEY,
       )) ?? null
     );
+  }
+
+  private async mobilePushTokens(): Promise<MobilePushTokenRecord[]> {
+    const stored =
+      (await this.state.storage.get<MobilePushTokenRecord[]>(
+        MOBILE_PUSH_TOKENS_KEY,
+      )) ?? [];
+    return stored.filter(
+      (record) =>
+        typeof record?.token === "string" &&
+        (record.platform === "ios" || record.platform === "android") &&
+        typeof record.createdAt === "number",
+    );
+  }
+
+  private async registerMobilePushToken(
+    platform: MobilePushPlatform,
+    token: string,
+  ): Promise<void> {
+    const current = await this.mobilePushTokens();
+    const next = current.filter((record) => record.token !== token);
+    next.push({ platform, token, createdAt: Date.now() });
+    await this.state.storage.put(
+      MOBILE_PUSH_TOKENS_KEY,
+      next.slice(-MAX_MOBILE_PUSH_TOKENS),
+    );
+  }
+
+  private async unregisterMobilePushToken(token: string): Promise<boolean> {
+    const current = await this.mobilePushTokens();
+    const next = current.filter((record) => record.token !== token);
+    if (next.length === current.length) return false;
+    if (next.length > 0)
+      await this.state.storage.put(MOBILE_PUSH_TOKENS_KEY, next);
+    else await this.state.storage.delete(MOBILE_PUSH_TOKENS_KEY);
+    return true;
+  }
+
+  private async dispatchMobilePush(message: MobilePushMessage): Promise<void> {
+    const config = resolveCloudApnsConfig(this.env);
+    if (!config) return;
+    this.apnsProvider ??= new CloudApnsProvider(config);
+    const rejections: string[] = [];
+    for (const record of await this.mobilePushTokens()) {
+      if (record.platform !== "ios") continue;
+      const result = await this.apnsProvider.send(record.token, message);
+      if (result.outcome === "unregistered") {
+        await this.unregisterMobilePushToken(record.token);
+      }
+      if (result.outcome === "rejected") {
+        rejections.push(
+          `${result.status}${result.reason ? ` ${result.reason}` : ""}`,
+        );
+      }
+    }
+    if (rejections.length > 0) {
+      throw new Error(
+        `[SharedRuntimeConversation] APNs rejected ${rejections.length} notification delivery attempt(s): ${rejections.join(", ")}`,
+      );
+    }
   }
 
   private async mirrorConversation(
@@ -790,6 +870,36 @@ export class SharedRuntimeConversation {
         },
         { status: 410 },
       );
+    }
+    if (payload.operation === "push-list") {
+      return Response.json({ tokens: await this.mobilePushTokens() });
+    }
+    if (payload.operation === "push-register") {
+      const token = payload.token?.trim();
+      if (
+        (payload.platform !== "ios" && payload.platform !== "android") ||
+        !token ||
+        token.length > 4096
+      ) {
+        return Response.json(
+          { success: false, error: "Invalid mobile push registration" },
+          { status: 400 },
+        );
+      }
+      await this.registerMobilePushToken(payload.platform, token);
+      return Response.json({ success: true }, { status: 201 });
+    }
+    if (payload.operation === "push-unregister") {
+      const token = payload.token?.trim();
+      if (!token) {
+        return Response.json(
+          { success: false, error: "Invalid mobile push token" },
+          { status: 400 },
+        );
+      }
+      return Response.json({
+        removed: await this.unregisterMobilePushToken(token),
+      });
     }
     const personal =
       payload.operation === "personal-bridge" ||
@@ -1334,6 +1444,9 @@ export class SharedRuntimeConversation {
           trustedMessageRole: payload.trustedMessageRole,
           trustedUserUtterance: payload.trustedUserUtterance,
           executionEngine,
+          mobilePushDispatch: async (message: MobilePushMessage) => {
+            await this.dispatchMobilePush(message);
+          },
         });
       }
       const result = await sharedRuntimeChatService.bridge(agent, payload.rpc, {
@@ -1344,6 +1457,9 @@ export class SharedRuntimeConversation {
         trustedMessageRole: payload.trustedMessageRole,
         trustedUserUtterance: payload.trustedUserUtterance,
         executionEngine,
+        mobilePushDispatch: async (message: MobilePushMessage) => {
+          await this.dispatchMobilePush(message);
+        },
       });
       return Response.json(result);
     });

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -84,6 +84,7 @@ type ConversationRequest =
       token: string;
     }
   | { operation: "push-unregister"; agentId: string; token: string }
+  | { operation: "push-dispatch"; agentId: string; message: MobilePushMessage }
   | {
       operation: "cutover-seal";
       agentId: string;
@@ -519,28 +520,68 @@ export class SharedRuntimeConversation {
     return true;
   }
 
+  private async unregisterMobilePushTokens(
+    tokens: ReadonlySet<string>,
+  ): Promise<void> {
+    if (tokens.size === 0) return;
+    const current = await this.mobilePushTokens();
+    const next = current.filter((record) => !tokens.has(record.token));
+    if (next.length === current.length) return;
+    if (next.length > 0)
+      await this.state.storage.put(MOBILE_PUSH_TOKENS_KEY, next);
+    else await this.state.storage.delete(MOBILE_PUSH_TOKENS_KEY);
+  }
+
   private async dispatchMobilePush(message: MobilePushMessage): Promise<void> {
     const config = resolveCloudApnsConfig(this.env);
     if (!config) return;
     this.apnsProvider ??= new CloudApnsProvider(config);
+    const provider = this.apnsProvider;
+    const records = (await this.mobilePushTokens()).filter(
+      (record) => record.platform === "ios",
+    );
+    const attempts = await Promise.allSettled(
+      records.map((record) => provider.send(record.token, message)),
+    );
+    const staleTokens = new Set<string>();
     const rejections: string[] = [];
-    for (const record of await this.mobilePushTokens()) {
-      if (record.platform !== "ios") continue;
-      const result = await this.apnsProvider.send(record.token, message);
-      if (result.outcome === "unregistered") {
-        await this.unregisterMobilePushToken(record.token);
+    for (const [index, attempt] of attempts.entries()) {
+      if (attempt.status === "rejected") {
+        rejections.push(
+          attempt.reason instanceof Error
+            ? attempt.reason.message
+            : String(attempt.reason),
+        );
+        continue;
       }
-      if (result.outcome === "rejected") {
+      const result = attempt.value;
+      if (result.outcome === "unregistered") {
+        staleTokens.add(records[index].token);
+      } else if (result.outcome === "rejected") {
         rejections.push(
           `${result.status}${result.reason ? ` ${result.reason}` : ""}`,
         );
       }
     }
+    await this.unregisterMobilePushTokens(staleTokens);
     if (rejections.length > 0) {
       throw new Error(
         `[SharedRuntimeConversation] APNs rejected ${rejections.length} notification delivery attempt(s): ${rejections.join(", ")}`,
       );
     }
+  }
+
+  private enqueueMobilePush(message: MobilePushMessage): void {
+    this.state.waitUntil(
+      this.dispatchMobilePush(message).catch(async (error: unknown) => {
+        // error-policy:J7 APNs fan-out is observed after the owning response;
+        // it must not hold the conversation's serialization lock.
+        const { logger } = await import("@/lib/utils/logger");
+        logger.warn("[SharedRuntimeConversation] mobile push dispatch failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }),
+    );
   }
 
   private async mirrorConversation(
@@ -876,11 +917,7 @@ export class SharedRuntimeConversation {
     }
     if (payload.operation === "push-register") {
       const token = payload.token?.trim();
-      if (
-        (payload.platform !== "ios" && payload.platform !== "android") ||
-        !token ||
-        token.length > 4096
-      ) {
+      if (payload.platform !== "ios" || !token || token.length > 4096) {
         return Response.json(
           { success: false, error: "Invalid mobile push registration" },
           { status: 400 },
@@ -900,6 +937,20 @@ export class SharedRuntimeConversation {
       return Response.json({
         removed: await this.unregisterMobilePushToken(token),
       });
+    }
+    if (payload.operation === "push-dispatch") {
+      if (
+        !payload.message ||
+        typeof payload.message.title !== "string" ||
+        !payload.message.title.trim()
+      ) {
+        return Response.json(
+          { success: false, error: "Invalid mobile push message" },
+          { status: 400 },
+        );
+      }
+      this.enqueueMobilePush(payload.message);
+      return Response.json({ success: true }, { status: 202 });
     }
     const personal =
       payload.operation === "personal-bridge" ||
@@ -1444,9 +1495,11 @@ export class SharedRuntimeConversation {
           trustedMessageRole: payload.trustedMessageRole,
           trustedUserUtterance: payload.trustedUserUtterance,
           executionEngine,
-          mobilePushDispatch: async (message: MobilePushMessage) => {
-            await this.dispatchMobilePush(message);
-          },
+          mobilePushDispatch: personal
+            ? async (message: MobilePushMessage) => {
+                this.enqueueMobilePush(message);
+              }
+            : undefined,
         });
       }
       const result = await sharedRuntimeChatService.bridge(agent, payload.rpc, {
@@ -1457,9 +1510,11 @@ export class SharedRuntimeConversation {
         trustedMessageRole: payload.trustedMessageRole,
         trustedUserUtterance: payload.trustedUserUtterance,
         executionEngine,
-        mobilePushDispatch: async (message: MobilePushMessage) => {
-          await this.dispatchMobilePush(message);
-        },
+        mobilePushDispatch: personal
+          ? async (message: MobilePushMessage) => {
+              this.enqueueMobilePush(message);
+            }
+          : undefined,
       });
       return Response.json(result);
     });

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -612,6 +612,7 @@ export class SharedRuntimeConversation {
     const recordTokenIds = await Promise.all(
       records.map((record) => mobilePushLedgerDigest(record.token)),
     );
+    const currentTokenIds = new Set(recordTokenIds);
     if (message.collapseKey) {
       ledgerId = await mobilePushLedgerDigest(message.collapseKey);
       const claim = await this.mutateMobilePushDeliveryLedger((ledger) => {
@@ -622,7 +623,13 @@ export class SharedRuntimeConversation {
           (existing?.status === "pending" &&
             now - existing.updatedAt < MOBILE_PUSH_PENDING_RETRY_MS);
         if (suppress) return { suppress: true, acceptedTokenIds: [] };
-        const previouslyAccepted = existing?.acceptedTokens ?? [];
+        const previouslyAccepted = [
+          ...new Set(
+            (existing?.acceptedTokens ?? []).filter((tokenId) =>
+              currentTokenIds.has(tokenId),
+            ),
+          ),
+        ].slice(-MAX_MOBILE_PUSH_TOKENS);
         ledger[ledgerId!] = {
           status: "pending",
           acceptedTokens: previouslyAccepted,
@@ -660,6 +667,13 @@ export class SharedRuntimeConversation {
     }
     await this.unregisterMobilePushTokens(staleTokens);
     if (ledgerId) {
+      const registeredTokenIds = new Set(
+        await Promise.all(
+          (await this.mobilePushTokens())
+            .filter((record) => record.platform === "ios")
+            .map((record) => mobilePushLedgerDigest(record.token)),
+        ),
+      );
       await this.mutateMobilePushDeliveryLedger((ledger) => {
         const currentAccepted = ledger[ledgerId!]?.acceptedTokens ?? [];
         ledger[ledgerId!] = {
@@ -667,9 +681,9 @@ export class SharedRuntimeConversation {
             transportFailures + providerRejections === 0
               ? "accepted"
               : "retryable",
-          acceptedTokens: [
-            ...new Set([...currentAccepted, ...settledTokenIds]),
-          ],
+          acceptedTokens: [...new Set([...currentAccepted, ...settledTokenIds])]
+            .filter((tokenId) => registeredTokenIds.has(tokenId))
+            .slice(-MAX_MOBILE_PUSH_TOKENS),
           updatedAt: Date.now(),
         };
       });

--- a/packages/cloud/api/test/fixtures/apns-provider-worker.ts
+++ b/packages/cloud/api/test/fixtures/apns-provider-worker.ts
@@ -1,0 +1,102 @@
+/** Exercises the cloud APNs provider inside Workerd without external network access or credentials. */
+
+import {
+  CloudApnsProvider,
+  ELIZA_IOS_BUNDLE_ID,
+  resolveCloudApnsConfig,
+} from "../../../shared/src/lib/mobile-push/apns-provider";
+
+function base64urlBytes(value: string): Uint8Array {
+  const padded = value
+    .replaceAll("-", "+")
+    .replaceAll("_", "/")
+    .padEnd(Math.ceil(value.length / 4) * 4, "=");
+  return Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+}
+
+function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return Uint8Array.from(bytes).buffer;
+}
+
+function pem(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  const body =
+    btoa(binary)
+      .match(/.{1,64}/g)
+      ?.join("\n") ?? "";
+  return `-----BEGIN PRIVATE KEY-----\n${body}\n-----END PRIVATE KEY-----`;
+}
+
+export default {
+  async fetch(): Promise<Response> {
+    const { privateKey, publicKey } = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      true,
+      ["sign", "verify"],
+    );
+    const config = resolveCloudApnsConfig({
+      ELIZA_APNS_KEY: pem(
+        new Uint8Array(await crypto.subtle.exportKey("pkcs8", privateKey)),
+      ),
+      ELIZA_APNS_KEY_ID: "WORKERKEY",
+      ELIZA_APNS_TEAM_ID: "WORKERTEAM",
+      ELIZA_APNS_TOPIC: ELIZA_IOS_BUNDLE_ID,
+      ELIZA_APNS_PRODUCTION: "0",
+    });
+    if (!config)
+      throw new Error("Workerd APNs fixture configuration was absent");
+
+    const requests: Array<{
+      authorization: string;
+      collapseId: string | null;
+      url: string;
+    }> = [];
+    const request = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      requests.push({
+        authorization: headers.get("authorization") ?? "",
+        collapseId: headers.get("apns-collapse-id"),
+        url: String(input),
+      });
+      return new Response(null, {
+        status: 200,
+        headers: { "apns-id": "workerd-accepted" },
+      });
+    }) as unknown as typeof fetch;
+    const provider = new CloudApnsProvider(config, request);
+    const now = 1_800_000_000_000;
+    const results = await Promise.all(
+      Array.from({ length: 4 }, (_, index) =>
+        provider.send(
+          `device-${index}`,
+          { title: "Ready", collapseKey: "reminder:occurrence-1" },
+          now,
+        ),
+      ),
+    );
+    const jwt = requests[0]?.authorization.replace("bearer ", "") ?? "";
+    const [header, payload, signature] = jwt.split(".");
+    const verified = await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" },
+      publicKey,
+      arrayBuffer(base64urlBytes(signature ?? "")),
+      new TextEncoder().encode(`${header}.${payload}`),
+    );
+    return Response.json({
+      accepted: results.every(
+        (result) =>
+          result.outcome === "accepted" && result.apnsId === "workerd-accepted",
+      ),
+      collapseIds: [...new Set(requests.map((request) => request.collapseId))],
+      jwtHeaders: [
+        ...new Set(requests.map((request) => request.authorization)),
+      ],
+      sandbox: requests.every((request) =>
+        request.url.startsWith("https://api.sandbox.push.apple.com/3/device/"),
+      ),
+      topic: config.topic,
+      verified,
+    });
+  },
+};

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -17,6 +17,11 @@
 import { type Context, Hono } from "hono";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
+  coordinateSharedPushList,
+  coordinateSharedPushRegister,
+  coordinateSharedPushUnregister,
+} from "@/lib/services/shared-runtime/conversation-coordinator";
+import {
   resolveSharedAgent,
   resolveSharedRuntimeWorkerRequestContext,
 } from "@/lib/services/shared-runtime/resolve-shared-agent";
@@ -43,6 +48,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 import { workflowRuntimeUnavailableResponse } from "../../workflows/_shared";
 
 const CORS_METHODS = "GET, POST, PUT, DELETE, OPTIONS";
+const MAX_PUSH_REGISTRATION_BODY_BYTES = 8_192;
 
 const app = new Hono<AppEnv>();
 
@@ -81,6 +87,17 @@ function viewNavigateTarget(path: string): string | null {
 function greetingConversationId(path: string): string | null {
   const m = /^conversations\/([^/]+)\/greeting$/.exec(path);
   return m ? decodeURIComponent(m[1]) : null;
+}
+
+function pushTokenDeleteTarget(path: string): string | null {
+  const prefix = "notifications/push-tokens/";
+  if (!path.startsWith(prefix)) return null;
+  const encoded = path.slice(prefix.length);
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -196,6 +213,20 @@ app.get("/", async (c) => {
   if ("error" in r) {
     return json(c, { success: false, error: r.error }, r.status);
   }
+  if (path === "notifications/push-tokens") {
+    const worker = resolveSharedRuntimeWorkerRequestContext(c);
+    if ("error" in worker) return json(c, worker, worker.status);
+    const tokens = await coordinateSharedPushList(r.agentId, {
+      namespace: worker.namespace,
+    });
+    return json(c, {
+      count: tokens.length,
+      platforms: {
+        ios: tokens.filter((token) => token.platform === "ios").length,
+        android: tokens.filter((token) => token.platform === "android").length,
+      },
+    });
+  }
   // The app's workflow clients use the full-runtime compatibility paths. A
   // shared agent cannot serve them, so surface the same typed capability gate
   // as the canonical `/workflows` proxy instead of an unrelated shell 404.
@@ -245,6 +276,45 @@ app.post("/", async (c) => {
     return json(c, { success: false, error: r.error }, r.status);
   }
   const path = shellPath(c);
+  if (path === "notifications/push-tokens") {
+    const worker = resolveSharedRuntimeWorkerRequestContext(c);
+    if ("error" in worker) return json(c, worker, worker.status);
+    const contentLength = Number(c.req.header("content-length") ?? 0);
+    if (
+      Number.isFinite(contentLength) &&
+      contentLength > MAX_PUSH_REGISTRATION_BODY_BYTES
+    ) {
+      return json(c, { success: false, error: "Request body too large" }, 413);
+    }
+    const rawBody = await c.req.text();
+    if (
+      new TextEncoder().encode(rawBody).length >
+      MAX_PUSH_REGISTRATION_BODY_BYTES
+    ) {
+      return json(c, { success: false, error: "Request body too large" }, 413);
+    }
+    let body: { platform?: unknown; token?: unknown } | null = null;
+    try {
+      body = JSON.parse(rawBody) as { platform?: unknown; token?: unknown };
+    } catch {
+      // error-policy:J3 malformed client JSON is an explicit invalid request.
+    }
+    const platform = body?.platform;
+    const token = typeof body?.token === "string" ? body.token.trim() : "";
+    if ((platform !== "ios" && platform !== "android") || !token) {
+      return json(
+        c,
+        { success: false, error: "Invalid mobile push registration" },
+        400,
+      );
+    }
+    await coordinateSharedPushRegister(
+      r.agentId,
+      { platform, token },
+      { namespace: worker.namespace },
+    );
+    return json(c, { ok: true }, 201);
+  }
   if (isWorkflowApiPath(path)) {
     return workflowUnavailable(c, r.agentId, r.agent.execution_tier);
   }
@@ -291,6 +361,24 @@ async function handleWorkflowMutation(c: Context<AppEnv>): Promise<Response> {
   const r = await resolveSharedAgent(c);
   if ("error" in r) {
     return json(c, { success: false, error: r.error }, r.status);
+  }
+  if (c.req.method === "DELETE") {
+    const token = pushTokenDeleteTarget(shellPath(c));
+    if (token !== null) {
+      if (!token)
+        return json(
+          c,
+          { success: false, error: "Invalid mobile push token" },
+          400,
+        );
+      const worker = resolveSharedRuntimeWorkerRequestContext(c);
+      if ("error" in worker) return json(c, worker, worker.status);
+      return json(c, {
+        ok: await coordinateSharedPushUnregister(r.agentId, token, {
+          namespace: worker.namespace,
+        }),
+      });
+    }
   }
   if (isWorkflowApiPath(shellPath(c))) {
     return workflowUnavailable(c, r.agentId, r.agent.execution_tier);

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -100,6 +100,28 @@ function pushTokenDeleteTarget(path: string): string | null {
   }
 }
 
+function isPersonalSharedAgent(
+  value: Awaited<ReturnType<typeof resolveSharedAgent>>,
+): boolean {
+  return (
+    !("error" in value) &&
+    "agentKind" in value &&
+    value.agentKind === "personal"
+  );
+}
+
+function personalPushUnavailable(c: Context<AppEnv>): Response {
+  return json(
+    c,
+    {
+      success: false,
+      error: "Mobile push is available only for Personal Shared agents",
+      code: "resource_not_found",
+    },
+    404,
+  );
+}
+
 /**
  * LifeOps activity-signal ingestion requires the personal-assistant plugin's
  * scheduled-task runtime, which only a dedicated agent runs. Returning a typed
@@ -214,6 +236,7 @@ app.get("/", async (c) => {
     return json(c, { success: false, error: r.error }, r.status);
   }
   if (path === "notifications/push-tokens") {
+    if (!isPersonalSharedAgent(r)) return personalPushUnavailable(c);
     const worker = resolveSharedRuntimeWorkerRequestContext(c);
     if ("error" in worker) return json(c, worker, worker.status);
     const tokens = await coordinateSharedPushList(r.agentId, {
@@ -277,6 +300,7 @@ app.post("/", async (c) => {
   }
   const path = shellPath(c);
   if (path === "notifications/push-tokens") {
+    if (!isPersonalSharedAgent(r)) return personalPushUnavailable(c);
     const worker = resolveSharedRuntimeWorkerRequestContext(c);
     if ("error" in worker) return json(c, worker, worker.status);
     const contentLength = Number(c.req.header("content-length") ?? 0);
@@ -301,7 +325,7 @@ app.post("/", async (c) => {
     }
     const platform = body?.platform;
     const token = typeof body?.token === "string" ? body.token.trim() : "";
-    if ((platform !== "ios" && platform !== "android") || !token) {
+    if (platform !== "ios" || !token) {
       return json(
         c,
         { success: false, error: "Invalid mobile push registration" },
@@ -363,7 +387,20 @@ async function handleWorkflowMutation(c: Context<AppEnv>): Promise<Response> {
     return json(c, { success: false, error: r.error }, r.status);
   }
   if (c.req.method === "DELETE") {
-    const token = pushTokenDeleteTarget(shellPath(c));
+    const path = shellPath(c);
+    if (path === "notifications/push-tokens" && !isPersonalSharedAgent(r)) {
+      return personalPushUnavailable(c);
+    }
+    let token = pushTokenDeleteTarget(path);
+    if (path === "notifications/push-tokens") {
+      let body: { token?: unknown } | null = null;
+      try {
+        body = (await c.req.json()) as { token?: unknown };
+      } catch {
+        // error-policy:J3 malformed client JSON is an explicit invalid request.
+      }
+      token = typeof body?.token === "string" ? body.token.trim() : "";
+    }
     if (token !== null) {
       if (!token)
         return json(

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -15,6 +15,7 @@
  * this adapter.
  */
 import { type Context, Hono } from "hono";
+import { MAX_MOBILE_PUSH_TOKEN_CHARACTERS } from "@/lib/mobile-push/types";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
   coordinateSharedPushList,
@@ -49,7 +50,6 @@ import { workflowRuntimeUnavailableResponse } from "../../workflows/_shared";
 
 const CORS_METHODS = "GET, POST, PUT, DELETE, OPTIONS";
 const MAX_PUSH_REGISTRATION_BODY_BYTES = 8_192;
-const MAX_PUSH_TOKEN_CHARACTERS = 4_096;
 
 const app = new Hono<AppEnv>();
 
@@ -329,7 +329,7 @@ app.post("/", async (c) => {
     if (
       platform !== "ios" ||
       !token ||
-      token.length > MAX_PUSH_TOKEN_CHARACTERS
+      token.length > MAX_MOBILE_PUSH_TOKEN_CHARACTERS
     ) {
       return json(
         c,
@@ -427,7 +427,7 @@ async function handleWorkflowMutation(c: Context<AppEnv>): Promise<Response> {
     }
     if (token !== null) {
       if (!isPersonalSharedAgent(r)) return personalPushUnavailable(c);
-      if (!token || token.length > MAX_PUSH_TOKEN_CHARACTERS)
+      if (!token || token.length > MAX_MOBILE_PUSH_TOKEN_CHARACTERS)
         return json(
           c,
           { success: false, error: "Invalid mobile push token" },

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -89,6 +89,17 @@ function greetingConversationId(path: string): string | null {
   return m ? decodeURIComponent(m[1]) : null;
 }
 
+function pushTokenDeleteTarget(path: string): string | null {
+  const prefix = "notifications/push-tokens/";
+  if (!path.startsWith(prefix)) return null;
+  const encoded = path.slice(prefix.length);
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return null;
+  }
+}
+
 function isPersonalSharedAgent(
   value: Awaited<ReturnType<typeof resolveSharedAgent>>,
 ): boolean {
@@ -377,20 +388,40 @@ async function handleWorkflowMutation(c: Context<AppEnv>): Promise<Response> {
   }
   if (c.req.method === "DELETE") {
     const path = shellPath(c);
-    if (path === "notifications/push-tokens" && !isPersonalSharedAgent(r)) {
-      return personalPushUnavailable(c);
-    }
-    let token: string | null = null;
+    let token = pushTokenDeleteTarget(path);
     if (path === "notifications/push-tokens") {
+      const contentLength = Number(c.req.header("content-length") ?? 0);
+      if (
+        Number.isFinite(contentLength) &&
+        contentLength > MAX_PUSH_REGISTRATION_BODY_BYTES
+      ) {
+        return json(
+          c,
+          { success: false, error: "Request body too large" },
+          413,
+        );
+      }
+      const rawBody = await c.req.text();
+      if (
+        new TextEncoder().encode(rawBody).length >
+        MAX_PUSH_REGISTRATION_BODY_BYTES
+      ) {
+        return json(
+          c,
+          { success: false, error: "Request body too large" },
+          413,
+        );
+      }
       let body: { token?: unknown } | null = null;
       try {
-        body = (await c.req.json()) as { token?: unknown };
+        body = JSON.parse(rawBody) as { token?: unknown };
       } catch {
         // error-policy:J3 malformed client JSON is an explicit invalid request.
       }
       token = typeof body?.token === "string" ? body.token.trim() : "";
     }
     if (token !== null) {
+      if (!isPersonalSharedAgent(r)) return personalPushUnavailable(c);
       if (!token)
         return json(
           c,

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -49,6 +49,7 @@ import { workflowRuntimeUnavailableResponse } from "../../workflows/_shared";
 
 const CORS_METHODS = "GET, POST, PUT, DELETE, OPTIONS";
 const MAX_PUSH_REGISTRATION_BODY_BYTES = 8_192;
+const MAX_PUSH_TOKEN_CHARACTERS = 4_096;
 
 const app = new Hono<AppEnv>();
 
@@ -325,7 +326,11 @@ app.post("/", async (c) => {
     }
     const platform = body?.platform;
     const token = typeof body?.token === "string" ? body.token.trim() : "";
-    if (platform !== "ios" || !token) {
+    if (
+      platform !== "ios" ||
+      !token ||
+      token.length > MAX_PUSH_TOKEN_CHARACTERS
+    ) {
       return json(
         c,
         { success: false, error: "Invalid mobile push registration" },
@@ -422,7 +427,7 @@ async function handleWorkflowMutation(c: Context<AppEnv>): Promise<Response> {
     }
     if (token !== null) {
       if (!isPersonalSharedAgent(r)) return personalPushUnavailable(c);
-      if (!token)
+      if (!token || token.length > MAX_PUSH_TOKEN_CHARACTERS)
         return json(
           c,
           { success: false, error: "Invalid mobile push token" },

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -89,17 +89,6 @@ function greetingConversationId(path: string): string | null {
   return m ? decodeURIComponent(m[1]) : null;
 }
 
-function pushTokenDeleteTarget(path: string): string | null {
-  const prefix = "notifications/push-tokens/";
-  if (!path.startsWith(prefix)) return null;
-  const encoded = path.slice(prefix.length);
-  try {
-    return decodeURIComponent(encoded);
-  } catch {
-    return null;
-  }
-}
-
 function isPersonalSharedAgent(
   value: Awaited<ReturnType<typeof resolveSharedAgent>>,
 ): boolean {
@@ -391,7 +380,7 @@ async function handleWorkflowMutation(c: Context<AppEnv>): Promise<Response> {
     if (path === "notifications/push-tokens" && !isPersonalSharedAgent(r)) {
       return personalPushUnavailable(c);
     }
-    let token = pushTokenDeleteTarget(path);
+    let token: string | null = null;
     if (path === "notifications/push-tokens") {
       let body: { token?: unknown } | null = null;
       try {

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -421,6 +421,11 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 #   CONTAINERS_SSH_KEY / AGENT_SSH_KEY Docker provider SSH private key for the Node sidecar
 #   HEADSCALE_API_KEY / HEADSCALE_INTERNAL_TOKEN
 #   TUNNEL_HOSTNAME_SIGNING_SECRET     Shared HMAC secret with tunnel-proxy
+#   ELIZA_APNS_KEY                     Apple APNs provider .p8 key contents
+#   ELIZA_APNS_KEY_ID                  Apple APNs provider key id
+#   ELIZA_APNS_TEAM_ID                 Apple Developer team id
+#   ELIZA_APNS_TOPIC                   Signed iOS bundle id (ai.elizaos.app)
+#   ELIZA_APNS_PRODUCTION              Explicit host selector: 0 sandbox, 1 production
 #   AGENT_SERVER_SHARED_SECRET / WAIFU_SERVICE_KEY
 #   WAIFU_BRIDGE_ORG_ID                Required owner org for waifu bridge user provisioning
 # -----------------------------------------------------------------------------

--- a/packages/cloud/shared/src/lib/mobile-push/apns-provider.test.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/apns-provider.test.ts
@@ -90,12 +90,12 @@ describe("CloudApnsProvider", () => {
     ).resolves.toBe(true);
   });
 
-  test.each(["Unregistered", "BadDeviceToken"] as const)(
+  test.each(["Unregistered", "BadDeviceToken", "ExpiredToken"] as const)(
     "classifies %s as durable-token cleanup",
     async (reason) => {
       const { config } = await fixture(true);
       const provider = new CloudApnsProvider(config, async () =>
-        Response.json({ reason }, { status: reason === "Unregistered" ? 410 : 400 }),
+        Response.json({ reason }, { status: reason === "BadDeviceToken" ? 400 : 410 }),
       );
       await expect(provider.send("dead", { title: "x" })).resolves.toEqual({
         outcome: "unregistered",
@@ -103,6 +103,24 @@ describe("CloudApnsProvider", () => {
       });
     },
   );
+
+  test("single-flights provider-token minting across concurrent sends", async () => {
+    const { config } = await fixture();
+    const authorizations: string[] = [];
+    const provider = new CloudApnsProvider(config, async (_url, init) => {
+      authorizations.push(new Headers(init?.headers).get("authorization") ?? "");
+      return new Response(null, { status: 200 });
+    });
+
+    await Promise.all(
+      Array.from({ length: 8 }, (_, index) =>
+        provider.send(`device-${index}`, { title: "Ready" }, 1_800_000_000_000),
+      ),
+    );
+
+    expect(authorizations).toHaveLength(8);
+    expect(new Set(authorizations).size).toBe(1);
+  });
 
   test("preserves non-token rejection status and reason", async () => {
     const { config } = await fixture();
@@ -114,5 +132,20 @@ describe("CloudApnsProvider", () => {
       status: 429,
       reason: "TooManyRequests",
     });
+  });
+
+  test("rejects an oversized alert locally before APNs egress", async () => {
+    const { config } = await fixture();
+    let calls = 0;
+    const provider = new CloudApnsProvider(config, async () => {
+      calls += 1;
+      return new Response(null, { status: 200 });
+    });
+    await expect(provider.send("live", { title: "x", body: "y".repeat(4_096) })).resolves.toEqual({
+      outcome: "rejected",
+      status: 413,
+      reason: "PayloadTooLarge",
+    });
+    expect(calls).toBe(0);
   });
 });

--- a/packages/cloud/shared/src/lib/mobile-push/apns-provider.test.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/apns-provider.test.ts
@@ -1,0 +1,118 @@
+/** Verifies Workerd APNs configuration, ES256 request shaping, and typed provider outcomes. */
+
+import { describe, expect, test } from "vitest";
+import { CloudApnsProvider, ELIZA_IOS_BUNDLE_ID, resolveCloudApnsConfig } from "./apns-provider";
+
+async function fixture(production = false) {
+  const { privateKey, publicKey } = await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  );
+  const pkcs8 = new Uint8Array(await crypto.subtle.exportKey("pkcs8", privateKey));
+  let binary = "";
+  for (const byte of pkcs8) binary += String.fromCharCode(byte);
+  const encoded =
+    btoa(binary)
+      .match(/.{1,64}/g)
+      ?.join("\n") ?? "";
+  const config = resolveCloudApnsConfig({
+    ELIZA_APNS_KEY: `-----BEGIN PRIVATE KEY-----\n${encoded}\n-----END PRIVATE KEY-----`,
+    ELIZA_APNS_KEY_ID: "KEY123",
+    ELIZA_APNS_TEAM_ID: "TEAM123",
+    ELIZA_APNS_TOPIC: ELIZA_IOS_BUNDLE_ID,
+    ELIZA_APNS_PRODUCTION: production ? "1" : "0",
+  });
+  if (!config) throw new Error("fixture APNs config did not resolve");
+  return { config, publicKey };
+}
+
+describe("CloudApnsProvider", () => {
+  test("is absent only when every APNs binding is absent", () => {
+    expect(resolveCloudApnsConfig({})).toBeNull();
+    expect(() => resolveCloudApnsConfig({ ELIZA_APNS_KEY_ID: "partial" })).toThrow("incomplete");
+  });
+
+  test("fails closed on topic and environment disagreement", async () => {
+    const { config } = await fixture();
+    expect(() =>
+      resolveCloudApnsConfig({
+        ...config,
+        ELIZA_APNS_KEY: config.key,
+        ELIZA_APNS_KEY_ID: config.keyId,
+        ELIZA_APNS_TEAM_ID: config.teamId,
+        ELIZA_APNS_TOPIC: "wrong.bundle",
+        ELIZA_APNS_PRODUCTION: "0",
+      }),
+    ).toThrow(ELIZA_IOS_BUNDLE_ID);
+    expect(() =>
+      resolveCloudApnsConfig({
+        ELIZA_APNS_KEY: config.key,
+        ELIZA_APNS_KEY_ID: config.keyId,
+        ELIZA_APNS_TEAM_ID: config.teamId,
+        ELIZA_APNS_TOPIC: ELIZA_IOS_BUNDLE_ID,
+        ELIZA_APNS_PRODUCTION: "true",
+      }),
+    ).toThrow('explicitly "0" or "1"');
+  });
+
+  test("sends a sandbox alert with a verifiable provider token", async () => {
+    const { config, publicKey } = await fixture();
+    let captured: { url: string; init: RequestInit } | undefined;
+    const provider = new CloudApnsProvider(config, async (url, init) => {
+      captured = { url: String(url), init: init ?? {} };
+      return new Response(null, { status: 200, headers: { "apns-id": "accepted-id" } });
+    });
+    await expect(
+      provider.send("device-token", { title: "Ready", body: "Open Eliza" }, 1_800_000_000_000),
+    ).resolves.toEqual({ outcome: "accepted", apnsId: "accepted-id" });
+    expect(captured?.url).toBe("https://api.sandbox.push.apple.com/3/device/device-token");
+    expect(new Headers(captured?.init.headers).get("apns-topic")).toBe(ELIZA_IOS_BUNDLE_ID);
+    const jwt = new Headers(captured?.init.headers).get("authorization")?.replace("bearer ", "");
+    if (!jwt) throw new Error("authorization token was not sent");
+    const [header, payload, signature] = jwt.split(".");
+    const decode = (value: string) =>
+      JSON.parse(atob(value.replaceAll("-", "+").replaceAll("_", "/")));
+    expect(decode(header)).toEqual({ alg: "ES256", kid: "KEY123" });
+    expect(decode(payload)).toMatchObject({ iss: "TEAM123", iat: 1_800_000_000 });
+    const padded = signature
+      .replaceAll("-", "+")
+      .replaceAll("_", "/")
+      .padEnd(Math.ceil(signature.length / 4) * 4, "=");
+    const signatureBytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+    await expect(
+      crypto.subtle.verify(
+        { name: "ECDSA", hash: "SHA-256" },
+        publicKey,
+        signatureBytes,
+        new TextEncoder().encode(`${header}.${payload}`),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  test.each(["Unregistered", "BadDeviceToken"] as const)(
+    "classifies %s as durable-token cleanup",
+    async (reason) => {
+      const { config } = await fixture(true);
+      const provider = new CloudApnsProvider(config, async () =>
+        Response.json({ reason }, { status: reason === "Unregistered" ? 410 : 400 }),
+      );
+      await expect(provider.send("dead", { title: "x" })).resolves.toEqual({
+        outcome: "unregistered",
+        reason,
+      });
+    },
+  );
+
+  test("preserves non-token rejection status and reason", async () => {
+    const { config } = await fixture();
+    const provider = new CloudApnsProvider(config, async () =>
+      Response.json({ reason: "TooManyRequests" }, { status: 429 }),
+    );
+    await expect(provider.send("live", { title: "x" })).resolves.toEqual({
+      outcome: "rejected",
+      status: 429,
+      reason: "TooManyRequests",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/mobile-push/apns-provider.test.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/apns-provider.test.ts
@@ -122,6 +122,27 @@ describe("CloudApnsProvider", () => {
     expect(new Set(authorizations).size).toBe(1);
   });
 
+  test("uses one bounded collapse id when an occurrence is replayed", async () => {
+    const { config } = await fixture();
+    const collapseIds: string[] = [];
+    const provider = new CloudApnsProvider(config, async (_url, init) => {
+      collapseIds.push(new Headers(init?.headers).get("apns-collapse-id") ?? "");
+      return new Response(null, { status: 200 });
+    });
+    const replayKey = `reminder:${"x".repeat(256)}:occurrence`;
+
+    await provider.send("device", { title: "Reminder", collapseKey: replayKey });
+    await provider.send("device", { title: "Reminder", collapseKey: replayKey });
+    await provider.send("device", {
+      title: "Reminder",
+      collapseKey: `${replayKey}:next`,
+    });
+
+    expect(collapseIds[0]).toBe(collapseIds[1]);
+    expect(collapseIds[0]?.length).toBeLessThanOrEqual(64);
+    expect(collapseIds[2]).not.toBe(collapseIds[0]);
+  });
+
   test("preserves non-token rejection status and reason", async () => {
     const { config } = await fixture();
     const provider = new CloudApnsProvider(config, async () =>

--- a/packages/cloud/shared/src/lib/mobile-push/apns-provider.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/apns-provider.ts
@@ -1,0 +1,129 @@
+/** Sends APNs alerts from Workerd with provider-token authentication and typed rejection results. */
+
+import type { MobilePushDeliveryResult, MobilePushMessage } from "./types";
+
+const APNS_SANDBOX_ORIGIN = "https://api.sandbox.push.apple.com";
+const APNS_PRODUCTION_ORIGIN = "https://api.push.apple.com";
+const APNS_PROVIDER_TOKEN_TTL_MS = 50 * 60 * 1000;
+export const ELIZA_IOS_BUNDLE_ID = "ai.elizaos.app";
+
+export interface CloudApnsBindings {
+  ELIZA_APNS_KEY?: string;
+  ELIZA_APNS_KEY_ID?: string;
+  ELIZA_APNS_TEAM_ID?: string;
+  ELIZA_APNS_TOPIC?: string;
+  ELIZA_APNS_PRODUCTION?: string;
+}
+
+export interface CloudApnsConfig {
+  key: string;
+  keyId: string;
+  teamId: string;
+  topic: typeof ELIZA_IOS_BUNDLE_ID;
+  production: boolean;
+}
+
+export function resolveCloudApnsConfig(bindings: CloudApnsBindings): CloudApnsConfig | null {
+  const key = bindings.ELIZA_APNS_KEY?.trim();
+  const keyId = bindings.ELIZA_APNS_KEY_ID?.trim();
+  const teamId = bindings.ELIZA_APNS_TEAM_ID?.trim();
+  const topic = bindings.ELIZA_APNS_TOPIC?.trim();
+  const production = bindings.ELIZA_APNS_PRODUCTION?.trim();
+  if (!key && !keyId && !teamId && !topic && !production) return null;
+  if (!key || !keyId || !teamId || !topic) {
+    throw new Error("Cloud APNs configuration is incomplete");
+  }
+  if (topic !== ELIZA_IOS_BUNDLE_ID) {
+    throw new Error(`Cloud APNs topic must be ${ELIZA_IOS_BUNDLE_ID}`);
+  }
+  if (production !== "0" && production !== "1") {
+    throw new Error('ELIZA_APNS_PRODUCTION must be explicitly "0" or "1"');
+  }
+  return { key, keyId, teamId, topic, production: production === "1" };
+}
+
+interface CachedProviderToken {
+  value: string;
+  mintedAt: number;
+}
+
+function base64url(value: Uint8Array | string): string {
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value;
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function pkcs8Bytes(pem: string): Uint8Array {
+  const encoded = pem
+    .replace("-----BEGIN PRIVATE KEY-----", "")
+    .replace("-----END PRIVATE KEY-----", "")
+    .replaceAll(/\s/g, "");
+  const binary = atob(encoded);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+export class CloudApnsProvider {
+  private cachedToken?: CachedProviderToken;
+
+  constructor(
+    private readonly config: CloudApnsConfig,
+    private readonly request: typeof fetch = fetch,
+  ) {}
+
+  private async providerToken(now: number): Promise<string> {
+    if (this.cachedToken && now - this.cachedToken.mintedAt < APNS_PROVIDER_TOKEN_TTL_MS) {
+      return this.cachedToken.value;
+    }
+    const key = await crypto.subtle.importKey(
+      "pkcs8",
+      Uint8Array.from(pkcs8Bytes(this.config.key)).buffer,
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["sign"],
+    );
+    const signingInput = `${base64url(JSON.stringify({ alg: "ES256", kid: this.config.keyId }))}.${base64url(
+      JSON.stringify({ iss: this.config.teamId, iat: Math.floor(now / 1000) }),
+    )}`;
+    const signature = await crypto.subtle.sign(
+      { name: "ECDSA", hash: "SHA-256" },
+      key,
+      new TextEncoder().encode(signingInput),
+    );
+    const value = `${signingInput}.${base64url(new Uint8Array(signature))}`;
+    this.cachedToken = { value, mintedAt: now };
+    return value;
+  }
+
+  async send(
+    token: string,
+    message: MobilePushMessage,
+    now = Date.now(),
+  ): Promise<MobilePushDeliveryResult> {
+    const origin = this.config.production ? APNS_PRODUCTION_ORIGIN : APNS_SANDBOX_ORIGIN;
+    const response = await this.request(`${origin}/3/device/${encodeURIComponent(token)}`, {
+      method: "POST",
+      headers: {
+        authorization: `bearer ${await this.providerToken(now)}`,
+        "apns-topic": this.config.topic,
+        "apns-push-type": "alert",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        aps: {
+          alert: { title: message.title, ...(message.body ? { body: message.body } : {}) },
+          sound: "default",
+        },
+        ...(message.data ?? {}),
+      }),
+    });
+    const apnsId = response.headers.get("apns-id") ?? undefined;
+    if (response.status === 200) return { outcome: "accepted", ...(apnsId ? { apnsId } : {}) };
+    const errorBody = (await response.json().catch(() => null)) as { reason?: unknown } | null;
+    const reason = typeof errorBody?.reason === "string" ? errorBody.reason : undefined;
+    if (reason === "Unregistered" || reason === "BadDeviceToken") {
+      return { outcome: "unregistered", reason };
+    }
+    return { outcome: "rejected", status: response.status, ...(reason ? { reason } : {}) };
+  }
+}

--- a/packages/cloud/shared/src/lib/mobile-push/apns-provider.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/apns-provider.ts
@@ -5,6 +5,8 @@ import type { MobilePushDeliveryResult, MobilePushMessage } from "./types";
 const APNS_SANDBOX_ORIGIN = "https://api.sandbox.push.apple.com";
 const APNS_PRODUCTION_ORIGIN = "https://api.push.apple.com";
 const APNS_PROVIDER_TOKEN_TTL_MS = 50 * 60 * 1000;
+const APNS_REQUEST_TIMEOUT_MS = 10_000;
+const APNS_MAX_PAYLOAD_BYTES = 4_096;
 export const ELIZA_IOS_BUNDLE_ID = "ai.elizaos.app";
 
 export interface CloudApnsBindings {
@@ -65,6 +67,8 @@ function pkcs8Bytes(pem: string): Uint8Array {
 
 export class CloudApnsProvider {
   private cachedToken?: CachedProviderToken;
+  private importedKey?: Promise<CryptoKey>;
+  private pendingToken?: Promise<CachedProviderToken>;
 
   constructor(
     private readonly config: CloudApnsConfig,
@@ -75,24 +79,32 @@ export class CloudApnsProvider {
     if (this.cachedToken && now - this.cachedToken.mintedAt < APNS_PROVIDER_TOKEN_TTL_MS) {
       return this.cachedToken.value;
     }
-    const key = await crypto.subtle.importKey(
-      "pkcs8",
-      Uint8Array.from(pkcs8Bytes(this.config.key)).buffer,
-      { name: "ECDSA", namedCurve: "P-256" },
-      false,
-      ["sign"],
-    );
-    const signingInput = `${base64url(JSON.stringify({ alg: "ES256", kid: this.config.keyId }))}.${base64url(
-      JSON.stringify({ iss: this.config.teamId, iat: Math.floor(now / 1000) }),
-    )}`;
-    const signature = await crypto.subtle.sign(
-      { name: "ECDSA", hash: "SHA-256" },
-      key,
-      new TextEncoder().encode(signingInput),
-    );
-    const value = `${signingInput}.${base64url(new Uint8Array(signature))}`;
-    this.cachedToken = { value, mintedAt: now };
-    return value;
+    this.pendingToken ??= (async () => {
+      this.importedKey ??= crypto.subtle.importKey(
+        "pkcs8",
+        Uint8Array.from(pkcs8Bytes(this.config.key)).buffer,
+        { name: "ECDSA", namedCurve: "P-256" },
+        false,
+        ["sign"],
+      );
+      const key = await this.importedKey;
+      const signingInput = `${base64url(JSON.stringify({ alg: "ES256", kid: this.config.keyId }))}.${base64url(
+        JSON.stringify({ iss: this.config.teamId, iat: Math.floor(now / 1000) }),
+      )}`;
+      const signature = await crypto.subtle.sign(
+        { name: "ECDSA", hash: "SHA-256" },
+        key,
+        new TextEncoder().encode(signingInput),
+      );
+      return { value: `${signingInput}.${base64url(new Uint8Array(signature))}`, mintedAt: now };
+    })();
+    const pendingToken = this.pendingToken;
+    try {
+      this.cachedToken = await pendingToken;
+      return this.cachedToken.value;
+    } finally {
+      if (this.pendingToken === pendingToken) this.pendingToken = undefined;
+    }
   }
 
   async send(
@@ -101,6 +113,16 @@ export class CloudApnsProvider {
     now = Date.now(),
   ): Promise<MobilePushDeliveryResult> {
     const origin = this.config.production ? APNS_PRODUCTION_ORIGIN : APNS_SANDBOX_ORIGIN;
+    const body = JSON.stringify({
+      ...(message.data ?? {}),
+      aps: {
+        alert: { title: message.title, ...(message.body ? { body: message.body } : {}) },
+        sound: "default",
+      },
+    });
+    if (new TextEncoder().encode(body).length > APNS_MAX_PAYLOAD_BYTES) {
+      return { outcome: "rejected", status: 413, reason: "PayloadTooLarge" };
+    }
     const response = await this.request(`${origin}/3/device/${encodeURIComponent(token)}`, {
       method: "POST",
       headers: {
@@ -109,19 +131,19 @@ export class CloudApnsProvider {
         "apns-push-type": "alert",
         "content-type": "application/json",
       },
-      body: JSON.stringify({
-        aps: {
-          alert: { title: message.title, ...(message.body ? { body: message.body } : {}) },
-          sound: "default",
-        },
-        ...(message.data ?? {}),
-      }),
+      body,
+      signal: AbortSignal.timeout(APNS_REQUEST_TIMEOUT_MS),
     });
     const apnsId = response.headers.get("apns-id") ?? undefined;
     if (response.status === 200) return { outcome: "accepted", ...(apnsId ? { apnsId } : {}) };
-    const errorBody = (await response.json().catch(() => null)) as { reason?: unknown } | null;
+    let errorBody: { reason?: unknown } | null = null;
+    try {
+      errorBody = (await response.json()) as { reason?: unknown };
+    } catch {
+      // error-policy:J3 an unreadable APNs rejection body has no typed reason.
+    }
     const reason = typeof errorBody?.reason === "string" ? errorBody.reason : undefined;
-    if (reason === "Unregistered" || reason === "BadDeviceToken") {
+    if (reason === "Unregistered" || reason === "BadDeviceToken" || reason === "ExpiredToken") {
       return { outcome: "unregistered", reason };
     }
     return { outcome: "rejected", status: response.status, ...(reason ? { reason } : {}) };

--- a/packages/cloud/shared/src/lib/mobile-push/apns-provider.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/apns-provider.ts
@@ -123,6 +123,13 @@ export class CloudApnsProvider {
     if (new TextEncoder().encode(body).length > APNS_MAX_PAYLOAD_BYTES) {
       return { outcome: "rejected", status: 413, reason: "PayloadTooLarge" };
     }
+    const collapseId = message.collapseKey
+      ? base64url(
+          new Uint8Array(
+            await crypto.subtle.digest("SHA-256", new TextEncoder().encode(message.collapseKey)),
+          ),
+        )
+      : undefined;
     const response = await this.request(`${origin}/3/device/${encodeURIComponent(token)}`, {
       method: "POST",
       headers: {
@@ -130,6 +137,7 @@ export class CloudApnsProvider {
         "apns-topic": this.config.topic,
         "apns-push-type": "alert",
         "content-type": "application/json",
+        ...(collapseId ? { "apns-collapse-id": collapseId } : {}),
       },
       body,
       signal: AbortSignal.timeout(APNS_REQUEST_TIMEOUT_MS),

--- a/packages/cloud/shared/src/lib/mobile-push/types.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/types.ts
@@ -16,5 +16,8 @@ export interface MobilePushMessage {
 
 export type MobilePushDeliveryResult =
   | { outcome: "accepted"; apnsId?: string }
-  | { outcome: "unregistered"; reason: "Unregistered" | "BadDeviceToken" }
+  | {
+      outcome: "unregistered";
+      reason: "Unregistered" | "BadDeviceToken" | "ExpiredToken";
+    }
   | { outcome: "rejected"; status: number; reason?: string };

--- a/packages/cloud/shared/src/lib/mobile-push/types.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/types.ts
@@ -2,6 +2,9 @@
 
 export type MobilePushPlatform = "ios" | "android";
 
+/** Maximum normalized token length accepted by every Cloud push authority boundary. */
+export const MAX_MOBILE_PUSH_TOKEN_CHARACTERS = 4_096;
+
 export interface MobilePushTokenRecord {
   token: string;
   platform: MobilePushPlatform;

--- a/packages/cloud/shared/src/lib/mobile-push/types.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/types.ts
@@ -11,6 +11,8 @@ export interface MobilePushTokenRecord {
 export interface MobilePushMessage {
   title: string;
   body?: string;
+  /** Stable occurrence key that APNs hashes into its bounded collapse header. */
+  collapseKey?: string;
   data?: Record<string, string | number | boolean | null>;
 }
 

--- a/packages/cloud/shared/src/lib/mobile-push/types.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/types.ts
@@ -1,0 +1,20 @@
+/** Defines the transport-neutral mobile-push records shared by Cloud registration and delivery. */
+
+export type MobilePushPlatform = "ios" | "android";
+
+export interface MobilePushTokenRecord {
+  token: string;
+  platform: MobilePushPlatform;
+  createdAt: number;
+}
+
+export interface MobilePushMessage {
+  title: string;
+  body?: string;
+  data?: Record<string, string | number | boolean | null>;
+}
+
+export type MobilePushDeliveryResult =
+  | { outcome: "accepted"; apnsId?: string }
+  | { outcome: "unregistered"; reason: "Unregistered" | "BadDeviceToken" }
+  | { outcome: "rejected"; status: number; reason?: string };

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -8,6 +8,7 @@
 
 import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
 import { InsufficientCreditsError, RateLimitError } from "../../api/errors";
+import type { MobilePushPlatform, MobilePushTokenRecord } from "../../mobile-push/types";
 import { logger } from "../../utils/logger";
 import type { BridgeRequest, BridgeResponse } from "../eliza-sandbox-bridge";
 import type { SharedTurnMessage } from "./run-shared-agent-turn";
@@ -37,6 +38,64 @@ export interface SharedConversationLifecycleEvent {
   id: string;
   content: string;
   createdAt: number;
+}
+
+export interface SharedMobilePushRegistration {
+  platform: MobilePushPlatform;
+  token: string;
+}
+
+async function coordinateSharedPushOperation<T>(
+  agentId: string,
+  operation: "push-list" | "push-register" | "push-unregister",
+  options: SharedConversationHistoryCoordinatorOptions,
+  value?: SharedMobilePushRegistration | { token: string },
+): Promise<T> {
+  const namespace = requireHistoryCoordinator(options);
+  const response = await coordinatorStub(namespace, agentId, agentId).fetch(
+    "https://shared-runtime.internal/mobile-push",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ operation, agentId, ...(value ?? {}) }),
+    },
+  );
+  await requireCoordinatorResponse(response, `mobile ${operation}`);
+  return (await response.json()) as T;
+}
+
+export async function coordinateSharedPushList(
+  agentId: string,
+  options: SharedConversationHistoryCoordinatorOptions,
+): Promise<MobilePushTokenRecord[]> {
+  const result = await coordinateSharedPushOperation<{ tokens: MobilePushTokenRecord[] }>(
+    agentId,
+    "push-list",
+    options,
+  );
+  return result.tokens;
+}
+
+export async function coordinateSharedPushRegister(
+  agentId: string,
+  registration: SharedMobilePushRegistration,
+  options: SharedConversationHistoryCoordinatorOptions,
+): Promise<void> {
+  await coordinateSharedPushOperation(agentId, "push-register", options, registration);
+}
+
+export async function coordinateSharedPushUnregister(
+  agentId: string,
+  token: string,
+  options: SharedConversationHistoryCoordinatorOptions,
+): Promise<boolean> {
+  const result = await coordinateSharedPushOperation<{ removed: boolean }>(
+    agentId,
+    "push-unregister",
+    options,
+    { token },
+  );
+  return result.removed;
 }
 
 export interface SharedCutoverSeal {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -8,7 +8,11 @@
 
 import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
 import { InsufficientCreditsError, RateLimitError } from "../../api/errors";
-import type { MobilePushPlatform, MobilePushTokenRecord } from "../../mobile-push/types";
+import type {
+  MobilePushMessage,
+  MobilePushPlatform,
+  MobilePushTokenRecord,
+} from "../../mobile-push/types";
 import { logger } from "../../utils/logger";
 import type { BridgeRequest, BridgeResponse } from "../eliza-sandbox-bridge";
 import type { SharedTurnMessage } from "./run-shared-agent-turn";
@@ -47,9 +51,9 @@ export interface SharedMobilePushRegistration {
 
 async function coordinateSharedPushOperation<T>(
   agentId: string,
-  operation: "push-list" | "push-register" | "push-unregister",
+  operation: "push-list" | "push-register" | "push-unregister" | "push-dispatch",
   options: SharedConversationHistoryCoordinatorOptions,
-  value?: SharedMobilePushRegistration | { token: string },
+  value?: SharedMobilePushRegistration | { token: string } | { message: MobilePushMessage },
 ): Promise<T> {
   const namespace = requireHistoryCoordinator(options);
   const response = await coordinatorStub(namespace, agentId, agentId).fetch(
@@ -96,6 +100,14 @@ export async function coordinateSharedPushUnregister(
     { token },
   );
   return result.removed;
+}
+
+export async function coordinateSharedPushDispatch(
+  agentId: string,
+  message: MobilePushMessage,
+  options: SharedConversationHistoryCoordinatorOptions,
+): Promise<void> {
+  await coordinateSharedPushOperation(agentId, "push-dispatch", options, { message });
 }
 
 export interface SharedCutoverSeal {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -24,6 +24,7 @@ import { type ActionResult, replaceNameTokens, type UUID } from "@elizaos/core/e
 import type { ScheduledTaskRunner, SharedReminderDelivery } from "@elizaos/plugin-scheduling/edge";
 import type { TodoStore } from "@elizaos/plugin-todos/edge";
 import { generateText, streamText } from "ai";
+import type { MobilePushMessage } from "../../mobile-push/types";
 import { CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../../models/catalog";
 import {
   getInteractiveCerebrasLanguageModel,
@@ -111,6 +112,9 @@ export interface RunSharedAgentTurnInput {
     reminders?: {
       delivery: SharedReminderDelivery;
       runner: ScheduledTaskRunner;
+    };
+    mobilePush?: {
+      dispatch: (message: MobilePushMessage) => Promise<void>;
     };
   };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -5,6 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { AgentRuntime } from "@elizaos/core/edge";
+import { NotificationService } from "@elizaos/core/services/notification";
 import type { ScheduledTask, ScheduledTaskRunner } from "@elizaos/plugin-scheduling/edge";
 import type { CreateTodoInput, TodoMutationRecord, TodoStore } from "@elizaos/plugin-todos/edge";
 
@@ -473,6 +474,118 @@ describe("Shared Eliza Workerd runtime", () => {
         (tool) => tool.function?.name === "HANDLE_RESPONSE",
       ),
     ).toBe(true);
+  });
+
+  test("awaits notification hydration before inference and dispatches through the genuine runtime", async () => {
+    const hydrationEntered = Promise.withResolvers<void>();
+    const releaseHydration = Promise.withResolvers<void>();
+    const originalStart = NotificationService.start;
+    let notificationService: NotificationService | undefined;
+    const startSpy = spyOn(NotificationService, "start").mockImplementation(async (runtime) => {
+      hydrationEntered.resolve();
+      await releaseHydration.promise;
+      const service = await originalStart(runtime);
+      notificationService = service as NotificationService;
+      return service;
+    });
+    const mobilePushDispatches: Array<Record<string, unknown>> = [];
+    let providerCalls = 0;
+    globalThis.fetch = (async () => {
+      providerCalls += 1;
+      if (!notificationService) {
+        throw new Error("Provider inference started before notification hydration completed");
+      }
+      await notificationService.notify({
+        title: "Runtime-ready reminder",
+        body: "Notification services are hydrated",
+        category: "reminder",
+        priority: "high",
+        source: "scheduling",
+        deepLink: "/automations/runtime-ready",
+      });
+      return Response.json({
+        id: "chatcmpl-shared-notification-ready",
+        object: "chat.completion",
+        created: 0,
+        model: "gemma-4-31b",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: null,
+              tool_calls: [
+                {
+                  id: "shared-notification-ready-response",
+                  type: "function",
+                  function: {
+                    name: "HANDLE_RESPONSE",
+                    arguments: JSON.stringify({
+                      shouldRespond: "RESPOND",
+                      thought: "The notification services are ready.",
+                      contexts: ["simple"],
+                      intents: [],
+                      candidateActionNames: [],
+                      replyText: "notification runtime ready",
+                      replyEffectStatus: "none",
+                      facts: [],
+                      relationships: [],
+                      addressedTo: [],
+                    }),
+                  },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      });
+    }) as typeof fetch;
+
+    try {
+      const { runSharedElizaRuntimeTurn } = await import("./shared-eliza-runtime");
+      const turn = runSharedElizaRuntimeTurn({
+        character: {
+          name: "Shared Eliza",
+          system: "You are Eliza.",
+          model: "gemma-4-31b",
+        },
+        history: [],
+        message: "run an ordinary shared turn",
+        agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
+        model: "gemma-4-31b",
+        execution: {
+          engine: "eliza-runtime",
+          agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
+          mobilePush: {
+            dispatch: async (message) => {
+              mobilePushDispatches.push(message);
+            },
+          },
+        },
+      });
+
+      await hydrationEntered.promise;
+      expect(providerCalls).toBe(0);
+      releaseHydration.resolve();
+      const result = await turn;
+
+      expect(result.reply).toBe("notification runtime ready");
+      expect(providerCalls).toBe(1);
+      expect(mobilePushDispatches).toHaveLength(1);
+      expect(mobilePushDispatches[0]).toMatchObject({
+        title: "Runtime-ready reminder",
+        body: "Notification services are hydrated",
+        data: {
+          category: "reminder",
+          deepLink: "/automations/runtime-ready",
+        },
+      });
+    } finally {
+      releaseHydration.resolve();
+      startSpy.mockRestore();
+    }
   });
 
   test("projects durable history into RECENT_MESSAGES in chronological order", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -7,6 +7,7 @@
 
 import {
   type AgentEventPayload,
+  AgentEventService,
   type AgentNotification,
   AgentRuntime,
   ChannelType,
@@ -26,6 +27,7 @@ import {
   type ToolDefinition,
   type UUID,
 } from "@elizaos/core/edge";
+import { NotificationService } from "@elizaos/core/services/notification";
 import { createSharedRemindersEdgePlugin } from "@elizaos/plugin-scheduling/edge";
 import { createTodosEdgePlugin } from "@elizaos/plugin-todos/edge";
 import { webSearchEdgeAction, webSearchEdgePlugin } from "@elizaos/plugin-web-search/edge";
@@ -120,6 +122,9 @@ export function subscribeSharedMobilePush(
 let edgeStreamingContextReady: Promise<void> | undefined;
 let sharedRuntimeKernelReady: Promise<void> | undefined;
 
+/** Canonical notification services required by the ephemeral Shared runtime. */
+export const SHARED_NOTIFICATION_SERVICES = [AgentEventService, NotificationService] as const;
+
 async function ensureEdgeStreamingContext(): Promise<void> {
   edgeStreamingContextReady ??= import("node:async_hooks").then(({ AsyncLocalStorage }) => {
     const storage = new AsyncLocalStorage<StreamingContext | undefined>();
@@ -144,6 +149,7 @@ function sharedModelPlugin(
   return {
     name: "shared-cerebras-model",
     description: "Platform-funded text generation for the Shared Workerd runtime.",
+    services: [...SHARED_NOTIFICATION_SERVICES],
     models: {
       [ModelType.RESPONSE_HANDLER]: handler,
       [ModelType.ACTION_PLANNER]: handler,
@@ -480,7 +486,13 @@ async function executeSharedElizaRuntimeTurn(
     await runtime.initialize({ skipMigrations: true });
     const pushDispatches: Promise<void>[] = [];
     const eventBus = runtime.getService(ServiceType.AGENT_EVENT);
+    const notificationService = runtime.getService(ServiceType.NOTIFICATION);
     const mobilePushDispatch = input.execution?.mobilePush?.dispatch;
+    if (mobilePushDispatch && (!isSharedNotificationEventBus(eventBus) || !notificationService)) {
+      throw new Error(
+        "Eliza Shared runtime initialized mobile push without canonical notification services",
+      );
+    }
     const unsubscribePush =
       mobilePushDispatch && isSharedNotificationEventBus(eventBus)
         ? subscribeSharedMobilePush(eventBus, mobilePushDispatch, pushDispatches)

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -110,6 +110,7 @@ export function subscribeSharedMobilePush(
       dispatch({
         title: notification.title,
         body: notification.body,
+        collapseKey: notification.id,
         data,
       }),
     );

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -485,9 +485,13 @@ async function executeSharedElizaRuntimeTurn(
   try {
     await runtime.initialize({ skipMigrations: true });
     const pushDispatches: Promise<void>[] = [];
-    const eventBus = runtime.getService(ServiceType.AGENT_EVENT);
-    const notificationService = runtime.getService(ServiceType.NOTIFICATION);
     const mobilePushDispatch = input.execution?.mobilePush?.dispatch;
+    const [eventBus, notificationService] = mobilePushDispatch
+      ? await Promise.all([
+          runtime.getServiceLoadPromise(ServiceType.AGENT_EVENT),
+          runtime.getServiceLoadPromise(ServiceType.NOTIFICATION),
+        ])
+      : [runtime.getService(ServiceType.AGENT_EVENT), runtime.getService(ServiceType.NOTIFICATION)];
     if (mobilePushDispatch && (!isSharedNotificationEventBus(eventBus) || !notificationService)) {
       throw new Error(
         "Eliza Shared runtime initialized mobile push without canonical notification services",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -6,6 +6,8 @@
  */
 
 import {
+  type AgentEventPayload,
+  type AgentNotification,
   AgentRuntime,
   ChannelType,
   createMessageMemory,
@@ -13,7 +15,9 @@ import {
   type IAgentRuntime,
   InMemoryDatabaseAdapter,
   ModelType,
+  NOTIFICATION_STREAM,
   type Plugin,
+  ServiceType,
   type StreamingContext,
   setStreamingContextManager,
   stringToUuid,
@@ -33,6 +37,7 @@ import {
   streamText,
   type ToolSet,
 } from "ai";
+import type { MobilePushMessage } from "../../mobile-push/types";
 import { getInteractiveCerebrasLanguageModel } from "../../providers/language-model";
 import { logger } from "../../utils/logger";
 import type {
@@ -56,6 +61,60 @@ type NativeTextModelResult = string & {
   usage: SharedAgentTurnUsage;
   providerMetadata: { modelName: string };
 };
+
+interface SharedNotificationEventBus {
+  subscribe(listener: (event: AgentEventPayload) => void): () => void;
+}
+
+type SharedMobilePushDispatch = (message: MobilePushMessage) => Promise<void>;
+
+function isSharedNotificationEventBus(value: unknown): value is SharedNotificationEventBus {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      "subscribe" in value &&
+      typeof value.subscribe === "function",
+  );
+}
+
+function notificationFromEvent(event: AgentEventPayload): AgentNotification | null {
+  const notification = event.data?.notification;
+  if (
+    event.stream !== NOTIFICATION_STREAM ||
+    !notification ||
+    typeof notification !== "object" ||
+    typeof (notification as AgentNotification).id !== "string" ||
+    typeof (notification as AgentNotification).title !== "string"
+  ) {
+    return null;
+  }
+  return notification as AgentNotification;
+}
+
+/** Bridges canonical notification events to the hosting authority's push sender. */
+export function subscribeSharedMobilePush(
+  eventBus: SharedNotificationEventBus,
+  dispatch: SharedMobilePushDispatch,
+  pending: Promise<void>[],
+): () => void {
+  return eventBus.subscribe((event) => {
+    const notification = notificationFromEvent(event);
+    if (!notification) return;
+    const data: Record<string, string | number | boolean | null> = {
+      notificationId: notification.id,
+      category: notification.category,
+    };
+    if (notification.deepLink) data.deepLink = notification.deepLink;
+    if (notification.groupKey) data.groupKey = notification.groupKey;
+    pending.push(
+      dispatch({
+        title: notification.title,
+        body: notification.body,
+        data,
+      }),
+    );
+  });
+}
 
 let edgeStreamingContextReady: Promise<void> | undefined;
 let sharedRuntimeKernelReady: Promise<void> | undefined;
@@ -418,6 +477,13 @@ async function executeSharedElizaRuntimeTurn(
 
   try {
     await runtime.initialize({ skipMigrations: true });
+    const pushDispatches: Promise<void>[] = [];
+    const eventBus = runtime.getService(ServiceType.AGENT_EVENT);
+    const mobilePushDispatch = input.execution?.mobilePush?.dispatch;
+    const unsubscribePush =
+      mobilePushDispatch && isSharedNotificationEventBus(eventBus)
+        ? subscribeSharedMobilePush(eventBus, mobilePushDispatch, pushDispatches)
+        : undefined;
     if (runtime.actions.some((action) => action.name === "VIEWS")) {
       throw new Error("Eliza Shared runtime must not register client view-navigation actions");
     }
@@ -508,6 +574,18 @@ async function executeSharedElizaRuntimeTurn(
           }
         : undefined,
     );
+    unsubscribePush?.();
+    const pushResults = await Promise.allSettled(pushDispatches);
+    for (const pushResult of pushResults) {
+      if (pushResult.status === "rejected") {
+        logger.warn("[shared-eliza-runtime] mobile push dispatch failed", {
+          error:
+            pushResult.reason instanceof Error
+              ? pushResult.reason.message
+              : String(pushResult.reason),
+        });
+      }
+    }
     const reply = result?.responseContent?.text?.trim() || delivered.at(-1)?.trim() || "";
     // A verified action may own the response and deliver it through the
     // callback with `agentVoiced`; core then correctly reports no second model

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-mobile-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-mobile-push.test.ts
@@ -2,9 +2,16 @@
 
 import type { AgentEventPayload } from "@elizaos/core/edge";
 import { describe, expect, it, vi } from "vitest";
-import { subscribeSharedMobilePush } from "./shared-eliza-runtime";
+import { SHARED_NOTIFICATION_SERVICES, subscribeSharedMobilePush } from "./shared-eliza-runtime";
 
 describe("subscribeSharedMobilePush", () => {
+  it("registers the canonical event bus and notification producer on Shared", () => {
+    expect(SHARED_NOTIFICATION_SERVICES.map((service) => service.serviceType)).toEqual([
+      "agent_event",
+      "notification",
+    ]);
+  });
+
   it("dispatches notification events with the canonical deep-link metadata", async () => {
     let listener: ((event: AgentEventPayload) => void) | undefined;
     const unsubscribe = vi.fn();

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-mobile-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-mobile-push.test.ts
@@ -46,6 +46,7 @@ describe("subscribeSharedMobilePush", () => {
     expect(dispatch).toHaveBeenCalledWith({
       title: "Reminder",
       body: "Leave for the airport",
+      collapseKey: "notification-1",
       data: {
         notificationId: "notification-1",
         category: "reminder",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-mobile-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-mobile-push.test.ts
@@ -1,0 +1,87 @@
+/** Verifies that canonical agent notification events dispatch one mobile-push payload through the Shared host boundary. */
+
+import type { AgentEventPayload } from "@elizaos/core/edge";
+import { describe, expect, it, vi } from "vitest";
+import { subscribeSharedMobilePush } from "./shared-eliza-runtime";
+
+describe("subscribeSharedMobilePush", () => {
+  it("dispatches notification events with the canonical deep-link metadata", async () => {
+    let listener: ((event: AgentEventPayload) => void) | undefined;
+    const unsubscribe = vi.fn();
+    const dispatch = vi.fn(async () => {});
+    const pending: Promise<void>[] = [];
+
+    const stop = subscribeSharedMobilePush(
+      {
+        subscribe(next) {
+          listener = next;
+          return unsubscribe;
+        },
+      },
+      dispatch,
+      pending,
+    );
+
+    listener?.({
+      runId: "run-1",
+      seq: 1,
+      stream: "notification",
+      ts: 1,
+      data: {
+        notification: {
+          id: "notification-1",
+          title: "Reminder",
+          body: "Leave for the airport",
+          category: "reminder",
+          priority: "high",
+          source: "scheduling",
+          deepLink: "/automations/flight",
+          groupKey: "flight",
+          createdAt: 1,
+        },
+      },
+    });
+
+    await Promise.all(pending);
+    expect(dispatch).toHaveBeenCalledWith({
+      title: "Reminder",
+      body: "Leave for the airport",
+      data: {
+        notificationId: "notification-1",
+        category: "reminder",
+        deepLink: "/automations/flight",
+        groupKey: "flight",
+      },
+    });
+    stop();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("ignores non-notification streams and malformed notification events", () => {
+    let listener: ((event: AgentEventPayload) => void) | undefined;
+    const dispatch = vi.fn(async () => {});
+    const pending: Promise<void>[] = [];
+    subscribeSharedMobilePush(
+      {
+        subscribe(next) {
+          listener = next;
+          return () => {};
+        },
+      },
+      dispatch,
+      pending,
+    );
+
+    listener?.({ runId: "run-1", seq: 1, stream: "tool", ts: 1, data: {} });
+    listener?.({
+      runId: "run-1",
+      seq: 2,
+      stream: "notification",
+      ts: 2,
+      data: { notification: { title: "missing id" } },
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(pending).toHaveLength(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.test.ts
@@ -133,6 +133,7 @@ describe("Shared reminder cron", () => {
       {
         title: "Reminder",
         body: "time to stand up and stretch",
+        collapseKey: "reminder-1:2026-08-14T20:00:00.000Z",
         data: {
           notificationId: "reminder-1:2026-08-14T20:00:00.000Z",
           category: "reminder",
@@ -245,24 +246,38 @@ describe("Shared reminder cron", () => {
         providerMessageIds: ["provider-recovered"],
       });
     }) as typeof fetch;
-    const dispatcher = sharedReminderDispatcher(env);
-    await expect(
-      dispatcher.dispatch({
-        taskId: "recovered-reminder",
-        promptInstructions: "recover me",
-        firedAtIso: "2026-08-15T20:05:00.000Z",
-        metadata: {
-          dispatchIdempotencyKey: "recovered-reminder:2026-08-15T20:00:00.000Z",
-          delivery: {
-            platform: "telegram",
-            project: "eliza-app",
-            chatId: "123456789",
-          },
+    const dispatcher = sharedReminderDispatcher(
+      env,
+      "personal:00000000-0000-5000-8000-000000000000",
+    );
+    const recoveredRecord = {
+      taskId: "recovered-reminder",
+      promptInstructions: "recover me",
+      firedAtIso: "2026-08-15T20:05:00.000Z",
+      metadata: {
+        dispatchIdempotencyKey: "recovered-reminder:2026-08-15T20:00:00.000Z",
+        delivery: {
+          platform: "telegram",
+          project: "eliza-app",
+          chatId: "123456789",
         },
-      }),
-    ).resolves.toMatchObject({ ok: true });
+      },
+    };
+    await expect(dispatcher.dispatch(recoveredRecord)).resolves.toMatchObject({
+      ok: true,
+    });
+    await expect(dispatcher.dispatch(recoveredRecord)).resolves.toMatchObject({
+      ok: true,
+    });
     await expect(requests[0]?.json()).resolves.toMatchObject({
       idempotencyKey: "recovered-reminder:2026-08-15T20:00:00.000Z",
+    });
+    expect(coordinateSharedPushDispatch).toHaveBeenCalledTimes(2);
+    expect(coordinateSharedPushDispatch.mock.calls[0]?.[1]).toMatchObject({
+      collapseKey: "recovered-reminder:2026-08-15T20:00:00.000Z",
+    });
+    expect(coordinateSharedPushDispatch.mock.calls[1]?.[1]).toMatchObject({
+      collapseKey: "recovered-reminder:2026-08-15T20:00:00.000Z",
     });
 
     await expect(
@@ -284,7 +299,7 @@ describe("Shared reminder cron", () => {
       acceptance: "not_accepted",
       userActionable: true,
     });
-    expect(requests).toHaveLength(1);
+    expect(requests).toHaveLength(2);
   });
 
   for (const status of [403, 429]) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.test.ts
@@ -3,10 +3,14 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 const listDueScheduledTaskRefs = mock(async () => [
-  { agentId: "personal:owner", taskId: "reminder-1" },
+  {
+    agentId: "personal:00000000-0000-5000-8000-000000000000",
+    taskId: "reminder-1",
+  },
 ]);
 const listRecoverableScheduledTaskRefs = mock(async () => []);
 const claims = new Set<string>();
+const coordinateSharedPushDispatch = mock(async () => {});
 const createSharedScheduledTaskRunner = mock(
   (
     agentId: string,
@@ -60,6 +64,9 @@ mock.module("./shared-scheduling", () => ({
   createSharedScheduledTaskRunner,
   executeSharedSchedulingSql: mock(async () => []),
 }));
+mock.module("./conversation-coordinator", () => ({
+  coordinateSharedPushDispatch,
+}));
 
 const { processDueSharedReminders, sharedReminderDispatcher } = await import(
   "./shared-reminder-cron"
@@ -72,6 +79,7 @@ afterEach(() => {
   listDueScheduledTaskRefs.mockClear();
   listRecoverableScheduledTaskRefs.mockClear();
   createSharedScheduledTaskRunner.mockClear();
+  coordinateSharedPushDispatch.mockClear();
   mock.restore();
 });
 
@@ -79,6 +87,7 @@ const env = {
   ELIZA_APP_WEBHOOK_GATEWAY_URL: "https://gateway.example/",
   ELIZA_APP_DISCORD_WEBHOOK_HANDLER_URL: "https://gateway-discord.example/",
   GATEWAY_INTERNAL_SECRET: "internal-secret",
+  SHARED_RUNTIME_CONVERSATIONS: { getByName: mock() },
 } as never;
 
 describe("Shared reminder cron", () => {
@@ -119,6 +128,21 @@ describe("Shared reminder cron", () => {
       text: "time to stand up and stretch",
       idempotencyKey: "reminder-1:2026-08-14T20:00:00.000Z",
     });
+    expect(coordinateSharedPushDispatch).toHaveBeenCalledWith(
+      "personal:00000000-0000-5000-8000-000000000000",
+      {
+        title: "Reminder",
+        body: "time to stand up and stretch",
+        data: {
+          notificationId: "reminder-1:2026-08-14T20:00:00.000Z",
+          category: "reminder",
+          deepLink: "/chat",
+          taskId: "reminder-1",
+          firedAtIso: "2026-08-14T20:00:00.000Z",
+        },
+      },
+      { namespace: env.SHARED_RUNTIME_CONVERSATIONS },
+    );
   });
 
   test("fails closed before egress when trusted delivery metadata is absent", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
@@ -198,6 +198,7 @@ export function sharedReminderDispatcher(env: Bindings, agentId?: string): Sched
               {
                 title: "Reminder",
                 body: text,
+                collapseKey: idempotencyKey,
                 data: {
                   notificationId: idempotencyKey,
                   category: "reminder",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
@@ -10,6 +10,9 @@ import {
   type SharedReminderDelivery,
 } from "@elizaos/plugin-scheduling/edge";
 import type { Bindings } from "../../../types/cloud-worker-env";
+import { logger } from "../../utils/logger";
+import { coordinateSharedPushDispatch } from "./conversation-coordinator";
+import { isPersonalSharedAgentId } from "./personal-shared-agent";
 import { createSharedScheduledTaskRunner, executeSharedSchedulingSql } from "./shared-scheduling";
 
 function reminderDelivery(record: ScheduledTaskDispatchRecord): SharedReminderDelivery {
@@ -57,7 +60,7 @@ async function readGatewayDeliveryResponse(
   }
 }
 
-export function sharedReminderDispatcher(env: Bindings): ScheduledTaskDispatcher {
+export function sharedReminderDispatcher(env: Bindings, agentId?: string): ScheduledTaskDispatcher {
   const secret = env.GATEWAY_INTERNAL_SECRET;
   if (!secret) {
     throw new Error("GATEWAY_INTERNAL_SECRET is not configured");
@@ -181,6 +184,41 @@ export function sharedReminderDispatcher(env: Bindings): ScheduledTaskDispatcher
           message: "Reminder delivery returned no verifiable provider receipt.",
         };
       }
+      if (agentId && isPersonalSharedAgentId(agentId)) {
+        const namespace = env.SHARED_RUNTIME_CONVERSATIONS;
+        if (!namespace) {
+          logger.warn("[SharedReminders] mobile push coordinator is unavailable", {
+            agentId,
+            taskId: record.taskId,
+          });
+        } else {
+          try {
+            await coordinateSharedPushDispatch(
+              agentId,
+              {
+                title: "Reminder",
+                body: text,
+                data: {
+                  notificationId: idempotencyKey,
+                  category: "reminder",
+                  deepLink: "/chat",
+                  taskId: record.taskId,
+                  firedAtIso: record.firedAtIso,
+                },
+              },
+              { namespace },
+            );
+          } catch (error) {
+            // error-policy:J7 remote push is diagnostic fan-out after the
+            // connector's verified acceptance and cannot refire that delivery.
+            logger.warn("[SharedReminders] mobile push dispatch failed", {
+              agentId,
+              taskId: record.taskId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }
+      }
       return {
         ok: true,
         channelKey: "current_dm",
@@ -216,7 +254,6 @@ export async function processDueSharedReminders(
     dueAtIso: now.toISOString(),
     limit,
   });
-  const dispatcher = sharedReminderDispatcher(env);
   let fired = 0;
   let raced = 0;
   let deferred = 0;
@@ -236,7 +273,10 @@ export async function processDueSharedReminders(
     const batch = work.slice(offset, offset + 10);
     const outcomes = await Promise.all(
       batch.map((item) =>
-        createSharedScheduledTaskRunner(item.agentId, dispatcher).fireWithResult(
+        createSharedScheduledTaskRunner(
+          item.agentId,
+          sharedReminderDispatcher(env, item.agentId),
+        ).fireWithResult(
           item.taskId,
           item.recovery ? { recoverFiredAtIso: item.firedAtIso } : { allowTerminalRefire: true },
         ),

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -215,6 +215,9 @@ export interface SharedRuntimeChatOptions {
   trustedUserUtterance?: string;
   /** Local/transition gate for proving the genuine Workerd AgentRuntime path. */
   executionEngine?: "direct-model" | "eliza-runtime";
+  mobilePushDispatch?: NonNullable<
+    NonNullable<RunSharedAgentTurnInput["execution"]>["mobilePush"]
+  >["dispatch"];
 }
 
 export {
@@ -238,6 +241,7 @@ function sharedElizaRuntimeExecution(
   agent: SharedRuntimeAgent,
   params: Record<string, unknown>,
   funding: SharedRuntimeChatOptions["funding"],
+  mobilePushDispatch?: SharedRuntimeChatOptions["mobilePushDispatch"],
 ): NonNullable<RunSharedAgentTurnInput["execution"]> {
   const reminderDelivery = funding === "platform" ? trustedReminderDelivery(params) : undefined;
   return {
@@ -264,6 +268,7 @@ function sharedElizaRuntimeExecution(
           },
         }
       : {}),
+    ...(mobilePushDispatch ? { mobilePush: { dispatch: mobilePushDispatch } } : {}),
   };
 }
 
@@ -992,7 +997,12 @@ export class SharedRuntimeChatService {
         ...(memoryStore ? { memory: memoryStore } : {}),
         ...(options.executionEngine === "eliza-runtime"
           ? {
-              execution: sharedElizaRuntimeExecution(agent, params, options.funding),
+              execution: sharedElizaRuntimeExecution(
+                agent,
+                params,
+                options.funding,
+                options.mobilePushDispatch,
+              ),
             }
           : {}),
       });
@@ -1186,7 +1196,12 @@ export class SharedRuntimeChatService {
         onProviderDispatch: billing?.markProviderDispatched,
         ...(options.executionEngine === "eliza-runtime"
           ? {
-              execution: sharedElizaRuntimeExecution(agent, params, options.funding),
+              execution: sharedElizaRuntimeExecution(
+                agent,
+                params,
+                options.funding,
+                options.mobilePushDispatch,
+              ),
             }
           : {}),
       });

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -414,6 +414,16 @@ export interface Bindings {
   ELIZA_WEB_PUSH_VAPID_PRIVATE_KEY?: string;
   /** VAPID contact subject sent to push services, e.g. `mailto:ops@example.com`. */
   ELIZA_WEB_PUSH_VAPID_SUBJECT?: string;
+  /** APNs provider key contents; secret and never returned to clients. */
+  ELIZA_APNS_KEY?: string;
+  /** APNs provider key id used as the ES256 JWT kid. */
+  ELIZA_APNS_KEY_ID?: string;
+  /** Apple Developer team id used as the ES256 JWT issuer. */
+  ELIZA_APNS_TEAM_ID?: string;
+  /** Must equal the signed iOS bundle id, ai.elizaos.app. */
+  ELIZA_APNS_TOPIC?: string;
+  /** Explicit APNs host selection: 0 sandbox, 1 production. */
+  ELIZA_APNS_PRODUCTION?: string;
   AGENT_ROUTER_ORIGIN_HOST?: string;
   /**
    * When `"true"`/`"1"`, the agent-router reaches a running sandbox through the

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -720,6 +720,11 @@ describe("canonical cloud deployment environment contract", () => {
     expect(publish.env?.ELIZA_APNS_PRODUCTION).toContain(
       "vars.ELIZA_APNS_PRODUCTION",
     );
+    expect(publish.run).toContain(
+      "Personal Shared APNs bindings must be configured all-or-none",
+    );
+    expect(publish.run).toContain('ELIZA_APNS_TOPIC" != "ai.elizaos.app');
+    expect(publish.run).toContain('ELIZA_APNS_PRODUCTION" != "0"');
     for (const name of requiredAuthWorkerSecretNames) {
       expect(publish.env?.[name]).toContain("secrets.");
       expect(publish.run).toContain(`\n  ${name} \\\n`);
@@ -762,6 +767,9 @@ describe("canonical cloud deployment environment contract", () => {
     }
     expect(inventory?.run).toContain(
       "Missing required Worker secret binding name(s)",
+    );
+    expect(inventory?.run).toContain(
+      "Personal Shared APNs bindings are partial",
     );
     expect(inventory?.run).toContain("values were not read");
   });

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -720,9 +720,8 @@ describe("canonical cloud deployment environment contract", () => {
     expect(publish.env?.ELIZA_APNS_PRODUCTION).toContain(
       "vars.ELIZA_APNS_PRODUCTION",
     );
-    expect(publish.run).toContain(
-      "Personal Shared APNs bindings must be configured all-or-none",
-    );
+    expect(publish.run).toContain("verify_apns_binding_candidates");
+    expect(publish.run).toContain("partial existing or configured bindings");
     expect(publish.run).toContain('ELIZA_APNS_TOPIC" != "ai.elizaos.app');
     expect(publish.run).toContain('ELIZA_APNS_PRODUCTION" != "0"');
     for (const name of requiredAuthWorkerSecretNames) {

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -705,6 +705,21 @@ describe("canonical cloud deployment environment contract", () => {
       'echo "::notice::$name is not configured; skipping"',
     );
     expect(publish.run).not.toContain("required_worker_provisioning_secrets=(");
+    for (const name of [
+      "ELIZA_APNS_KEY",
+      "ELIZA_APNS_KEY_ID",
+      "ELIZA_APNS_TEAM_ID",
+      "ELIZA_APNS_TOPIC",
+      "ELIZA_APNS_PRODUCTION",
+    ]) {
+      expect(publish.env?.[name]).toBeDefined();
+      expect(publish.run).toContain(`\n  ${name} \\\n`);
+    }
+    expect(publish.env?.ELIZA_APNS_KEY).toContain("secrets.ELIZA_APNS_KEY");
+    expect(publish.env?.ELIZA_APNS_TOPIC).toContain("vars.ELIZA_APNS_TOPIC");
+    expect(publish.env?.ELIZA_APNS_PRODUCTION).toContain(
+      "vars.ELIZA_APNS_PRODUCTION",
+    );
     for (const name of requiredAuthWorkerSecretNames) {
       expect(publish.env?.[name]).toContain("secrets.");
       expect(publish.run).toContain(`\n  ${name} \\\n`);

--- a/packages/ui/src/api/client-notifications.test.ts
+++ b/packages/ui/src/api/client-notifications.test.ts
@@ -54,17 +54,16 @@ describe("ElizaClient push-token verbs", () => {
     });
   });
 
-  it("DELETEs the URL-encoded token on unregister", async () => {
+  it("DELETEs the token in a body so device identifiers never enter request URLs", async () => {
     const client = new ElizaClient("http://agent.example:31337", "token");
     const fetch = vi.fn(async () => ({ ok: true }));
     client.fetch = fetch as typeof client.fetch;
 
-    // A token with a slash must be percent-encoded so it stays one path segment.
     await client.unregisterPushToken("tok/with+slash");
 
-    expect(fetch).toHaveBeenCalledWith(
-      "/api/notifications/push-tokens/tok%2Fwith%2Bslash",
-      { method: "DELETE" },
-    );
+    expect(fetch).toHaveBeenCalledWith("/api/notifications/push-tokens", {
+      method: "DELETE",
+      body: JSON.stringify({ token: "tok/with+slash" }),
+    });
   });
 });

--- a/packages/ui/src/api/client-notifications.ts
+++ b/packages/ui/src/api/client-notifications.ts
@@ -129,10 +129,10 @@ ElizaClient.prototype.unregisterPushToken = async function (
   this: ElizaClient,
   token: string,
 ): Promise<{ ok: boolean }> {
-  return this.fetch<{ ok: boolean }>(
-    `/api/notifications/push-tokens/${encodeURIComponent(token)}`,
-    { method: "DELETE" },
-  );
+  return this.fetch<{ ok: boolean }>("/api/notifications/push-tokens", {
+    method: "DELETE",
+    body: JSON.stringify({ token }),
+  });
 };
 
 // Dev-only seed (the server 404s it in production builds): paints a demo

--- a/packages/ui/src/components/shell/notifications-boot.test.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.test.tsx
@@ -6,8 +6,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   init: vi.fn(),
   push: vi.fn(async () => undefined),
+  refreshPush: vi.fn(async () => undefined),
+  unsubscribeBase: vi.fn(),
+  onBaseUrlChange: vi.fn(),
   seed: vi.fn(async () => undefined),
   setTab: vi.fn(),
+}));
+
+vi.mock("../../api/client", () => ({
+  client: { onBaseUrlChange: mocks.onBaseUrlChange },
 }));
 
 vi.mock("../../state", () => ({ useAppSelector: () => mocks.setTab }));
@@ -17,6 +24,7 @@ vi.mock("../../state/notifications/notification-store", () => ({
 }));
 vi.mock("../../state/notifications/push-registration", () => ({
   initPushRegistration: mocks.push,
+  refreshPushRegistrationAuthority: mocks.refreshPush,
 }));
 
 import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
@@ -29,6 +37,8 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
+
+mocks.onBaseUrlChange.mockReturnValue(mocks.unsubscribeBase);
 
 describe("notification boot boundaries", () => {
   it("starts WebSocket ingress from the headless data boot", () => {
@@ -43,5 +53,18 @@ describe("notification boot boundaries", () => {
 
     act(() => window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT)));
     expect(mocks.setTab).toHaveBeenCalledWith("chat");
+  });
+
+  it("rotates push ownership on base and token authority changes", async () => {
+    const { unmount } = render(<NotificationsShellBoot />);
+    const baseListener = mocks.onBaseUrlChange.mock.calls[0]?.[0];
+    expect(baseListener).toBeTypeOf("function");
+
+    act(() => baseListener?.("https://agent-b.example"));
+    act(() => window.dispatchEvent(new Event("steward-token-sync")));
+    await waitFor(() => expect(mocks.refreshPush).toHaveBeenCalledTimes(2));
+
+    unmount();
+    expect(mocks.unsubscribeBase).toHaveBeenCalledOnce();
   });
 });

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -7,14 +7,20 @@
  * "Notifications", the `<scheme>://notifications` deep link) by navigating to
  * Home.
  */
+
+import { logger } from "@elizaos/logger";
 import { useEffect } from "react";
+import { client } from "../../api/client";
 import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
 import { useAppSelector } from "../../state";
 import {
   initNotifications,
   seedDevNotificationsIfEmpty,
 } from "../../state/notifications/notification-store";
-import { initPushRegistration } from "../../state/notifications/push-registration";
+import {
+  initPushRegistration,
+  refreshPushRegistrationAuthority,
+} from "../../state/notifications/push-registration";
 
 /**
  * Boots data ingress independently of the paintable app shell. Startup, auth,
@@ -36,6 +42,22 @@ export function NotificationsShellBoot(): null {
     // Native-only, gated on granted permission, guarded against double-register.
     // The token POST is what makes the server's APNs/FCM stack a live pipeline.
     void initPushRegistration();
+    const refreshAuthority = (force = false) => {
+      void refreshPushRegistrationAuthority(undefined, force).catch(
+        (error: unknown) => {
+          // error-policy:J1 the shell transport boundary reports failed revoke or
+          // re-registration without turning an authority switch into a UI crash.
+          logger.error(
+            { src: "push-registration", error },
+            "[push-registration] failed to rotate device push authority",
+          );
+        },
+      );
+    };
+    const onBaseAuthorityChange = () => refreshAuthority(true);
+    const onTokenAuthorityChange = () => refreshAuthority();
+    const unsubscribeBase = client.onBaseUrlChange(onBaseAuthorityChange);
+    window.addEventListener("steward-token-sync", onTokenAuthorityChange);
     // Dev builds only: paint the demo spread when the inbox is empty so the
     // inline home notification surface is visible by default while developing.
     // Prod bundles compile `import.meta.env.DEV` to false, so this is stripped.
@@ -44,6 +66,10 @@ export function NotificationsShellBoot(): null {
     } catch {
       // `import.meta.env` unavailable (non-Vite host) — treat as non-dev.
     }
+    return () => {
+      unsubscribeBase();
+      window.removeEventListener("steward-token-sync", onTokenAuthorityChange);
+    };
   }, []);
 
   // Route every "open notifications" entry point to the combined home/apps

--- a/packages/ui/src/state/notifications/push-registration.test.ts
+++ b/packages/ui/src/state/notifications/push-registration.test.ts
@@ -20,6 +20,7 @@ import {
   initPushRegistration,
   isRemotePushTransportEnabled,
   type PushRegistrationDeps,
+  refreshPushRegistrationAuthority,
   unregisterPushToken,
 } from "./push-registration";
 
@@ -71,6 +72,7 @@ function makeDeps(
     registerToken: vi.fn(async () => ({ ok: true })),
     unregisterToken: vi.fn(async () => ({ ok: true })),
     navigate: vi.fn(),
+    sleep: vi.fn(async () => {}),
   };
 }
 
@@ -258,6 +260,63 @@ describe("initPushRegistration", () => {
 
     await unregisterPushToken(deps);
     expect(deps.unregisterToken).toHaveBeenCalledWith("tok-to-drop");
+  });
+
+  it("retries a failed token POST without requiring another OS event", async () => {
+    const plugin = makePlugin("granted");
+    const deps = makeDeps(plugin, "ios");
+    const registerToken = vi.fn(async () => ({ ok: true }));
+    deps.registerToken = registerToken;
+    registerToken
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce({ ok: true });
+
+    await initPushRegistration(deps);
+    emitRegistration(plugin, "retry-post-token");
+    await flush();
+
+    expect(registerToken).toHaveBeenCalledTimes(3);
+    expect(deps.sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("revokes from the old authority before registering on a new authority", async () => {
+    const plugin = makePlugin("granted");
+    const deps = makeDeps(plugin, "ios");
+    let authorityKey = "agent-a";
+    const unregisterA = vi.fn(async () => ({ ok: true }));
+    const registerA = vi.fn(async () => ({ ok: true }));
+    const unregisterB = vi.fn(async () => ({ ok: true }));
+    const registerB = vi.fn(async () => ({ ok: true }));
+    deps.captureAuthority = () =>
+      authorityKey === "agent-a"
+        ? {
+            key: authorityKey,
+            registerToken: registerA,
+            unregisterToken: unregisterA,
+          }
+        : {
+            key: authorityKey,
+            registerToken: registerB,
+            unregisterToken: unregisterB,
+          };
+
+    await initPushRegistration(deps);
+    emitRegistration(plugin, "authority-token");
+    await flush();
+    expect(registerA).toHaveBeenCalledWith("ios", "authority-token");
+
+    authorityKey = "agent-b";
+    await Promise.all([
+      refreshPushRegistrationAuthority(deps),
+      refreshPushRegistrationAuthority(deps),
+    ]);
+    expect(unregisterA).toHaveBeenCalledWith("authority-token");
+    expect(plugin.__registerCalls).toBe(2);
+    emitRegistration(plugin, "authority-token");
+    await flush();
+    expect(registerB).toHaveBeenCalledWith("ios", "authority-token");
+    expect(unregisterB).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/state/notifications/push-registration.test.ts
+++ b/packages/ui/src/state/notifications/push-registration.test.ts
@@ -318,6 +318,84 @@ describe("initPushRegistration", () => {
     expect(registerB).toHaveBeenCalledWith("ios", "authority-token");
     expect(unregisterB).not.toHaveBeenCalled();
   });
+
+  it("cleans an old-authority POST that completes after the authority changes", async () => {
+    const plugin = makePlugin("granted");
+    const deps = makeDeps(plugin, "ios");
+    let authorityKey = "agent-a";
+    let finishRegisterA: (() => void) | undefined;
+    const registerA = vi.fn(
+      () =>
+        new Promise<{ ok: true }>((resolve) => {
+          finishRegisterA = () => resolve({ ok: true });
+        }),
+    );
+    const unregisterA = vi.fn(async () => ({ ok: true }));
+    const registerB = vi.fn(async () => ({ ok: true }));
+    const unregisterB = vi.fn(async () => ({ ok: true }));
+    deps.captureAuthority = () =>
+      authorityKey === "agent-a"
+        ? {
+            key: authorityKey,
+            registerToken: registerA,
+            unregisterToken: unregisterA,
+          }
+        : {
+            key: authorityKey,
+            registerToken: registerB,
+            unregisterToken: unregisterB,
+          };
+
+    await initPushRegistration(deps);
+    emitRegistration(plugin, "racing-token");
+    await flush();
+    expect(registerA).toHaveBeenCalledOnce();
+
+    authorityKey = "agent-b";
+    await refreshPushRegistrationAuthority(deps);
+    finishRegisterA?.();
+    await flush();
+
+    expect(unregisterA).toHaveBeenCalledWith("racing-token");
+    emitRegistration(plugin, "racing-token");
+    await flush();
+    expect(registerB).toHaveBeenCalledWith("ios", "racing-token");
+  });
+
+  it("revokes a rotated OS token after the replacement is registered", async () => {
+    const plugin = makePlugin("granted");
+    const deps = makeDeps(plugin, "ios");
+
+    await initPushRegistration(deps);
+    emitRegistration(plugin, "old-token");
+    await flush();
+    emitRegistration(plugin, "new-token");
+    await flush();
+
+    expect(deps.registerToken).toHaveBeenNthCalledWith(2, "ios", "new-token");
+    expect(deps.unregisterToken).toHaveBeenCalledWith("old-token");
+  });
+
+  it("does not mistake a failed old-token cleanup for a failed replacement POST", async () => {
+    const loggedError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const plugin = makePlugin("granted");
+    const deps = makeDeps(plugin, "ios");
+    deps.unregisterToken = vi.fn(async () => {
+      throw new Error("cleanup unavailable");
+    });
+
+    await initPushRegistration(deps);
+    emitRegistration(plugin, "old-token");
+    await flush();
+    emitRegistration(plugin, "new-token");
+    await flush();
+    emitRegistration(plugin, "new-token");
+    await flush();
+
+    expect(deps.registerToken).toHaveBeenCalledTimes(2);
+    expect(deps.unregisterToken).toHaveBeenCalledTimes(3);
+    expect(loggedError).toHaveBeenCalled();
+  });
 });
 
 describe("isRemotePushTransportEnabled", () => {

--- a/packages/ui/src/state/notifications/push-registration.test.ts
+++ b/packages/ui/src/state/notifications/push-registration.test.ts
@@ -376,6 +376,32 @@ describe("initPushRegistration", () => {
     expect(deps.unregisterToken).toHaveBeenCalledWith("old-token");
   });
 
+  it("serializes overlapping token callbacks so an older completion cannot win", async () => {
+    const plugin = makePlugin("granted");
+    const deps = makeDeps(plugin, "ios");
+    let finishOld: (() => void) | undefined;
+    deps.registerToken = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: true }>((resolve) => {
+            finishOld = () => resolve({ ok: true });
+          }),
+      )
+      .mockResolvedValue({ ok: true });
+
+    await initPushRegistration(deps);
+    emitRegistration(plugin, "old-token");
+    emitRegistration(plugin, "new-token");
+    await flush();
+    expect(deps.registerToken).toHaveBeenCalledTimes(1);
+
+    finishOld?.();
+    await flush();
+    expect(deps.registerToken).toHaveBeenNthCalledWith(2, "ios", "new-token");
+    expect(deps.unregisterToken).toHaveBeenCalledWith("old-token");
+  });
+
   it("does not mistake a failed old-token cleanup for a failed replacement POST", async () => {
     const loggedError = vi.spyOn(console, "error").mockImplementation(() => {});
     const plugin = makePlugin("granted");
@@ -393,7 +419,7 @@ describe("initPushRegistration", () => {
     await flush();
 
     expect(deps.registerToken).toHaveBeenCalledTimes(2);
-    expect(deps.unregisterToken).toHaveBeenCalledTimes(3);
+    expect(deps.unregisterToken).toHaveBeenCalledTimes(6);
     expect(loggedError).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/state/notifications/push-registration.ts
+++ b/packages/ui/src/state/notifications/push-registration.ts
@@ -99,14 +99,34 @@ let startPromise: Promise<void> | null = null;
 let listenerPromise: Promise<void> | null = null;
 /** The most recent token we POSTed, so a re-fired `registration` is a no-op. */
 let activeAuthorityKey: string | null = null;
+let authorityEpoch = 0;
 let authorityTransition: Promise<void> = Promise.resolve();
 let registeredToken: {
   value: string;
   authorityKey: string;
   unregister: PushRegistrationDeps["unregisterToken"];
+  sleep?: PushRegistrationDeps["sleep"];
 } | null = null;
 
 const TOKEN_POST_RETRY_DELAYS_MS = [0, 250, 1_000] as const;
+
+async function unregisterWithRetry(
+  unregister: PushRegistrationDeps["unregisterToken"],
+  value: string,
+  sleep: PushRegistrationDeps["sleep"],
+): Promise<void> {
+  let lastError: unknown;
+  for (const delayMs of TOKEN_POST_RETRY_DELAYS_MS) {
+    if (delayMs > 0) await sleep?.(delayMs);
+    try {
+      await unregister(value);
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
 
 /** Only the native mobile platforms carry a remote-push transport. */
 function pushPlatform(platform: FrontendPlatform): "ios" | "android" | null {
@@ -147,6 +167,7 @@ async function onRegistration(
     registerToken: deps.registerToken,
     unregisterToken: deps.unregisterToken,
   };
+  const epoch = authorityEpoch;
   if (
     registeredToken?.value === value &&
     registeredToken.authorityKey === authority.key
@@ -155,21 +176,44 @@ async function onRegistration(
   }
   let lastError: unknown;
   for (const delayMs of TOKEN_POST_RETRY_DELAYS_MS) {
+    if (epoch !== authorityEpoch || authority.key !== activeAuthorityKey)
+      return;
     if (delayMs > 0) {
       await (deps.sleep ?? defaultDeps.sleep)?.(delayMs);
     }
     try {
       await authority.registerToken(platform, value);
-      registeredToken = {
-        value,
-        authorityKey: authority.key,
-        unregister: authority.unregisterToken,
-      };
-      lastError = undefined;
-      break;
     } catch (error) {
       lastError = error;
+      continue;
     }
+    if (epoch !== authorityEpoch || authority.key !== activeAuthorityKey) {
+      await unregisterWithRetry(
+        authority.unregisterToken,
+        value,
+        deps.sleep ?? defaultDeps.sleep,
+      );
+      return;
+    }
+    const previous = registeredToken;
+    registeredToken = {
+      value,
+      authorityKey: authority.key,
+      unregister: authority.unregisterToken,
+      sleep: deps.sleep,
+    };
+    if (
+      previous &&
+      (previous.value !== value || previous.authorityKey !== authority.key)
+    ) {
+      await unregisterWithRetry(
+        previous.unregister,
+        previous.value,
+        previous.sleep ?? defaultDeps.sleep,
+      );
+    }
+    lastError = undefined;
+    break;
   }
   if (lastError !== undefined) throw lastError;
   logger.info(
@@ -284,8 +328,12 @@ export async function unregisterPushToken(
 ): Promise<void> {
   const token = registeredToken;
   if (!token) return;
-  registeredToken = null;
-  await token.unregister(token.value);
+  await unregisterWithRetry(
+    token.unregister,
+    token.value,
+    token.sleep ?? defaultDeps.sleep,
+  );
+  if (registeredToken === token) registeredToken = null;
 }
 
 /** Revoke the prior authority's token, then acquire it for the current target. */
@@ -293,6 +341,13 @@ export function refreshPushRegistrationAuthority(
   deps: PushRegistrationDeps = defaultDeps,
   force = false,
 ): Promise<void> {
+  const requestedAuthorityKey = (
+    deps.captureAuthority?.() ?? { key: "default" }
+  ).key;
+  if (!force && requestedAuthorityKey === activeAuthorityKey) {
+    return authorityTransition;
+  }
+  authorityEpoch += 1;
   const transition = authorityTransition
     .catch(() => undefined)
     .then(async () => {
@@ -313,6 +368,7 @@ export function __resetPushRegistrationForTests(): void {
   startPromise = null;
   listenerPromise = null;
   activeAuthorityKey = null;
+  authorityEpoch = 0;
   authorityTransition = Promise.resolve();
   registeredToken = null;
 }

--- a/packages/ui/src/state/notifications/push-registration.ts
+++ b/packages/ui/src/state/notifications/push-registration.ts
@@ -101,12 +101,15 @@ let listenerPromise: Promise<void> | null = null;
 let activeAuthorityKey: string | null = null;
 let authorityEpoch = 0;
 let authorityTransition: Promise<void> = Promise.resolve();
-let registeredToken: {
+let registrationTransition: Promise<void> = Promise.resolve();
+interface RegisteredPushToken {
   value: string;
   authorityKey: string;
   unregister: PushRegistrationDeps["unregisterToken"];
   sleep?: PushRegistrationDeps["sleep"];
-} | null = null;
+}
+let registeredToken: RegisteredPushToken | null = null;
+let pendingRevocations: RegisteredPushToken[] = [];
 
 const TOKEN_POST_RETRY_DELAYS_MS = [0, 250, 1_000] as const;
 
@@ -126,6 +129,38 @@ async function unregisterWithRetry(
     }
   }
   throw lastError;
+}
+
+function queueRevocation(token: RegisteredPushToken): void {
+  if (
+    pendingRevocations.some(
+      (candidate) =>
+        candidate.value === token.value &&
+        candidate.authorityKey === token.authorityKey,
+    )
+  ) {
+    return;
+  }
+  pendingRevocations.push(token);
+}
+
+async function drainPendingRevocations(): Promise<void> {
+  const failed: RegisteredPushToken[] = [];
+  let firstError: unknown;
+  for (const token of pendingRevocations) {
+    try {
+      await unregisterWithRetry(
+        token.unregister,
+        token.value,
+        token.sleep ?? defaultDeps.sleep,
+      );
+    } catch (error) {
+      firstError ??= error;
+      failed.push(token);
+    }
+  }
+  pendingRevocations = failed;
+  if (firstError !== undefined) throw firstError;
 }
 
 /** Only the native mobile platforms carry a remote-push transport. */
@@ -168,6 +203,7 @@ async function onRegistration(
     unregisterToken: deps.unregisterToken,
   };
   const epoch = authorityEpoch;
+  await drainPendingRevocations();
   if (
     registeredToken?.value === value &&
     registeredToken.authorityKey === authority.key
@@ -188,11 +224,13 @@ async function onRegistration(
       continue;
     }
     if (epoch !== authorityEpoch || authority.key !== activeAuthorityKey) {
-      await unregisterWithRetry(
-        authority.unregisterToken,
+      queueRevocation({
         value,
-        deps.sleep ?? defaultDeps.sleep,
-      );
+        authorityKey: authority.key,
+        unregister: authority.unregisterToken,
+        sleep: deps.sleep,
+      });
+      await drainPendingRevocations();
       return;
     }
     const previous = registeredToken;
@@ -206,11 +244,8 @@ async function onRegistration(
       previous &&
       (previous.value !== value || previous.authorityKey !== authority.key)
     ) {
-      await unregisterWithRetry(
-        previous.unregister,
-        previous.value,
-        previous.sleep ?? defaultDeps.sleep,
-      );
+      queueRevocation(previous);
+      await drainPendingRevocations();
     }
     lastError = undefined;
     break;
@@ -220,6 +255,23 @@ async function onRegistration(
     { src: "push-registration", platform },
     "[push-registration] registered device push token",
   );
+}
+
+function enqueueRegistration(
+  deps: PushRegistrationDeps,
+  platform: "ios" | "android",
+  token: PushRegistrationToken,
+): void {
+  registrationTransition = registrationTransition
+    .then(() => onRegistration(deps, platform, token))
+    .catch((error: unknown) => {
+      // error-policy:J1 the native registration event is a transport boundary;
+      // retaining pending revocations lets a later event retry cleanup.
+      logger.error(
+        { src: "push-registration", platform, error },
+        "[push-registration] failed to register device push token",
+      );
+    });
 }
 
 /**
@@ -296,14 +348,7 @@ async function addPushListeners(
     throw new Error("PushNotifications.addListener is unavailable");
   }
   await addListener("registration", (token: PushRegistrationToken) => {
-    void onRegistration(deps, platform, token).catch((error: unknown) => {
-      // error-policy:J1 transport boundary — a failed token POST leaves
-      // registeredToken null so the next `registration` retries; surface it.
-      logger.error(
-        { src: "push-registration", platform, error },
-        "[push-registration] failed to register device push token",
-      );
-    });
+    enqueueRegistration(deps, platform, token);
   });
 
   await addListener("registrationError", (error: PushRegistrationError) => {
@@ -327,13 +372,11 @@ export async function unregisterPushToken(
   _deps: PushRegistrationDeps = defaultDeps,
 ): Promise<void> {
   const token = registeredToken;
-  if (!token) return;
-  await unregisterWithRetry(
-    token.unregister,
-    token.value,
-    token.sleep ?? defaultDeps.sleep,
-  );
-  if (registeredToken === token) registeredToken = null;
+  if (token) {
+    queueRevocation(token);
+    if (registeredToken === token) registeredToken = null;
+  }
+  await drainPendingRevocations();
 }
 
 /** Revoke the prior authority's token, then acquire it for the current target. */
@@ -348,17 +391,27 @@ export function refreshPushRegistrationAuthority(
     return authorityTransition;
   }
   authorityEpoch += 1;
-  const transition = authorityTransition
-    .catch(() => undefined)
-    .then(async () => {
-      const nextAuthorityKey = (deps.captureAuthority?.() ?? { key: "default" })
-        .key;
-      if (!force && nextAuthorityKey === activeAuthorityKey) return;
-      await unregisterPushToken(deps);
-      startPromise = null;
-      activeAuthorityKey = null;
-      await initPushRegistration(deps);
-    });
+  const performTransition = async () => {
+    const nextAuthorityKey = (deps.captureAuthority?.() ?? { key: "default" })
+      .key;
+    if (!force && nextAuthorityKey === activeAuthorityKey) return;
+    await unregisterPushToken(deps);
+    startPromise = null;
+    activeAuthorityKey = null;
+    await initPushRegistration(deps);
+  };
+  const transition = authorityTransition.then(
+    performTransition,
+    async (error) => {
+      // error-policy:J5 the failed transition remains observed by the caller;
+      // log it before recovering the serialization queue for the next event.
+      logger.warn(
+        { src: "push-registration", error },
+        "[push-registration] recovering failed authority transition",
+      );
+      await performTransition();
+    },
+  );
   authorityTransition = transition;
   return transition;
 }
@@ -370,5 +423,7 @@ export function __resetPushRegistrationForTests(): void {
   activeAuthorityKey = null;
   authorityEpoch = 0;
   authorityTransition = Promise.resolve();
+  registrationTransition = Promise.resolve();
   registeredToken = null;
+  pendingRevocations = [];
 }

--- a/packages/ui/src/state/notifications/push-registration.ts
+++ b/packages/ui/src/state/notifications/push-registration.ts
@@ -27,7 +27,7 @@
  */
 
 import { logger } from "@elizaos/logger";
-import { client } from "../../api/client";
+import { client, ElizaClient } from "../../api/client";
 import {
   getPushNotificationsPlugin,
   type PushActionPerformed,
@@ -39,6 +39,7 @@ import {
   type FrontendPlatform,
   getFrontendPlatform,
 } from "../../platform/platform-guards";
+import { loadAgentProfileRegistry } from "../agent-profiles";
 import { navigateDeepLink } from "./navigate-deep-link";
 
 /**
@@ -57,6 +58,27 @@ export interface PushRegistrationDeps {
   ) => Promise<unknown>;
   unregisterToken: (token: string) => Promise<unknown>;
   navigate: (deepLink: string) => void;
+  captureAuthority?: () => PushRegistrationAuthority;
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
+export interface PushRegistrationAuthority {
+  key: string;
+  registerToken: PushRegistrationDeps["registerToken"];
+  unregisterToken: PushRegistrationDeps["unregisterToken"];
+}
+
+function captureClientAuthority(): PushRegistrationAuthority {
+  const baseUrl = client.getBaseUrl();
+  const token = client.getRestAuthToken();
+  const profileId = loadAgentProfileRegistry().activeProfileId ?? "unscoped";
+  const authorityClient = new ElizaClient(baseUrl, token ?? undefined);
+  return {
+    key: `${profileId}\u0000${baseUrl}\u0000${token ?? ""}`,
+    registerToken: (platform, value) =>
+      authorityClient.registerPushToken(platform, value),
+    unregisterToken: (value) => authorityClient.unregisterPushToken(value),
+  };
 }
 
 const defaultDeps: PushRegistrationDeps = {
@@ -66,12 +88,25 @@ const defaultDeps: PushRegistrationDeps = {
   registerToken: (platform, token) => client.registerPushToken(platform, token),
   unregisterToken: (token) => client.unregisterPushToken(token),
   navigate: navigateDeepLink,
+  captureAuthority: captureClientAuthority,
+  sleep: (delayMs) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, delayMs);
+    }),
 };
 
 let startPromise: Promise<void> | null = null;
 let listenerPromise: Promise<void> | null = null;
 /** The most recent token we POSTed, so a re-fired `registration` is a no-op. */
-let registeredToken: string | null = null;
+let activeAuthorityKey: string | null = null;
+let authorityTransition: Promise<void> = Promise.resolve();
+let registeredToken: {
+  value: string;
+  authorityKey: string;
+  unregister: PushRegistrationDeps["unregisterToken"];
+} | null = null;
+
+const TOKEN_POST_RETRY_DELAYS_MS = [0, 250, 1_000] as const;
 
 /** Only the native mobile platforms carry a remote-push transport. */
 function pushPlatform(platform: FrontendPlatform): "ios" | "android" | null {
@@ -106,9 +141,37 @@ async function onRegistration(
   token: PushRegistrationToken,
 ): Promise<void> {
   const value = token.value?.trim();
-  if (!value || value === registeredToken) return;
-  await deps.registerToken(platform, value);
-  registeredToken = value;
+  if (!value) return;
+  const authority = deps.captureAuthority?.() ?? {
+    key: "default",
+    registerToken: deps.registerToken,
+    unregisterToken: deps.unregisterToken,
+  };
+  if (
+    registeredToken?.value === value &&
+    registeredToken.authorityKey === authority.key
+  ) {
+    return;
+  }
+  let lastError: unknown;
+  for (const delayMs of TOKEN_POST_RETRY_DELAYS_MS) {
+    if (delayMs > 0) {
+      await (deps.sleep ?? defaultDeps.sleep)?.(delayMs);
+    }
+    try {
+      await authority.registerToken(platform, value);
+      registeredToken = {
+        value,
+        authorityKey: authority.key,
+        unregister: authority.unregisterToken,
+      };
+      lastError = undefined;
+      break;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  if (lastError !== undefined) throw lastError;
   logger.info(
     { src: "push-registration", platform },
     "[push-registration] registered device push token",
@@ -141,6 +204,8 @@ async function startPushRegistration(
   const platform = pushPlatform(deps.getPlatform());
   if (!platform) return false;
   if (!deps.isRemotePushEnabled(platform)) return false;
+
+  activeAuthorityKey = (deps.captureAuthority?.() ?? { key: "default" }).key;
 
   const plugin = deps.getPlugin();
   if (
@@ -215,17 +280,39 @@ async function addPushListeners(
 
 /** Drop this device's token server-side and locally (logout / revoke). */
 export async function unregisterPushToken(
-  deps: PushRegistrationDeps = defaultDeps,
+  _deps: PushRegistrationDeps = defaultDeps,
 ): Promise<void> {
   const token = registeredToken;
   if (!token) return;
   registeredToken = null;
-  await deps.unregisterToken(token);
+  await token.unregister(token.value);
+}
+
+/** Revoke the prior authority's token, then acquire it for the current target. */
+export function refreshPushRegistrationAuthority(
+  deps: PushRegistrationDeps = defaultDeps,
+  force = false,
+): Promise<void> {
+  const transition = authorityTransition
+    .catch(() => undefined)
+    .then(async () => {
+      const nextAuthorityKey = (deps.captureAuthority?.() ?? { key: "default" })
+        .key;
+      if (!force && nextAuthorityKey === activeAuthorityKey) return;
+      await unregisterPushToken(deps);
+      startPromise = null;
+      activeAuthorityKey = null;
+      await initPushRegistration(deps);
+    });
+  authorityTransition = transition;
+  return transition;
 }
 
 /** Test-only reset of the module-level registration guards. */
 export function __resetPushRegistrationForTests(): void {
   startPromise = null;
   listenerPromise = null;
+  activeAuthorityKey = null;
+  authorityTransition = Promise.resolve();
   registeredToken = null;
 }


### PR DESCRIPTION
Closes #21052.

## Outcome

Completes the source-side Personal Shared iOS remote-push path without adding a second scheduler or registry:

- mounts authenticated Shared push-token GET/POST/DELETE routes at the app's existing per-agent base;
- keeps tokens in the canonical per-agent SharedRuntimeConversation Durable Object;
- bridges canonical notification events to a Workerd-native APNs ES256 provider;
- selects sandbox/production explicitly and requires topic `ai.elizaos.app`;
- handles APNs accept/reject results and removes `BadDeviceToken`/`Unregistered` records;
- forwards push-token mutations to the selected target in remote runtime mode;
- scopes mobile registration to agent/base/account authority, revokes from the old authenticated authority, re-registers after switches, and retries token POSTs;
- wires the existing protected Cloudflare release workflow to optional APNs bindings. Missing bindings leave Shared APNs dormant.

No visual/product Apple work, credential creation, deployment, production mutation, or physical-device action is included.

## Topology

`iOS token -> selected agent push-token route -> selected agent authority`

- Personal Shared: SharedRuntimeConversation DO token state + Workerd APNs sender.
- Dedicated/local/remote target: existing @elizaos/agent PushTokenRegistry + NotificationPushService.
- Remote controller: mutation forwarder only; it does not own a second token registry.

## Focused evidence

- `bun test packages/cloud/shared/src/lib/mobile-push/apns-provider.test.ts` — 6 pass
- `bun test packages/cloud/shared/src/lib/services/shared-runtime/shared-mobile-push.test.ts` — 2 pass
- `bun test packages/cloud/api/src/shared-runtime-conversation.test.ts` — 24 pass
- `bun test packages/cloud/api/__tests__/shared-agent-cloud-push-route.test.ts` — 5 pass
- `bun test packages/agent/src/api/runtime-mode/remote-forwarder.test.ts` — 12 pass
- `bun test packages/ui/src/state/notifications/push-registration.test.ts` — 17 pass
- `bun x vitest run packages/ui/src/components/shell/notifications-boot.test.tsx --coverage.enabled=false` — 3 pass
- `bun test packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts` — 21 pass
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/agent typecheck`

`packages/cloud/api` compilation is independently blocked on current develop by pre-existing test mock tuple inference errors in by-token, analytics period, OAuth connections, and voice list tests; no APNs-owned file appears in those diagnostics.

## Human-only Apple/ops gates

Do not paste values into this PR.

1. An authorized Apple operator supplies an APNs provider key, key id, and team id through the protected deployment environment.
2. Set `ELIZA_APNS_TOPIC=ai.elizaos.app`.
3. Set `ELIZA_APNS_PRODUCTION=0` only for a development-signed sandbox build; set `1` only when the installed app's provisioning/aps-environment is production.
4. Confirm the signed app entitlement, provisioning profile, APNs host selection, and topic agree before any live send.
5. Deploy through the protected release workflow only with explicit rollout authority.
6. On a signed physical iPhone, prove registration against the selected agent, then capture a real banner while backgrounded and while killed.
7. Capture APNs `200`/apns-id for acceptance and a controlled invalid/dead token cleanup receipt, without exposing token or credential values.

Current machine evidence from codex/ios-acceptance remains: no valid Apple signing identities/profiles and no APNs environment bindings were available, so the signed-device banner gate is intentionally unproven.
