### PR TITLE
fix(ios): verify HealthKit provisioning authority

### DIFF
--- a/packages/app-core/scripts/mobile/ios-healthkit-authority.mjs
+++ b/packages/app-core/scripts/mobile/ios-healthkit-authority.mjs
@@ -1,0 +1,131 @@
+/**
+ * Validates the provisioning authority required before an iOS build may
+ * publish an enabled HealthKit marker into its native Info.plist.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+
+const REQUIRED_HEALTHKIT_ENTITLEMENTS = Object.freeze([
+  "com.apple.developer.healthkit",
+  "com.apple.developer.healthkit.background-delivery",
+]);
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function dictAfterKey(plist, key) {
+  const keyMatch = new RegExp(
+    `<key>\\s*${escapeRegExp(key)}\\s*</key>`,
+    "m",
+  ).exec(plist);
+  if (!keyMatch) return null;
+  const dictStart = plist.indexOf(
+    "<dict>",
+    keyMatch.index + keyMatch[0].length,
+  );
+  if (dictStart === -1) return null;
+  const tokenPattern = /<\/?dict>/g;
+  tokenPattern.lastIndex = dictStart;
+  let depth = 0;
+  for (
+    let match = tokenPattern.exec(plist);
+    match;
+    match = tokenPattern.exec(plist)
+  ) {
+    depth += match[0] === "<dict>" ? 1 : -1;
+    if (depth === 0) return plist.slice(dictStart, tokenPattern.lastIndex);
+  }
+  return null;
+}
+
+function plistBooleanIsTrue(plist, key) {
+  return new RegExp(
+    `<key>\\s*${escapeRegExp(key)}\\s*</key>\\s*<true\\s*/>`,
+    "m",
+  ).test(plist);
+}
+
+function plistString(plist, key) {
+  const match = new RegExp(
+    `<key>\\s*${escapeRegExp(key)}\\s*</key>\\s*<string>\\s*([^<]+?)\\s*</string>`,
+    "m",
+  ).exec(plist);
+  return match?.[1]?.trim() ?? null;
+}
+
+function decodeProvisioningProfile(profilePath, run = spawnSync) {
+  if (!profilePath || !fs.existsSync(profilePath)) {
+    throw new Error(
+      `HealthKit provisioning profile does not exist: ${profilePath ?? "(not set)"}`,
+    );
+  }
+  const raw = fs.readFileSync(profilePath);
+  const text = raw.toString("utf8");
+  if (text.includes("<plist")) return text;
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "Binary HealthKit provisioning profiles require macOS security cms decoding",
+    );
+  }
+  const result = run("security", ["cms", "-D", "-i", profilePath], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0 || !result.stdout?.includes("<plist")) {
+    throw new Error(
+      result.stderr?.trim() ||
+        `security cms could not decode HealthKit provisioning profile ${profilePath}`,
+    );
+  }
+  return result.stdout;
+}
+
+/**
+ * An enabled marker is trustworthy only when an explicit profile proves that
+ * the current bundle receives both HealthKit entitlements. Disabled builds do
+ * not need signing material and remain the safe default.
+ */
+export function assertIosHealthKitBuildAuthority({
+  enabled,
+  appId,
+  provisioningProfilePath,
+  run,
+}) {
+  if (!enabled) return;
+  if (typeof appId !== "string" || appId.trim().length === 0) {
+    throw new Error("HealthKit build authority requires the iOS app id");
+  }
+  if (!provisioningProfilePath) {
+    throw new Error(
+      "ELIZA_IOS_HEALTHKIT_ENABLED=1 requires MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE so signed HealthKit authority can be verified",
+    );
+  }
+  const profile = decodeProvisioningProfile(provisioningProfilePath, run);
+  const entitlements = dictAfterKey(profile, "Entitlements");
+  if (!entitlements) {
+    throw new Error(
+      "HealthKit provisioning profile has no Entitlements dictionary",
+    );
+  }
+  const missing = REQUIRED_HEALTHKIT_ENTITLEMENTS.filter(
+    (key) => !plistBooleanIsTrue(entitlements, key),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `HealthKit provisioning profile is missing required entitlements: ${missing.join(", ")}`,
+    );
+  }
+  const applicationIdentifier = plistString(
+    entitlements,
+    "application-identifier",
+  );
+  if (
+    !applicationIdentifier ||
+    (applicationIdentifier !== appId &&
+      !applicationIdentifier.endsWith(`.${appId}`))
+  ) {
+    throw new Error(
+      `HealthKit provisioning profile application-identifier ${JSON.stringify(applicationIdentifier)} does not match ${appId}`,
+    );
+  }
+}

--- a/packages/app-core/scripts/mobile/ios-healthkit-authority.test.mjs
+++ b/packages/app-core/scripts/mobile/ios-healthkit-authority.test.mjs
@@ -1,0 +1,95 @@
+/** Tests HealthKit build authority against deterministic provisioning profiles. */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { assertIosHealthKitBuildAuthority } from "./ios-healthkit-authority.mjs";
+
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeProfile({
+  applicationIdentifier = "TEAM123.ai.elizaos.app",
+  healthKit = true,
+  backgroundDelivery = true,
+} = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "healthkit-profile-"));
+  tempDirs.push(dir);
+  const profilePath = path.join(dir, "profile.mobileprovision");
+  fs.writeFileSync(
+    profilePath,
+    `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>Entitlements</key><dict>
+<key>application-identifier</key><string>${applicationIdentifier}</string>
+<key>com.apple.developer.healthkit</key>${healthKit ? "<true/>" : "<false/>"}
+<key>com.apple.developer.healthkit.background-delivery</key>${backgroundDelivery ? "<true/>" : "<false/>"}
+</dict>
+</dict></plist>`,
+  );
+  return profilePath;
+}
+
+describe("assertIosHealthKitBuildAuthority", () => {
+  it("keeps disabled builds independent of signing material", () => {
+    expect(() =>
+      assertIosHealthKitBuildAuthority({
+        enabled: false,
+        appId: "ai.elizaos.app",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts an enabled profile bound to the app with both entitlements", () => {
+    expect(() =>
+      assertIosHealthKitBuildAuthority({
+        enabled: true,
+        appId: "ai.elizaos.app",
+        provisioningProfilePath: writeProfile(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects enabled builds without an explicit provisioning profile", () => {
+    expect(() =>
+      assertIosHealthKitBuildAuthority({
+        enabled: true,
+        appId: "ai.elizaos.app",
+      }),
+    ).toThrow(/requires MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE/);
+  });
+
+  it("rejects profiles missing either required entitlement", () => {
+    expect(() =>
+      assertIosHealthKitBuildAuthority({
+        enabled: true,
+        appId: "ai.elizaos.app",
+        provisioningProfilePath: writeProfile({ healthKit: false }),
+      }),
+    ).toThrow(/com\.apple\.developer\.healthkit/);
+    expect(() =>
+      assertIosHealthKitBuildAuthority({
+        enabled: true,
+        appId: "ai.elizaos.app",
+        provisioningProfilePath: writeProfile({ backgroundDelivery: false }),
+      }),
+    ).toThrow(/background-delivery/);
+  });
+
+  it("rejects a profile issued for another bundle", () => {
+    expect(() =>
+      assertIosHealthKitBuildAuthority({
+        enabled: true,
+        appId: "ai.elizaos.app",
+        provisioningProfilePath: writeProfile({
+          applicationIdentifier: "TEAM123.example.other",
+        }),
+      }),
+    ).toThrow(/does not match ai\.elizaos\.app/);
+  });
+});

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -141,6 +141,7 @@ import {
   validateAndroidAppActionsXmlResource,
 } from "./mobile/android-manifest.mjs";
 import { escapeRegExp, escapeXmlText } from "./mobile/escape.mjs";
+import { assertIosHealthKitBuildAuthority } from "./mobile/ios-healthkit-authority.mjs";
 import {
   mergeIosInfoPlist,
   readIosApnsBuildFlag,
@@ -3698,6 +3699,15 @@ function overlayIos() {
   if (fs.existsSync(plistPath)) {
     let plist = fs.readFileSync(plistPath, "utf8");
     let dirty = false;
+    const healthKitEnabled = readIosHealthKitBuildFlag(
+      process.env.ELIZA_IOS_HEALTHKIT_ENABLED,
+    );
+    assertIosHealthKitBuildAuthority({
+      enabled: healthKitEnabled,
+      appId: APP.appId,
+      provisioningProfilePath:
+        process.env.MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE,
+    });
     // UIBackgroundModes and BGTaskSchedulerPermittedIdentifiers are MERGED,
     // not force-set: the template Info.plist already declares the modes the
     // ElizaTasks plugin needs (`processing`, `remote-notification`) and the
@@ -3709,9 +3719,7 @@ function overlayIos() {
       appName: APP.appName,
       urlScheme: APP.urlScheme,
       apnsEnabled: readIosApnsBuildFlag(process.env.VITE_ELIZA_APNS_ENABLED),
-      healthKitEnabled: readIosHealthKitBuildFlag(
-        process.env.ELIZA_IOS_HEALTHKIT_ENABLED,
-      ),
+      healthKitEnabled,
     });
     if (nextPlist.changed) {
       plist = nextPlist.content;

--- a/plugins/plugin-native-mobile-signals/AGENTS.md
+++ b/plugins/plugin-native-mobile-signals/AGENTS.md
@@ -75,8 +75,8 @@ bun run --cwd plugins/plugin-native-mobile-signals validate:ios-screen-time  # n
 
 | Variable | Required | Description |
 |---|---|---|
-| `ELIZA_IOS_HEALTHKIT_ENABLED` | No | Exact `"1"` tells the canonical iOS build to publish `ELIZA_HEALTHKIT_ENABLED=1` in the final native plist. Missing, empty, or `"0"` disables HealthKit; every other value fails the build. Use only when the signed app actually carries the HealthKit capability. |
-| `MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE` | No | Path to the `.mobileprovision` file used by `validate:ios-screen-time` to verify Screen Time entitlements in the provisioning profile. |
+| `ELIZA_IOS_HEALTHKIT_ENABLED` | No | Exact `"1"` asks the canonical iOS build to publish `ELIZA_HEALTHKIT_ENABLED=1`. Missing, empty, or `"0"` disables HealthKit; every other value fails the build. Enabling also requires a verified provisioning profile. |
+| `MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE` | When HealthKit is enabled | Path to the app's `.mobileprovision`. The canonical build verifies bundle binding plus HealthKit and background-delivery entitlements before publishing an enabled marker; `validate:ios-screen-time` also checks Screen Time authority. |
 | `MOBILE_SIGNALS_REQUIRE_IOS_PROVISIONING_PROFILE` | No | Set to `"1"` to make `validate:ios-screen-time` fail if no provisioning profile is supplied. |
 
 No runtime environment variables are read by the plugin itself. The native
@@ -87,11 +87,13 @@ marker explicitly enables the capability.
 ## iOS requirements
 
 HealthKit calls are default-off. The canonical app build accepts only
-`ELIZA_IOS_HEALTHKIT_ENABLED=1` and mirrors that decision into the final native
-plist. Disabled or malformed markers expose a truthful unavailable state and
-must not call HealthKit authorization, status, query, or background-delivery
-APIs. Enabling the flag without a matching Apple signing entitlement is a
-build/release configuration error, not a runtime fallback.
+`ELIZA_IOS_HEALTHKIT_ENABLED=1`, requires
+`MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE`, verifies that profile is bound to
+the app id and grants both required HealthKit entitlements, then mirrors the
+decision into the final native plist. Disabled or malformed markers expose a
+truthful unavailable state and must not call HealthKit authorization, status,
+query, or background-delivery APIs. An enabled unsigned or unprovisioned build
+fails before the marker is emitted.
 
 Screen Time / DeviceActivity features require additional entitlements and Xcode targets. The `validate:ios-screen-time` script checks:
 

--- a/plugins/plugin-native-mobile-signals/CLAUDE.md
+++ b/plugins/plugin-native-mobile-signals/CLAUDE.md
@@ -75,8 +75,8 @@ bun run --cwd plugins/plugin-native-mobile-signals validate:ios-screen-time  # n
 
 | Variable | Required | Description |
 |---|---|---|
-| `ELIZA_IOS_HEALTHKIT_ENABLED` | No | Exact `"1"` tells the canonical iOS build to publish `ELIZA_HEALTHKIT_ENABLED=1` in the final native plist. Missing, empty, or `"0"` disables HealthKit; every other value fails the build. Use only when the signed app actually carries the HealthKit capability. |
-| `MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE` | No | Path to the `.mobileprovision` file used by `validate:ios-screen-time` to verify Screen Time entitlements in the provisioning profile. |
+| `ELIZA_IOS_HEALTHKIT_ENABLED` | No | Exact `"1"` asks the canonical iOS build to publish `ELIZA_HEALTHKIT_ENABLED=1`. Missing, empty, or `"0"` disables HealthKit; every other value fails the build. Enabling also requires a verified provisioning profile. |
+| `MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE` | When HealthKit is enabled | Path to the app's `.mobileprovision`. The canonical build verifies bundle binding plus HealthKit and background-delivery entitlements before publishing an enabled marker; `validate:ios-screen-time` also checks Screen Time authority. |
 | `MOBILE_SIGNALS_REQUIRE_IOS_PROVISIONING_PROFILE` | No | Set to `"1"` to make `validate:ios-screen-time` fail if no provisioning profile is supplied. |
 
 No runtime environment variables are read by the plugin itself. The native
@@ -87,11 +87,13 @@ marker explicitly enables the capability.
 ## iOS requirements
 
 HealthKit calls are default-off. The canonical app build accepts only
-`ELIZA_IOS_HEALTHKIT_ENABLED=1` and mirrors that decision into the final native
-plist. Disabled or malformed markers expose a truthful unavailable state and
-must not call HealthKit authorization, status, query, or background-delivery
-APIs. Enabling the flag without a matching Apple signing entitlement is a
-build/release configuration error, not a runtime fallback.
+`ELIZA_IOS_HEALTHKIT_ENABLED=1`, requires
+`MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE`, verifies that profile is bound to
+the app id and grants both required HealthKit entitlements, then mirrors the
+decision into the final native plist. Disabled or malformed markers expose a
+truthful unavailable state and must not call HealthKit authorization, status,
+query, or background-delivery APIs. An enabled unsigned or unprovisioned build
+fails before the marker is emitted.
 
 Screen Time / DeviceActivity features require additional entitlements and Xcode targets. The `validate:ios-screen-time` script checks:
 

--- a/plugins/plugin-native-mobile-signals/README.md
+++ b/plugins/plugin-native-mobile-signals/README.md
@@ -72,8 +72,10 @@ await MobileSignals.stopMonitoring();
 
 HealthKit is disabled by default in local, unsigned, and Simulator builds. A
 signed build that includes the HealthKit capability must set the exact build
-flag `ELIZA_IOS_HEALTHKIT_ENABLED=1`; the canonical mobile build writes the
-matching `ELIZA_HEALTHKIT_ENABLED=1` marker into the final app `Info.plist`.
+flag `ELIZA_IOS_HEALTHKIT_ENABLED=1` and provide its profile through
+`MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE`; the canonical mobile build verifies
+the app binding and required entitlements before writing the matching
+`ELIZA_HEALTHKIT_ENABLED=1` marker into the final app `Info.plist`.
 Any missing, disabled, or malformed marker fails closed before the plugin calls
 HealthKit authorization, status, query, or background-delivery APIs.
 
@@ -115,8 +117,8 @@ await MobileSignals.openSettings({ target: "usageAccess" });
 
 | Variable | Description |
 |---|---|
-| `ELIZA_IOS_HEALTHKIT_ENABLED` | Exact `"1"` enables HealthKit in a correctly signed iOS build; missing, empty, or `"0"` keeps it unavailable. Any other value fails the build. |
-| `MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE` | Path to a `.mobileprovision` to inspect for Screen Time entitlements during `validate:ios-screen-time`. |
+| `ELIZA_IOS_HEALTHKIT_ENABLED` | Exact `"1"` enables HealthKit only after the canonical build verifies the app's provisioning profile; missing, empty, or `"0"` keeps it unavailable. Any other value fails the build. |
+| `MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE` | Required when HealthKit is enabled; also inspected for Screen Time entitlements during `validate:ios-screen-time`. |
 | `MOBILE_SIGNALS_REQUIRE_IOS_PROVISIONING_PROFILE` | Set to `"1"` to fail validation when no provisioning profile is supplied. |
 
 ## Platform notes


### PR DESCRIPTION
Part of #21081. Follow-up to #21043.

## Root repair

The merged #21043 runtime gate trusted `ELIZA_IOS_HEALTHKIT_ENABLED=1` as build authority. Its own unsigned enabled artifact therefore received `ELIZA_HEALTHKIT_ENABLED=1` without proving the code signature could carry HealthKit entitlements.

This change makes the canonical build verify `MOBILE_SIGNALS_IOS_PROVISIONING_PROFILE` before it emits an enabled marker. It requires a profile bound to the configured app id with both `com.apple.developer.healthkit` and `com.apple.developer.healthkit.background-delivery`. Missing, unreadable, mismatched, or under-entitled profiles fail the build. Default-off builds remain independent of signing material.

## Exact revision

- head: `2a5009ffde14e5ce21cfba7fa0d4b5988da6b547`
- tree: `2f3bb588b4e26fec9b0b96b5c0e4745269cb6199`
- exact validation base: `24330919e6fe501b78fb133551ad009ec5a18c0c`
- repair commit: `2a5009ffde14e5ce21cfba7fa0d4b5988da6b547`

## Exact-head validation

- plist/build Vitest: 3 files, 29/29 tests PASS
- Swift native contract suite: 13/13 PASS
- app-core typecheck: PASS
- plugin typecheck: PASS
- plugin lint: PASS
- CLAUDE/AGENTS parity: 155 pairs PASS
- diff-check: PASS

No deploy, signing, profile mutation, secret mutation, or device action occurred.

## Honest evidence boundary

Source safety is complete and independently reviewable. Signed physical-device HealthKit authorization, query, and background-delivery proof remains pending on #21081 because this machine has no valid Apple signing identity or matching provisioning profile. Merging this source guard must not close that device acceptance boundary.

AI provider/model: OpenAI / Codex
Client / agent tooling: Codex Desktop
Attribution status: self-reported; no signed contribution receipt claimed.