### PR TITLE
feat(cloud): sealed shared-to-dedicated memory transfer per #20923 spec

### DIFF
--- a/packages/agent/src/api/memory-import.test.ts
+++ b/packages/agent/src/api/memory-import.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Contract tests for the sealed memory importer (#20923 rebuild).
+ * Deterministic recorder-double runtime; every #20923 blocker is pinned:
+ * digest/count conservation is proven BEFORE any write, id conflicts with
+ * different content fail the whole request (identical content replays
+ * idempotently), existing scaffolding is never overwritten, vectors and
+ * ids/timestamps/content land verbatim through the all-or-nothing batch, and
+ * the source-agent remap follows the seal's single authority.
+ */
+
+import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import {
+  computeSharedMemoryTransferDigest,
+  type SealedMemoryExportRow,
+} from "@elizaos/shared/contracts/shared-memory-transfer";
+import { describe, expect, it } from "vitest";
+import { importSealedMemories } from "./memory-import.ts";
+
+const LOCAL_AGENT = "11111111-1111-4111-8111-111111111111" as UUID;
+const SOURCE_AGENT = "8f1f7f72-0577-4b4a-b15b-229c751d5484";
+const USER_ENTITY = "1d88c441-09a2-47ac-a8fd-a502884390c3";
+const ROOM = "866e5ec5-5e66-4387-9333-6be867377d63";
+const WORLD = "d04cf4d3-a60e-4209-ad78-d67d6a38ff95";
+
+interface RecordedRuntime {
+  runtime: AgentRuntime;
+  batches: Array<Array<{ memory: Memory; tableName: string }>>;
+  worldsCreated: string[];
+  roomsCreated: string[];
+  entitiesCreated: string[];
+  existingMemories: Map<string, Memory>;
+  existingWorlds: Set<string>;
+  existingRooms: Set<string>;
+  existingEntities: Set<string>;
+}
+
+function recorderRuntime(): RecordedRuntime {
+  const state: RecordedRuntime = {
+    runtime: undefined as unknown as AgentRuntime,
+    batches: [],
+    worldsCreated: [],
+    roomsCreated: [],
+    entitiesCreated: [],
+    existingMemories: new Map(),
+    existingWorlds: new Set(),
+    existingRooms: new Set(),
+    existingEntities: new Set(),
+  };
+  state.runtime = {
+    agentId: LOCAL_AGENT,
+    getMemoryById: async (id: string) => state.existingMemories.get(id) ?? null,
+    getRoom: async (id: string) =>
+      state.existingRooms.has(id) ? { id } : null,
+    getEntityById: async (id: string) =>
+      state.existingEntities.has(id) ? { id } : null,
+    ensureWorldExists: async (world: { id: string }) => {
+      state.worldsCreated.push(world.id);
+    },
+    ensureRoomExists: async (room: { id: string }) => {
+      state.roomsCreated.push(room.id);
+    },
+    createEntity: async (entity: { id: string }) => {
+      state.entitiesCreated.push(entity.id);
+      return true;
+    },
+    adapter: {
+      getWorldsByIds: async (ids: string[]) =>
+        ids.filter((id) => state.existingWorlds.has(id)).map((id) => ({ id })),
+      createMemories: async (
+        batch: Array<{ memory: Memory; tableName: string }>,
+      ) => {
+        state.batches.push(batch);
+        return batch.map((entry) => entry.memory.id as UUID);
+      },
+    },
+  } as unknown as AgentRuntime;
+  return state;
+}
+
+function exportRow(
+  index: number,
+  overrides: Partial<SealedMemoryExportRow> = {},
+): SealedMemoryExportRow {
+  return {
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+    type: "messages",
+    created_at: "2026-08-17T03:44:45.770Z",
+    content: { text: `m${index}`, source: "shared-runtime" },
+    entity_id: USER_ENTITY,
+    room_id: ROOM,
+    world_id: WORLD,
+    metadata: { source: "shared-runtime-transfer" },
+    embedding: {
+      dim_384: Array.from({ length: 384 }, (_, i) => Math.sin(i + index) / 2),
+    },
+    ...overrides,
+  };
+}
+
+function sealedRequest(rows: SealedMemoryExportRow[]) {
+  return {
+    seal: {
+      row_count: rows.length,
+      embedding_count: rows.filter((row) => row.embedding).length,
+      digest: computeSharedMemoryTransferDigest(rows),
+      source_agent_id: SOURCE_AGENT,
+      organization_id: "75ae457b-801f-43e1-9d95-5585147655cd",
+      user_id: "f210269b-8148-428b-8c24-91da4c95c727",
+    },
+    rows,
+  };
+}
+
+describe("sealed memory import", () => {
+  it("lands rows verbatim in one atomic batch with the documented remap", async () => {
+    const state = recorderRuntime();
+    const rows = [
+      exportRow(0),
+      exportRow(1, {
+        entity_id: SOURCE_AGENT,
+        content: { text: "agent reply" },
+      }),
+    ];
+    const outcome = await importSealedMemories(
+      state.runtime,
+      sealedRequest(rows),
+    );
+
+    expect(outcome.status).toBe(200);
+    expect(outcome.body).toMatchObject({
+      ok: true,
+      imported: 2,
+      skipped_existing: 0,
+      embeddings_written: 2,
+      digest_verified: true,
+    });
+    expect(state.batches).toHaveLength(1);
+    const [user, agent] = state.batches[0] ?? [];
+    expect(user?.memory.id).toBe(rows[0]?.id as UUID);
+    expect(user?.memory.createdAt).toBe(Date.parse("2026-08-17T03:44:45.770Z"));
+    expect(JSON.stringify(user?.memory.content)).toBe(
+      JSON.stringify(rows[0]?.content),
+    );
+    expect(user?.memory.embedding).toEqual(rows[0]?.embedding?.dim_384);
+    expect(user?.memory.entityId).toBe(USER_ENTITY as UUID);
+    expect(user?.memory.agentId).toBe(LOCAL_AGENT);
+    // Only the seal's source agent id remaps; the seal is the single authority.
+    expect(agent?.memory.entityId).toBe(LOCAL_AGENT);
+  });
+
+  it("proves digest conservation before any write", async () => {
+    const state = recorderRuntime();
+    const rows = [exportRow(0)];
+    const request = sealedRequest(rows);
+    request.rows[0] = exportRow(0, { content: { text: "tampered" } });
+
+    const outcome = await importSealedMemories(state.runtime, request);
+    expect(outcome.status).toBe(409);
+    expect(outcome.body).toMatchObject({
+      ok: false,
+      code: "IMPORT_DIGEST_MISMATCH",
+    });
+    expect(state.batches).toHaveLength(0);
+    expect(state.worldsCreated).toHaveLength(0);
+  });
+
+  it("fails count mismatches against the seal before any write", async () => {
+    const state = recorderRuntime();
+    const rows = [exportRow(0), exportRow(1)];
+    const request = sealedRequest(rows);
+    request.seal.row_count = 3;
+    const outcome = await importSealedMemories(state.runtime, request);
+    expect(outcome.status).toBe(409);
+    expect(outcome.body).toMatchObject({ code: "IMPORT_ROW_COUNT_MISMATCH" });
+    expect(state.batches).toHaveLength(0);
+  });
+
+  it("an existing id with DIFFERENT content fails the whole request as a conflict", async () => {
+    const state = recorderRuntime();
+    const rows = [exportRow(0), exportRow(1)];
+    state.existingMemories.set(
+      rows[0]?.id as string,
+      {
+        id: rows[0]?.id,
+        content: { text: "something else entirely" },
+      } as Memory,
+    );
+
+    const outcome = await importSealedMemories(
+      state.runtime,
+      sealedRequest(rows),
+    );
+    expect(outcome.status).toBe(409);
+    expect(outcome.body).toMatchObject({
+      ok: false,
+      code: "IMPORT_ID_CONFLICT",
+    });
+    // Fail-closed: the non-conflicting row must NOT have been written either.
+    expect(state.batches).toHaveLength(0);
+  });
+
+  it("an existing id with IDENTICAL content replays idempotently", async () => {
+    const state = recorderRuntime();
+    const rows = [exportRow(0), exportRow(1)];
+    state.existingMemories.set(
+      rows[0]?.id as string,
+      {
+        id: rows[0]?.id,
+        content: rows[0]?.content,
+      } as Memory,
+    );
+
+    const outcome = await importSealedMemories(
+      state.runtime,
+      sealedRequest(rows),
+    );
+    expect(outcome.status).toBe(200);
+    expect(outcome.body).toMatchObject({
+      ok: true,
+      imported: 1,
+      skipped_existing: 1,
+      embeddings_written: 1,
+    });
+    expect(state.batches[0]).toHaveLength(1);
+    expect(state.batches[0]?.[0]?.memory.id).toBe(rows[1]?.id as UUID);
+  });
+
+  it("never overwrites existing scaffolding; absent scaffolding is created", async () => {
+    const state = recorderRuntime();
+    state.existingWorlds.add(WORLD);
+    state.existingEntities.add(USER_ENTITY);
+
+    const outcome = await importSealedMemories(
+      state.runtime,
+      sealedRequest([exportRow(0)]),
+    );
+    expect(outcome.status).toBe(200);
+    // Existing world + entity untouched; only the absent room is created.
+    expect(state.worldsCreated).toHaveLength(0);
+    expect(state.entitiesCreated).toHaveLength(0);
+    expect(state.roomsCreated).toEqual([ROOM]);
+  });
+
+  it("rejects malformed payloads at the boundary", async () => {
+    const state = recorderRuntime();
+    const bad = sealedRequest([exportRow(0)]);
+    (bad.rows[0] as { embedding: unknown }).embedding = { dim_384: [1, 2, 3] };
+    const outcome = await importSealedMemories(state.runtime, bad);
+    expect(outcome.status).toBe(400);
+    expect(outcome.body).toMatchObject({ code: "IMPORT_INVALID_PAYLOAD" });
+    expect(state.batches).toHaveLength(0);
+  });
+
+  it("vectors pass through without rounding", async () => {
+    const state = recorderRuntime();
+    const precise = Array.from(
+      { length: 384 },
+      (_, i) => 0.123456789 + i * 1e-9,
+    );
+    const rows = [exportRow(0, { embedding: { dim_384: precise } })];
+    await importSealedMemories(state.runtime, sealedRequest(rows));
+    expect(state.batches[0]?.[0]?.memory.embedding).toEqual(precise);
+  });
+});

--- a/packages/agent/src/api/memory-import.test.ts
+++ b/packages/agent/src/api/memory-import.test.ts
@@ -25,6 +25,7 @@ const WORLD = "d04cf4d3-a60e-4209-ad78-d67d6a38ff95";
 interface RecordedRuntime {
   runtime: AgentRuntime;
   batches: Array<Array<{ memory: Memory; tableName: string }>>;
+  batchConflictPolicies: Array<string | undefined>;
   worldsCreated: string[];
   roomsCreated: string[];
   entitiesCreated: string[];
@@ -38,6 +39,7 @@ function recorderRuntime(): RecordedRuntime {
   const state: RecordedRuntime = {
     runtime: undefined as unknown as AgentRuntime,
     batches: [],
+    batchConflictPolicies: [],
     worldsCreated: [],
     roomsCreated: [],
     entitiesCreated: [],
@@ -68,8 +70,10 @@ function recorderRuntime(): RecordedRuntime {
         ids.filter((id) => state.existingWorlds.has(id)).map((id) => ({ id })),
       createMemories: async (
         batch: Array<{ memory: Memory; tableName: string }>,
+        options?: { onIdConflict?: string },
       ) => {
         state.batches.push(batch);
+        state.batchConflictPolicies.push(options?.onIdConflict);
         return batch.map((entry) => entry.memory.id as UUID);
       },
     },
@@ -132,9 +136,11 @@ describe("sealed memory import", () => {
       imported: 2,
       skipped_existing: 0,
       embeddings_written: 2,
+      embeddings_skipped_verified: 0,
       digest_verified: true,
     });
     expect(state.batches).toHaveLength(1);
+    expect(state.batchConflictPolicies).toEqual(["error"]);
     const [user, agent] = state.batches[0] ?? [];
     expect(user?.memory.id).toBe(rows[0]?.id as UUID);
     expect(user?.memory.createdAt).toBe(Date.parse("2026-08-17T03:44:45.770Z"));
@@ -206,7 +212,15 @@ describe("sealed memory import", () => {
       rows[0]?.id as string,
       {
         id: rows[0]?.id,
+        type: rows[0]?.type,
+        agentId: LOCAL_AGENT,
+        entityId: rows[0]?.entity_id,
+        roomId: rows[0]?.room_id,
+        worldId: rows[0]?.world_id,
+        createdAt: Date.parse(rows[0]?.created_at as string),
         content: rows[0]?.content,
+        metadata: rows[0]?.metadata,
+        embedding: rows[0]?.embedding?.dim_384,
       } as Memory,
     );
 
@@ -220,9 +234,37 @@ describe("sealed memory import", () => {
       imported: 1,
       skipped_existing: 1,
       embeddings_written: 1,
+      embeddings_skipped_verified: 1,
     });
     expect(state.batches[0]).toHaveLength(1);
     expect(state.batches[0]?.[0]?.memory.id).toBe(rows[1]?.id as UUID);
+  });
+
+  it("refuses same-content replays when any persisted field differs", async () => {
+    const state = recorderRuntime();
+    const transferred = exportRow(0);
+    state.existingMemories.set(transferred.id, {
+      id: transferred.id as UUID,
+      type: transferred.type,
+      agentId: LOCAL_AGENT,
+      entityId: transferred.entity_id as UUID,
+      roomId: transferred.room_id as UUID,
+      worldId: transferred.world_id as UUID,
+      createdAt: Date.parse(transferred.created_at),
+      content: transferred.content as Memory["content"],
+      metadata: transferred.metadata as Memory["metadata"],
+      embedding: transferred.embedding?.dim_384.map((value, index) =>
+        index === 0 ? value + 0.01 : value,
+      ),
+    } as Memory);
+
+    const outcome = await importSealedMemories(
+      state.runtime,
+      sealedRequest([transferred]),
+    );
+    expect(outcome.status).toBe(409);
+    expect(outcome.body).toMatchObject({ code: "IMPORT_ID_CONFLICT" });
+    expect(state.batches).toHaveLength(0);
   });
 
   it("never overwrites existing scaffolding; absent scaffolding is created", async () => {

--- a/packages/agent/src/api/memory-import.ts
+++ b/packages/agent/src/api/memory-import.ts
@@ -24,13 +24,13 @@ import {
   type UUID,
 } from "@elizaos/core";
 import {
+  canonicalSharedMemoryJson,
   computeSharedMemoryTransferDigest,
   type SealedImportConflict,
   type SealedImportResponse,
   type SealedMemoryImportRequest,
   SealedMemoryImportRequestSchema,
   SHARED_MEMORY_TRANSFER_SOURCE,
-  sharedMemoryContentHash,
 } from "@elizaos/shared/contracts/shared-memory-transfer";
 import type { MemoryRouteContext } from "./memory-routes.ts";
 
@@ -40,6 +40,43 @@ export const MEMORY_IMPORT_MAX_BODY_BYTES = 16 * 1024 * 1024;
 export type SealedImportOutcome =
   | { status: 200; body: SealedImportResponse }
   | { status: 400 | 409; body: { ok: false; error: string; code: string } };
+
+function targetMemory(
+  runtime: AgentRuntime,
+  request: SealedMemoryImportRequest,
+  row: SealedMemoryImportRequest["rows"][number],
+): Memory {
+  const sourceAgentId = request.seal.source_agent_id;
+  return {
+    id: row.id as UUID,
+    agentId: runtime.agentId,
+    entityId: (row.entity_id === sourceAgentId || row.entity_id === null
+      ? runtime.agentId
+      : row.entity_id) as UUID,
+    roomId: (row.room_id ?? undefined) as UUID,
+    worldId: (row.world_id ??
+      (row.room_id ? `${runtime.agentId}` : undefined)) as UUID | undefined,
+    content: row.content as Memory["content"],
+    metadata: row.metadata as Memory["metadata"],
+    createdAt: Date.parse(row.created_at),
+    ...(row.embedding ? { embedding: row.embedding.dim_384 } : {}),
+  } as Memory;
+}
+
+function storedRowFingerprint(memory: Memory, tableName: string): string {
+  return canonicalSharedMemoryJson({
+    id: memory.id ?? null,
+    agentId: memory.agentId ?? null,
+    entityId: memory.entityId ?? null,
+    roomId: memory.roomId ?? null,
+    worldId: memory.worldId ?? null,
+    type: tableName,
+    createdAt: memory.createdAt ?? null,
+    content: memory.content,
+    metadata: memory.metadata ?? {},
+    embedding: memory.embedding ?? null,
+  });
+}
 
 function failure(
   status: 400 | 409,
@@ -158,20 +195,25 @@ export async function importSealedMemories(
   const conflicts: SealedImportConflict[] = [];
   const toImport: typeof request.rows = [];
   let skippedExisting = 0;
+  let skippedExistingEmbeddings = 0;
   for (const row of request.rows) {
     const existing = await runtime.getMemoryById(row.id as UUID);
     if (!existing) {
       toImport.push(row);
       continue;
     }
+    const expected = targetMemory(runtime, request, row);
+    const existingType = (existing as Memory & { type?: string }).type;
     if (
-      sharedMemoryContentHash(existing.content) ===
-      sharedMemoryContentHash(row.content)
+      existingType === row.type &&
+      storedRowFingerprint(existing, existingType) ===
+        storedRowFingerprint(expected, row.type)
     ) {
       skippedExisting += 1;
+      if (row.embedding) skippedExistingEmbeddings += 1;
       continue;
     }
-    conflicts.push({ id: row.id, reason: "content-mismatch" });
+    conflicts.push({ id: row.id, reason: "stored-row-mismatch" });
   }
   if (conflicts.length > 0) {
     return {
@@ -186,22 +228,8 @@ export async function importSealedMemories(
 
   await ensureScaffoldingIfAbsent(runtime, request);
 
-  const sourceAgentId = request.seal.source_agent_id;
   const batch = toImport.map((row) => ({
-    memory: {
-      id: row.id as UUID,
-      agentId: runtime.agentId,
-      entityId: (row.entity_id === sourceAgentId || row.entity_id === null
-        ? runtime.agentId
-        : row.entity_id) as UUID,
-      roomId: (row.room_id ?? undefined) as UUID,
-      worldId: (row.world_id ??
-        (row.room_id ? `${runtime.agentId}` : undefined)) as UUID | undefined,
-      content: row.content as Memory["content"],
-      metadata: row.metadata as Memory["metadata"],
-      createdAt: Date.parse(row.created_at),
-      ...(row.embedding ? { embedding: row.embedding.dim_384 } : {}),
-    } as Memory,
+    memory: targetMemory(runtime, request, row),
     tableName: row.type,
     unique: true,
   }));
@@ -210,7 +238,46 @@ export async function importSealedMemories(
   // verbatim and skips the runtime wrapper's redaction and fact dedupe, which
   // would mutate transferred history.
   if (batch.length > 0) {
-    await runtime.adapter.createMemories(batch);
+    try {
+      await runtime.adapter.createMemories(batch, { onIdConflict: "error" });
+    } catch (cause) {
+      // A racing identical request may have committed between the pre-read and
+      // the strict transaction. Certify every row from storage before calling
+      // that race an idempotent replay; divergent or partial state never gets
+      // fabricated as success.
+      let identicalRace = true;
+      let observedConflictingRow = false;
+      for (const row of toImport) {
+        const existing = await runtime.getMemoryById(row.id as UUID);
+        const existingType = (existing as (Memory & { type?: string }) | null)
+          ?.type;
+        if (
+          !existing ||
+          existingType !== row.type ||
+          storedRowFingerprint(existing, existingType) !==
+            storedRowFingerprint(targetMemory(runtime, request, row), row.type)
+        ) {
+          identicalRace = false;
+          observedConflictingRow ||= existing !== null;
+          break;
+        }
+      }
+      if (identicalRace) {
+        skippedExisting += batch.length;
+        skippedExistingEmbeddings += toImport.filter(
+          (row) => row.embedding,
+        ).length;
+        batch.length = 0;
+      } else if (observedConflictingRow) {
+        return failure(
+          409,
+          "IMPORT_ID_CONFLICT",
+          "Import refused: an id was concurrently written with different stored fields",
+        );
+      } else {
+        throw cause;
+      }
+    }
   }
 
   return {
@@ -221,6 +288,9 @@ export async function importSealedMemories(
       skipped_existing: skippedExisting,
       embeddings_written: batch.filter((entry) => entry.memory.embedding)
         .length,
+      // Count only embeddings whose skipped rows passed full stored-row
+      // equality. The pusher combines this with newly written embeddings.
+      embeddings_skipped_verified: skippedExistingEmbeddings,
       conflicts: [],
       digest_verified: true,
     },

--- a/packages/agent/src/api/memory-import.ts
+++ b/packages/agent/src/api/memory-import.ts
@@ -1,0 +1,246 @@
+/**
+ * Sealed bulk import of transferred Shared memories into this agent's
+ * database — the container-side landing half of a Shared→Dedicated cutover,
+ * rebuilt to the #20923 containment contract.
+ *
+ * Order of proof, all BEFORE any write: boundary validation (shared wire
+ * schema), conservation (row/embedding counts against the seal and a digest
+ * recompute over the received rows — transport truncation or tampering fails
+ * here, never a bare-2xx pass), then id-conflict detection (an existing row
+ * with DIFFERENT content is a 409 conflict that fails the whole request;
+ * identical content is idempotent `skipped_existing`). Scaffolding rows
+ * (worlds/rooms/entities) are created ONLY when absent — an existing row is
+ * never overwritten. The writes land through the adapter's all-or-nothing
+ * `createMemories` batch, with ids, timestamps, content, and vectors
+ * verbatim; the ONLY mutation is the documented remap: rows authored by
+ * `seal.source_agent_id` (and every row's owning agent) become THIS runtime's
+ * agent id, since the source agent has no row here and recall scopes locally.
+ */
+
+import {
+  type AgentRuntime,
+  ChannelType,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import {
+  computeSharedMemoryTransferDigest,
+  type SealedImportConflict,
+  type SealedImportResponse,
+  type SealedMemoryImportRequest,
+  SealedMemoryImportRequestSchema,
+  SHARED_MEMORY_TRANSFER_SOURCE,
+  sharedMemoryContentHash,
+} from "@elizaos/shared/contracts/shared-memory-transfer";
+import type { MemoryRouteContext } from "./memory-routes.ts";
+
+/** Seal + 500 vectored rows is ~4KB/row; this bounds the request body. */
+export const MEMORY_IMPORT_MAX_BODY_BYTES = 16 * 1024 * 1024;
+
+export type SealedImportOutcome =
+  | { status: 200; body: SealedImportResponse }
+  | { status: 400 | 409; body: { ok: false; error: string; code: string } };
+
+function failure(
+  status: 400 | 409,
+  code: string,
+  error: string,
+): SealedImportOutcome {
+  return { status, body: { ok: false, error, code } };
+}
+
+async function ensureScaffoldingIfAbsent(
+  runtime: AgentRuntime,
+  request: SealedMemoryImportRequest,
+): Promise<void> {
+  const sourceAgentId = request.seal.source_agent_id;
+
+  const worldIds = new Set<string>();
+  const roomWorlds = new Map<string, string>();
+  const transferWorldId = `${runtime.agentId}`;
+  for (const row of request.rows) {
+    const worldId = row.world_id ?? (row.room_id ? transferWorldId : undefined);
+    if (worldId) worldIds.add(worldId);
+    if (row.room_id) roomWorlds.set(row.room_id, worldId ?? transferWorldId);
+  }
+  for (const worldId of worldIds) {
+    // Create-if-absent ONLY: an existing world (any name/metadata) is left
+    // byte-untouched — the upsert path runs solely when nothing exists.
+    const existing = (
+      await runtime.adapter.getWorldsByIds([worldId as UUID])
+    )?.[0];
+    if (existing) continue;
+    await runtime.ensureWorldExists({
+      id: worldId as UUID,
+      name: "Transferred shared history",
+      agentId: runtime.agentId,
+      metadata: { type: SHARED_MEMORY_TRANSFER_SOURCE },
+    });
+  }
+  for (const [roomId, worldId] of roomWorlds) {
+    const existing = await runtime.getRoom(roomId as UUID);
+    if (existing) continue;
+    await runtime.ensureRoomExists({
+      id: roomId as UUID,
+      name: "Transferred shared history",
+      source: SHARED_MEMORY_TRANSFER_SOURCE,
+      type: ChannelType.DM,
+      worldId: worldId as UUID,
+      metadata: { type: SHARED_MEMORY_TRANSFER_SOURCE },
+    });
+  }
+
+  const entityIds = new Set<string>();
+  for (const row of request.rows) {
+    if (row.entity_id && row.entity_id !== sourceAgentId) {
+      entityIds.add(row.entity_id);
+    }
+  }
+  for (const entityId of entityIds) {
+    const existing = await runtime.getEntityById(entityId as UUID);
+    if (existing) continue;
+    await runtime.createEntity({
+      id: entityId as UUID,
+      names: ["Transferred user"],
+      agentId: runtime.agentId,
+      metadata: { type: SHARED_MEMORY_TRANSFER_SOURCE },
+    });
+  }
+}
+
+/**
+ * Validate, prove conservation, detect conflicts, then land the batch
+ * atomically. Exported for direct unit coverage; the route is a thin shell.
+ */
+export async function importSealedMemories(
+  runtime: AgentRuntime,
+  raw: unknown,
+): Promise<SealedImportOutcome> {
+  const parsed = SealedMemoryImportRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const path = issue?.path.length ? ` at ${issue.path.join(".")}` : "";
+    return failure(
+      400,
+      "IMPORT_INVALID_PAYLOAD",
+      `${issue?.message ?? "Invalid import payload"}${path}`,
+    );
+  }
+  const request = parsed.data;
+
+  // Conservation BEFORE any write: counts and digest must match the seal.
+  if (request.rows.length !== request.seal.row_count) {
+    return failure(
+      409,
+      "IMPORT_ROW_COUNT_MISMATCH",
+      `Seal claims ${request.seal.row_count} rows; request carries ${request.rows.length}`,
+    );
+  }
+  const embeddingCount = request.rows.filter((row) => row.embedding).length;
+  if (embeddingCount !== request.seal.embedding_count) {
+    return failure(
+      409,
+      "IMPORT_EMBEDDING_COUNT_MISMATCH",
+      `Seal claims ${request.seal.embedding_count} embeddings; request carries ${embeddingCount}`,
+    );
+  }
+  const digest = computeSharedMemoryTransferDigest(request.rows);
+  if (digest !== request.seal.digest) {
+    return failure(
+      409,
+      "IMPORT_DIGEST_MISMATCH",
+      "Recomputed payload digest does not match the seal",
+    );
+  }
+
+  // Id-conflict pre-check BEFORE any write: same id + same content is an
+  // idempotent replay; same id + different content fails the whole request.
+  const conflicts: SealedImportConflict[] = [];
+  const toImport: typeof request.rows = [];
+  let skippedExisting = 0;
+  for (const row of request.rows) {
+    const existing = await runtime.getMemoryById(row.id as UUID);
+    if (!existing) {
+      toImport.push(row);
+      continue;
+    }
+    if (
+      sharedMemoryContentHash(existing.content) ===
+      sharedMemoryContentHash(row.content)
+    ) {
+      skippedExisting += 1;
+      continue;
+    }
+    conflicts.push({ id: row.id, reason: "content-mismatch" });
+  }
+  if (conflicts.length > 0) {
+    return {
+      status: 409,
+      body: {
+        ok: false,
+        error: `Import refused: ${conflicts.length} id conflict(s) with different content`,
+        code: "IMPORT_ID_CONFLICT",
+      },
+    };
+  }
+
+  await ensureScaffoldingIfAbsent(runtime, request);
+
+  const sourceAgentId = request.seal.source_agent_id;
+  const batch = toImport.map((row) => ({
+    memory: {
+      id: row.id as UUID,
+      agentId: runtime.agentId,
+      entityId: (row.entity_id === sourceAgentId || row.entity_id === null
+        ? runtime.agentId
+        : row.entity_id) as UUID,
+      roomId: (row.room_id ?? undefined) as UUID,
+      worldId: (row.world_id ??
+        (row.room_id ? `${runtime.agentId}` : undefined)) as UUID | undefined,
+      content: row.content as Memory["content"],
+      metadata: row.metadata as Memory["metadata"],
+      createdAt: Date.parse(row.created_at),
+      ...(row.embedding ? { embedding: row.embedding.dim_384 } : {}),
+    } as Memory,
+    tableName: row.type,
+    unique: true,
+  }));
+
+  // Adapter-direct all-or-nothing batch: preserves ids/timestamps/vectors
+  // verbatim and skips the runtime wrapper's redaction and fact dedupe, which
+  // would mutate transferred history.
+  if (batch.length > 0) {
+    await runtime.adapter.createMemories(batch);
+  }
+
+  return {
+    status: 200,
+    body: {
+      ok: true,
+      imported: batch.length,
+      skipped_existing: skippedExisting,
+      embeddings_written: batch.filter((entry) => entry.memory.embedding)
+        .length,
+      conflicts: [],
+      digest_verified: true,
+    },
+  };
+}
+
+/** POST /api/memories/import — sealed transfer landing endpoint. */
+export async function handleMemoryImportRoute(
+  ctx: MemoryRouteContext,
+): Promise<boolean> {
+  const { req, res, runtime, json, error, readJsonBody } = ctx;
+  if (!runtime) {
+    error(res, "Agent runtime is not available", 503);
+    return true;
+  }
+  const raw = await readJsonBody<Record<string, unknown>>(req, res, {
+    maxBytes: MEMORY_IMPORT_MAX_BODY_BYTES,
+  });
+  if (raw === null) return true;
+  const outcome = await importSealedMemories(runtime, raw);
+  json(res, outcome.body, outcome.status);
+  return true;
+}

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -450,6 +450,13 @@ export async function handleMemoryRoutes(
     return true;
   }
 
+  // Dispatched before ensureMemoryConnection: a sealed transfer import must
+  // not create the client-chat room, and it manages its own scaffolding rows.
+  if (method === "POST" && pathname === "/api/memories/import") {
+    const { handleMemoryImportRoute } = await import("./memory-import.ts");
+    return handleMemoryImportRoute(ctx);
+  }
+
   const resolvedAgentName = resolveAgentName(runtime, agentName);
   const { roomId, entityId } = await ensureMemoryConnection(
     runtime,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -126,7 +126,10 @@ import {
   type SharedAgentTurnUsage,
   type SharedTurnMessage,
 } from "./shared-runtime/run-shared-agent-turn";
-import { transferSharedMemoriesToDedicated } from "./shared-runtime/shared-memory-transfer";
+import {
+  SHARED_MEMORY_TRANSFER_FAILED,
+  transferSharedMemoriesToDedicated,
+} from "./shared-runtime/shared-memory-transfer";
 import { applyPooledCredentialsToBootstrapEnv } from "./team-credential-pool/bootstrap-env";
 import {
   formatWakeRestoreIntegrityError,
@@ -3541,31 +3544,21 @@ export class ElizaSandboxService {
           const transferToken = (
             (rec.environment_vars ?? {}) as Record<string, string>
           ).ELIZA_API_TOKEN?.trim();
-          try {
-            if (!transferToken) {
-              throw new Error("agent ELIZA_API_TOKEN is unavailable for the memory transfer");
-            }
-            const transfer = await transferSharedMemoriesToDedicated(
-              { id: rec.id, organization_id: rec.organization_id, user_id: rec.user_id },
-              { baseUrl: handle.bridgeUrl, apiToken: transferToken },
-            );
-            if (transfer.rows > 0) {
-              logger.info("[agent-sandbox] Shared memory history transferred", {
-                agentId: rec.id,
-                ...transfer,
-              });
-            }
-          } catch (error) {
-            // error-policy:J4 designed degrade — the history copy is additive
-            // and re-runnable against the sealed idempotent importer; failing
-            // the provision would trade a booting agent for a memory copy.
-            logger.warn(
-              "[agent-sandbox] Shared memory transfer failed; container boots without transferred history",
-              {
-                agentId: rec.id,
-                error: error instanceof Error ? error.message : String(error),
-              },
-            );
+          if (!transferToken) {
+            throw new Error("agent ELIZA_API_TOKEN is unavailable for the memory transfer");
+          }
+          // Feature-enabled promotion is fail-closed. Once this provision is
+          // committed as running it is no longer an empty boot, so swallowing
+          // a failure here would permanently strand the Shared history.
+          const transfer = await transferSharedMemoriesToDedicated(
+            { id: rec.id, organization_id: rec.organization_id, user_id: rec.user_id },
+            { baseUrl: handle.bridgeUrl, apiToken: transferToken },
+          );
+          if (transfer.rows > 0) {
+            logger.info("[agent-sandbox] Shared memory history transferred", {
+              agentId: rec.id,
+              ...transfer,
+            });
           }
         }
 
@@ -3660,6 +3653,15 @@ export class ElizaSandboxService {
             error: `Replacement cleanup is still pending: ${
               stopErr instanceof Error ? stopErr.message : String(stopErr)
             }`,
+          };
+        }
+
+        if (err instanceof ElizaError && err.code === SHARED_MEMORY_TRANSFER_FAILED) {
+          return {
+            success: false,
+            retryable: true,
+            sandboxRecord: await agentSandboxesRepository.findById(rec.id),
+            error: msg,
           };
         }
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -126,6 +126,7 @@ import {
   type SharedAgentTurnUsage,
   type SharedTurnMessage,
 } from "./shared-runtime/run-shared-agent-turn";
+import { transferSharedMemoriesToDedicated } from "./shared-runtime/shared-memory-transfer";
 import { applyPooledCredentialsToBootstrapEnv } from "./team-credential-pool/bootstrap-env";
 import {
   formatWakeRestoreIntegrityError,
@@ -3517,6 +3518,55 @@ export class ElizaSandboxService {
             agentId: rec.id,
             backupId: backup.id,
           });
+        }
+
+        // 6. Shared→Dedicated memory transfer (#20923 rebuild), DEFAULT OFF —
+        // ELIZA_SHARED_MEMORY_TRANSFER_ENABLED must be exactly "true". Fires
+        // only when the container boots EMPTY (no backup existed, nothing
+        // restored, not an explicit fresh-boot consent, not a pool row): the
+        // in-Worker shared runtime served this agent during its bootstrap
+        // window and wrote its turns to shared_agent_memories; a first
+        // container otherwise boots with none of that history. The push is
+        // sealed + conservation-validated end to end and the importer is
+        // idempotent, so an interrupted transfer converges on the next empty
+        // boot or explicit re-run.
+        if (
+          process.env.ELIZA_SHARED_MEMORY_TRANSFER_ENABLED === "true" &&
+          !isWarmPoolProvision &&
+          rec.execution_tier !== "shared" &&
+          !backup &&
+          !restoreState &&
+          restoreOverride?.kind !== "fresh-boot"
+        ) {
+          const transferToken = (
+            (rec.environment_vars ?? {}) as Record<string, string>
+          ).ELIZA_API_TOKEN?.trim();
+          try {
+            if (!transferToken) {
+              throw new Error("agent ELIZA_API_TOKEN is unavailable for the memory transfer");
+            }
+            const transfer = await transferSharedMemoriesToDedicated(
+              { id: rec.id, organization_id: rec.organization_id, user_id: rec.user_id },
+              { baseUrl: handle.bridgeUrl, apiToken: transferToken },
+            );
+            if (transfer.rows > 0) {
+              logger.info("[agent-sandbox] Shared memory history transferred", {
+                agentId: rec.id,
+                ...transfer,
+              });
+            }
+          } catch (error) {
+            // error-policy:J4 designed degrade — the history copy is additive
+            // and re-runnable against the sealed idempotent importer; failing
+            // the provision would trade a booting agent for a memory copy.
+            logger.warn(
+              "[agent-sandbox] Shared memory transfer failed; container boots without transferred history",
+              {
+                agentId: rec.id,
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
+          }
         }
 
         let completed = updated;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-sealed-export.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-sealed-export.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Contract tests for the sealed Shared memory export (#20923 rebuild) against
+ * REAL in-process PGlite: the walk runs inside one snapshot seam, the seal's
+ * digest/counts are the manifest of the exact rows walked, scope derivation
+ * matches the Shared turn-path writer, vectors export verbatim, and an
+ * anomalous stored vector fails the export with a typed error instead of a
+ * dropped-but-successful result.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+import { stringToUuid } from "@elizaos/core/edge";
+import { computeSharedMemoryTransferDigest } from "@elizaos/shared/contracts/shared-memory-transfer";
+import { pushSchema } from "drizzle-kit/api";
+import { sql } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
+import { sharedAgentMemoriesWriter } from "../../../db/repositories/shared-agent-memories";
+import { organizations } from "../../../db/schemas/organizations";
+import { sharedAgentMemories } from "../../../db/schemas/shared-agent-memories";
+import { users } from "../../../db/schemas/users";
+import {
+  exportSealedSharedMemories,
+  sealedExportScopeForAgent,
+} from "./shared-memory-sealed-export";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+
+const ORG = "11111111-1111-4111-8111-111111111111";
+const USER = "33333333-3333-4333-8333-333333333333";
+const AGENT = { id: "personal:aaa", organization_id: ORG, user_id: USER };
+const scope = sealedExportScopeForAgent(AGENT);
+const ROOM = "77777777-7777-4777-8777-777777777777";
+
+// PGlite has no multi-connection MVCC; the walk still exercises the real
+// paged query through this pass-through snapshot seam.
+const passThroughSnapshot = async <T>(fn: (tx: never) => Promise<T>): Promise<T> => {
+  const { dbRead } = await import("../../../db/client");
+  return fn(dbRead as never);
+};
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    return;
+  }
+  try {
+    await dbWrite.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
+    const { apply } = await pushSchema(
+      { organizations, users, sharedAgentMemories } as never,
+      dbWrite as never,
+    );
+    await apply();
+    await dbWrite
+      .insert(organizations)
+      .values([{ id: ORG, name: "Org", slug: "org" }])
+      .onConflictDoNothing();
+    await dbWrite
+      .insert(users)
+      .values([{ id: USER, organization_id: ORG, steward_user_id: "steward-u" }])
+      .onConflictDoNothing();
+  } catch (error) {
+    pgliteReady = false;
+    console.error("[sealed-export.test] PGlite setup failed", error);
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(pgliteReady).toBe(true);
+  await dbWrite.delete(sharedAgentMemories);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+async function seedRow(index: number, embedding?: number[]) {
+  await sharedAgentMemoriesWriter.insertMemory({
+    id: `cccccccc-cccc-4ccc-8ccc-${String(index).padStart(12, "0")}`,
+    scope,
+    entityId: USER,
+    roomId: ROOM,
+    type: "messages",
+    content: { text: `m${index}` },
+    ...(embedding ? { embedding, embeddingModel: "bge-small-en-v1.5" } : {}),
+  });
+}
+
+describe("sealed shared memory export (real PGlite)", () => {
+  test("scope derivation matches the turn-path writer", () => {
+    expect(scope.agentId).toBe(stringToUuid("shared-todos:agent:personal:aaa"));
+    expect(scope.organizationId).toBe(ORG);
+    expect(scope.userId).toBe(USER);
+  });
+
+  test("the seal is the manifest of the walked rows, vectors verbatim", async () => {
+    const precise = Array.from({ length: 384 }, (_, i) => 0.123456789 + i * 1e-9);
+    await seedRow(0, precise);
+    await seedRow(1);
+    await seedRow(
+      2,
+      Array.from({ length: 384 }, () => 0.25),
+    );
+
+    const sealed = await exportSealedSharedMemories(AGENT, {
+      withSnapshot: passThroughSnapshot as never,
+    });
+
+    expect(sealed.seal.row_count).toBe(3);
+    expect(sealed.seal.embedding_count).toBe(2);
+    expect(sealed.seal.source_agent_id).toBe(scope.agentId);
+    expect(sealed.seal.digest).toBe(computeSharedMemoryTransferDigest(sealed.rows));
+    expect(sealed.rows.map((row) => row.content)).toEqual([
+      { text: "m0" },
+      { text: "m1" },
+      { text: "m2" },
+    ]);
+    // Verbatim relative to storage: the column is real[] (float4), so the
+    // export carries the stored single-precision value with NO further
+    // rounding (the removed importer-side toFixed(6) was coarser than this).
+    expect(sealed.rows[0]?.embedding?.dim_384).toHaveLength(384);
+    expect(sealed.rows[0]?.embedding?.dim_384?.[0]).toBeCloseTo(0.123456789, 7);
+    // Pins the removed toFixed(6) coarsening: 6dp would have stored 0.123457.
+    expect(sealed.rows[0]?.embedding?.dim_384?.[0]).not.toBe(0.123457);
+    expect(sealed.rows[1]?.embedding).toBeUndefined();
+  });
+
+  test("rows outside the tenant scope are invisible", async () => {
+    await seedRow(0);
+    await sharedAgentMemoriesWriter.insertMemory({
+      scope: { organizationId: ORG, userId: USER, agentId: stringToUuid("other-agent") },
+      roomId: ROOM,
+      type: "messages",
+      content: { text: "other tenant agent" },
+    });
+    const sealed = await exportSealedSharedMemories(AGENT, {
+      withSnapshot: passThroughSnapshot as never,
+    });
+    expect(sealed.seal.row_count).toBe(1);
+  });
+
+  test("an anomalous stored vector fails the export with a typed error", async () => {
+    await seedRow(
+      0,
+      Array.from({ length: 768 }, () => 0.1),
+    );
+    await expect(
+      exportSealedSharedMemories(AGENT, {
+        withSnapshot: passThroughSnapshot as never,
+      }),
+    ).rejects.toMatchObject({ code: "SHARED_MEMORY_EXPORT_ANOMALOUS_VECTOR" });
+  });
+
+  test("an empty scope seals a zero manifest", async () => {
+    const sealed = await exportSealedSharedMemories(AGENT, {
+      withSnapshot: passThroughSnapshot as never,
+    });
+    expect(sealed.seal.row_count).toBe(0);
+    expect(sealed.rows).toEqual([]);
+    expect(sealed.seal.digest).toBe(computeSharedMemoryTransferDigest([]));
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-sealed-export.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-sealed-export.ts
@@ -1,0 +1,155 @@
+/**
+ * Sealed export of a tenant's Shared memory history for the Shared→Dedicated
+ * cutover, rebuilt to the #20923 containment contract. The whole export reads
+ * one REPEATABLE READ transaction (a single MVCC snapshot — concurrent turn
+ * writes cannot yield a stale prefix that reports itself complete), and the
+ * result carries the shared wire contract's transactional seal: counts plus
+ * the order-sensitive digest the importer recomputes over what it actually
+ * received before any write.
+ *
+ * Fidelity: `content` passes through byte-identical, identities and
+ * `created_at` are preserved exactly, and vectors are exported VERBATIM. The
+ * source→local agent remap is not guessed per row: the seal names the
+ * `source_agent_id` once and the importer applies the documented remap against
+ * it. A vector whose dimension has no importer column FAILS the export with a
+ * typed error — never a dropped-but-successful result.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import {
+  computeSharedMemoryTransferDigest,
+  type SealedExportSeal,
+  type SealedMemoryExportRow,
+  SHARED_MEMORY_TRANSFER_SOURCE,
+  SHARED_MEMORY_TRANSFER_VECTOR_DIMENSION,
+} from "@elizaos/shared/contracts/shared-memory-transfer";
+import { and, asc, eq, sql } from "drizzle-orm";
+import { dbRead } from "../../../db/client";
+import type { SharedAgentMemoryScope } from "../../../db/repositories/shared-agent-memories";
+import {
+  type SharedAgentMemoryRow,
+  sharedAgentMemories,
+} from "../../../db/schemas/shared-agent-memories";
+import { sharedTodoStorageScope } from "./shared-runtime-storage-identity";
+
+export const SHARED_MEMORY_EXPORT_ANOMALOUS_VECTOR = "SHARED_MEMORY_EXPORT_ANOMALOUS_VECTOR";
+export const SEALED_EXPORT_PAGE = 200;
+
+export interface SealedMemoryExport {
+  seal: SealedExportSeal;
+  rows: SealedMemoryExportRow[];
+}
+
+/** The identity triple of the agent whose Shared history is being exported. */
+export interface SealedExportAgent {
+  id: string;
+  organization_id: string;
+  user_id: string;
+}
+
+/**
+ * The DB scope the Shared turn path writes this agent's memories under —
+ * the todo-storage derivation of the serving agent id, mirroring
+ * `sharedTurnMemoryStore` in shared-runtime-chat.
+ */
+export function sealedExportScopeForAgent(agent: SealedExportAgent): SharedAgentMemoryScope {
+  return {
+    organizationId: agent.organization_id,
+    userId: agent.user_id,
+    agentId: sharedTodoStorageScope({
+      sourceAgentId: agent.id,
+      ownerId: agent.user_id,
+    }).agentId,
+  };
+}
+
+function toExportRow(row: SharedAgentMemoryRow): SealedMemoryExportRow {
+  const base: SealedMemoryExportRow = {
+    id: row.id,
+    type: row.type,
+    created_at: row.created_at.toISOString(),
+    content: row.content as Record<string, unknown>,
+    entity_id: row.entity_id,
+    room_id: row.room_id,
+    world_id: row.world_id,
+    metadata: { source: SHARED_MEMORY_TRANSFER_SOURCE },
+  };
+  const vector = row.embedding;
+  if (!Array.isArray(vector) || vector.length === 0) return base;
+  if (vector.length !== SHARED_MEMORY_TRANSFER_VECTOR_DIMENSION) {
+    // Fail-closed: an anomalous stored vector is an upstream defect the
+    // transfer must surface, never a row quietly exported without recall.
+    throw new ElizaError("Shared memory export found a vector with no importable dimension", {
+      code: SHARED_MEMORY_EXPORT_ANOMALOUS_VECTOR,
+      context: { memoryId: row.id, dimension: vector.length },
+    });
+  }
+  return { ...base, embedding: { dim_384: [...vector] } };
+}
+
+export interface SealedExportDeps {
+  /** Test seam: runs `fn` against one consistent snapshot. Defaults to a
+   *  REPEATABLE READ transaction on the shared read client. */
+  withSnapshot?: <T>(fn: (tx: typeof dbRead) => Promise<T>) => Promise<T>;
+}
+
+async function defaultWithSnapshot<T>(fn: (tx: typeof dbRead) => Promise<T>): Promise<T> {
+  return await dbRead.transaction(async (tx) => fn(tx as unknown as typeof dbRead), {
+    isolationLevel: "repeatable read",
+  });
+}
+
+/**
+ * Export the agent's complete Shared history under one sealed snapshot. The
+ * seal's counts and digest are computed from the rows actually walked, so the
+ * seal IS the manifest of this exact payload.
+ */
+export async function exportSealedSharedMemories(
+  agent: SealedExportAgent,
+  deps: SealedExportDeps = {},
+): Promise<SealedMemoryExport> {
+  const scope = sealedExportScopeForAgent(agent);
+  const withSnapshot = deps.withSnapshot ?? defaultWithSnapshot;
+
+  const rows = await withSnapshot(async (tx) => {
+    const out: SealedMemoryExportRow[] = [];
+    let after: { createdAt: Date; id: string } | undefined;
+    for (;;) {
+      const page = await tx
+        .select()
+        .from(sharedAgentMemories)
+        .where(
+          and(
+            eq(sharedAgentMemories.organization_id, scope.organizationId),
+            eq(sharedAgentMemories.user_id, scope.userId),
+            eq(sharedAgentMemories.agent_id, scope.agentId),
+            ...(after
+              ? [
+                  sql`(${sharedAgentMemories.created_at}, ${sharedAgentMemories.id}) > (${after.createdAt}, ${after.id}::uuid)`,
+                ]
+              : []),
+          ),
+        )
+        .orderBy(asc(sharedAgentMemories.created_at), asc(sharedAgentMemories.id))
+        .limit(SEALED_EXPORT_PAGE);
+      if (page.length === 0) break;
+      for (const row of page) out.push(toExportRow(row));
+      const last = page[page.length - 1] as SharedAgentMemoryRow;
+      after = { createdAt: last.created_at, id: last.id };
+      if (page.length < SEALED_EXPORT_PAGE) break;
+    }
+    return out;
+  });
+
+  return {
+    seal: {
+      row_count: rows.length,
+      embedding_count: rows.filter((row) => row.embedding).length,
+      digest: computeSharedMemoryTransferDigest(rows),
+      source_agent_id: scope.agentId,
+      organization_id: scope.organizationId,
+      user_id: scope.userId,
+    },
+    rows,
+  };
+}

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Contract tests for the sealed transfer push (#20923 rebuild). Deterministic
+ * doubles for export and fetch; pins the containment blockers: the token
+ * never leaves toward a non-allowlisted authority (refused BEFORE export or
+ * fetch), every request carries a timeout signal, a bare-2xx or
+ * non-conserving importer response is a typed failure, and totals must
+ * conserve the sealed manifest.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  computeSharedMemoryTransferDigest,
+  type SealedMemoryExportRow,
+} from "@elizaos/shared/contracts/shared-memory-transfer";
+import type { SealedMemoryExport } from "./shared-memory-sealed-export";
+import {
+  assertTransferTargetAllowed,
+  transferSharedMemoriesToDedicated,
+} from "./shared-memory-transfer";
+
+const AGENT = {
+  id: "personal:327fd128-cb80-5f3a-aedd-47b3c465c805",
+  organization_id: "75ae457b-801f-43e1-9d95-5585147655cd",
+  user_id: "f210269b-8148-428b-8c24-91da4c95c727",
+};
+const TARGET = { baseUrl: "http://100.64.0.10:2138", apiToken: "tok" };
+
+function row(index: number): SealedMemoryExportRow {
+  return {
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+    type: "messages",
+    created_at: new Date(1755400000000 + index * 1000).toISOString(),
+    content: { text: `m${index}` },
+    entity_id: "3a0731c4-5a3c-4a3f-9d6e-0f6f10a4c111",
+    room_id: "9610511b-dff2-5ca3-989a-8e1004ff44b1",
+    world_id: "022a61e3-2968-4c5a-a510-ac7bac458464",
+    metadata: { source: "shared-runtime-transfer" },
+    embedding: { dim_384: Array.from({ length: 384 }, () => 0.5) },
+  };
+}
+
+function sealedExport(rows: SealedMemoryExportRow[]): SealedMemoryExport {
+  return {
+    seal: {
+      row_count: rows.length,
+      embedding_count: rows.filter((r) => r.embedding).length,
+      digest: computeSharedMemoryTransferDigest(rows),
+      source_agent_id: "55555555-5555-4555-8555-555555555555",
+      organization_id: AGENT.organization_id,
+      user_id: AGENT.user_id,
+    },
+    rows,
+  };
+}
+
+function recordingFetch(
+  respond: (body: { seal: { row_count: number }; rows: unknown[] }) => unknown,
+) {
+  const calls: Array<{ url: string; signal: AbortSignal | undefined; auth: string }> = [];
+  const impl = (async (url: RequestInfo | URL, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body));
+    calls.push({
+      url: String(url),
+      signal: init?.signal ?? undefined,
+      auth: (init?.headers as Record<string, string>)?.Authorization ?? "",
+    });
+    return Response.json(respond(body));
+  }) as typeof fetch;
+  return { impl, calls };
+}
+
+function okResponse(body: { rows: unknown[] }) {
+  return {
+    ok: true,
+    imported: body.rows.length,
+    skipped_existing: 0,
+    embeddings_written: body.rows.length,
+    conflicts: [],
+    digest_verified: true,
+  };
+}
+
+describe("assertTransferTargetAllowed", () => {
+  test("tailnet CGNAT addresses and .eliza.local pass; everything else refuses", () => {
+    expect(() => assertTransferTargetAllowed("http://100.64.0.10:2138")).not.toThrow();
+    expect(() => assertTransferTargetAllowed("http://100.127.9.3:2138")).not.toThrow();
+    expect(() => assertTransferTargetAllowed("https://agent-x.tunnel.eliza.local")).not.toThrow();
+    for (const bad of [
+      "https://evil.example.com",
+      "http://100.128.0.1", // outside 100.64/10
+      "http://100.63.255.255",
+      "https://eliza.local.evil.com",
+      "ftp://100.64.0.10",
+      "not a url",
+    ]) {
+      expect(() => assertTransferTargetAllowed(bad)).toThrow();
+    }
+  });
+});
+
+describe("transferSharedMemoriesToDedicated", () => {
+  test("a disallowed target is refused BEFORE export or token egress", async () => {
+    let exported = false;
+    const net = recordingFetch(okResponse);
+    await expect(
+      transferSharedMemoriesToDedicated(
+        AGENT,
+        { baseUrl: "https://evil.example.com", apiToken: "tok" },
+        {
+          exportImpl: (async () => {
+            exported = true;
+            return sealedExport([]);
+          }) as never,
+          fetchImpl: net.impl,
+        },
+      ),
+    ).rejects.toMatchObject({ code: "SHARED_MEMORY_TRANSFER_TARGET_REFUSED" });
+    expect(exported).toBe(false);
+    expect(net.calls).toHaveLength(0);
+  });
+
+  test("pushes conservation-validated batches with timeout signals attached", async () => {
+    const rows = Array.from({ length: 3 }, (_, i) => row(i));
+    const net = recordingFetch(okResponse);
+    const result = await transferSharedMemoriesToDedicated(AGENT, TARGET, {
+      exportImpl: (async () => sealedExport(rows)) as never,
+      fetchImpl: net.impl,
+    });
+    expect(result).toEqual({
+      rows: 3,
+      batches: 1,
+      imported: 3,
+      skippedExisting: 0,
+      embeddingsWritten: 3,
+    });
+    expect(net.calls[0]?.url).toBe("http://100.64.0.10:2138/api/memories/import");
+    expect(net.calls[0]?.auth).toBe("Bearer tok");
+    expect(net.calls[0]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("a bare-2xx response failing conservation is a typed failure", async () => {
+    const rows = [row(0), row(1)];
+    // Importer claims ok but under-reports: imported+skipped !== rows.
+    const net = recordingFetch((body) => ({
+      ok: true,
+      imported: body.rows.length - 1,
+      skipped_existing: 0,
+      embeddings_written: body.rows.length - 1,
+      conflicts: [],
+      digest_verified: true,
+    }));
+    await expect(
+      transferSharedMemoriesToDedicated(AGENT, TARGET, {
+        exportImpl: (async () => sealedExport(rows)) as never,
+        fetchImpl: net.impl,
+      }),
+    ).rejects.toMatchObject({ code: "SHARED_MEMORY_TRANSFER_FAILED" });
+  });
+
+  test("ok:false and missing digest verification are typed failures", async () => {
+    const rows = [row(0)];
+    for (const bad of [
+      { ...okResponse({ rows }), ok: false },
+      { ...okResponse({ rows }), digest_verified: false },
+    ]) {
+      const net = recordingFetch(() => bad);
+      await expect(
+        transferSharedMemoriesToDedicated(AGENT, TARGET, {
+          exportImpl: (async () => sealedExport(rows)) as never,
+          fetchImpl: net.impl,
+        }),
+      ).rejects.toMatchObject({ code: "SHARED_MEMORY_TRANSFER_FAILED" });
+    }
+  });
+
+  test("a fresh container must write every batch embedding", async () => {
+    const rows = [row(0), row(1)];
+    const net = recordingFetch((body) => ({
+      ok: true,
+      imported: body.rows.length,
+      skipped_existing: 0,
+      // Silently dropped vectors on a fresh container must not pass.
+      embeddings_written: body.rows.length - 1,
+      conflicts: [],
+      digest_verified: true,
+    }));
+    await expect(
+      transferSharedMemoriesToDedicated(AGENT, TARGET, {
+        exportImpl: (async () => sealedExport(rows)) as never,
+        fetchImpl: net.impl,
+      }),
+    ).rejects.toMatchObject({ code: "SHARED_MEMORY_TRANSFER_FAILED" });
+  });
+
+  test("an empty history is a zero-count no-op without network calls", async () => {
+    const net = recordingFetch(okResponse);
+    const result = await transferSharedMemoriesToDedicated(AGENT, TARGET, {
+      exportImpl: (async () => sealedExport([])) as never,
+      fetchImpl: net.impl,
+    });
+    expect(result.rows).toBe(0);
+    expect(net.calls).toHaveLength(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.test.ts
@@ -56,13 +56,19 @@ function sealedExport(rows: SealedMemoryExportRow[]): SealedMemoryExport {
 function recordingFetch(
   respond: (body: { seal: { row_count: number }; rows: unknown[] }) => unknown,
 ) {
-  const calls: Array<{ url: string; signal: AbortSignal | undefined; auth: string }> = [];
+  const calls: Array<{
+    url: string;
+    signal: AbortSignal | undefined;
+    auth: string;
+    redirect: RequestRedirect | undefined;
+  }> = [];
   const impl = (async (url: RequestInfo | URL, init?: RequestInit) => {
     const body = JSON.parse(String(init?.body));
     calls.push({
       url: String(url),
       signal: init?.signal ?? undefined,
       auth: (init?.headers as Record<string, string>)?.Authorization ?? "",
+      redirect: init?.redirect,
     });
     return Response.json(respond(body));
   }) as typeof fetch;
@@ -75,6 +81,7 @@ function okResponse(body: { rows: unknown[] }) {
     imported: body.rows.length,
     skipped_existing: 0,
     embeddings_written: body.rows.length,
+    embeddings_skipped_verified: 0,
     conflicts: [],
     digest_verified: true,
   };
@@ -136,6 +143,25 @@ describe("transferSharedMemoriesToDedicated", () => {
     expect(net.calls[0]?.url).toBe("http://100.64.0.10:2138/api/memories/import");
     expect(net.calls[0]?.auth).toBe("Bearer tok");
     expect(net.calls[0]?.signal).toBeInstanceOf(AbortSignal);
+    expect(net.calls[0]?.redirect).toBe("error");
+  });
+
+  test("the seal binds metadata and world identity", () => {
+    const original = row(0);
+    const metadataChanged = {
+      ...original,
+      metadata: { ...original.metadata, source: "tampered" },
+    };
+    const worldChanged = {
+      ...original,
+      world_id: "11111111-1111-4111-8111-111111111111",
+    };
+    expect(computeSharedMemoryTransferDigest([metadataChanged])).not.toBe(
+      computeSharedMemoryTransferDigest([original]),
+    );
+    expect(computeSharedMemoryTransferDigest([worldChanged])).not.toBe(
+      computeSharedMemoryTransferDigest([original]),
+    );
   });
 
   test("a bare-2xx response failing conservation is a typed failure", async () => {
@@ -146,6 +172,7 @@ describe("transferSharedMemoriesToDedicated", () => {
       imported: body.rows.length - 1,
       skipped_existing: 0,
       embeddings_written: body.rows.length - 1,
+      embeddings_skipped_verified: 0,
       conflicts: [],
       digest_verified: true,
     }));
@@ -173,6 +200,22 @@ describe("transferSharedMemoriesToDedicated", () => {
     }
   });
 
+  test("rejects malformed or negative receipts before conservation arithmetic", async () => {
+    const rows = [row(0)];
+    for (const bad of [
+      { ...okResponse({ rows }), imported: -1, skipped_existing: 2 },
+      { ...okResponse({ rows }), imported: "1" },
+    ]) {
+      const net = recordingFetch(() => bad);
+      await expect(
+        transferSharedMemoriesToDedicated(AGENT, TARGET, {
+          exportImpl: (async () => sealedExport(rows)) as never,
+          fetchImpl: net.impl,
+        }),
+      ).rejects.toMatchObject({ code: "SHARED_MEMORY_TRANSFER_FAILED" });
+    }
+  });
+
   test("a fresh container must write every batch embedding", async () => {
     const rows = [row(0), row(1)];
     const net = recordingFetch((body) => ({
@@ -181,6 +224,45 @@ describe("transferSharedMemoriesToDedicated", () => {
       skipped_existing: 0,
       // Silently dropped vectors on a fresh container must not pass.
       embeddings_written: body.rows.length - 1,
+      embeddings_skipped_verified: 0,
+      conflicts: [],
+      digest_verified: true,
+    }));
+    await expect(
+      transferSharedMemoriesToDedicated(AGENT, TARGET, {
+        exportImpl: (async () => sealedExport(rows)) as never,
+        fetchImpl: net.impl,
+      }),
+    ).rejects.toMatchObject({ code: "SHARED_MEMORY_TRANSFER_FAILED" });
+  });
+
+  test("one skipped row cannot excuse missing embeddings on newly imported rows", async () => {
+    const rows = [row(0), row(1), row(2)];
+    const net = recordingFetch(() => ({
+      ok: true,
+      imported: 2,
+      skipped_existing: 1,
+      embeddings_written: 0,
+      embeddings_skipped_verified: 1,
+      conflicts: [],
+      digest_verified: true,
+    }));
+    await expect(
+      transferSharedMemoriesToDedicated(AGENT, TARGET, {
+        exportImpl: (async () => sealedExport(rows)) as never,
+        fetchImpl: net.impl,
+      }),
+    ).rejects.toMatchObject({ code: "SHARED_MEMORY_TRANSFER_FAILED" });
+  });
+
+  test("skipped rows cannot be misreported as newly written embeddings", async () => {
+    const rows = [row(0), row(1)];
+    const net = recordingFetch(() => ({
+      ok: true,
+      imported: 0,
+      skipped_existing: 2,
+      embeddings_written: 2,
+      embeddings_skipped_verified: 0,
       conflicts: [],
       digest_verified: true,
     }));

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.ts
@@ -18,6 +18,7 @@ import { ElizaError } from "@elizaos/core";
 import {
   computeSharedMemoryTransferDigest,
   type SealedImportResponse,
+  SealedImportResponseSchema,
   type SealedMemoryExportRow,
   SHARED_MEMORY_TRANSFER_MAX_ROWS,
 } from "@elizaos/shared/contracts/shared-memory-transfer";
@@ -123,9 +124,9 @@ function validateBatchResponse(
     response.conflicts.length === 0 &&
     response.imported + response.skipped_existing === rows.length &&
     response.embeddings_written <= batchEmbeddings &&
-    // Fresh-container case (the actual promotion path): nothing pre-existed,
-    // so every batch embedding must have been written.
-    (response.skipped_existing > 0 || response.embeddings_written === batchEmbeddings);
+    response.embeddings_written <= response.imported &&
+    response.embeddings_skipped_verified <= response.skipped_existing &&
+    response.embeddings_written + response.embeddings_skipped_verified === batchEmbeddings;
   if (!conserves) {
     throw new ElizaError("Dedicated container import response failed conservation validation", {
       code: SHARED_MEMORY_TRANSFER_FAILED,
@@ -133,6 +134,7 @@ function validateBatchResponse(
         imported: response.imported,
         skippedExisting: response.skipped_existing,
         embeddingsWritten: response.embeddings_written,
+        embeddingsSkippedVerified: response.embeddings_skipped_verified,
         batchRows: rows.length,
         batchEmbeddings,
         ok: response.ok,
@@ -149,23 +151,62 @@ async function postBatch(
   fetchImpl: typeof fetch,
 ): Promise<SealedImportResponse> {
   const base = assertTransferTargetAllowed(target.baseUrl);
-  const response = await fetchImpl(new URL("/api/memories/import", base).toString(), {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${target.apiToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ seal, rows }),
-    signal: AbortSignal.timeout(transferTimeoutMs()),
-  });
+  let response: Response;
+  try {
+    response = await fetchImpl(new URL("/api/memories/import", base).toString(), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${target.apiToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ seal, rows }),
+      signal: AbortSignal.timeout(transferTimeoutMs()),
+      // Memory payloads and bearer credentials must never be replayed to a
+      // redirect-selected authority or path.
+      redirect: "error",
+    });
+  } catch (cause) {
+    // error-policy:J2 context-adding rethrow — provisioning must distinguish
+    // retryable transfer transport failure from a completed promotion.
+    throw new ElizaError("Dedicated container memory import transport failed", {
+      code: SHARED_MEMORY_TRANSFER_FAILED,
+      cause,
+      context: { batchSize: rows.length },
+      severity: "ephemeral",
+    });
+  }
   if (!response.ok) {
-    const detail = (await response.text().catch(() => "")).slice(0, 300);
+    let detail = "";
+    try {
+      detail = (await response.text()).slice(0, 300);
+    } catch {
+      // error-policy:J1 the status remains the authoritative transport error;
+      // an unreadable optional response body must not replace it.
+    }
     throw new ElizaError("Dedicated container rejected a memory import batch", {
       code: SHARED_MEMORY_TRANSFER_FAILED,
       context: { status: response.status, detail, batchSize: rows.length },
     });
   }
-  return (await response.json()) as SealedImportResponse;
+  let receipt: unknown;
+  try {
+    receipt = await response.json();
+  } catch (cause) {
+    // error-policy:J2 malformed transport data is a typed transfer failure.
+    throw new ElizaError("Dedicated container returned unreadable import JSON", {
+      code: SHARED_MEMORY_TRANSFER_FAILED,
+      cause,
+      context: { batchSize: rows.length },
+    });
+  }
+  const parsed = SealedImportResponseSchema.safeParse(receipt);
+  if (!parsed.success) {
+    throw new ElizaError("Dedicated container returned an invalid import receipt", {
+      code: SHARED_MEMORY_TRANSFER_FAILED,
+      context: { issue: parsed.error.issues[0]?.message ?? "invalid receipt" },
+    });
+  }
+  return parsed.data;
 }
 
 /**

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-transfer.ts
@@ -1,0 +1,216 @@
+/**
+ * Sealed push of an exported Shared history into a Dedicated container —
+ * the delivery leg of the Shared→Dedicated cutover, rebuilt to the #20923
+ * containment contract.
+ *
+ * Egress discipline: the container base URL must pass an authority allowlist
+ * BEFORE the agent's API token is attached (tailnet hosts by default —
+ * headscale CGNAT addresses and configured domain suffixes; anything else is
+ * a typed refusal), and every request carries a hard timeout. Response
+ * discipline: a batch only counts when the importer answered `ok` with
+ * `digest_verified` and the counts conserve (`imported + skipped_existing`
+ * equals the batch size; embeddings conserve exactly on a fresh container).
+ * Anything less is a typed failure — a partial transfer is re-runnable
+ * against the idempotent importer, never silently reported complete.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import {
+  computeSharedMemoryTransferDigest,
+  type SealedImportResponse,
+  type SealedMemoryExportRow,
+  SHARED_MEMORY_TRANSFER_MAX_ROWS,
+} from "@elizaos/shared/contracts/shared-memory-transfer";
+import {
+  exportSealedSharedMemories,
+  type SealedExportAgent,
+  type SealedMemoryExport,
+} from "./shared-memory-sealed-export";
+
+export const SHARED_MEMORY_TRANSFER_FAILED = "SHARED_MEMORY_TRANSFER_FAILED";
+export const SHARED_MEMORY_TRANSFER_TARGET_REFUSED = "SHARED_MEMORY_TRANSFER_TARGET_REFUSED";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_ALLOWED_HOST_SUFFIXES = [".eliza.local"];
+
+/** Container ingress: tailnet-reachable base URL plus its ELIZA_API_TOKEN. */
+export interface SharedMemoryTransferTarget {
+  baseUrl: string;
+  apiToken: string;
+}
+
+export interface SharedMemoryTransferResult {
+  rows: number;
+  batches: number;
+  imported: number;
+  skippedExisting: number;
+  embeddingsWritten: number;
+}
+
+/** Headscale/Tailscale CGNAT range: 100.64.0.0/10. */
+function isTailnetAddress(host: string): boolean {
+  const match = /^100\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/.exec(host);
+  if (!match) return false;
+  const second = Number(match[1]);
+  return second >= 64 && second <= 127;
+}
+
+function allowedHostSuffixes(): string[] {
+  const raw = process.env.ELIZA_MEMORY_TRANSFER_ALLOWED_HOST_SUFFIXES;
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return DEFAULT_ALLOWED_HOST_SUFFIXES;
+  }
+  return raw
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.startsWith("."));
+}
+
+/**
+ * The agent's API token may only travel to a container-shaped authority.
+ * Exported for direct unit coverage.
+ */
+export function assertTransferTargetAllowed(baseUrl: string): URL {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    // error-policy:J2 unparseable target becomes the typed refusal below
+    throw new ElizaError("Memory transfer target URL is unparseable", {
+      code: SHARED_MEMORY_TRANSFER_TARGET_REFUSED,
+      context: { baseUrl },
+    });
+  }
+  const host = url.hostname.toLowerCase();
+  const allowed =
+    isTailnetAddress(host) || allowedHostSuffixes().some((suffix) => host.endsWith(suffix));
+  if (!allowed || (url.protocol !== "http:" && url.protocol !== "https:")) {
+    throw new ElizaError("Memory transfer target is outside the container authority allowlist", {
+      code: SHARED_MEMORY_TRANSFER_TARGET_REFUSED,
+      context: { host, protocol: url.protocol },
+    });
+  }
+  return url;
+}
+
+function transferTimeoutMs(): number {
+  const raw = process.env.ELIZA_MEMORY_TRANSFER_TIMEOUT_MS;
+  const parsed = raw ? Number(raw) : Number.NaN;
+  return Number.isSafeInteger(parsed) && parsed >= 1_000 && parsed <= 300_000
+    ? parsed
+    : DEFAULT_TIMEOUT_MS;
+}
+
+function batchSeal(full: SealedMemoryExport["seal"], rows: readonly SealedMemoryExportRow[]) {
+  return {
+    row_count: rows.length,
+    embedding_count: rows.filter((row) => row.embedding).length,
+    digest: computeSharedMemoryTransferDigest(rows),
+    source_agent_id: full.source_agent_id,
+    organization_id: full.organization_id,
+    user_id: full.user_id,
+  };
+}
+
+function validateBatchResponse(
+  response: SealedImportResponse,
+  rows: readonly SealedMemoryExportRow[],
+): void {
+  const batchEmbeddings = rows.filter((row) => row.embedding).length;
+  const conserves =
+    response.ok === true &&
+    response.digest_verified === true &&
+    Array.isArray(response.conflicts) &&
+    response.conflicts.length === 0 &&
+    response.imported + response.skipped_existing === rows.length &&
+    response.embeddings_written <= batchEmbeddings &&
+    // Fresh-container case (the actual promotion path): nothing pre-existed,
+    // so every batch embedding must have been written.
+    (response.skipped_existing > 0 || response.embeddings_written === batchEmbeddings);
+  if (!conserves) {
+    throw new ElizaError("Dedicated container import response failed conservation validation", {
+      code: SHARED_MEMORY_TRANSFER_FAILED,
+      context: {
+        imported: response.imported,
+        skippedExisting: response.skipped_existing,
+        embeddingsWritten: response.embeddings_written,
+        batchRows: rows.length,
+        batchEmbeddings,
+        ok: response.ok,
+        digestVerified: response.digest_verified,
+      },
+    });
+  }
+}
+
+async function postBatch(
+  target: SharedMemoryTransferTarget,
+  seal: ReturnType<typeof batchSeal>,
+  rows: readonly SealedMemoryExportRow[],
+  fetchImpl: typeof fetch,
+): Promise<SealedImportResponse> {
+  const base = assertTransferTargetAllowed(target.baseUrl);
+  const response = await fetchImpl(new URL("/api/memories/import", base).toString(), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${target.apiToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ seal, rows }),
+    signal: AbortSignal.timeout(transferTimeoutMs()),
+  });
+  if (!response.ok) {
+    const detail = (await response.text().catch(() => "")).slice(0, 300);
+    throw new ElizaError("Dedicated container rejected a memory import batch", {
+      code: SHARED_MEMORY_TRANSFER_FAILED,
+      context: { status: response.status, detail, batchSize: rows.length },
+    });
+  }
+  return (await response.json()) as SealedImportResponse;
+}
+
+/**
+ * Export the agent's Shared history under one sealed snapshot and push it to
+ * the container in conservation-validated batches. Safe to re-run: replayed
+ * rows come back as `skipped_existing`, and any failure is typed and total.
+ */
+export async function transferSharedMemoriesToDedicated(
+  agent: SealedExportAgent,
+  target: SharedMemoryTransferTarget,
+  options: {
+    exportImpl?: typeof exportSealedSharedMemories;
+    fetchImpl?: typeof fetch;
+  } = {},
+): Promise<SharedMemoryTransferResult> {
+  // Refuse the target BEFORE reading anything or attaching the token.
+  assertTransferTargetAllowed(target.baseUrl);
+  const exportImpl = options.exportImpl ?? exportSealedSharedMemories;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const sealed = await exportImpl(agent);
+  const result: SharedMemoryTransferResult = {
+    rows: sealed.rows.length,
+    batches: 0,
+    imported: 0,
+    skippedExisting: 0,
+    embeddingsWritten: 0,
+  };
+
+  for (let start = 0; start < sealed.rows.length; start += SHARED_MEMORY_TRANSFER_MAX_ROWS) {
+    const rows = sealed.rows.slice(start, start + SHARED_MEMORY_TRANSFER_MAX_ROWS);
+    const response = await postBatch(target, batchSeal(sealed.seal, rows), rows, fetchImpl);
+    validateBatchResponse(response, rows);
+    result.batches += 1;
+    result.imported += response.imported;
+    result.skippedExisting += response.skipped_existing;
+    result.embeddingsWritten += response.embeddings_written;
+  }
+
+  // Whole-export conservation against the sealed manifest.
+  if (result.imported + result.skippedExisting !== sealed.seal.row_count) {
+    throw new ElizaError("Memory transfer total does not conserve the seal", {
+      code: SHARED_MEMORY_TRANSFER_FAILED,
+      context: { ...result, sealedRowCount: sealed.seal.row_count },
+    });
+  }
+  return result;
+}

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -400,6 +400,7 @@ export abstract class DatabaseAdapter<DB extends object = object>
 	// ── Memory CRUD (batch-only) ─────────────────────────────────────────
 	abstract createMemories(
 		memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
+		options?: { onIdConflict?: "ignore" | "error" },
 	): Promise<UUID[]>;
 	abstract updateMemories(
 		memories: Array<Partial<Memory> & { id: UUID; metadata?: MemoryMetadata }>,

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -1217,8 +1217,17 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	// Batch memory methods
 	async createMemories(
 		memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
+		options: { onIdConflict?: "ignore" | "error" } = {},
 	): Promise<UUID[]> {
 		const ids: UUID[] = [];
+		if (options.onIdConflict === "error") {
+			const conflict = memories.find(({ memory }) =>
+				memory.id ? this.memoriesById.has(String(memory.id)) : false,
+			);
+			if (conflict?.memory.id) {
+				throw new Error(`Memory id already exists: ${conflict.memory.id}`);
+			}
+		}
 		for (const { memory, tableName, unique } of memories) {
 			const gen =
 				typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -1272,9 +1272,13 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	 * Changed from boolean return which was ambiguous (false = failed OR already exists?).
 	 *
 	 * @returns Array of created memory IDs (in same order as input)
+	 * @param options.onIdConflict `error` makes a batch reject and roll back when
+	 * any requested ID already exists; adapters with transactions must apply it
+	 * atomically. The default preserves replay-tolerant legacy behavior.
 	 */
 	createMemories(
 		memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
+		options?: { onIdConflict?: "ignore" | "error" },
 	): Promise<UUID[]>;
 	/**
 	 * Batch update memories

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -313,6 +313,16 @@
       "import": "./dist/contracts/scheduled-task-execution.js",
       "default": "./dist/contracts/scheduled-task-execution.js"
     },
+    "./contracts/shared-memory-transfer": {
+      "types": "./dist/contracts/shared-memory-transfer.d.ts",
+      "eliza-source": {
+        "types": "./src/contracts/shared-memory-transfer.ts",
+        "import": "./src/contracts/shared-memory-transfer.ts",
+        "default": "./src/contracts/shared-memory-transfer.ts"
+      },
+      "import": "./dist/contracts/shared-memory-transfer.js",
+      "default": "./dist/contracts/shared-memory-transfer.js"
+    },
     "./utils/asset-url": {
       "types": "./dist/utils/asset-url.d.ts",
       "eliza-source": {

--- a/packages/shared/src/contracts/shared-memory-transfer.ts
+++ b/packages/shared/src/contracts/shared-memory-transfer.ts
@@ -1,0 +1,117 @@
+/**
+ * Wire contract for the sealed Shared→Dedicated memory transfer (#20923
+ * containment rebuild). One module defines the payload types, the boundary
+ * validation schema, and the seal digest so the cloud exporter and the
+ * container importer can never drift: the exporter computes the digest over
+ * the rows it walked inside one MVCC snapshot, and the importer recomputes it
+ * over the rows it actually received BEFORE any write — count and content
+ * conservation are proven, not assumed from an HTTP status.
+ */
+
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+/** The only vector width the Dedicated core schema can land (`dim_384`). */
+export const SHARED_MEMORY_TRANSFER_VECTOR_DIMENSION = 384;
+/** Hard cap per import request; large histories ship as multiple batches. */
+export const SHARED_MEMORY_TRANSFER_MAX_ROWS = 500;
+/** Provenance stamped into every transferred row's metadata. */
+export const SHARED_MEMORY_TRANSFER_SOURCE = "shared-runtime-transfer";
+
+const UuidSchema = z.uuid();
+
+export const SealedMemoryExportRowSchema = z.object({
+  id: UuidSchema,
+  type: z.string().trim().min(1).max(64),
+  created_at: z.iso.datetime(),
+  content: z.record(z.string(), z.unknown()),
+  entity_id: UuidSchema.nullable(),
+  room_id: UuidSchema.nullable(),
+  world_id: UuidSchema.nullable(),
+  metadata: z.record(z.string(), z.unknown()),
+  embedding: z
+    .object({
+      dim_384: z
+        .array(z.number().finite())
+        .length(SHARED_MEMORY_TRANSFER_VECTOR_DIMENSION),
+    })
+    .optional(),
+});
+
+export const SealedExportSealSchema = z.object({
+  row_count: z.number().int().min(0),
+  embedding_count: z.number().int().min(0),
+  digest: z.string().regex(/^[0-9a-f]{64}$/),
+  source_agent_id: UuidSchema,
+  organization_id: UuidSchema,
+  user_id: UuidSchema,
+});
+
+export const SealedMemoryImportRequestSchema = z.object({
+  seal: SealedExportSealSchema,
+  rows: z
+    .array(SealedMemoryExportRowSchema)
+    .max(SHARED_MEMORY_TRANSFER_MAX_ROWS),
+});
+
+export type SealedMemoryExportRow = z.infer<typeof SealedMemoryExportRowSchema>;
+export type SealedExportSeal = z.infer<typeof SealedExportSealSchema>;
+export type SealedMemoryImportRequest = z.infer<
+  typeof SealedMemoryImportRequestSchema
+>;
+
+/** A same-id row whose stored content differs from the transferred row. */
+export interface SealedImportConflict {
+  id: string;
+  reason: "content-mismatch";
+}
+
+/**
+ * Importer response. `ok` is true only when every non-conflicting row landed
+ * and conservation held; the caller must additionally verify
+ * `imported + skipped_existing === rows.length` and never trust a bare 2xx.
+ */
+export interface SealedImportResponse {
+  ok: boolean;
+  imported: number;
+  skipped_existing: number;
+  embeddings_written: number;
+  conflicts: SealedImportConflict[];
+  digest_verified: boolean;
+}
+
+function rowDigestLine(row: SealedMemoryExportRow): string {
+  const contentHash = createHash("sha256")
+    .update(JSON.stringify(row.content))
+    .digest("hex");
+  const vectorHash = row.embedding
+    ? createHash("sha256").update(row.embedding.dim_384.join(",")).digest("hex")
+    : "-";
+  return [
+    row.id,
+    row.created_at,
+    row.type,
+    row.entity_id ?? "-",
+    row.room_id ?? "-",
+    contentHash,
+    vectorHash,
+  ].join("|");
+}
+
+/**
+ * Order-sensitive digest over the exported rows. Exporter and importer MUST
+ * both use this exact function; the request `seal.digest` binds the payload.
+ */
+export function computeSharedMemoryTransferDigest(
+  rows: readonly SealedMemoryExportRow[],
+): string {
+  const chain = createHash("sha256");
+  for (const row of rows) chain.update(rowDigestLine(row)).update("\n");
+  chain.update(String(rows.length));
+  return chain.digest("hex");
+}
+
+/** Stable per-row content hash used for id-conflict comparison on import. */
+export function sharedMemoryContentHash(content: unknown): string {
+  return createHash("sha256").update(JSON.stringify(content)).digest("hex");
+}

--- a/packages/shared/src/contracts/shared-memory-transfer.ts
+++ b/packages/shared/src/contracts/shared-memory-transfer.ts
@@ -28,7 +28,9 @@ export const SealedMemoryExportRowSchema = z.object({
   entity_id: UuidSchema.nullable(),
   room_id: UuidSchema.nullable(),
   world_id: UuidSchema.nullable(),
-  metadata: z.record(z.string(), z.unknown()),
+  metadata: z
+    .object({ source: z.literal(SHARED_MEMORY_TRANSFER_SOURCE) })
+    .catchall(z.unknown()),
   embedding: z
     .object({
       dim_384: z
@@ -63,7 +65,7 @@ export type SealedMemoryImportRequest = z.infer<
 /** A same-id row whose stored content differs from the transferred row. */
 export interface SealedImportConflict {
   id: string;
-  reason: "content-mismatch";
+  reason: "stored-row-mismatch";
 }
 
 /**
@@ -76,13 +78,49 @@ export interface SealedImportResponse {
   imported: number;
   skipped_existing: number;
   embeddings_written: number;
+  embeddings_skipped_verified: number;
   conflicts: SealedImportConflict[];
   digest_verified: boolean;
 }
 
+export const SealedImportResponseSchema = z.object({
+  ok: z.literal(true),
+  imported: z.number().int().min(0),
+  skipped_existing: z.number().int().min(0),
+  embeddings_written: z.number().int().min(0),
+  embeddings_skipped_verified: z.number().int().min(0),
+  conflicts: z.array(
+    z.object({
+      id: UuidSchema,
+      reason: z.literal("stored-row-mismatch"),
+    }),
+  ),
+  digest_verified: z.literal(true),
+});
+
+/** Canonical JSON used by seals and replay checks, independent of jsonb key order. */
+export function canonicalSharedMemoryJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalSharedMemoryJson(entry)).join(",")}]`;
+  }
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(
+      ([key, entry]) =>
+        `${JSON.stringify(key)}:${canonicalSharedMemoryJson(entry)}`,
+    )
+    .join(",")}}`;
+}
+
 function rowDigestLine(row: SealedMemoryExportRow): string {
   const contentHash = createHash("sha256")
-    .update(JSON.stringify(row.content))
+    .update(canonicalSharedMemoryJson(row.content))
+    .digest("hex");
+  const metadataHash = createHash("sha256")
+    .update(canonicalSharedMemoryJson(row.metadata))
     .digest("hex");
   const vectorHash = row.embedding
     ? createHash("sha256").update(row.embedding.dim_384.join(",")).digest("hex")
@@ -93,7 +131,9 @@ function rowDigestLine(row: SealedMemoryExportRow): string {
     row.type,
     row.entity_id ?? "-",
     row.room_id ?? "-",
+    row.world_id ?? "-",
     contentHash,
+    metadataHash,
     vectorHash,
   ].join("|");
 }
@@ -109,9 +149,4 @@ export function computeSharedMemoryTransferDigest(
   for (const row of rows) chain.update(rowDigestLine(row)).update("\n");
   chain.update(String(rows.length));
   return chain.digest("hex");
-}
-
-/** Stable per-row content hash used for id-conflict comparison on import. */
-export function sharedMemoryContentHash(content: unknown): string {
-  return createHash("sha256").update(JSON.stringify(content)).digest("hex");
 }

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -974,8 +974,14 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
   }
 
   async createMemories(
-    memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>
+    memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
+    options: { onIdConflict?: "ignore" | "error" } = {}
   ): Promise<UUID[]> {
+    if (options.onIdConflict === "error") {
+      throw new Error(
+        "Strict atomic memory creation is unavailable for the non-transactional in-memory adapter"
+      );
+    }
     const ids: UUID[] = [];
     for (const { memory, tableName, unique = false } of memories) {
       const id = (memory.id ?? randomUUID()) as UUID;

--- a/plugins/plugin-inmemorydb/strict-memory-create.test.ts
+++ b/plugins/plugin-inmemorydb/strict-memory-create.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Real MemoryStorage coverage for strict memory creation. The ephemeral
+ * adapter has no rollback primitive, so it must reject the atomic SQL-only
+ * contract before writing any row rather than expose partial-import success.
+ */
+import { randomUUID } from "node:crypto";
+import type { Memory, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./adapter";
+import { MemoryStorage } from "./storage-memory";
+
+describe("InMemoryDatabaseAdapter strict memory creation", () => {
+  it("fails before writing any requested row", async () => {
+    const agentId = randomUUID() as UUID;
+    const adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), agentId);
+    await adapter.initialize();
+    const memories = [0, 1].map(
+      (index): Memory => ({
+        id: randomUUID() as UUID,
+        agentId,
+        entityId: randomUUID() as UUID,
+        roomId: randomUUID() as UUID,
+        content: { text: `memory ${index}` },
+      })
+    );
+
+    await expect(
+      adapter.createMemories(
+        memories.map((memory) => ({ memory, tableName: "messages" })),
+        { onIdConflict: "error" }
+      )
+    ).rejects.toThrow(/unavailable for the non-transactional/);
+    await expect(
+      adapter.getMemoriesByIds(memories.map((memory) => memory.id as UUID))
+    ).resolves.toEqual([]);
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
@@ -202,6 +202,30 @@ describe("Memory Integration Tests", () => {
     expect(await adapter.getMemoryById(rolledBack[0].id as UUID)).toBeNull();
   });
 
+  it("strict overlapping batches never partially commit around a shared id", async () => {
+    const sharedId = v4() as UUID;
+    const leftOnly = createTestMemory({ text: "left only" });
+    const rightOnly = createTestMemory({ text: "right only" });
+    const leftShared = { ...createTestMemory({ text: "left shared" }), id: sharedId };
+    const rightShared = { ...createTestMemory({ text: "right shared" }), id: sharedId };
+
+    const outcomes = await Promise.allSettled([
+      adapter.createMemories(
+        [leftOnly, leftShared].map((memory) => ({ memory, tableName: "messages" })),
+        { onIdConflict: "error" }
+      ),
+      adapter.createMemories(
+        [rightShared, rightOnly].map((memory) => ({ memory, tableName: "messages" })),
+        { onIdConflict: "error" }
+      ),
+    ]);
+
+    expect(outcomes.map((outcome) => outcome.status).sort()).toEqual(["fulfilled", "rejected"]);
+    const leftCommitted = (await adapter.getMemoryById(leftOnly.id as UUID)) !== null;
+    const rightCommitted = (await adapter.getMemoryById(rightOnly.id as UUID)) !== null;
+    expect([leftCommitted, rightCommitted].filter(Boolean)).toHaveLength(1);
+  });
+
   afterEach(async () => {
     // Clean up memories after each test to ensure isolation
     const db = adapter.getDatabase() as DrizzleDatabase;

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -2795,6 +2795,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       const row = result[0];
       return {
         id: row.memory.id as UUID,
+        type: row.memory.type,
         createdAt: row.memory.createdAt.getTime(),
         content:
           typeof row.memory.content === "string"
@@ -3615,7 +3616,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     tx: DrizzleDatabase,
     memory: Memory & { metadata?: MemoryMetadata },
     tableName: string,
-    memoryId: UUID
+    memoryId: UUID,
+    onIdConflict: "ignore" | "error" = "ignore"
   ): Promise<void> {
     // Ensure we always pass a JSON string to the SQL bind parameter; if we pass an
     // object directly PG sees `[object Object]` and fails the `::jsonb` cast.
@@ -3625,24 +3627,23 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     const metadataToInsert =
       typeof memory.metadata === "string" ? memory.metadata : JSON.stringify(memory.metadata ?? {});
 
-    const inserted = await tx
-      .insert(memoryTable)
-      .values([
-        {
-          id: memoryId,
-          type: tableName,
-          content: sql`${contentToInsert}::jsonb`,
-          metadata: sql`${metadataToInsert}::jsonb`,
-          entityId: memory.entityId,
-          roomId: memory.roomId,
-          worldId: memory.worldId,
-          agentId: memory.agentId || this.agentId,
-          unique: memory.unique,
-          createdAt: memory.createdAt !== undefined ? new Date(memory.createdAt) : new Date(),
-        },
-      ])
-      .onConflictDoNothing()
-      .returning();
+    const insert = tx.insert(memoryTable).values([
+      {
+        id: memoryId,
+        type: tableName,
+        content: sql`${contentToInsert}::jsonb`,
+        metadata: sql`${metadataToInsert}::jsonb`,
+        entityId: memory.entityId,
+        roomId: memory.roomId,
+        worldId: memory.worldId,
+        agentId: memory.agentId || this.agentId,
+        unique: memory.unique,
+        createdAt: memory.createdAt !== undefined ? new Date(memory.createdAt) : new Date(),
+      },
+    ]);
+    const inserted = await (onIdConflict === "ignore"
+      ? insert.onConflictDoNothing().returning()
+      : insert.returning());
 
     if (inserted.length === 0) {
       return;
@@ -6373,7 +6374,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   // ── Memory batch methods ──────────────────────────────────────────────
 
   async createMemories(
-    memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>
+    memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
+    options: { onIdConflict?: "ignore" | "error" } = {}
   ): Promise<UUID[]> {
     if (memories.length === 0) return [];
 
@@ -6396,7 +6398,13 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
 
     await this.withEntityContext(entityContext, async (tx) => {
       for (const entry of prepared) {
-        await this.insertMemoryInTransaction(tx, entry.memory, entry.tableName, entry.id);
+        await this.insertMemoryInTransaction(
+          tx,
+          entry.memory,
+          entry.tableName,
+          entry.id,
+          options.onIdConflict
+        );
       }
     });
 

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -3459,7 +3459,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     }
   ): Promise<Memory[]> {
     return this.withDatabase(async () => {
-      const cleanVector = embedding.map((n) => (Number.isFinite(n) ? Number(n.toFixed(6)) : 0));
+      const cleanVector = embedding.map((n) => (Number.isFinite(n) ? n : 0));
       const activeColumn = embeddingTable[this.embeddingDimension];
       const count = params.count ?? 10;
 
@@ -3674,9 +3674,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           createdAt: memory.createdAt !== undefined ? new Date(memory.createdAt) : new Date(),
         };
 
-        const cleanVector = memory.embedding.map((n) =>
-          Number.isFinite(n) ? Number(n.toFixed(6)) : 0
-        );
+        const cleanVector = memory.embedding.map((n) => (Number.isFinite(n) ? n : 0));
 
         embeddingValues[this.embeddingDimension] = cleanVector;
 
@@ -3746,9 +3744,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
                 "Skipping embedding update: dimension mismatch with configured column"
               );
             } else {
-              const cleanVector = memory.embedding.map((n) =>
-                Number.isFinite(n) ? Number(n.toFixed(6)) : 0
-              );
+              const cleanVector = memory.embedding.map((n) => (Number.isFinite(n) ? n : 0));
 
               // Check if embedding exists
               const existingEmbedding = await tx

--- a/plugins/plugin-sql/src/pglite/adapter.ts
+++ b/plugins/plugin-sql/src/pglite/adapter.ts
@@ -338,9 +338,10 @@ export class PgliteDatabaseAdapter extends BaseDrizzleAdapter {
   }
 
   async createMemories(
-    memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>
+    memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
+    options: { onIdConflict?: "ignore" | "error" } = {}
   ): Promise<UUID[]> {
-    const ids = await super.createMemories(memories);
+    const ids = await super.createMemories(memories, options);
     for (let index = 0; index < memories.length; index++) {
       const memory = memories[index].memory;
       this.manager.notifyWrite("memories", "insert", {


### PR DESCRIPTION
Rebuild of the Shared→Dedicated memory transfer, designed point-by-point to the #20923 containment blockers. **Requesting @lalalune review — this surface is shaw's call; not self-merging regardless of CI state.** The whole stack ships dark: the only caller is behind `ELIZA_SHARED_MEMORY_TRANSFER_ENABLED` (exact `"true"`, default OFF).

## Blocker → design mapping

| #20923 blocker | This PR |
|---|---|
| No sealed source snapshot / stale-prefix completion | Export walks ONE `REPEATABLE READ` transaction; the seal (counts + order-sensitive SHA-256 digest) is computed from the rows actually walked — the seal IS the manifest of the exact payload. |
| Silent same-id acceptance | Importer pre-checks every id BEFORE any write: identical content ⇒ idempotent `skipped_existing`; different content ⇒ 409 `IMPORT_ID_CONFLICT` failing the WHOLE request (the non-conflicting rows are not written either). |
| Room/world overwrite | Scaffolding is create-if-absent only — existence is checked first and an existing world/room/entity is never touched. |
| Ambiguous source-agent remap | The seal carries `source_agent_id` once as the single remap authority; no per-row inference. |
| Non-atomic / racing writes | One adapter `createMemories` call per request — the documented all-or-nothing batch transaction. |
| Rounded vectors | plugin-sql's `toFixed(6)` vector coarsening removed at all three sites (finite-guard kept); vectors now land verbatim at the storage column's own (float4) precision, pinned by test. |
| Bare-2xx trust | Pusher requires `ok === true`, `digest_verified === true`, zero conflicts, `imported + skipped_existing === batch`, and exact embedding conservation on a fresh container; plus whole-export conservation against the seal. Importer itself recomputes the digest over the received rows before any write. |
| Unguarded token egress / no timeout | Target must pass the authority allowlist (headscale CGNAT 100.64/10 + `.eliza.local`, extendable via `ELIZA_MEMORY_TRANSFER_ALLOWED_HOST_SUFFIXES`) BEFORE the token is attached — refused targets never see a request; every request carries `AbortSignal.timeout` (30s default, bounded env override). |
| Dropped embeddings coexisting with success | An anomalous stored vector FAILS the export with `SHARED_MEMORY_EXPORT_ANOMALOUS_VECTOR`; there is no dropped-but-successful state anywhere in the stack. |

## Layout

- `packages/shared/src/contracts/shared-memory-transfer.ts` — ONE wire contract (types + zod boundary schema + digest) imported by both sides, so exporter and importer cannot drift.
- `packages/cloud/shared/.../shared-memory-sealed-export.ts` — snapshot walk + seal.
- `packages/cloud/shared/.../shared-memory-transfer.ts` — allowlisted, timeout-bounded, conservation-validated push.
- `packages/agent/src/api/memory-import.ts` — sealed transactional importer (`POST /api/memories/import`, behind the agent API auth layer; dispatched before `ensureMemoryConnection`).
- `packages/cloud/shared/.../eliza-sandbox.ts` — flag-gated empty-boot caller (default OFF; skips warm-pool rows, restored boots, and explicit fresh-boot consent).

## Evidence

- Importer: 8/8 (verbatim landing + remap authority, digest/count conservation pre-write, conflict fail-closed incl. innocent rows, idempotent replay, no-scaffolding-overwrite, boundary rejection, unrounded vectors).
- Push: 6/6 (allowlist matrix incl. CGNAT edges + refusal BEFORE export/token egress, timeout signal presence, bare-2xx conservation failure, ok:false / digest_verified:false, fresh-container embedding conservation, empty no-op).
- Sealed export: 5/5 on REAL PGlite (scope pinned to the turn-path writer derivation, seal-is-manifest with float4-verbatim vectors + explicit not-toFixed(6) pin, tenant isolation, anomalous-vector typed failure, empty manifest).
- eliza-sandbox suite 224/224 (hook inert at default flag); typecheck clean across all four packages; Biome clean.
- Live proof plan (post-approval): flag ON in staging, promote a Shared-history agent, verify container rows/digest and recall parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)