### PR TITLE
fix: validate decoded route identifiers

### DIFF
--- a/packages/agent/src/api/app-package-routes.test.ts
+++ b/packages/agent/src/api/app-package-routes.test.ts
@@ -112,6 +112,25 @@ describe("dynamic app-package route dispatch", () => {
     },
   );
 
+  it.each([
+    "%2F",
+    "%5C",
+    ".",
+    "..",
+    "%00",
+    "%20",
+    "%252F",
+    "A",
+    "a".repeat(129),
+  ])("rejects non-canonical decoded app slug %s", async (encodedSlug) => {
+    const { context, error } = createContext(`/api/apps/${encodedSlug}/run`);
+
+    await expect(handleAppPackageRoutes(context)).resolves.toBe(true);
+
+    expect(error).toHaveBeenCalledWith(context.res, "Invalid app slug", 400);
+    expect(importAppRouteModuleMock).not.toHaveBeenCalled();
+  });
+
   it("dispatches a valid encoded slug with a request-bound body reader", async () => {
     const { context, error, readJsonBody, req, res } = createContext(
       "/api/apps/example%2Dapp/run",

--- a/packages/agent/src/api/app-package-routes.ts
+++ b/packages/agent/src/api/app-package-routes.ts
@@ -10,6 +10,7 @@ import type {
   AppPackageRouteContext,
   AppPackageRouteDispatchContext,
 } from "@elizaos/core";
+import { isValidAppRouteSlug } from "@elizaos/shared";
 import {
   type AppRouteModule,
   importAppRouteModule,
@@ -69,8 +70,12 @@ export async function handleAppPackageRoutes(
   const decodedSlug = decodePathComponent(encodedSlug, ctx.res, "app slug");
   if (decodedSlug === null) return true;
 
-  const slug = decodedSlug.trim();
-  if (!slug || RESERVED_APP_ROUTE_SLUGS.has(slug)) return false;
+  const slug = decodedSlug;
+  if (RESERVED_APP_ROUTE_SLUGS.has(slug)) return false;
+  if (!isValidAppRouteSlug(slug)) {
+    ctx.error(ctx.res, "Invalid app slug", 400);
+    return true;
+  }
 
   const routeModule = await importAppRouteModule(slug);
   if (!routeModule) return false;

--- a/packages/agent/src/api/registry-routes.test.ts
+++ b/packages/agent/src/api/registry-routes.test.ts
@@ -92,4 +92,26 @@ describe("handleRegistryRoutes path encoding validation", () => {
       },
     });
   });
+
+  it.each([
+    "%2F",
+    "%5C",
+    ".",
+    "..",
+    "%00",
+    "%20",
+    "%252F",
+    "UPPER",
+    "a".repeat(215),
+  ])("rejects non-canonical decoded plugin name %s", async (encodedName) => {
+    const { ctx, error, getRegistryPlugin } = createRegistryContext(
+      "GET",
+      `/api/registry/plugins/${encodedName}`,
+    );
+
+    await expect(handleRegistryRoutes(ctx)).resolves.toBe(true);
+
+    expect(error).toHaveBeenCalledWith(ctx.res, "Invalid plugin name", 400);
+    expect(getRegistryPlugin).not.toHaveBeenCalled();
+  });
 });

--- a/packages/agent/src/api/registry-routes.ts
+++ b/packages/agent/src/api/registry-routes.ts
@@ -7,6 +7,7 @@
  * upstream failures surface as 502.
  */
 import type { RouteHelpers, RouteRequestMeta } from "@elizaos/core";
+import { isValidRegistryPackageName } from "@elizaos/registry";
 import { parseClampedInteger } from "@elizaos/shared";
 import type {
   RegistryPluginInfo,
@@ -123,6 +124,10 @@ export async function handleRegistryRoutes(
       "plugin name",
     );
     if (name === null) return true;
+    if (!isValidRegistryPackageName(name)) {
+      error(res, "Invalid plugin name", 400);
+      return true;
+    }
     try {
       const pluginManager = getPluginManager();
       const info = await pluginManager.getRegistryPlugin(name);

--- a/packages/agent/src/api/server-helpers.ts
+++ b/packages/agent/src/api/server-helpers.ts
@@ -22,6 +22,7 @@ import {
   type UUID,
   validateUuid,
 } from "@elizaos/core";
+import { decodeUrlPathComponent } from "@elizaos/shared";
 import {
   normalizeCharacterLanguage,
   resolveStylePresetByAvatarIndex,
@@ -441,12 +442,12 @@ export function decodePathComponent(
   res: http.ServerResponse,
   fieldName: string,
 ): string | null {
-  try {
-    return decodeURIComponent(raw);
-  } catch {
+  const decoded = decodeUrlPathComponent(raw);
+  if (!decoded.ok) {
     error(res, `Invalid ${fieldName}: malformed URL encoding`, 400);
     return null;
   }
+  return decoded.value;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/registry/schema/registry-entry.schema.json
+++ b/packages/registry/schema/registry-entry.schema.json
@@ -20,6 +20,7 @@
     "package": {
       "type": "string",
       "description": "npm package name. The @elizaos/* scope is reserved for first-party.",
+      "maxLength": 214,
       "pattern": "^(?:@[a-z0-9][a-z0-9._-]*\\/)?[a-z0-9][a-z0-9._-]*$",
       "not": { "pattern": "^@elizaos\\/" }
     },

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -16,6 +16,7 @@ export {
 } from "./loader.ts";
 export {
   assertRegistryEntry,
+  isValidRegistryPackageName,
   validateRegistryEntry,
 } from "./schema.ts";
 export type {

--- a/packages/registry/src/registry.test.ts
+++ b/packages/registry/src/registry.test.ts
@@ -72,6 +72,12 @@ describe("validateRegistryEntry", () => {
     );
   });
 
+  it("rejects package names longer than the npm limit", () => {
+    expect(
+      validateRegistryEntry({ ...VALID, package: "a".repeat(215) }),
+    ).toContain("package must be a valid npm package name");
+  });
+
   it("rejects a non-github repository", () => {
     const errors = validateRegistryEntry({
       ...VALID,

--- a/packages/registry/src/schema.ts
+++ b/packages/registry/src/schema.ts
@@ -27,6 +27,15 @@ const VALID_SESSION_FEATURES = new Set([
   "suggestions",
 ]);
 
+/** Accepts the canonical package-name grammar used by registry entries. */
+export function isValidRegistryPackageName(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= 214 &&
+    PACKAGE_NAME_RE.test(value)
+  );
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -251,7 +260,7 @@ export function validateRegistryEntry(value: unknown): string[] {
   }
 
   const pkg = value.package;
-  if (typeof pkg !== "string" || !PACKAGE_NAME_RE.test(pkg)) {
+  if (!isValidRegistryPackageName(pkg)) {
     errors.push("package must be a valid npm package name");
   } else if (pkg.startsWith("@elizaos/")) {
     errors.push("package must not use the reserved @elizaos/* scope");

--- a/packages/shared/src/contracts/apps.test.ts
+++ b/packages/shared/src/contracts/apps.test.ts
@@ -22,8 +22,25 @@ import {
   AppVerifyResultSchema,
   AppViewerAuthMessageSchema,
   AppViewerConfigSchema,
+  isValidAppRouteSlug,
   PostRelaunchAppResponseSchema,
 } from "./apps.js";
+
+describe("isValidAppRouteSlug", () => {
+  it.each(["feed", "example-app", "app_2", "app.v2"])(
+    "accepts canonical slug %s",
+    (slug) => expect(isValidAppRouteSlug(slug)).toBe(true),
+  );
+
+  it.each(["", ".", "..", "a/b", "a\\b", "A", "a b", "a%2Fb"])(
+    "rejects non-canonical slug %s",
+    (slug) => expect(isValidAppRouteSlug(slug)).toBe(false),
+  );
+
+  it("rejects overlong slugs", () => {
+    expect(isValidAppRouteSlug("a".repeat(129))).toBe(false);
+  });
+});
 
 const HEALTHY_FACET = { state: "healthy" as const, message: null };
 const HEALTH_DETAILS = {

--- a/packages/shared/src/contracts/apps.ts
+++ b/packages/shared/src/contracts/apps.ts
@@ -8,6 +8,18 @@ import curatedAppDefinitions from "@elizaos/registry/first-party/curated-app-def
 };
 import z from "zod";
 
+const APP_ROUTE_SLUG_RE = /^[a-z0-9](?:[a-z0-9._-]{0,127})$/;
+
+/** Accepts canonical app slugs used to select installed route modules. */
+export function isValidAppRouteSlug(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    APP_ROUTE_SLUG_RE.test(value) &&
+    value !== "." &&
+    value !== ".."
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Runtime-registered curated apps — keyed on a global Symbol so the same
 // store is shared across @elizaos/shared, @elizaos/app-core, and any plugin

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -331,6 +331,7 @@ export * from "./utils/namespace-defaults.js";
 export * from "./utils/number-parsing.js";
 export { parseClampedInteger } from "./utils/number-parsing.js";
 export * from "./utils/owner-name.js";
+export * from "./utils/path-component.js";
 export * from "./utils/permission-deep-links.js";
 export * from "./utils/rate-limiter.js";
 export * from "./utils/serialise.js";

--- a/packages/shared/src/utils/path-component.test.ts
+++ b/packages/shared/src/utils/path-component.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Deterministic coverage for transport-neutral URL path-component decoding.
+ */
+
+import { describe, expect, it } from "vitest";
+import { decodeUrlPathComponent } from "./path-component";
+
+describe("decodeUrlPathComponent", () => {
+  it.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed encoding %s",
+    (raw) => {
+      expect(decodeUrlPathComponent(raw)).toEqual({
+        ok: false,
+        reason: "malformed-encoding",
+      });
+    },
+  );
+
+  it("decodes valid UTF-8 and leaves domain validation to the caller", () => {
+    expect(decodeUrlPathComponent("caf%C3%A9")).toEqual({
+      ok: true,
+      value: "café",
+    });
+    expect(decodeUrlPathComponent("a%2Fb")).toEqual({
+      ok: true,
+      value: "a/b",
+    });
+    expect(decodeUrlPathComponent("a%252Fb")).toEqual({
+      ok: true,
+      value: "a%2Fb",
+    });
+  });
+});

--- a/packages/shared/src/utils/path-component.ts
+++ b/packages/shared/src/utils/path-component.ts
@@ -1,0 +1,18 @@
+/**
+ * Decodes one URL path component without binding validation to an HTTP server.
+ * Callers translate malformed encoding at their transport boundary and apply
+ * domain-specific grammar checks to the decoded value.
+ */
+
+export type PathComponentDecodeResult =
+  | { ok: true; value: string }
+  | { ok: false; reason: "malformed-encoding" };
+
+export function decodeUrlPathComponent(raw: string): PathComponentDecodeResult {
+  try {
+    return { ok: true, value: decodeURIComponent(raw) };
+  } catch {
+    // error-policy:J3 malformed percent escapes are explicit invalid input.
+    return { ok: false, reason: "malformed-encoding" };
+  }
+}

--- a/plugins/plugin-agent-skills/src/api/skills-routes.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.test.ts
@@ -25,21 +25,6 @@ function createSkillsContext(
   const res = {} as http.ServerResponse;
   const json = vi.fn();
   const error = vi.fn();
-  const decodePathComponent = vi.fn(
-    (raw: string, response: http.ServerResponse, fieldName: string) => {
-      try {
-        return decodeURIComponent(raw);
-      } catch {
-        error(
-          response,
-          `Invalid ${fieldName}: malformed URL encoding`,
-          400,
-        );
-        return null;
-      }
-    },
-  );
-
   const ctx: SkillsRouteContext = {
     req,
     res,
@@ -59,7 +44,6 @@ function createSkillsContext(
     error,
     readJsonBody: vi.fn().mockResolvedValue({}),
     readBody: vi.fn().mockResolvedValue(""),
-    decodePathComponent,
     discoverSkills: vi.fn().mockResolvedValue([]),
     ...overrides,
   };
@@ -82,6 +66,27 @@ describe("handleSkillsRoutes path encoding validation", () => {
       "Invalid skill slug: malformed URL encoding",
       400,
     );
+  });
+
+  it.each([
+    "%2F",
+    "%5C",
+    ".",
+    "..",
+    "%00",
+    "%20",
+    "%252F",
+    "UPPER",
+    "a".repeat(65),
+  ])("rejects non-canonical decoded catalog slug %s", async (encodedSlug) => {
+    const { ctx, error } = createSkillsContext(
+      "GET",
+      `/api/skills/catalog/${encodedSlug}`,
+    );
+
+    await expect(handleSkillsRoutes(ctx)).resolves.toBe(true);
+
+    expect(error).toHaveBeenCalledWith(ctx.res, "Invalid skill slug", 400);
   });
 
   it("rejects malformed percent-encoding on GET /api/skills/:id/scan with 400", async () => {
@@ -255,7 +260,7 @@ describe("handleSkillsRoutes path encoding validation", () => {
 
     expect(error).toHaveBeenCalledWith(
       ctx.res,
-      expect.stringContaining("Invalid skill ID"),
+      "Invalid skill slug",
       400,
     );
   });

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -17,6 +17,7 @@ import type { AgentRuntime } from "@elizaos/core";
 import { logger, readWorkspaceFolderConfig } from "@elizaos/core";
 import type { ReadJsonBodyOptions } from "@elizaos/shared";
 import {
+  decodeUrlPathComponent,
   PostMarketplaceInstallRequestSchema,
   PostMarketplaceUninstallRequestSchema,
   PostSkillAcknowledgeRequestSchema,
@@ -33,6 +34,7 @@ import {
   searchSkillsMarketplace,
   uninstallMarketplaceSkill,
 } from "../services/skill-marketplace";
+import { SKILL_NAME_MAX_LENGTH, SKILL_NAME_PATTERN } from "../types";
 import { skillScaffoldMarkdown } from "./skill-scaffold";
 
 const WORKSPACE_MARKERS = [
@@ -151,11 +153,6 @@ export interface SkillsRouteContext {
     options?: ReadJsonBodyOptions,
   ) => Promise<T | null>;
   readBody: (req: http.IncomingMessage) => Promise<string>;
-  decodePathComponent: (
-    raw: string,
-    res: http.ServerResponse,
-    fieldName: string,
-  ) => string | null;
   // Functions from server.ts that skills routes need
   discoverSkills: (
     workspaceDir: string,
@@ -198,12 +195,18 @@ function decodeAndValidateSkillId(
   rawSkillId: string,
   res: http.ServerResponse,
   errorFn: SkillsRouteContext["error"],
-  decodePathComponent: SkillsRouteContext["decodePathComponent"],
-  fieldName = "skill ID",
 ): string | null {
-  const skillId = decodePathComponent(rawSkillId, res, fieldName);
-  if (skillId === null) return null;
-  return validateSkillId(skillId, res, errorFn);
+  const decoded = decodeUrlPathComponent(rawSkillId);
+  if (!decoded.ok) {
+    // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input.
+    errorFn(res, "Invalid skill ID: malformed URL encoding", 400);
+    return null;
+  }
+  return validateSkillId(decoded.value, res, errorFn);
+}
+
+function isValidCatalogSkillSlug(slug: string): boolean {
+  return slug.length <= SKILL_NAME_MAX_LENGTH && SKILL_NAME_PATTERN.test(slug);
 }
 
 // ---------------------------------------------------------------------------
@@ -383,7 +386,6 @@ export async function handleSkillsRoutes(
     error,
     readJsonBody,
     discoverSkills,
-    decodePathComponent,
   } = ctx;
 
   // ── GET /api/skills/catalog ───────────────────────────────────────────
@@ -499,14 +501,19 @@ export async function handleSkillsRoutes(
 
   // ── GET /api/skills/catalog/:slug ──────────────────────────────────────
   if (method === "GET" && pathname.startsWith("/api/skills/catalog/")) {
-    const slug = decodeAndValidateSkillId(
+    const decoded = decodeUrlPathComponent(
       pathname.slice("/api/skills/catalog/".length),
-      res,
-      error,
-      decodePathComponent,
-      "skill slug",
     );
-    if (slug === null) return true;
+    if (!decoded.ok) {
+      // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding is invalid client input
+      error(res, "Invalid skill slug: malformed URL encoding", 400);
+      return true;
+    }
+    const slug = decoded.value;
+    if (!isValidCatalogSkillSlug(slug)) {
+      error(res, "Invalid skill slug", 400);
+      return true;
+    }
     // Exclude "search" which is handled above
     if (slug && slug !== "search") {
       if (!shouldExposeBinanceSkillId(slug)) {
@@ -758,7 +765,6 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
-      decodePathComponent,
     );
     if (!skillId) return true;
     const workspaceDir =
@@ -784,7 +790,6 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
-      decodePathComponent,
     );
     if (!skillId) return true;
     const rawAck = await readJsonBody<Record<string, unknown>>(req, res);
@@ -936,7 +941,6 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
-      decodePathComponent,
     );
     if (!skillId) return true;
     const workspaceDir =
@@ -1019,7 +1023,6 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
-      decodePathComponent,
     );
     if (!skillId) return true;
     const workspaceDir =
@@ -1103,7 +1106,6 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
-      decodePathComponent,
     );
     if (!skillId) return true;
 
@@ -1168,7 +1170,6 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
-      decodePathComponent,
     );
     if (!skillId) return true;
 
@@ -1203,7 +1204,6 @@ export async function handleSkillsRoutes(
       pathname.split("/")[3],
       res,
       error,
-      decodePathComponent,
     );
     if (!skillId) return true;
     const rawSource = await readJsonBody<Record<string, unknown>>(req, res);
@@ -1303,7 +1303,6 @@ export async function handleSkillsRoutes(
       pathname.slice("/api/skills/".length),
       res,
       error,
-      decodePathComponent,
     );
     if (!skillId) return true;
     const workspaceDir =


### PR DESCRIPTION
Closes #21110.

## Summary

This closes the validation gaps that remained after #20955, #20960, and #20965:

- adds one transport-neutral `decodeUrlPathComponent` result in `@elizaos/shared`;
- keeps the Agent HTTP helper responsible only for translating malformed encoding to a 400;
- makes plugin-agent-skills use the same pure decoder instead of an injected Agent-specific helper;
- validates decoded app route slugs, registry package names, skill IDs, and catalog slugs before any lookup, filesystem/state access, or dynamic module import;
- pins encoded separators, backslashes, dot segments, controls, spaces, double encoding, case, invalid UTF-8, incomplete escapes, and length limits.

## Risk

Low and fail-closed. Canonical identifiers retain their current dispatch behavior. Inputs outside the existing domain grammars now receive an explicit 400 instead of reaching downstream resolution.

## Verification (exact head `7e2b7a86c6d`)

- Registry: 6 files / 37 tests passed; typecheck, Biome, and 46-entry validation passed.
- plugin-agent-skills: 17 files / 78 tests passed; typecheck, Biome, and build passed.
- Agent focused routes: 2 files / 28 tests passed; targeted Biome and package build passed.
- Shared focused contract/decoder coverage: 62 tests passed; shared typecheck and Biome passed.
- Full shared lane: 138/139 files and 1,822/1,823 tests passed. The sole failure is the pre-existing `host-execution-env.test.ts` boot-PATH assertion on this host; it is outside this diff and reproduces in isolation.
- Root `bun run verify`: 208/210 Turbo tasks passed before stopping in unrelated Cloud API test typing (`route.delete-github-repo.test.ts`, `route.purge-volume.test.ts`, market trade mock tuples, and backup catalog UUID fixture typing). Every affected package gate above is green.
- `git diff --check`: clean.

## Evidence

<!-- evidence-head:7e2b7a86c6de2d6d3fd66cb7ae737168b7fcc0c7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic HTTP validation only; there is no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - pure request-boundary validation is exercised without a running backend; exact route test output is recorded under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change or client state transition.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head validation transcript:

```text
Registry: 6 files / 37 tests passed; typecheck, Biome, and 46-entry validation passed.
plugin-agent-skills: 17 files / 78 tests passed; typecheck, Biome, and build passed.
Agent routes: 2 files / 28 tests passed; targeted Biome and package build passed.
Shared decoder/contracts: 62 focused tests passed; typecheck and Biome passed.
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Contribution provenance

- AI provider/model: OpenAI / GPT-5
- Client / agent tooling: Codex Desktop
- Contribution skill revision: elizaOS/eliza@f0950d77564332d613cc3648fe4bcd850877ac22:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

— [codex-root-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@f0950d77564332d613cc3648fe4bcd850877ac22:packages/skills/skills/contribute-to-eliza"} -->
