### PR TITLE
fix(core): guard optional options in hasActionContext and add test suite

### DIFF
--- a/packages/core/src/utils/action-validation.test.ts
+++ b/packages/core/src/utils/action-validation.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for hasActionContext in packages/core/src/utils/action-validation.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { AgentContext, Memory, State } from "../types/index";
+import { hasActionContext } from "./action-validation";
+import {
+	CONTEXT_ROUTING_METADATA_KEY,
+	CONTEXT_ROUTING_STATE_KEY,
+} from "./context-routing";
+
+describe("hasActionContext", () => {
+	const baseMessage: Memory = {
+		id: "11111111-1111-1111-1111-111111111111" as `${string}-${string}-${string}-${string}-${string}`,
+		entityId:
+			"22222222-2222-2222-2222-222222222222" as `${string}-${string}-${string}-${string}-${string}`,
+		roomId:
+			"33333333-3333-3333-3333-333333333333" as `${string}-${string}-${string}-${string}-${string}`,
+		content: {
+			text: "test message",
+		},
+	};
+
+	it("returns false safely without throwing when options is undefined", () => {
+		expect(hasActionContext(baseMessage, undefined, undefined)).toBe(false);
+	});
+
+	it("returns true when state context routing overlaps declared action contexts", () => {
+		const state: State = {
+			values: {
+				[CONTEXT_ROUTING_STATE_KEY]: {
+					primaryContext: "trading",
+					secondaryContexts: ["wallet"],
+				},
+			},
+			data: {},
+			text: "",
+		};
+
+		const eligible = hasActionContext(baseMessage, state, {
+			contexts: ["trading" as AgentContext],
+		});
+		expect(eligible).toBe(true);
+	});
+
+	it("returns true when message metadata context routing overlaps declared action contexts", () => {
+		const messageWithContext: Memory = {
+			...baseMessage,
+			content: {
+				text: "swap sol for usdc",
+				metadata: {
+					[CONTEXT_ROUTING_METADATA_KEY]: {
+						primaryContext: "crypto",
+						secondaryContexts: ["trading"],
+					},
+				},
+			},
+		};
+
+		const eligible = hasActionContext(messageWithContext, undefined, {
+			contexts: ["trading" as AgentContext],
+		});
+		expect(eligible).toBe(true);
+	});
+
+	it("returns false when active contexts do not overlap declared action contexts", () => {
+		const state: State = {
+			values: {
+				[CONTEXT_ROUTING_STATE_KEY]: {
+					primaryContext: "social",
+					secondaryContexts: ["chat"],
+				},
+			},
+			data: {},
+			text: "",
+		};
+
+		const eligible = hasActionContext(baseMessage, state, {
+			contexts: ["trading" as AgentContext],
+		});
+		expect(eligible).toBe(false);
+	});
+});

--- a/packages/core/src/utils/action-validation.ts
+++ b/packages/core/src/utils/action-validation.ts
@@ -24,8 +24,8 @@ export interface ActionContextValidationOptions {
 export function hasActionContext(
 	message: Memory,
 	state: State | undefined,
-	options: ActionContextValidationOptions,
+	options?: ActionContextValidationOptions,
 ): boolean {
 	const activeContexts = getActiveRoutingContextsForTurn(state, message);
-	return routingContextsOverlap(options.contexts, activeContexts);
+	return routingContextsOverlap(options?.contexts, activeContexts);
 }


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/action-validation.ts`, `hasActionContext` previously accessed `options.contexts` directly, which threw an unhandled `TypeError` when `options` was omitted or undefined in ad-hoc callers.
2. Updated `hasActionContext` to use optional chaining (`options?.contexts`).
3. Added comprehensive unit test suite in `packages/core/src/utils/action-validation.test.ts`.

Closes #21079.

## Verification

Exact commit: `8e2e8d8ea2`.

- Focused unit test suite `packages/core/src/utils/action-validation.test.ts`: 4/4 tests passing (4 assertions).
- Biome format on `@elizaos/core`: 1284 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - action context validation utility; no rendered UI changed.
- [x] N/A - action context validation utility; no rendered UI changed.
- [x] N/A - deterministic context routing validation tests.
- [x] Focused test suite transcript:
```text
✓ hasActionContext > returns false safely without throwing when options is undefined [0.64ms]
✓ hasActionContext > returns true when state context routing overlaps declared action contexts [1.13ms]
✓ hasActionContext > returns true when message metadata context routing overlaps declared action contexts [0.17ms]
✓ hasActionContext > returns false when active contexts do not overlap declared action contexts [0.11ms]
4 pass, 0 fail, 4 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@dfd25bd1b500e5eeb43734a66a1f0a2df255d812:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@dfd25bd1b500e5eeb43734a66a1f0a2df255d812:packages/skills/skills/contribute-to-eliza"} -->