### PR TITLE
perf(agent): cache memory-search corpus + BM25 index per room

### DIFF
--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -46,6 +46,8 @@ const MEMORY_SEARCH_SCAN_LIMIT = 2_000;
  * writes (remember/delete/patch) invalidate explicitly and a row-count check
  * runs before every reuse, so the TTL only bounds staleness from
  * out-of-band *edits* that change text without changing the row count.
+ * Expiry triggers a background refresh (the cached corpus is still served),
+ * so the warm path never pays the multi-second rebuild synchronously.
  */
 const MEMORY_SEARCH_CACHE_TTL_MS = 10_000;
 const MEMORY_SEARCH_CACHE_MAX_ENTRIES = 4;
@@ -227,9 +229,22 @@ type MemorySearchCorpus = {
  *    count-preserving out-of-band edits.
  */
 const memorySearchCorpusCache = new Map<string, MemorySearchCorpus>();
+const memorySearchRefreshInFlight = new Map<
+  string,
+  Promise<MemorySearchCorpus>
+>();
+// Bumped on invalidation; an in-flight rebuild only publishes to the cache if
+// no invalidation happened after its scan began (prevents a background
+// refresh started before a delete/patch from resurrecting pre-mutation data).
+let memorySearchCacheGeneration = 0;
 
 export function invalidateMemorySearchCache(): void {
+  memorySearchCacheGeneration += 1;
   memorySearchCorpusCache.clear();
+  // In-flight rebuilds began against pre-invalidation data; drop them so no
+  // caller reuses a scan that predates the mutation (the generation check
+  // already stops them from publishing).
+  memorySearchRefreshInFlight.clear();
 }
 
 async function countRoomMessages(
@@ -246,17 +261,12 @@ async function countRoomMessages(
   }
 }
 
-async function getMemorySearchCorpus(
+async function buildMemorySearchCorpus(
   runtime: AgentRuntime,
   roomId: UUID,
+  key: string,
 ): Promise<MemorySearchCorpus> {
-  const key = `${runtime.agentId}:${roomId}`;
-  const cached = memorySearchCorpusCache.get(key);
-  if (cached && Date.now() - cached.builtAt <= MEMORY_SEARCH_CACHE_TTL_MS) {
-    const rowCount = await countRoomMessages(runtime, roomId);
-    if (rowCount !== null && rowCount === cached.rowCount) return cached;
-  }
-
+  const generationAtStart = memorySearchCacheGeneration;
   const [memories, countedRows] = await Promise.all([
     runtime.getMemories({
       roomId,
@@ -295,7 +305,13 @@ async function getMemorySearchCorpus(
     builtAt: Date.now(),
   };
 
-  if (countedRows !== null) {
+  // Only publish when (a) a freshness signal exists (COUNT worked) and (b) no
+  // invalidation raced this build; a stale publish could resurrect
+  // pre-mutation data for up to a TTL.
+  if (
+    countedRows !== null &&
+    generationAtStart === memorySearchCacheGeneration
+  ) {
     memorySearchCorpusCache.set(key, corpus);
     // Bounded: this endpoint is effectively single-room per agent, so the map
     // should hold one live entry; the cap only guards against key churn.
@@ -313,6 +329,48 @@ async function getMemorySearchCorpus(
   }
 
   return corpus;
+}
+
+async function getMemorySearchCorpus(
+  runtime: AgentRuntime,
+  roomId: UUID,
+): Promise<MemorySearchCorpus> {
+  const key = `${runtime.agentId}:${roomId}`;
+  const cached = memorySearchCorpusCache.get(key);
+  if (cached) {
+    const rowCount = await countRoomMessages(runtime, roomId);
+    if (rowCount !== null && rowCount === cached.rowCount) {
+      if (Date.now() - cached.builtAt <= MEMORY_SEARCH_CACHE_TTL_MS) {
+        return cached;
+      }
+      // Row count still matches but the entry aged out: serve the cached
+      // corpus (bounded staleness for count-preserving out-of-band edits)
+      // and refresh in the background so no request pays the rebuild.
+      if (!memorySearchRefreshInFlight.has(key)) {
+        const refresh = buildMemorySearchCorpus(runtime, roomId, key);
+        memorySearchRefreshInFlight.set(key, refresh);
+        refresh
+          .catch(() => {
+            // Background refresh failure keeps serving the cached corpus;
+            // the next TTL expiry retries.
+          })
+          .finally(() => {
+            // Only clear our own registration; invalidation may have
+            // replaced it with a newer rebuild.
+            if (memorySearchRefreshInFlight.get(key) === refresh) {
+              memorySearchRefreshInFlight.delete(key);
+            }
+          });
+      }
+      return cached;
+    }
+    // Count mismatch (out-of-band create/delete) or unknown count: rebuild
+    // synchronously so results reflect the mutation immediately.
+  }
+
+  const inFlight = memorySearchRefreshInFlight.get(key);
+  if (inFlight) return inFlight;
+  return buildMemorySearchCorpus(runtime, roomId, key);
 }
 
 async function searchMemoryNotes(

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -44,13 +44,13 @@ const MEMORY_SEARCH_SCAN_LIMIT = 2_000;
 /**
  * Warm-corpus reuse window for the hash-memory search cache. Module-local
  * writes (remember/delete/patch) invalidate explicitly and a row-count check
- * runs before every reuse, so the TTL only bounds staleness from
- * out-of-band *edits* that change text without changing the row count.
- * Expiry triggers a background refresh (the cached corpus is still served),
- * so the warm path never pays the multi-second rebuild synchronously.
+ * runs before every reuse. Count-preserving out-of-band edits trigger refresh
+ * after 10 seconds and may be served stale only until the 20-second hard bound.
  */
 const MEMORY_SEARCH_CACHE_TTL_MS = 10_000;
+const MEMORY_SEARCH_CACHE_MAX_STALE_MS = 20_000;
 const MEMORY_SEARCH_CACHE_MAX_ENTRIES = 4;
+const MEMORY_SEARCH_CACHE_MAX_TEXT_BYTES = 8 * 1024 * 1024;
 const MEMORY_SEARCH_DEFAULT_LIMIT = 10;
 const MEMORY_SEARCH_MAX_LIMIT = 50;
 const QUICK_CONTEXT_DEFAULT_LIMIT = 8;
@@ -212,8 +212,14 @@ type MemorySearchCorpus = {
   builtAt: number;
 };
 
+type MemorySearchCacheSlot = {
+  generation: number;
+  corpus?: MemorySearchCorpus;
+  inFlight?: Promise<MemorySearchCorpus>;
+};
+
 /**
- * Per-(agentId, roomId) corpus + BM25 index cache for the hash-memory search
+ * Per-runtime, per-room corpus + BM25 index cache for the hash-memory search
  * endpoints. Building this per request was the whole latency story: a full
  * `getMemories` scan (up to {@link MEMORY_SEARCH_SCAN_LIMIT} rows, some
  * multi-KB) plus a fresh BM25 tokenize/index pass cost ~2s+ at ~2k rows while
@@ -225,26 +231,39 @@ type MemorySearchCorpus = {
  *    (remember / DELETE / PATCH);
  *  - a cheap COUNT check before every reuse catches out-of-band creates and
  *    deletes immediately;
- *  - a short TTL ({@link MEMORY_SEARCH_CACHE_TTL_MS}) bounds staleness from
- *    count-preserving out-of-band edits.
+ *  - a short TTL triggers refresh for count-preserving out-of-band edits, and
+ *    {@link MEMORY_SEARCH_CACHE_MAX_STALE_MS} is their absolute stale bound.
  */
-const memorySearchCorpusCache = new Map<string, MemorySearchCorpus>();
-const memorySearchRefreshInFlight = new Map<
-  string,
-  Promise<MemorySearchCorpus>
+let memorySearchCorpusCaches = new WeakMap<
+  AgentRuntime,
+  Map<string, MemorySearchCacheSlot>
 >();
-// Bumped on invalidation; an in-flight rebuild only publishes to the cache if
-// no invalidation happened after its scan began (prevents a background
-// refresh started before a delete/patch from resurrecting pre-mutation data).
-let memorySearchCacheGeneration = 0;
 
-export function invalidateMemorySearchCache(): void {
-  memorySearchCacheGeneration += 1;
-  memorySearchCorpusCache.clear();
-  // In-flight rebuilds began against pre-invalidation data; drop them so no
-  // caller reuses a scan that predates the mutation (the generation check
-  // already stops them from publishing).
-  memorySearchRefreshInFlight.clear();
+export function invalidateMemorySearchCache(
+  runtime?: AgentRuntime,
+  roomId?: UUID,
+): void {
+  if (!runtime) {
+    // Test/process reset only. Runtime-owned maps otherwise disappear when the
+    // runtime is collected, without keeping tenant state alive module-wide.
+    memorySearchCorpusCaches = new WeakMap();
+    return;
+  }
+  const cache = memorySearchCorpusCaches.get(runtime);
+  if (!cache) return;
+  const invalidateSlot = (slot: MemorySearchCacheSlot) => {
+    slot.generation++;
+    slot.corpus = undefined;
+    // Detach an older build so a request arriving after this mutation cannot
+    // join a pre-mutation snapshot. Its generation check prevents publishing.
+    slot.inFlight = undefined;
+  };
+  if (roomId) {
+    const slot = cache.get(roomId);
+    if (slot) invalidateSlot(slot);
+    return;
+  }
+  for (const slot of cache.values()) invalidateSlot(slot);
 }
 
 async function countRoomMessages(
@@ -253,33 +272,75 @@ async function countRoomMessages(
 ): Promise<number | null> {
   if (typeof runtime.countMemories !== "function") return null;
   try {
-    return await runtime.countMemories({ roomId, tableName: "messages" });
-  } catch {
-    // A failing COUNT must not take down search; treat as unknown so the
-    // caller falls back to a full rebuild.
+    return await runtime.countMemories({
+      agentId: runtime.agentId as UUID,
+      roomId,
+      tableName: "messages",
+    });
+  } catch (error) {
+    // error-policy:J7 A freshness-probe failure is reported but cannot turn a
+    // safe uncached search into a user-visible route failure.
+    runtime.reportError("MemorySearchCache.countRoomMessages", error, {
+      roomId,
+    });
     return null;
+  }
+}
+
+function runtimeMemorySearchCache(
+  runtime: AgentRuntime,
+): Map<string, MemorySearchCacheSlot> {
+  let cache = memorySearchCorpusCaches.get(runtime);
+  if (!cache) {
+    cache = new Map();
+    memorySearchCorpusCaches.set(runtime, cache);
+  }
+  return cache;
+}
+
+function evictOldMemorySearchCorpora(
+  cache: Map<string, MemorySearchCacheSlot>,
+  retainedRoomId: string,
+): void {
+  const populated = [...cache.entries()].filter(([, slot]) => slot.corpus);
+  if (populated.length <= MEMORY_SEARCH_CACHE_MAX_ENTRIES) return;
+  populated.sort(
+    ([, left], [, right]) =>
+      (left.corpus?.builtAt ?? 0) - (right.corpus?.builtAt ?? 0),
+  );
+  for (const [key, slot] of populated) {
+    if (key === retainedRoomId || slot.inFlight) continue;
+    cache.delete(key);
+    if (
+      [...cache.values()].filter((candidate) => candidate.corpus).length <=
+      MEMORY_SEARCH_CACHE_MAX_ENTRIES
+    ) {
+      break;
+    }
   }
 }
 
 async function buildMemorySearchCorpus(
   runtime: AgentRuntime,
   roomId: UUID,
-  key: string,
-): Promise<MemorySearchCorpus> {
-  const generationAtStart = memorySearchCacheGeneration;
-  const [memories, countedRows] = await Promise.all([
-    runtime.getMemories({
-      roomId,
-      tableName: "messages",
-      limit: MEMORY_SEARCH_SCAN_LIMIT,
-      includeEmbedding: false, // only reads content.text
-    }),
-    countRoomMessages(runtime, roomId),
-  ]);
+): Promise<{ corpus: MemorySearchCorpus; cacheable: boolean }> {
+  // The two counts form a lightweight seqlock around the scan. A create/delete
+  // interleaving with getMemories makes the counts disagree, so that mixed
+  // snapshot can answer this request but is never published for later reuse.
+  const countBefore = await countRoomMessages(runtime, roomId);
+  const memories = await runtime.getMemories({
+    agentId: runtime.agentId as UUID,
+    roomId,
+    tableName: "messages",
+    limit: MEMORY_SEARCH_SCAN_LIMIT,
+    includeEmbedding: false, // only reads content.text
+  });
+  const countAfter =
+    countBefore === null ? null : await countRoomMessages(runtime, roomId);
 
-  // Gather hash-memory candidates first; the BM25 corpus is built once here
-  // and reused across queries until invalidation.
   const candidates: MemorySearchCandidate[] = [];
+  const textEncoder = new TextEncoder();
+  let retainedTextBytes = 0;
   for (const memory of memories) {
     const text = (
       memory.content as { text?: string } | undefined
@@ -288,6 +349,7 @@ async function buildMemorySearchCorpus(
     const source = (memory.content as { source?: string } | undefined)?.source;
     if (source !== HASH_MEMORY_SOURCE) continue;
     if (!memory.id || typeof memory.createdAt !== "number") continue;
+    retainedTextBytes += textEncoder.encode(text).byteLength;
     candidates.push({
       id: memory.id,
       text,
@@ -295,82 +357,82 @@ async function buildMemorySearchCorpus(
     });
   }
 
-  const corpus: MemorySearchCorpus = {
-    candidates,
-    bm25: new BM25(
-      candidates.map((c) => ({ content: c.text })),
-      { stemming: true },
-    ),
-    rowCount: countedRows ?? memories.length,
-    builtAt: Date.now(),
+  return {
+    corpus: {
+      candidates,
+      bm25: new BM25(
+        candidates.map((candidate) => ({ content: candidate.text })),
+        { stemming: true },
+      ),
+      rowCount: countAfter ?? memories.length,
+      builtAt: Date.now(),
+    },
+    cacheable:
+      countBefore !== null &&
+      countAfter !== null &&
+      countBefore === countAfter &&
+      retainedTextBytes <= MEMORY_SEARCH_CACHE_MAX_TEXT_BYTES,
   };
+}
 
-  // Only publish when (a) a freshness signal exists (COUNT worked) and (b) no
-  // invalidation raced this build; a stale publish could resurrect
-  // pre-mutation data for up to a TTL.
-  if (
-    countedRows !== null &&
-    generationAtStart === memorySearchCacheGeneration
-  ) {
-    memorySearchCorpusCache.set(key, corpus);
-    // Bounded: this endpoint is effectively single-room per agent, so the map
-    // should hold one live entry; the cap only guards against key churn.
-    if (memorySearchCorpusCache.size > MEMORY_SEARCH_CACHE_MAX_ENTRIES) {
-      let oldestKey: string | undefined;
-      let oldestBuiltAt = Number.POSITIVE_INFINITY;
-      for (const [entryKey, entry] of memorySearchCorpusCache) {
-        if (entry.builtAt < oldestBuiltAt) {
-          oldestBuiltAt = entry.builtAt;
-          oldestKey = entryKey;
-        }
+function startMemorySearchCorpusBuild(
+  runtime: AgentRuntime,
+  roomId: UUID,
+  cache: Map<string, MemorySearchCacheSlot>,
+  slot: MemorySearchCacheSlot,
+): Promise<MemorySearchCorpus> {
+  if (slot.inFlight) return slot.inFlight;
+  const generation = slot.generation;
+  const build = buildMemorySearchCorpus(runtime, roomId).then(
+    ({ corpus, cacheable }) => {
+      if (slot.generation === generation) {
+        slot.corpus = cacheable ? corpus : undefined;
+        if (cacheable) evictOldMemorySearchCorpora(cache, roomId);
       }
-      if (oldestKey !== undefined) memorySearchCorpusCache.delete(oldestKey);
-    }
-  }
-
-  return corpus;
+      return corpus;
+    },
+  );
+  slot.inFlight = build;
+  // error-policy:J7 A background refresh is observed and reported here; a
+  // synchronous caller awaiting the same promise still receives the failure.
+  void build.then(
+    () => {
+      if (slot.inFlight === build) slot.inFlight = undefined;
+    },
+    (error: unknown) => {
+      if (slot.inFlight === build) slot.inFlight = undefined;
+      runtime.reportError("MemorySearchCache.refresh", error, { roomId });
+    },
+  );
+  return build;
 }
 
 async function getMemorySearchCorpus(
   runtime: AgentRuntime,
   roomId: UUID,
 ): Promise<MemorySearchCorpus> {
-  const key = `${runtime.agentId}:${roomId}`;
-  const cached = memorySearchCorpusCache.get(key);
+  const cache = runtimeMemorySearchCache(runtime);
+  let slot = cache.get(roomId);
+  if (!slot) {
+    slot = { generation: 0 };
+    cache.set(roomId, slot);
+  }
+  const cached = slot.corpus;
   if (cached) {
     const rowCount = await countRoomMessages(runtime, roomId);
     if (rowCount !== null && rowCount === cached.rowCount) {
-      if (Date.now() - cached.builtAt <= MEMORY_SEARCH_CACHE_TTL_MS) {
+      const age = Date.now() - cached.builtAt;
+      if (age <= MEMORY_SEARCH_CACHE_TTL_MS) return cached;
+      if (age <= MEMORY_SEARCH_CACHE_MAX_STALE_MS) {
+        // Keep the first post-TTL request warm while one shared refresh runs.
+        // The absolute max-stale boundary below prevents persistent failures
+        // from extending this stale-while-revalidate window indefinitely.
+        startMemorySearchCorpusBuild(runtime, roomId, cache, slot);
         return cached;
       }
-      // Row count still matches but the entry aged out: serve the cached
-      // corpus (bounded staleness for count-preserving out-of-band edits)
-      // and refresh in the background so no request pays the rebuild.
-      if (!memorySearchRefreshInFlight.has(key)) {
-        const refresh = buildMemorySearchCorpus(runtime, roomId, key);
-        memorySearchRefreshInFlight.set(key, refresh);
-        refresh
-          .catch(() => {
-            // Background refresh failure keeps serving the cached corpus;
-            // the next TTL expiry retries.
-          })
-          .finally(() => {
-            // Only clear our own registration; invalidation may have
-            // replaced it with a newer rebuild.
-            if (memorySearchRefreshInFlight.get(key) === refresh) {
-              memorySearchRefreshInFlight.delete(key);
-            }
-          });
-      }
-      return cached;
     }
-    // Count mismatch (out-of-band create/delete) or unknown count: rebuild
-    // synchronously so results reflect the mutation immediately.
   }
-
-  const inFlight = memorySearchRefreshInFlight.get(key);
-  if (inFlight) return inFlight;
-  return buildMemorySearchCorpus(runtime, roomId, key);
+  return await startMemorySearchCorpusBuild(runtime, roomId, cache, slot);
 }
 
 async function searchMemoryNotes(
@@ -669,7 +731,7 @@ export async function handleMemoryRoutes(
       },
     });
     await runtime.createMemory(message, "messages");
-    invalidateMemorySearchCache();
+    invalidateMemorySearchCache(runtime, roomId);
     json(res, {
       ok: true,
       id: message.id,
@@ -926,7 +988,7 @@ export async function handleMemoryRoutes(
 
     if (method === "DELETE") {
       await runtime.deleteMemory(memoryId);
-      invalidateMemorySearchCache();
+      invalidateMemorySearchCache(runtime, roomId);
       json(res, { deleted: true, id: memoryId });
       return true;
     }
@@ -969,7 +1031,7 @@ export async function handleMemoryRoutes(
       content: nextContent,
       embedding,
     });
-    invalidateMemorySearchCache();
+    invalidateMemorySearchCache(runtime, roomId);
 
     const updated = await runtime.getMemoryById(memoryId);
     json(res, { updated: true, id: memoryId, memory: updated });

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -441,6 +441,13 @@ async function getMemorySearchCorpus(
   if (cached) {
     const rowCount = await countRoomMessages(runtime, roomId);
 
+    // Eviction may have orphaned this slot while COUNT was pending. Re-enter
+    // through the canonical map so the replacement build can be single-flighted
+    // and published for later requests.
+    if (cache.get(roomId) !== slot) {
+      return await getMemorySearchCorpus(runtime, roomId);
+    }
+
     // A module-local mutation may have invalidated this slot while COUNT was
     // pending. Never return the snapshot captured before that mutation.
     if (slot.corpus !== cached) {

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -41,6 +41,14 @@ export const HASH_MEMORY_SOURCE = "hash_memory";
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MEMORY_SEARCH_SCAN_LIMIT = 2_000;
+/**
+ * Warm-corpus reuse window for the hash-memory search cache. Module-local
+ * writes (remember/delete/patch) invalidate explicitly and a row-count check
+ * runs before every reuse, so the TTL only bounds staleness from
+ * out-of-band *edits* that change text without changing the row count.
+ */
+const MEMORY_SEARCH_CACHE_TTL_MS = 10_000;
+const MEMORY_SEARCH_CACHE_MAX_ENTRIES = 4;
 const MEMORY_SEARCH_DEFAULT_LIMIT = 10;
 const MEMORY_SEARCH_MAX_LIMIT = 50;
 const QUICK_CONTEXT_DEFAULT_LIMIT = 8;
@@ -144,6 +152,20 @@ export function rankByKeyword<T>(
     items.map((item) => ({ content: getText(item) })),
     { stemming: true },
   );
+  return rankWithIndex(query, items, bm25);
+}
+
+/**
+ * Same ranking contract as {@link rankByKeyword} but against a prebuilt BM25
+ * index whose docs correspond 1:1 (by array index) with `items`. This is the
+ * shared scoring tail, so cached and cold paths cannot drift.
+ */
+function rankWithIndex<T>(
+  query: string,
+  items: T[],
+  bm25: BM25,
+): Array<{ item: T; score: number }> {
+  if (items.length === 0) return [];
   const results = bm25.search(query, items.length);
   if (results.length === 0) return items.map((item) => ({ item, score: 0 }));
   const firstScore = results[0]?.score;
@@ -177,21 +199,77 @@ export function matchesKeyword(text: string, query: string): boolean {
     .some((term) => normalizedText.includes(term));
 }
 
-async function searchMemoryNotes(
+type MemorySearchCandidate = { id: UUID; text: string; createdAt: number };
+
+type MemorySearchCorpus = {
+  candidates: MemorySearchCandidate[];
+  /** BM25 index whose doc order matches `candidates` by array index. */
+  bm25: BM25;
+  /** Room message-row count observed when this corpus was built. */
+  rowCount: number;
+  builtAt: number;
+};
+
+/**
+ * Per-(agentId, roomId) corpus + BM25 index cache for the hash-memory search
+ * endpoints. Building this per request was the whole latency story: a full
+ * `getMemories` scan (up to {@link MEMORY_SEARCH_SCAN_LIMIT} rows, some
+ * multi-KB) plus a fresh BM25 tokenize/index pass cost ~2s+ at ~2k rows while
+ * the actual query scoring is sub-millisecond.
+ *
+ * Freshness model (memories can be written outside this module, e.g. normal
+ * chat writes to the "messages" table):
+ *  - explicit invalidation on every mutation routed through this module
+ *    (remember / DELETE / PATCH);
+ *  - a cheap COUNT check before every reuse catches out-of-band creates and
+ *    deletes immediately;
+ *  - a short TTL ({@link MEMORY_SEARCH_CACHE_TTL_MS}) bounds staleness from
+ *    count-preserving out-of-band edits.
+ */
+const memorySearchCorpusCache = new Map<string, MemorySearchCorpus>();
+
+export function invalidateMemorySearchCache(): void {
+  memorySearchCorpusCache.clear();
+}
+
+async function countRoomMessages(
   runtime: AgentRuntime,
   roomId: UUID,
-  query: string,
-  limit: number,
-): Promise<MemorySearchHit[]> {
-  const memories = await runtime.getMemories({
-    roomId,
-    tableName: "messages",
-    limit: MEMORY_SEARCH_SCAN_LIMIT,
-    includeEmbedding: false, // only reads content.text
-  });
+): Promise<number | null> {
+  if (typeof runtime.countMemories !== "function") return null;
+  try {
+    return await runtime.countMemories({ roomId, tableName: "messages" });
+  } catch {
+    // A failing COUNT must not take down search; treat as unknown so the
+    // caller falls back to a full rebuild.
+    return null;
+  }
+}
 
-  // Gather hash-memory candidates first, then BM25-rank them as a corpus.
-  const candidates: Array<{ id: UUID; text: string; createdAt: number }> = [];
+async function getMemorySearchCorpus(
+  runtime: AgentRuntime,
+  roomId: UUID,
+): Promise<MemorySearchCorpus> {
+  const key = `${runtime.agentId}:${roomId}`;
+  const cached = memorySearchCorpusCache.get(key);
+  if (cached && Date.now() - cached.builtAt <= MEMORY_SEARCH_CACHE_TTL_MS) {
+    const rowCount = await countRoomMessages(runtime, roomId);
+    if (rowCount !== null && rowCount === cached.rowCount) return cached;
+  }
+
+  const [memories, countedRows] = await Promise.all([
+    runtime.getMemories({
+      roomId,
+      tableName: "messages",
+      limit: MEMORY_SEARCH_SCAN_LIMIT,
+      includeEmbedding: false, // only reads content.text
+    }),
+    countRoomMessages(runtime, roomId),
+  ]);
+
+  // Gather hash-memory candidates first; the BM25 corpus is built once here
+  // and reused across queries until invalidation.
+  const candidates: MemorySearchCandidate[] = [];
   for (const memory of memories) {
     const text = (
       memory.content as { text?: string } | undefined
@@ -207,10 +285,48 @@ async function searchMemoryNotes(
     });
   }
 
-  const hits: MemorySearchHit[] = rankByKeyword(
-    query,
+  const corpus: MemorySearchCorpus = {
     candidates,
-    (c) => c.text,
+    bm25: new BM25(
+      candidates.map((c) => ({ content: c.text })),
+      { stemming: true },
+    ),
+    rowCount: countedRows ?? memories.length,
+    builtAt: Date.now(),
+  };
+
+  if (countedRows !== null) {
+    memorySearchCorpusCache.set(key, corpus);
+    // Bounded: this endpoint is effectively single-room per agent, so the map
+    // should hold one live entry; the cap only guards against key churn.
+    if (memorySearchCorpusCache.size > MEMORY_SEARCH_CACHE_MAX_ENTRIES) {
+      let oldestKey: string | undefined;
+      let oldestBuiltAt = Number.POSITIVE_INFINITY;
+      for (const [entryKey, entry] of memorySearchCorpusCache) {
+        if (entry.builtAt < oldestBuiltAt) {
+          oldestBuiltAt = entry.builtAt;
+          oldestKey = entryKey;
+        }
+      }
+      if (oldestKey !== undefined) memorySearchCorpusCache.delete(oldestKey);
+    }
+  }
+
+  return corpus;
+}
+
+async function searchMemoryNotes(
+  runtime: AgentRuntime,
+  roomId: UUID,
+  query: string,
+  limit: number,
+): Promise<MemorySearchHit[]> {
+  const corpus = await getMemorySearchCorpus(runtime, roomId);
+
+  const hits: MemorySearchHit[] = rankWithIndex(
+    query,
+    corpus.candidates,
+    corpus.bm25,
   )
     .filter(({ score }) => score > 0)
     .map(({ item, score }) => ({
@@ -495,6 +611,7 @@ export async function handleMemoryRoutes(
       },
     });
     await runtime.createMemory(message, "messages");
+    invalidateMemorySearchCache();
     json(res, {
       ok: true,
       id: message.id,
@@ -751,6 +868,7 @@ export async function handleMemoryRoutes(
 
     if (method === "DELETE") {
       await runtime.deleteMemory(memoryId);
+      invalidateMemorySearchCache();
       json(res, { deleted: true, id: memoryId });
       return true;
     }
@@ -793,6 +911,7 @@ export async function handleMemoryRoutes(
       content: nextContent,
       embedding,
     });
+    invalidateMemorySearchCache();
 
     const updated = await runtime.getMemoryById(memoryId);
     json(res, { updated: true, id: memoryId, memory: updated });

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -239,6 +239,14 @@ let memorySearchCorpusCaches = new WeakMap<
   Map<string, MemorySearchCacheSlot>
 >();
 
+function invalidateMemorySearchCacheSlot(slot: MemorySearchCacheSlot): void {
+  slot.generation++;
+  slot.corpus = undefined;
+  // Detach an older build so a request arriving after invalidation cannot join
+  // a stale snapshot. Its generation check prevents that build from publishing.
+  slot.inFlight = undefined;
+}
+
 export function invalidateMemorySearchCache(
   runtime?: AgentRuntime,
   roomId?: UUID,
@@ -251,19 +259,12 @@ export function invalidateMemorySearchCache(
   }
   const cache = memorySearchCorpusCaches.get(runtime);
   if (!cache) return;
-  const invalidateSlot = (slot: MemorySearchCacheSlot) => {
-    slot.generation++;
-    slot.corpus = undefined;
-    // Detach an older build so a request arriving after this mutation cannot
-    // join a pre-mutation snapshot. Its generation check prevents publishing.
-    slot.inFlight = undefined;
-  };
   if (roomId) {
     const slot = cache.get(roomId);
-    if (slot) invalidateSlot(slot);
+    if (slot) invalidateMemorySearchCacheSlot(slot);
     return;
   }
-  for (const slot of cache.values()) invalidateSlot(slot);
+  for (const slot of cache.values()) invalidateMemorySearchCacheSlot(slot);
 }
 
 async function countRoomMessages(
@@ -420,6 +421,13 @@ async function getMemorySearchCorpus(
   const cached = slot.corpus;
   if (cached) {
     const rowCount = await countRoomMessages(runtime, roomId);
+
+    // A module-local mutation may have invalidated this slot while COUNT was
+    // pending. Never return the snapshot captured before that mutation.
+    if (slot.corpus !== cached) {
+      return await startMemorySearchCorpusBuild(runtime, roomId, cache, slot);
+    }
+
     if (rowCount !== null && rowCount === cached.rowCount) {
       const age = Date.now() - cached.builtAt;
       if (age <= MEMORY_SEARCH_CACHE_TTL_MS) return cached;
@@ -430,6 +438,12 @@ async function getMemorySearchCorpus(
         startMemorySearchCorpusBuild(runtime, roomId, cache, slot);
         return cached;
       }
+    } else {
+      // A changed/unknown count makes both the cached corpus and any older
+      // background refresh ineligible. Detach that refresh before rebuilding;
+      // otherwise this request could join a snapshot that predates the count
+      // mismatch it just observed.
+      invalidateMemorySearchCacheSlot(slot);
     }
   }
   return await startMemorySearchCorpusBuild(runtime, roomId, cache, slot);

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -406,6 +406,27 @@ function startMemorySearchCorpusBuild(
   return build;
 }
 
+async function awaitCurrentMemorySearchCorpusBuild(
+  runtime: AgentRuntime,
+  roomId: UUID,
+  cache: Map<string, MemorySearchCacheSlot>,
+  slot: MemorySearchCacheSlot,
+): Promise<MemorySearchCorpus> {
+  while (true) {
+    const generation = slot.generation;
+    const corpus = await startMemorySearchCorpusBuild(
+      runtime,
+      roomId,
+      cache,
+      slot,
+    );
+    // Invalidation already prevents this build from publishing. It must also
+    // prevent a request awaiting the old generation from returning that stale
+    // snapshot after the mutation has completed.
+    if (slot.generation === generation) return corpus;
+  }
+}
+
 async function getMemorySearchCorpus(
   runtime: AgentRuntime,
   roomId: UUID,
@@ -423,7 +444,12 @@ async function getMemorySearchCorpus(
     // A module-local mutation may have invalidated this slot while COUNT was
     // pending. Never return the snapshot captured before that mutation.
     if (slot.corpus !== cached) {
-      return await startMemorySearchCorpusBuild(runtime, roomId, cache, slot);
+      return await awaitCurrentMemorySearchCorpusBuild(
+        runtime,
+        roomId,
+        cache,
+        slot,
+      );
     }
 
     if (rowCount !== null && rowCount === cached.rowCount) {
@@ -444,7 +470,12 @@ async function getMemorySearchCorpus(
       invalidateMemorySearchCacheSlot(slot);
     }
   }
-  return await startMemorySearchCorpusBuild(runtime, roomId, cache, slot);
+  return await awaitCurrentMemorySearchCorpusBuild(
+    runtime,
+    roomId,
+    cache,
+    slot,
+  );
 }
 
 async function searchMemoryNotes(

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -274,7 +274,6 @@ async function countRoomMessages(
   if (typeof runtime.countMemories !== "function") return null;
   try {
     return await runtime.countMemories({
-      agentId: runtime.agentId as UUID,
       roomId,
       tableName: "messages",
     });
@@ -330,7 +329,6 @@ async function buildMemorySearchCorpus(
   // snapshot can answer this request but is never published for later reuse.
   const countBefore = await countRoomMessages(runtime, roomId);
   const memories = await runtime.getMemories({
-    agentId: runtime.agentId as UUID,
     roomId,
     tableName: "messages",
     limit: MEMORY_SEARCH_SCAN_LIMIT,

--- a/packages/agent/src/api/memory-search-cache.test.ts
+++ b/packages/agent/src/api/memory-search-cache.test.ts
@@ -340,6 +340,43 @@ describe("GET /api/memory/search corpus cache", () => {
     expect(getMemories).toHaveBeenCalledTimes(2);
   });
 
+  test("retries a cold build invalidated by a completed mutation", async () => {
+    const target = "aaaaaaaa-0000-4000-8000-000000000005";
+    const store: Store = { rows: [note(target, "original wording", 1)] };
+    const { runtime, getMemories } = makeRuntime(store);
+    let releaseScan = () => {};
+    const scanGate = new Promise<void>((resolve) => {
+      releaseScan = resolve;
+    });
+    getMemories.mockImplementationOnce(async () => {
+      const staleSnapshot = [...store.rows];
+      await scanGate;
+      return staleSnapshot;
+    });
+
+    const pendingSearch = search(runtime, "gyroscope");
+    await vi.waitFor(() => expect(getMemories).toHaveBeenCalledOnce());
+
+    const response: { value?: unknown } = {};
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "PATCH",
+        path: `/api/memories/${target}`,
+        body: { text: "corrected wording about the gyroscope" },
+        response,
+      }),
+    );
+    releaseScan();
+
+    await expect(pendingSearch).resolves.toEqual([
+      expect.objectContaining({
+        text: "corrected wording about the gyroscope",
+      }),
+    ]);
+    expect(getMemories).toHaveBeenCalledTimes(2);
+  });
+
   test("out-of-band create (row count change) is picked up on the next search", async () => {
     const store: Store = {
       rows: [note("aaaaaaaa-0000-4000-8000-000000000001", "baseline note", 1)],

--- a/packages/agent/src/api/memory-search-cache.test.ts
+++ b/packages/agent/src/api/memory-search-cache.test.ts
@@ -9,6 +9,7 @@ import {
   type AgentRuntime,
   InMemoryDatabaseAdapter,
   type Memory,
+  stringToUuid,
   type UUID,
 } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -338,6 +339,131 @@ describe("GET /api/memory/search corpus cache", () => {
       }),
     ]);
     expect(getMemories).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not return a cached snapshot whose COUNT-waiting slot was evicted", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const target = "aaaaaaaa-0000-4000-8000-000000000005";
+    const roomId = (name: string) =>
+      stringToUuid(`${name}-hash-memory-room`) as UUID;
+    const stores = new Map<UUID, Store>([
+      [roomId("A"), { rows: [note(target, "original wording", 1)] }],
+      [
+        roomId("B"),
+        {
+          rows: [note("bbbbbbbb-0000-4000-8000-000000000001", "room B", 1)],
+        },
+      ],
+      [
+        roomId("C"),
+        {
+          rows: [note("cccccccc-0000-4000-8000-000000000001", "room C", 1)],
+        },
+      ],
+      [
+        roomId("D"),
+        {
+          rows: [note("dddddddd-0000-4000-8000-000000000001", "room D", 1)],
+        },
+      ],
+      [
+        roomId("E"),
+        {
+          rows: [note("eeeeeeee-0000-4000-8000-000000000001", "room E", 1)],
+        },
+      ],
+    ]);
+    const getMemories = vi.fn(
+      async ({ roomId: currentRoomId }: { roomId: UUID }) => [
+        ...(stores.get(currentRoomId)?.rows ?? []),
+      ],
+    );
+    const countMemories = vi.fn(
+      async ({ roomId: currentRoomId }: { roomId: UUID }) =>
+        stores.get(currentRoomId)?.rows.length ?? 0,
+    );
+    const runtime = {
+      agentId: AGENT_ID,
+      character: { name: "A" },
+      ensureConnection: vi.fn(async () => undefined),
+      getMemories,
+      countMemories,
+      getMemoryById: vi.fn(async (id: UUID) => {
+        for (const store of stores.values()) {
+          const row = store.rows.find((candidate) => candidate.id === id);
+          if (row) return row;
+        }
+        return null;
+      }),
+      updateMemory: vi.fn(
+        async (patch: { id: UUID; content: Record<string, unknown> }) => {
+          for (const store of stores.values()) {
+            const row = store.rows.find(
+              (candidate) => candidate.id === patch.id,
+            );
+            if (row) row.content = patch.content as Memory["content"];
+          }
+        },
+      ),
+      useModel: vi.fn(async () => [0.1, 0.2, 0.3]),
+      reportError: vi.fn(() => undefined),
+    } as unknown as AgentRuntime;
+
+    for (const [index, room] of ["A", "B", "C", "D"].entries()) {
+      vi.setSystemTime(new Date(1_000 + index));
+      runtime.character.name = room;
+      await search(runtime, "gyroscope");
+    }
+
+    let releaseCount = () => {};
+    const countGate = new Promise<void>((resolve) => {
+      releaseCount = resolve;
+    });
+    let markCountEntered = () => {};
+    const countEntered = new Promise<void>((resolve) => {
+      markCountEntered = resolve;
+    });
+    let gateNextACount = true;
+    countMemories.mockImplementation(async ({ roomId: currentRoomId }) => {
+      if (gateNextACount && currentRoomId === roomId("A")) {
+        gateNextACount = false;
+        markCountEntered();
+        await countGate;
+      }
+      return stores.get(currentRoomId)?.rows.length ?? 0;
+    });
+    runtime.character.name = "A";
+    const pendingSearch = search(runtime, "gyroscope");
+    await countEntered;
+
+    vi.setSystemTime(new Date(2_000));
+    runtime.character.name = "E";
+    await search(runtime, "gyroscope");
+
+    const response: { value?: unknown } = {};
+    runtime.character.name = "A";
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "PATCH",
+        path: `/api/memories/${target}`,
+        body: { text: "corrected wording about the gyroscope" },
+        response,
+      }),
+    );
+    releaseCount();
+
+    await expect(pendingSearch).resolves.toEqual([
+      expect.objectContaining({
+        text: "corrected wording about the gyroscope",
+      }),
+    ]);
+    await expect(search(runtime, "gyroscope")).resolves.toEqual([
+      expect.objectContaining({
+        text: "corrected wording about the gyroscope",
+      }),
+    ]);
+    expect(getMemories).toHaveBeenCalledTimes(6);
   });
 
   test("retries a cold build invalidated by a completed mutation", async () => {

--- a/packages/agent/src/api/memory-search-cache.test.ts
+++ b/packages/agent/src/api/memory-search-cache.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Regression coverage for the /api/memory/search corpus + BM25 cache:
+ * identical ranking cached vs cold, explicit invalidation on module-local
+ * mutations (remember / DELETE / PATCH), count-based staleness detection for
+ * out-of-band writes, and the TTL bound for count-preserving edits.
+ */
+
+import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { MemoryRouteContext } from "./memory-routes.ts";
+import {
+  HASH_MEMORY_SOURCE,
+  handleMemoryRoutes,
+  invalidateMemorySearchCache,
+} from "./memory-routes.ts";
+
+const AGENT_ID = "11111111-1111-4111-8111-111111111111" as UUID;
+
+type Store = { rows: Memory[] };
+
+function note(id: string, text: string, createdAt: number): Memory {
+  return {
+    id: id as UUID,
+    entityId: AGENT_ID,
+    agentId: AGENT_ID,
+    roomId: "22222222-2222-4222-8222-222222222222" as UUID,
+    createdAt,
+    content: { text, source: HASH_MEMORY_SOURCE },
+  } as Memory;
+}
+
+function makeRuntime(store: Store) {
+  const getMemories = vi.fn(async () => [...store.rows]);
+  const countMemories = vi.fn(async () => store.rows.length);
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    ensureConnection: vi.fn(async () => undefined),
+    getMemories,
+    countMemories,
+    getMemoryById: vi.fn(
+      async (id: UUID) => store.rows.find((row) => row.id === id) ?? null,
+    ),
+    createMemory: vi.fn(async (memory: Memory) => {
+      store.rows.push(memory);
+      return memory.id;
+    }),
+    deleteMemory: vi.fn(async (id: UUID) => {
+      store.rows = store.rows.filter((row) => row.id !== id);
+    }),
+    updateMemory: vi.fn(
+      async (patch: { id: UUID; content: Record<string, unknown> }) => {
+        const row = store.rows.find((r) => r.id === patch.id);
+        if (row) row.content = patch.content as Memory["content"];
+      },
+    ),
+    useModel: vi.fn(async () => [0.1, 0.2, 0.3]),
+  } as unknown as AgentRuntime;
+  return { runtime, getMemories, countMemories };
+}
+
+function contextFor(args: {
+  runtime: AgentRuntime;
+  method: string;
+  path: string;
+  body?: Record<string, unknown>;
+  response: { value?: unknown };
+}): MemoryRouteContext {
+  return {
+    req: {} as never,
+    res: {} as never,
+    method: args.method,
+    pathname: args.path.split("?")[0] ?? args.path,
+    url: new URL(`https://agent.test${args.path}`),
+    runtime: args.runtime,
+    agentName: "Eliza",
+    json: (_res, value) => {
+      args.response.value = value;
+    },
+    error: (_res, message, status) => {
+      throw new Error(`unexpected ${status}: ${message}`);
+    },
+    readJsonBody: async <T extends object>() => (args.body ?? {}) as T,
+  };
+}
+
+async function search(
+  runtime: AgentRuntime,
+  query: string,
+): Promise<Array<{ id: string; text: string; score: number }>> {
+  const response: { value?: unknown } = {};
+  const handled = await handleMemoryRoutes(
+    contextFor({
+      runtime,
+      method: "GET",
+      path: `/api/memory/search?q=${encodeURIComponent(query)}&limit=50`,
+      response,
+    }),
+  );
+  expect(handled).toBe(true);
+  return (
+    response.value as {
+      results: Array<{ id: string; text: string; score: number }>;
+    }
+  ).results;
+}
+
+beforeEach(() => {
+  invalidateMemorySearchCache();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("GET /api/memory/search corpus cache", () => {
+  test("warm search reuses the corpus (no rescan) and returns identical ordering", async () => {
+    const store: Store = {
+      rows: [
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000001",
+          "alexis gym signup together planned",
+          3,
+        ),
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000002",
+          "shipping the voice pipeline tonight",
+          2,
+        ),
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000003",
+          "alexis prefers morning workouts at the gym",
+          1,
+        ),
+      ],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+
+    const cold = await search(runtime, "alexis gym");
+    expect(getMemories).toHaveBeenCalledTimes(1);
+
+    const warm = await search(runtime, "alexis gym");
+    expect(getMemories).toHaveBeenCalledTimes(1); // corpus reused
+    expect(warm).toEqual(cold);
+
+    // Cold path after explicit invalidation must produce the exact same
+    // ranking (cache is a pure perf optimization, not a semantic change).
+    invalidateMemorySearchCache();
+    const rebuilt = await search(runtime, "alexis gym");
+    expect(getMemories).toHaveBeenCalledTimes(2);
+    expect(rebuilt).toEqual(cold);
+  });
+
+  test("remember invalidates: new note is searchable immediately", async () => {
+    const store: Store = {
+      rows: [
+        note("aaaaaaaa-0000-4000-8000-000000000001", "old note about tea", 1),
+      ],
+    };
+    const { runtime } = makeRuntime(store);
+
+    await search(runtime, "quartz"); // prime the cache
+
+    const response: { value?: unknown } = {};
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "POST",
+        path: "/api/memory/remember",
+        body: { text: "the quartz deadline moved to friday" },
+        response,
+      }),
+    );
+    expect(response.value).toEqual(expect.objectContaining({ ok: true }));
+
+    const results = await search(runtime, "quartz");
+    expect(results.some((r) => r.text.includes("quartz deadline"))).toBe(true);
+  });
+
+  test("DELETE invalidates: removed note stops appearing immediately", async () => {
+    const target = "aaaaaaaa-0000-4000-8000-000000000009";
+    const store: Store = {
+      rows: [
+        note(target, "obsolete plan about zeppelin logistics", 2),
+        note("aaaaaaaa-0000-4000-8000-000000000002", "unrelated note", 1),
+      ],
+    };
+    const { runtime } = makeRuntime(store);
+
+    const before = await search(runtime, "zeppelin");
+    expect(before.some((r) => r.id === target)).toBe(true);
+
+    const response: { value?: unknown } = {};
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "DELETE",
+        path: `/api/memories/${target}`,
+        response,
+      }),
+    );
+    expect(response.value).toEqual(expect.objectContaining({ deleted: true }));
+
+    const after = await search(runtime, "zeppelin");
+    expect(after.some((r) => r.id === target)).toBe(false);
+  });
+
+  test("PATCH invalidates: edited text is searchable immediately", async () => {
+    const target = "aaaaaaaa-0000-4000-8000-000000000005";
+    const store: Store = {
+      rows: [note(target, "original wording", 1)],
+    };
+    const { runtime } = makeRuntime(store);
+
+    await search(runtime, "gyroscope"); // prime the cache with the old text
+
+    const response: { value?: unknown } = {};
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "PATCH",
+        path: `/api/memories/${target}`,
+        body: { text: "corrected wording about the gyroscope" },
+        response,
+      }),
+    );
+    expect(response.value).toEqual(expect.objectContaining({ updated: true }));
+
+    const results = await search(runtime, "gyroscope");
+    expect(results.some((r) => r.id === target)).toBe(true);
+  });
+
+  test("out-of-band create (row count change) is picked up on the next search", async () => {
+    const store: Store = {
+      rows: [note("aaaaaaaa-0000-4000-8000-000000000001", "baseline note", 1)],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+
+    await search(runtime, "meteor");
+    expect(getMemories).toHaveBeenCalledTimes(1);
+
+    // Simulate a write that did NOT go through this module (normal chat
+    // writing to the "messages" table).
+    store.rows.push(
+      note("aaaaaaaa-0000-4000-8000-000000000002", "meteor shower friday", 2),
+    );
+
+    const results = await search(runtime, "meteor");
+    expect(getMemories).toHaveBeenCalledTimes(2); // count mismatch forced rebuild
+    expect(results.some((r) => r.text.includes("meteor shower"))).toBe(true);
+  });
+
+  test("count-preserving out-of-band edit is served fresh after the TTL", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T00:00:00Z"));
+    const target = "aaaaaaaa-0000-4000-8000-000000000001";
+    const store: Store = { rows: [note(target, "stale text", 1)] };
+    const { runtime } = makeRuntime(store);
+
+    await search(runtime, "kestrel");
+
+    // In-place edit that keeps the row count identical.
+    const row = store.rows.find((r) => r.id === target);
+    if (row)
+      row.content = { text: "kestrel sighting", source: HASH_MEMORY_SOURCE };
+
+    // Within the TTL the cached corpus may be served (bounded staleness).
+    vi.advanceTimersByTime(1_000);
+    // After the TTL the rebuild must observe the edit.
+    vi.advanceTimersByTime(15_000);
+    const results = await search(runtime, "kestrel");
+    expect(results.some((r) => r.text === "kestrel sighting")).toBe(true);
+  });
+
+  test("runtime without countMemories degrades to the uncached scan", async () => {
+    const store: Store = {
+      rows: [
+        note("aaaaaaaa-0000-4000-8000-000000000001", "fallback path note", 1),
+      ],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    (runtime as unknown as Record<string, unknown>).countMemories = undefined;
+
+    const first = await search(runtime, "fallback");
+    const second = await search(runtime, "fallback");
+    expect(getMemories).toHaveBeenCalledTimes(2); // no cache without a freshness signal
+    expect(second).toEqual(first);
+  });
+});

--- a/packages/agent/src/api/memory-search-cache.test.ts
+++ b/packages/agent/src/api/memory-search-cache.test.ts
@@ -5,7 +5,12 @@
  * bounded refresh failure, runtime isolation, rebuild races, and memory limits.
  */
 
-import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import {
+  type AgentRuntime,
+  InMemoryDatabaseAdapter,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { MemoryRouteContext } from "./memory-routes.ts";
 import {
@@ -58,6 +63,41 @@ function makeRuntime(store: Store) {
     reportError: vi.fn(() => undefined),
   } as unknown as AgentRuntime;
   return { runtime, getMemories, countMemories };
+}
+
+async function makeAdapterRuntime() {
+  const adapter = new InMemoryDatabaseAdapter();
+  await adapter.initialize();
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    ensureConnection: vi.fn(async () => undefined),
+    getMemories: vi.fn(
+      async (params: Parameters<InMemoryDatabaseAdapter["getMemories"]>[0]) =>
+        adapter.getMemories(params),
+    ),
+    countMemories: vi.fn(
+      async (params: { roomId?: UUID; tableName?: string }) =>
+        adapter.countMemories({
+          roomIds: params.roomId ? [params.roomId] : undefined,
+          tableName: params.tableName,
+        }),
+    ),
+    getMemoryById: vi.fn(
+      async (id: UUID) => (await adapter.getMemoriesByIds([id]))[0] ?? null,
+    ),
+    createMemory: vi.fn(
+      async (memory: Memory, tableName: string) =>
+        (await adapter.createMemories([{ memory, tableName }]))[0],
+    ),
+    deleteMemory: vi.fn(async (id: UUID) => adapter.deleteMemories([id])),
+    updateMemory: vi.fn(async (patch: Partial<Memory> & { id: UUID }) =>
+      adapter.updateMemories([patch]),
+    ),
+    useModel: vi.fn(async () => [0.1, 0.2, 0.3]),
+    reportError: vi.fn(() => undefined),
+  } as unknown as AgentRuntime;
+  return { runtime, adapter };
 }
 
 function contextFor(args: {
@@ -115,6 +155,38 @@ afterEach(() => {
 });
 
 describe("GET /api/memory/search corpus cache", () => {
+  test("finds remember-created rows through the real adapter", async () => {
+    const { runtime } = await makeAdapterRuntime();
+    for (const text of [
+      "quartz deadline moved to Friday",
+      "voice pipeline ships tonight",
+      "morning workout at the gym",
+    ]) {
+      const response: { value?: unknown } = {};
+      await handleMemoryRoutes(
+        contextFor({
+          runtime,
+          method: "POST",
+          path: "/api/memory/remember",
+          body: { text },
+          response,
+        }),
+      );
+    }
+
+    const results = await search(runtime, "quartz");
+
+    expect(results).toEqual([
+      expect.objectContaining({ text: "quartz deadline moved to Friday" }),
+    ]);
+    expect(runtime.getMemories).toHaveBeenCalledWith(
+      expect.not.objectContaining({ agentId: expect.anything() }),
+    );
+    expect(runtime.countMemories).toHaveBeenCalledWith(
+      expect.not.objectContaining({ agentId: expect.anything() }),
+    );
+  });
+
   test("warm search reuses the corpus (no rescan) and returns identical ordering", async () => {
     const store: Store = {
       rows: [

--- a/packages/agent/src/api/memory-search-cache.test.ts
+++ b/packages/agent/src/api/memory-search-cache.test.ts
@@ -231,6 +231,43 @@ describe("GET /api/memory/search corpus cache", () => {
     expect(results.some((r) => r.id === target)).toBe(true);
   });
 
+  test("does not return a cached snapshot invalidated while COUNT is pending", async () => {
+    const target = "aaaaaaaa-0000-4000-8000-000000000005";
+    const store: Store = { rows: [note(target, "original wording", 1)] };
+    const { runtime, getMemories, countMemories } = makeRuntime(store);
+    await search(runtime, "gyroscope");
+
+    let releaseCount = () => {};
+    const countGate = new Promise<void>((resolve) => {
+      releaseCount = resolve;
+    });
+    countMemories.mockImplementationOnce(async () => {
+      await countGate;
+      return store.rows.length;
+    });
+    const pendingSearch = search(runtime, "gyroscope");
+    await vi.waitFor(() => expect(countMemories).toHaveBeenCalledTimes(3));
+
+    const response: { value?: unknown } = {};
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "PATCH",
+        path: `/api/memories/${target}`,
+        body: { text: "corrected wording about the gyroscope" },
+        response,
+      }),
+    );
+    releaseCount();
+
+    await expect(pendingSearch).resolves.toEqual([
+      expect.objectContaining({
+        text: "corrected wording about the gyroscope",
+      }),
+    ]);
+    expect(getMemories).toHaveBeenCalledTimes(2);
+  });
+
   test("out-of-band create (row count change) is picked up on the next search", async () => {
     const store: Store = {
       rows: [note("aaaaaaaa-0000-4000-8000-000000000001", "baseline note", 1)],
@@ -249,6 +286,44 @@ describe("GET /api/memory/search corpus cache", () => {
     const results = await search(runtime, "meteor");
     expect(getMemories).toHaveBeenCalledTimes(2); // count mismatch forced rebuild
     expect(results.some((r) => r.text.includes("meteor shower"))).toBe(true);
+  });
+
+  test("count mismatch supersedes an older in-flight background refresh", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T00:00:00Z"));
+    const store: Store = {
+      rows: [note("aaaaaaaa-0000-4000-8000-000000000001", "baseline note", 1)],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    await search(runtime, "meteor");
+
+    let releaseStaleScan = () => {};
+    const staleScanGate = new Promise<void>((resolve) => {
+      releaseStaleScan = resolve;
+    });
+    getMemories.mockImplementationOnce(async () => {
+      const staleSnapshot = [...store.rows];
+      await staleScanGate;
+      return staleSnapshot;
+    });
+
+    // Start a stale-while-revalidate build and leave its old snapshot in flight.
+    vi.advanceTimersByTime(11_000);
+    await search(runtime, "meteor");
+    await vi.waitFor(() => expect(getMemories).toHaveBeenCalledTimes(2));
+
+    // The next request observes the changed count. It must start a new scan,
+    // not join the older refresh that captured the one-row corpus.
+    store.rows.push(
+      note("aaaaaaaa-0000-4000-8000-000000000002", "meteor shower friday", 2),
+    );
+    const freshSearch = search(runtime, "meteor");
+    await vi.waitFor(() => expect(getMemories).toHaveBeenCalledTimes(3));
+    await expect(freshSearch).resolves.toEqual([
+      expect.objectContaining({ text: "meteor shower friday" }),
+    ]);
+
+    releaseStaleScan();
   });
 
   test("count-preserving edit refreshes after one bounded stale response", async () => {

--- a/packages/agent/src/api/memory-search-cache.test.ts
+++ b/packages/agent/src/api/memory-search-cache.test.ts
@@ -1,8 +1,8 @@
 /**
  * Regression coverage for the /api/memory/search corpus + BM25 cache:
  * identical ranking cached vs cold, explicit invalidation on module-local
- * mutations (remember / DELETE / PATCH), count-based staleness detection for
- * out-of-band writes, and the TTL bound for count-preserving edits.
+ * mutations (remember / DELETE / PATCH), count-based staleness detection,
+ * bounded refresh failure, runtime isolation, rebuild races, and memory limits.
  */
 
 import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
@@ -55,6 +55,7 @@ function makeRuntime(store: Store) {
       },
     ),
     useModel: vi.fn(async () => [0.1, 0.2, 0.3]),
+    reportError: vi.fn(() => undefined),
   } as unknown as AgentRuntime;
   return { runtime, getMemories, countMemories };
 }
@@ -250,7 +251,7 @@ describe("GET /api/memory/search corpus cache", () => {
     expect(results.some((r) => r.text.includes("meteor shower"))).toBe(true);
   });
 
-  test("count-preserving out-of-band edit is picked up after the TTL (background refresh)", async () => {
+  test("count-preserving edit refreshes after one bounded stale response", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-17T00:00:00Z"));
     const target = "aaaaaaaa-0000-4000-8000-000000000001";
@@ -264,15 +265,46 @@ describe("GET /api/memory/search corpus cache", () => {
     if (row)
       row.content = { text: "kestrel sighting", source: HASH_MEMORY_SOURCE };
 
-    // After the TTL the first search may still serve the cached corpus
-    // (stale-while-revalidate) but must kick off a refresh.
+    // The first request after the TTL remains warm and launches one refresh.
     vi.advanceTimersByTime(16_000);
-    await search(runtime, "kestrel");
-    // Let the background rebuild's microtasks settle (mock I/O is instant).
-    for (let i = 0; i < 10; i++) await Promise.resolve();
+    const staleWhileRefreshing = await search(runtime, "kestrel");
+    expect(staleWhileRefreshing).toEqual([]);
+    for (let index = 0; index < 10; index++) await Promise.resolve();
 
     const results = await search(runtime, "kestrel");
     expect(results.some((r) => r.text === "kestrel sighting")).toBe(true);
+  });
+
+  test("persistent refresh failure cannot extend staleness past the hard bound", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T00:00:00Z"));
+    const store: Store = {
+      rows: [note("aaaaaaaa-0000-4000-8000-000000000001", "old osprey", 1)],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    await search(runtime, "osprey");
+    const row = store.rows[0];
+    if (row)
+      row.content = {
+        text: "replacement condor",
+        source: HASH_MEMORY_SOURCE,
+      };
+    getMemories.mockRejectedValue(new Error("refresh backend unavailable"));
+
+    vi.advanceTimersByTime(11_000);
+    const boundedStale = await search(runtime, "osprey");
+    expect(boundedStale).toHaveLength(1);
+    for (let index = 0; index < 10; index++) await Promise.resolve();
+
+    vi.advanceTimersByTime(10_000);
+    await expect(search(runtime, "osprey")).rejects.toThrow(
+      "refresh backend unavailable",
+    );
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "MemorySearchCache.refresh",
+      expect.objectContaining({ message: "refresh backend unavailable" }),
+      expect.objectContaining({ roomId: expect.any(String) }),
+    );
   });
 
   test("runtime without countMemories degrades to the uncached scan", async () => {
@@ -288,5 +320,126 @@ describe("GET /api/memory/search corpus cache", () => {
     const second = await search(runtime, "fallback");
     expect(getMemories).toHaveBeenCalledTimes(2); // no cache without a freshness signal
     expect(second).toEqual(first);
+  });
+
+  test("isolates equal-count corpora owned by distinct runtime instances", async () => {
+    const firstStore: Store = {
+      rows: [
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000001",
+          "first runtime albatross",
+          1,
+        ),
+      ],
+    };
+    const secondStore: Store = {
+      rows: [
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000002",
+          "second runtime kestrel",
+          1,
+        ),
+      ],
+    };
+    const first = makeRuntime(firstStore);
+    const second = makeRuntime(secondStore);
+
+    expect(await search(first.runtime, "albatross")).toHaveLength(1);
+    const secondResults = await search(second.runtime, "kestrel");
+
+    expect(secondResults.map((result) => result.text)).toEqual([
+      "second runtime kestrel",
+    ]);
+    expect(second.getMemories).toHaveBeenCalledOnce();
+  });
+
+  test("does not publish a corpus whose scan raced a row-count change", async () => {
+    const store: Store = {
+      rows: [
+        note("aaaaaaaa-0000-4000-8000-000000000001", "baseline sparrow", 1),
+      ],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    getMemories.mockImplementationOnce(async () => {
+      const staleSnapshot = [...store.rows];
+      store.rows.push(
+        note("aaaaaaaa-0000-4000-8000-000000000002", "racing pelican", 2),
+      );
+      return staleSnapshot;
+    });
+
+    expect(await search(runtime, "pelican")).toEqual([]);
+    const fresh = await search(runtime, "pelican");
+
+    expect(getMemories).toHaveBeenCalledTimes(2);
+    expect(fresh.map((result) => result.text)).toEqual(["racing pelican"]);
+  });
+
+  test("single-flights concurrent cold rebuilds for one runtime and room", async () => {
+    const store: Store = {
+      rows: [
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000001",
+          "shared rebuild puffin",
+          1,
+        ),
+      ],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    let releaseScan = () => {};
+    const scanGate = new Promise<void>((resolve) => {
+      releaseScan = resolve;
+    });
+    getMemories.mockImplementationOnce(async () => {
+      await scanGate;
+      return [...store.rows];
+    });
+
+    const first = search(runtime, "puffin");
+    const second = search(runtime, "puffin");
+    await vi.waitFor(() => expect(getMemories).toHaveBeenCalledOnce());
+    releaseScan();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.any(Array),
+      expect.any(Array),
+    ]);
+    expect(getMemories).toHaveBeenCalledOnce();
+  });
+
+  test("reports count failures and keeps the fallback corpus uncached", async () => {
+    const store: Store = {
+      rows: [
+        note("aaaaaaaa-0000-4000-8000-000000000001", "fallback count heron", 1),
+      ],
+    };
+    const { runtime, getMemories, countMemories } = makeRuntime(store);
+    countMemories.mockRejectedValue(new Error("count backend unavailable"));
+
+    await search(runtime, "heron");
+    await search(runtime, "heron");
+
+    expect(getMemories).toHaveBeenCalledTimes(2);
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "MemorySearchCache.countRoomMessages",
+      expect.objectContaining({ message: "count backend unavailable" }),
+      expect.objectContaining({ roomId: expect.any(String) }),
+    );
+  });
+
+  test("does not retain a corpus whose source text exceeds the byte budget", async () => {
+    const rows = Array.from({ length: 2_000 }, (_, index) =>
+      note(
+        `aaaaaaaa-0000-4000-8000-${index.toString().padStart(12, "0")}`,
+        `oversized-${index}-${"x".repeat(4_200)}`,
+        index,
+      ),
+    );
+    const { runtime, getMemories } = makeRuntime({ rows });
+
+    await search(runtime, "term-not-present");
+    await search(runtime, "term-not-present");
+
+    expect(getMemories).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/agent/src/api/memory-search-cache.test.ts
+++ b/packages/agent/src/api/memory-search-cache.test.ts
@@ -250,7 +250,7 @@ describe("GET /api/memory/search corpus cache", () => {
     expect(results.some((r) => r.text.includes("meteor shower"))).toBe(true);
   });
 
-  test("count-preserving out-of-band edit is served fresh after the TTL", async () => {
+  test("count-preserving out-of-band edit is picked up after the TTL (background refresh)", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-17T00:00:00Z"));
     const target = "aaaaaaaa-0000-4000-8000-000000000001";
@@ -264,10 +264,13 @@ describe("GET /api/memory/search corpus cache", () => {
     if (row)
       row.content = { text: "kestrel sighting", source: HASH_MEMORY_SOURCE };
 
-    // Within the TTL the cached corpus may be served (bounded staleness).
-    vi.advanceTimersByTime(1_000);
-    // After the TTL the rebuild must observe the edit.
-    vi.advanceTimersByTime(15_000);
+    // After the TTL the first search may still serve the cached corpus
+    // (stale-while-revalidate) but must kick off a refresh.
+    vi.advanceTimersByTime(16_000);
+    await search(runtime, "kestrel");
+    // Let the background rebuild's microtasks settle (mock I/O is instant).
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+
     const results = await search(runtime, "kestrel");
     expect(results.some((r) => r.text === "kestrel sighting")).toBe(true);
   });


### PR DESCRIPTION
# Relates to

Fixes #21633.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto `origin/develop` at `e76c033041235b22ebdf2ecd7192f8202e44585a` with zero conflicts.
- [ ] `bun install` completed with Bun 1.3.14 and the frozen lockfile; root `bun run verify` is recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the route and resulting memory behavior from the exact-head evidence below.

# Contribution provenance

The original three implementation commits still require a PR-specific self-report from their author; a request is posted in the conversation. The rows below truthfully cover the later review and repair commits only and do not infer provenance from another PR.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes - review and repair commits only; original implementation disclosure pending author confirmation`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/GPT-5 - review and repair commits only`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop - review and repair commits only`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3b42290f915d112abebe188851e51596ddeb2284:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported; original implementation pending`

# Sync with develop

- [x] Rebased onto `origin/develop` `e76c033041235b22ebdf2ecd7192f8202e44585a`; zero conflicts.
- [ ] Root `bun run verify` result is recorded under **Known gaps / failures**.

# Risks

Medium. The change retains up to four BM25 corpora per runtime and intentionally permits a bounded stale-while-revalidate window for count-preserving out-of-band edits. Mutation invalidation, count mismatch, generation fencing, hard staleness bounds, runtime isolation, source-text budget, and real-adapter room scoping have regression coverage. The scan and COUNT remain room-scoped to preserve compatibility with existing `remember` rows, which do not carry `agentId`.

# Background

## What does this PR do?

`GET /api/memory/search` and the shared memory portion of `GET /api/context/quick` previously fetched up to 2,000 message rows and rebuilt a stemmed BM25 corpus for every query. This PR caches the candidate corpus and BM25 index per runtime and room, reuses it on warm searches, explicitly invalidates route-owned mutations, checks row count for out-of-band creates/deletes, and refreshes count-preserving edits on a bounded stale-while-revalidate schedule.

Independent review found and repaired five correctness races/contract gaps:

- a count mismatch can no longer join an older in-flight refresh that predates the mismatch;
- a mutation that completes while COUNT is pending cannot return the previously captured corpus;
- the scan and COUNT no longer add an `agentId` predicate that excluded real rows created by `POST /api/memory/remember`;
- a cold build invalidated by a completed mutation retries instead of returning its captured stale snapshot;
- a COUNT-waiting slot evicted before mutation invalidation re-enters through the canonical cache map, preventing an orphaned stale return and preserving single-flight publication.

## What kind of change is this?

Performance improvement with non-breaking correctness repairs.

# Documentation changes needed?

No user-facing documentation change is required. The cache freshness and bounds are documented at the implementation boundary and covered by tests.

# Testing

## Where should a reviewer start?

- `packages/agent/src/api/memory-routes.ts`
- `packages/agent/src/api/memory-search-cache.test.ts`

## Detailed testing steps

On exact head `3b42290f915d112abebe188851e51596ddeb2284` with Bun 1.3.14:

```text
bunx vitest run packages/agent/src/api/memory-search-cache.test.ts packages/agent/src/api/memory-routes.encoding.test.ts packages/agent/src/api/memory-feed-cursor.test.ts packages/agent/src/api/memory-remember-idempotency.test.ts --coverage.enabled=false --maxWorkers=1

Test Files  4 passed (4)
Tests       31 passed (31)
```

Changed-file Biome and `git diff --check` pass on the same head.

# Evidence Gate

<!-- evidence-head:3b42290f915d112abebe188851e51596ddeb2284 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server/runtime change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server/runtime change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - server/runtime change exercised through the HTTP route harness; no visual user flow changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head route regression evidence is recorded below; prior adapter evidence is retained for comparison:

```jsonl
{"head":"3b42290f915d112abebe188851e51596ddeb2284","suite":"memory-search-cache.test.ts"}
{"event":"prime","rooms":["A","B","C","D"]}
{"event":"count-wait","room":"A"}
{"event":"evict","primedRoom":"E","evictedRoom":"A"}
{"event":"patch","room":"A","text":"corrected wording about the gyroscope"}
{"event":"assert","pendingResult":"corrected wording about the gyroscope","warmResult":"corrected wording about the gyroscope","messageScans":6}
```

Prior adapter sample:

```jsonl
{"event":"route","method":"GET","path":"/api/memory/search?q=quartz&limit=10","results":["quartz deadline moved to Friday"],"messageScans":1}
{"event":"cache-proof","scansAfterCold":1,"scansAfterWarm":1,"corpusReused":true}
{"event":"route","method":"PATCH","updatedText":"corrected gyroscope deadline","messageScans":1}
{"event":"route","method":"GET","path":"/api/memory/search?q=gyroscope&limit=10","results":["corrected gyroscope deadline"],"messageScans":2}
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, planner, action, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head domain artifact from the deterministic A-D/E eviction route regression:

```json
{
  "head": "3b42290f915d112abebe188851e51596ddeb2284",
  "roomsPrimed": ["A", "B", "C", "D", "E"],
  "mutation": "PATCH A while its evicted slot awaited COUNT",
  "pendingText": "corrected wording about the gyroscope",
  "canonicalWarmText": "corrected wording about the gyroscope",
  "scans": 6
}
```

Prior adapter artifact:

```json
{
  "storedRows": [
    {"text":"corrected gyroscope deadline","source":"hash_memory","embeddingDimensions":3}
  ],
  "scansAfterMutation": 2,
  "queryResult": "corrected gyroscope deadline"
}
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Prior pre-rebase adapter route log

The earlier harness called the real `handleMemoryRoutes` implementation over the core `InMemoryDatabaseAdapter` in a no-secret environment. The first search performed one message scan; the second warm query reused the corpus (`1 -> 1`). PATCH invalidated the corpus, and the next query rebuilt it (`1 -> 2`) and returned the corrected text.

```jsonl
{"component":"MemorySearchEvidence","event":"route","method":"GET","path":"/api/memory/search?q=quartz&limit=10","handled":true,"response":{"query":"quartz","results":[{"text":"quartz deadline moved to Friday","score":1}],"count":1,"limit":10},"messageScans":1}
{"component":"MemorySearchEvidence","event":"route","method":"GET","path":"/api/memory/search?q=deadline&limit=10","handled":true,"response":{"query":"deadline","results":[{"text":"quartz deadline moved to Friday","score":1}],"count":1,"limit":10},"messageScans":1}
{"component":"MemorySearchEvidence","event":"cache-proof","scansAfterCold":1,"scansAfterWarm":1,"corpusReused":true}
{"component":"MemorySearchEvidence","event":"route","method":"PATCH","path":"/api/memories/<generated-id>","handled":true,"response":{"updated":true,"memory":{"content":{"text":"corrected gyroscope deadline","source":"hash_memory"},"embedding":[0.1,0.2,0.3]}},"messageScans":1}
{"component":"MemorySearchEvidence","event":"route","method":"GET","path":"/api/memory/search?q=gyroscope&limit=10","handled":true,"response":{"query":"gyroscope","results":[{"text":"corrected gyroscope deadline","score":1}],"count":1,"limit":10},"messageScans":2}
```

## Domain artifact

```json
{"storedRows":[{"text":"corrected gyroscope deadline","source":"hash_memory","embeddingDimensions":3}],"scansAfterMutation":2}
```

## Original live performance observation

The author separately reported on the PR that a live ~2,160-row deployment improved from 2.0-2.5 seconds per query to 19-30 ms warm across 12 runs. That observation predates the final repaired head and is retained as author-reported performance context, not exact-head proof.

## Known gaps / failures

- Original implementation provenance is not publicly self-reported for this PR. A direct author request is open; this remains a merge blocker.
- A fresh exact-head independent approval is required because prior approval targeted obsolete head `5fc43e0` and the reviewer-requested repair changed the head again.
- The clean package typecheck previously stopped on unrelated missing generated/workspace exports (`plugin-capacitor-bridge`, `plugin-wallet/diagnostic`, `plugin-video`, `plugin-vision`, `plugin-notes`, `cloud-routing`, and `plugin-todos`). No diagnostic points to either changed file. Root `bun run verify` has not completed on this head under the shared host's concurrent test/build load.
- Podman could not stay running on this host. Final focused execution used a fresh exact-head archive/no-secret environment with an empty HOME, null Git configs, and outbound package access pointed at a closed local endpoint.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@3b42290f915d112abebe188851e51596ddeb2284:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex/pr_21128]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@3b42290f915d112abebe188851e51596ddeb2284:packages/skills/skills/contribute-to-eliza"} -->


## Prior PGlite revalidation (pre-eviction-fence head)

A reviewer rebased the then-current branch onto `origin/develop` `e76c033041235b22ebdf2ecd7192f8202e44585a`, repaired the remaining cold-build invalidation race, and exercised the production PGlite adapter plus its actual 170-statement migration stack. COUNT and scan remained room-scoped; cold search scanned once, warm search reused that corpus without another scan, and DELETE invalidation forced the second scan and removed the persisted result.

```json
{"adapter":"PgliteDatabaseAdapter","coldMs":387.348667,"warmMs":105.774333,"scansAfterCold":1,"scansAfterWarm":1,"scansAfterDelete":2,"resultCountAfterDelete":0}
```

Exact-head focused validation: four files passed, 31 tests passed; changed-file Biome and `git diff --check` passed. Package typecheck reached only unrelated missing generated/workspace exports (`plugin-capacitor-bridge`, `plugin-wallet/diagnostic`, `plugin-video`, `plugin-vision`, `plugin-notes`, `cloud-routing`, and `plugin-todos`); neither changed file produced a diagnostic. The original implementation provenance remains pending and is still a merge blocker. On exact head `3b42290f915d112abebe188851e51596ddeb2284`, the four focused route suites pass 31/31, including the deterministic room-aware eviction race; changed-file Biome and `git diff --check` pass.
