### PR TITLE
fix(cloud): reject unknown container-delete purgeVolume flag

### DIFF
--- a/packages/cloud/api/v1/containers/[id]/route.purge-volume.test.ts
+++ b/packages/cloud/api/v1/containers/[id]/route.purge-volume.test.ts
@@ -88,12 +88,27 @@ describe("DELETE /api/v1/containers/:id purgeVolume identity", () => {
     });
   });
 
+  test.each([
+    ["false", false],
+    ["true", true],
+  ] as const)(
+    "applies purgeVolume=%s consistently when mode=stop",
+    async (raw, expected) => {
+      const response = await del(`?mode=stop&purgeVolume=${raw}`);
+
+      expect(response.status).toBe(200);
+      expect(stopContainer).toHaveBeenCalledTimes(1);
+      expect(stopContainer.mock.calls[0][2]).toMatchObject({
+        purgeVolume: expected,
+      });
+      expect(deleteContainer).not.toHaveBeenCalled();
+    },
+  );
+
   test.each(["FALSE", "TRUE", "0", "1", "no", "yes", "foo"])(
     "rejects purgeVolume=%s before deleteContainer",
     async (token) => {
-      const response = await del(
-        `?purgeVolume=${encodeURIComponent(token)}`,
-      );
+      const response = await del(`?purgeVolume=${encodeURIComponent(token)}`);
       expect(response.status).toBe(400);
       const body = (await response.json()) as { error: string };
       expect(body.error).toBe("Invalid purgeVolume");

--- a/packages/cloud/api/v1/containers/[id]/route.purge-volume.test.ts
+++ b/packages/cloud/api/v1/containers/[id]/route.purge-volume.test.ts
@@ -1,0 +1,104 @@
+/**
+ * DELETE /api/v1/containers/:id `purgeVolume` is container-delete volume
+ * identity, not leftover tax on app-delete GitHub-repo flag. Stock
+ * develop used `z.coerce.boolean()`, so `purgeVolume=false` / `FALSE`
+ * still rm -rf'd the host volume.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+const ORG_A = "11111111-1111-4111-8111-111111111111";
+const CONTAINER_ID = "ctr-keep-volume";
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+const deleteContainer = mock(async () => undefined);
+const stopContainer = mock(async () => ({
+  id: CONTAINER_ID,
+  status: "stopped",
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: ORG_A,
+  }),
+}));
+mock.module("@/lib/services/containers/hetzner-client/client", () => ({
+  getHetznerContainersClient: () => ({
+    deleteContainer,
+    stopContainer,
+  }),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_c: unknown, error: unknown) => {
+    throw error;
+  },
+}));
+
+const { default: detailRoute } = await import("./route");
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.route("/api/v1/containers/:id", detailRoute);
+  return app;
+}
+
+function del(query = "") {
+  return buildApp().request(
+    `/api/v1/containers/${CONTAINER_ID}${query}`,
+    { method: "DELETE" },
+    ENV,
+  );
+}
+
+describe("DELETE /api/v1/containers/:id purgeVolume identity", () => {
+  beforeEach(() => {
+    deleteContainer.mockClear();
+    stopContainer.mockClear();
+  });
+
+  test.each(["", "?purgeVolume=", "?purgeVolume=false"])(
+    "accepts %s as keep the host volume",
+    async (query) => {
+      const response = await del(query);
+      expect(response.status).toBe(200);
+      expect(deleteContainer).toHaveBeenCalledTimes(1);
+      expect(deleteContainer.mock.calls[0][2]).toMatchObject({
+        purgeVolume: false,
+      });
+      expect(stopContainer).not.toHaveBeenCalled();
+    },
+  );
+
+  test("accepts purgeVolume=true as destroy the host volume", async () => {
+    const response = await del("?purgeVolume=true");
+    expect(response.status).toBe(200);
+    expect(deleteContainer).toHaveBeenCalledTimes(1);
+    expect(deleteContainer.mock.calls[0][2]).toMatchObject({
+      purgeVolume: true,
+    });
+  });
+
+  test.each(["FALSE", "TRUE", "0", "1", "no", "yes", "foo"])(
+    "rejects purgeVolume=%s before deleteContainer",
+    async (token) => {
+      const response = await del(
+        `?purgeVolume=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid purgeVolume");
+      expect(deleteContainer).not.toHaveBeenCalled();
+      expect(stopContainer).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/containers/[id]/route.ts
+++ b/packages/cloud/api/v1/containers/[id]/route.ts
@@ -113,8 +113,6 @@ app.patch("/", async (c) => {
 const DeleteSchema = z.object({
   /** `stop` preserves the row (billing off); `delete` removes it. */
   mode: z.enum(["stop", "delete"]).optional(),
-  /** Destructive: also rm -rf the host volume / delete the hcloud volume. */
-  purgeVolume: z.coerce.boolean().optional(),
 });
 
 // DELETE /api/v1/containers/:id — stop (preserve row) or delete (remove row)
@@ -125,9 +123,27 @@ app.delete("/", async (c) => {
     if (!id) {
       return c.json({ success: false, error: "Missing container id" }, 400);
     }
+    // Container-delete volume identity, not leftover tax on app-delete
+    // GitHub-repo flag. z.coerce.boolean treated purgeVolume=false / FALSE
+    // as true, so a keep-volume request still rm -rf'd the host volume.
+    const requestedPurge = c.req.query("purgeVolume");
+    if (
+      requestedPurge != null &&
+      requestedPurge !== "" &&
+      requestedPurge !== "true" &&
+      requestedPurge !== "false"
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: "Invalid purgeVolume",
+          message: 'purgeVolume must be "true" or "false".',
+        },
+        400,
+      );
+    }
     const parsed = DeleteSchema.safeParse({
       mode: c.req.query("mode"),
-      purgeVolume: c.req.query("purgeVolume"),
     });
     if (!parsed.success) {
       return c.json(
@@ -139,7 +155,7 @@ app.delete("/", async (c) => {
       );
     }
     const mode = parsed.data.mode ?? "delete";
-    const purgeVolume = parsed.data.purgeVolume ?? false;
+    const purgeVolume = requestedPurge === "true";
     const client = getHetznerContainersClient();
 
     if (mode === "stop") {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on container-delete
`purgeVolume` identity. Destructive host-volume class, not leftover
tax on app-delete GitHub-repo flag, telegram webhook flag, share-ingest
consume, Life Ops inbox bools, models catalogOnly/refresh, payment-request
public, market-trades tx_type, market-candles type, github-complete target,
cloneType, token-lookup chain, analytics-breakdown timeRange,
admin-redemptions network, OAuth platform, app-analytics period, ad-account
platform, my-agents category, advertising campaign filters, AI-pricing
catalog filters, admin metrics timeRange, analytics view, Vertex scope,
ingress-map format, promote-assets platform, influencer bookings party,
X connectionRole, my-agents sortBy, logs since, analytics periods,
analytics export type, admin redemption status, views viewType,
relationships scope, commands surface, approvals state, database-rows
sort/page, memory-viewer type, VFS encoding, Cloud JSON-400,
prefix-coerced limit, percent-encoded paths, SIWS chainId, orchestrator
lines, provisioning-worker env ints, invites-accept, cli-auth, redemption
quote, compat agent-logs, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. DELETE `purgeVolume` only on `/api/v1/containers/:id`.
Omitted/empty/`false` still keeps the host volume (today's default).
Exact `true` still destroys it. Unknown / uppercase tokens 400 before
deleteContainer. App-delete GitHub-repo flag stays untouched. `mode`
stay `stop`/`delete`.

# Background

## What does this PR do?

`DELETE /api/v1/containers/:id` parsed `purgeVolume` with
`z.coerce.boolean()`. `Boolean("false")` is `true`, so
`purgeVolume=false` / `FALSE` silently rm -rf'd the host volume
instead of a 400.

- omitted / empty / `false` → **200** keep the host volume
- exact `true` → **200** destroy the host volume
- `FALSE` / `TRUE` / `0` / `1` / `no` / `yes` / `foo` → **400** before deleteContainer

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The volume-purge flag is chosen from `purgeVolume`. A keep-volume
`purgeVolume=false` after coerce, or `FALSE` after a client uppercases
the bool, must not destroy the disk. This is container-delete volume
identity, not leftover tax on app-delete GitHub-repo flag.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/containers/[id]/route.purge-volume.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test 'v1/containers/[id]/route.purge-volume.test.ts'
```

11 passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; container-delete `purgeVolume` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; container-delete `purgeVolume` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; container-delete `purgeVolume` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real purgeVolume tokens and assert 400 before deleteContainer; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no volume export; illegal tokens 400 before deleteContainer.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`purgeVolume` tokens reject; omitted/canonical still bind the matching
cleanup.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file container-delete
purgeVolume parse with a green focused suite (11 tests). Full monorepo
verify is unrelated to this query grammar and was skipped to keep the
proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:208f83a0f3827904fbb7603805b143d2bcf1722e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->

## Maintainer repair and validation

Added stop-mode coverage because both `stopContainer` and `deleteContainer` receive this destructive option, and repaired formatting. Exact-head production-handler tests pass 13/13; touched-file Biome and diff-check are clean. Package typecheck is blocked in the sparse review environment only by the absent `@cloudflare/workers-types` dependency. Repair head: `208f83a0f3827904fbb7603805b143d2bcf1722e`.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@1e35881438947162f2499106cf796b09cc48b46e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-b]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@1e35881438947162f2499106cf796b09cc48b46e:packages/skills/skills/contribute-to-eliza"} -->