### PR TITLE
fix(ci): restore Android device E2E cadence

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,6 +6,7 @@ self-hosted-runner:
     - prod-ops
     - prod-ops-1
     - prod-ops-2
+    - android-device
 
 paths:
   .github/workflows/*.yml:

--- a/.github/scripts/device-e2e/arm64-local-preflight.sh
+++ b/.github/scripts/device-e2e/arm64-local-preflight.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Validates the dedicated Android local-runtime runner before build or device
+# mutation. This lane fails closed unless the host and attached target are both
+# ARM64 and the repository-pinned toolchains are already installed.
+
+set -euo pipefail
+
+[[ "$(node --version)" == "v24.15.0" ]] || {
+  echo "Android ARM64 lane requires Node v24.15.0" >&2
+  exit 1
+}
+[[ "$(bun --version)" == "1.3.14" ]] || {
+  echo "Android ARM64 lane requires Bun 1.3.14" >&2
+  exit 1
+}
+[[ "$(node -p 'process.arch')" == "arm64" ]] || {
+  echo "Android ARM64 lane requires an arm64 host" >&2
+  exit 1
+}
+
+command -v java >/dev/null
+command -v adb >/dev/null
+
+mapfile -t attached_devices < <(adb devices | awk 'NR > 1 && $2 == "device" { print $1 }')
+if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+  printf '%s\n' "${attached_devices[@]}" | grep -Fx -- "$ANDROID_SERIAL" >/dev/null || {
+    echo "ANDROID_SERIAL=$ANDROID_SERIAL is not an attached authorized device" >&2
+    exit 1
+  }
+elif [[ ${#attached_devices[@]} -eq 1 ]]; then
+  ANDROID_SERIAL=${attached_devices[0]}
+else
+  echo "Set ANDROID_SERIAL when the runner does not have exactly one attached device" >&2
+  exit 1
+fi
+
+device_abi=$(adb -s "$ANDROID_SERIAL" shell getprop ro.product.cpu.abi | tr -d '\r')
+[[ "$device_abi" == "arm64-v8a" ]] || {
+  echo "Android local-runtime lane requires arm64-v8a; found ${device_abi:-missing}" >&2
+  exit 1
+}
+[[ "$(adb -s "$ANDROID_SERIAL" shell getprop sys.boot_completed | tr -d '\r')" == "1" ]] || {
+  echo "Android device $ANDROID_SERIAL has not completed boot" >&2
+  exit 1
+}
+
+printf 'ANDROID_SERIAL=%s\n' "$ANDROID_SERIAL" >> "${GITHUB_ENV:?GITHUB_ENV is required}"
+printf 'Validated ARM64 host and Android target %s (%s)\n' "$ANDROID_SERIAL" "$device_abi"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,10 +39,19 @@ Representative examples:
   WebKit fixture gates when `packages/ui/src/**` changes.
 - `device-e2e.yml` is the exact-head Android-emulator and iOS-simulator
   device-bundle producer (#19640). Canonical `ci.yml` calls it only for PRs
-  carrying the `ci:device` label; `workflow_dispatch` is the on-demand route.
+  carrying the `ci:device` label; `workflow_dispatch` is the on-demand route,
+  and a weekly cadence hard-gates the explicit host-safe Android subset.
+  [![scheduled device e2e](https://github.com/elizaOS/eliza/actions/workflows/device-e2e.yml/badge.svg?branch=develop&event=schedule)](https://github.com/elizaOS/eliza/actions/workflows/device-e2e.yml?query=event%3Aschedule)
   Both jobs run the bundle-owning runners with `--output` and upload the full
   bundle (`inline/`, `logs/`, `summary.json`, `junit.xml`) on success and
   failure, without reading any repository secret.
+- `android-arm64-local-e2e.yml` is the separate weekly and dispatchable
+  self-hosted physical-device lane for the embedded Bun + GGUF agent. Its
+  `[self-hosted, Linux, ARM64, android-device]` labels are an infrastructure
+  contract: the job stays queued until such a runner is online, then fails
+  closed unless both the host and attached Android target pass ARM64 and pinned
+  toolchain preflight. It runs local chat plus local-runtime/route WebView
+  probes; on-device voice remains separately qualified.
 
 ## Manual operations
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,13 +45,15 @@ Representative examples:
   Both jobs run the bundle-owning runners with `--output` and upload the full
   bundle (`inline/`, `logs/`, `summary.json`, `junit.xml`) on success and
   failure, without reading any repository secret.
-- `android-arm64-local-e2e.yml` is the separate weekly and dispatchable
+- `android-arm64-local-e2e.yml` is the separate weekly, schedule-only
   self-hosted physical-device lane for the embedded Bun + GGUF agent. Its
   `[self-hosted, Linux, ARM64, android-device]` labels are an infrastructure
   contract: the job stays queued until such a runner is online, then fails
   closed unless both the host and attached Android target pass ARM64 and pinned
   toolchain preflight. It runs local chat plus local-runtime/route WebView
-  probes; on-device voice remains separately qualified.
+  probes; on-device voice remains separately qualified. Manual arbitrary-ref
+  dispatch is intentionally unavailable because this runner persists and owns
+  a physical device.
 
 ## Manual operations
 

--- a/.github/workflows/android-arm64-local-e2e.yml
+++ b/.github/workflows/android-arm64-local-e2e.yml
@@ -1,0 +1,64 @@
+name: Android ARM64 Local Runtime E2E
+
+# Physical-device proof for the embedded Bun + GGUF runtime (#13580). This is
+# deliberately separate from the hosted x86_64 emulator: the hosted image can
+# prove remote-host WebView behavior but cannot execute the on-device runtime.
+# The self-hosted runner must carry all four labels below and the pinned tools;
+# preflight fails before build if either the host or attached Android target is
+# not ARM64. No voice probe runs here because ASR/TTS model provisioning is an
+# independent hardware contract.
+
+on:
+  schedule:
+    - cron: "47 10 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: android-arm64-local-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CI: "true"
+  ELIZA_MOBILE_REPO_ROOT: ${{ github.workspace }}
+  ELIZA_WEBVIEW_DEBUG: "1"
+  ELIZA_BUN_RISCV64_OPTIONAL: "1"
+  ELIZA_ANDROID_BACKEND: "local"
+  ELIZA_ANDROID_REQUIRE_AGENT: "1"
+  ELIZA_PAIRING_DISABLED: "1"
+  ELIZA_DEVICE_BUNDLE_ROOT: ${{ github.workspace }}/device-e2e-artifacts
+
+jobs:
+  android-arm64-local-runtime:
+    name: ARM64 local agent + WebView bundle
+    runs-on: [self-hosted, Linux, ARM64, android-device]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: recursive
+
+      - name: Fail-closed ARM64 device preflight
+        run: bash .github/scripts/device-e2e/arm64-local-preflight.sh
+
+      - name: Install pinned workspace
+        run: bun install --frozen-lockfile
+
+      - name: Local runtime and WebView bundle
+        run: >-
+          node packages/app/scripts/android-e2e.mjs
+          --build
+          --no-emulator-boot
+          --arm64-local-probes
+          --output "$ELIZA_DEVICE_BUNDLE_ROOT/android-arm64-local"
+
+      - name: Upload ARM64 local-runtime bundle
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: android-arm64-local-runtime-bundle
+          path: device-e2e-artifacts/android-arm64-local/**
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/android-arm64-local-e2e.yml
+++ b/.github/workflows/android-arm64-local-e2e.yml
@@ -11,11 +11,15 @@ name: Android ARM64 Local Runtime E2E
 on:
   schedule:
     - cron: "47 10 * * 1"
-  workflow_dispatch:
 
 concurrency:
-  group: android-arm64-local-e2e-${{ github.ref }}
-  cancel-in-progress: true
+  # This persistent physical-device runner is deliberately schedule-only. An
+  # arbitrary-ref workflow_dispatch would let branch-controlled workflow code
+  # execute on the runner, and cancellation could interrupt an APK install or
+  # leave the attached device between test states.
+  group: android-arm64-local-e2e
+  cancel-in-progress: false
+  queue: max
 
 permissions:
   contents: read

--- a/.github/workflows/device-e2e.yml
+++ b/.github/workflows/device-e2e.yml
@@ -1,10 +1,11 @@
 name: Device E2E
 
 # Exact-head Android emulator and iOS simulator device-bundle proof (#19640,
-# #14336). The retired android-device-e2e.yml / mobile-build-smoke.yml producers
-# were deleted by the CI consolidation (926dc8b58a1); this workflow restores a
-# minimal route without the retired sprawl. Each job hands the whole lane to
-# the single bundle-owning runner (android-e2e.mjs / ios-e2e.mjs --output) so
+# #14336, #13580). The retired android-device-e2e.yml / mobile-build-smoke.yml
+# producers were deleted by the CI consolidation (926dc8b58a1); this workflow
+# owns the current hosted-device route without reviving that sprawl. Each job
+# hands the whole lane to the single bundle-owning runner
+# (android-e2e.mjs / ios-e2e.mjs --output) so
 # build, install, boot, and drive failures all land inside one bundle root
 # (inline/, logs/, summary.json, junit.xml), and the artifact is uploaded on
 # success AND failure. No repository secrets are read anywhere, so fork PRs
@@ -13,17 +14,22 @@ name: Device E2E
 # Reachability: repository policy forbids direct pull-request triggers
 # (audit:workflow-triggers), so canonical ci.yml calls this workflow behind the
 # `ci:device` label gate — the emulator/simulator legs are heavy and a PR runs
-# them only when explicitly opted in. Labels are read from the run's event
+# them only when explicitly opted in. A weekly schedule protects the hosted
+# Android subset between PR opt-ins; its event-filtered status badge is linked
+# from .github/workflows/README.md so failures stay visible outside run history.
+# Labels are read from the run's event
 # payload, so apply `ci:device` before the head push (or re-open) that should
 # carry the proof. workflow_dispatch remains the on-demand route for arbitrary
 # refs.
 
 on:
+  schedule:
+    - cron: "17 9 * * 1"
   workflow_call:
   workflow_dispatch:
 
 concurrency:
-  group: device-e2e-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref }}
+  group: device-e2e-${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && format('{0}-{1}', github.event_name, github.run_id) || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -77,9 +83,10 @@ jobs:
             | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules && sudo udevadm trigger --name-match=kvm
 
-      # android-e2e.mjs owns the whole lane inside the emulator session — APK
-      # build (--build), install, WebView route coverage — so every preflight
-      # failure is a recorded bundle step instead of a bundle-less job failure.
+      # android-e2e.mjs owns the whole lane inside the emulator session. The
+      # explicit host probe set is limited to onboarding, route rendering, and
+      # the native-plugin bridge: local-agent, destructive lifecycle, launcher
+      # soak, and voice specs have separate hardware prerequisites.
       - name: Android device-bundle run
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d
         with:
@@ -88,7 +95,7 @@ jobs:
           ram-size: 6144M
           # avx2/fma passthrough so the (x86) on-device agent doesn't SIGILL.
           emulator-options: -no-window -no-snapshot -no-boot-anim -gpu swiftshader_indirect -qemu -cpu qemu64,+avx,+avx2,+f16c,+fma
-          script: node packages/app/scripts/android-e2e.mjs --build --skip-local-chat --no-emulator-boot --output "$ELIZA_DEVICE_BUNDLE_ROOT/android"
+          script: node packages/app/scripts/android-e2e.mjs --build --skip-local-chat --no-emulator-boot --start-host-agent --host-emulator-probes --output "$ELIZA_DEVICE_BUNDLE_ROOT/android"
 
       - name: Upload Android device bundle
         if: always()
@@ -96,7 +103,7 @@ jobs:
         with:
           name: android-device-e2e-bundle
           path: device-e2e-artifacts/android/**
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 14
 
   ios-simulator-bundle:
@@ -149,5 +156,5 @@ jobs:
         with:
           name: ios-simulator-e2e-bundle
           path: device-e2e-artifacts/ios/**
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/device-e2e.yml
+++ b/.github/workflows/device-e2e.yml
@@ -108,6 +108,10 @@ jobs:
 
   ios-simulator-bundle:
     name: iOS simulator bundle
+    # The unattended cadence restores Android coverage only. Keep the existing
+    # iOS producer available to labeled PR callers and explicit dispatches
+    # without adding an unrelated weekly macOS runner allocation.
+    if: github.event_name != 'schedule'
     runs-on: macos-15
     timeout-minutes: 90
     env:

--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -1,21 +1,15 @@
 #!/usr/bin/env node
-// Android end-to-end orchestrator. Single entrypoint that brings the device into
-// a known-good state and runs the real-backend e2e suites, surfacing every
-// failure loudly (non-zero exit). Steps:
-//   1. Ensure an emulator/device is attached (boots an AVD with adequate RAM if
-//      none is running) and, for emulators, SELinux is permissive so the
-//      embedded on-device agent can run.
-//   2. Ensure the WebView-debuggable debug APK is installed.
-//   3. Local route: bring up the on-device agent + smallest model and assert a
-//      real chat round-trip (mobile-local-chat-smoke). Loud fail if the local
-//      runtime or model does not come up.
-//   4. Playwright route coverage: drive the real WebView across every route.
-//   5. (optional) Cloud route: real Hetzner provisioning probe.
-//
-// Flags: --serial <s>  --skip-local-chat  --skip-route-coverage  --cloud
-//        --launcher-loop (≥200-action seeded launcher gesture loop; opt-in)
-//        --force-build/--build (build the APK first)  --skip-build
-//        --no-emulator-boot  --no-wait
+/**
+ * Orchestrates Android device E2E from device preparation through a finalized
+ * evidence bundle. The explicit host-emulator and ARM64-local probe sets keep
+ * remote x86 coverage separate from embedded-agent and voice prerequisites;
+ * every selected probe is a hard gate.
+ *
+ * Flags: --serial <s>, --skip-local-chat, --skip-route-coverage, --cloud,
+ * --launcher-loop, --start-host-agent, --host-emulator-probes,
+ * --arm64-local-probes, --force-build/--build, --skip-build,
+ * --no-emulator-boot, and --no-wait.
+ */
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -55,6 +49,7 @@ import {
   startBundleStep,
 } from "./lib/device-e2e-bundle.mjs";
 import { acquireDeviceLease, isDeviceLeased } from "./lib/device-lease.mjs";
+import { startDeviceE2eHostAgent } from "./lib/host-agent.mjs";
 
 const appDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
 const elizaRoot = path.resolve(appDir, "..", "..");
@@ -65,6 +60,21 @@ const val = (flag, fb) => {
   return i >= 0 ? process.argv[i + 1] : fb;
 };
 const log = (m) => console.log(`[android-e2e] ${m}`);
+
+// These lists are intentionally explicit. The hosted x86_64 emulator must not
+// accidentally inherit a new local-runtime, destructive lifecycle, or voice
+// spec merely because it was added under test/android. ARM64 local proof owns
+// the embedded agent and its WebView contract, while voice remains a separate
+// hardware-qualified lane with its own model prerequisites.
+const HOST_EMULATOR_PROBES = [
+  "test/android/onboarding-to-home.android.spec.ts",
+  "test/android/route-coverage.android.spec.ts",
+  "test/android/native-plugin-view-smoke.android.spec.ts",
+];
+const ARM64_LOCAL_PROBES = [
+  "test/android/local-runtime.android.spec.ts",
+  "test/android/route-coverage.android.spec.ts",
+];
 
 // Smallest local tier; same id the smoke + catalog use.
 const SMOKE_MODEL = {
@@ -406,8 +416,52 @@ async function main() {
   let finalResult = "failed";
   let finalError = null;
   let routeRecording = null;
+  let hostAgent = null;
+
+  const hostEmulatorProbes = has("--host-emulator-probes");
+  const arm64LocalProbes = has("--arm64-local-probes");
+  const backend = (process.env.ELIZA_ANDROID_BACKEND ?? "local").toLowerCase();
 
   try {
+    {
+      const step = startBundleStep(bundle, "validate Android lane selection");
+      try {
+        if (hostEmulatorProbes && arm64LocalProbes) {
+          throw new Error(
+            "--host-emulator-probes and --arm64-local-probes are mutually exclusive.",
+          );
+        }
+        if (hostEmulatorProbes && backend !== "host") {
+          throw new Error(
+            "--host-emulator-probes requires ELIZA_ANDROID_BACKEND=host.",
+          );
+        }
+        if (arm64LocalProbes && backend !== "local") {
+          throw new Error(
+            "--arm64-local-probes requires ELIZA_ANDROID_BACKEND=local.",
+          );
+        }
+        if (hostEmulatorProbes && !has("--skip-local-chat")) {
+          throw new Error(
+            "--host-emulator-probes requires --skip-local-chat; x86 must not run the embedded local agent.",
+          );
+        }
+        if (arm64LocalProbes && has("--skip-local-chat")) {
+          throw new Error(
+            "--arm64-local-probes must run the local chat smoke; remove --skip-local-chat.",
+          );
+        }
+        if (has("--start-host-agent") && backend !== "host") {
+          throw new Error(
+            "--start-host-agent requires ELIZA_ANDROID_BACKEND=host.",
+          );
+        }
+        finishBundleStep(bundle, step, "passed");
+      } catch (error) {
+        failAndroidStep(bundle, step, error);
+        throw error;
+      }
+    }
     {
       const step = startBundleStep(bundle, "resolve Android SDK");
       try {
@@ -473,6 +527,23 @@ async function main() {
 
     ensureFreshApkInstalled(bundle, adb, serial);
 
+    if (has("--start-host-agent")) {
+      const step = startBundleStep(bundle, "start deterministic host agent");
+      try {
+        hostAgent = await startDeviceE2eHostAgent({
+          repoRoot: elizaRoot,
+          artifactDir: bundle.logsDir,
+          requestedPort: 31337,
+          log,
+        });
+        process.env.ELIZA_ANDROID_HOST_AGENT_PORT = String(hostAgent.port);
+        finishBundleStep(bundle, step, "passed");
+      } catch (error) {
+        failAndroidStep(bundle, step, error);
+        throw error;
+      }
+    }
+
     if (!has("--skip-local-chat")) {
       const modelPath = ensureSmokeModelCached();
       log("local route: on-device agent + smallest model + real chat…");
@@ -496,11 +567,9 @@ async function main() {
     }
 
     if (!has("--skip-route-coverage")) {
-      // The Playwright config runs route-coverage AND the on-device voice
-      // round-trip; the latter needs the ASR/TTS GGUFs staged (the chat smoke only
-      // stages the text model, and an `adb install -r` cycle can drop the
-      // separately-pushed voice models).
-      {
+      // Only the legacy full-directory lane includes on-device voice. Explicit
+      // host/local probe sets keep that hardware-and-model contract separate.
+      if (!hostEmulatorProbes && !arm64LocalProbes) {
         const step = startBundleStep(bundle, "stage Android voice models");
         try {
           stageVoiceModels(adb, serial);
@@ -520,6 +589,11 @@ async function main() {
         log,
       });
       try {
+        const selectedProbes = hostEmulatorProbes
+          ? HOST_EMULATOR_PROBES
+          : arm64LocalProbes
+            ? ARM64_LOCAL_PROBES
+            : [];
         run(
           bundle,
           "Android route coverage",
@@ -528,6 +602,7 @@ async function main() {
             "scripts/run-ui-playwright.mjs",
             "--config",
             "playwright.android.config.ts",
+            ...selectedProbes,
           ],
           {
             ANDROID_SERIAL: serial,
@@ -606,11 +681,24 @@ async function main() {
     log("ALL ANDROID E2E PASSED ✅");
   } catch (error) {
     finalError = error;
-    throw error;
   } finally {
     if (routeRecording) {
       const videoPath = await routeRecording.stop();
       if (videoPath) recordBundleArtifact(bundle, videoPath, "video");
+    }
+    if (hostAgent) {
+      const step = startBundleStep(bundle, "stop deterministic host agent");
+      try {
+        await hostAgent.stop();
+        finishBundleStep(bundle, step, "passed");
+      } catch (error) {
+        // error-policy:J1 runner boundary records teardown failure before exiting
+        finishBundleStep(bundle, step, "failed", error);
+        finalResult = "failed";
+        if (!finalError) {
+          finalError = error;
+        }
+      }
     }
     if (adb && serial) {
       try {
@@ -658,6 +746,7 @@ async function main() {
     }
     log(`bundle: ${bundleRoot}`);
   }
+  if (finalError) throw finalError;
 }
 
 main().catch((error) => {

--- a/packages/app/test/android/README.md
+++ b/packages/app/test/android/README.md
@@ -112,15 +112,18 @@ bun run --cwd packages/app test:e2e:android:routes
 | `--build` | Build the APK before installing |
 | `--skip-local-chat` | Skip the on-device agent/chat bring-up |
 | `--skip-route-coverage` | Skip the Playwright WebView sweep |
+| `--start-host-agent` | Start and health-check the deterministic app-core host agent, then stop it in runner teardown (host backend only) |
+| `--host-emulator-probes` | Run only onboarding, route rendering, and native-plugin bridge specs; requires host backend + `--skip-local-chat` |
+| `--arm64-local-probes` | Run local chat plus local-runtime and route-rendering WebView specs; requires local backend and an ARM64 device |
 | `--cloud` | Also run the real Cloud runtime probe (shared by default; not dedicated/Hetzner ingress proof) |
 | `--no-emulator-boot` | Use an already-running device, don't boot an AVD |
 | `ELIZA_ANDROID_REQUIRE_AGENT=0` | Don't gate route coverage on local agent health (cloud/remote mode) |
 | `ELIZA_EMULATOR_MEMORY_MB` / `ELIZA_EMULATOR_CORES` | Override emulator sizing |
 
-## CI onboarding lane
+## CI device lanes
 
-`android-device-e2e.yml` now runs a load-bearing first-run lane before the
-best-effort route sweep:
+The scheduled and `ci:device`-label-gated Android job in
+`.github/workflows/device-e2e.yml` is a load-bearing x86_64 host-emulator lane:
 
 1. Start `packages/app-core/scripts/serve-real-local-agent.ts` on host
    `127.0.0.1:31337` with pairing disabled and deterministic model handlers.
@@ -128,13 +131,30 @@ best-effort route sweep:
 3. Run `test/android/onboarding-to-home.android.spec.ts` with
    `ELIZA_ANDROID_BACKEND=host`, so global setup wires `adb reverse
    tcp:31337 -> host:31337`.
-4. The spec navigates the installed app to `/?reset`, taps through Remote
-   onboarding, posts first-run to the real host agent, and asserts
-   `home-launcher-surface[data-page="home"]` plus the chat composer.
+4. Hard-gate the explicit host-safe set: remote onboarding, route rendering,
+   and the native `ElizaSystem` plugin bridge. A newly added Android spec does
+   not enter this set implicitly.
+5. Stop the host agent in `android-e2e.mjs` teardown and upload its log inside
+   the device bundle. Missing bundles are upload failures, not warnings.
 
 Artifacts are written under
 `packages/app/test-results/android-onboarding-to-home/`:
-`home-landing.png`, `onboarding-to-home.mp4`, and `host-agent.log`.
+`home-landing.png`, `onboarding-to-home.mp4`, and `host-agent.log`; the bundle
+root also includes `inline/`, `logs/`, `summary.json`, and `junit.xml`.
+
+`.github/workflows/android-arm64-local-e2e.yml` is the separate weekly and
+manual local-runtime lane. It targets a self-hosted Linux runner labeled
+`ARM64` and `android-device`, then fails closed unless Node 24.15.0, Bun 1.3.14,
+an authorized booted `arm64-v8a` Android target, Java, and adb are present. It
+runs the real local chat smoke followed by `local-runtime.android.spec.ts` and
+`route-coverage.android.spec.ts`. The repository does not currently provide
+that runner, so a queued job is an infrastructure prerequisite rather than
+device proof. Do not cite this workflow as ARM64 evidence until a completed
+bundle from the current revision has been inspected.
+
+Local voice, destructive lifecycle, launcher soak, touch, and sleep/wake are
+not smuggled into either set. Run their focused commands explicitly on hardware
+that satisfies their model, privilege, and lifecycle prerequisites.
 
 ## On-device agent: where it runs
 
@@ -145,7 +165,7 @@ even after SELinux-permissive + 6GB + AVX2 (an emulator/runtime incompatibility
 the branded AOSP build avoids). So the on-device LOCAL route is validated on a
 device runner; the smoke surfaces the emulator failure loudly.
 
-## Known last gate: device pairing
+## Device pairing
 
 With a healthy on-device agent, the WebView still gates the shell behind the
 app's **device-pairing** screen ("Pairing Required — generate a code on the
@@ -155,8 +175,9 @@ server, paste it here"). For unattended e2e the agent should run with
 `GET /api/auth/pair-code` → `POST /api/auth/pair` handshake and seed the
 resulting session. Until then, route coverage needs a backend that's already
 "connected" — a cloud-onboarded agent (`ELIZA_ANDROID_BACKEND` + a cloud token)
-or pairing disabled in the test build. This is the one remaining wiring step to
-fully-green on-device route coverage.
+or pairing disabled in the test build. The local-runtime CI lane uses the
+pairing-disabled test contract while the host-emulator lane adopts a
+deterministic remote host over `adb reverse`.
 
 The repo-wide app test-auth contract lives in
 [`../../docs/TEST_AUTH.md`](../../docs/TEST_AUTH.md). It records which

--- a/packages/app/test/android/README.md
+++ b/packages/app/test/android/README.md
@@ -142,15 +142,16 @@ Artifacts are written under
 `home-landing.png`, `onboarding-to-home.mp4`, and `host-agent.log`; the bundle
 root also includes `inline/`, `logs/`, `summary.json`, and `junit.xml`.
 
-`.github/workflows/android-arm64-local-e2e.yml` is the separate weekly and
-manual local-runtime lane. It targets a self-hosted Linux runner labeled
+`.github/workflows/android-arm64-local-e2e.yml` is the separate weekly,
+schedule-only local-runtime lane. It targets a self-hosted Linux runner labeled
 `ARM64` and `android-device`, then fails closed unless Node 24.15.0, Bun 1.3.14,
 an authorized booted `arm64-v8a` Android target, Java, and adb are present. It
 runs the real local chat smoke followed by `local-runtime.android.spec.ts` and
 `route-coverage.android.spec.ts`. The repository does not currently provide
 that runner, so a queued job is an infrastructure prerequisite rather than
-device proof. Do not cite this workflow as ARM64 evidence until a completed
-bundle from the current revision has been inspected.
+device proof. Arbitrary-ref manual dispatch is intentionally unavailable on
+this persistent physical-device runner. Do not cite this workflow as ARM64
+evidence until a completed bundle from the current revision has been inspected.
 
 Local voice, destructive lifecycle, launcher soak, touch, and sleep/wake are
 not smuggled into either set. Run their focused commands explicitly on hardware

--- a/packages/app/test/android/route-coverage.android.spec.ts
+++ b/packages/app/test/android/route-coverage.android.spec.ts
@@ -3,11 +3,11 @@
 // is the Android equivalent of the browser all-pages-clicksafe sweep, but with
 // no API mocking — the app talks to the real on-device agent.
 //
-// The assertion here is "navigates client-side + mounts its React root + does
-// not trip the error boundary", NOT the exact per-route content: those text
-// assertions live in the (mocked) ui-smoke suite and don't hold against real,
-// unseeded backend data. This sweep's job is to guarantee every route is
-// on-device navigable and render-safe on the real WebView.
+// Every route must retain the requested pathname. Direct product routes also
+// reuse their canonical page-ready marker, so a shared shell or router fallback
+// cannot satisfy the whole matrix. Manager-provided views have no static
+// per-view DOM contract, so they retain the pathname + nonblank/error-boundary
+// proof against the real, unseeded backend.
 //
 // It reuses the canonical route enumerations so coverage stays in lock-step with
 // the product: DIRECT_ROUTE_CASES (app-window / app-shell pages) and
@@ -16,12 +16,28 @@ import {
   DIRECT_ROUTE_CASES,
   MANAGER_VISIBLE_VIEW_TILE_CASES,
 } from "../ui-smoke/apps-session-route-cases";
-import { expect, gotoRoute, test, waitForShellReady } from "./android-harness";
+import {
+  expect,
+  expectRouteReady,
+  gotoRoute,
+  type ReadyCheck,
+  test,
+  waitForShellReady,
+} from "./android-harness";
 
-type RouteCase = { name: string; path: string };
+type RouteCase = {
+  name: string;
+  path: string;
+  readyChecks?: readonly ReadyCheck[];
+};
 
 const ROUTES: RouteCase[] = [
-  ...DIRECT_ROUTE_CASES.map((c) => ({ name: c.name, path: c.path })),
+  ...DIRECT_ROUTE_CASES.map((route) => ({
+    name: route.name,
+    path: route.path,
+    readyChecks:
+      "selector" in route ? [{ selector: route.selector }] : route.readyChecks,
+  })),
   ...MANAGER_VISIBLE_VIEW_TILE_CASES.map((v) => ({
     name: `view ${v.viewId}`,
     path: v.expectedPath,
@@ -47,8 +63,19 @@ test.describe("android route coverage (real backend)", () => {
       page,
     }) => {
       await gotoRoute(page, route.path);
+      await expect
+        .poll(() => page.evaluate(() => window.location.pathname), {
+          timeout: 45_000,
+          message: `${route.name}: router did not retain ${route.path}`,
+        })
+        .toBe(route.path);
       // React root stays mounted.
       await expect(page.locator("#root")).toBeVisible({ timeout: 45_000 });
+      if (route.readyChecks?.length) {
+        await expectRouteReady(page, route.name, route.readyChecks, {
+          timeoutMs: 45_000,
+        });
+      }
       // The route paints SOMETHING (not a blank white screen) within the window.
       await expect
         .poll(

--- a/packages/scripts/__tests__/device-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/device-e2e-workflow.test.ts
@@ -14,12 +14,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -53,7 +48,11 @@ interface CallerJob {
 }
 
 interface Workflow {
-  concurrency?: { group?: string; "cancel-in-progress"?: boolean | string };
+  concurrency?: {
+    group?: string;
+    "cancel-in-progress"?: boolean | string;
+    queue?: string;
+  };
   env?: Record<string, string>;
   jobs?: Record<string, WorkflowJob>;
   on?: Record<string, unknown>;
@@ -67,6 +66,9 @@ const arm64WorkflowSource = read(
 );
 const arm64Workflow = Bun.YAML.parse(arm64WorkflowSource) as Workflow;
 const androidRunnerSource = read("packages/app/scripts/android-e2e.mjs");
+const androidRouteCoverageSource = read(
+  "packages/app/test/android/route-coverage.android.spec.ts",
+);
 const arm64PreflightSource = read(
   ".github/scripts/device-e2e/arm64-local-preflight.sh",
 );
@@ -138,9 +140,7 @@ describe("device-e2e workflow trigger reaches both bundle producers (#19640)", (
     );
     const script = runner.with?.script ?? "";
     expect(script).toContain("packages/app/scripts/android-e2e.mjs");
-    expect(script).toContain(
-      '--output "$ELIZA_DEVICE_BUNDLE_ROOT/android"',
-    );
+    expect(script).toContain('--output "$ELIZA_DEVICE_BUNDLE_ROOT/android"');
     expect(script).toContain("--start-host-agent");
     expect(script).toContain("--host-emulator-probes");
     expect(script).toContain("--skip-local-chat");
@@ -151,6 +151,7 @@ describe("device-e2e workflow trigger reaches both bundle producers (#19640)", (
 
   test("the iOS job invokes ios-e2e.mjs with --output inside the artifact root", () => {
     const job = requireJob(iosJob, "ios-simulator-bundle");
+    expect(job.if).toBe("github.event_name != 'schedule'");
     expect(String(job["runs-on"])).toMatch(/^macos-/);
     const runner = findStep(
       job,
@@ -203,6 +204,12 @@ describe("Android probe partitioning (#13580)", () => {
     expect(hostSet).not.toContain("launcher-gesture-loop.android.spec.ts");
     expect(androidRunnerSource).toContain("startDeviceE2eHostAgent");
     expect(androidRunnerSource).toContain("await hostAgent.stop()");
+  });
+
+  test("route coverage proves the requested path and canonical page marker", () => {
+    expect(androidRouteCoverageSource).toContain("window.location.pathname");
+    expect(androidRouteCoverageSource).toContain("route.readyChecks");
+    expect(androidRouteCoverageSource).toContain("expectRouteReady(");
   });
 
   test("ARM64 local set includes chat-backed WebView proof but excludes voice", () => {
@@ -264,11 +271,22 @@ describe("Android probe partitioning (#13580)", () => {
 describe("ARM64 local-runtime workflow (#13580)", () => {
   const armJob = arm64Workflow.jobs?.["android-arm64-local-runtime"];
 
-  test("has its own cadence and exact self-hosted device labels", () => {
+  test("is schedule-only and cannot execute an arbitrary dispatched ref", () => {
     expect(arm64Workflow.on && "schedule" in arm64Workflow.on).toBe(true);
     expect(arm64Workflow.on && "workflow_dispatch" in arm64Workflow.on).toBe(
-      true,
+      false,
     );
+    expect(arm64Workflow.on && "pull_request" in arm64Workflow.on).toBe(false);
+    expect(arm64Workflow.on && "push" in arm64Workflow.on).toBe(false);
+  });
+
+  test("serializes physical-device mutation without cancelling an active run", () => {
+    expect(arm64Workflow.concurrency?.group).toBe("android-arm64-local-e2e");
+    expect(arm64Workflow.concurrency?.["cancel-in-progress"]).toBe(false);
+    expect(arm64Workflow.concurrency?.queue).toBe("max");
+  });
+
+  test("requires the exact self-hosted device labels", () => {
     expect(
       requireJob(armJob, "android-arm64-local-runtime")["runs-on"],
     ).toEqual(["self-hosted", "Linux", "ARM64", "android-device"]);

--- a/packages/scripts/__tests__/device-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/device-e2e-workflow.test.ts
@@ -1,5 +1,6 @@
 /**
- * Contract for the label-gated device-bundle workflow (#19640, #14336).
+ * Contract for hosted and ARM64 Android device-bundle workflows
+ * (#19640, #14336, #13580).
  *
  * The CI consolidation removed every live route to the exact-head Android and
  * iOS device-bundle proof. device-e2e.yml restores one: this suite pins that
@@ -12,7 +13,16 @@
  * Parses the real workflow YAML; deterministic, no network or devices.
  */
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const repoRoot = new URL("../../../", import.meta.url);
 
@@ -31,7 +41,7 @@ interface WorkflowStep {
 interface WorkflowJob {
   env?: Record<string, string>;
   if?: string;
-  "runs-on"?: string;
+  "runs-on"?: string | string[];
   steps?: WorkflowStep[];
   "timeout-minutes"?: number;
 }
@@ -52,6 +62,15 @@ interface Workflow {
 
 const workflowSource = read(".github/workflows/device-e2e.yml");
 const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const arm64WorkflowSource = read(
+  ".github/workflows/android-arm64-local-e2e.yml",
+);
+const arm64Workflow = Bun.YAML.parse(arm64WorkflowSource) as Workflow;
+const androidRunnerSource = read("packages/app/scripts/android-e2e.mjs");
+const arm64PreflightSource = read(
+  ".github/scripts/device-e2e/arm64-local-preflight.sh",
+);
+const workflowReadme = read(".github/workflows/README.md");
 const ci = Bun.YAML.parse(read(".github/workflows/ci.yml")) as {
   jobs?: Record<string, CallerJob>;
 };
@@ -92,10 +111,20 @@ describe("device-e2e workflow trigger reaches both bundle producers (#19640)", (
   });
 
   test("the producer stays callable and dispatchable but never directly PR/push triggered", () => {
+    expect(workflow.on && "schedule" in workflow.on).toBe(true);
     expect(workflow.on && "workflow_call" in workflow.on).toBe(true);
     expect(workflow.on && "workflow_dispatch" in workflow.on).toBe(true);
     expect(workflow.on && "pull_request" in (workflow.on ?? {})).toBe(false);
     expect(workflow.on && "push" in (workflow.on ?? {})).toBe(false);
+  });
+
+  test("scheduled failures have a visible event-filtered workflow badge", () => {
+    expect(workflowReadme).toContain(
+      "actions/workflows/device-e2e.yml/badge.svg?branch=develop&event=schedule",
+    );
+    expect(workflowReadme).toContain(
+      "actions/workflows/device-e2e.yml?query=event%3Aschedule",
+    );
   });
 
   test("the Android job invokes the bundle-owning runner with --output inside the artifact root", () => {
@@ -112,6 +141,9 @@ describe("device-e2e workflow trigger reaches both bundle producers (#19640)", (
     expect(script).toContain(
       '--output "$ELIZA_DEVICE_BUNDLE_ROOT/android"',
     );
+    expect(script).toContain("--start-host-agent");
+    expect(script).toContain("--host-emulator-probes");
+    expect(script).toContain("--skip-local-chat");
     expect(job.env?.ELIZA_DEVICE_BUNDLE_ROOT).toBe(
       "${{ github.workspace }}/device-e2e-artifacts",
     );
@@ -119,7 +151,7 @@ describe("device-e2e workflow trigger reaches both bundle producers (#19640)", (
 
   test("the iOS job invokes ios-e2e.mjs with --output inside the artifact root", () => {
     const job = requireJob(iosJob, "ios-simulator-bundle");
-    expect(job["runs-on"]).toMatch(/^macos-/);
+    expect(String(job["runs-on"])).toMatch(/^macos-/);
     const runner = findStep(
       job,
       (step) => step.run?.includes("packages/app/scripts/ios-e2e.mjs") === true,
@@ -139,6 +171,7 @@ describe("device-e2e workflow trigger reaches both bundle producers (#19640)", (
     );
     expect(android.if).toBe("always()");
     expect(android.with?.path).toContain("device-e2e-artifacts/android/**");
+    expect(android.with?.["if-no-files-found"]).toBe("error");
 
     const ios = findStep(
       requireJob(iosJob, "ios-simulator-bundle"),
@@ -147,6 +180,131 @@ describe("device-e2e workflow trigger reaches both bundle producers (#19640)", (
     );
     expect(ios.if).toBe("always()");
     expect(ios.with?.path).toContain("device-e2e-artifacts/ios/**");
+    expect(ios.with?.["if-no-files-found"]).toBe("error");
+  });
+});
+
+describe("Android probe partitioning (#13580)", () => {
+  test("hosted x86 hard-gates only the explicit host-safe probe set", () => {
+    for (const path of [
+      "test/android/onboarding-to-home.android.spec.ts",
+      "test/android/route-coverage.android.spec.ts",
+      "test/android/native-plugin-view-smoke.android.spec.ts",
+    ]) {
+      expect(androidRunnerSource).toContain(path);
+    }
+    const hostSet = androidRunnerSource.match(
+      /const HOST_EMULATOR_PROBES = \[([\s\S]*?)\];/,
+    )?.[1];
+    expect(hostSet).toBeTruthy();
+    expect(hostSet).not.toContain("local-runtime.android.spec.ts");
+    expect(hostSet).not.toContain("voice-selftest.android.spec.ts");
+    expect(hostSet).not.toContain("lifecycle.android.spec.ts");
+    expect(hostSet).not.toContain("launcher-gesture-loop.android.spec.ts");
+    expect(androidRunnerSource).toContain("startDeviceE2eHostAgent");
+    expect(androidRunnerSource).toContain("await hostAgent.stop()");
+  });
+
+  test("ARM64 local set includes chat-backed WebView proof but excludes voice", () => {
+    const localSet = androidRunnerSource.match(
+      /const ARM64_LOCAL_PROBES = \[([\s\S]*?)\];/,
+    )?.[1];
+    expect(localSet).toContain("local-runtime.android.spec.ts");
+    expect(localSet).toContain("route-coverage.android.spec.ts");
+    expect(localSet).not.toContain("voice-selftest.android.spec.ts");
+    expect(androidRunnerSource).toContain(
+      "--arm64-local-probes must run the local chat smoke",
+    );
+  });
+
+  test("invalid host/local selection exits nonzero with a finalized failed bundle", () => {
+    const output = mkdtempSync(path.join(os.tmpdir(), "eliza-android-lane-"));
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [
+          path.join(
+            fileURLToPath(repoRoot),
+            "packages/app/scripts/android-e2e.mjs",
+          ),
+          "--host-emulator-probes",
+          "--skip-local-chat",
+          "--output",
+          output,
+        ],
+        {
+          cwd: fileURLToPath(repoRoot),
+          encoding: "utf8",
+          env: { ...process.env, ELIZA_ANDROID_BACKEND: "local" },
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "--host-emulator-probes requires ELIZA_ANDROID_BACKEND=host",
+      );
+      expect(existsSync(path.join(output, "summary.json"))).toBe(true);
+      expect(existsSync(path.join(output, "junit.xml"))).toBe(true);
+      const summary = JSON.parse(
+        readFileSync(path.join(output, "summary.json"), "utf8"),
+      ) as { result: string; steps: Array<{ name: string; status: string }> };
+      expect(summary.result).toBe("failed");
+      expect(summary.steps).toContainEqual(
+        expect.objectContaining({
+          name: "validate Android lane selection",
+          status: "failed",
+        }),
+      );
+    } finally {
+      rmSync(output, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("ARM64 local-runtime workflow (#13580)", () => {
+  const armJob = arm64Workflow.jobs?.["android-arm64-local-runtime"];
+
+  test("has its own cadence and exact self-hosted device labels", () => {
+    expect(arm64Workflow.on && "schedule" in arm64Workflow.on).toBe(true);
+    expect(arm64Workflow.on && "workflow_dispatch" in arm64Workflow.on).toBe(
+      true,
+    );
+    expect(
+      requireJob(armJob, "android-arm64-local-runtime")["runs-on"],
+    ).toEqual(["self-hosted", "Linux", "ARM64", "android-device"]);
+  });
+
+  test("fails closed on pinned ARM64 host/device prerequisites", () => {
+    expect(arm64PreflightSource).toContain('"v24.15.0"');
+    expect(arm64PreflightSource).toContain('"1.3.14"');
+    expect(arm64PreflightSource).toContain("process.arch");
+    expect(arm64PreflightSource).toContain('"arm64-v8a"');
+    expect(arm64PreflightSource).toContain("sys.boot_completed");
+    expect(arm64PreflightSource).toContain("GITHUB_ENV");
+  });
+
+  test("runs the explicit local probe set and uploads exact artifacts honestly", () => {
+    const job = requireJob(armJob, "android-arm64-local-runtime");
+    const runner = findStep(
+      job,
+      (step) => step.run?.includes("--arm64-local-probes") === true,
+      "ARM64 local runner",
+    );
+    expect(runner.run).toContain("packages/app/scripts/android-e2e.mjs");
+    expect(runner.run).toContain("--no-emulator-boot");
+    expect(runner.run).toContain(
+      '--output "$ELIZA_DEVICE_BUNDLE_ROOT/android-arm64-local"',
+    );
+    const upload = findStep(
+      job,
+      (step) => step.uses?.startsWith("actions/upload-artifact@") === true,
+      "ARM64 upload",
+    );
+    expect(upload.if).toBe("always()");
+    expect(upload.with?.path).toContain(
+      "device-e2e-artifacts/android-arm64-local/**",
+    );
+    expect(upload.with?.["if-no-files-found"]).toBe("error");
   });
 });
 
@@ -183,7 +341,10 @@ describe("device-e2e workflow hygiene", () => {
   });
 
   test("every third-party action is pinned by full commit SHA", () => {
-    const uses = [...workflowSource.matchAll(/uses:\s*([^\s]+)/g)]
+    const uses = [
+      ...workflowSource.matchAll(/uses:\s*([^\s]+)/g),
+      ...arm64WorkflowSource.matchAll(/uses:\s*([^\s]+)/g),
+    ]
       .map((match) => match[1])
       .filter((ref) => !ref.startsWith("./"));
     expect(uses.length).toBeGreaterThan(0);


### PR DESCRIPTION
# Relates to

Relates to #13580. This PR restores Android device-E2E infrastructure; it does not close the issue until real ARM64/device evidence exists.

- [x] Targets `develop` and was rebased onto `origin/develop` at exact-head creation.
- [ ] Exact-head hosted device artifacts and full CI are pending.
- [x] ARM64 hardware absence is reported as a blocker, never a fabricated pass.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@dc189c3e7b9e1f479a69411548ed6db00511d290:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `2b88e84d180`; zero conflicts.
- [ ] Full exact-head CI/device workflow pending.

# Risks

Medium. This adds recurring hosted-emulator usage and a dormant schedule-only self-hosted ARM64/device lane. Security review removed arbitrary-ref manual dispatch from the persistent physical runner, prevents cancellation during device mutation, and keeps the unattended schedule Android-only.

# Background

## What does this PR do?

- Restores weekly hosted Android emulator cadence in the consolidated device workflow.
- Starts/stops the host agent deterministically and gates an explicit emulator-supported onboarding/route/native-plugin subset.
- Adds a separate fail-closed ARM64 + `arm64-v8a` physical/local-runtime lane with pinned toolchain and artifact contracts.
- Restricts the privileged persistent ARM64/device runner to the default-branch schedule; branch-controlled manual dispatch is intentionally unavailable.
- Serializes physical mutation with one non-canceling concurrency group and `queue:max`.
- Prevents the Android weekly schedule from accidentally allocating the unrelated 90-minute macOS iOS job.
- Proves each direct route retains its pathname and reaches one of its canonical route-ready markers, so a generic mounted shell cannot satisfy route coverage.
- Finalizes failed evidence bundles before nonzero exit and documents honest x86/ARM64/lifecycle/voice partitions.

## What kind of change is this?

CI/device-test reliability and security hardening.

# Documentation changes needed?

Updated `.github/workflows/README.md` and `packages/app/test/android/README.md`.

# Testing

## Where should a reviewer start?

Start with both workflow triggers/concurrency blocks, then `route-coverage.android.spec.ts` and `device-e2e-workflow.test.ts`.

## Detailed testing steps

- Pinned Bun 1.3.14 / Node 24.15.0 focused suite: 33/33 passing.
- Actionlint passed on both workflows.
- ARM preflight `bash -n` passed.
- App lint passed across 303 files.
- Biome passed; only two pre-existing GitHub-expression warnings remain.
- `git diff --check` passed.
- App typecheck was topology-blocked in the isolated worktree by absent built workspace artifacts; exact-head CI is authoritative.

# Evidence Gate

<!-- evidence-head:4e192c28ab9c0623c720cf5cc543360abe0cba58 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow/test/docs only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow/test/docs only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - exact-head hosted device recording is pending; no product UI source changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production backend path changed; deterministic host-agent lifecycle is covered by focused tests.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime request/state code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain state changes; hosted `summary.json`, JUnit, logs, and video remain pending on the exact-head Actions runner.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Known gaps / failures

- No `[self-hosted, Linux, ARM64, android-device]` runner or physical-device bundle exists. The schedule-only workflow is infrastructure, not #13580 acceptance.
- Exact-head hosted emulator bundle summary, JUnit, logs, and video must be dispatched and inspected before merge.
- The isolated app typecheck could not resolve absent built workspace artifacts; exact-head CI must supply the full topology.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@dc189c3e7b9e1f479a69411548ed6db00511d290:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@dc189c3e7b9e1f479a69411548ed6db00511d290:packages/skills/skills/contribute-to-eliza"} -->