### PR TITLE
fix(core): prevent same-millisecond temp file collision in atomic-json helpers

### DIFF
--- a/packages/core/src/utils/atomic-json.test.ts
+++ b/packages/core/src/utils/atomic-json.test.ts
@@ -99,4 +99,40 @@ describe("atomic-json", () => {
 			expect(raw).toBe('{"b":2}\n');
 		});
 	});
+
+	describe("concurrency and validation", () => {
+		it("handles multiple concurrent writes to separate files without collision", async () => {
+			const writes = Array.from({ length: 20 }, (_, i) => {
+				const file = path.join(tempDir, `concurrent-${i}.json`);
+				return writeJsonAtomic(file, { index: i, timestamp: Date.now() });
+			});
+
+			await Promise.all(writes);
+
+			for (let i = 0; i < 20; i++) {
+				const readBack = await readJsonFile<{ index: number }>(
+					path.join(tempDir, `concurrent-${i}.json`),
+				);
+				expect(readBack?.index).toBe(i);
+			}
+		});
+
+		it("rejects non-string or empty file paths", async () => {
+			await expect(
+				writeJsonAtomic("" as unknown as string, {}),
+			).rejects.toThrow(TypeError);
+			await expect(
+				writeJsonAtomic(null as unknown as string, {}),
+			).rejects.toThrow(TypeError);
+			expect(() => writeJsonAtomicSync("" as unknown as string, {})).toThrow(
+				TypeError,
+			);
+			await expect(readJsonFile("" as unknown as string)).rejects.toThrow(
+				TypeError,
+			);
+			expect(() => readJsonFileSync("" as unknown as string)).toThrow(
+				TypeError,
+			);
+		});
+	});
 });

--- a/packages/core/src/utils/atomic-json.test.ts
+++ b/packages/core/src/utils/atomic-json.test.ts
@@ -7,7 +7,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	readJsonFile,
 	readJsonFileSync,
@@ -23,6 +23,7 @@ describe("atomic-json", () => {
 	});
 
 	afterEach(async () => {
+		vi.restoreAllMocks();
 		await fsp.rm(tempDir, { recursive: true, force: true });
 	});
 
@@ -101,20 +102,19 @@ describe("atomic-json", () => {
 	});
 
 	describe("concurrency and validation", () => {
-		it("handles multiple concurrent writes to separate files without collision", async () => {
-			const writes = Array.from({ length: 20 }, (_, i) => {
-				const file = path.join(tempDir, `concurrent-${i}.json`);
-				return writeJsonAtomic(file, { index: i, timestamp: Date.now() });
-			});
+		it("handles concurrent same-target writes in the same millisecond", async () => {
+			vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+			const target = path.join(tempDir, "concurrent.json");
+			const writes = Array.from({ length: 20 }, (_, index) =>
+				writeJsonAtomic(target, { index }),
+			);
 
 			await Promise.all(writes);
 
-			for (let i = 0; i < 20; i++) {
-				const readBack = await readJsonFile<{ index: number }>(
-					path.join(tempDir, `concurrent-${i}.json`),
-				);
-				expect(readBack?.index).toBe(i);
-			}
+			const readBack = await readJsonFile<{ index: number }>(target);
+			expect(readBack?.index).toBeGreaterThanOrEqual(0);
+			expect(readBack?.index).toBeLessThan(20);
+			expect((await fsp.readdir(tempDir)).sort()).toEqual(["concurrent.json"]);
 		});
 
 		it("rejects non-string or empty file paths", async () => {

--- a/packages/core/src/utils/atomic-json.ts
+++ b/packages/core/src/utils/atomic-json.ts
@@ -52,8 +52,11 @@ function normalizeOptions(
 	};
 }
 
+let tmpSequenceCounter = 0;
+
 function tmpPathFor(filePath: string): string {
-	return `${filePath}.tmp-${process.pid}-${Date.now()}`;
+	tmpSequenceCounter = (tmpSequenceCounter + 1) % 1_000_000;
+	return `${filePath}.tmp-${process.pid}-${Date.now()}-${tmpSequenceCounter}`;
 }
 
 function serialize(value: unknown, opts: NormalizedWriteOptions): string {
@@ -61,11 +64,18 @@ function serialize(value: unknown, opts: NormalizedWriteOptions): string {
 	return opts.trailingNewline ? `${body}\n` : body;
 }
 
+function assertFilePath(filePath: string): void {
+	if (typeof filePath !== "string" || filePath.trim().length === 0) {
+		throw new TypeError("filePath must be a non-empty string");
+	}
+}
+
 export async function writeJsonAtomic(
 	filePath: string,
 	value: unknown,
 	opts?: WriteJsonAtomicOptions,
 ): Promise<void> {
+	assertFilePath(filePath);
 	const o = normalizeOptions(opts);
 	if (!o.skipMkdir) {
 		await fsp.mkdir(path.dirname(filePath), {
@@ -102,6 +112,7 @@ export function writeJsonAtomicSync(
 	value: unknown,
 	opts?: WriteJsonAtomicOptions,
 ): void {
+	assertFilePath(filePath);
 	const o = normalizeOptions(opts);
 	if (!o.skipMkdir) {
 		fs.mkdirSync(path.dirname(filePath), {
@@ -137,6 +148,7 @@ export function writeJsonAtomicSync(
  * JSON and filesystem failures surface to the caller.
  */
 export async function readJsonFile<T>(filePath: string): Promise<T | null> {
+	assertFilePath(filePath);
 	try {
 		const raw = await fsp.readFile(filePath, "utf-8");
 		return JSON.parse(raw) as T;
@@ -155,6 +167,7 @@ export async function readJsonFile<T>(filePath: string): Promise<T | null> {
  * malformed JSON and filesystem failures surface to the caller.
  */
 export function readJsonFileSync<T>(filePath: string): T | null {
+	assertFilePath(filePath);
 	try {
 		const raw = fs.readFileSync(filePath, "utf-8");
 		return JSON.parse(raw) as T;

--- a/packages/core/src/utils/atomic-json.ts
+++ b/packages/core/src/utils/atomic-json.ts
@@ -8,7 +8,7 @@
  *   - mode 0o600 on the written file (secret-grade)
  *   - dir mode 0o700 when the parent has to be created
  *   - JSON 2-space indent, no trailing newline
- *   - tmp filename `${filePath}.tmp-${pid}-${Date.now()}` (multi-process safe)
+ *   - tmp filename `${filePath}.tmp-${pid}-${Date.now()}-${sequence}`
  *   - parent directory created with mkdir recursive
  *
  * On failure, the temp file is best-effort removed.
@@ -52,10 +52,10 @@ function normalizeOptions(
 	};
 }
 
-let tmpSequenceCounter = 0;
+let tmpSequenceCounter = 0n;
 
 function tmpPathFor(filePath: string): string {
-	tmpSequenceCounter = (tmpSequenceCounter + 1) % 1_000_000;
+	tmpSequenceCounter += 1n;
 	return `${filePath}.tmp-${process.pid}-${Date.now()}-${tmpSequenceCounter}`;
 }
 
@@ -88,6 +88,7 @@ export async function writeJsonAtomic(
 		await fsp.writeFile(tmp, serialize(value, o), {
 			encoding: "utf-8",
 			mode: o.mode,
+			flag: "wx",
 		});
 		await fsp.rename(tmp, filePath);
 	} finally {
@@ -125,6 +126,7 @@ export function writeJsonAtomicSync(
 		fs.writeFileSync(tmp, serialize(value, o), {
 			encoding: "utf-8",
 			mode: o.mode,
+			flag: "wx",
 		});
 		fs.renameSync(tmp, filePath);
 	} finally {


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/atomic-json.ts`, `tmpPathFor` generated temporary file paths using `${filePath}.tmp-${process.pid}-${Date.now()}`. Concurrent async writes in the same process within the same millisecond timestamp generated colliding temporary file paths, risking race conditions and file corruption on rename.
2. Added a cyclic monotonic sequence counter (`tmpSequenceCounter`) to guarantee collision-free temporary file paths across same-millisecond invocations.
3. Added non-empty string validation for `filePath` across `writeJsonAtomic`, `writeJsonAtomicSync`, `readJsonFile`, and `readJsonFileSync`.
4. Added concurrent write and validation unit tests in `packages/core/src/utils/atomic-json.test.ts`.

Closes #21096.

## Verification

Exact commit: `e492070fad`.

- Focused unit test suite `packages/core/src/utils/atomic-json.test.ts`: 10/10 tests passing (33 assertions).
- Biome format on `@elizaos/core`: 1291 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - file storage atomic JSON utility; no rendered UI changed.
- [x] N/A - file storage atomic JSON utility; no rendered UI changed.
- [x] N/A - deterministic atomic file writing/reading tests.
- [x] Focused test suite transcript:
```text
✓ atomic-json > writeJsonAtomic & readJsonFile (async) > writes and reads json data atomically [2.21ms]
✓ atomic-json > writeJsonAtomic & readJsonFile (async) > returns null for non-existent files (ENOENT) [0.50ms]
✓ atomic-json > writeJsonAtomic & readJsonFile (async) > throws for malformed JSON [0.57ms]
✓ atomic-json > writeJsonAtomic & readJsonFile (async) > supports custom formatting options like trailingNewline and indent [0.67ms]
✓ atomic-json > writeJsonAtomicSync & readJsonFileSync (sync) > writes and reads json data synchronously [0.87ms]
✓ atomic-json > writeJsonAtomicSync & readJsonFileSync (sync) > returns null for non-existent files (ENOENT) [2.35ms]
✓ atomic-json > writeJsonAtomicSync & readJsonFileSync (sync) > throws for malformed JSON [0.45ms]
✓ atomic-json > writeJsonAtomicSync & readJsonFileSync (sync) > supports custom formatting options synchronously [0.39ms]
✓ atomic-json > concurrency and validation > handles multiple concurrent writes to separate files without collision [2.28ms]
✓ atomic-json > concurrency and validation > rejects non-string or empty file paths [0.71ms]
10 pass, 0 fail, 33 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - local test directory cleaned up in afterEach.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@f88d57ccab006c9a9307738b5550aee7bb033100:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@f88d57ccab006c9a9307738b5550aee7bb033100:packages/skills/skills/contribute-to-eliza"} -->

## Maintainer repair and validation

The original concurrency test wrote twenty different destinations, so their temp prefixes could not collide even on the buggy implementation. It now freezes `Date.now`, concurrently writes the same target twenty times, verifies the final file is one complete payload, and proves no temp files remain. The sequence is an unbounded practical `bigint` rather than wrapping after one million calls. Temp creation now uses exclusive `wx` mode so a pre-existing file or symlink cannot be overwritten/followed; the operation fails closed instead. PID + timestamp + process-wide sequence remains portable and separates live processes. Exact-head core Vitest passes 10/10; touched-file Biome and diff-check are clean. Core typecheck is blocked only by sparse-environment dependency gaps (`@noble/*`, `drizzle-orm`, `ai`, `mammoth`, `unpdf`, `dedent`, `dotenv`), with no changed-file diagnostic. Repair head: `28ba2c862593caec29c29ce1744bbc626abf98fc`.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@2741ce88d27af20e687377f1b311f2c2ea43faf2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-b]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@2741ce88d27af20e687377f1b311f2c2ea43faf2:packages/skills/skills/contribute-to-eliza"} -->