### PR TITLE
fix(inmemorydb): purge room vectors on deletion

### DIFF
--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -1309,6 +1309,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
   async deleteRooms(roomIds: UUID[]): Promise<void> {
     if (roomIds.length === 0) return;
     const set = new Set(roomIds);
+    const memories = await this.storage.getWhere<StoredMemory>(COLLECTIONS.MEMORIES, (m) =>
+      set.has(m.roomId as UUID)
+    );
+    const memoryIds = memories
+      .map((memory) => memory.id)
+      .filter((id): id is UUID => id !== undefined);
     for (const id of roomIds) {
       await this.storage.delete(COLLECTIONS.ROOMS, id);
     }
@@ -1316,9 +1322,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     await this.storage.deleteWhere<StoredParticipant>(COLLECTIONS.PARTICIPANTS, (p) =>
       set.has(p.roomId as UUID)
     );
-    await this.storage.deleteWhere<StoredMemory>(COLLECTIONS.MEMORIES, (m) =>
-      set.has(m.roomId as UUID)
-    );
+    await this.deleteMemories(memoryIds);
   }
 
   // ── Participant CRUD ──────────────────────────────────────────────────

--- a/plugins/plugin-inmemorydb/embedding-dimension.test.ts
+++ b/plugins/plugin-inmemorydb/embedding-dimension.test.ts
@@ -1,8 +1,8 @@
 /**
- * Exercises the in-memory adapter's embedding-width switch path against the
- * real MemoryStorage and EphemeralHNSW index. The cleanup must remove
- * old-width vectors before any active-width search or insert touches the HNSW
- * graph, otherwise cosine comparisons throw on mixed dimensions.
+ * Exercises the in-memory adapter's embedding-index lifecycle against the real
+ * MemoryStorage and EphemeralHNSW index. Cleanup paths must keep stored memory
+ * rows and indexed vectors synchronized so searches neither compare mixed
+ * dimensions nor lose live results behind deleted candidates.
  */
 import { randomUUID } from "node:crypto";
 import type { Memory, UUID } from "@elizaos/core";
@@ -60,5 +60,48 @@ describe("clearEmbeddingsOutsideActiveDimension", () => {
     });
     expect(results.map((result) => result.id)).toEqual([freshId]);
     expect(await adapter.clearEmbeddingsOutsideActiveDimension()).toEqual([]);
+  });
+});
+
+describe("room deletion embedding cleanup", () => {
+  it("removes deleted-room vectors so they cannot crowd live memories out of search", async () => {
+    const agentId = randomUUID() as UUID;
+    const entityId = randomUUID() as UUID;
+    const deletedRoomId = randomUUID() as UUID;
+    const liveRoomId = randomUUID() as UUID;
+    const adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), agentId);
+    await adapter.initialize();
+    await adapter.ensureEmbeddingDimension(2);
+
+    const deletedMemories = [
+      memoryForRoom(deletedRoomId, [1, 0], "deleted nearest"),
+      memoryForRoom(deletedRoomId, [0.999, 0.001], "deleted second nearest"),
+    ];
+    const liveMemory = memoryForRoom(liveRoomId, [0.8, 0.6], "live farther result");
+
+    await adapter.createMemories(
+      [...deletedMemories, liveMemory].map((memory) => ({ memory, tableName: "memories" }))
+    );
+    await adapter.deleteRooms([deletedRoomId]);
+
+    const results = await adapter.searchMemories({
+      tableName: "memories",
+      embedding: [1, 0],
+      match_threshold: 0,
+      count: 1,
+    });
+
+    expect(results.map((result) => result.id)).toEqual([liveMemory.id]);
+
+    function memoryForRoom(roomId: UUID, embedding: number[], text: string): Memory {
+      return {
+        id: randomUUID() as UUID,
+        agentId,
+        entityId,
+        roomId,
+        content: { text },
+        embedding,
+      };
+    }
   });
 });


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->
AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: re-ran the full mutation check myself from a clean revert of just the source fix (confirmed red, then restored and confirmed green), re-ran the full package test suite, typecheck, and lint myself, and independently traced the reachability chain (`runtime.ts::deleteRoom` -> `conversation-routes.ts::deleteConversationRoomData`, and the live `searchMemories` callers) against the current source.

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low. Changes only the memory-cleanup path inside `deleteRooms` to delegate to the existing, already-used `deleteMemories` helper instead of calling `storage.deleteWhere` directly. No API surface change, no schema change.

# Background

## What does this PR do?

`InMemoryDatabaseAdapter.deleteRooms` removed room memories from `MemoryStorage` but left their vectors in `EphemeralHNSW`. `searchMemories` asks HNSW for a bounded candidate set (`limit * 2`) and silently skips any candidate missing from storage. Two or more deleted near-neighbor vectors could therefore fill that bounded candidate set and push a valid, farther live memory out of the results entirely.

Fix: room deletion now collects the affected memory IDs and delegates to the existing `deleteMemories` path (already used by `deleteAllMemories` for the same reason), which removes both the storage row and the HNSW vector.

## What kind of change is this?

Bug fix — no new capability, no schema change.

# Documentation changes needed?

No.

# Testing

New test in `plugins/plugin-inmemorydb/embedding-dimension.test.ts`: creates two deleted nearest vectors plus one live farther vector, deletes the first room, and asserts a one-result semantic search still returns the live memory.

# Evidence Gate

<!-- evidence-head:055c071d931056bb925c4ffefa3bab4dce66d0b0 -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend logic fix, no UI surface
- <!-- evidence-row:walkthrough-video --> N/A - not applicable to a backend logic fix
- <!-- evidence-row:backend-logs -->
  Mutation check, reverted just the source fix via `git apply -R`, kept the test:
  ```text
  AssertionError: expected [] to deeply equal [ Array(1) ]
  - Expected
  - ["3653015a-cca4-4c9a-be1c-fc577634454b"]
  + Received
  + []
  Test Files  1 failed (1)
       Tests  1 failed | 1 passed (2)
  ```
  Restored: `Test Files  8 passed (8)` / `Tests  19 passed (19)` for the full package.
- <!-- evidence-row:frontend-logs --> N/A - no frontend
- <!-- evidence-row:llm-trajectory --> N/A - deterministic storage/index logic, no LLM in the loop
- <!-- evidence-row:domain-artifacts --> N/A
- <!-- evidence-row:ocr-review --> N/A

## Known gaps / failures

None found. `tsc --noEmit -p tsconfig.json` and `bunx @biomejs/biome check .` both clean on the touched package.

## Reachability

- `packages/core/src/runtime.ts::deleteRoom` delegates to the adapter's `deleteRoom`/`deleteRooms`.
- `packages/agent/src/api/conversation-routes.ts::deleteConversationRoomData` calls `runtime.deleteRoom(roomId)` when deleting a conversation - a live, user-triggered path.
- `searchMemories` on this adapter has live callers in core providers, `packages/agent/src/actions/database.ts`, cloud memory services, the personal-assistant plugin, and other plugins. Reachable for any runtime configured with the opt-in in-memory adapter (`plugins/plugin-inmemorydb`).

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported


## Maintainer validation

Validated exact head `055c071d931056bb925c4ffefa3bab4dce66d0b0` against current `develop`. The approach is correct: room deletion must remove the same memory IDs from both `MemoryStorage` and `EphemeralHNSW`, and delegation to the established `deleteMemories()` helper preserves that invariant. Current `develop` still contains the stale-vector path and no overlapping open PR was found.

- Focused real storage/HNSW suite: 2/2 passed.
- Full `@elizaos/plugin-inmemorydb` suite: 8 files, 19/19 passed.
- Package `tsc --noEmit -p tsconfig.json`: passed.
- Biome on both changed files: passed.
- Mutation proof: reverting only the source fix while retaining the test fails with `expected [] to deeply equal [liveMemory.id]`; restoring the exact head returns green.
- `git diff origin/develop...HEAD --check`: passed.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@a20031b7e028822c28c1865bac55c15cb03a3fdb:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@a20031b7e028822c28c1865bac55c15cb03a3fdb:packages/skills/skills/contribute-to-eliza"} -->
