### PR TITLE
fix(cloud): clone birdeye timeout+refund to dexscreener proxy with Hono proof

### DIFF
--- a/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.timeout.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.timeout.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Covers DexScreener proxy deadlines and credit refunds (clone of birdeye timeout fix).
+ * The harness exercises failures during both fetch and response-body consumption.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Context } from "hono";
+import type { AppEnv } from "../../../types/cloud-worker-env";
+import * as authActual from "../../auth/workers-hono-auth";
+import * as creditsActual from "../credits";
+import * as pricingActual from "./pricing";
+
+const realCredits = { ...creditsActual };
+const realPricing = { ...pricingActual };
+const realAuth = { ...authActual };
+
+const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
+const COST = 0.0003;
+
+const deductCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+const refundCredits = mock<(args: unknown) => Promise<unknown>>();
+const getServiceMethodCost = mock<(service: string, method: string) => Promise<number>>();
+const requireUserOrApiKeyWithOrg = mock<(c: unknown) => Promise<{ organization_id: string }>>();
+
+mock.module("../credits", () => ({
+  ...realCredits,
+  creditsService: { ...realCredits.creditsService, deductCredits, refundCredits },
+}));
+
+mock.module("./pricing", () => ({ ...realPricing, getServiceMethodCost }));
+
+mock.module("../../auth/workers-hono-auth", () => ({
+  ...realAuth,
+  requireUserOrApiKeyWithOrg,
+}));
+
+const { handleDexscreenerProxyGet } = await import("./dexscreener-handler");
+
+const originalFetch = globalThis.fetch;
+
+function makeContext(path: string): Context<AppEnv> {
+  const url = `https://api.elizacloud.ai/proxy/${path}`;
+  return {
+    env: {} as unknown as AppEnv["Bindings"],
+    req: {
+      param: (key: string) => (key === "*" ? path : undefined),
+      url,
+      header: (_name: string) => undefined,
+    },
+    json: (body: unknown, status?: number) => Response.json(body, { status: status ?? 200 }),
+  } as unknown as Context<AppEnv>;
+}
+
+beforeEach(() => {
+  deductCredits.mockReset();
+  refundCredits.mockReset();
+  getServiceMethodCost.mockReset();
+  requireUserOrApiKeyWithOrg.mockReset();
+  deductCredits.mockResolvedValue({ success: true });
+  refundCredits.mockResolvedValue({ success: true });
+  getServiceMethodCost.mockResolvedValue(COST);
+  requireUserOrApiKeyWithOrg.mockResolvedValue({ organization_id: ORG_ID });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  mock.module("../credits", () => realCredits);
+  mock.module("./pricing", () => realPricing);
+  mock.module("../../auth/workers-hono-auth", () => realAuth);
+});
+
+describe("dexscreener proxy — timeout covers fetch+body and transport refunds", () => {
+  test("AbortError during fetch refunds once and returns 504", async () => {
+    globalThis.fetch = mock(async () => {
+      const err = new Error("This operation was aborted");
+      err.name = "AbortError";
+      throw err;
+    }) as unknown as typeof fetch;
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/tokens/So111"));
+    expect(res.status).toBe(504);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("timeout");
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+    const args = refundCredits.mock.calls[0]?.[0] as {
+      organizationId: string;
+      amount: number;
+    };
+    expect(args.organizationId).toBe(ORG_ID);
+    expect(args.amount).toBe(COST);
+  });
+
+  test("AbortError during body read (stalled body) refunds once and returns 504", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    const originalText = Response.prototype.text;
+    Response.prototype.text = mock(async function (this: Response) {
+      const err = new Error("This operation was aborted");
+      err.name = "AbortError";
+      throw err;
+    }) as unknown as typeof Response.prototype.text;
+    try {
+      const res = await handleDexscreenerProxyGet(makeContext("latest/dex/tokens/So111"));
+      expect(res.status).toBe(504);
+      expect(refundCredits).toHaveBeenCalledTimes(1);
+    } finally {
+      Response.prototype.text = originalText;
+    }
+  });
+
+  test("non-Abort transport failure refunds once and returns 502", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new TypeError("fetch failed: DNS error");
+    }) as unknown as typeof fetch;
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/tokens/So111"));
+    expect(res.status).toBe(502);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+  });
+
+  test("upstream 5xx refunds once and forwards status", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response("upstream down", { status: 502, headers: { "Content-Type": "text/plain" } }),
+    ) as unknown as typeof fetch;
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/tokens/So111"));
+    expect(res.status).toBe(502);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+  });
+
+  test("success 200 does not refund, 4xx refunds (free upstream)", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response('{"ok":1}', { status: 200, headers: { "Content-Type": "application/json" } }),
+    ) as unknown as typeof fetch;
+    let res = await handleDexscreenerProxyGet(makeContext("latest/dex/tokens/So111"));
+    expect(res.status).toBe(200);
+    expect(refundCredits).not.toHaveBeenCalled();
+    refundCredits.mockReset();
+    refundCredits.mockResolvedValue({ success: true } as unknown as never);
+    globalThis.fetch = mock(
+      async () =>
+        new Response('{"error":"bad"}', {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    res = await handleDexscreenerProxyGet(makeContext("latest/dex/tokens/So111"));
+    expect(res.status).toBe(400);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.timeout.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.timeout.test.ts
@@ -1,8 +1,8 @@
 /**
- * Covers DexScreener proxy deadlines and credit refunds (clone of birdeye timeout fix).
- * The harness exercises failures during both fetch and response-body consumption.
+ * Exercises the real DexScreener proxy handler with deterministic upstream,
+ * timer, billing, and authentication seams, including fetch and body stalls.
  */
-import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, jest, mock, test } from "bun:test";
 import type { Context } from "hono";
 import type { AppEnv } from "../../../types/cloud-worker-env";
 import * as authActual from "../../auth/workers-hono-auth";
@@ -62,6 +62,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  jest.useRealTimers();
   globalThis.fetch = originalFetch;
 });
 
@@ -71,14 +72,47 @@ afterAll(() => {
   mock.module("../../auth/workers-hono-auth", () => realAuth);
 });
 
+function rejectWhenAborted(signal: AbortSignal | null | undefined): Promise<never> {
+  if (!signal) return Promise.reject(new Error("fetch signal is required"));
+  return new Promise((_, reject) => {
+    const rejectAbort = () => {
+      const error = new Error("This operation was aborted");
+      error.name = "AbortError";
+      reject(error);
+    };
+    if (signal.aborted) rejectAbort();
+    else signal.addEventListener("abort", rejectAbort, { once: true });
+  });
+}
+
+async function waitFor(check: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (check()) return;
+    await Promise.resolve();
+  }
+  expect(check()).toBe(true);
+}
+
 describe("dexscreener proxy — timeout covers fetch+body and transport refunds", () => {
-  test("AbortError during fetch refunds once and returns 504", async () => {
-    globalThis.fetch = mock(async () => {
-      const err = new Error("This operation was aborted");
-      err.name = "AbortError";
-      throw err;
-    }) as unknown as typeof fetch;
-    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/tokens/So111"));
+  test("the real deadline aborts a stalled fetch, refunds once, and returns 504", async () => {
+    jest.useFakeTimers();
+    const fetchMock = mock(async (_input: RequestInfo | URL, init?: RequestInit) =>
+      rejectWhenAborted(init?.signal),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const responsePromise = handleDexscreenerProxyGet(makeContext("latest/dex/tokens/So111"));
+    await waitFor(() => fetchMock.mock.calls.length === 1);
+    const signal = fetchMock.mock.calls[0]?.[1]?.signal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+
+    jest.advanceTimersByTime(9_999);
+    expect(signal?.aborted).toBe(false);
+    expect(refundCredits).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+
+    const res = await responsePromise;
     expect(res.status).toBe(504);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("timeout");
@@ -91,27 +125,54 @@ describe("dexscreener proxy — timeout covers fetch+body and transport refunds"
     expect(args.amount).toBe(COST);
   });
 
-  test("AbortError during body read (stalled body) refunds once and returns 504", async () => {
-    globalThis.fetch = mock(
-      async () =>
-        new Response("{}", {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-    ) as unknown as typeof fetch;
-    const originalText = Response.prototype.text;
-    Response.prototype.text = mock(async function (this: Response) {
-      const err = new Error("This operation was aborted");
-      err.name = "AbortError";
-      throw err;
-    }) as unknown as typeof Response.prototype.text;
-    try {
-      const res = await handleDexscreenerProxyGet(makeContext("latest/dex/tokens/So111"));
-      expect(res.status).toBe(504);
-      expect(refundCredits).toHaveBeenCalledTimes(1);
-    } finally {
-      Response.prototype.text = originalText;
-    }
+  test("the same real deadline covers a stalled body read", async () => {
+    jest.useFakeTimers();
+    let bodyReadStarted = false;
+    let requestSignal: AbortSignal | null | undefined;
+    const fetchMock = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestSignal = init?.signal;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({ "Content-Type": "application/json" }),
+        text: () => {
+          bodyReadStarted = true;
+          return rejectWhenAborted(requestSignal);
+        },
+      } as Response;
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const responsePromise = handleDexscreenerProxyGet(makeContext("latest/dex/tokens/So111"));
+    await waitFor(() => bodyReadStarted);
+    expect(requestSignal).toBeInstanceOf(AbortSignal);
+    expect(requestSignal?.aborted).toBe(false);
+    jest.advanceTimersByTime(10_000);
+
+    const res = await responsePromise;
+    expect(requestSignal?.aborted).toBe(true);
+    expect(res.status).toBe(504);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+  });
+
+  test("a completed response clears the deadline instead of aborting later", async () => {
+    jest.useFakeTimers();
+    let requestSignal: AbortSignal | null | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestSignal = init?.signal;
+      return new Response('{"ok":1}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/tokens/So111"));
+    expect(res.status).toBe(200);
+    expect(requestSignal).toBeInstanceOf(AbortSignal);
+    expect(requestSignal?.aborted).toBe(false);
+    jest.advanceTimersByTime(10_000);
+    expect(requestSignal?.aborted).toBe(false);
+    expect(refundCredits).not.toHaveBeenCalled();
   });
 
   test("non-Abort transport failure refunds once and returns 502", async () => {

--- a/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.ts
@@ -62,14 +62,44 @@ export async function handleDexscreenerProxyGet(c: Context<AppEnv>): Promise<Res
       upstreamUrl.searchParams.set(key, value);
     });
 
-    const upstreamResponse = await fetch(upstreamUrl.toString(), {
-      headers: {
-        Accept: "application/json",
-        "User-Agent": c.req.header("User-Agent") ?? "ElizaCloud-DexScreener-Proxy/1.0",
-      },
-    });
-
-    const body = await upstreamResponse.text();
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10_000);
+    let upstreamResponse: Response;
+    let body: string;
+    try {
+      upstreamResponse = await fetch(upstreamUrl.toString(), {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": c.req.header("User-Agent") ?? "ElizaCloud-DexScreener-Proxy/1.0",
+        },
+        signal: controller.signal,
+      });
+      body = await upstreamResponse.text();
+    } catch (error) {
+      const isAbort = error instanceof Error && error.name === "AbortError";
+      await creditsService
+        .refundCredits({
+          organizationId: organization_id,
+          amount: cost,
+          description: `API proxy refund: dexscreener — getRequest (upstream ${isAbort ? "timeout" : "transport failure"})`,
+          metadata: {
+            type: "proxy_dexscreener_refund",
+            service: "dexscreener",
+            method: "getRequest",
+            path: pathStr,
+            reason: isAbort ? "upstream timeout" : "upstream transport failure",
+          },
+        })
+        .catch((refundError) => {
+          logger.warn("[DexscreenerProxy] refund after upstream failure failed", {
+            error: refundError instanceof Error ? refundError.message : String(refundError),
+          });
+        });
+      if (isAbort) return c.json({ error: "Upstream service timeout" }, 504);
+      return c.json({ error: "Upstream service unavailable" }, 502);
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!upstreamResponse.ok) {
       logger.warn("[DexscreenerProxy] upstream non-OK", {

--- a/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.ts
@@ -11,6 +11,7 @@ import { creditsService } from "../credits";
 import { getServiceMethodCost } from "./pricing";
 
 const UPSTREAM_ORIGIN = "https://api.dexscreener.com";
+const UPSTREAM_TIMEOUT_MS = 10_000;
 
 /** DexScreener open endpoints are under `latest/` — keep allowlist tight. */
 function isAllowedDexPath(pathStr: string): boolean {
@@ -63,7 +64,7 @@ export async function handleDexscreenerProxyGet(c: Context<AppEnv>): Promise<Res
     });
 
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10_000);
+    const timeoutId = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
     let upstreamResponse: Response;
     let body: string;
     try {
@@ -76,6 +77,8 @@ export async function handleDexscreenerProxyGet(c: Context<AppEnv>): Promise<Res
       });
       body = await upstreamResponse.text();
     } catch (error) {
+      // error-policy:J1 upstream boundary — translate transport and deadline
+      // failures after refunding the prepaid request cost.
       const isAbort = error instanceof Error && error.name === "AbortError";
       await creditsService
         .refundCredits({
@@ -91,6 +94,8 @@ export async function handleDexscreenerProxyGet(c: Context<AppEnv>): Promise<Res
           },
         })
         .catch((refundError) => {
+          // error-policy:J4 the upstream request is already a visible failure;
+          // preserve it while recording the secondary refund fault.
           logger.warn("[DexscreenerProxy] refund after upstream failure failed", {
             error: refundError instanceof Error ? refundError.message : String(refundError),
           });


### PR DESCRIPTION
# Relates to

No linked issue. This repairs the DexScreener sibling of the Birdeye upstream deadline/refund fix merged in #20749.

- [x] Targets `develop` and is rebased onto current `origin/develop` (`2b88e84d180108ffec5257f29ad813770830f80f`) with zero conflicts.
- [x] Pinned-Bun focused suites and the full owning-package typecheck pass after sync.
- [x] The exact-head deadline/refund transcript below demonstrates behavior without code inspection.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`, `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2b88e84d180108ffec5257f29ad813770830f80f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [x] Owning package typecheck, focused suites, Biome, and diff checks pass on the pushed head.

# Risks

Medium because this is a prepaid credit path. The change is narrowly scoped to DexScreener transport behavior after a successful deduction: a 10-second deadline now covers both connection and response-body consumption; timeout and transport failure refund once and return explicit 504/502 responses. Existing free-upstream policy remains unchanged: 4xx/5xx refund, while 200 does not. Tests also prove a successful response clears the deadline instead of being aborted later.

# Background

## What does this PR do?

The DexScreener proxy previously performed an unbounded `fetch` and body read after deducting credits. A stalled upstream could hang indefinitely, while a transport exception fell through to the outer boundary without refunding the successful deduction.

The handler now passes an `AbortController` signal to `fetch`, holds the deadline through `response.text()`, clears it in `finally`, refunds transport/deadline failures, and translates them to 502/504. Required J1/J4 error-policy annotations document the primary boundary translation and secondary refund-failure degradation.

The initial tests only threw synthetic `AbortError`s, which did not prove the timer was connected to the fetch signal. The repaired suite advances fake time against the production handler and verifies the exact signal at 9,999 ms and 10,000 ms for both a stalled fetch and a stalled body.

## What kind of change is this?

Bug fix; no schema, dependency, UI, or successful-response contract change.

# Documentation changes needed?

No. This aligns DexScreener with the existing Birdeye transport discipline.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.timeout.test.ts` drives the real exported handler with deterministic auth, billing, upstream, and timer seams.

## Detailed testing steps

Exact head `07ad0806c051d776c4af8174c1757e8224009a03`:

```text
bunx bun@1.3.14 test packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.timeout.test.ts
6 pass, 0 fail, 27 assertions

bunx bun@1.3.14 test packages/cloud/shared/src/lib/services/proxy/birdeye-handler.timeout.test.ts
5 pass, 0 fail, 15 assertions

bunx bun@1.3.14 run --cwd packages/cloud/shared typecheck
exit 0

bunx bun@1.3.14 x @biomejs/biome check <two touched files>
Checked 2 files. No fixes applied.

git diff --check origin/develop...HEAD
exit 0
```

The DexScreener suite proves: no abort/refund at 9,999 ms; abort of the exact fetch signal at 10,000 ms; the same deadline covers a stalled body read; successful completion cancels the timer; non-abort transport failure returns 502/refunds once; upstream 5xx and 4xx retain free-upstream refunds; success does not refund. The established Birdeye sibling suite remains green.

# Evidence Gate

<!-- evidence-head:07ad0806c051d776c4af8174c1757e8224009a03 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only proxy transport change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only proxy transport change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual or interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live production Worker was invoked; the exact-head handler transcript above records 6/6 DexScreener deadline/refund tests and 5/5 Birdeye sibling tests passing.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, agent, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent artifact is produced; the observable outputs are HTTP statuses and refund calls asserted by the handler suite.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM participates in this transport boundary.

## Backend + frontend logs

The exact-head test transcript in **Testing** records status and refund behavior. No frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI code changed.

## Audio / voice walkthrough

N/A - no voice or audio surface changed.

## Known gaps / failures

- No live production Worker request was made: that would require production authentication, a real credit deduction, and shared external state. The production handler itself is exercised locally with deterministic timing and real AbortSignal propagation; no result is fabricated.
- Root `bun run verify` was not repeated. The full owning-package TypeScript check, focused monetary-path suites, sibling regression suite, Biome, and diff validation all pass on the exact pushed head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@2b88e84d180108ffec5257f29ad813770830f80f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review_lane_a]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@2b88e84d180108ffec5257f29ad813770830f80f:packages/skills/skills/contribute-to-eliza"} -->
