### PR TITLE
refactor(cloud): centralize market trade contracts

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/route.delete-github-repo.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.delete-github-repo.test.ts
@@ -15,6 +15,8 @@ mock.module("@/lib/utils/logger", () => ({
 const ORG_A = "11111111-1111-4111-8111-111111111111";
 const APP_ID = "99999999-9999-4999-8999-000000000001";
 const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+type DeleteAppWithCleanup =
+  typeof import("@/lib/services/app-cleanup").deleteAppWithCleanup;
 
 const getById = mock(async (id: string) =>
   id === APP_ID
@@ -22,7 +24,9 @@ const getById = mock(async (id: string) =>
     : null,
 );
 const deleteAppWithCleanup = mock(
-  async (_appId: string, _options: { deleteGitHubRepo?: boolean } = {}) => ({
+  async (
+    ..._args: Parameters<DeleteAppWithCleanup>
+  ): Promise<Awaited<ReturnType<DeleteAppWithCleanup>>> => ({
     success: true,
     errors: [],
     cleaned: {
@@ -30,6 +34,7 @@ const deleteAppWithCleanup = mock(
       githubRepoDeleted: true,
       secretBindingsRemoved: 0,
       managedDomainsUnlinked: 0,
+      containersTornDown: 0,
     },
   }),
 );

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
@@ -13,7 +13,12 @@ import {
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "GET, OPTIONS";
-export const TOKEN_TRADE_TYPES = ["swap", "add", "remove", "all"] as const;
+export const TOKEN_TRADE_TYPES = Object.freeze([
+  "swap",
+  "add",
+  "remove",
+  "all",
+] as const);
 const TOKEN_TRADE_TYPE_SET = new Set<string>(TOKEN_TRADE_TYPES);
 
 function isTokenTradeType(

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
@@ -1,4 +1,4 @@
-// Handles v1 cloud API v1 market trades chain address route traffic with route-local auth expectations.
+/** Proxies validated token-trade history requests to the market-data provider. */
 import { Hono } from "hono";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { executeWithBody } from "@/lib/services/proxy/engine";
@@ -13,6 +13,14 @@ import {
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "GET, OPTIONS";
+export const TOKEN_TRADE_TYPES = ["swap", "add", "remove", "all"] as const;
+const TOKEN_TRADE_TYPE_SET = new Set<string>(TOKEN_TRADE_TYPES);
+
+function isTokenTradeType(
+  value: string,
+): value is (typeof TOKEN_TRADE_TYPES)[number] {
+  return TOKEN_TRADE_TYPE_SET.has(value);
+}
 
 async function __hono_OPTIONS() {
   return handleCorsOptions(CORS_METHODS);
@@ -64,19 +72,17 @@ async function __hono_GET(
   // Token-trade type identity, not leftover tax on market-candles
   // OHLCV type. Unknown tokens (SWAP / buy / 1e2) used to be
   // forwarded to the paid market-data provider.
-  const TX_TYPES = ["swap", "add", "remove", "all"] as const;
   const requestedTxType = searchParams.get("tx_type");
   if (
     requestedTxType != null &&
     requestedTxType !== "" &&
-    !TX_TYPES.includes(requestedTxType as (typeof TX_TYPES)[number])
+    !isTokenTradeType(requestedTxType)
   ) {
     return applyCorsHeaders(
       Response.json(
         {
           error: "Invalid tx_type",
-          details:
-            "tx_type must be a canonical Birdeye trade type (swap, add, remove, all).",
+          details: `tx_type must be a canonical Birdeye trade type (${TOKEN_TRADE_TYPES.join(", ")}).`,
         },
         { status: 400 },
       ),

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
@@ -40,7 +40,7 @@ mock.module("@/lib/services/proxy/services/market-data", () => ({
   marketDataHandler: {},
 }));
 
-const route = (await import("./route")).default;
+const { default: route, TOKEN_TRADE_TYPES } = await import("./route");
 const app = new Hono().route("/api/v1/market/trades/:chain/:address", route);
 
 function trades(query = "") {
@@ -68,31 +68,17 @@ describe("GET /api/v1/market/trades token-trade type identity", () => {
     },
   );
 
-  test("accepts tx_type=swap as the swap trade series", async () => {
-    const response = await trades("?tx_type=swap");
-    expect(response.status).toBe(200);
-    expect(executeWithBody).toHaveBeenCalledTimes(1);
-    const body = executeWithBody.mock.calls[0][3] as {
-      params: Record<string, string>;
-    };
-    expect(body.params.tx_type).toBe("swap");
-  });
-
-  test("accepts tx_type=add as the add-liquidity series", async () => {
-    const response = await trades("?tx_type=add");
-    expect(response.status).toBe(200);
-    expect(executeWithBody.mock.calls[0][3]).toMatchObject({
-      params: { tx_type: "add" },
-    });
-  });
-
-  test("accepts tx_type=all as the unfiltered trade series", async () => {
-    const response = await trades("?tx_type=all");
-    expect(response.status).toBe(200);
-    expect(executeWithBody.mock.calls[0][3]).toMatchObject({
-      params: { tx_type: "all" },
-    });
-  });
+  test.each([...TOKEN_TRADE_TYPES])(
+    "accepts tx_type=%s as a canonical Birdeye trade series",
+    async (txType) => {
+      const response = await trades(`?tx_type=${txType}`);
+      expect(response.status).toBe(200);
+      expect(executeWithBody).toHaveBeenCalledTimes(1);
+      expect(executeWithBody.mock.calls[0][3]).toMatchObject({
+        params: { tx_type: txType },
+      });
+    },
+  );
 
   test.each(["SWAP", "buy", "sell", "foo", "1e2"])(
     "rejects tx_type=%s before executeWithBody",

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
@@ -7,21 +7,15 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
-import type {
-  ProxyRequestBody,
-  ServiceConfig,
-  ServiceHandler,
-} from "@/lib/services/proxy/types";
 
 const SOLANA_TOKEN = "So11111111111111111111111111111111111111112";
+const EXPECTED_TOKEN_TRADE_TYPES = ["swap", "add", "remove", "all"] as const;
 
-const executeWithBody = mock(
-  async (
-    _config: ServiceConfig,
-    _work: ServiceHandler,
-    _request: Request,
-    _body: ProxyRequestBody,
-  ) => Response.json({ success: true }),
+type ExecuteWithBody =
+  typeof import("@/lib/services/proxy/engine").executeWithBody;
+
+const executeWithBody = mock(async (..._args: Parameters<ExecuteWithBody>) =>
+  Response.json({ success: true }),
 );
 
 mock.module("@/lib/services/proxy/engine", () => ({
@@ -68,7 +62,12 @@ describe("GET /api/v1/market/trades token-trade type identity", () => {
     },
   );
 
-  test.each([...TOKEN_TRADE_TYPES])(
+  test("keeps the canonical Birdeye token-trade contract exhaustive", () => {
+    expect(TOKEN_TRADE_TYPES).toEqual(EXPECTED_TOKEN_TRADE_TYPES);
+    expect(Object.isFrozen(TOKEN_TRADE_TYPES)).toBe(true);
+  });
+
+  test.each([...EXPECTED_TOKEN_TRADE_TYPES])(
     "accepts tx_type=%s as a canonical Birdeye trade series",
     async (txType) => {
       const response = await trades(`?tx_type=${txType}`);
@@ -85,8 +84,12 @@ describe("GET /api/v1/market/trades token-trade type identity", () => {
     async (token) => {
       const response = await trades(`?tx_type=${encodeURIComponent(token)}`);
       expect(response.status).toBe(400);
-      const body = (await response.json()) as { error: string };
+      const body = (await response.json()) as {
+        error: string;
+        details: string;
+      };
       expect(body.error).toBe("Invalid tx_type");
+      expect(body.details).toContain("swap, add, remove, all");
       expect(executeWithBody).not.toHaveBeenCalled();
     },
   );


### PR DESCRIPTION
# Relates to

Follow-up to merged #21076 and #21078.

- [x] Targets `develop` and was rebased over the post-merge Cloud test fixes.
- [ ] Full pinned-toolchain verification is pending exact-head CI.
- [x] Independent review was completed on the prior equivalent tree and has been requested again for the rebased head.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at exact head creation; the duplicate mock-typing commit was dropped in favor of merged #21113.
- [ ] `bun run verify` pending exact-head CI.

# Risks

Low. The route retains the same four accepted Birdeye values and rejection response; this centralizes the immutable allowlist and strengthens its tests.

# Background

## What does this PR do?

- Moves `swap`, `add`, `remove`, and `all` to one frozen module-scope tuple and a Set-backed type guard, avoiding per-request allocation and an unchecked cast.
- Derives the validation detail from that canonical tuple.
- Tests an independent literal external contract so removing a production value cannot silently remove its own test.
- Constrains touched route mocks with `Parameters`/`ReturnType` from their real collaborators, including the destructive cleanup result.

Birdeye's token-trades contract documents the accepted `tx_type` values as `swap`, `add`, `remove`, and `all`: https://docs.birdeye.so/reference/get-defi-txs-token

## What kind of change is this?

Behavior-preserving refactor plus contract-hardening tests.

# Documentation changes needed?

No product documentation change is needed.

# Testing

## Where should a reviewer start?

Start with `route.ts` and `route.tx-type.test.ts`; verify the test-owned tuple is independent from the implementation tuple.

## Detailed testing steps

- Focused exact-tree diagnostic: 23/23 tests, 87 assertions.
- Biome passed on all three touched files.
- `git diff --check` passed.
- Exact-head CI run: https://github.com/elizaOS/eliza/actions/runs/32013069444

# Evidence Gate

<!-- evidence-head:a6eaf7d25cb85c05d042fb3e171079e5d2935365 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Cloud route/test change; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Cloud route/test change; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live provider call was made during review; focused route tests prove rejection occurs before the upstream collaborator.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, storage, registry, or generated artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI source changed.

# Known gaps / failures

The local focused run used the available Bun 1.4.0-canary.1 rather than pinned Bun 1.3.14; it is diagnostic. Exact-head CI is the authoritative gate. No paid Birdeye request was issued because the changed behavior is pre-provider input validation.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->