### PR TITLE
fix(orchestrator): vacuous checks for static deliverables; guard boot-window escalations

### DIFF
--- a/packages/agent/src/services/escalation.ts
+++ b/packages/agent/src/services/escalation.ts
@@ -286,10 +286,11 @@ async function sendToChannel(
       resolveScopedSendSource(resolvedContact?.source ?? channel, (source) =>
         hasRuntimeSendHandler(runtime, source),
       );
-    if (
-      targetSource === MESSAGE_SOURCE_CLIENT_CHAT &&
-      !hasRuntimeSendHandler(runtime, targetSource)
-    ) {
+    // Boot-window guard for EVERY source (live: the boot's own
+    // service-failure escalation fired before the discord handler registered
+    // and the send threw). A missing handler is a skip — escalation's
+    // channel/wait retry machinery re-attempts once runtime wiring completes.
+    if (!hasRuntimeSendHandler(runtime, targetSource)) {
       logMissingSendHandlerOnce("escalation", targetSource);
       return false;
     }

--- a/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
@@ -114,9 +114,17 @@ describe("deterministicLedgerVerdict", () => {
   });
 
   test("an unsatisfied check criterion stays undetermined and blocks allMet", () => {
+    // A code file in the deliverable makes the check APPLICABLE — the
+    // static-only vacuous leg (see the dedicated describe) must not fire.
     const verdict = deterministicLedgerVerdict(
       ["the live URL is reachable", "tests pass"],
-      quickAppFacts,
+      {
+        ...quickAppFacts,
+        ledgerVerifiedFiles: [
+          ...quickAppFacts.ledgerVerifiedFiles,
+          "data/apps/canon-clock/main.ts",
+        ],
+      },
     );
     expect(verdict.allMet).toBe(false);
     expect(verdict.undetermined).toEqual(["tests pass"]);
@@ -227,10 +235,13 @@ describe("deterministicLedgerVerdict", () => {
 
   test("renders met bases and undetermined markers", () => {
     const rendered = renderDeterministicVerdict(
-      deterministicLedgerVerdict(
-        ["the live URL is reachable", "tests pass"],
-        quickAppFacts,
-      ),
+      deterministicLedgerVerdict(["the live URL is reachable", "tests pass"], {
+        ...quickAppFacts,
+        ledgerVerifiedFiles: [
+          ...quickAppFacts.ledgerVerifiedFiles,
+          "data/apps/canon-clock/main.ts",
+        ],
+      }),
     );
     expect(rendered).toContain("MET: the live URL is reachable");
     expect(rendered).toContain("undetermined (needs judgment): tests pass");
@@ -310,5 +321,52 @@ describe("generateDefaultAcceptanceCriteria enforcement (#20794)", () => {
     expect(criteria.join("\n")).not.toContain("agent-home/canon-clock.html");
     expect(criteria).toContain("the live URL is reachable");
     expect(criteria.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("static-only deliverable check inapplicability (ember-tide live shape)", () => {
+  const staticFacts = {
+    verifiedPublicUrls: ["https://nubilio.org/apps/ember-tide/"],
+    ledgerVerifiedFiles: ["data/apps/ember-tide/index.html"],
+    hasChangeSet: false,
+    greenChecks: { test: false, build: false, lint: false },
+  };
+
+  test("typecheck/lint/tests are vacuously met when the deliverable is static-only", () => {
+    const verdict = deterministicLedgerVerdict(
+      ["typecheck passes", "lint passes", "tests pass"],
+      staticFacts,
+    );
+    expect(verdict.allMet).toBe(true);
+    for (const result of verdict.results) {
+      expect(result.basis).toContain("inapplicable");
+    }
+  });
+
+  test("any code file in the deliverable keeps check criteria undetermined", () => {
+    const verdict = deterministicLedgerVerdict(["typecheck passes"], {
+      ...staticFacts,
+      ledgerVerifiedFiles: [
+        "data/apps/ember-tide/index.html",
+        "data/apps/ember-tide/main.ts",
+      ],
+    });
+    expect(verdict.allMet).toBe(false);
+  });
+
+  test("no verified files means no vacuous satisfaction", () => {
+    const verdict = deterministicLedgerVerdict(["lint passes"], {
+      ...staticFacts,
+      ledgerVerifiedFiles: [],
+    });
+    expect(verdict.allMet).toBe(false);
+  });
+
+  test("green output still wins over the inapplicability leg", () => {
+    const verdict = deterministicLedgerVerdict(["tests pass"], {
+      ...staticFacts,
+      greenChecks: { test: true, build: false, lint: false },
+    });
+    expect(verdict.results[0]?.basis).toBe("green test output captured");
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
@@ -178,6 +178,20 @@ function urlCriterionBasis(
   return hit ? `probed URL answered: ${hit}` : undefined;
 }
 
+/** File extensions with no typecheck/lint/test surface. A deliverable made
+ *  ONLY of these cannot satisfy a check-class criterion by running anything —
+ *  the check is vacuous, and demanding it burned every verify attempt on live
+ *  quick-apps (ember-tide: typecheck/lint criteria against one static page). */
+const STATIC_ASSET_RE =
+  /\.(?:html?|css|svg|png|jpe?g|gif|webp|ico|md|txt|json|woff2?)$/i;
+
+function staticOnlyDeliverable(facts: DeterministicEvidenceFacts): boolean {
+  return (
+    facts.ledgerVerifiedFiles.length > 0 &&
+    facts.ledgerVerifiedFiles.every((file) => STATIC_ASSET_RE.test(file))
+  );
+}
+
 /** Deterministic facts the orchestrator already holds at completion. */
 export interface DeterministicEvidenceFacts {
   /** Router-probed URLs that answered, non-loopback only. */
@@ -259,11 +273,27 @@ export function deterministicCriterionCheck(
       : { criterion, status: "undetermined" };
   }
   if (TEST_CRITERION_RE.test(criterion)) {
+    if (!facts.greenChecks.test && staticOnlyDeliverable(facts)) {
+      return {
+        criterion,
+        status: "met",
+        basis:
+          "inapplicable: verified deliverable contains only static assets (no test surface)",
+      };
+    }
     return facts.greenChecks.test
       ? { criterion, status: "met", basis: "green test output captured" }
       : { criterion, status: "undetermined" };
   }
   if (BUILD_CRITERION_RE.test(criterion)) {
+    if (!facts.greenChecks.build && staticOnlyDeliverable(facts)) {
+      return {
+        criterion,
+        status: "met",
+        basis:
+          "inapplicable: verified deliverable contains only static assets (no build surface)",
+      };
+    }
     return facts.greenChecks.build
       ? {
           criterion,
@@ -273,6 +303,14 @@ export function deterministicCriterionCheck(
       : { criterion, status: "undetermined" };
   }
   if (LINT_CRITERION_RE.test(criterion)) {
+    if (!facts.greenChecks.lint && staticOnlyDeliverable(facts)) {
+      return {
+        criterion,
+        status: "met",
+        basis:
+          "inapplicable: verified deliverable contains only static assets (no lint surface)",
+      };
+    }
     return facts.greenChecks.lint
       ? { criterion, status: "met", basis: "green lint output captured" }
       : { criterion, status: "undetermined" };


### PR DESCRIPTION
Two live findings from the box re-proof of #21114/#21118 (ember-tide, 09:12Z).

## 1. Static deliverables vs check-class criteria

The #21114 recovery WORKED on ember-tide — every attempt's persisted bundle carried `fsVerifiedFiles: ['data/apps/ember-tide/index.html']` and four probed `verifiedUrls` including the public one. The task still parked because the minted criteria (`typecheck passes`, `lint passes`, plus one content check) never reference the URL or file: two check-class criteria that a one-page static deliverable can never satisfy by running anything burned all three attempts regardless of evidence quality — and criteria arrive from multiple origins (planner-supplied, model-refined), so the template fix alone cannot close this.

Fix at the verify layer, deterministically: when the VERIFIED deliverable consists only of static assets (html/css/svg/images/md/txt/json/fonts — the ledger/fs-verified file list, not narration), an unsatisfied test/typecheck/lint criterion is **vacuously met** with an explicit `inapplicable: … (no <check> surface)` basis. Conservative by construction: any code file among the verified files keeps checks undetermined exactly as before; green output still wins with its real basis; no verified files → no vacuous leg.

## 2. Boot-window escalation guard

#21118's scoped-key resolution is correct post-boot, but the boot's own service-failure escalation fired before ANY connector handler registered — nothing to resolve against, verbatim fallback, thrown send ("Failed to send to channel discord-nubs-test", observed at boot marker+98 lines). The existing missing-handler skip guard was `client_chat`-only; it now guards every source: no registered handler → `logMissingSendHandlerOnce` + skip, and escalation's channel/wait retry machinery re-attempts after runtime wiring completes instead of throwing mid-boot.

## Evidence

- 4 new inapplicability tests (live ember-tide shape end-to-end: `typecheck/lint/tests` vacuously met with inapplicable bases; code-file-present keeps undetermined; empty verified files no vacuous leg; green output precedence) + 2 existing tests deliberately updated to pin the APPLICABLE case (code file added to the fixture — their old fixture was static-only and now correctly satisfies).
- Affected suites: producible-evidence + quick-app-evidence + auto-goal-verify 95/95; escalation-channels + scoped-source 9/9.
- Plugin + agent typecheck clean; Biome clean.
- Live re-proof: next box dist rebuild re-runs the quick-app probe — expected deterministic promotion (URL/file evidence present since #21114; the check-criteria burn is what this removes) — and a clean boot with the deferred escalation logged once instead of thrown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)