### PR TITLE
fix(orchestrator): key check inapplicability on real check surfaces

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/producible-evidence.test.ts
@@ -370,3 +370,44 @@ describe("static-only deliverable check inapplicability (ember-tide live shape)"
     expect(verdict.results[0]?.basis).toBe("green test output captured");
   });
 });
+
+describe("check-surface inapplicability (dawn-mesa live shape)", () => {
+  const dawnMesaFacts = {
+    verifiedPublicUrls: ["https://nubilio.org/apps/dawn-mesa/"],
+    ledgerVerifiedFiles: [
+      "data/apps/dawn-mesa/index.html",
+      "data/apps/dawn-mesa/script.js",
+    ],
+    hasChangeSet: false,
+    greenChecks: { test: false, build: false, lint: false },
+    checkSurfaces: { typecheck: false, lint: false, test: false },
+  };
+
+  test("a vanilla script.js deliverable with no surfaces satisfies check criteria vacuously", () => {
+    const verdict = deterministicLedgerVerdict(
+      ["typecheck passes", "lint passes", "tests pass"],
+      dawnMesaFacts,
+    );
+    expect(verdict.allMet).toBe(true);
+    for (const result of verdict.results) {
+      expect(result.basis).toContain("inapplicable: no");
+    }
+  });
+
+  test("a present surface keeps that check strict even with script.js", () => {
+    const verdict = deterministicLedgerVerdict(["typecheck passes"], {
+      ...dawnMesaFacts,
+      checkSurfaces: { typecheck: true, lint: false, test: false },
+    });
+    expect(verdict.allMet).toBe(false);
+  });
+
+  test("absent surface facts stay strict for code deliverables", () => {
+    const { checkSurfaces: _omit, ...withoutSurfaces } = dawnMesaFacts;
+    const verdict = deterministicLedgerVerdict(
+      ["typecheck passes"],
+      withoutSurfaces,
+    );
+    expect(verdict.allMet).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/quick-app-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/quick-app-evidence.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vitest";
 import {
   collectFsObservedFiles,
   deriveRouteMappedUrls,
+  detectCheckSurfaces,
   mineCandidatePaths,
   probeMappedUrls,
 } from "../services/quick-app-evidence.js";
@@ -104,5 +105,53 @@ describe("probeMappedUrls", () => {
       fetchImpl,
     );
     expect(verified).toEqual(["https://a.example/good/"]);
+  });
+});
+
+describe("detectCheckSurfaces (dawn-mesa boundary)", () => {
+  it("a vanilla script.js app dir with no tooling has no check surfaces (real fs)", () => {
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "surface-"));
+    try {
+      const appDir = path.join(workdir, "data", "apps", "dawn-mesa");
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(path.join(appDir, "index.html"), "<html></html>");
+      fs.writeFileSync(path.join(appDir, "script.js"), "console.log(1)");
+      // Root tooling exists (the static SERVER's) — must NOT count for the app.
+      fs.writeFileSync(path.join(workdir, "package.json"), "{}");
+      fs.writeFileSync(path.join(workdir, "tsconfig.json"), "{}");
+
+      const surfaces = detectCheckSurfaces(workdir, [
+        "data/apps/dawn-mesa/index.html",
+        "data/apps/dawn-mesa/script.js",
+      ]);
+      expect(surfaces).toEqual({ typecheck: false, lint: false, test: false });
+    } finally {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("a deliverable AT a tooling boundary detects runnable checks (real fs)", () => {
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "surface-"));
+    try {
+      fs.writeFileSync(path.join(workdir, "package.json"), "{}");
+      fs.writeFileSync(path.join(workdir, "tsconfig.json"), "{}");
+      fs.writeFileSync(path.join(workdir, "biome.json"), "{}");
+      fs.writeFileSync(path.join(workdir, "calc.js"), "console.log(1)");
+
+      const surfaces = detectCheckSurfaces(workdir, ["calc.js"]);
+      expect(surfaces).toEqual({ typecheck: true, lint: true, test: true });
+    } finally {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("a test file among the deliverable implies a test surface", () => {
+    const surfaces = detectCheckSurfaces(
+      "/nonexistent-root",
+      ["pkg/thing.test.ts"],
+      () => false,
+    );
+    expect(surfaces.test).toBe(true);
+    expect(surfaces.typecheck).toBe(false);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
@@ -127,6 +127,9 @@ export interface CompletionEvidenceBundle {
    *  observation-grade evidence for adapters that fold tool results into
    *  messages (#20794 live residual). */
   fsVerifiedFiles?: string[];
+  /** Check classes runnable where the verified deliverable lives (tooling
+   *  manifests observed in its own directories); absent = unknown. */
+  checkSurfaces?: { typecheck: boolean; lint: boolean; test: boolean };
   /** Screenshot artifact paths found on the task/session. */
   screenshots: string[];
   /** Path to the persisted trajectory JSONL artifact for this completion. */

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -201,6 +201,7 @@ import { extractPullRequestLink } from "./pull-request-link.js";
 import {
   collectFsObservedFiles,
   deriveRouteMappedUrls,
+  detectCheckSurfaces,
   mineCandidatePaths,
   probeMappedUrls,
 } from "./quick-app-evidence.js";
@@ -2492,6 +2493,17 @@ export class OrchestratorTaskService extends Service {
       }
     }
 
+    // Which check classes the verified deliverable can actually RUN —
+    // detected in the deliverable's own directories (see detectCheckSurfaces).
+    const surfaceFiles = [
+      ...(ledgerVerdict.ledgerObserved ? ledgerVerdict.verifiedClaims : []),
+      ...fsVerifiedFiles,
+    ];
+    const checkSurfaces =
+      reportingSession?.workdir && surfaceFiles.length > 0
+        ? detectCheckSurfaces(reportingSession.workdir, surfaceFiles)
+        : undefined;
+
     return {
       summary,
       diffSummary,
@@ -2505,6 +2517,7 @@ export class OrchestratorTaskService extends Service {
           }
         : {}),
       ...(fsVerifiedFiles.length > 0 ? { fsVerifiedFiles } : {}),
+      ...(checkSurfaces ? { checkSurfaces } : {}),
       screenshots: [...new Set(screenshots)],
     };
   }
@@ -4123,6 +4136,9 @@ export class OrchestratorTaskService extends Service {
             ...(bundle.ledgerVerifiedFiles ?? []),
             ...(bundle.fsVerifiedFiles ?? []),
           ],
+          ...(bundle.checkSurfaces
+            ? { checkSurfaces: bundle.checkSurfaces }
+            : {}),
           hasChangeSet: Boolean(bundle.diffSummary?.trim()),
           greenChecks: {
             test: isGreenCheckOutput(deterministicToolOutput?.test),

--- a/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
@@ -192,6 +192,22 @@ function staticOnlyDeliverable(facts: DeterministicEvidenceFacts): boolean {
   );
 }
 
+/**
+ * A check is vacuous when the verified deliverable provably cannot run it:
+ * either every verified file is a static asset, or the deliverable's own
+ * directories carry no tooling manifest for that check class (a vanilla
+ * browser script.js with no tsconfig/lint/test surface — the dawn-mesa
+ * shape). Absent surface facts mean unknown, which stays strict.
+ */
+function checkInapplicable(
+  facts: DeterministicEvidenceFacts,
+  check: "typecheck" | "lint" | "test",
+): boolean {
+  if (facts.ledgerVerifiedFiles.length === 0) return false;
+  if (staticOnlyDeliverable(facts)) return true;
+  return facts.checkSurfaces ? facts.checkSurfaces[check] === false : false;
+}
+
 /** Deterministic facts the orchestrator already holds at completion. */
 export interface DeterministicEvidenceFacts {
   /** Router-probed URLs that answered, non-loopback only. */
@@ -202,6 +218,10 @@ export interface DeterministicEvidenceFacts {
   hasChangeSet: boolean;
   /** Mined green output present per check class. */
   greenChecks: { test: boolean; build: boolean; lint: boolean };
+  /** Which check classes are RUNNABLE where the verified deliverable lives
+   *  (tooling manifests observed in the deliverable's own directories — see
+   *  detectCheckSurfaces). Absent = unknown = strict. */
+  checkSurfaces?: { typecheck: boolean; lint: boolean; test: boolean };
 }
 
 export interface DeterministicCriterionResult {
@@ -273,12 +293,13 @@ export function deterministicCriterionCheck(
       : { criterion, status: "undetermined" };
   }
   if (TEST_CRITERION_RE.test(criterion)) {
-    if (!facts.greenChecks.test && staticOnlyDeliverable(facts)) {
+    if (!facts.greenChecks.test && checkInapplicable(facts, "test")) {
       return {
         criterion,
         status: "met",
-        basis:
-          "inapplicable: verified deliverable contains only static assets (no test surface)",
+        basis: staticOnlyDeliverable(facts)
+          ? "inapplicable: verified deliverable contains only static assets (no test surface)"
+          : "inapplicable: no test tooling in the deliverable's directories",
       };
     }
     return facts.greenChecks.test
@@ -286,12 +307,13 @@ export function deterministicCriterionCheck(
       : { criterion, status: "undetermined" };
   }
   if (BUILD_CRITERION_RE.test(criterion)) {
-    if (!facts.greenChecks.build && staticOnlyDeliverable(facts)) {
+    if (!facts.greenChecks.build && checkInapplicable(facts, "typecheck")) {
       return {
         criterion,
         status: "met",
-        basis:
-          "inapplicable: verified deliverable contains only static assets (no build surface)",
+        basis: staticOnlyDeliverable(facts)
+          ? "inapplicable: verified deliverable contains only static assets (no build surface)"
+          : "inapplicable: no typecheck tooling in the deliverable's directories",
       };
     }
     return facts.greenChecks.build
@@ -303,12 +325,13 @@ export function deterministicCriterionCheck(
       : { criterion, status: "undetermined" };
   }
   if (LINT_CRITERION_RE.test(criterion)) {
-    if (!facts.greenChecks.lint && staticOnlyDeliverable(facts)) {
+    if (!facts.greenChecks.lint && checkInapplicable(facts, "lint")) {
       return {
         criterion,
         status: "met",
-        basis:
-          "inapplicable: verified deliverable contains only static assets (no lint surface)",
+        basis: staticOnlyDeliverable(facts)
+          ? "inapplicable: verified deliverable contains only static assets (no lint surface)"
+          : "inapplicable: no lint tooling in the deliverable's directories",
       };
     }
     return facts.greenChecks.lint

--- a/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
@@ -148,3 +148,86 @@ export async function probeMappedUrls(
   }
   return verified;
 }
+
+/** Tooling manifests that make a check-class criterion RUNNABLE where the
+ *  deliverable lives. Grouped by the check they enable. */
+const TYPECHECK_SURFACE_FILES = [
+  "tsconfig.json",
+  "tsconfig.base.json",
+  "jsconfig.json",
+];
+const LINT_SURFACE_FILES = [
+  "biome.json",
+  "biome.jsonc",
+  ".eslintrc",
+  ".eslintrc.js",
+  ".eslintrc.cjs",
+  ".eslintrc.json",
+  "eslint.config.js",
+  "eslint.config.mjs",
+];
+const TEST_SURFACE_FILES = [
+  "vitest.config.ts",
+  "vitest.config.js",
+  "jest.config.js",
+  "jest.config.ts",
+  "package.json",
+];
+const TEST_FILE_RE = /\.(?:test|spec)\.[jt]sx?$/i;
+
+export interface CheckSurfaces {
+  typecheck: boolean;
+  lint: boolean;
+  test: boolean;
+}
+
+/**
+ * Detect which check classes are RUNNABLE for the verified deliverable, by
+ * direct inspection of the deliverable's OWN directories — deliberately not
+ * the workdir root. A route workdir's root tooling (e.g. the static server's
+ * Next.js package.json/tsconfig) governs the server code, not the static app
+ * bundles it serves; a vanilla script.js beside index.html with no manifest
+ * in its directory is exactly as untypecheckable as the HTML (#20794
+ * dawn-mesa). Deliverables that live AT a tooling boundary (a file next to
+ * package.json / tsconfig, or a sub-package with its own manifests) detect as
+ * runnable and keep the strict path.
+ */
+export function detectCheckSurfaces(
+  workdir: string,
+  relativeFiles: readonly string[],
+  existsImpl?: (absolutePath: string) => boolean,
+): CheckSurfaces {
+  const exists =
+    existsImpl ??
+    ((absolutePath: string): boolean => {
+      try {
+        return fs.statSync(absolutePath).isFile();
+      } catch {
+        // error-policy:J3 an unreadable marker is explicitly not a surface
+        return false;
+      }
+    });
+  const root = path.resolve(workdir);
+  const dirs = new Set<string>();
+  for (const file of relativeFiles.slice(0, MAX_CANDIDATE_PATHS)) {
+    const dir = path.resolve(root, path.dirname(file));
+    const relative = path.relative(root, dir);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) continue;
+    dirs.add(dir);
+  }
+  const anyMarker = (names: readonly string[]): boolean => {
+    for (const dir of dirs) {
+      for (const name of names) {
+        if (exists(path.join(dir, name))) return true;
+      }
+    }
+    return false;
+  };
+  return {
+    typecheck: anyMarker(TYPECHECK_SURFACE_FILES),
+    lint: anyMarker(LINT_SURFACE_FILES),
+    test:
+      anyMarker(TEST_SURFACE_FILES) ||
+      relativeFiles.some((file) => TEST_FILE_RE.test(file)),
+  };
+}


### PR DESCRIPTION
Final boundary iteration of the #20794 quick-app arc, from the dawn-mesa live probe: the whole stack engaged (recovery evidence rich, URLs probed, boot escalation guard clean) but the task still parked because #21127's inapplicability rule classifies by file EXTENSION — `script.js` counts as "code", so the strict path held. A vanilla browser script beside `index.html` has no more typecheck/lint surface than the HTML: no tsconfig, no lint config, no test script, nothing to run.

## The boundary

`detectCheckSurfaces(workdir, verifiedFiles)`: which check classes are RUNNABLE where the deliverable lives, by direct fs inspection of the deliverable's OWN directories — deliberately not the workdir root. That scoping is load-bearing: the live route workdir's root carries the static SERVER's Next.js `package.json` + `tsconfig.json`, which govern the server code, not the static app bundles it serves — a root-scoped probe would have re-broken every quick-app. A deliverable AT a tooling boundary (file next to package.json/tsconfig/lint config, sub-package with its own manifests, or a `*.test.*` file among the verified set) detects as runnable and keeps the strict path.

The verify-time rule becomes: an unsatisfied test/typecheck/lint criterion is vacuously met (explicit basis naming which case) when the verified deliverable is static-assets-only OR its surfaces detect the check as not runnable; absent surface facts = unknown = strict, so every caller without the new field keeps exact prior behavior. Green output still wins with its real basis.

## Evidence

- `detectCheckSurfaces`: 3 new REAL-filesystem tests — the exact dawn-mesa shape (script.js app dir under a root WITH package.json+tsconfig → no surfaces), a deliverable at the tooling boundary (→ all surfaces), and test-file implication.
- `producible-evidence`: 3 new — dawn-mesa facts vacuously met with "inapplicable: no <check> tooling" bases, present-surface stays strict even with script.js, absent-surface stays strict.
- Affected suites 106/106; plugin typecheck clean; Biome clean.
- Live re-proof: next box rebuild re-runs the probe (peer session standing by) — expected deterministic promotion of the index.html+script.js class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)