### PR TITLE
test(app): use canonical composer locator across scenarios

### DIFF
--- a/packages/app/test/ui-smoke/auth-startup.spec.ts
+++ b/packages/app/test/ui-smoke/auth-startup.spec.ts
@@ -37,9 +37,7 @@ async function fulfillJson(
 }
 
 function chatComposer(page: Page) {
-  return page
-    .locator('[data-testid="chat-composer-textarea"]')
-    .or(page.getByLabel("message"));
+  return page.getByTestId("chat-composer-textarea");
 }
 
 async function routeAuthStatus(

--- a/packages/app/test/ui-smoke/plugin-views-visual.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-views-visual.spec.ts
@@ -186,11 +186,9 @@ test.describe("registered plugin views visual coverage", () => {
             name: /expand conversation|collapse conversation/i,
           }),
         );
-        const assistantComposer = page
-          .getByTestId("chat-composer-textarea")
-          .or(page.getByLabel("message"))
-          .or(page.getByLabel("Message Eliza"))
-          .first();
+        const assistantComposer = page.getByTestId(
+          "chat-composer-textarea",
+        );
         if ((await assistantLauncher.count()) > 0) {
           await assistantLauncher.first().click();
         }


### PR DESCRIPTION
# Relates to

Follow-up to #21104. The original deflake fixed one ambiguous composer locator, but two sibling scenarios retained the same substring-match failure mode.

- [x] Targets `develop` and was rebased onto the latest `origin/develop` at creation.
- [ ] Full `bun install` and `bun run verify` are delegated to exact-head CI.
- [x] The change is reviewable from the focused locator diff and exact-head checks.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` at head creation; zero conflicts.
- [ ] `bun run verify` pending exact-head CI.

# Risks

Low. Test-only Playwright locator changes; no shipped application/runtime code changes.

# Background

## What does this PR do?

Uses the canonical `chat-composer-textarea` test ID in `auth-startup.spec.ts` and `plugin-views-visual.spec.ts`. This removes the remaining fallbacks where `getByLabel("message")` could also select rendered `Show message actions` controls. It also prevents `.first()` from silently focusing the wrong control.

## What kind of change is this?

Test reliability follow-up; no product behavior change.

# Documentation changes needed?

No documentation changes are required.

# Testing

## Where should a reviewer start?

Review the two changed `chatComposer`/`assistantComposer` locators and compare them with the canonical test ID used across the rest of the UI-smoke suite.

## Detailed testing steps

- Biome check passed for both changed specs.
- `git diff --check` passed.
- Exact-head CI is requested after PR creation.

# Evidence Gate

<!-- evidence-head:d9e03c0a84a4ceec9605f31c46da24cd5d3203f8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only locator change; no rendered pixels changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only locator change; no rendered pixels changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only locator change; no user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code or request path changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime code or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain state or generated artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI source changed.

# Known gaps / failures

The local machine exposes Bun 1.4.0 and Node 23.3.0 rather than the repository-pinned Bun 1.3.14 and Node 24.15.0. Local Biome was diagnostic only; exact-head CI is the authoritative gate.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->