### PR TITLE
fix(desktop): restore cloud sign-in pill

### DIFF
--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
@@ -115,9 +115,9 @@ export function resolveDesktopShellWindowPresentation(
 export const DEFAULT_BOTTOM_BAR_WIDTH = 96;
 export const DEFAULT_BOTTOM_BAR_HEIGHT = 56;
 
-/** Intermediate hit area around the cloud-only "Sign in to Eliza" chip. */
-export const AUTH_GATE_BOTTOM_BAR_WIDTH = 240;
-export const AUTH_GATE_BOTTOM_BAR_HEIGHT = DEFAULT_BOTTOM_BAR_HEIGHT;
+/** Hit area around the cloud-only "Sign in with Eliza Cloud" action. */
+export const AUTH_GATE_BOTTOM_BAR_WIDTH = 336;
+export const AUTH_GATE_BOTTOM_BAR_HEIGHT = 72;
 
 /** Expanded native hit area around the 560×640 glass panel and bottom pill. */
 export const EXPANDED_BOTTOM_BAR_WIDTH = 600;

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -415,7 +415,7 @@ describe("DesktopManager main window controls", () => {
     expect(window.setFrame).toHaveBeenLastCalledWith(502, 694, 96, 56);
 
     await manager.setBottomBarExpanded({ expanded: false, chip: true });
-    expect(window.setFrame).toHaveBeenLastCalledWith(430, 694, 240, 56);
+    expect(window.setFrame).toHaveBeenLastCalledWith(382, 678, 336, 72);
     await manager.dispose();
   });
 
@@ -430,7 +430,7 @@ describe("DesktopManager main window controls", () => {
       manager.setMainWindow(window as never);
       await vi.advanceTimersByTimeAsync(5_000);
 
-      expect(window.setFrame).toHaveBeenLastCalledWith(430, 694, 240, 56);
+      expect(window.setFrame).toHaveBeenLastCalledWith(382, 678, 336, 72);
       await manager.dispose();
     } finally {
       vi.useRealTimers();
@@ -451,7 +451,7 @@ describe("DesktopManager main window controls", () => {
       ).rejects.toThrow("native frame unavailable");
       await vi.advanceTimersByTimeAsync(5_000);
 
-      expect(window.setFrame).toHaveBeenLastCalledWith(430, 694, 240, 56);
+      expect(window.setFrame).toHaveBeenLastCalledWith(382, 678, 336, 72);
       expect(window.setFrame).toHaveBeenCalledTimes(2);
       await manager.dispose();
     } finally {
@@ -469,7 +469,7 @@ describe("DesktopManager main window controls", () => {
       expect(window.setFrame).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(5_000);
-      expect(window.setFrame).toHaveBeenLastCalledWith(430, 694, 240, 56);
+      expect(window.setFrame).toHaveBeenLastCalledWith(382, 678, 336, 72);
       await manager.dispose();
     } finally {
       vi.useRealTimers();

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -14,6 +14,8 @@
  * On a cloud-only build the `needs-auth` phase replaces both gestures with a
  * labeled chip that launches Cloud sign-in. Hold is not armed there.
  */
+
+import { LoaderCircle, LogIn } from "lucide-react";
 import * as React from "react";
 
 import { useBranding } from "../../config/branding";
@@ -86,7 +88,7 @@ const PROCESS_DOTS = [
  * Each shell phase reads distinctly at a glance (the capsule is the only
  * always-visible surface, so it carries all ambient status):
  *   booting     — dim pulsing handle ("waking up").
- *   needs-auth  — dark labeled chip ("Sign in to {appName}").
+ *   needs-auth  — orange labeled action ("Sign in with {appName} Cloud").
  *   idle        — solid white handle ("here, ready").
  *   listening   — dark chip, live waveform bars ("mic is hot").
  *   processing  — dark chip, pulsing dots — mic closed,
@@ -215,12 +217,12 @@ export function HomePill({
     else onOpen();
   }, [isOpen, onOpen, onClose]);
 
-  const signInLabel = `Sign in to ${appName}`;
+  const signInLabel = `Sign in with ${appName} Cloud`;
   const chipExpanded =
     phase === "listening" || phase === "processing" || needsAuth;
   const label = needsAuth
     ? signingIn
-      ? `Signing in to ${appName}`
+      ? `Signing in to ${appName} Cloud`
       : signInLabel
     : phase === "listening"
       ? `${appName} is listening — release to send`
@@ -247,9 +249,10 @@ export function HomePill({
       onPointerCancel={handlePointerCancel}
       style={{ zIndex: Z_SHELL_OVERLAY }}
       className={cn(
-        "group pointer-events-auto relative mb-2 flex h-8 items-center justify-center rounded-full bg-transparent p-0",
-        needsAuth ? "w-[13rem]" : "w-16",
-        "transition-transform duration-200 hover:bg-transparent active:scale-95",
+        "group pointer-events-auto relative mb-2 flex items-center justify-center rounded-full bg-transparent p-0",
+        needsAuth ? "h-12 w-[18rem]" : "h-8 w-16",
+        "transition-transform duration-200 hover:bg-transparent",
+        needsAuth ? "active:scale-[0.96]" : "active:scale-95",
         "focus-visible:bg-transparent focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
       )}
     >
@@ -263,11 +266,13 @@ export function HomePill({
           // Listening carries live bars; processing swaps them for dots;
           // needs-auth fills the chip with the sign-in label.
           needsAuth
-            ? "h-7 min-w-[11.5rem] px-3 bg-neutral-900/95"
+            ? "h-11 w-full gap-2 bg-[#FF5800] px-5 group-hover:bg-[#D94B00]"
             : chipExpanded
               ? "h-7 w-20 gap-[3px] bg-neutral-900/95"
               : "h-2.5 w-12 gap-[3px] bg-white/95 group-hover:w-14",
-          chipExpanded && "shadow-[0_4px_16px_rgba(0,0,0,0.35)]",
+          needsAuth
+            ? "shadow-[0_8px_24px_rgba(255,88,0,0.42),0_0_0_1px_rgba(255,255,255,0.18)]"
+            : chipExpanded && "shadow-[0_4px_16px_rgba(0,0,0,0.35)]",
           !chipExpanded &&
             (phase === "responding"
               ? speaking
@@ -276,7 +281,7 @@ export function HomePill({
                   "shadow-[0_0_14px_rgba(255,138,42,0.85),0_0_0_1px_rgba(255,138,42,0.5)]"
                 : "shadow-[0_0_10px_rgba(255,138,42,0.6),0_0_0_1px_rgba(0,0,0,0.12)]"
               : "shadow-[0_0_0_1px_rgba(0,0,0,0.12)]"),
-          (phase === "booting" || (needsAuth && signingIn)) &&
+          phase === "booting" &&
             "animate-pulse opacity-65 motion-reduce:animate-none",
           phase === "responding" &&
             !speaking &&
@@ -284,12 +289,29 @@ export function HomePill({
         )}
       >
         {needsAuth && (
-          <span
-            data-testid="shell-home-pill-sign-in"
-            className="whitespace-nowrap text-[11px] font-medium tracking-tight text-white/95"
-          >
-            {signInLabel}
-          </span>
+          <>
+            {signingIn ? (
+              <LoaderCircle
+                aria-hidden="true"
+                data-testid="shell-home-pill-sign-in-spinner"
+                className="size-4 shrink-0 animate-spin text-white motion-reduce:animate-none"
+                strokeWidth={2}
+              />
+            ) : (
+              <LogIn
+                aria-hidden="true"
+                data-testid="shell-home-pill-sign-in-icon"
+                className="size-4 shrink-0 text-white"
+                strokeWidth={2}
+              />
+            )}
+            <span
+              data-testid="shell-home-pill-sign-in"
+              className="whitespace-nowrap text-sm font-semibold leading-none text-white"
+            >
+              {signInLabel}
+            </span>
+          </>
         )}
         {phase === "listening" &&
           WAVE_BARS.map((bar) => (

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -190,21 +190,27 @@ describe("HomePill", () => {
         {...hold}
       />,
     );
-    const btn = screen.getByRole("button", { name: /sign in to eliza/i });
+    const btn = screen.getByRole("button", {
+      name: /sign in with eliza cloud/i,
+    });
     expect(btn.getAttribute("data-phase")).toBe("needs-auth");
     expect(btn.hasAttribute("aria-pressed")).toBe(false);
     expect(screen.getByTestId("shell-home-pill-sign-in").textContent).toBe(
-      "Sign in to Eliza",
+      "Sign in with Eliza Cloud",
     );
     const mark = screen.getByTestId("shell-home-pill-mark");
-    expect(mark.className).toContain("bg-neutral-900/95");
-    expect(mark.className).toContain("min-w-[11.5rem]");
+    expect(btn.className).toContain("h-12");
+    expect(btn.className).toContain("w-[18rem]");
+    expect(mark.className).toContain("h-11");
+    expect(mark.className).toContain("w-full");
+    expect(mark.className).toContain("bg-[#FF5800]");
+    expect(screen.getByTestId("shell-home-pill-sign-in-icon")).toBeTruthy();
     expect(screen.queryAllByTestId("shell-home-pill-wave-bar")).toHaveLength(0);
     fireEvent.click(btn);
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
-  it("pulses the sign-in chip while Cloud login is in flight", () => {
+  it("keeps the sign-in chip opaque and shows a spinner during Cloud login", () => {
     render(
       <HomePill
         phase="needs-auth"
@@ -213,10 +219,14 @@ describe("HomePill", () => {
         onClose={() => {}}
       />,
     );
-    expect(screen.getByTestId("shell-home-pill-mark").className).toContain(
-      "animate-pulse",
-    );
-    const btn = screen.getByRole("button", { name: /signing in to eliza/i });
+    const mark = screen.getByTestId("shell-home-pill-mark");
+    expect(mark.className).not.toContain("opacity-65");
+    expect(mark.className).not.toContain("animate-pulse");
+    expect(screen.getByTestId("shell-home-pill-sign-in-spinner")).toBeTruthy();
+    expect(screen.queryByTestId("shell-home-pill-sign-in-icon")).toBeNull();
+    const btn = screen.getByRole("button", {
+      name: /signing in to eliza cloud/i,
+    });
     expect(btn.getAttribute("aria-busy")).toBe("true");
     expect(btn.hasAttribute("aria-pressed")).toBe(false);
   });

--- a/packages/ui/src/components/shell/__tests__/shell-auth-gate.test.ts
+++ b/packages/ui/src/components/shell/__tests__/shell-auth-gate.test.ts
@@ -20,7 +20,13 @@ const AUTH_PHASES: AuthStatusState["phase"][] = [
 describe("deriveShellAuthGate", () => {
   it("never gates a non-cloud-only build, including a local owner-key session", () => {
     for (const authPhase of AUTH_PHASES) {
-      expect(deriveShellAuthGate({ cloudOnly: false, authPhase })).toEqual({
+      expect(
+        deriveShellAuthGate({
+          cloudOnly: false,
+          authPhase,
+          hasUsableCloudSession: false,
+        }),
+      ).toEqual({
         gated: false,
         phase: "clear",
       });
@@ -29,24 +35,50 @@ describe("deriveShellAuthGate", () => {
 
   it("treats cloud-only authenticated as clear", () => {
     expect(
-      deriveShellAuthGate({ cloudOnly: true, authPhase: "authenticated" }),
+      deriveShellAuthGate({
+        cloudOnly: true,
+        authPhase: "authenticated",
+        hasUsableCloudSession: true,
+      }),
     ).toEqual({ gated: false, phase: "clear" });
   });
 
   it("treats cloud-only unauthenticated as needs-auth", () => {
     expect(
-      deriveShellAuthGate({ cloudOnly: true, authPhase: "unauthenticated" }),
+      deriveShellAuthGate({
+        cloudOnly: true,
+        authPhase: "unauthenticated",
+        hasUsableCloudSession: false,
+      }),
     ).toEqual({ gated: true, phase: "needs-auth" });
   });
 
-  it("keeps loading and server_unavailable on checking so the chip cannot flash", () => {
+  it.each(["loading", "authenticated", "server_unavailable"] as const)(
+    "requires sign-in without a stored Cloud session while auth is %s",
+    (authPhase) => {
+      expect(
+        deriveShellAuthGate({
+          cloudOnly: true,
+          authPhase,
+          hasUsableCloudSession: false,
+        }),
+      ).toEqual({ gated: true, phase: "needs-auth" });
+    },
+  );
+
+  it("keeps loading and server_unavailable on checking when a Cloud session exists", () => {
     expect(
-      deriveShellAuthGate({ cloudOnly: true, authPhase: "loading" }),
+      deriveShellAuthGate({
+        cloudOnly: true,
+        authPhase: "loading",
+        hasUsableCloudSession: true,
+      }),
     ).toEqual({ gated: true, phase: "checking" });
     expect(
       deriveShellAuthGate({
         cloudOnly: true,
         authPhase: "server_unavailable",
+        hasUsableCloudSession: true,
       }),
     ).toEqual({ gated: true, phase: "checking" });
   });

--- a/packages/ui/src/components/shell/__tests__/useShellAuthGate.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellAuthGate.test.tsx
@@ -4,7 +4,11 @@
 // Thin React binding over deriveShellAuthGate. Real hook; branding and the
 // auth snapshot are injected through their public test/context seams.
 
-import { cleanup, renderHook } from "@testing-library/react";
+import {
+  clearStoredStewardToken,
+  writeStoredStewardToken,
+} from "@elizaos/shared/steward-session-client";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { BrandingConfig } from "../../../config/branding-base";
@@ -29,6 +33,7 @@ function wrapperFor(cloudOnly: boolean) {
 
 afterEach(() => {
   cleanup();
+  clearStoredStewardToken();
   __resetAuthStatusForTests();
 });
 
@@ -46,6 +51,31 @@ describe("useShellAuthGate", () => {
     const { result } = renderHook(() => useShellAuthGate(), {
       wrapper: wrapperFor(true),
     });
+    expect(result.current).toEqual({ gated: true, phase: "needs-auth" });
+  });
+
+  it.each(["loading", "server_unavailable"] as const)(
+    "shows needs-auth without a stored Cloud session while auth is %s",
+    (phase) => {
+      __setAuthStatusForTests({ phase });
+      const { result } = renderHook(() => useShellAuthGate(), {
+        wrapper: wrapperFor(true),
+      });
+      expect(result.current).toEqual({ gated: true, phase: "needs-auth" });
+    },
+  );
+
+  it("reacts to the canonical Cloud session event", () => {
+    __setAuthStatusForTests({ phase: "loading" });
+    const { result } = renderHook(() => useShellAuthGate(), {
+      wrapper: wrapperFor(true),
+    });
+    expect(result.current).toEqual({ gated: true, phase: "needs-auth" });
+
+    act(() => writeStoredStewardToken("opaque-cloud-session"));
+    expect(result.current).toEqual({ gated: true, phase: "checking" });
+
+    act(() => clearStoredStewardToken());
     expect(result.current).toEqual({ gated: true, phase: "needs-auth" });
   });
 });

--- a/packages/ui/src/components/shell/shell-auth-gate.ts
+++ b/packages/ui/src/components/shell/shell-auth-gate.ts
@@ -22,6 +22,7 @@ export interface ShellAuthGate {
 export interface DeriveShellAuthGateInput {
   cloudOnly: boolean;
   authPhase: AuthStatusState["phase"];
+  hasUsableCloudSession: boolean;
 }
 
 export interface DeriveShellPhaseInput {
@@ -37,15 +38,20 @@ export interface DeriveShellPhaseInput {
 /**
  * Compose branding + the shared auth snapshot into the pill gate.
  *
- * `loading` and `server_unavailable` stay on `checking` so a slow probe never
- * flashes the sign-in chip. The native-owner-key trap is the `cloudOnly`
- * guard: without it a local desktop owner token would look like Cloud.
+ * A cloud-only desktop requires the canonical Steward session token in
+ * addition to a successful backend auth probe. Without that token, a local
+ * owner credential can make `/api/auth/me` look authenticated even though the
+ * user has never signed in to Cloud. A present token remains gated on
+ * `checking` while the probe is unresolved or unavailable.
  */
 export function deriveShellAuthGate(
   input: DeriveShellAuthGateInput,
 ): ShellAuthGate {
   if (!input.cloudOnly) {
     return { gated: false, phase: "clear" };
+  }
+  if (!input.hasUsableCloudSession) {
+    return { gated: true, phase: "needs-auth" };
   }
   if (input.authPhase === "authenticated") {
     return { gated: false, phase: "clear" };

--- a/packages/ui/src/components/shell/useShellAuthGate.ts
+++ b/packages/ui/src/components/shell/useShellAuthGate.ts
@@ -1,22 +1,54 @@
 /**
- * React binding for {@link deriveShellAuthGate}: branding `cloudOnly` plus the
- * shared auth snapshot, with no extra network traffic.
+ * React binding for {@link deriveShellAuthGate}: branding `cloudOnly`, the
+ * canonical Steward session, and the shared auth snapshot, with no extra
+ * network traffic.
  *
  * Subscribe-only (`observeOnly`) so the pill can read the app-level
  * `/api/auth/me` probe. The first-run conductor still owns the first sign-in
  * card; this hook is the resting / recovery gate after that card is closed.
  */
 
+import {
+  STEWARD_SESSION_CHANGE_EVENT,
+  STEWARD_TOKEN_KEY,
+} from "@elizaos/shared/steward-session-client";
+import { useSyncExternalStore } from "react";
 import { useBranding } from "../../config/branding";
 import { useAuthStatus } from "../../hooks/useAuthStatus";
+import { hasUsableStoredStewardToken } from "../../state/cloud-steward-login";
 import { deriveShellAuthGate, type ShellAuthGate } from "./shell-auth-gate";
+
+function subscribeToStoredCloudSession(onStoreChange: () => void): () => void {
+  if (typeof window === "undefined") return () => undefined;
+
+  const onSessionChange = () => onStoreChange();
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === STEWARD_TOKEN_KEY) onStoreChange();
+  };
+  window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, onSessionChange);
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener(STEWARD_SESSION_CHANGE_EVENT, onSessionChange);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function noStoredCloudSession(): boolean {
+  return false;
+}
 
 export function useShellAuthGate(): ShellAuthGate {
   const { cloudOnly } = useBranding();
   const { state } = useAuthStatus({ observeOnly: true });
+  const hasUsableCloudSession = useSyncExternalStore(
+    subscribeToStoredCloudSession,
+    hasUsableStoredStewardToken,
+    noStoredCloudSession,
+  );
   return deriveShellAuthGate({
     cloudOnly: cloudOnly === true,
     authPhase: state.phase,
+    hasUsableCloudSession,
   });
 }
 


### PR DESCRIPTION
# Relates to

Operator-requested fix for the cloud-only desktop sign-in and push-to-talk gate.

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [ ] `bun run verify` passes. Current unrelated blockers are recorded below.
- [x] The native behavior was exercised in the rebuilt macOS app.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - local contribute-to-eliza workflow; external receipt path prohibited by repository instructions`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `6679aa19e9`; zero conflicts.
- [ ] `bun run verify` passes post-sync. See known gaps.

# Risks

Low to medium. The change only affects cloud-only desktop auth gating and the native frame used by the signed-out pill. Local-runtime builds retain their existing gate behavior.

# Background

## What does this PR do?

- Requires a usable stored Steward session before a cloud-only desktop pill can clear its auth gate, even when the backend auth probe appears authenticated.
- Shows the sign-in action while the auth probe is loading or unavailable instead of leaving a tiny inert booting handle.
- Reacts immediately to canonical Steward session and storage events.
- Changes the CTA to `Sign in with Eliza Cloud`.
- Enlarges the CTA to a 288x44 opaque orange control inside a 336x72 native frame.
- Keeps the busy state fully opaque and swaps the login icon for a reduced-motion-safe spinner.
- Keeps click, Fn-hold, and PTT gestures routed away from microphone capture until Cloud authentication clears.

## What kind of change is this?

Bug fix and desktop UI improvement.

# Documentation changes needed?

No external documentation change is required; source comments and tests describe the corrected contract.

# Testing

## Where should a reviewer start?

- `packages/ui/src/components/shell/shell-auth-gate.ts`
- `packages/ui/src/components/shell/useShellAuthGate.ts`
- `packages/ui/src/components/shell/HomePill.tsx`
- `packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts`

## Detailed testing steps

1. Build with `ELIZA_DESKTOP_CLOUD_ONLY=1 node packages/app-core/scripts/desktop-build.mjs build --cloud-only`.
2. Launch the packaged `Eliza-dev.app` with no stored `steward_session_token`.
3. Verify the bottom pill reads `Sign in with Eliza Cloud`, is fully visible, and uses the large opaque orange treatment.
4. Click it and verify the control remains opaque, exposes `Signing in to Eliza Cloud`, and shows a spinner rather than opening the microphone.
5. Restore a valid Steward token and authenticated probe; verify the pill returns to the compact launcher.

Focused results after rebase:

- UI auth gate and HomePill: 45 passed.
- Electrobun frame/window behavior: 46 passed.
- `packages/ui` typecheck: passed.
- `packages/ui` lint: passed with 8 pre-existing cookie warnings.
- Cloud-only desktop build: passed and produced a signed dev app.
- Computer Use native QA: signed-out and busy states rendered with full text, opaque orange background, and correct accessible names.

# Evidence Gate

<!-- evidence-head:ef86292ca0dce1f07f1974dde66240021da7331e -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: captured during native QA but not yet uploaded to GitHub.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: captured during native QA but not yet uploaded to GitHub.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: not yet attached.
<!-- evidence-row:backend-logs -->
- [x] N/A - the behavior is renderer state plus native window sizing; no backend mutation was introduced.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs: inspected during native QA but not yet attached.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, model, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, scheduled-task, audio, or generated domain artifact changed.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: the full app audit reached 117 passing captures before it was intentionally stopped for the final opacity adjustment; final OCR output is not attached.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

The native Web Inspector confirmed renderer build `085286cbad30`, the `chat-overlay` shell mode, canonical Steward session event handling, and the expected accessible state transition from `Sign in with Eliza Cloud` to `Signing in to Eliza Cloud`.

## Screenshots (before / after) + video walkthrough

Pending upload. This draft should not be marked ready for review until the required media rows are complete.

## Audio / voice walkthrough

N/A - microphone capture is deliberately blocked by this auth gate; no STT, TTS, or voice pipeline changed.

## Known gaps / failures

- `bun install` passes on pinned Bun 1.3.14.
- `bun run verify` currently fails on current `develop` because `ensure-plugin-test-conventions:check` reports 394 orphaned vendored OpenCode/llama tests. This branch does not touch those test lanes or vendors.
- `packages/app-core` and Electrobun typechecks currently fail on current `develop` at `packages/agent/src/api/server.ts:2572`: `decodePathComponent` is not present in `SkillsRouteContext`. This branch does not touch that contract.
- The app visual audit had 117 passing captures before the final busy-opacity change made that run stale; the focused HomePill regression test and real native QA cover the final opaque busy state.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - local workflow, repository-forbidden external receipt path omitted
Attribution status: self-reported
— codex-cloud-pill
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex-desktop","skill_revision":"N/A-local-workflow"} -->
