### PR TITLE
fix(orchestrator): recover deterministic evidence for ledger-less quick-apps

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/quick-app-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/quick-app-evidence.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Contract tests for quick-app evidence recovery (#20794 live residual):
+ * candidate mining is claims-only, fs verification is real stat inspection
+ * (traversal-guarded, mtime-gated), route URL mapping follows the operator
+ * config with the index.html directory form, and probing verifies only what
+ * actually answers 200. Deterministic — fs and fetch are injected doubles,
+ * with one real-filesystem case in a temp dir.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  collectFsObservedFiles,
+  deriveRouteMappedUrls,
+  mineCandidatePaths,
+  probeMappedUrls,
+} from "../services/quick-app-evidence.js";
+
+describe("mineCandidatePaths", () => {
+  it("mines the live incident shape and ignores non-path prose", () => {
+    const mined = mineCandidatePaths([
+      "Wrote 10092 bytes to /home/milady/projects/agent-home/data/apps/echo-fade/index.html",
+      "then I considered v1.2 and e.g. other options",
+      "also touched data/apps/echo-fade/style.css today",
+    ]);
+    expect(mined).toContain(
+      "/home/milady/projects/agent-home/data/apps/echo-fade/index.html",
+    );
+    expect(mined).toContain("data/apps/echo-fade/style.css");
+    expect(mined.join(" ")).not.toContain("v1.2");
+  });
+});
+
+describe("collectFsObservedFiles", () => {
+  it("verifies real files in a temp workdir and rejects traversal + stale mtimes", () => {
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "qa-evidence-"));
+    try {
+      const appDir = path.join(workdir, "data", "apps", "echo-fade");
+      fs.mkdirSync(appDir, { recursive: true });
+      const file = path.join(appDir, "index.html");
+      fs.writeFileSync(file, "<html></html>");
+      const stale = path.join(workdir, "stale.html");
+      fs.writeFileSync(stale, "old");
+      const past = new Date(Date.now() - 3_600_000);
+      fs.utimesSync(stale, past, past);
+
+      const observed = collectFsObservedFiles({
+        workdir,
+        candidatePaths: [
+          file, // absolute form
+          "data/apps/echo-fade/index.html", // relative form (deduped)
+          "stale.html", // pre-session mtime → rejected
+          "../outside.html", // traversal → rejected
+          "data/apps/echo-fade/missing.html", // absent → rejected
+        ],
+        sessionStartedAt: Date.now() - 60_000,
+      });
+      expect(observed).toEqual(["data/apps/echo-fade/index.html"]);
+    } finally {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("deriveRouteMappedUrls", () => {
+  it("maps files through the operator config, with the index directory form", () => {
+    const urls = deriveRouteMappedUrls(
+      ["data/apps/echo-fade/index.html"],
+      [{ urlPrefix: "https://nubilio.org/apps", localPath: "data/apps" }],
+    );
+    expect(urls).toContain("https://nubilio.org/apps/echo-fade/index.html");
+    expect(urls).toContain("https://nubilio.org/apps/echo-fade/");
+  });
+
+  it("files outside the mapping and absent mappings yield nothing", () => {
+    expect(
+      deriveRouteMappedUrls(
+        ["src/other.ts"],
+        [{ urlPrefix: "https://nubilio.org/apps", localPath: "data/apps" }],
+      ),
+    ).toEqual([]);
+    expect(
+      deriveRouteMappedUrls(["data/apps/x/index.html"], undefined),
+    ).toEqual([]);
+  });
+});
+
+describe("probeMappedUrls", () => {
+  it("verifies only URLs that answer ok; failures and non-200s drop out", async () => {
+    const fetchImpl = (async (url: RequestInfo | URL) => {
+      const target = String(url);
+      if (target.endsWith("/good/")) return new Response("ok", { status: 200 });
+      if (target.endsWith("/gone/")) return new Response("no", { status: 404 });
+      throw new Error("network unreachable");
+    }) as typeof fetch;
+    const verified = await probeMappedUrls(
+      [
+        "https://a.example/good/",
+        "https://a.example/gone/",
+        "https://a.example/down/",
+      ],
+      fetchImpl,
+    );
+    expect(verified).toEqual(["https://a.example/good/"]);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
@@ -27,8 +27,8 @@ const MIN_GOAL_CHARS = 8;
 
 /**
  * The base coding criteria. Every "build something in the repo" task type
- * extends this set, so a coding task and an app-build task share the same
- * green-bar checks and the app-build only ADDS its live-URL criterion.
+ * extends this set; app-build deliberately does NOT inherit it (see the
+ * template comment below).
  */
 const CODING_CRITERIA: readonly string[] = [
   "typecheck passes",
@@ -47,7 +47,16 @@ export const DEFAULT_CRITERIA_TEMPLATES: Readonly<
   Record<OrchestratorTaskType, readonly string[]>
 > = {
   coding: CODING_CRITERIA,
-  "app-build": [...CODING_CRITERIA, "the live URL is reachable"],
+  // Serve-focused on purpose (#20794 live residual): a quick one-file app has
+  // no test/typecheck surface, so inheriting the coding checks manufactured
+  // criteria NO static deliverable could ever satisfy and burned every verify
+  // attempt. A goal that genuinely involves code checks says so, and the model
+  // refinement adds them back from the goal text.
+  "app-build": [
+    "the live URL is reachable",
+    "the deliverable file exists in the workdir",
+    "the page serves the requested content",
+  ],
   "view-create": [
     "a Plugin.views entry is declared with a viewKind",
     "the view appears in /api/views",

--- a/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
@@ -122,6 +122,11 @@ export interface CompletionEvidenceBundle {
     path: string;
     reason: "rejected-write" | "no-write-observed";
   }>;
+  /** Files verified by direct fs inspection of the session workdir (exists +
+   *  mtime after session start) when the structured tool ledger is absent —
+   *  observation-grade evidence for adapters that fold tool results into
+   *  messages (#20794 live residual). */
+  fsVerifiedFiles?: string[];
   /** Screenshot artifact paths found on the task/session. */
   screenshots: string[];
   /** Path to the persisted trajectory JSONL artifact for this completion. */
@@ -440,6 +445,20 @@ export function buildCompletionEvidenceString(
 
   if (bundle.verifiedUrls.length > 0) {
     sections.push(renderUrlsSection(bundle.verifiedUrls));
+    hasRicherSection = true;
+  }
+
+  // Observation-grade file evidence for ledger-less adapters (#20794): each
+  // path was stat-verified in the session workdir with a post-start mtime —
+  // direct inspection, not worker narration — so it counts as richer evidence.
+  const fsVerified = bundle.fsVerifiedFiles ?? [];
+  if (fsVerified.length > 0) {
+    sections.push(
+      [
+        "## FS-VERIFIED FILES (stat-observed in the session workdir, modified after session start)",
+        ...fsVerified.map((file) => `- ${file}`),
+      ].join("\n"),
+    );
     hasRicherSection = true;
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -199,6 +199,12 @@ import {
 } from "./project-binding.js";
 import { extractPullRequestLink } from "./pull-request-link.js";
 import {
+  collectFsObservedFiles,
+  deriveRouteMappedUrls,
+  mineCandidatePaths,
+  probeMappedUrls,
+} from "./quick-app-evidence.js";
+import {
   readSmithersDurableRunLink,
   runDurableTask,
   type SmithersDurableRunLink,
@@ -2446,6 +2452,46 @@ export class OrchestratorTaskService extends Service {
       extractWriteLedger(sessionEvents),
     );
 
+    // Ledger-less adapters starve the deterministic pre-pass (#20794 live
+    // residual): recover observation-grade evidence by direct inspection.
+    // Claims (mined paths, captured change set) only select WHAT to inspect;
+    // fs stat inside the session workdir and a real HTTP probe of the route's
+    // operator-configured public mapping are what produce evidence.
+    let fsVerifiedFiles: string[] = [];
+    const reportingSession = doc.sessions.find(
+      (session) => session.sessionId === sessionId,
+    );
+    if (
+      reportingSession?.workdir &&
+      (!ledgerVerdict.ledgerObserved ||
+        ledgerVerdict.verifiedClaims.length === 0)
+    ) {
+      fsVerifiedFiles = collectFsObservedFiles({
+        workdir: reportingSession.workdir,
+        candidatePaths: [
+          ...(changeSet?.changedFiles ?? []),
+          ...mineCandidatePaths([summary, ...subAgentReplies]),
+        ],
+        sessionStartedAt: reportingSession.registeredAt,
+      });
+      if (fsVerifiedFiles.length > 0 && verifiedUrls.length === 0) {
+        const routeMeta = isRecord(reportingSession.metadata)
+          ? reportingSession.metadata.workdirRoute
+          : undefined;
+        const urlMappings =
+          isRecord(routeMeta) && Array.isArray(routeMeta.urlMappings)
+            ? (routeMeta.urlMappings as {
+                urlPrefix: string;
+                localPath: string;
+              }[])
+            : undefined;
+        const probed = await probeMappedUrls(
+          deriveRouteMappedUrls(fsVerifiedFiles, urlMappings),
+        );
+        verifiedUrls.push(...probed);
+      }
+    }
+
     return {
       summary,
       diffSummary,
@@ -2458,6 +2504,7 @@ export class OrchestratorTaskService extends Service {
             unverifiedClaimedFiles: ledgerVerdict.unverifiedClaims,
           }
         : {}),
+      ...(fsVerifiedFiles.length > 0 ? { fsVerifiedFiles } : {}),
       screenshots: [...new Set(screenshots)],
     };
   }
@@ -4072,7 +4119,10 @@ export class OrchestratorTaskService extends Service {
           verifiedPublicUrls: bundle.verifiedUrls.filter(
             isPubliclyReachableUrl,
           ),
-          ledgerVerifiedFiles: bundle.ledgerVerifiedFiles ?? [],
+          ledgerVerifiedFiles: [
+            ...(bundle.ledgerVerifiedFiles ?? []),
+            ...(bundle.fsVerifiedFiles ?? []),
+          ],
           hasChangeSet: Boolean(bundle.diffSummary?.trim()),
           greenChecks: {
             test: isGreenCheckOutput(deterministicToolOutput?.test),

--- a/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
@@ -288,7 +288,7 @@ export function deterministicCriterionCheck(
   }
   if (
     FILE_CRITERION_RE.test(criterion) &&
-    !CONTENT_OR_BEHAVIOR_RE.test(criterion)
+    !CONTENT_OR_BEHAVIOR_RE.test(assertion)
   ) {
     const basis = fileCriterionBasis(criterion, facts);
     return basis

--- a/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
@@ -1,0 +1,150 @@
+/**
+ * Deterministic evidence recovery for quick-app completions (#20794 live
+ * residual). On adapter paths that fold tool results into messages, a
+ * completed one-file app leaves the evidence bundle starved: no structured
+ * write ledger, no router-probed URL, no changeset — so the deterministic
+ * pre-pass sees nothing and working deliverables fall to the judge with
+ * "no evidence" and park.
+ *
+ * Two honest facts the orchestrator can OBSERVE directly, without trusting
+ * worker narration: a claimed file either exists in the session workdir with
+ * an mtime after the session started (fs stat — direct inspection), or it
+ * does not; and a route-mapped public URL either answers HTTP 200 right now
+ * (real probe) or it does not. Claims select WHAT to inspect; only the
+ * inspection result becomes evidence.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { WorkdirRouteUrlMapping } from "./task-agent-routing.js";
+
+const MAX_CANDIDATE_PATHS = 24;
+const MAX_PROBE_URLS = 5;
+const PROBE_TIMEOUT_MS = 5_000;
+
+/** Absolute or workdir-relative file-path tokens in worker output. */
+const PATH_CANDIDATE_RE =
+  /(?:^|[\s"'`(=])((?:\/|(?:[\w.-]+\/)+)[\w./-]*[\w-]\.[A-Za-z]{1,8})(?=$|[\s"'`),])/gm;
+
+/** Mine candidate file paths from worker-reported text. Claims only — the
+ *  caller verifies each against the real filesystem before anything counts. */
+export function mineCandidatePaths(texts: readonly string[]): string[] {
+  const out = new Set<string>();
+  for (const text of texts) {
+    for (const match of text.matchAll(PATH_CANDIDATE_RE)) {
+      const candidate = match[1];
+      if (candidate) out.add(candidate);
+      if (out.size >= MAX_CANDIDATE_PATHS) return [...out];
+    }
+  }
+  return [...out];
+}
+
+export interface FsObservedFilesInput {
+  workdir: string;
+  candidatePaths: readonly string[];
+  /** Epoch ms the session started; only newer mtimes count as session work. */
+  sessionStartedAt: number;
+  /** Test seam over fs.statSync. */
+  statImpl?: (absolutePath: string) => { mtimeMs: number } | undefined;
+}
+
+function defaultStat(absolutePath: string): { mtimeMs: number } | undefined {
+  try {
+    const stat = fs.statSync(absolutePath);
+    return stat.isFile() ? { mtimeMs: stat.mtimeMs } : undefined;
+  } catch {
+    // error-policy:J3 an unreadable/absent candidate is explicitly not
+    // observed evidence — the caller treats it as unverified, never as a file.
+    return undefined;
+  }
+}
+
+/**
+ * Verify candidate paths by direct filesystem inspection: the file must
+ * resolve INSIDE the session workdir (no traversal) and carry an mtime at or
+ * after session start. Returns workdir-relative paths, deterministic order.
+ */
+export function collectFsObservedFiles(input: FsObservedFilesInput): string[] {
+  const stat = input.statImpl ?? defaultStat;
+  const root = path.resolve(input.workdir);
+  const observed: string[] = [];
+  for (const candidate of input.candidatePaths.slice(0, MAX_CANDIDATE_PATHS)) {
+    const absolute = path.resolve(root, candidate);
+    const relative = path.relative(root, absolute);
+    if (
+      relative === "" ||
+      relative.startsWith("..") ||
+      path.isAbsolute(relative)
+    ) {
+      continue;
+    }
+    const info = stat(absolute);
+    if (!info) continue;
+    if (info.mtimeMs + 1 < input.sessionStartedAt) continue;
+    observed.push(relative);
+  }
+  return [...new Set(observed)].sort();
+}
+
+/**
+ * Map workdir-relative files to their public URLs through the route's
+ * operator-configured `urlMappings`. `index.html` additionally maps to its
+ * directory URL — the address a person would actually open.
+ */
+export function deriveRouteMappedUrls(
+  relativeFiles: readonly string[],
+  urlMappings: readonly WorkdirRouteUrlMapping[] | undefined,
+): string[] {
+  if (!urlMappings || urlMappings.length === 0) return [];
+  const urls = new Set<string>();
+  for (const file of relativeFiles) {
+    for (const mapping of urlMappings) {
+      const localPrefix = mapping.localPath
+        .replace(/^\.?\//, "")
+        .replace(/\/+$/, "");
+      const normalized = file.replace(/^\.?\//, "");
+      if (localPrefix.length > 0 && !normalized.startsWith(`${localPrefix}/`)) {
+        continue;
+      }
+      const remainder =
+        localPrefix.length > 0
+          ? normalized.slice(localPrefix.length + 1)
+          : normalized;
+      const base = mapping.urlPrefix.replace(/\/+$/, "");
+      urls.add(`${base}/${remainder}`);
+      if (remainder.endsWith("/index.html")) {
+        urls.add(`${base}/${remainder.slice(0, -"index.html".length)}`);
+      } else if (remainder === "index.html") {
+        urls.add(`${base}/`);
+      }
+    }
+  }
+  return [...urls].slice(0, MAX_PROBE_URLS * 2);
+}
+
+/**
+ * Probe candidate URLs and return those answering 200 — the same epistemic
+ * status as router-probed URLs: verified by request, never by narration.
+ * Bounded and timeout-guarded; probe failures simply do not verify.
+ */
+export async function probeMappedUrls(
+  urls: readonly string[],
+  fetchImpl: typeof fetch = fetch,
+): Promise<string[]> {
+  const verified: string[] = [];
+  for (const url of urls.slice(0, MAX_PROBE_URLS)) {
+    try {
+      const response = await fetchImpl(url, {
+        method: "GET",
+        redirect: "follow",
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      });
+      if (response.ok) verified.push(url);
+    } catch {
+      // error-policy:J3 an unreachable candidate is explicitly unverified —
+      // absence from the result is the honest outcome, never a fake 200.
+    }
+  }
+  return verified;
+}


### PR DESCRIPTION
Live residual of #20794, from the post-merge battery on the box: echo-fade and glass-orbit both built and served correctly and STILL burned 3/3 verify attempts and parked. The persisted completion-evidence bundles show why — the deterministic pre-pass (#20961) was starved of facts on this adapter path: `verifiedUrls: []`, no write ledger, no changeset, despite a real tool receipt "Wrote 10092 bytes to …/echo-fade/index.html". Everything fell to the judge with no evidence sections, and the judge (correctly, given what it saw) failed it.

## What changed

1. **Observation-grade evidence recovery** (`quick-app-evidence.ts`): when the structured tool ledger is absent/empty, claims (mined paths + captured change set) select WHAT to inspect and only direct inspection produces evidence — `stat()` inside the session workdir (traversal-guarded, mtime ≥ session start) yields `fsVerifiedFiles`; the route's operator-configured `urlMappings` derive public URLs for those files (including the `index.html` → directory form) and a real bounded, timeout-guarded HTTP probe adds the 200s to `verifiedUrls`. Same epistemic class as router probes: verified by request/inspection, never narration.
2. **Serve-focused app-build criteria**: the app-build template no longer inherits typecheck/lint/tests — criteria no static one-file deliverable can ever satisfy (the live parks' "no code or test evidence" demand). Goals genuinely involving code checks get them back through the model refinement from the goal text.
3. **Repairs the red develop test** left by the #21038 tail ("a matching explicit URL can satisfy a reachability-only claim", red on clean develop): prose-classifying guards now judge the criterion's PROSE with explicit URLs stripped (an app slug like `canon-clock` is not a "clock behavior" demand), and the explicit-URL reachability form ("<url> is reachable") is recognized as the strictest liveness claim — `urlCriterionBasis` still requires that exact URL to have been probed.

## Evidence

- New `quick-app-evidence.test.ts`: 5/5 — live-incident path mining shape, REAL temp-filesystem verification (absolute+relative dedupe, stale-mtime and traversal and absent rejected), URL mapping incl. directory form and outside-mapping/absent-mapping empties, probe semantics (200 only; 404 and network failure drop out).
- `producible-evidence.test.ts`: 37/37 including the previously-red reachability test; `auto-goal-verify.test.ts`: 46/46.
- Plugin typecheck clean; Biome clean.
- Live proof: next box dist rebuild re-runs the quick-app scenario (coordinated with the live-box session) — expected: fs-verified file + probed mapped URL sections in the bundle and deterministic promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)