### PR TITLE
fix(app): finish full iOS device e2e signing lane

### DIFF
--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -164,6 +164,13 @@ deploy/log/capture work and wait up to `ELIZA_IOS_DEVICE_UNLOCK_WAIT_SECONDS`
 # app explicitly → codesign verify → devicectl install → launch.
 bun run --cwd packages/app ios:device:deploy -- --device <id>   # flags: --skip-build --no-launch --identity <sha1>
 
+# With ASC credentials set, reconcile supported Bundle ID capabilities from
+# every target entitlement, mint development profiles, decode them, and fail if
+# the profile does not grant the target (including exact App Groups).
+bun run --cwd packages/app ios:device:provision -- --device <udid> --product <unsigned App.app>
+# Family Controls approval and exact App Group registration/assignment remain
+# Account Holder/Admin prerequisites: the public ASC API cannot grant them.
+
 # Bounded console capture (relaunches the app with devicectl --console attached,
 # default 120 s) and/or pull the boot-trace JSON from the app data container.
 # ENGINE OBSERVABILITY: use --no-console --pull-boot-trace. Attached console runs
@@ -180,6 +187,11 @@ bun run --cwd packages/app ios:device:logs -- --device <id> --no-console --pull-
 # Pass --only-testing AppUITests/<Class>[/test] for a single narrow shard.
 bun run --cwd packages/app capture:ios-sim:boot                  # simulator (booted sim auto-detected)
 bun run --cwd packages/app ios:device:capture -- --device <id> --app-path <signed App.app>  # physical device
+
+# Full physical-device acceptance: fresh full app+appex deploy, fresh unsigned
+# XCUITest build, graft-sign runner, BootCapture, then boot-trace pull. Extension
+# stripping is available only as the explicit degraded --skip-appexes mode.
+bun run --cwd packages/app ios:device:e2e -- --device <id>
 
 # Strict simulator boot/chat health gate: same harness, but error-card,
 # no-reply, all-skipped, and zero-passed summaries are hard failures.

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -170,6 +170,9 @@ bun run --cwd packages/app ios:device:deploy -- --device <id>   # flags: --skip-
 bun run --cwd packages/app ios:device:provision -- --device <udid> --product <unsigned App.app>
 # Family Controls approval and exact App Group registration/assignment remain
 # Account Holder/Admin prerequisites: the public ASC API cannot grant them.
+# Stale/invalid immutable profiles are preserved while a uniquely named
+# replacement is created; rerun after an administrator corrects a managed grant.
+# A decoded, covering replacement is reused on later runs.
 
 # Bounded console capture (relaunches the app with devicectl --console attached,
 # default 120 s) and/or pull the boot-trace JSON from the app data container.

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -164,6 +164,13 @@ deploy/log/capture work and wait up to `ELIZA_IOS_DEVICE_UNLOCK_WAIT_SECONDS`
 # app explicitly → codesign verify → devicectl install → launch.
 bun run --cwd packages/app ios:device:deploy -- --device <id>   # flags: --skip-build --no-launch --identity <sha1>
 
+# With ASC credentials set, reconcile supported Bundle ID capabilities from
+# every target entitlement, mint development profiles, decode them, and fail if
+# the profile does not grant the target (including exact App Groups).
+bun run --cwd packages/app ios:device:provision -- --device <udid> --product <unsigned App.app>
+# Family Controls approval and exact App Group registration/assignment remain
+# Account Holder/Admin prerequisites: the public ASC API cannot grant them.
+
 # Bounded console capture (relaunches the app with devicectl --console attached,
 # default 120 s) and/or pull the boot-trace JSON from the app data container.
 # ENGINE OBSERVABILITY: use --no-console --pull-boot-trace. Attached console runs
@@ -180,6 +187,11 @@ bun run --cwd packages/app ios:device:logs -- --device <id> --no-console --pull-
 # Pass --only-testing AppUITests/<Class>[/test] for a single narrow shard.
 bun run --cwd packages/app capture:ios-sim:boot                  # simulator (booted sim auto-detected)
 bun run --cwd packages/app ios:device:capture -- --device <id> --app-path <signed App.app>  # physical device
+
+# Full physical-device acceptance: fresh full app+appex deploy, fresh unsigned
+# XCUITest build, graft-sign runner, BootCapture, then boot-trace pull. Extension
+# stripping is available only as the explicit degraded --skip-appexes mode.
+bun run --cwd packages/app ios:device:e2e -- --device <id>
 
 # Strict simulator boot/chat health gate: same harness, but error-card,
 # no-reply, all-skipped, and zero-passed summaries are hard failures.

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -170,6 +170,9 @@ bun run --cwd packages/app ios:device:deploy -- --device <id>   # flags: --skip-
 bun run --cwd packages/app ios:device:provision -- --device <udid> --product <unsigned App.app>
 # Family Controls approval and exact App Group registration/assignment remain
 # Account Holder/Admin prerequisites: the public ASC API cannot grant them.
+# Stale/invalid immutable profiles are preserved while a uniquely named
+# replacement is created; rerun after an administrator corrects a managed grant.
+# A decoded, covering replacement is reused on later runs.
 
 # Bounded console capture (relaunches the app with devicectl --console attached,
 # default 120 s) and/or pull the boot-trace JSON from the app data container.

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -56,7 +56,17 @@ bun run test:e2e       # Playwright UI smoke (ui-smoke config)
 bun run ios            # Build + open Xcode
 bun run android        # Build + open Android Studio
 bun run cap:sync       # Capacitor sync (both platforms) + patch iOS plist
+
+# Physical iPhone lane (macOS + Apple development credentials/device required)
+bun run ios:device:provision -- --device <udid> --product <App.app>
+bun run ios:device:e2e -- --device <id> # full app+appexes + freshly graft-signed XCUITest runner
 ```
+
+Provisioning enables capabilities exposed by the public App Store Connect API,
+then decodes every minted profile and verifies the complete target entitlement
+set. Family Controls approval and exact App Group registration/assignment must
+already be completed by an Apple Account Holder/Admin; missing grants fail the
+lane rather than silently installing a reduced app.
 
 The desktop shell is built by Electrobun from the repo root (`bun run dev:desktop`),
 not from inside this package â `packages/app` only produces the renderer.

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -66,7 +66,11 @@ Provisioning enables capabilities exposed by the public App Store Connect API,
 then decodes every minted profile and verifies the complete target entitlement
 set. Family Controls approval and exact App Group registration/assignment must
 already be completed by an Apple Account Holder/Admin; missing grants fail the
-lane rather than silently installing a reduced app.
+lane rather than silently installing a reduced app. Capability changes can
+invalidate immutable profiles, so the provisioner preserves the prior profile
+and creates a uniquely named replacement; rerun it after an administrator fixes
+a missing managed grant. Later runs reuse the first replacement whose decoded
+grants still cover the target instead of minting another profile.
 
 The desktop shell is built by Electrobun from the repo root (`bun run dev:desktop`),
 not from inside this package â `packages/app` only produces the renderer.

--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -47,11 +47,13 @@ import {
 } from "./ios-device-devicectl.mjs";
 import {
   assertDeviceUnlocked,
+  buildCodesignVerificationPlan,
   buildIosXcuitestShardPlan,
   buildPlistXml,
   buildRunnerCodesignPlan,
   buildSimctlListappsArgs,
   classifyCodesignPreflight,
+  classifyCodesignVerificationResults,
   classifyIsolatedReruns,
   classifyRunnerSigningMode,
   classifyXcresultSummaryForGate,
@@ -327,10 +329,51 @@ function runCaptureCommand(command, args, { label, required = true } = {}) {
  */
 function isCodeSigned(appPath) {
   if (!fs.existsSync(appPath)) return false;
-  const result = spawnSync("codesign", ["--verify", "--strict", appPath], {
-    stdio: "ignore",
+  const nested = [];
+  const stack = [appPath];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (/\.(?:appex|app|framework|xctest)$/.test(entry.name)) {
+          nested.push(full);
+        }
+        // Framework contents are sealed as a unit and may contain version
+        // symlink layouts; verify the framework itself without traversing it.
+        if (!entry.name.endsWith(".framework")) stack.push(full);
+      } else if (entry.name.endsWith(".dylib")) {
+        nested.push(full);
+      }
+    }
+  }
+  const targets = [...new Set(nested)].sort((a, b) => b.length - a.length);
+  targets.push(appPath);
+  const results = targets.map((target) => ({
+    path: target,
+    deep: false,
+    valid:
+      spawnSync("codesign", ["--verify", "--strict", target], {
+        stdio: "ignore",
+      }).status === 0,
+  }));
+  results.push({
+    path: appPath,
+    deep: true,
+    valid:
+      spawnSync("codesign", ["--verify", "--deep", "--strict", appPath], {
+        stdio: "ignore",
+      }).status === 0,
   });
-  return result.status === 0;
+  const verdict = classifyCodesignVerificationResults(results);
+  if (!verdict.valid) {
+    log(
+      `codesign reuse rejected: ${verdict.failures
+        .map((failure) => `${failure.path}${failure.deep ? " (deep)" : ""}`)
+        .join(", ")}`,
+    );
+  }
+  return verdict.valid;
 }
 
 /** Loose dylibs under `root`, excluding anything inside a .framework (those are signed as units). */
@@ -383,6 +426,7 @@ function graftSignRunner({ runnerApp, deviceUdid, workDir }) {
   const { selected: profile, rejected } = selectProvisioningProfile(profiles, {
     bundleId: runnerBundleId,
     deviceUdid,
+    requireGetTaskAllow: true,
   });
   if (!profile) {
     const rejectedLines = rejected
@@ -483,8 +527,15 @@ function graftSignRunner({ runnerApp, deviceUdid, workDir }) {
     signArgs.push(step.path);
     runInherit("codesign", signArgs);
   }
-  runInherit("codesign", ["--verify", "--deep", "--strict", runnerApp]);
-  log("runner codesign --verify --deep --strict: OK");
+  for (const verification of buildCodesignVerificationPlan(plan, runnerApp)) {
+    runInherit("codesign", [
+      "--verify",
+      ...(verification.deep ? ["--deep"] : []),
+      "--strict",
+      verification.path,
+    ]);
+  }
+  log("runner explicit nested + deep codesign verification: OK");
 }
 
 /**

--- a/packages/app/scripts/ios-device-deploy.mjs
+++ b/packages/app/scripts/ios-device-deploy.mjs
@@ -44,6 +44,7 @@ import {
 import {
   assertDeviceUnlocked,
   buildCodesignPlan,
+  buildCodesignVerificationPlan,
   buildPlistXml,
   DEFAULT_APP_BUNDLE_ID,
   deriveSigningEntitlements,
@@ -356,8 +357,15 @@ function signApp({
     runInherit("codesign", args);
   }
 
-  runInherit("codesign", ["--verify", "--deep", "--strict", stagedApp]);
-  log("codesign --verify --deep --strict: OK");
+  for (const verification of buildCodesignVerificationPlan(plan, stagedApp)) {
+    runInherit("codesign", [
+      "--verify",
+      ...(verification.deep ? ["--deep"] : []),
+      "--strict",
+      verification.path,
+    ]);
+  }
+  log("explicit nested + deep codesign verification: OK");
 }
 
 // ── Main ────────────────────────────────────────────────────────────────

--- a/packages/app/scripts/ios-device-e2e.mjs
+++ b/packages/app/scripts/ios-device-e2e.mjs
@@ -7,8 +7,7 @@
  *
  * Chains three already-proven scripts through the argv builders in
  * `lib/ios-device-e2e-lib.mjs`:
- *   1. ios-device-deploy.mjs  --skip-appexes  (build → sign → devicectl install;
- *      appex surfaces excluded — logged loudly by the deploy script). The deploy
+ *   1. ios-device-deploy.mjs (build → sign full app + appexes → install). The deploy
  *      also writes the renderer-freshness assert + the deploy ledger row.
  *   2. ios-device-capture.mjs --platform device  (BootCapture — the ON-DEVICE
  *      assertion: did the freshly deployed app reach home or the error card?
@@ -31,7 +30,7 @@
  *
  * Usage:
  *   node scripts/ios-device-e2e.mjs [--device <id>] [--skip-appexes]
- *     [--no-skip-appexes] [--skip-logs] [--require-chat]
+ *     [--skip-logs] [--require-chat]
  *     [--bundle-id <id>] [--output <dir>]
  */
 import { spawnSync } from "node:child_process";
@@ -195,17 +194,11 @@ function captureDeviceFailure(bundle, step, error) {
 
 async function main() {
   const args = parseCliArgs(process.argv.slice(2), {
-    booleans: [
-      "skip-appexes",
-      "no-skip-appexes",
-      "skip-logs",
-      "require-chat",
-      "help",
-    ],
+    booleans: ["skip-appexes", "skip-logs", "require-chat", "help"],
   });
   if (args.help) {
     console.log(
-      "Usage: node scripts/ios-device-e2e.mjs [--device <id>] [--no-skip-appexes] [--skip-logs] [--require-chat] [--bundle-id <id>] [--output <dir>]",
+      "Usage: node scripts/ios-device-e2e.mjs [--device <id>] [--skip-appexes] [--skip-logs] [--require-chat] [--bundle-id <id>] [--output <dir>]",
     );
     return;
   }
@@ -229,9 +222,9 @@ async function main() {
     `device: ${device.name} (identifier ${device.identifier}, udid ${device.udid})`,
   );
 
-  // --skip-appexes is the default unattended posture (PR #13174); --no-skip-appexes
-  // opts back in when per-appex profiles exist.
-  const skipAppexes = !args["no-skip-appexes"];
+  // Full app + appexes is the acceptance path. --skip-appexes is an explicit
+  // degraded-mode escape hatch recorded in bundle metadata.
+  const skipAppexes = Boolean(args["skip-appexes"]);
   const bundleId = args["bundle-id"] || null;
   activeDeviceContext = {
     bundleId,
@@ -280,6 +273,13 @@ async function main() {
           scriptsDir,
           deviceId,
           outputDir: smokeDir,
+          appPath: path.join(
+            appRoot,
+            "ios",
+            "build",
+            "device-deploy-stage",
+            "App.app",
+          ),
           requireChat: Boolean(args["require-chat"]),
           bundleId,
         });

--- a/packages/app/scripts/ios-device-lib.mjs
+++ b/packages/app/scripts/ios-device-lib.mjs
@@ -287,11 +287,12 @@ export function normalizeProvisioningProfile(plist, sourcePath) {
  * Returns { ok, reasons } — reasons is the list of disqualifiers (empty when ok).
  *
  * @param {ReturnType<typeof normalizeProvisioningProfile>} profile
- * @param {{ bundleId: string, deviceUdid: string | null, now?: Date }} target
+ * @param {{ bundleId: string, deviceUdid: string | null, now?: Date,
+ *           requireGetTaskAllow?: boolean }} target
  */
 export function profileMatchesTarget(
   profile,
-  { bundleId, deviceUdid, now = new Date() },
+  { bundleId, deviceUdid, now = new Date(), requireGetTaskAllow = false },
 ) {
   const reasons = [];
   const appId = profile.applicationIdentifier;
@@ -320,6 +321,11 @@ export function profileMatchesTarget(
     if (!profile.provisionedDevices.includes(deviceUdid)) {
       reasons.push(`device UDID ${deviceUdid} not in ProvisionedDevices`);
     }
+  }
+  if (requireGetTaskAllow && !profile.getTaskAllow) {
+    reasons.push(
+      "profile is not a development/debug profile (get-task-allow is not true)",
+    );
   }
   return { ok: reasons.length === 0, reasons };
 }
@@ -496,6 +502,31 @@ export function buildRunnerCodesignPlan(layout) {
     entitlementsPath: layout.entitlementsPath,
   });
   return steps;
+}
+
+/**
+ * Expand a signing plan into explicit inner-to-outer verification targets.
+ * A final deep verification is useful, but it is not a substitute for checking
+ * every nested code object: codesign --deep has historically missed unsigned
+ * dylibs inside extensions on this lane.
+ */
+export function buildCodesignVerificationPlan(signingPlan, rootPath) {
+  const seen = new Set();
+  const targets = [];
+  for (const step of signingPlan) {
+    if (!step?.path || seen.has(step.path)) continue;
+    seen.add(step.path);
+    targets.push({ path: step.path, deep: false });
+  }
+  if (!seen.has(rootPath)) targets.push({ path: rootPath, deep: false });
+  targets.push({ path: rootPath, deep: true });
+  return targets;
+}
+
+/** Classify actual per-object codesign exits; one failed nested/deep check fails reuse. */
+export function classifyCodesignVerificationResults(results) {
+  const failures = results.filter((result) => !result.valid);
+  return { valid: failures.length === 0, failures };
 }
 
 /**

--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -17,6 +17,7 @@ import {
 import {
   assertDeviceUnlocked,
   buildCodesignPlan,
+  buildCodesignVerificationPlan,
   buildIosXcuitestShardPlan,
   buildOnlyTestingIdentifier,
   buildPlistXml,
@@ -24,6 +25,7 @@ import {
   buildSimctlListappsArgs,
   CONSOLE_SIGTRAP_SIGNATURE,
   classifyCodesignPreflight,
+  classifyCodesignVerificationResults,
   classifyConsoleExit,
   classifyIsolatedReruns,
   classifyRunnerSigningMode,
@@ -263,6 +265,24 @@ describe("profileMatchesTarget", () => {
   });
 });
 
+describe("development runner profile requirement (#13567)", () => {
+  it("rejects a distribution profile without get-task-allow", () => {
+    const verdict = profileMatchesTarget(
+      normalized({
+        appIdentifier: `${TEAM}.ai.elizaos.app.xctrunner`,
+        getTaskAllow: false,
+      }),
+      {
+        bundleId: "ai.elizaos.app.xctrunner",
+        deviceUdid: DEVICE_UDID,
+        requireGetTaskAllow: true,
+      },
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reasons.join(" ")).toMatch(/get-task-allow/);
+  });
+});
+
 describe("selectProvisioningProfile", () => {
   const target = { bundleId: "ai.elizaos.app", deviceUdid: DEVICE_UDID };
 
@@ -445,6 +465,40 @@ describe("buildRunnerCodesignPlan (#13567)", () => {
     });
     expect(plan).toEqual([
       { path: "/dd/AppUITests-Runner.app", entitlementsPath: "/out/ent.plist" },
+    ]);
+  });
+});
+
+describe("buildCodesignVerificationPlan (#13567)", () => {
+  it("checks every nested object explicitly before the root deep check", () => {
+    expect(
+      buildCodesignVerificationPlan(
+        [
+          { path: "/App/F.framework", entitlementsPath: null },
+          { path: "/App/PlugIns/E.appex", entitlementsPath: "/ent.plist" },
+          { path: "/App", entitlementsPath: "/app.plist" },
+        ],
+        "/App",
+      ),
+    ).toEqual([
+      { path: "/App/F.framework", deep: false },
+      { path: "/App/PlugIns/E.appex", deep: false },
+      { path: "/App", deep: false },
+      { path: "/App", deep: true },
+    ]);
+  });
+});
+
+describe("classifyCodesignVerificationResults (#13567)", () => {
+  it("rejects reuse when the outer bundle is valid but nested code is invalid", () => {
+    const verdict = classifyCodesignVerificationResults([
+      { path: "/Runner.app/PlugIns/Tests.xctest", deep: false, valid: false },
+      { path: "/Runner.app", deep: false, valid: true },
+      { path: "/Runner.app", deep: true, valid: true },
+    ]);
+    expect(verdict.valid).toBe(false);
+    expect(verdict.failures.map((failure) => failure.path)).toEqual([
+      "/Runner.app/PlugIns/Tests.xctest",
     ]);
   });
 });

--- a/packages/app/scripts/ios-device-provision.mjs
+++ b/packages/app/scripts/ios-device-provision.mjs
@@ -25,10 +25,14 @@
  * Bundle ids are resolved from (in precedence order): explicit `--bundle-id`
  * flags, then the appexes discovered inside `--product <App.app>/PlugIns/*.appex`
  * (their `CFBundleIdentifier`) plus the app itself. Idempotent — an already
- * registered device / existing bundle id is reused; each device gets its own
- * stable profile name, so provisioning one device never removes another
- * device's working profile. Existing valid profiles are reused; an invalid
- * same-name profile fails the run instead of being deleted before replacement.
+ * registered device / existing bundle id is reused. Before minting, supported
+ * Bundle ID capabilities are reconciled from the maintained target entitlement
+ * files; every downloaded profile is decoded and must grant all target
+ * entitlements (including exact App Groups) or the run fails closed. Each
+ * device gets its own stable profile name, so provisioning one device never
+ * removes another device's working profile. Existing valid profiles are
+ * reused; an invalid same-name profile fails the run instead of being deleted
+ * before replacement.
  * Minted profiles are written into the profiles dir where `discoverProfiles()`
  * looks.
  *
@@ -43,6 +47,8 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parsePlist } from "./ios-device-lib.mjs";
 
 export const ASC_API_BASE = "https://api.appstoreconnect.apple.com";
 export const ASC_AUDIENCE = "appstoreconnect-v1";
@@ -220,6 +226,143 @@ export async function ensureBundleId(
   return { id: created.data.id, created: true };
 }
 
+const ENTITLEMENT_REQUIREMENTS = Object.freeze({
+  "com.apple.developer.associated-domains": {
+    capabilityType: "ASSOCIATED_DOMAINS",
+  },
+  "com.apple.developer.family-controls": {
+    managed:
+      "Family Controls is approval-gated; an Account Holder/Admin must enable the approved capability on this App ID",
+  },
+  "com.apple.developer.healthkit": { capabilityType: "HEALTHKIT" },
+  "com.apple.developer.healthkit.background-delivery": {
+    managed:
+      "HealthKit background delivery is validated from the minted profile after enabling HEALTHKIT",
+  },
+  "com.apple.developer.kernel.extended-virtual-addressing": {
+    managed:
+      "extended virtual addressing is profile-managed and has no App Store Connect CapabilityType",
+  },
+  "com.apple.developer.kernel.increased-memory-limit": {
+    managed:
+      "increased memory limit is profile-managed and has no App Store Connect CapabilityType",
+  },
+  "com.apple.security.application-groups": {
+    capabilityType: "APP_GROUPS",
+    managed:
+      "App Group identifiers must already be registered and assigned to the App ID by an Account Holder/Admin; the public ASC API only enables APP_GROUPS",
+  },
+  "aps-environment": { capabilityType: "PUSH_NOTIFICATIONS" },
+});
+
+export function classifyEntitlementProvisioningRequirements(entitlements = {}) {
+  const supportedCapabilities = new Set();
+  const profileValidatedManaged = [];
+  const unclassified = [];
+  for (const key of Object.keys(entitlements)) {
+    const requirement = ENTITLEMENT_REQUIREMENTS[key];
+    if (!requirement) {
+      unclassified.push(key);
+      continue;
+    }
+    if (requirement.capabilityType) {
+      supportedCapabilities.add(requirement.capabilityType);
+    }
+    if (requirement.managed) {
+      profileValidatedManaged.push({ key, guidance: requirement.managed });
+    }
+  }
+  return {
+    supportedCapabilities: [...supportedCapabilities].sort(),
+    profileValidatedManaged,
+    unclassified,
+  };
+}
+
+export function capabilitiesForEntitlements(entitlements = {}) {
+  return classifyEntitlementProvisioningRequirements(entitlements)
+    .supportedCapabilities;
+}
+
+/** Reconcile every ASC-supported capability implied by target entitlements. */
+export async function reconcileBundleCapabilities(
+  asc,
+  { bundleIdRef, entitlements = {} },
+) {
+  const listed = await asc(
+    "GET",
+    `/v1/bundleIds/${bundleIdRef}/bundleIdCapabilities?limit=200`,
+  );
+  const existing = new Set(
+    (listed.data ?? []).map((row) => row.attributes?.capabilityType),
+  );
+  const enabled = [];
+  for (const capabilityType of capabilitiesForEntitlements(entitlements)) {
+    if (!existing.has(capabilityType)) {
+      await asc("POST", "/v1/bundleIdCapabilities", {
+        data: {
+          type: "bundleIdCapabilities",
+          attributes: { capabilityType },
+          relationships: {
+            bundleId: { data: { type: "bundleIds", id: bundleIdRef } },
+          },
+        },
+      });
+    }
+    enabled.push(capabilityType);
+  }
+  return enabled;
+}
+
+function entitlementValueCovered(required, granted) {
+  if (required === true) return granted === true;
+  if (Array.isArray(required)) {
+    return (
+      Array.isArray(granted) && required.every((item) => granted.includes(item))
+    );
+  }
+  // Build-variable values such as $(APS_ENVIRONMENT) mean the entitlement must
+  // exist; the profile chooses the concrete development value.
+  if (typeof required === "string" && /^\$\(.+\)$/.test(required)) {
+    return granted !== undefined && granted !== false;
+  }
+  return Object.is(required, granted);
+}
+
+export function validateProvisioningEntitlements(
+  required,
+  granted,
+  bundleIdentifier,
+) {
+  const requirements = classifyEntitlementProvisioningRequirements(required);
+  if (requirements.unclassified.length > 0) {
+    throw new Error(
+      `Provisioning requirements for ${bundleIdentifier} contain unclassified target entitlements: ${requirements.unclassified.join(", ")}. ` +
+        "Add an explicit ASC-supported or profile-managed policy before minting.",
+    );
+  }
+  const missing = Object.entries(required ?? {})
+    .filter(([key, value]) => !entitlementValueCovered(value, granted?.[key]))
+    .map(([key]) => key);
+  if (missing.length > 0) {
+    const guidance = requirements.profileValidatedManaged
+      .filter((row) => missing.includes(row.key))
+      .map((row) => `${row.key}: ${row.guidance}`)
+      .join("; ");
+    throw new Error(
+      `Provisioning profile for ${bundleIdentifier} does not grant target entitlements: ${missing.join(", ")}. ` +
+        `${guidance || "Reconcile the Bundle ID capabilities in App Store Connect before deploying."}`,
+    );
+  }
+}
+
+export function decodeMobileProvision(file) {
+  const xml = execFileSync("security", ["cms", "-D", "-i", file], {
+    encoding: "utf8",
+  });
+  return parsePlist(xml);
+}
+
 /**
  * Keep development profile names stable per bundle+device without embedding the
  * full UDID in ASC-visible names.
@@ -353,7 +496,10 @@ export function writeProfile(profileData, dir = profilesDir()) {
  * each `CFBundleIdentifier` (`plutil`, macOS). `runPlutil` is injectable for
  * tests; the default shells out to `plutil`.
  */
-export function discoverAppBundleIds(productAppDir, { runPlutil } = {}) {
+export function discoverAppBundleIds(
+  productAppDir,
+  { runPlutil, readTargetEntitlements } = {},
+) {
   const read =
     runPlutil ||
     ((plistPath) =>
@@ -362,10 +508,49 @@ export function discoverAppBundleIds(productAppDir, { runPlutil } = {}) {
         ["-extract", "CFBundleIdentifier", "raw", "-o", "-", plistPath],
         { encoding: "utf8" },
       ).trim());
+  const entitlementsRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    "app-core",
+    "platforms",
+    "ios",
+    "App",
+    "App",
+  );
+  const readEntitlements =
+    readTargetEntitlements ??
+    ((targetName) => {
+      const source =
+        targetName === "App"
+          ? path.join(entitlementsRoot, "App.entitlements")
+          : path.join(
+              entitlementsRoot,
+              targetName,
+              `${targetName}.entitlements`,
+            );
+      if (!fs.existsSync(source)) {
+        throw new Error(
+          `No maintained entitlement source found for iOS target ${targetName}: ${source}`,
+        );
+      }
+      const xml = execFileSync(
+        "plutil",
+        ["-convert", "xml1", "-o", "-", source],
+        {
+          encoding: "utf8",
+        },
+      );
+      return parsePlist(xml);
+    });
   const out = [];
   const appPlist = path.join(productAppDir, "Info.plist");
   if (fs.existsSync(appPlist)) {
-    out.push({ identifier: read(appPlist), name: "App" });
+    out.push({
+      identifier: read(appPlist),
+      name: "App",
+      entitlements: readEntitlements("App"),
+    });
   }
   const plugIns = path.join(productAppDir, "PlugIns");
   if (fs.existsSync(plugIns)) {
@@ -376,6 +561,7 @@ export function discoverAppBundleIds(productAppDir, { runPlutil } = {}) {
         out.push({
           identifier: read(plist),
           name: appex.replace(/\.appex$/, ""),
+          entitlements: readEntitlements(appex.replace(/\.appex$/, "")),
         });
       }
     }
@@ -414,6 +600,7 @@ export async function provision({
   fetchImpl = fetch,
   dir = profilesDir(),
   now,
+  decodeProfile = decodeMobileProvision,
 }) {
   if (!udid) throw new Error("provision: a device UDID is required.");
   validateBundleIds(bundleIds);
@@ -427,6 +614,10 @@ export async function provision({
       identifier: bid.identifier,
       name: bid.name,
     });
+    await reconcileBundleCapabilities(asc, {
+      bundleIdRef: bundle.id,
+      entitlements: bid.entitlements ?? {},
+    });
     const profileName = developmentProfileName(bid.identifier, device.id);
     const profile = await mintDevelopmentProfile(asc, {
       name: profileName,
@@ -435,6 +626,12 @@ export async function provision({
       certificateIds,
     });
     const file = writeProfile(profile, dir);
+    const decoded = decodeProfile(file);
+    validateProvisioningEntitlements(
+      bid.entitlements ?? {},
+      decoded?.Entitlements ?? {},
+      bid.identifier,
+    );
     results.push({
       identifier: bid.identifier,
       bundleCreated: bundle.created,

--- a/packages/app/scripts/ios-device-provision.mjs
+++ b/packages/app/scripts/ios-device-provision.mjs
@@ -31,8 +31,8 @@
  * entitlements (including exact App Groups) or the run fails closed. Each
  * device gets its own stable profile name, so provisioning one device never
  * removes another device's working profile. Existing valid profiles are
- * reused; an invalid same-name profile fails the run instead of being deleted
- * before replacement.
+ * reused; invalid or stale same-name profiles are preserved while a uniquely
+ * named replacement is created and validated.
  * Minted profiles are written into the profiles dir where `discoverProfiles()`
  * looks.
  *
@@ -377,11 +377,29 @@ export function developmentProfileName(identifier, deviceId) {
 }
 
 /**
+ * Give a replacement profile a collision-resistant name while leaving the
+ * previous profile intact. ASC profile names are unique and profiles are
+ * immutable, so recovery must create-before-delete; stale profiles can be
+ * retired manually after the replacement has been exercised on a device.
+ */
+export function replacementDevelopmentProfileName(
+  stableName,
+  randomUuid = () => crypto.randomUUID(),
+) {
+  const suffix = String(randomUuid()).replaceAll("-", "").slice(0, 12);
+  if (!suffix) {
+    throw new Error(
+      "Unable to generate a development profile replacement name.",
+    );
+  }
+  return `${stableName} - refresh-${suffix}`;
+}
+
+/**
  * Mint a development profile for a bundle id, or reuse a same-named profile
  * that already covers this bundle/device/certificate set. Development profiles
  * are immutable and ASC profile names are unique, so an invalid same-name
- * profile fails closed instead of deleting the last usable profile before a
- * replacement exists.
+ * profile is preserved while a uniquely named replacement is created.
  */
 function relationshipIds(resource, relationship) {
   const data = resource?.relationships?.[relationship]?.data;
@@ -414,44 +432,10 @@ export function profileIsUsable(profile, now = new Date()) {
   return true;
 }
 
-export async function mintDevelopmentProfile(
+async function createDevelopmentProfile(
   asc,
   { name, bundleIdRef, deviceIds, certificateIds },
 ) {
-  const existing = await asc(
-    "GET",
-    `/v1/profiles?filter[name]=${encodeURIComponent(name)}&include=bundleId,devices,certificates&limit=1`,
-  );
-  if (existing.data && existing.data.length > 0) {
-    const profile = existing.data[0];
-    if (
-      profileCoversRequest(profile, { bundleIdRef, deviceIds, certificateIds })
-    ) {
-      if (!profileIsUsable(profile)) {
-        throw new Error(
-          `Existing development profile "${name}" covers the requested bundle/device/certificate set, ` +
-            "but is expired or inactive. Remove or rename that profile in ASC, then rerun.",
-        );
-      }
-      if (profile.attributes?.profileContent) return profile;
-      const fetched = await asc("GET", `/v1/profiles/${profile.id}`);
-      if (!profileIsUsable(fetched.data)) {
-        throw new Error(
-          `Existing development profile "${name}" covers the requested bundle/device/certificate set, ` +
-            "but is expired or inactive. Remove or rename that profile in ASC, then rerun.",
-        );
-      }
-      if (fetched.data?.attributes?.profileContent) return fetched.data;
-      throw new Error(
-        `Existing development profile "${name}" covers the requested bundle/device/certificate set, ` +
-          "but App Store Connect did not return profileContent. Download it in ASC or remove the stale profile before rerunning.",
-      );
-    }
-    throw new Error(
-      `Existing development profile "${name}" does not cover the requested bundle/device/certificate set. ` +
-        "Refusing to delete it before a replacement exists; remove or rename that profile in ASC, then rerun.",
-    );
-  }
   const created = await asc("POST", "/v1/profiles", {
     data: {
       type: "profiles",
@@ -468,6 +452,137 @@ export async function mintDevelopmentProfile(
     },
   });
   return created.data;
+}
+
+async function createReplacementDevelopmentProfile(
+  asc,
+  { name, bundleIdRef, deviceIds, certificateIds, replacementNameFactory },
+) {
+  return {
+    profile: await createDevelopmentProfile(asc, {
+      name: replacementDevelopmentProfileName(name, replacementNameFactory),
+      bundleIdRef,
+      deviceIds,
+      certificateIds,
+    }),
+    reused: false,
+  };
+}
+
+async function listReusableDevelopmentProfiles(
+  asc,
+  { stableName, bundleIdRef, deviceIds, certificateIds },
+) {
+  const listed = await asc(
+    "GET",
+    `/v1/bundleIds/${bundleIdRef}/profiles?fields[profiles]=name,profileType,profileState,profileContent,uuid,createdDate,expirationDate&limit=200`,
+  );
+  const refreshPrefix = `${stableName} - refresh-`;
+  const named = (listed.data ?? []).filter((profile) => {
+    const profileName = profile.attributes?.name;
+    const profileType = profile.attributes?.profileType;
+    return (
+      (profileName === stableName || profileName?.startsWith(refreshPrefix)) &&
+      (!profileType || profileType === "IOS_APP_DEVELOPMENT")
+    );
+  });
+  named.sort((left, right) => {
+    const leftCreated = Date.parse(left.attributes?.createdDate ?? "") || 0;
+    const rightCreated = Date.parse(right.attributes?.createdDate ?? "") || 0;
+    return rightCreated - leftCreated;
+  });
+
+  const reusable = [];
+  for (const summary of named) {
+    if (!profileIsUsable(summary)) continue;
+    const fetched = await asc(
+      "GET",
+      `/v1/profiles/${summary.id}?include=bundleId,devices,certificates`,
+    );
+    const profile = fetched.data;
+    if (
+      profileIsUsable(profile) &&
+      profileCoversRequest(profile, {
+        bundleIdRef,
+        deviceIds,
+        certificateIds,
+      }) &&
+      profile.attributes?.profileContent
+    ) {
+      reusable.push(profile);
+    }
+  }
+  return { reusable, namedCount: named.length };
+}
+
+async function resolveDevelopmentProfile(
+  asc,
+  { name, bundleIdRef, deviceIds, certificateIds, replacementNameFactory },
+) {
+  const existing = await asc(
+    "GET",
+    `/v1/profiles?filter[name]=${encodeURIComponent(name)}&include=bundleId,devices,certificates&limit=1`,
+  );
+  if (existing.data && existing.data.length > 0) {
+    const profile = existing.data[0];
+    if (
+      profileCoversRequest(profile, { bundleIdRef, deviceIds, certificateIds })
+    ) {
+      if (!profileIsUsable(profile)) {
+        return createReplacementDevelopmentProfile(asc, {
+          name,
+          bundleIdRef,
+          deviceIds,
+          certificateIds,
+          replacementNameFactory,
+        });
+      }
+      if (profile.attributes?.profileContent) {
+        return { profile, reused: true };
+      }
+      const fetched = await asc("GET", `/v1/profiles/${profile.id}`);
+      if (!profileIsUsable(fetched.data)) {
+        return createReplacementDevelopmentProfile(asc, {
+          name,
+          bundleIdRef,
+          deviceIds,
+          certificateIds,
+          replacementNameFactory,
+        });
+      }
+      if (fetched.data?.attributes?.profileContent) {
+        return { profile: fetched.data, reused: true };
+      }
+      return createReplacementDevelopmentProfile(asc, {
+        name,
+        bundleIdRef,
+        deviceIds,
+        certificateIds,
+        replacementNameFactory,
+      });
+    }
+    return createReplacementDevelopmentProfile(asc, {
+      name,
+      replacementNameFactory,
+      bundleIdRef,
+      deviceIds,
+      certificateIds,
+    });
+  }
+  return {
+    profile: await createDevelopmentProfile(asc, {
+      name,
+      bundleIdRef,
+      deviceIds,
+      certificateIds,
+    }),
+    reused: false,
+  };
+}
+
+export async function mintDevelopmentProfile(asc, request) {
+  const resolution = await resolveDevelopmentProfile(asc, request);
+  return resolution.profile;
 }
 
 /**
@@ -601,6 +716,7 @@ export async function provision({
   dir = profilesDir(),
   now,
   decodeProfile = decodeMobileProvision,
+  replacementNameFactory,
 }) {
   if (!udid) throw new Error("provision: a device UDID is required.");
   validateBundleIds(bundleIds);
@@ -619,19 +735,55 @@ export async function provision({
       entitlements: bid.entitlements ?? {},
     });
     const profileName = developmentProfileName(bid.identifier, device.id);
-    const profile = await mintDevelopmentProfile(asc, {
-      name: profileName,
+    const listedProfiles = await listReusableDevelopmentProfiles(asc, {
+      stableName: profileName,
       bundleIdRef: bundle.id,
       deviceIds: [device.id],
       certificateIds,
     });
-    const file = writeProfile(profile, dir);
-    const decoded = decodeProfile(file);
-    validateProvisioningEntitlements(
-      bid.entitlements ?? {},
-      decoded?.Entitlements ?? {},
-      bid.identifier,
-    );
+    let profile = null;
+    let file = null;
+    for (const candidate of listedProfiles.reusable) {
+      const candidateFile = writeProfile(candidate, dir);
+      const decoded = decodeProfile(candidateFile);
+      try {
+        validateProvisioningEntitlements(
+          bid.entitlements ?? {},
+          decoded?.Entitlements ?? {},
+          bid.identifier,
+        );
+        profile = candidate;
+        file = candidateFile;
+        break;
+      } catch {
+        // error-policy:J3 ASC profile content is untrusted input; an explicit
+        // validation failure rejects only this candidate and scans the rest.
+        // An ACTIVE profile can still carry stale managed grants. Keep scanning
+        // newer/older candidates before minting another immutable profile.
+      }
+    }
+    if (!profile) {
+      const createName =
+        listedProfiles.namedCount === 0
+          ? profileName
+          : replacementDevelopmentProfileName(
+              profileName,
+              replacementNameFactory,
+            );
+      profile = await createDevelopmentProfile(asc, {
+        name: createName,
+        bundleIdRef: bundle.id,
+        deviceIds: [device.id],
+        certificateIds,
+      });
+      file = writeProfile(profile, dir);
+      const decoded = decodeProfile(file);
+      validateProvisioningEntitlements(
+        bid.entitlements ?? {},
+        decoded?.Entitlements ?? {},
+        bid.identifier,
+      );
+    }
     results.push({
       identifier: bid.identifier,
       bundleCreated: bundle.created,

--- a/packages/app/scripts/ios-device-provision.test.mjs
+++ b/packages/app/scripts/ios-device-provision.test.mjs
@@ -3,8 +3,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-
+import { parsePlist } from "./ios-device-lib.mjs";
 import {
+  capabilitiesForEntitlements,
+  classifyEntitlementProvisioningRequirements,
   createAscJwt,
   developmentProfileName,
   discoverAppBundleIds,
@@ -15,8 +17,10 @@ import {
   profileCoversRequest,
   profileIsUsable,
   provision,
+  reconcileBundleCapabilities,
   resolveAscCredentials,
   validateBundleIds,
+  validateProvisioningEntitlements,
   writeProfile,
 } from "./ios-device-provision.mjs";
 
@@ -202,6 +206,118 @@ describe("ensureDeviceRegistered / ensureBundleId — idempotent", () => {
     const asc = makeAscClient({ jwt: "t", fetchImpl });
     const r = await ensureBundleId(asc, { identifier: "ai.elizaos.app" });
     expect(r).toEqual({ id: "B1", created: false });
+  });
+});
+
+describe("ASC capability and app-group reconciliation", () => {
+  it("enables every missing ASC-supported target capability", async () => {
+    const fetchImpl = mockFetch({
+      "GET /v1/bundleIds/B1/bundleIdCapabilities": { body: { data: [] } },
+      "POST /v1/bundleIdCapabilities": { status: 201, body: { data: {} } },
+    });
+    const asc = makeAscClient({ jwt: "t", fetchImpl });
+    const enabled = await reconcileBundleCapabilities(asc, {
+      bundleIdRef: "B1",
+      entitlements: {
+        "com.apple.developer.associated-domains": ["applinks:eliza.app"],
+        "com.apple.security.application-groups": ["group.ai.elizaos.app"],
+      },
+    });
+    expect(enabled).toEqual(["APP_GROUPS", "ASSOCIATED_DOMAINS"]);
+    expect(
+      fetchImpl.calls.filter((c) => c.path === "/v1/bundleIdCapabilities"),
+    ).toHaveLength(2);
+  });
+
+  it("maps every maintained entitlement requiring ASC capability state", () => {
+    expect(
+      capabilitiesForEntitlements({
+        "aps-environment": "development",
+        "com.apple.developer.healthkit": true,
+      }),
+    ).toEqual(["HEALTHKIT", "PUSH_NOTIFICATIONS"]);
+  });
+
+  it("classifies every entitlement in the maintained app and appex targets", () => {
+    const repoRelative = path.join(
+      process.cwd(),
+      "packages/app-core/platforms/ios/App/App",
+    );
+    const packageRelative = path.join(
+      process.cwd(),
+      "../app-core/platforms/ios/App/App",
+    );
+    const root = fs.existsSync(repoRelative) ? repoRelative : packageRelative;
+    const files = [
+      "App.entitlements",
+      "WebsiteBlockerContentExtension/WebsiteBlockerContentExtension.entitlements",
+      "DeviceActivityMonitorExtension/DeviceActivityMonitorExtension.entitlements",
+      "DeviceActivityReportExtension/DeviceActivityReportExtension.entitlements",
+      "ElizaWidgets/ElizaWidgets.entitlements",
+      "ElizaKeyboard/ElizaKeyboard.entitlements",
+    ];
+    const keys = new Set();
+    for (const file of files) {
+      const parsed = parsePlist(fs.readFileSync(path.join(root, file), "utf8"));
+      for (const key of Object.keys(parsed)) keys.add(key);
+    }
+    const classified = classifyEntitlementProvisioningRequirements(
+      Object.fromEntries([...keys].map((key) => [key, true])),
+    );
+    expect(classified.unclassified).toEqual([]);
+    expect(classified.supportedCapabilities).toEqual([
+      "APP_GROUPS",
+      "ASSOCIATED_DOMAINS",
+      "HEALTHKIT",
+      "PUSH_NOTIFICATIONS",
+    ]);
+    expect(classified.profileValidatedManaged.map((row) => row.key)).toEqual(
+      expect.arrayContaining([
+        "com.apple.developer.family-controls",
+        "com.apple.developer.healthkit.background-delivery",
+        "com.apple.developer.kernel.increased-memory-limit",
+        "com.apple.developer.kernel.extended-virtual-addressing",
+        "com.apple.security.application-groups",
+      ]),
+    );
+  });
+});
+
+describe("profile entitlement validation", () => {
+  it("accepts granted arrays and concrete build-variable values", () => {
+    expect(() =>
+      validateProvisioningEntitlements(
+        {
+          "aps-environment": "$(APS_ENVIRONMENT)",
+          "com.apple.security.application-groups": ["group.ai.elizaos.app"],
+        },
+        {
+          "aps-environment": "development",
+          "com.apple.security.application-groups": ["group.ai.elizaos.app"],
+        },
+        "ai.elizaos.app",
+      ),
+    ).not.toThrow();
+  });
+
+  it("fails closed and names missing target entitlements", () => {
+    expect(() =>
+      validateProvisioningEntitlements(
+        { "com.apple.developer.family-controls": true },
+        {},
+        "ai.elizaos.app",
+      ),
+    ).toThrow(/ai\.elizaos\.app.*family-controls.*Account Holder\/Admin/);
+  });
+
+  it("fails closed on target entitlements without an explicit policy", () => {
+    expect(() =>
+      validateProvisioningEntitlements(
+        { "com.apple.developer.future-capability": true },
+        { "com.apple.developer.future-capability": true },
+        "ai.elizaos.app",
+      ),
+    ).toThrow(/unclassified target entitlements.*future-capability/);
   });
 });
 
@@ -466,10 +582,21 @@ describe("discoverAppBundleIds", () => {
       [path.join(app, "PlugIns", "Widgets.appex", "Info.plist")]:
         "ai.elizaos.app.widgets",
     };
-    const out = discoverAppBundleIds(app, { runPlutil: (p) => ids[p] });
+    const out = discoverAppBundleIds(app, {
+      runPlutil: (p) => ids[p],
+      readTargetEntitlements: (name) => ({ target: name }),
+    });
     expect(out).toEqual([
-      { identifier: "ai.elizaos.app", name: "App" },
-      { identifier: "ai.elizaos.app.widgets", name: "Widgets" },
+      {
+        identifier: "ai.elizaos.app",
+        name: "App",
+        entitlements: { target: "App" },
+      },
+      {
+        identifier: "ai.elizaos.app.widgets",
+        name: "Widgets",
+        entitlements: { target: "Widgets" },
+      },
     ]);
   });
 });
@@ -499,6 +626,9 @@ describe("provision — full idempotent flow", () => {
       "GET /v1/certificates": { body: { data: [{ id: "CERT" }] } },
       "GET /v1/bundleIds": { body: { data: [] } },
       "POST /v1/bundleIds": { status: 201, body: { data: { id: "BID" } } },
+      "GET /v1/bundleIds/BID/bundleIdCapabilities": {
+        body: { data: [] },
+      },
       "GET /v1/profiles": { body: { data: [] } },
       "POST /v1/profiles": {
         status: 201,
@@ -521,6 +651,7 @@ describe("provision — full idempotent flow", () => {
       fetchImpl,
       dir,
       now: 1_700_000_000,
+      decodeProfile: () => ({ Entitlements: {} }),
     });
     expect(result.device).toEqual({ id: "DEV", created: true });
     expect(result.certificateIds).toEqual(["CERT"]);

--- a/packages/app/scripts/ios-device-provision.test.mjs
+++ b/packages/app/scripts/ios-device-provision.test.mjs
@@ -18,6 +18,7 @@ import {
   profileIsUsable,
   provision,
   reconcileBundleCapabilities,
+  replacementDevelopmentProfileName,
   resolveAscCredentials,
   validateBundleIds,
   validateProvisioningEntitlements,
@@ -355,7 +356,7 @@ describe("mintDevelopmentProfile", () => {
     ]);
   });
 
-  it("fails closed when a same-named profile does not cover the request", async () => {
+  it("preserves and replaces a same-named profile that does not cover the request", async () => {
     const fetchImpl = mockFetch({
       "GET /v1/profiles": {
         body: {
@@ -374,22 +375,38 @@ describe("mintDevelopmentProfile", () => {
           ],
         },
       },
+      "POST /v1/profiles": {
+        status: 201,
+        body: {
+          data: {
+            id: "REPLACEMENT",
+            attributes: { name: "replacement", profileContent: "AA==" },
+          },
+        },
+      },
     });
     const asc = makeAscClient({ jwt: "t", fetchImpl });
-    await expect(
-      mintDevelopmentProfile(asc, {
-        name: "n",
-        bundleIdRef: "B1",
-        deviceIds: ["DEV1"],
-        certificateIds: ["C1"],
-      }),
-    ).rejects.toThrow(/Refusing to delete/);
+    const profile = await mintDevelopmentProfile(asc, {
+      name: "n",
+      bundleIdRef: "B1",
+      deviceIds: ["DEV1"],
+      certificateIds: ["C1"],
+      replacementNameFactory: () => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    });
+    expect(profile.id).toBe("REPLACEMENT");
     expect(fetchImpl.calls.map((c) => `${c.method} ${c.path}`)).toEqual([
       "GET /v1/profiles",
+      "POST /v1/profiles",
     ]);
+    expect(fetchImpl.calls.some((call) => call.method === "DELETE")).toBe(
+      false,
+    );
+    expect(fetchImpl.calls.at(-1).body.data.attributes.name).toBe(
+      "n - refresh-aaaaaaaabbbb",
+    );
   });
 
-  it("fails closed when a same-named profile is expired even if it covers the request", async () => {
+  it("preserves and replaces an expired same-named profile", async () => {
     const fetchImpl = mockFetch({
       "GET /v1/profiles": {
         body: {
@@ -414,19 +431,32 @@ describe("mintDevelopmentProfile", () => {
           ],
         },
       },
+      "POST /v1/profiles": {
+        status: 201,
+        body: {
+          data: {
+            id: "REPLACEMENT",
+            attributes: { name: "replacement", profileContent: "AA==" },
+          },
+        },
+      },
     });
     const asc = makeAscClient({ jwt: "t", fetchImpl });
-    await expect(
-      mintDevelopmentProfile(asc, {
-        name: "n",
-        bundleIdRef: "B1",
-        deviceIds: ["DEV1"],
-        certificateIds: ["C1"],
-      }),
-    ).rejects.toThrow(/expired or inactive/);
+    const profile = await mintDevelopmentProfile(asc, {
+      name: "n",
+      bundleIdRef: "B1",
+      deviceIds: ["DEV1"],
+      certificateIds: ["C1"],
+      replacementNameFactory: () => "ffffffff-1111-2222-3333-444444444444",
+    });
+    expect(profile.id).toBe("REPLACEMENT");
     expect(fetchImpl.calls.map((c) => `${c.method} ${c.path}`)).toEqual([
       "GET /v1/profiles",
+      "POST /v1/profiles",
     ]);
+    expect(fetchImpl.calls.some((call) => call.method === "DELETE")).toBe(
+      false,
+    );
   });
 
   it("mints a new development profile when no same-named profile exists", async () => {
@@ -539,6 +569,15 @@ describe("developmentProfileName", () => {
     expect(first).not.toBe(second);
     expect(developmentProfileName("ai.elizaos.app", "DEVICE-A")).toBe(first);
   });
+
+  it("uses a collision-resistant suffix for preserved-profile replacements", () => {
+    expect(
+      replacementDevelopmentProfileName(
+        "Eliza Dev - ai.elizaos.app - abc",
+        () => "12345678-90ab-cdef-1234-567890abcdef",
+      ),
+    ).toBe("Eliza Dev - ai.elizaos.app - abc - refresh-1234567890ab");
+  });
 });
 
 describe("writeProfile", () => {
@@ -629,7 +668,7 @@ describe("provision — full idempotent flow", () => {
       "GET /v1/bundleIds/BID/bundleIdCapabilities": {
         body: { data: [] },
       },
-      "GET /v1/profiles": { body: { data: [] } },
+      "GET /v1/bundleIds/BID/profiles": { body: { data: [] } },
       "POST /v1/profiles": {
         status: 201,
         body: {
@@ -690,6 +729,239 @@ describe("provision — full idempotent flow", () => {
         dir: tmpDir(),
       }),
     ).rejects.toThrow(/No DEVELOPMENT certificate/);
+  });
+
+  it("creates a replacement after capability reconciliation invalidates the stable profile", async () => {
+    const dir = tmpDir();
+    const stableName = developmentProfileName("ai.elizaos.app", "DEV");
+    let stableProfileState = "ACTIVE";
+    const goodContent = Buffer.from("good-grants").toString("base64");
+    const fetchImpl = mockFetch({
+      "GET /v1/devices": { body: { data: [{ id: "DEV" }] } },
+      "GET /v1/certificates": { body: { data: [{ id: "CERT" }] } },
+      "GET /v1/bundleIds": { body: { data: [{ id: "BID" }] } },
+      "GET /v1/bundleIds/BID/bundleIdCapabilities": {
+        body: { data: [] },
+      },
+      "POST /v1/bundleIdCapabilities": () => {
+        // Apple invalidates profiles that use an App ID whose capabilities
+        // changed. The following profile lookup must observe that transition.
+        stableProfileState = "INVALID";
+        return { status: 201, body: { data: {} } };
+      },
+      "GET /v1/bundleIds/BID/profiles": () => ({
+        body: {
+          data: [
+            {
+              id: "STABLE",
+              attributes: {
+                name: stableName,
+                profileType: "IOS_APP_DEVELOPMENT",
+                profileState: stableProfileState,
+              },
+            },
+          ],
+        },
+      }),
+      "POST /v1/profiles": (_method, _url, body) => ({
+        status: 201,
+        body: {
+          data: {
+            id: "REPLACEMENT",
+            attributes: {
+              name: body.data.attributes.name,
+              uuid: "REPLACEMENT-UUID",
+              profileContent: goodContent,
+            },
+          },
+        },
+      }),
+    });
+
+    const result = await provision({
+      creds: { keyId: "K", issuerId: "I", privateKeyPem: P8 },
+      udid: "UDID",
+      bundleIds: [
+        {
+          identifier: "ai.elizaos.app",
+          name: "App",
+          entitlements: {
+            "com.apple.security.application-groups": ["group.ai.elizaos.app"],
+          },
+        },
+      ],
+      fetchImpl,
+      dir,
+      now: 1_700_000_000,
+      decodeProfile: (file) => ({
+        Entitlements: fs.readFileSync(file, "utf8").includes("good-grants")
+          ? {
+              "com.apple.security.application-groups": ["group.ai.elizaos.app"],
+            }
+          : {},
+      }),
+      replacementNameFactory: () => "11111111-2222-3333-4444-555555555555",
+    });
+
+    expect(result.results[0].profile).toBe(
+      `${stableName} - refresh-111111112222`,
+    );
+    expect(fetchImpl.calls.some((call) => call.method === "DELETE")).toBe(
+      false,
+    );
+    expect(
+      fetchImpl.calls.map((call) => `${call.method} ${call.path}`),
+    ).toEqual(
+      expect.arrayContaining([
+        "POST /v1/bundleIdCapabilities",
+        "GET /v1/bundleIds/BID/profiles",
+        "POST /v1/profiles",
+      ]),
+    );
+  });
+
+  it("recovers on rerun after an admin corrects a stale App Group grant", async () => {
+    const dir = tmpDir();
+    const stableName = developmentProfileName("ai.elizaos.app", "DEV");
+    const staleContent = Buffer.from("stale-grants").toString("base64");
+    const goodContent = Buffer.from("good-grants").toString("base64");
+    let adminAssignedGroup = false;
+    let replacementCount = 0;
+    const replacements = [];
+    const replacementUuids = [
+      "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "ffffffff-1111-2222-3333-444444444444",
+    ];
+    const fetchImpl = mockFetch({
+      "GET /v1/devices": { body: { data: [{ id: "DEV" }] } },
+      "GET /v1/certificates": { body: { data: [{ id: "CERT" }] } },
+      "GET /v1/bundleIds": { body: { data: [{ id: "BID" }] } },
+      "GET /v1/bundleIds/BID/bundleIdCapabilities": {
+        body: {
+          data: [{ attributes: { capabilityType: "APP_GROUPS" } }],
+        },
+      },
+      "GET /v1/bundleIds/BID/profiles": () => ({
+        body: {
+          data: [
+            {
+              id: "STABLE",
+              attributes: {
+                name: stableName,
+                profileType: "IOS_APP_DEVELOPMENT",
+                profileState: "ACTIVE",
+                createdDate: "2026-08-17T00:00:00Z",
+              },
+            },
+            ...replacements.map((profile) => ({
+              id: profile.id,
+              attributes: {
+                name: profile.attributes.name,
+                profileType: "IOS_APP_DEVELOPMENT",
+                profileState: "ACTIVE",
+                createdDate: profile.attributes.createdDate,
+              },
+            })),
+          ],
+        },
+      }),
+      "GET /v1/profiles/STABLE": {
+        body: {
+          data: {
+            id: "STABLE",
+            attributes: {
+              name: stableName,
+              uuid: "STABLE-UUID",
+              profileState: "ACTIVE",
+              profileContent: staleContent,
+            },
+            relationships: {
+              bundleId: { data: { id: "BID" } },
+              devices: { data: [{ id: "DEV" }] },
+              certificates: { data: [{ id: "CERT" }] },
+            },
+          },
+        },
+      },
+      "GET /v1/profiles/REPLACEMENT-1": () => ({
+        body: { data: replacements[0] },
+      }),
+      "GET /v1/profiles/REPLACEMENT-2": () => ({
+        body: { data: replacements[1] },
+      }),
+      "POST /v1/profiles": (_method, _url, body) => {
+        replacementCount += 1;
+        const profile = {
+          id: `REPLACEMENT-${replacementCount}`,
+          attributes: {
+            name: body.data.attributes.name,
+            uuid: `REPLACEMENT-UUID-${replacementCount}`,
+            createdDate: `2026-08-17T00:0${replacementCount}:00Z`,
+            profileState: "ACTIVE",
+            profileContent: adminAssignedGroup ? goodContent : staleContent,
+          },
+          relationships: {
+            bundleId: { data: { id: "BID" } },
+            devices: { data: [{ id: "DEV" }] },
+            certificates: { data: [{ id: "CERT" }] },
+          },
+        };
+        replacements.push(profile);
+        return {
+          status: 201,
+          body: { data: profile },
+        };
+      },
+    });
+    const request = {
+      creds: { keyId: "K", issuerId: "I", privateKeyPem: P8 },
+      udid: "UDID",
+      bundleIds: [
+        {
+          identifier: "ai.elizaos.app",
+          name: "App",
+          entitlements: {
+            "com.apple.security.application-groups": ["group.ai.elizaos.app"],
+          },
+        },
+      ],
+      fetchImpl,
+      dir,
+      now: 1_700_000_000,
+      decodeProfile: (file) => ({
+        Entitlements: fs.readFileSync(file, "utf8").includes("good-grants")
+          ? {
+              "com.apple.security.application-groups": ["group.ai.elizaos.app"],
+            }
+          : {},
+      }),
+      replacementNameFactory: () => replacementUuids.shift(),
+    };
+
+    await expect(provision(request)).rejects.toThrow(
+      /does not grant target entitlements.*application-groups/,
+    );
+    adminAssignedGroup = true;
+    const recovered = await provision(request);
+    const recoveredAgain = await provision(request);
+
+    expect(recovered.results[0].profile).toBe(
+      `${stableName} - refresh-ffffffff1111`,
+    );
+    expect(recoveredAgain.results[0].profile).toBe(
+      recovered.results[0].profile,
+    );
+    const profilePosts = fetchImpl.calls.filter(
+      (call) => call.method === "POST" && call.path === "/v1/profiles",
+    );
+    expect(profilePosts.map((call) => call.body.data.attributes.name)).toEqual([
+      `${stableName} - refresh-aaaaaaaabbbb`,
+      `${stableName} - refresh-ffffffff1111`,
+    ]);
+    expect(profilePosts).toHaveLength(2);
+    expect(fetchImpl.calls.some((call) => call.method === "DELETE")).toBe(
+      false,
+    );
   });
 
   it("requires a udid and at least one bundle id", async () => {

--- a/packages/app/scripts/lib/ios-device-e2e-lib.mjs
+++ b/packages/app/scripts/lib/ios-device-e2e-lib.mjs
@@ -46,7 +46,7 @@ export function planIosDeviceE2eSteps({ skipLogs = false } = {}) {
   const steps = [
     {
       id: "deploy",
-      label: "deploy signed App.app to the device (--skip-appexes)",
+      label: "deploy signed App.app + appexes to the device",
     },
     {
       id: "smoke",
@@ -64,11 +64,8 @@ export function planIosDeviceE2eSteps({ skipLogs = false } = {}) {
 }
 
 /**
- * Absolute node argv for the deploy step. `--skip-appexes` is the default
- * unattended posture (PR #13174, research doc Q6): per-appex profiles need an
- * ASC API key, so widget/keyboard/device-activity surfaces are stripped and the
- * deploy logs that loudly. `--device` is always passed through so the whole lane
- * pins one phone.
+ * Absolute node argv for the deploy step. Full app + appexes is the default;
+ * `skipAppexes` is an explicit degraded-mode escape hatch.
  *
  * @param {{ scriptsDir: string, deviceId: string, skipAppexes?: boolean,
  *           skipBuild?: boolean, noLaunch?: boolean, bundleId?: string | null }} opts
@@ -77,7 +74,7 @@ export function planIosDeviceE2eSteps({ skipLogs = false } = {}) {
 export function buildDeviceDeployCommand({
   scriptsDir,
   deviceId,
-  skipAppexes = true,
+  skipAppexes = false,
   skipBuild = false,
   noLaunch = false,
   bundleId = null,
@@ -97,20 +94,19 @@ export function buildDeviceDeployCommand({
 }
 
 /**
- * Absolute node argv for the on-device BootCapture assertion. `--skip-build`
- * is forced: deploy already built + installed the current tree, so the capture
- * must reuse that install, never rebuild a second bundle. `--output` targets the
- * run bundle's `smoke/` subdir so the assertion's attachments land inside the
- * triage bundle.
+ * Absolute node argv for the on-device BootCapture assertion. The current
+ * XCUITest runner is rebuilt and graft-signed by default; `appPath` points its
+ * xctestrun at the exact signed app installed by the preceding deploy.
  *
  * @param {{ scriptsDir: string, deviceId: string, outputDir: string,
- *           requireChat?: boolean, bundleId?: string | null }} opts
+ *           appPath: string, requireChat?: boolean, bundleId?: string | null }} opts
  * @returns {{ cmd: string, args: string[] }}
  */
 export function buildDeviceSmokeCommand({
   scriptsDir,
   deviceId,
   outputDir,
+  appPath,
   requireChat = false,
   bundleId = null,
 }) {
@@ -118,13 +114,15 @@ export function buildDeviceSmokeCommand({
     throw new Error("buildDeviceSmokeCommand: deviceId is required");
   if (!outputDir)
     throw new Error("buildDeviceSmokeCommand: outputDir is required");
+  if (!appPath) throw new Error("buildDeviceSmokeCommand: appPath is required");
   const args = [
     path.join(scriptsDir, "ios-device-capture.mjs"),
     "--platform",
     "device",
     "--device",
     deviceId,
-    "--skip-build",
+    "--app-path",
+    appPath,
     "--output",
     outputDir,
   ];

--- a/packages/app/scripts/lib/ios-device-e2e-lib.test.mjs
+++ b/packages/app/scripts/lib/ios-device-e2e-lib.test.mjs
@@ -36,26 +36,25 @@ describe("planIosDeviceE2eSteps", () => {
 });
 
 describe("buildDeviceDeployCommand", () => {
-  it("passes --skip-appexes by default plus the device", () => {
+  it("deploys the full app + appexes by default", () => {
     const { cmd, args } = buildDeviceDeployCommand({ scriptsDir, deviceId });
     expect(cmd).toBe("node");
     expect(args).toEqual([
       path.join(scriptsDir, "ios-device-deploy.mjs"),
       "--device",
       deviceId,
-      "--skip-appexes",
     ]);
   });
-  it("omits --skip-appexes when opted out and threads optional flags", () => {
+  it("supports explicit degraded appex skipping and threads optional flags", () => {
     const { args } = buildDeviceDeployCommand({
       scriptsDir,
       deviceId,
-      skipAppexes: false,
+      skipAppexes: true,
       skipBuild: true,
       noLaunch: true,
       bundleId: "ai.elizaos.app",
     });
-    expect(args).not.toContain("--skip-appexes");
+    expect(args).toContain("--skip-appexes");
     expect(args).toContain("--skip-build");
     expect(args).toContain("--no-launch");
     expect(args).toContain("--bundle-id");
@@ -69,11 +68,12 @@ describe("buildDeviceDeployCommand", () => {
 });
 
 describe("buildDeviceSmokeCommand", () => {
-  it("forces --skip-build and targets the smoke output dir", () => {
+  it("rebuilds the runner and targets the signed deployed app", () => {
     const { args } = buildDeviceSmokeCommand({
       scriptsDir,
       deviceId,
       outputDir: "/bundle/smoke",
+      appPath: "/stage/App.app",
     });
     expect(args).toEqual([
       path.join(scriptsDir, "ios-device-capture.mjs"),
@@ -81,7 +81,8 @@ describe("buildDeviceSmokeCommand", () => {
       "device",
       "--device",
       deviceId,
-      "--skip-build",
+      "--app-path",
+      "/stage/App.app",
       "--output",
       "/bundle/smoke",
     ]);
@@ -91,6 +92,7 @@ describe("buildDeviceSmokeCommand", () => {
       scriptsDir,
       deviceId,
       outputDir: "/bundle/smoke",
+      appPath: "/stage/App.app",
       requireChat: true,
     });
     expect(args).toContain("--require-chat");


### PR DESCRIPTION
# Relates to

Progresses #13567. Physical-device and live Apple Developer verification remain required before the issue can close.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] Pinned focused gates passed; full exact-head `bun install` and `bun run verify` are pending CI.
- [x] A reviewer can confirm the repository-side behavior from the focused tests below. Live-device acceptance is explicitly residual.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@dc189c3e7b9e1f479a69411548ed6db00511d290:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` is pending exact-head CI; the isolated root run was interrupted during unrelated full-repo Turbo work.

# Risks

Medium. This changes physical-device deployment, Apple Developer provisioning, signing validation, and XCUITest orchestration. The paths now fail closed when maintained entitlements cannot be proven by a decoded profile, but a credentialed macOS host and physical iOS device are still required to validate Apple's live services and device behavior.

# Background

## What does this PR do?

- Makes the one-command iOS device E2E lane build a current XCUITest runner, graft-sign it, rewrite the `.xctestrun` to the exact staged signed app, and avoid stale forced `--skip-build` behavior.
- Deploys the full application plus app extensions by default; `--skip-appexes` remains an explicit degraded mode.
- Reconciles ASC-supported capabilities, classifies Apple-managed or approval-gated entitlements explicitly, and validates every maintained target entitlement against the decoded provisioning profile.
- Preserves stale profiles, creates uniquely named replacements, discovers and reuses proven refresh profiles on later runs, and never deletes the last usable profile.
- Requires a development runner profile with `get-task-allow` and rejects reuse when any nested signed code fails explicit or deep verification.
- Adds focused orchestration, provisioning, entitlement, profile, and signing tests, including outer-valid/nested-invalid runner classification.

## What kind of change is this?

Bug fix and reliability improvement.

# Documentation changes needed?

Documentation was updated in `packages/app/README.md` and the package guide. The guide's `CLAUDE.md` and `AGENTS.md` remain byte-identical.

# Testing

## Where should a reviewer start?

Start with the iOS device orchestration and provisioning tests, then inspect `ios-device-capture.mjs` signing reuse and `ios-device-provision.mjs` entitlement reconciliation.

## Detailed testing steps

```bash
bun x vitest run packages/app/scripts/ios-device-provision.test.mjs packages/app/scripts/ios-device-lib.test.mjs packages/app/scripts/lib/ios-device-e2e-lib.test.mjs
bun test packages/app/scripts packages/app/test/mobile-smoke-scripts.test.ts
bun run --cwd packages/app lint
bun run check:agents-claude
git diff --check codex/tmp-13567-develop...HEAD
```

Observed results:

- Focused provisioning/signing/entitlement suite: 153/153 tests passed; final provisioning recovery suite: 34/34 at the rebased head.
- App script aggregate: 814 passed and 1 skipped; one unrelated Playwright parent timed out after its exact-Node nested worker passed.
- Package lint: passed; 303 files checked, no fixes applied.
- Guide parity: passed for 155 tracked pairs.
- Diff whitespace check: passed.

# Evidence Gate

<!-- evidence-head:29a5fd6556ebfb5f26dfc2b7a52ceb28d4036c77 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - no rendered UI surface changed; this is native CLI/orchestration and documentation work.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - a truthful walkthrough requires a credentialed macOS host and physical iOS device, unavailable in this Linux environment.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend surface changed; native physical-device logs remain residual.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - live ASC provisioning profiles, signed app bundles, and device captures cannot be truthfully produced without Apple credentials, macOS signing tools, and hardware.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

N/A - no backend or frontend behavior changed. The relevant native/device logs require the residual hardware run.

## Screenshots (before / after) + video walkthrough

N/A - no UI changed. A physical-device walkthrough must be captured on the supported target rather than fabricated from this Linux environment.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- Live Apple Developer capability/profile reconciliation was not exercised because this environment has no Apple credentials or macOS `security`/`codesign` toolchain. Exact App Group registration and assignment are Apple-managed prerequisites: enabling `APP_GROUPS` alone does not associate `group.ai.elizaos.app`, so the lane fails closed until an Account Holder/Admin completes that association.
- Family Controls is approval-gated and must be enabled by an authorized Apple account owner. HealthKit background delivery, increased-memory-limit, and extended-virtual-addressing are explicitly treated as managed profile grants and validated fail-closed rather than claimed as automatically reconciled.
- A physical iOS install, current-revision XCUITest execution, screenshots/video, and device logs remain required before #13567 is ready to close.
- `bun run verify` reached 208/210 tasks and then failed in the unrelated current-develop `@elizaos/cloud-api#typecheck` task. Reported errors were in cloud API route tuple typing and shared agent-backup-catalog UUID template typing; this PR does not touch those packages.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@dc189c3e7b9e1f479a69411548ed6db00511d290:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-oldest50-13567]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@dc189c3e7b9e1f479a69411548ed6db00511d290:packages/skills/skills/contribute-to-eliza"} -->