### PR TITLE
fix(cloud): green cloud-api typecheck — type route/test mocks properly

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/route.delete-github-repo.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.delete-github-repo.test.ts
@@ -21,16 +21,18 @@ const getById = mock(async (id: string) =>
     ? { id: APP_ID, organization_id: ORG_A, github_repo: "elizaOS-apps/keep" }
     : null,
 );
-const deleteAppWithCleanup = mock(async () => ({
-  success: true,
-  errors: [],
-  cleaned: {
-    domainsRemoved: 0,
-    githubRepoDeleted: true,
-    secretBindingsRemoved: 0,
-    managedDomainsUnlinked: 0,
-  },
-}));
+const deleteAppWithCleanup = mock(
+  async (_appId: string, _options: { deleteGitHubRepo?: boolean } = {}) => ({
+    success: true,
+    errors: [],
+    cleaned: {
+      domainsRemoved: 0,
+      githubRepoDeleted: true,
+      secretBindingsRemoved: 0,
+      managedDomainsUnlinked: 0,
+    },
+  }),
+);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg: async () => ({

--- a/packages/cloud/api/v1/containers/[id]/route.purge-volume.test.ts
+++ b/packages/cloud/api/v1/containers/[id]/route.purge-volume.test.ts
@@ -20,11 +20,23 @@ const ORG_A = "11111111-1111-4111-8111-111111111111";
 const CONTAINER_ID = "ctr-keep-volume";
 const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
 
-const deleteContainer = mock(async () => undefined);
-const stopContainer = mock(async () => ({
-  id: CONTAINER_ID,
-  status: "stopped",
-}));
+const deleteContainer = mock(
+  async (
+    _containerId: string,
+    _organizationId: string,
+    _options: { purgeVolume?: boolean } = {},
+  ) => undefined,
+);
+const stopContainer = mock(
+  async (
+    _containerId: string,
+    _organizationId: string,
+    _options: { purgeVolume?: boolean } = {},
+  ) => ({
+    id: CONTAINER_ID,
+    status: "stopped",
+  }),
+);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg: async () => ({

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
@@ -7,10 +7,22 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import type {
+  ProxyRequestBody,
+  ServiceConfig,
+  ServiceHandler,
+} from "@/lib/services/proxy/types";
 
 const SOLANA_TOKEN = "So11111111111111111111111111111111111111112";
 
-const executeWithBody = mock(async () => Response.json({ success: true }));
+const executeWithBody = mock(
+  async (
+    _config: ServiceConfig,
+    _work: ServiceHandler,
+    _request: Request,
+    _body: ProxyRequestBody,
+  ) => Response.json({ success: true }),
+);
 
 mock.module("@/lib/services/proxy/engine", () => ({
   executeWithBody,

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
@@ -45,6 +45,7 @@ import { dockerNodes } from "../../schemas/docker-nodes";
 import { organizations } from "../../schemas/organizations";
 import { userCharacters } from "../../schemas/user-characters";
 import { users } from "../../schemas/users";
+import type { AgentBackupOperationExecution } from "../agent-backup-catalog";
 import {
   agentBackupObjectInventoryDigest,
   buildAgentBackupObjectKey,
@@ -696,7 +697,7 @@ async function claimExecution(backupId: string) {
 async function reserveCopy(
   backupId: string,
   copyRole: "primary" | "secondary",
-  execution: Awaited<ReturnType<typeof claimExecution>>,
+  execution: AgentBackupOperationExecution,
   descriptor = objectDescriptor(),
 ) {
   return reserveAgentBackupObject({
@@ -717,7 +718,7 @@ async function reserveCopy(
 
 async function markPresentAndVerified(
   objectId: string,
-  execution: Awaited<ReturnType<typeof claimExecution>>,
+  execution: AgentBackupOperationExecution,
   receipt = SHA_D,
 ) {
   await markAgentBackupObjectUploading({


### PR DESCRIPTION
## Summary

`bun run --cwd packages/cloud/api typecheck` is red on develop tip, breaking the CI/Tests lanes and `bun run verify`. All 14 errors are confined to four test files introduced by today's route-identity and storage/backup PRs:

- `packages/cloud/api/v1/apps/[id]/route.delete-github-repo.test.ts` — 2× TS2493
- `packages/cloud/api/v1/containers/[id]/route.purge-volume.test.ts` — 3× TS2493
- `packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts` — 4× TS2493 + 2× TS2352
- `packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts` — 3× TS2345

## Fix

Types only — no production code and no runtime behavior change in the tests:

- The three route tests declared their `bun:test` mocks as zero-arg closures, so `mock.calls` inferred the empty tuple `[]` and every `calls[0][n]` index was TS2493 (and the `as`-casts from `undefined` were TS2352). Each mock now carries the real production call signature (`deleteAppWithCleanup(appId, options)`, `deleteContainer`/`stopContainer(containerId, organizationId, options)`, `executeWithBody(config, work, request, body)` typed via `ServiceConfig` / `ServiceHandler` / `ProxyRequestBody` from `@/lib/services/proxy/types`).
- The pglite test helpers (`reserveCopy`, `markPresentAndVerified`) took `Awaited<ReturnType<typeof claimExecution>>`, whose `generation` infers node's UUID template-literal type, rejecting the production claim's `generation: string`. They now take the exported `AgentBackupOperationExecution` boundary type from `../agent-backup-catalog`, which is what the repository functions actually accept.

## Evidence

- `bun run --cwd packages/cloud/api typecheck` — green (tsc `--noEmit` 0 errors + `check:worker-bundle` wrangler dry-run completes)
- `bun run --cwd packages/cloud/shared typecheck` — green (0 errors)
- `bun test` on the three api route tests: 34 pass / 0 fail (126 expect calls)
- `bun test src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts` in `packages/cloud/shared`: 21 pass / 0 fail (100 expect calls)
- Biome check on all four files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
