### PR TITLE
fix(cloud): reject unknown voice-list includeInactive flag

### DIFF
--- a/packages/cloud/api/v1/voice/list/route.include-inactive.test.ts
+++ b/packages/cloud/api/v1/voice/list/route.include-inactive.test.ts
@@ -92,10 +92,7 @@ describe("GET /api/v1/voice/list includeInactive identity", () => {
 
   test("accepts includeInactive=true as the full Voice Studio catalog", async () => {
     listByOrganization.mockResolvedValueOnce({
-      voices: [
-        voiceRow("instant", true),
-        voiceRow("professional", false),
-      ],
+      voices: [voiceRow("instant", true), voiceRow("professional", false)],
       total: 2,
       limit: 50,
       offset: 0,
@@ -118,6 +115,24 @@ describe("GET /api/v1/voice/list includeInactive identity", () => {
       expect(response.status).toBe(400);
       const body = (await response.json()) as { error: string };
       expect(body.error).toBe("Invalid includeInactive");
+      expect(listByOrganization).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?includeInactive=false&includeInactive=true",
+    "?includeInactive=true&includeInactive=false",
+    "?includeInactive=true&includeInactive=true",
+    "?includeInactive=&includeInactive=false",
+  ])(
+    "rejects ambiguous duplicate query %s before repository access",
+    async (query) => {
+      const response = await listVoices(query);
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        error: "Invalid includeInactive",
+      });
       expect(listByOrganization).not.toHaveBeenCalled();
     },
   );

--- a/packages/cloud/api/v1/voice/list/route.include-inactive.test.ts
+++ b/packages/cloud/api/v1/voice/list/route.include-inactive.test.ts
@@ -1,0 +1,124 @@
+/**
+ * GET /api/v1/voice/list `includeInactive` is Voice Studio
+ * inactive-row identity, not leftover tax on cloneType (#21047) or
+ * prefix-coerced limit. Stock develop treated any non-exact `true`
+ * token as hide-inactive, so `includeInactive=TRUE` still listed
+ * only live clones instead of a 400.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+function voiceRow(cloneType: "instant" | "professional", isActive = true) {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+  return {
+    id: `voice-${cloneType}`,
+    elevenlabsVoiceId: `el-${cloneType}`,
+    name: `${cloneType} voice`,
+    description: null,
+    cloneType,
+    sampleCount: 1,
+    totalAudioDurationSeconds: 1,
+    audioQualityScore: "1.00",
+    usageCount: 0,
+    lastUsedAt: null,
+    isActive,
+    isPublic: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+const listByOrganization = mock(
+  async (
+    _organizationId: string,
+    _options: {
+      includeInactive?: boolean;
+      cloneType?: "instant" | "professional";
+      limit?: number;
+      offset?: number;
+    },
+  ) => ({
+    voices: [voiceRow("instant"), voiceRow("professional")],
+    total: 2,
+    limit: 50,
+    offset: 0,
+    hasMore: false,
+  }),
+);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>
+    c.json({ error: "internal_error" }, 500),
+}));
+mock.module("@/db/repositories/user-voices", () => ({
+  userVoicesRepository: { listByOrganization },
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/v1/voice/list", route);
+
+function listVoices(query = "") {
+  return app.request(`/api/v1/voice/list${query}`);
+}
+
+describe("GET /api/v1/voice/list includeInactive identity", () => {
+  beforeEach(() => {
+    listByOrganization.mockClear();
+  });
+
+  test.each(["", "?includeInactive=", "?includeInactive=false"])(
+    "accepts %s as the live Voice Studio catalog",
+    async (query) => {
+      const response = await listVoices(query);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { success: boolean };
+      expect(body.success).toBe(true);
+      expect(listByOrganization).toHaveBeenCalledTimes(1);
+      expect(listByOrganization.mock.calls[0][1]).toMatchObject({
+        includeInactive: false,
+      });
+    },
+  );
+
+  test("accepts includeInactive=true as the full Voice Studio catalog", async () => {
+    listByOrganization.mockResolvedValueOnce({
+      voices: [
+        voiceRow("instant", true),
+        voiceRow("professional", false),
+      ],
+      total: 2,
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+    });
+    const response = await listVoices("?includeInactive=true");
+    expect(response.status).toBe(200);
+    expect(listByOrganization).toHaveBeenCalledTimes(1);
+    expect(listByOrganization.mock.calls[0][1]).toMatchObject({
+      includeInactive: true,
+    });
+  });
+
+  test.each(["FALSE", "TRUE", "0", "1", "no", "yes", "foo"])(
+    "rejects includeInactive=%s before listByOrganization",
+    async (token) => {
+      const response = await listVoices(
+        `?includeInactive=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid includeInactive");
+      expect(listByOrganization).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/voice/list/route.ts
+++ b/packages/cloud/api/v1/voice/list/route.ts
@@ -68,7 +68,25 @@ app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    const includeInactive = c.req.query("includeInactive") === "true";
+    // Voice Studio inactive-row identity, not leftover tax on cloneType
+    // (#21047). includeInactive=TRUE used to silently hide soft-deleted
+    // voices instead of 400.
+    const requestedInactive = c.req.query("includeInactive");
+    if (
+      requestedInactive != null &&
+      requestedInactive !== "" &&
+      requestedInactive !== "true" &&
+      requestedInactive !== "false"
+    ) {
+      return c.json(
+        {
+          error: "Invalid includeInactive",
+          message: 'includeInactive must be "true" or "false".',
+        },
+        400,
+      );
+    }
+    const includeInactive = requestedInactive === "true";
     const cloneType = parseVoiceCloneType(c.req.query("cloneType"));
     if (cloneType === null) {
       return c.json({ error: "Invalid cloneType" }, 400);

--- a/packages/cloud/api/v1/voice/list/route.ts
+++ b/packages/cloud/api/v1/voice/list/route.ts
@@ -71,17 +71,20 @@ app.get("/", async (c) => {
     // Voice Studio inactive-row identity, not leftover tax on cloneType
     // (#21047). includeInactive=TRUE used to silently hide soft-deleted
     // voices instead of 400.
-    const requestedInactive = c.req.query("includeInactive");
+    const inactiveValues = c.req.queries("includeInactive") ?? [];
+    const requestedInactive = inactiveValues[0];
     if (
-      requestedInactive != null &&
-      requestedInactive !== "" &&
-      requestedInactive !== "true" &&
-      requestedInactive !== "false"
+      inactiveValues.length > 1 ||
+      (requestedInactive != null &&
+        requestedInactive !== "" &&
+        requestedInactive !== "true" &&
+        requestedInactive !== "false")
     ) {
       return c.json(
         {
           error: "Invalid includeInactive",
-          message: 'includeInactive must be "true" or "false".',
+          message:
+            'includeInactive must be specified at most once as "true" or "false".',
         },
         400,
       );


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on voice-list
`includeInactive` identity. Voice Studio inactive-row class, leftover
tax after cloneType (#21047). Not leftover tax on analytics-export
includeMetadata, agent-resume sync, app-promote history, prefix-coerced
limit/offset, models catalogOnly/refresh, Life Ops inbox bools, or
telegram webhook flag.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `includeInactive` only on `/api/v1/voice/list`.
Omitted/empty/`false` still hide soft-deleted voices (today's default).
Exact `true` still includes inactive rows.
Unknown / uppercase tokens 400 before listByOrganization.
cloneType / limit / offset parsers stay untouched.

# Background

## What does this PR do?

`GET /api/v1/voice/list` treated any non-exact `true` token as
hide-inactive. `includeInactive=TRUE` silently listed only live clones
instead of a 400.

- omitted / empty / `false` → live Voice Studio catalog (200)
- exact `true` → full catalog including soft-deleted voices
- `FALSE` / `TRUE` / `0` / `1` / `no` / `yes` / `foo` → **400** before listByOrganization

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers opt into inactive rows with `?includeInactive=true`. A common
`includeInactive=TRUE` after a client uppercases the bool must not
silently hide those rows. This is leftover tax after cloneType
(#21047), which left the includeInactive parser untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/voice/list/route.include-inactive.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/voice/list/route.include-inactive.test.ts
```

11 passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; voice-list `includeInactive` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; voice-list `includeInactive` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; voice-list `includeInactive` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real includeInactive tokens and assert 400 before listByOrganization; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no container export; illegal tokens 400 before listByOrganization.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`includeInactive` tokens reject; omitted/canonical still bind the matching
inactive-row path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file voice-list
includeInactive parse with a green focused suite (11 tests). Full monorepo
verify is unrelated to this query grammar and was skipped to keep the
proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:85104f759af90a8b2532e2a22d5af8c2c2d2a432 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->

## Maintainer repair and validation

Hono’s single-value `query()` accessor accepted the first duplicate, so conflicting values could select different inactive-row visibility across parsers/proxies. The route now uses `queries()` and rejects every duplicate occurrence, including identical and empty duplicates, before `listByOrganization`. Exact-head production-route tests pass 15/15; touched-file Biome and diff-check are clean. Cloud API typecheck is blocked in the sparse review environment only by absent `@cloudflare/workers-types`. Repair head: `85104f759af90a8b2532e2a22d5af8c2c2d2a432`.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@972cf5d8f3be22e791f943cc33e75139edf81de5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-b]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@972cf5d8f3be22e791f943cc33e75139edf81de5:packages/skills/skills/contribute-to-eliza"} -->