### PR TITLE
fix(cloud): clamp native planner loop bounds with parseClampedInteger

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/native-planner-limits.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/native-planner-limits.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Verifies the production native-planner setting resolver across defaults,
+ * canonical values, invalid input, lower/upper bounds, and message overrides.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  type NativePlannerLimitSetting,
+  resolveNativePlannerLimits,
+} from "./native-planner-limits";
+
+const defaults = {
+  maxIterations: 6,
+  maxConsecutiveFailures: 2,
+  maxParseRetries: 2,
+  maxSummaryRetries: 2,
+} as const;
+
+function resolve(
+  settings: Partial<Record<NativePlannerLimitSetting, unknown>> = {},
+  maxIterationsOverride?: number,
+) {
+  return resolveNativePlannerLimits((name) => settings[name], maxIterationsOverride);
+}
+
+describe("resolveNativePlannerLimits", () => {
+  test("uses production defaults when settings are absent or blank", () => {
+    expect(resolve()).toEqual(defaults);
+    expect(
+      resolve({
+        NATIVE_PLANNER_MAX_ITERATIONS: "",
+        NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES: "  ",
+        NATIVE_PLANNER_PARSE_RETRIES: null,
+        NATIVE_RESPONSE_PARSE_RETRIES: undefined,
+      }),
+    ).toEqual(defaults);
+  });
+
+  test("accepts canonical values for all four limits", () => {
+    expect(
+      resolve({
+        NATIVE_PLANNER_MAX_ITERATIONS: "12",
+        NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES: 4,
+        NATIVE_PLANNER_PARSE_RETRIES: "3",
+        NATIVE_RESPONSE_PARSE_RETRIES: 5,
+      }),
+    ).toEqual({
+      maxIterations: 12,
+      maxConsecutiveFailures: 4,
+      maxParseRetries: 3,
+      maxSummaryRetries: 5,
+    });
+  });
+
+  test.each(["abc", "1e2", "2.5", "Infinity", "9007199254740992"])(
+    "falls back for non-canonical or unsafe input %j",
+    (value) => {
+      expect(
+        resolve({
+          NATIVE_PLANNER_MAX_ITERATIONS: value,
+          NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES: value,
+          NATIVE_PLANNER_PARSE_RETRIES: value,
+          NATIVE_RESPONSE_PARSE_RETRIES: value,
+        }),
+      ).toEqual(defaults);
+    },
+  );
+
+  test("clamps every setting to its production bounds", () => {
+    expect(
+      resolve({
+        NATIVE_PLANNER_MAX_ITERATIONS: "999999",
+        NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES: "999999",
+        NATIVE_PLANNER_PARSE_RETRIES: "999999",
+        NATIVE_RESPONSE_PARSE_RETRIES: "999999",
+      }),
+    ).toEqual({
+      maxIterations: 20,
+      maxConsecutiveFailures: 10,
+      maxParseRetries: 5,
+      maxSummaryRetries: 5,
+    });
+    expect(
+      resolve({
+        NATIVE_PLANNER_MAX_ITERATIONS: "-1",
+        NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES: "0",
+        NATIVE_PLANNER_PARSE_RETRIES: "-20",
+        NATIVE_RESPONSE_PARSE_RETRIES: "0",
+      }),
+    ).toEqual({
+      maxIterations: 1,
+      maxConsecutiveFailures: 1,
+      maxParseRetries: 1,
+      maxSummaryRetries: 1,
+    });
+  });
+
+  test("the message override takes precedence but cannot bypass the iteration cap", () => {
+    expect(resolve({ NATIVE_PLANNER_MAX_ITERATIONS: "3" }, 8).maxIterations).toBe(8);
+    expect(resolve({ NATIVE_PLANNER_MAX_ITERATIONS: "3" }, 1000).maxIterations).toBe(20);
+    expect(resolve({ NATIVE_PLANNER_MAX_ITERATIONS: "3" }, Number.NaN).maxIterations).toBe(6);
+  });
+});

--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/native-planner-limits.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/native-planner-limits.ts
@@ -1,0 +1,55 @@
+/**
+ * Resolves bounded native-planner loop and model-retry limits from runtime
+ * settings, with an optional per-message iteration override.
+ */
+
+import { parseClampedInteger } from "@elizaos/shared";
+
+export type NativePlannerLimitSetting =
+  | "NATIVE_PLANNER_MAX_ITERATIONS"
+  | "NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES"
+  | "NATIVE_PLANNER_PARSE_RETRIES"
+  | "NATIVE_RESPONSE_PARSE_RETRIES";
+
+export type NativePlannerSettingReader = (name: NativePlannerLimitSetting) => unknown;
+
+export interface NativePlannerLimits {
+  maxIterations: number;
+  maxConsecutiveFailures: number;
+  maxParseRetries: number;
+  maxSummaryRetries: number;
+}
+
+// Permit deliberate tuning above the defaults while bounding per-message model
+// and action fanout. Parse retries retain the service's historical ceiling of 5.
+const ITERATION_BOUNDS = { min: 1, max: 20, fallback: 6 } as const;
+const FAILURE_BOUNDS = { min: 1, max: 10, fallback: 2 } as const;
+const PARSE_RETRY_BOUNDS = { min: 1, max: 5, fallback: 2 } as const;
+
+function boundedInteger(
+  value: unknown,
+  bounds: { min: number; max: number; fallback: number },
+): number {
+  return parseClampedInteger(value == null ? undefined : String(value), bounds);
+}
+
+export function resolveNativePlannerLimits(
+  getSetting: NativePlannerSettingReader,
+  maxIterationsOverride?: number,
+): NativePlannerLimits {
+  return {
+    maxIterations: boundedInteger(
+      maxIterationsOverride ?? getSetting("NATIVE_PLANNER_MAX_ITERATIONS"),
+      ITERATION_BOUNDS,
+    ),
+    maxConsecutiveFailures: boundedInteger(
+      getSetting("NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES"),
+      FAILURE_BOUNDS,
+    ),
+    maxParseRetries: boundedInteger(getSetting("NATIVE_PLANNER_PARSE_RETRIES"), PARSE_RETRY_BOUNDS),
+    maxSummaryRetries: boundedInteger(
+      getSetting("NATIVE_RESPONSE_PARSE_RETRIES"),
+      PARSE_RETRY_BOUNDS,
+    ),
+  };
+}

--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
@@ -26,7 +26,6 @@ import {
   type UUID,
 } from "@elizaos/core";
 import { v4 } from "uuid";
-import { parseClampedInteger } from "@elizaos/shared";
 import { createPerfTrace } from "../../../../utils/perf-trace";
 import { invalidateActionValidationCache } from "../../providers/actions";
 import {
@@ -68,6 +67,7 @@ import {
   resolveShouldRespondStepModel,
   withScopedTextModel,
 } from "./model-resolution";
+import { resolveNativePlannerLimits } from "./native-planner-limits";
 import { getRetryDelay, parseStructuredModelObject, withRetry } from "./retry";
 import {
   EMPTY_STATE,
@@ -530,17 +530,11 @@ export class CloudBootstrapMessageService implements IMessageService {
       runtime.character.system = "Select and execute actions to fulfill user requests.";
     }
 
-    const maxIterations =
-      options?.maxNativePlannerIterations ??
-      parseClampedInteger(String(runtime.getSetting("NATIVE_PLANNER_MAX_ITERATIONS") ?? "6"), {
-        min: 1,
-        max: 20,
-        fallback: 6,
-      });
-    const maxConsecutiveFailures = parseClampedInteger(
-      String(runtime.getSetting("NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES") ?? "2"),
-      { min: 1, max: 10, fallback: 2 },
-    );
+    const { maxIterations, maxConsecutiveFailures, maxParseRetries, maxSummaryRetries } =
+      resolveNativePlannerLimits(
+        (name) => runtime.getSetting(name),
+        options?.maxNativePlannerIterations,
+      );
     let iterationCount = 0;
     let consecutiveFailures = 0;
     let incompleteReason: string | null = null;
@@ -668,12 +662,8 @@ export class CloudBootstrapMessageService implements IMessageService {
         logger.info(`[LLM:nativePlanner] User Prompt:\n${prompt}`);
         logger.info("==============================================");
 
-        // PERF: Reduced from 5 to 3 retries. Each retry adds 1-4s with exponential backoff.
-        // 3 balances latency (~6-12s max) vs. reliability for complex native-planner queries
-        // where LLMs occasionally produce malformed JSON. Override via NATIVE_PLANNER_PARSE_RETRIES.
-        const maxParseRetries = parseInt(
-          String(runtime.getSetting("NATIVE_PLANNER_PARSE_RETRIES") ?? "2"),
-        );
+        // Each retry adds model latency, so the request-scoped resolver bounds
+        // operator tuning before this loop begins.
         let stepResultRaw = "";
         let parsedStep: ValidatedNativePlannerDecision | null = null;
 
@@ -1097,9 +1087,6 @@ export class CloudBootstrapMessageService implements IMessageService {
       logger.info(`[LLM:nativeResponse] User Prompt:\n${summaryPrompt}`);
       logger.info("==============================================");
 
-      const maxSummaryRetries = parseInt(
-        String(runtime.getSetting("NATIVE_RESPONSE_PARSE_RETRIES") ?? "2"),
-      );
       let finalOutput = "";
       let summary: Record<string, unknown> | null = null;
 

--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
@@ -26,6 +26,7 @@ import {
   type UUID,
 } from "@elizaos/core";
 import { v4 } from "uuid";
+import { parseClampedInteger } from "@elizaos/shared";
 import { createPerfTrace } from "../../../../utils/perf-trace";
 import { invalidateActionValidationCache } from "../../providers/actions";
 import {
@@ -531,9 +532,14 @@ export class CloudBootstrapMessageService implements IMessageService {
 
     const maxIterations =
       options?.maxNativePlannerIterations ??
-      parseInt(String(runtime.getSetting("NATIVE_PLANNER_MAX_ITERATIONS") ?? "6"));
-    const maxConsecutiveFailures = parseInt(
+      parseClampedInteger(String(runtime.getSetting("NATIVE_PLANNER_MAX_ITERATIONS") ?? "6"), {
+        min: 1,
+        max: 20,
+        fallback: 6,
+      });
+    const maxConsecutiveFailures = parseClampedInteger(
       String(runtime.getSetting("NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES") ?? "2"),
+      { min: 1, max: 10, fallback: 2 },
     );
     let iterationCount = 0;
     let consecutiveFailures = 0;


### PR DESCRIPTION
## Summary

Bounds the cloud native planner's iteration, consecutive-failure, parse-retry, and summary-retry controls with the shared strict integer parser.

The original head only clamped two environment settings and left the per-message iteration override plus two retry settings able to bypass safe bounds. The repaired head centralizes all four limits in a production resolver, snapshots them once per request, and adds direct tests against that production module.

## Scope

- Clamp native planner iterations to `1..20` with fallback `6`.
- Clamp consecutive failures to `1..10` with fallback `2`.
- Clamp planner and response parse retries to `1..5` with fallback `2`.
- Apply the same iteration cap to the per-message `maxNativePlannerIterations` override.
- Reject malformed numeric spellings through `parseClampedInteger` rather than accepting partial `parseInt` parses.

## Exact revision reviewed

- PR head: `2ee6cda384d8a71c38775a757326ebd94e9999f1`
- Base used for repair: `a20031b7e028822c28c1865bac55c15cb03a3fdb`

## Verification

- `bunx bun@1.3.14 test packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/native-planner-limits.test.ts` — 9 passed, 0 failed, 13 assertions.
- `bunx bun@1.3.14 run --cwd packages/cloud/shared typecheck` — passed.
- Biome check on the two production files and focused test — passed.
- `git diff --check origin/develop...HEAD` — passed.

The focused suite covers absent and blank settings, canonical values, malformed input (`abc`, scientific notation, decimals, `Infinity`, unsafe integers), lower and upper clamping for all controls, override precedence, oversized override clamping, and `NaN` fallback.

## Evidence matrix

| Evidence | Status |
| --- | --- |
| Unit/contract transcript | PASS on exact head `2ee6cda384d8a71c38775a757326ebd94e9999f1`; commands and results above. |
| Typecheck/lint | PASS on exact head; full owning-workspace typecheck and focused Biome check. |
| Backend logs | N/A — this repair is a deterministic limit resolver; the focused exact-head transcript is recorded above. |
| Frontend screenshots/video/console/network | N/A — no frontend or UI surface changes. |
| Native/device/connector evidence | N/A — no native, device, or connector path changes. |
| Live-model trajectory | **MISSING — required before merge.** This changes the maximum number of native-planner model calls. A real exact-head trajectory must exercise the actual planner with default, malformed fallback, upper-bound clamp, and per-message override cases and record call counts/results. |

## Known gaps / merge blocker

The repaired current head has deterministic production-module coverage but no real current-head live-model trajectory. Because the change directly affects model-call counts, the resolver suite is necessary but not sufficient evidence. After live evidence is attached, refresh the evidence head if any commit changes and request independent current-head review.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`, `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a20031b7e028822c28c1865bac55c15cb03a3fdb:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@a20031b7e028822c28c1865bac55c15cb03a3fdb:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-a]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@a20031b7e028822c28c1865bac55c15cb03a3fdb:packages/skills/skills/contribute-to-eliza"} -->
