### PR TITLE
fix(cloud): reject unknown agent-create autoProvision flag

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/route.auto-provision.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.auto-provision.test.ts
@@ -1,0 +1,170 @@
+/**
+ * POST /api/v1/eliza/agents `autoProvision` is agent-create provision
+ * identity, not leftover tax on app-delete GitHub-repo flag or telegram
+ * webhook. Stock develop treated any non-exact `false` token as
+ * provision, so `autoProvision=FALSE` still ran the credit gate and
+ * eager container provision.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+const ORG_A = "11111111-1111-4111-8111-111111111111";
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+const checkAgentCreditGate = mock(async () => ({
+  allowed: false,
+  balance: 0,
+  error: "insufficient",
+}));
+const createAgent = mock(async () => ({
+  agent: {
+    id: "agent-1",
+    agent_name: "keep-offline",
+    status: "pending",
+    created_at: "2026-01-01T00:00:00.000Z",
+    execution_tier: "dedicated-always",
+  },
+  idempotent: true,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: ORG_A,
+  }),
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+mock.module("@/lib/services/agent-billing-gate-402", () => ({
+  insufficientCredits402: () => ({ error: "insufficient credits" }),
+}));
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  AgentImageNotAllowedError: class AgentImageNotAllowedError extends Error {},
+  AgentQuotaExceededError: class AgentQuotaExceededError extends Error {},
+  elizaSandboxService: { createAgent, listAgents: mock(async () => []) },
+}));
+mock.module("@/db/repositories/characters", () => ({
+  userCharactersRepository: {
+    findByIdInOrganizationForWrite: mock(async () => null),
+    findByIdsInOrganization: mock(async () => []),
+  },
+}));
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: { delete: mock(async () => undefined) },
+}));
+mock.module("@/lib/services/eliza-agent-config", () => ({
+  stripReservedElizaConfigKeys: (config: unknown) => config ?? {},
+  withReusedElizaCharacterOwnership: (config: unknown) => config,
+}));
+mock.module("@/lib/services/eliza-managed-launch", () => ({
+  prepareManagedElizaEnvironment: mock(async () => ({
+    changed: false,
+    environmentVars: {},
+  })),
+}));
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentProvision: mock(async () => ({ id: "job-1" })),
+    triggerImmediate: mock(async () => undefined),
+  },
+}));
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth: mock(async () => ({ ok: true })),
+  provisioningWorkerFailureBody: () => ({ error: "worker" }),
+}));
+mock.module("@/lib/config/containers-env", () => ({
+  containersEnv: {},
+}));
+mock.module("@/lib/eliza-agent-web-ui", () => ({
+  getElizaAgentPublicWebUiUrl: () => "https://example.test",
+}));
+mock.module("@/lib/constants/agent-sandbox-quota", () => ({
+  getMaxNonTerminalAgentsForOrg: () => 3,
+}));
+mock.module("@/lib/services/shared-runtime/agent-tier", () => ({
+  getAgentTier: (input: { alwaysOn?: boolean; dockerImage?: string }) =>
+    input.dockerImage
+      ? "custom"
+      : input.alwaysOn
+        ? "dedicated-always"
+        : "shared",
+  tierProvisionsEagerly: (tier: string) =>
+    tier === "dedicated-always" || tier === "custom",
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  ApiError: class ApiError extends Error {},
+  NotFoundError: class NotFoundError extends Error {},
+  ValidationError: (message: string) => {
+    const error = new Error(message);
+    error.name = "ValidationError";
+    return error;
+  },
+}));
+
+const { default: agentsRoute } = await import("./route");
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.route("/api/v1/eliza/agents", agentsRoute);
+  return app;
+}
+
+function post(query = "") {
+  return buildApp().request(
+    `/api/v1/eliza/agents${query}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentName: "keep-offline", alwaysOn: true }),
+    },
+    ENV,
+  );
+}
+
+describe("POST /api/v1/eliza/agents autoProvision identity", () => {
+  beforeEach(() => {
+    checkAgentCreditGate.mockClear();
+    createAgent.mockClear();
+  });
+
+  test.each(["", "?autoProvision=", "?autoProvision=true"])(
+    "accepts %s as eager-provision (credit gate runs)",
+    async (query) => {
+      const response = await post(query);
+      expect(response.status).toBe(402);
+      expect(checkAgentCreditGate).toHaveBeenCalledTimes(1);
+      expect(createAgent).not.toHaveBeenCalled();
+    },
+  );
+
+  test("accepts autoProvision=false as skip the credit gate", async () => {
+    const response = await post("?autoProvision=false");
+    expect(response.status).toBe(200);
+    expect(checkAgentCreditGate).not.toHaveBeenCalled();
+    expect(createAgent).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["FALSE", "TRUE", "0", "1", "no", "yes", "foo"])(
+    "rejects autoProvision=%s before credit gate and create",
+    async (token) => {
+      const response = await post(
+        `?autoProvision=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid autoProvision");
+      expect(checkAgentCreditGate).not.toHaveBeenCalled();
+      expect(createAgent).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/eliza/agents/route.auto-provision.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.auto-provision.test.ts
@@ -1,9 +1,6 @@
 /**
- * POST /api/v1/eliza/agents `autoProvision` is agent-create provision
- * identity, not leftover tax on app-delete GitHub-repo flag or telegram
- * webhook. Stock develop treated any non-exact `false` token as
- * provision, so `autoProvision=FALSE` still ran the credit gate and
- * eager container provision.
+ * Exercises the real Hono agent-create handler's `autoProvision` boundary
+ * while replacing its authentication, billing, and persistence collaborators.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
@@ -161,8 +158,25 @@ describe("POST /api/v1/eliza/agents autoProvision identity", () => {
         `?autoProvision=${encodeURIComponent(token)}`,
       );
       expect(response.status).toBe(400);
-      const body = (await response.json()) as { error: string };
-      expect(body.error).toBe("Invalid autoProvision");
+      const responseBody = (await response.json()) as unknown;
+      expect(responseBody).toEqual({
+        success: false,
+        error: "Invalid autoProvision",
+        message: 'autoProvision must be "true" or "false".',
+      });
+      expect(checkAgentCreditGate).not.toHaveBeenCalled();
+      expect(createAgent).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?autoProvision=false&autoProvision=true",
+    "?autoProvision=false&autoProvision=false",
+  ])(
+    "rejects duplicate autoProvision values before side effects",
+    async (query) => {
+      const response = await post(query);
+      expect(response.status).toBe(400);
       expect(checkAgentCreditGate).not.toHaveBeenCalled();
       expect(createAgent).not.toHaveBeenCalled();
     },

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -294,6 +294,26 @@ app.get("/", async (c) => {
 
 app.post("/", async (c) => {
   const user = await requireUserOrApiKeyWithOrg(c);
+  // Agent-create autoProvision identity, not leftover tax on app-delete
+  // GitHub-repo flag or telegram webhook. autoProvision=FALSE used to
+  // still eager-provision (credit gate + container).
+  const requestedAutoProvision = c.req.query("autoProvision");
+  if (
+    requestedAutoProvision != null &&
+    requestedAutoProvision !== "" &&
+    requestedAutoProvision !== "true" &&
+    requestedAutoProvision !== "false"
+  ) {
+    return c.json(
+      {
+        success: false,
+        error: "Invalid autoProvision",
+        message: 'autoProvision must be "true" or "false".',
+      },
+      400,
+    );
+  }
+
   const body = await c.req.json().catch(() => {
     throw ValidationError("Invalid JSON");
   });
@@ -306,7 +326,7 @@ app.post("/", async (c) => {
   }
 
   const autoProvision =
-    c.req.query("autoProvision") !== "false" &&
+    requestedAutoProvision !== "false" &&
     parsed.data.autoProvision !== false;
 
   const sanitizedConfig = stripReservedElizaConfigKeys(parsed.data.agentConfig);

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -294,15 +294,16 @@ app.get("/", async (c) => {
 
 app.post("/", async (c) => {
   const user = await requireUserOrApiKeyWithOrg(c);
-  // Agent-create autoProvision identity, not leftover tax on app-delete
-  // GitHub-repo flag or telegram webhook. autoProvision=FALSE used to
-  // still eager-provision (credit gate + container).
-  const requestedAutoProvision = c.req.query("autoProvision");
+  // Provisioning can spend credits, so accept only one unambiguous canonical
+  // boolean token before either the billing gate or create path can run.
+  const requestedAutoProvisionValues = c.req.queries("autoProvision") ?? [];
+  const requestedAutoProvision = requestedAutoProvisionValues[0];
   if (
-    requestedAutoProvision != null &&
-    requestedAutoProvision !== "" &&
-    requestedAutoProvision !== "true" &&
-    requestedAutoProvision !== "false"
+    requestedAutoProvisionValues.length > 1 ||
+    (requestedAutoProvision != null &&
+      requestedAutoProvision !== "" &&
+      requestedAutoProvision !== "true" &&
+      requestedAutoProvision !== "false")
   ) {
     return c.json(
       {
@@ -326,8 +327,7 @@ app.post("/", async (c) => {
   }
 
   const autoProvision =
-    requestedAutoProvision !== "false" &&
-    parsed.data.autoProvision !== false;
+    requestedAutoProvision !== "false" && parsed.data.autoProvision !== false;
 
   const sanitizedConfig = stripReservedElizaConfigKeys(parsed.data.agentConfig);
   let linkedCharacter: UserCharacter | undefined;


### PR DESCRIPTION
# Summary

`POST /api/v1/eliza/agents` now accepts only an omitted/empty, canonical `true`, or canonical `false` `autoProvision` query value. Invalid and duplicate values return 400 before the credit gate or agent creation.

This is a spending boundary: `false` opts out of eager provisioning, so ambiguous duplicate parameters must not be resolved differently by proxies and application code. The JSON body’s typed `autoProvision: false` opt-out remains unchanged.

# Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6, openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Cursor, Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1681ef1dae5fa85d488a7684761a6a21fc15f50b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Exact-head review

- Candidate `94941d78aa3487bbdc8cb78a9247e7bbd2209e7e`, rebased on `1681ef1dae5fa85d488a7684761a6a21fc15f50b`.
- Pinned Bun 1.3.14 real Hono handler suite: 13 passed, 0 failed, 46 assertions.
- Biome checked both files with no fixes; `git diff --check` clean.
- Full Cloud API typecheck was attempted twice. No touched-file error remains; current `develop` is blocked in unrelated route tests (`apps/[id]`, `containers/[id]`, `market/trades`) and cloud-shared/plugin dependency types. Sparse Worker dry-run is likewise blocked by absent cloud-sdk/drizzle workspace artifacts, not this route.

# Risks

Low. Canonical existing clients are unchanged. Previously ambiguous or malformed query input now fails closed before credit-bearing side effects.

# Evidence Gate
<!-- evidence-head:94941d78aa3487bbdc8cb78a9247e7bbd2209e7e -->
<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend query boundary; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend query boundary; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI workflow`.
<!-- evidence-row:backend-logs -->
- [x]
  ```text
  bun test v1.3.14
  route.auto-provision.test.ts: 13 pass, 0 fail, 46 assertions
  Biome: Checked 2 files. No fixes applied; git diff --check clean
  Cloud API typecheck: touched files clean; unrelated current-develop errors listed above
  ```
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend path changed`.
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model, prompt, or agent behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x]
  ```text
  omitted/empty/true => credit gate runs; false => create without credit gate
  FALSE/TRUE/0/1/no/yes/foo => 400 before credit gate and create
  duplicate false+true and false+false => 400 before credit gate and create
  ```
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered surface`.

---
— [codex-root/pr-21093-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@1681ef1dae5fa85d488a7684761a6a21fc15f50b:packages/skills/skills/contribute-to-eliza"} -->
