### PR TITLE
fix(agent): reject malformed connector-account route encoding

### DIFF
--- a/packages/agent/src/api/connector-account-routes.test.ts
+++ b/packages/agent/src/api/connector-account-routes.test.ts
@@ -412,6 +412,71 @@ describe("connector account routes", () => {
     vi.clearAllMocks();
   });
 
+  it.each([
+    ["provider", "/api/connectors/%/accounts"],
+    ["namespace", "/api/connectors/slack/%ZZ"],
+    ["account id", "/api/connectors/slack/accounts/%E0%A4"],
+    ["action", "/api/connectors/slack/accounts/acct_1/%2"],
+  ])(
+    "rejects malformed %s encoding before authorization or storage",
+    async (_segment, pathname) => {
+      const authorize = vi.fn(async () => true);
+      const { ctx, captured, runtime } = createConnectorAccountHarness({
+        method: "GET",
+        pathname,
+        authorize,
+      });
+
+      await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
+
+      expect(captured.status).toBe(400);
+      expect(captured.body).toEqual({
+        error: "Invalid connector route encoding",
+      });
+      expect(authorize).not.toHaveBeenCalled();
+      expect(runtime.getService).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves valid encoded provider, account, and action segments", async () => {
+    const { ctx, captured, storage } = createConnectorAccountHarness({
+      method: "POST",
+      pathname: "/api/connectors/%73lack/accounts/acct%5Fencoded/t%65st",
+    });
+    await storage.upsertAccount({
+      id: "acct_encoded",
+      provider: "slack",
+      role: "OWNER",
+      purpose: ["messaging"],
+      accessGate: "open",
+      status: "connected",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
+
+    expect(captured.status).toBe(200);
+    expect(captured.body).toMatchObject({
+      ok: true,
+      provider: "slack",
+      account: { id: "acct_encoded" },
+    });
+  });
+
+  it("still falls through for paths outside the connector namespace", async () => {
+    const authorize = vi.fn(async () => true);
+    const { ctx, runtime } = createConnectorAccountHarness({
+      method: "GET",
+      pathname: "/api/other/%",
+      authorize,
+    });
+
+    await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(false);
+    expect(authorize).not.toHaveBeenCalled();
+    expect(runtime.getService).not.toHaveBeenCalled();
+  });
+
   it("handles connector account namespace separately from connector config routes", async () => {
     const { ctx, captured, storage } = createConnectorAccountHarness({
       method: "GET",

--- a/packages/agent/src/api/connector-account-routes.test.ts
+++ b/packages/agent/src/api/connector-account-routes.test.ts
@@ -375,7 +375,10 @@ function createConnectorAccountHarness(options: {
     statusCode: 200,
     setHeader: vi.fn(),
     write: vi.fn(),
-    end: vi.fn(),
+    end: vi.fn((body?: string) => {
+      captured.status = res.statusCode;
+      captured.body = body ? JSON.parse(body) : null;
+    }),
   } as unknown as ServerResponse;
   const pathname = options.pathname.split("?")[0];
   const ctx: ConnectorAccountRouteContext = {
@@ -417,6 +420,8 @@ describe("connector account routes", () => {
     ["namespace", "/api/connectors/slack/%ZZ"],
     ["account id", "/api/connectors/slack/accounts/%E0%A4"],
     ["action", "/api/connectors/slack/accounts/acct_1/%2"],
+    ["OAuth tail", "/api/connectors/slack/oauth/%"],
+    ["audit tail", "/api/connectors/slack/audit/%ZZ"],
   ])(
     "rejects malformed %s encoding before authorization or storage",
     async (_segment, pathname) => {
@@ -431,7 +436,7 @@ describe("connector account routes", () => {
 
       expect(captured.status).toBe(400);
       expect(captured.body).toEqual({
-        error: "Invalid connector route encoding",
+        error: "Invalid connector route: malformed URL encoding",
       });
       expect(authorize).not.toHaveBeenCalled();
       expect(runtime.getService).not.toHaveBeenCalled();

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -27,6 +27,7 @@ import type { ReadJsonBodyOptions } from "@elizaos/shared";
 import type { infer as ZodInfer } from "zod";
 import * as zod from "zod";
 import { resolveDirectRequestOrigin } from "./request-origin.ts";
+import { decodePathComponent } from "./server-helpers.ts";
 import { isBlockedObjectKey } from "./server-helpers-config.ts";
 
 const z = (zod as typeof zod & { z?: typeof zod }).z ?? zod;
@@ -245,6 +246,7 @@ const INVALID_CONNECTOR_SCOPED_PATH = Symbol("invalid-connector-scoped-path");
 
 function parseConnectorScopedPath(
   pathname: string,
+  res: http.ServerResponse,
 ): ConnectorScopedPath | typeof INVALID_CONNECTOR_SCOPED_PATH | null {
   if (!pathname.startsWith(CONNECTORS_PREFIX)) {
     return null;
@@ -255,13 +257,11 @@ function parseConnectorScopedPath(
     .filter(Boolean);
   const segments: string[] = [];
   for (const segment of encodedSegments) {
-    try {
-      segments.push(decodeURIComponent(segment));
-    } catch {
-      // error-policy:J3 untrusted connector path segments with malformed
-      // percent-encoding are explicit invalid input, never dispatcher errors.
+    const decoded = decodePathComponent(segment, res, "connector route");
+    if (decoded === null) {
       return INVALID_CONNECTOR_SCOPED_PATH;
     }
+    segments.push(decoded);
   }
   if (segments.length < 2) return null;
   const provider = segments[0]?.trim().toLowerCase() ?? "";
@@ -676,9 +676,8 @@ export async function handleConnectorAccountRoutes(
   ctx: ConnectorAccountRouteContext,
 ): Promise<boolean> {
   const { req, res, method, pathname, json, error, readJsonBody } = ctx;
-  const parsedPath = parseConnectorScopedPath(pathname);
+  const parsedPath = parseConnectorScopedPath(pathname, res);
   if (parsedPath === INVALID_CONNECTOR_SCOPED_PATH) {
-    error(res, "Invalid connector route encoding", 400);
     return true;
   }
   if (!parsedPath) {

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -235,19 +235,34 @@ function hasPrivacyConfirmation(
   return phrase === "SHARE";
 }
 
-function parseConnectorScopedPath(pathname: string): {
+interface ConnectorScopedPath {
   provider: string;
   namespace: "accounts" | "oauth" | "audit";
   rest: string[];
-} | null {
+}
+
+const INVALID_CONNECTOR_SCOPED_PATH = Symbol("invalid-connector-scoped-path");
+
+function parseConnectorScopedPath(
+  pathname: string,
+): ConnectorScopedPath | typeof INVALID_CONNECTOR_SCOPED_PATH | null {
   if (!pathname.startsWith(CONNECTORS_PREFIX)) {
     return null;
   }
-  const segments = pathname
+  const encodedSegments = pathname
     .slice(CONNECTORS_PREFIX.length)
     .split("/")
-    .filter(Boolean)
-    .map((segment) => decodeURIComponent(segment));
+    .filter(Boolean);
+  const segments: string[] = [];
+  for (const segment of encodedSegments) {
+    try {
+      segments.push(decodeURIComponent(segment));
+    } catch {
+      // error-policy:J3 untrusted connector path segments with malformed
+      // percent-encoding are explicit invalid input, never dispatcher errors.
+      return INVALID_CONNECTOR_SCOPED_PATH;
+    }
+  }
   if (segments.length < 2) return null;
   const provider = segments[0]?.trim().toLowerCase() ?? "";
   const namespace = segments[1];
@@ -265,7 +280,7 @@ function parseConnectorScopedPath(pathname: string): {
 }
 
 function isUnauthenticatedOAuthCallback(
-  parsedPath: NonNullable<ReturnType<typeof parseConnectorScopedPath>>,
+  parsedPath: ConnectorScopedPath,
   method: string,
 ): boolean {
   return (
@@ -276,7 +291,7 @@ function isUnauthenticatedOAuthCallback(
 }
 
 function authorizationRequestForPath(
-  parsedPath: NonNullable<ReturnType<typeof parseConnectorScopedPath>>,
+  parsedPath: ConnectorScopedPath,
   method: string,
   pathname: string,
 ): ConnectorAccountRouteAuthorizationRequest {
@@ -662,6 +677,10 @@ export async function handleConnectorAccountRoutes(
 ): Promise<boolean> {
   const { req, res, method, pathname, json, error, readJsonBody } = ctx;
   const parsedPath = parseConnectorScopedPath(pathname);
+  if (parsedPath === INVALID_CONNECTOR_SCOPED_PATH) {
+    error(res, "Invalid connector route encoding", 400);
+    return true;
+  }
   if (!parsedPath) {
     return false;
   }


### PR DESCRIPTION
# Relates to

Fixes #21063

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`1e35881438947162f2499106cf796b09cc48b46e`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      root-verifier blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the
      focused real-handler matrix below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@1e35881438947162f2499106cf796b09cc48b46e`; zero conflicts.
- [x] `bun run verify` was run post-sync. It passed repository contracts through
      the monorepo typecheck/lint fan-out, then stopped on an unrelated existing
      CRLF formatting error in
      `packages/app/src/shims/solana-wallet-adapter-react-ui.css`. This branch
      changes only the two Agent route files listed below.

# Risks

Low. The behavior change is limited to malformed percent-encoding under the
connector-account namespace. Valid encoded segments, authorization, OAuth,
persistence, metadata, and non-connector dispatcher fallthrough remain covered.

# Background

## What does this PR do?

- catches `decodeURIComponent` failures at the connector-account HTTP boundary;
- returns a handled `400 { error: "Invalid connector route encoding" }` before
  authorization or storage resolution;
- preserves ordinary dispatcher fallthrough for paths outside this namespace;
- adds malformed provider, namespace, account-id, and action cases plus valid
  encoded and unrelated-path controls.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This fixes malformed-input handling without changing a supported API shape.

# Testing

## Where should a reviewer start?

- `packages/agent/src/api/connector-account-routes.ts`
- `packages/agent/src/api/connector-account-routes.test.ts`

## Detailed testing steps

Exact reviewed head: `81f69eb30c938ce78a6481ea5c6a00f1fa814702`

```text
bun install --force --frozen-lockfile --ignore-scripts
  PASS — 7,084 packages installed; lockfile unchanged

ELIZA_SKIP_LOCAL_UPSTREAMS=1 bunx vitest run \
  src/api/connector-account-routes.test.ts \
  src/api/connector-account-routes.durable.test.ts \
  --coverage.enabled=false --reporter=dot
  PASS — 2 files, 21 tests

bunx @biomejs/biome check \
  packages/agent/src/api/connector-account-routes.ts \
  packages/agent/src/api/connector-account-routes.test.ts
  PASS — 2 files, no fixes

bun run --cwd packages/agent typecheck
  PASS

bun run --cwd packages/agent build
  PASS — 196 emitted import rewrites

bun run verify
  PARTIAL/UNRELATED — repository contracts, i18n, dependency checks, alias-read
  guard, and the changed Agent lint lane passed. The monorepo fan-out then failed
  on pre-existing CRLF formatting in
  packages/app/src/shims/solana-wallet-adapter-react-ui.css. This branch has no
  packages/app diff.

git diff --check
  PASS
```

# Evidence Gate

<!-- evidence-head:81f69eb30c938ce78a6481ea5c6a00f1fa814702 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - HTTP malformed-input handling has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - HTTP malformed-input handling has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic route behavior is fully represented by the handler matrix.
<!-- evidence-row:backend-logs -->
- [x] N/A - the invalid-input branch intentionally emits no structured log; the
      real handler tests assert the 400 body and zero authorization/storage calls.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, evaluator, or model path changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - rejection occurs before persistence and deliberately creates no artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or UI surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM or model-routing behavior changed.

## Backend + frontend logs

N/A - this boundary produces a direct HTTP 400 before side effects. The focused
test transcript above is the applicable deterministic domain evidence.

## Screenshots (before / after) + video walkthrough

N/A - no rendered surface changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- The first clean Windows install left Vitest partially linked; a forced frozen
  relink repaired it without lockfile changes.
- The Agent test harness otherwise prefers a neighboring checkout literally
  named `eliza`; its documented `ELIZA_SKIP_LOCAL_UPSTREAMS=1` mode was used so
  this disposable worktree resolved its own installed packages.
- Root `bun run verify` stops on the unrelated CRLF formatting failure described
  above. Scoped tests, changed-file Biome, Agent typecheck, and Agent build pass
  on the exact head.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@1e35881438947162f2499106cf796b09cc48b46e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-connector-route-encoding]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@1e35881438947162f2499106cf796b09cc48b46e:packages/skills/skills/contribute-to-eliza"} -->
