### PR TITLE
fix(cloud): reject unknown ballot public flag

### DIFF
--- a/packages/cloud/api/v1/ballots/[id]/route.public-query.test.ts
+++ b/packages/cloud/api/v1/ballots/[id]/route.public-query.test.ts
@@ -1,0 +1,117 @@
+/**
+ * GET /api/v1/ballots/:id `public` is checkout-visibility identity,
+ * leftover tax after payment-request public (#20954). Stock develop
+ * treated every non-exact `1` token as the authenticated creator view,
+ * so `public=true` still required auth instead of a 400.
+ * Ballot id parser stays untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const BALLOT_ID = "11111111-1111-4111-8111-111111111111";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+const getMock = mock(async (_id: string, _organizationId: string) => null);
+const getBallotMock = mock(async (_id: string) => null);
+
+const ballotRow = {
+  id: BALLOT_ID,
+  organizationId: "org-1",
+  agentId: "agent-1",
+  purpose: "secret vote",
+  participants: [],
+  threshold: 1,
+  status: "open",
+  tallyResult: null,
+  expiresAt: new Date("2026-01-02T00:00:00.000Z"),
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  metadata: { tokenHashByIdentity: { voter: "secret-hash" } },
+};
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/db/repositories/secret-ballots", () => ({
+  secretBallotsRepository: { getBallot: getBallotMock },
+}));
+mock.module("@/lib/services/secret-ballots", () => ({
+  createSecretBallotsService: () => ({ get: getMock }),
+  redactSecretBallotForPublic: (row: typeof ballotRow) => ({
+    ...row,
+    metadata: {},
+  }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: "standard" },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (
+    c: { json: (body: unknown, status: number) => Response },
+    _error: unknown,
+  ) => c.json({ success: false, error: "internal error" }, 500),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(() => undefined) },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id", route);
+
+function expectNoLookup() {
+  expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+  expect(getMock).not.toHaveBeenCalled();
+  expect(getBallotMock).not.toHaveBeenCalled();
+}
+
+describe("GET /api/v1/ballots/:id public visibility identity", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    getMock.mockClear();
+    getBallotMock.mockClear();
+    getMock.mockResolvedValue(ballotRow);
+    getBallotMock.mockResolvedValue(ballotRow);
+  });
+
+  test.each(["", "?public="])(
+    "accepts %s as the authenticated creator view",
+    async (query) => {
+      const response = await app.request(`/${BALLOT_ID}${query}`);
+      expect(response.status).toBe(200);
+      expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+      expect(getMock).toHaveBeenCalledWith(BALLOT_ID, "org-1");
+      expect(getBallotMock).not.toHaveBeenCalled();
+    },
+  );
+
+  test("accepts public=1 as the unauthenticated redacted ballot", async () => {
+    const response = await app.request(`/${BALLOT_ID}?public=1`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      success: boolean;
+      ballot: { id: string; metadata: Record<string, unknown> };
+    };
+    expect(body.success).toBe(true);
+    expect(body.ballot.id).toBe(BALLOT_ID);
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+    expect(getBallotMock).toHaveBeenCalledWith(BALLOT_ID);
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  test.each(["true", "yes", "TRUE", "0", "foo", "1e2"])(
+    "rejects public=%s before public or creator lookup",
+    async (token) => {
+      const response = await app.request(
+        `/${BALLOT_ID}?public=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toMatch(/public/i);
+      expectNoLookup();
+    },
+  );
+});

--- a/packages/cloud/api/v1/ballots/[id]/route.public-query.test.ts
+++ b/packages/cloud/api/v1/ballots/[id]/route.public-query.test.ts
@@ -102,7 +102,7 @@ describe("GET /api/v1/ballots/:id public visibility identity", () => {
     expect(getMock).not.toHaveBeenCalled();
   });
 
-  test.each(["true", "yes", "TRUE", "0", "foo", "1e2"])(
+  test.each(["true", "yes", "TRUE", "0", "foo", "1e2", "1.0", "+1", " 1"])(
     "rejects public=%s before public or creator lookup",
     async (token) => {
       const response = await app.request(
@@ -114,4 +114,15 @@ describe("GET /api/v1/ballots/:id public visibility identity", () => {
       expectNoLookup();
     },
   );
+
+  test.each([
+    "?public=1&public=1",
+    "?public=1&public=",
+    "?public=&public=1",
+    "?public=foo&public=1",
+  ])("rejects duplicate public values in %s before lookup", async (query) => {
+    const response = await app.request(`/${BALLOT_ID}${query}`);
+    expect(response.status).toBe(400);
+    expectNoLookup();
+  });
 });

--- a/packages/cloud/api/v1/ballots/[id]/route.ts
+++ b/packages/cloud/api/v1/ballots/[id]/route.ts
@@ -35,17 +35,20 @@ app.get("/", async (c) => {
     // DTO. Missing or empty selects the authenticated creator view; any
     // other token is leftover identity after payment-request public
     // (#20954) and must fail before authentication or lookup.
-    const requestedPublic = c.req.query("public");
+    const requestedPublicValues = c.req.queries("public") ?? [];
+    const requestedPublic = requestedPublicValues[0];
     if (
-      requestedPublic !== undefined &&
-      requestedPublic !== "" &&
-      requestedPublic !== "1"
+      requestedPublicValues.length > 1 ||
+      (requestedPublic !== undefined &&
+        requestedPublic !== "" &&
+        requestedPublic !== "1")
     ) {
       return c.json(
         {
           success: false,
           error: "invalid_public",
-          message: 'public must be "1" for the redacted ballot view.',
+          message:
+            'public must be specified at most once as "1" for the redacted ballot view.',
         },
         400,
       );

--- a/packages/cloud/api/v1/ballots/[id]/route.ts
+++ b/packages/cloud/api/v1/ballots/[id]/route.ts
@@ -31,7 +31,26 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: parsedId.error }, 400);
     }
     const { id } = parsedId;
-    const isPublic = c.req.query("public") === "1";
+    // Only the exact token `1` selects the unauthenticated, redacted ballot
+    // DTO. Missing or empty selects the authenticated creator view; any
+    // other token is leftover identity after payment-request public
+    // (#20954) and must fail before authentication or lookup.
+    const requestedPublic = c.req.query("public");
+    if (
+      requestedPublic !== undefined &&
+      requestedPublic !== "" &&
+      requestedPublic !== "1"
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: "invalid_public",
+          message: 'public must be "1" for the redacted ballot view.',
+        },
+        400,
+      );
+    }
+    const isPublic = requestedPublic === "1";
     const service = createSecretBallotsService({
       repository: secretBallotsRepository,
     });


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on ballot
`public` identity. Leftover tax after payment-request public (#20954). Not
leftover tax on voice-list includeInactive, analytics-export includeMetadata,
x-feed connectionRole, x/status connectionRole, agent-resume sync, or
prefix-coerced limit/offset.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `public` only on `/api/v1/ballots/:id`.
Omitted/empty still bind the authenticated creator view (today's default).
Exact `1` still binds the unauthenticated redacted ballot.
Unknown / `true` / `TRUE` / `0` tokens 400 before auth or lookup.
Ballot id parser stays untouched.

# Background

## What does this PR do?

`GET /api/v1/ballots/:id` treated every non-exact `1` token as the
authenticated creator view. `public=true` silently required auth instead
of a 400.

- omitted / empty → authenticated creator view (200)
- exact `1` → unauthenticated redacted ballot
- `true` / `TRUE` / `0` / `yes` / `foo` / `1e2` → **400** before auth or lookup

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers opt into the redacted public ballot with `?public=1`. A common
`public=true` after a client sends a boolean must not silently flip to the
authenticated creator path. This is leftover tax after payment-request
public (#20954), which left the ballot parser untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/ballots/[id]/route.public-query.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test 'v1/ballots/[id]/route.public-query.test.ts'
```

9 passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; ballot `public` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; ballot `public` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; ballot `public` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real public tokens and assert 400 before auth or lookup; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no ballot artifact; illegal tokens 400 before getBallot.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`public` tokens reject; omitted/canonical still bind the matching
creator-or-redacted path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file ballot public parse
with a green focused suite (9 tests). Full monorepo verify is unrelated
to this query grammar and was skipped to keep the proof tied to the
changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3b1a09cc4f157eb653d5a28eaf620c21f117aac9 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Maintainer validation and repair

Validated exact head `3b1a09cc4f157eb653d5a28eaf620c21f117aac9`, rebased onto current `develop`. The strict one-token grammar is correct, but the original implementation read only one value and therefore accepted ambiguous duplicate keys depending on order. The maintainer repair now inspects every `public` value and rejects duplicates before authentication or either ballot lookup.

- Real Hono route suite: 16/16 passed, 75 assertions. Coverage includes omitted/empty, exact `1`, malformed/case/decimal/signed/whitespace tokens, repeated canonical values, and conflicting duplicate orders; every rejected request asserts zero auth/storage calls.
- Biome on both changed files: passed.
- `git diff origin/develop...HEAD --check`: passed.
- Cloud API typecheck was attempted; the isolated sparse clone lacks the existing `@cloudflare/workers-types` type package, so compilation stopped at TS2688 before checking project files. The focused Bun route compiler/test emitted no changed-file diagnostic.
- Current-develop/open-PR search found no duplicate ballot fix.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@4a1380f82d25ddf90f9fe76937d1cfe10613bc74:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@4a1380f82d25ddf90f9fe76937d1cfe10613bc74:packages/skills/skills/contribute-to-eliza"} -->
