### PR TITLE
fix(shared): reject negated navigation in view command matcher

### DIFF
--- a/packages/shared/src/views/view-command-matcher.ts
+++ b/packages/shared/src/views/view-command-matcher.ts
@@ -980,6 +980,10 @@ function nounAlt(items: readonly string[]): string {
 const VERB_ALT = alt(NAV_VERBS);
 const VW_ALT = alt(VIEW_WORDS);
 const POSS_ALT = alt(POSSESSIVES);
+const NEGATED_NAVIGATION_RE = new RegExp(
+  `(?:${alt(["do not", "don't", "dont", "never"])})[\\s\\p{P}]+(?:${VERB_ALT})`,
+  "iu",
+);
 const CLOUD_APPS_VIEW_ID = "cloud-apps";
 const CLOUD_APPS_STRONG_NAV_VERBS = [
   // en
@@ -1191,6 +1195,7 @@ export function matchViewCommand(text: string | undefined): string | null {
   if (!raw || raw.length > 160) return null; // commands are short
   const lower = raw.toLowerCase();
   if (looksLikeCompanionActionRequest(lower)) return null;
+  if (NEGATED_NAVIGATION_RE.test(lower)) return null;
   if (BARE_HOME_NAVIGATION.test(lower)) return "chat";
   const variants = [lower, stripDiacritics(lower)];
   if (variants.some((variant) => CLOUD_APPS_COMMAND_RE.test(variant))) {

--- a/packages/shared/src/views/view-command-matcher.ts
+++ b/packages/shared/src/views/view-command-matcher.ts
@@ -980,8 +980,43 @@ function nounAlt(items: readonly string[]): string {
 const VERB_ALT = alt(NAV_VERBS);
 const VW_ALT = alt(VIEW_WORDS);
 const POSS_ALT = alt(POSSESSIVES);
+const NAVIGATION_NEGATIONS = [
+  // en
+  "do not",
+  "don't",
+  "don’t",
+  "dont",
+  "never",
+  "not",
+  "no",
+  // es / pt
+  "nunca",
+  "não",
+  "nao",
+  // fr
+  "ne",
+  "pas",
+  "jamais",
+  // de
+  "nicht",
+  "nie",
+  "niemals",
+  // zh
+  "不要",
+  "不用",
+  "别",
+  "別",
+  "勿",
+  // vi / tl
+  "đừng",
+  "không",
+  "khong",
+  "huwag",
+] as const;
+const NEGATION_ALT = alt(NAVIGATION_NEGATIONS);
+const SAME_CLAUSE_GAP = "[^.!?;\\n]";
 const NEGATED_NAVIGATION_RE = new RegExp(
-  `(?:${alt(["do not", "don't", "dont", "never"])})[\\s\\p{P}]+(?:${VERB_ALT})`,
+  `(?:${NEGATION_ALT}|(?<![\\p{L}\\p{N}])n['’])${SAME_CLAUSE_GAP}{0,48}?(?:${VERB_ALT})|(?:${VERB_ALT})${SAME_CLAUSE_GAP}{0,24}?(?:${NEGATION_ALT})`,
   "iu",
 );
 const CLOUD_APPS_VIEW_ID = "cloud-apps";

--- a/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
+++ b/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
@@ -223,6 +223,9 @@ describe("matchViewCommand — precision (must NOT match)", () => {
 		"go back over the paragraph",
 		"go back and explain what changed",
 		"when I go back to school",
+		"do not open settings",
+		"don't open settings",
+		"never open settings",
 		"",
 		"   ",
 	];

--- a/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
+++ b/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
@@ -100,6 +100,47 @@ describe("matchViewCommand — multilingual", () => {
 	}
 });
 
+describe("matchViewCommand — negated navigation", () => {
+	const negatedCommands = [
+		// English direct, indirect, punctuation, and typographic apostrophe forms.
+		"do not open settings",
+		"don't open settings",
+		"don’t open settings",
+		"I don't want to open settings",
+		"don't try to open settings",
+		"never ever open settings",
+		"do not, under any circumstances, open settings",
+		"do not open settings, open calendar",
+		// The matcher is multilingual, so its side-effect guard must be too.
+		"no abrir ajustes",
+		"não abrir configurações",
+		"ne pas ouvrir les paramètres",
+		"n’ouvre pas les paramètres",
+		"nicht öffnen die einstellungen",
+		"öffne nicht die einstellungen",
+		"不要打开设置",
+		"別打開設定",
+		"đừng mở cài đặt",
+		"huwag buksan ang settings",
+	] as const;
+
+	it.each(negatedCommands)("%j stays in normal action planning", (text) => {
+		expect(matchViewCommand(text)).toBeNull();
+	});
+
+	it("does not treat a negation prefix inside a word as negation", () => {
+		expect(matchViewCommand("notable request: open settings")).toBe("settings");
+	});
+
+	it("does not carry negation across a sentence boundary", () => {
+		expect(matchViewCommand("Never mind. Open settings")).toBe("settings");
+	});
+
+	it("does not confuse an unaccented Vietnamese noun with negation", () => {
+		expect(matchViewCommand("open ung dung dam may")).toBe("cloud-apps");
+	});
+});
+
 describe("matchViewCommand — localized Knowledge labels", () => {
 	const cases = [
 		["en", "Knowledge", "open Knowledge"],
@@ -223,9 +264,6 @@ describe("matchViewCommand — precision (must NOT match)", () => {
 		"go back over the paragraph",
 		"go back and explain what changed",
 		"when I go back to school",
-		"do not open settings",
-		"don't open settings",
-		"never open settings",
 		"",
 		"   ",
 	];


### PR DESCRIPTION
# Relates to

No linked issue; this repairs a newly identified deterministic-navigation bug.

- [x] This PR targets `develop` and is rebased onto current `origin/develop` (`7f33adca78e035f59aebb060b36327329ccc281a`) with zero conflicts.
- [ ] `bun install` and the repository-wide `bun run verify` were not repeated for this two-file matcher repair; the exact scoped tests, both owning typechecks, Biome, and diff checks are recorded below.
- [x] A reviewer can confirm the behavior from the exact-head test transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex CLI / AgentRouter`, `Claude Code`, `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7f33adca78e035f59aebb060b36327329ccc281a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [ ] Repository-wide `bun run verify` was not run; scoped verification is complete and listed below.

# Risks

Low-to-medium. This matcher can trigger a navigation side effect, so false negatives can violate an explicit refusal and false positives can suppress valid navigation. The repair is clause-bounded, multilingual, and covered by affirmative controls plus the exhaustive navigation matrix. A matrix run caught and drove removal of an unsafe Vietnamese transliteration before this head was pushed.

# Background

## What does this PR do?

Prevents the deterministic multilingual view matcher from treating negated navigation as an affirmative command. The original direct-English guard missed indirect phrasing (`I don't want to open settings`), curly apostrophes, intervening punctuation/words, multilingual negation, and post-verbal French/German forms.

The repaired guard rejects pre- or post-verbal negation within the same short clause, remains bounded at sentence terminators, and preserves affirmative commands. Ambiguous mixed commands such as `do not open settings, open calendar` fail closed into normal action planning rather than navigating to the forbidden destination.

## What kind of change is this?

Bug fix; no schema, API, dependency, or UI change.

# Documentation changes needed?

No. The existing package guide already requires this fast path to remain multilingual and precision-first.

# Testing

## Where should a reviewer start?

`packages/shared/src/views/view-command-matcher.ts` and the production-import tests in `plugins/plugin-app-control/src/actions/view-command-matcher.test.ts`.

## Detailed testing steps

At exact head `577b304608d0b35357778aeae58d2942b27da9af`:

```text
bunx bun@1.3.14 run --cwd plugins/plugin-app-control test -- src/actions/view-command-matcher.test.ts src/actions/view-matrix.test.ts
Test Files  2 passed (2)
Tests  970 passed (970)

bunx bun@1.3.14 run --cwd packages/shared typecheck
exit 0

bunx bun@1.3.14 run --cwd plugins/plugin-app-control typecheck
exit 0

bunx bun@1.3.14 x @biomejs/biome check packages/shared/src/views/view-command-matcher.ts plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
Checked 2 files. No fixes applied.

git diff --check origin/develop...HEAD
exit 0
```

The 970 assertions cover direct/indirect English negation, curly apostrophes, punctuation, mixed commands, Spanish, Portuguese, French, German, Chinese, Vietnamese, and Tagalog; affirmative sentence-boundary and substring controls; every registered view noun; and Cloud Apps arbitration.

# Evidence Gate

<!-- evidence-head:577b304608d0b35357778aeae58d2942b27da9af -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - deterministic text matcher; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - deterministic text matcher; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual or interactive UI surface changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - pure deterministic library matcher; no server process or logging boundary changed. Exact-head production-import and exhaustive caller-contract test output is included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, network, or state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this is the explicitly zero-model deterministic fast path; model execution would not exercise the changed branch.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this pure matcher produces no persistent domain artifact; its return values are asserted directly across 970 exact-head cases above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - the changed matcher runs before/without an LLM by contract.

## Backend + frontend logs

N/A - no transport or frontend boundary changed. The exact-head deterministic output transcript is in **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - no UI code or rendered surface changed.

## Audio / voice walkthrough

N/A - no audio, speech, or transcript surface changed.

## Known gaps / failures

- Repository-wide `bun install` and `bun run verify` were not repeated. The pinned-Bun focused suites, exhaustive view matrix, both owning package typechecks, Biome, and diff check all pass on the exact pushed head.
- An exploratory broader run initially exposed the unsafe unaccented Vietnamese token and separately hit an unrelated timeout in `views-show-home.repro.test.ts`; the collision was repaired and the authoritative matcher plus exhaustive matrix then passed 970/970. The timed-out test exercises a different Notes/home action path and is outside this two-file matcher contract.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@7f33adca78e035f59aebb060b36327329ccc281a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review_lane_a]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@7f33adca78e035f59aebb060b36327329ccc281a:packages/skills/skills/contribute-to-eliza"} -->
