### PR TITLE
fix(app): boot web path in plain browser contexts (scenario E2E)

### DIFF
--- a/packages/app/test/ui-smoke/shell-view-agent-bridge-inventory.spec.ts
+++ b/packages/app/test/ui-smoke/shell-view-agent-bridge-inventory.spec.ts
@@ -87,6 +87,30 @@ const TRANSCRIPT_DETAIL = {
   ],
 };
 
+// The trajectories toolbar (export/clear-all) only mounts when the list is
+// non-empty, so the bridge inventory needs at least one recorded trajectory.
+const TRAJECTORY_SUMMARY = {
+  id: "trajectory-smoke-1",
+  agentId: "ui-smoke-agent",
+  source: "conversation",
+  status: "completed",
+  startTime: 1_700_000_004_000,
+  endTime: 1_700_000_004_800,
+  durationMs: 800,
+  llmCallCount: 1,
+  providerAccessCount: 0,
+  totalPromptTokens: 128,
+  totalCompletionTokens: 64,
+  scenarioId: null,
+  batchId: null,
+  createdAt: "2023-11-14T22:13:24.000Z",
+  updatedAt: "2023-11-14T22:13:24.800Z",
+  roomId: "ui-smoke-room",
+  entityId: null,
+  conversationId: null,
+  metadata: {},
+};
+
 const SHELL_VIEW_TARGETS: readonly {
   label: string;
   path: string;
@@ -195,6 +219,26 @@ async function installBridgeInventoryFixtures(page: Page): Promise<void> {
       body: JSON.stringify({ transcript: TRANSCRIPT_DETAIL }),
     }),
   );
+  // Registered after installDefaultAppRoutes, so this wins for the list path;
+  // stats/config/latest/detail fall back to the shared empty-state stubs.
+  await page.route("**/api/trajectories**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() !== "GET" || url.pathname !== "/api/trajectories") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        trajectories: [TRAJECTORY_SUMMARY],
+        total: 1,
+        offset: Number(url.searchParams.get("offset") ?? 0),
+        limit: Number(url.searchParams.get("limit") ?? 50),
+      }),
+    });
+  });
 }
 
 async function waitForAgentBridge(page: Page): Promise<void> {

--- a/packages/app/test/ui-smoke/warming-shell-startup.spec.ts
+++ b/packages/app/test/ui-smoke/warming-shell-startup.spec.ts
@@ -14,9 +14,12 @@ import { installDefaultAppRoutes, openAppPath } from "./helpers";
  */
 
 function chatComposer(page: Page) {
+  // The label fallback must be exact: substring matching would also hit chat
+  // message bubbles labeled "Show message actions" once the greeting renders,
+  // making the union locator ambiguous under strict mode.
   return page
     .locator('[data-testid="chat-composer-textarea"]')
-    .or(page.getByLabel("message"));
+    .or(page.getByLabel("message", { exact: true }));
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up cleanup for the dominant Scenario E2E failure on develop (run 32004218753, "Zero-Key app browser all-pages" et al.).

**The dominant boot failure is already fixed on develop.** The 93 route tests failed with `[desktop-shell] Native Electrobun bridge is unavailable` because the all-pages fixture injects `__ELIZA_ELECTROBUN_RPC__` (making `isElectrobunRuntime()` true) but only stubbed the permissions RPCs. Commit `7139cf165a17` ("fix(app): restore native macOS shortcut bridge (#19923)", 2026-08-15) added strict `desktopGetVersion` / `desktopRegisterShortcut` validation to `initializeDesktopShell()`, so every desktop-persona probe aborted at boot. That was fixed on develop by `d6cb381d8c63` ("fix(app): boot all-pages browser lane with the full Electrobun startup contract", closes #20968) — landed 24 minutes after the failing run started. The environment classification itself is sound: a genuinely plain browser context (no injected RPC) boots the web path; only fixtures that deliberately impersonate the Electrobun host must satisfy the startup contract. Nothing about the real desktop-shell contract is weakened.

This PR fixes the two remaining failures in the same lane (both reproduce locally at develop head):

- **warming-shell-startup.spec.ts:94 strict-mode violation** — the composer union locator's `getByLabel("message")` half substring-matches every chat bubble labeled "Show **message** actions" once the greeting renders (5 matches in CI, 2 locally). Fixed with `{ exact: true }`; the `data-testid` half is unchanged.
- **shell-view-agent-bridge-inventory.spec.ts:268** — `trajectories-export-open` / `trajectories-clear-all-open` no longer register because `9a5e2fce4aa1` gated the Trajectories toolbar behind a non-empty list (`hasActiveFilters || trajectories.length > 0`) and the shared fixture serves an empty list, so the controls never mount. The fixture now serves one recorded trajectory for the list path; stats/config/latest/detail still fall back to the shared empty-state stubs. This looks like deliberate empty-state cleanup, so the fix exercises the populated state rather than reverting the product gate.

Test-only change; no product code touched.

## Evidence

Local headless runs at `8e320044f9fc` + this change (`CI=true`, chromium):

```
Running 3 tests using 1 worker
  ✓  1 shell-view-agent-bridge-inventory.spec.ts:312:1 › shell views expose concrete chat/voice-drivable controls through the agent bridge (12.3s)
  ✓  2 shell-view-agent-bridge-inventory.spec.ts:325:1 › shell bridge can fill and click representative editable controls (4.0s)
  ✓  3 warming-shell-startup.spec.ts:74:1 › the shell + composer paint while the agent warms up, then go live (2.1s)
  3 passed (29.4s)
```

Boot-path proof that the formerly-dominant failure is green at head (the exact CI-failing tests):

```
  ✓  1 all-pages-clicksafe.spec.ts:1001:5 › route renders without console failures: desktop onboarding (first run) (2.0s)
  ✓  2 all-pages-clicksafe.spec.ts:1001:5 › route renders without console failures: desktop assistant home (1.5s)
  2 passed (17.4s)
```

Before this change, both specs failed locally with exactly the CI errors (strict-mode 2/5-element ambiguity; `Received: []` for the trajectories agent ids).

Biome clean on both files. `bun run --cwd packages/app typecheck` covers `src/**` only (specs excluded); its current failures are pre-existing cross-package issues in `packages/agent` (dual drizzle install across worktree node_modules, unbuilt plugin dist) untouched by this test-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)