### PR TITLE
fix(cloud): reject unknown approval-request public flag

### DIFF
--- a/packages/cloud/api/v1/approval-requests/[id]/route.public-query.test.ts
+++ b/packages/cloud/api/v1/approval-requests/[id]/route.public-query.test.ts
@@ -1,0 +1,118 @@
+/**
+ * GET /api/v1/approval-requests/:id `public` is checkout-visibility identity,
+ * leftover tax after payment-request public (#20954) and ballot public
+ * (#21131). Stock develop treated every non-exact `1` token as the
+ * authenticated creator view, so `public=true` still required auth instead
+ * of a 400. Approval id parser stays untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const APPROVAL_ID = "11111111-1111-4111-8111-111111111111";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+const getMock = mock(async (_id: string, _organizationId: string) => null);
+const getPublicMock = mock(async (_id: string) => null);
+
+const approvalRow = {
+  id: APPROVAL_ID,
+  organizationId: "org-1",
+  agentId: "agent-1",
+  status: "pending",
+  challengeKind: "signature",
+  challengePayload: { message: "sign this" },
+  signatureText: "secret-signature",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/db/repositories/approval-requests", () => ({
+  approvalRequestsRepository: {},
+}));
+mock.module("@/lib/services/approval-requests", () => ({
+  createApprovalRequestsService: () => ({
+    get: getMock,
+    getPublic: getPublicMock,
+  }),
+  redactApprovalRequestForPublic: (row: typeof approvalRow) => {
+    const { signatureText: _signatureText, ...publicRow } = row;
+    return publicRow;
+  },
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: "standard" },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (
+    c: { json: (body: unknown, status: number) => Response },
+    _error: unknown,
+  ) => c.json({ success: false, error: "internal error" }, 500),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(() => undefined) },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id", route);
+
+function expectNoLookup() {
+  expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+  expect(getMock).not.toHaveBeenCalled();
+  expect(getPublicMock).not.toHaveBeenCalled();
+}
+
+describe("GET /api/v1/approval-requests/:id public visibility identity", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    getMock.mockClear();
+    getPublicMock.mockClear();
+    getMock.mockResolvedValue(approvalRow);
+    getPublicMock.mockResolvedValue(approvalRow);
+  });
+
+  test.each(["", "?public="])(
+    "accepts %s as the authenticated creator view",
+    async (query) => {
+      const response = await app.request(`/${APPROVAL_ID}${query}`);
+      expect(response.status).toBe(200);
+      expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+      expect(getMock).toHaveBeenCalledWith(APPROVAL_ID, "org-1");
+      expect(getPublicMock).not.toHaveBeenCalled();
+    },
+  );
+
+  test("accepts public=1 as the unauthenticated redacted approval", async () => {
+    const response = await app.request(`/${APPROVAL_ID}?public=1`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      success: boolean;
+      approvalRequest: { id: string; signatureText?: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.approvalRequest.id).toBe(APPROVAL_ID);
+    expect(body.approvalRequest.signatureText).toBeUndefined();
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+    expect(getPublicMock).toHaveBeenCalledWith(APPROVAL_ID);
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  test.each(["true", "yes", "TRUE", "0", "foo", "1e2"])(
+    "rejects public=%s before public or creator lookup",
+    async (token) => {
+      const response = await app.request(
+        `/${APPROVAL_ID}?public=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toMatch(/public/i);
+      expectNoLookup();
+    },
+  );
+});

--- a/packages/cloud/api/v1/approval-requests/[id]/route.public-query.test.ts
+++ b/packages/cloud/api/v1/approval-requests/[id]/route.public-query.test.ts
@@ -1,21 +1,12 @@
 /**
- * GET /api/v1/approval-requests/:id `public` is checkout-visibility identity,
- * leftover tax after payment-request public (#20954) and ballot public
- * (#21131). Stock develop treated every non-exact `1` token as the
- * authenticated creator view, so `public=true` still required auth instead
- * of a 400. Approval id parser stays untouched.
+ * Exercises the real approval-request GET route's public/creator selection.
+ * Authentication and persistence are mocked so the suite can assert that
+ * invalid or ambiguous query input has no downstream side effects.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
 const APPROVAL_ID = "11111111-1111-4111-8111-111111111111";
-
-const requireUserOrApiKeyWithOrg = mock(async () => ({
-  id: "user-1",
-  organization_id: "org-1",
-}));
-const getMock = mock(async (_id: string, _organizationId: string) => null);
-const getPublicMock = mock(async (_id: string) => null);
 
 const approvalRow = {
   id: APPROVAL_ID,
@@ -28,6 +19,20 @@ const approvalRow = {
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 };
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+const getMock = mock(
+  async (
+    _id: string,
+    _organizationId: string,
+  ): Promise<typeof approvalRow | null> => null,
+);
+const getPublicMock = mock(
+  async (_id: string): Promise<typeof approvalRow | null> => null,
+);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
@@ -115,4 +120,15 @@ describe("GET /api/v1/approval-requests/:id public visibility identity", () => {
       expectNoLookup();
     },
   );
+
+  test.each([
+    "?public=1&public=true",
+    "?public=true&public=1",
+    "?public=&public=1",
+    "?public=1&public=1",
+  ])("rejects ambiguous duplicate query %s before lookup", async (query) => {
+    const response = await app.request(`/${APPROVAL_ID}${query}`);
+    expect(response.status).toBe(400);
+    expectNoLookup();
+  });
 });

--- a/packages/cloud/api/v1/approval-requests/[id]/route.ts
+++ b/packages/cloud/api/v1/approval-requests/[id]/route.ts
@@ -44,8 +44,27 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: parsedId.error }, 400);
     }
     const { id } = parsedId;
-
-    const isPublic = c.req.query("public") === "1";
+    // Only the exact token `1` selects the unauthenticated, redacted
+    // approval DTO. Missing or empty selects the authenticated creator
+    // view; any other token is leftover identity after payment-request
+    // public (#20954) and ballot public (#21131) and must fail before
+    // authentication or lookup.
+    const requestedPublic = c.req.query("public");
+    if (
+      requestedPublic !== undefined &&
+      requestedPublic !== "" &&
+      requestedPublic !== "1"
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: "invalid_public",
+          message: 'public must be "1" for the redacted approval view.',
+        },
+        400,
+      );
+    }
+    const isPublic = requestedPublic === "1";
     const service = getApprovalRequestsService();
 
     if (isPublic) {

--- a/packages/cloud/api/v1/approval-requests/[id]/route.ts
+++ b/packages/cloud/api/v1/approval-requests/[id]/route.ts
@@ -44,16 +44,15 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: parsedId.error }, 400);
     }
     const { id } = parsedId;
-    // Only the exact token `1` selects the unauthenticated, redacted
-    // approval DTO. Missing or empty selects the authenticated creator
-    // view; any other token is leftover identity after payment-request
-    // public (#20954) and ballot public (#21131) and must fail before
-    // authentication or lookup.
-    const requestedPublic = c.req.query("public");
+    // The public view is an unauthenticated security boundary, so ambiguous
+    // duplicates and every token other than the documented empty/`1` forms
+    // must fail before authentication or lookup.
+    const requestedPublicValues = c.req.queries("public");
+    const requestedPublic = requestedPublicValues?.[0];
     if (
-      requestedPublic !== undefined &&
-      requestedPublic !== "" &&
-      requestedPublic !== "1"
+      requestedPublicValues !== undefined &&
+      (requestedPublicValues.length !== 1 ||
+        (requestedPublic !== "" && requestedPublic !== "1"))
     ) {
       return c.json(
         {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on approval-request
`public` identity. Leftover tax after payment-request public (#20954) and
ballot public (#21131). Not leftover tax on x-feed connectionRole, voice-list
includeInactive, analytics-export includeMetadata, agent-resume sync,
agent-provision sync, or prefix-coerced limit/offset.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `public` only on `/api/v1/approval-requests/:id`.
Omitted/empty still bind the authenticated creator row (today's default).
Exact `1` still binds the unauthenticated redacted approval DTO.
Unknown / uppercase tokens 400 before auth or lookup.
Approval id parser stays untouched.

# Background

## What does this PR do?

`GET /api/v1/approval-requests/:id` treated every non-exact `1` token as the
authenticated creator view. `public=true` silently required auth instead of a
400.

- omitted / empty → creator view (200)
- exact `1` → redacted public approval
- `true` / `TRUE` / `yes` / `0` / `foo` / `1e2` → **400** before auth or lookup

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers select the unauthenticated signer DTO with `?public=1`. A common
`public=true` after a client boolean-stringifies the flag must not silently
require auth and expose `signatureText` on the creator path. This is leftover
tax after payment-request public (#20954) and ballot public (#21131), which
left the approval-request parser untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/approval-requests/[id]/route.public-query.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/approval-requests/[id]/route.public-query.test.ts
```

9 passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; approval-request `public` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; approval-request `public` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; approval-request `public` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real public tokens and assert 400 before auth or lookup; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no approval write; illegal tokens 400 before public or creator lookup.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`public` tokens reject; omitted/canonical still bind the matching
creator-or-public path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file approval-request public
parse with a green focused suite (9 tests). Full monorepo verify is
unrelated to this query grammar and was skipped to keep the proof tied
to the changed path.

## Maintainer repair verification

The first-value parser accepted ambiguous duplicates such as `public=1&public=true` and `public=&public=1`. Repaired head `39bf9bfbce2ff0666d787596591882fa94741563` uses the full Hono query-value list and rejects every duplicate before auth or lookup. Exact-head focused route suite: 13/13 tests, 61 assertions. Focused Biome: pass. `tsc --noEmit`: pass. The Worker dry-run portion of `typecheck` could not run in the space-constrained isolated assembly because unrelated cloud-sdk workspace sources were not materialized; no route TypeScript errors remain.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Cursor`, `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3517e4ff503de0c8d4da6922de89d8a9ea635670:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:39bf9bfbce2ff0666d787596591882fa94741563 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@3517e4ff503de0c8d4da6922de89d8a9ea635670:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-a]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@3517e4ff503de0c8d4da6922de89d8a9ea635670:packages/skills/skills/contribute-to-eliza"} -->