### PR TITLE
fix(core): sanitize non-string inputs in describeUserReference and userReferenceLogView

### DIFF
--- a/packages/core/src/utils/reference-echo.test.ts
+++ b/packages/core/src/utils/reference-echo.test.ts
@@ -81,6 +81,12 @@ describe("describeUserReference", () => {
 		expect(describeUserReference(123 as unknown as string, FALLBACK)).toBe(
 			FALLBACK,
 		);
+		expect(
+			describeUserReference(
+				undefined as unknown as string,
+				undefined as unknown as string,
+			),
+		).toBe("target");
 	});
 });
 

--- a/packages/core/src/utils/reference-echo.test.ts
+++ b/packages/core/src/utils/reference-echo.test.ts
@@ -70,6 +70,18 @@ describe("describeUserReference", () => {
 			"the requested target",
 		);
 	});
+
+	it("handles non-string arguments safely without throwing", () => {
+		expect(
+			describeUserReference(undefined as unknown as string, FALLBACK),
+		).toBe(FALLBACK);
+		expect(describeUserReference(null as unknown as string, FALLBACK)).toBe(
+			FALLBACK,
+		);
+		expect(describeUserReference(123 as unknown as string, FALLBACK)).toBe(
+			FALLBACK,
+		);
+	});
 });
 
 describe("userReferenceLogView", () => {
@@ -81,6 +93,12 @@ describe("userReferenceLogView", () => {
 		expect(userReferenceLogView("plain reference")).toBe("plain reference");
 		expect(userReferenceLogView("")).toBe("");
 		expect(userReferenceLogView("   ")).toBe("");
+	});
+
+	it("handles non-string arguments safely without throwing", () => {
+		expect(userReferenceLogView(undefined as unknown as string)).toBe("");
+		expect(userReferenceLogView(null as unknown as string)).toBe("");
+		expect(userReferenceLogView(42 as unknown as string)).toBe("");
 	});
 
 	it("holds the 120-character boundary exactly", () => {

--- a/packages/core/src/utils/reference-echo.ts
+++ b/packages/core/src/utils/reference-echo.ts
@@ -17,10 +17,12 @@ export function describeUserReference(
 	reference: string,
 	fallback: string,
 ): string {
-	const trimmed = reference.trim();
+	const safeRef = typeof reference === "string" ? reference : "";
+	const safeFallback = typeof fallback === "string" ? fallback : "target";
+	const trimmed = safeRef.trim();
 	const nameShaped =
 		trimmed.length > 0 && trimmed.length <= 64 && !/[\r\n]/.test(trimmed);
-	return nameShaped ? `"${trimmed}"` : fallback;
+	return nameShaped ? `"${trimmed}"` : safeFallback;
 }
 
 /**
@@ -29,6 +31,7 @@ export function describeUserReference(
  * one line, clamped to 120 chars with a trailing ellipsis.
  */
 export function userReferenceLogView(reference: string): string {
-	const collapsed = reference.replace(/\s+/g, " ").trim();
+	const safeRef = typeof reference === "string" ? reference : "";
+	const collapsed = safeRef.replace(/\s+/g, " ").trim();
 	return collapsed.length > 120 ? `${collapsed.slice(0, 119)}…` : collapsed;
 }


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/reference-echo.ts`, `describeUserReference` and `userReferenceLogView` called `.trim()` and `.replace()` directly on `reference`, which threw unhandled `TypeError` crashes when passed non-string or undefined inputs.
2. Sanitized `reference` and `fallback` parameters using string type guards (`typeof val === "string"`).
3. Added unit regression test coverage in `packages/core/src/utils/reference-echo.test.ts`.

Closes #21085.

## Verification

Exact commit: `49fdfd21e0`.

- Focused unit test suite `packages/core/src/utils/reference-echo.test.ts`: 14/14 tests passing (33 assertions).
- Biome format on `@elizaos/core`: 1284 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - reference text formatting utility; no rendered UI changed.
- [x] N/A - reference text formatting utility; no rendered UI changed.
- [x] N/A - deterministic reference formatting tests.
- [x] Focused test suite transcript:
```text
✓ describeUserReference > quotes a name-shaped reference [0.20ms]
✓ describeUserReference > trims before quoting and before measuring [0.05ms]
✓ describeUserReference > falls back for an empty or whitespace-only reference [0.03ms]
✓ describeUserReference > holds the 64-character boundary exactly [0.03ms]
✓ describeUserReference > falls back for anything multi-line [0.06ms]
✓ describeUserReference > treats a horizontal tab as name-shaped [0.03ms]
✓ describeUserReference > returns the caller's fallback verbatim [0.02ms]
✓ describeUserReference > handles non-string arguments safely without throwing [0.04ms]
✓ userReferenceLogView > collapses every whitespace run to a single space and trims [0.08ms]
✓ userReferenceLogView > returns a short reference unchanged after collapsing [0.03ms]
✓ userReferenceLogView > handles non-string arguments safely without throwing [0.02ms]
✓ userReferenceLogView > holds the 120-character boundary exactly [0.03ms]
✓ userReferenceLogView > measures the boundary after collapsing, not before [0.27ms]
✓ userReferenceLogView > appends exactly one ellipsis character when clamping [0.04ms]
14 pass, 0 fail, 33 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@28009fbdd6fe25b060d4b29bb30b35586ae797db:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@28009fbdd6fe25b060d4b29bb30b35586ae797db:packages/skills/skills/contribute-to-eliza"} -->

## Maintainer validation

Added the missing regression for a simultaneously invalid reference and fallback, proving the generic `target` boundary behavior. Core Vitest remains 14/14; touched-file Biome and diff-check are clean. Repair head: `bbebf5fdf463b705c874c04ac20bab9da0571ab3`.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@8e320044f9fcc0282ea2ca79b3b6d7bfea37187b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-b]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@8e320044f9fcc0282ea2ca79b3b6d7bfea37187b:packages/skills/skills/contribute-to-eliza"} -->