### PR TITLE
fix(agent): resolve scoped owner-contact keys to registered send handlers

### DIFF
--- a/packages/agent/src/config/owner-contacts.scoped-source.test.ts
+++ b/packages/agent/src/config/owner-contacts.scoped-source.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Deterministic contract for scoped owner-contact send-source resolution
+ * (live incident: key "discord-nubs-test" used verbatim as a send source →
+ * "Send handler not found" on every escalation).
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveScopedSendSource } from "./owner-contacts.ts";
+
+describe("resolveScopedSendSource", () => {
+  const handlers = new Set([
+    "discord",
+    "telegram",
+    "client_chat",
+    "telegram-account",
+  ]);
+  const has = (source: string) => handlers.has(source);
+
+  it("resolves the live-incident scoped key to its connector", () => {
+    expect(resolveScopedSendSource("discord-nubs-test", has)).toBe("discord");
+  });
+
+  it("a full key that IS a handler wins over its prefix", () => {
+    expect(resolveScopedSendSource("telegram-account", has)).toBe(
+      "telegram-account",
+    );
+  });
+
+  it("prefers the longest registered prefix at '-' boundaries", () => {
+    expect(resolveScopedSendSource("telegram-account-backup", has)).toBe(
+      "telegram-account",
+    );
+  });
+
+  it("an unscoped registered source passes through", () => {
+    expect(resolveScopedSendSource("discord", has)).toBe("discord");
+  });
+
+  it("no registered handler at any boundary returns the full key for honest reporting", () => {
+    expect(resolveScopedSendSource("matrix-nubs", has)).toBe("matrix-nubs");
+    expect(resolveScopedSendSource("", has)).toBe("");
+  });
+});

--- a/packages/agent/src/config/owner-contacts.ts
+++ b/packages/agent/src/config/owner-contacts.ts
@@ -112,6 +112,29 @@ function sourceSupportsOwnerEntityFallback(source: string): boolean {
   return source === MESSAGE_SOURCE_CLIENT_CHAT || source === "discord";
 }
 
+/**
+ * Resolve the SEND source for an owner-contact key. Keys are contact names,
+ * not necessarily handler names: a scoped key like "discord-nubs-test" means
+ * "the discord handler, this specific contact". The full key wins when a
+ * handler is registered under it; otherwise the longest "-"-boundary prefix
+ * with a registered handler carries the delivery. No handler at any boundary
+ * returns the full key so the caller's missing-handler path still reports the
+ * configured name.
+ */
+export function resolveScopedSendSource(
+  key: string,
+  hasHandler: (source: string) => boolean,
+): string {
+  const trimmed = key.trim();
+  if (!trimmed || hasHandler(trimmed)) return trimmed;
+  const parts = trimmed.split("-");
+  for (let end = parts.length - 1; end >= 1; end--) {
+    const prefix = parts.slice(0, end).join("-");
+    if (hasHandler(prefix)) return prefix;
+  }
+  return trimmed;
+}
+
 export function resolveOwnerContactSource(
   ownerContacts: OwnerContactsConfig,
   source: string | null | undefined,

--- a/packages/agent/src/config/zod-schema.agent-runtime.ts
+++ b/packages/agent/src/config/zod-schema.agent-runtime.ts
@@ -633,6 +633,7 @@ const uuidPattern =
 
 export const OwnerContactEntrySchema = z
   .object({
+    source: z.string().trim().min(1).optional(),
     entityId: z.string().regex(uuidPattern, "invalid UUID").optional(),
     channelId: z.string().optional(),
     roomId: z.string().regex(uuidPattern, "invalid UUID").optional(),

--- a/packages/agent/src/services/escalation.ts
+++ b/packages/agent/src/services/escalation.ts
@@ -20,6 +20,7 @@ import {
   loadOwnerContactsConfig,
   type OwnerContactRoutingHint,
   resolveOwnerContactWithFallback,
+  resolveScopedSendSource,
 } from "../config/owner-contacts.ts";
 import type {
   EscalationConfig,
@@ -276,7 +277,15 @@ async function sendToChannel(
   }
 
   try {
-    const targetSource = resolvedContact?.source ?? channel;
+    // A contact's explicit `source` wins; otherwise a scoped contact key
+    // ("discord-nubs-test") resolves to the registered handler it scopes
+    // ("discord") instead of being used verbatim as a send source that no
+    // handler serves.
+    const targetSource =
+      contact.source?.trim() ||
+      resolveScopedSendSource(resolvedContact?.source ?? channel, (source) =>
+        hasRuntimeSendHandler(runtime, source),
+      );
     if (
       targetSource === MESSAGE_SOURCE_CLIENT_CHAT &&
       !hasRuntimeSendHandler(runtime, targetSource)

--- a/packages/shared/src/config/types.agent-defaults.ts
+++ b/packages/shared/src/config/types.agent-defaults.ts
@@ -178,6 +178,10 @@ export type CliBackendConfig = {
  * Each key is a source name (e.g. "client_chat", "telegram", "discord").
  */
 export type OwnerContactEntry = {
+  /** Explicit send-handler source for this contact. A scoped key like
+   *  "discord-nubs-test" names the CONTACT; this names the CONNECTOR the
+   *  delivery must go through when the key itself is not a handler name. */
+  source?: string;
   /** Entity ID in the runtime (UUID). */
   entityId?: string;
   /** Platform-specific channel/chat ID (e.g. Telegram numeric chat ID). */


### PR DESCRIPTION
Live incident from the box (ledgered by the live-box session): the escalation config's owner-contact KEY was used verbatim as the send source — key `discord-nubs-test` (a scoped contact name) → `sendMessageToTarget(source: "discord-nubs-test")` → "Send handler not found" on EVERY escalation, silently killing the owner-escalation path until the box config was hand-edited.

## What changed

- **Scoped-key resolution** (`resolveScopedSendSource` in `owner-contacts.ts`): an owner-contact key names a CONTACT, not necessarily a handler. The full key wins when a handler is registered under it (so `telegram-account` keeps working); otherwise the longest `-`-boundary prefix with a registered handler carries the delivery (`discord-nubs-test` → `discord`); no registered handler at any boundary returns the full key so the existing missing-handler log still reports the configured name honestly.
- **Explicit override**: `OwnerContactEntry` gains an optional `source` field (shared type + zod schema) — an entry can pin its connector outright, and it wins over parsing.
- **Escalation wiring**: `sendToChannel` resolves the target source through explicit `contact.source` → scoped resolution against the runtime's registered handlers.

## Evidence

- New `owner-contacts.scoped-source.test.ts`: 5/5 — the live-incident shape, full-key-is-handler precedence (`telegram-account`), longest-prefix preference, unscoped passthrough, and honest full-key fallback when nothing matches.
- `escalation-channels.test.ts`: 4/4 unchanged; agent + shared typecheck clean on touched files; Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)