### PR TITLE
fix(cloud): reject unknown agent-provision sync flag

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.sync.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.sync.test.ts
@@ -1,0 +1,179 @@
+/**
+ * POST /api/v1/eliza/agents/:id/provision `sync` is provision-wait identity,
+ * leftover tax after agent-resume sync (#21099). Stock develop treated any
+ * non-exact `true` token as async, so `sync=TRUE` still enqueued a 202 job
+ * instead of the blocking fallback. Credit / warm-pool / enqueue parsers
+ * stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+const ORG_A = "11111111-1111-4111-8111-111111111111";
+const AGENT_ID = "agent-provision-1";
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+const getAgentForWrite = mock(async () => ({
+  id: AGENT_ID,
+  organization_id: ORG_A,
+  agent_name: "already-up",
+  execution_tier: "dedicated-always",
+  status: "running",
+  bridge_url: "https://bridge.example.test",
+  health_url: "https://health.example.test",
+}));
+const provision = mock(async () => ({
+  success: true,
+  bridgeUrl: "https://bridge.example.test",
+  healthUrl: "https://health.example.test",
+}));
+const checkAgentCreditGate = mock(async () => ({
+  allowed: true,
+  balance: 5,
+  error: "",
+}));
+const enqueueAgentProvision = mock(async () => ({
+  job: { id: "job-1", status: "queued" },
+  created: true,
+}));
+const triggerImmediate = mock(async () => undefined);
+const checkProvisioningWorkerHealth = mock(async () => ({ ok: true }));
+const claimWarmContainer = mock(async () => null);
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: { id: "user-1", organization_id: ORG_A },
+  }),
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+mock.module("@/lib/services/agent-billing-gate-402", () => ({
+  insufficientCredits402: () => ({ error: "insufficient credits" }),
+}));
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: { getAgentForWrite, provision },
+}));
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: { enqueueAgentProvision, triggerImmediate },
+}));
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth,
+  provisioningWorkerFailureBody: () => ({ error: "worker" }),
+}));
+mock.module("@/lib/services/proxy/cors", () => ({
+  applyCorsHeaders: (response: Response) => response,
+  handleCorsOptions: () => new Response(null, { status: 204 }),
+}));
+mock.module("@/lib/api/errors", () => ({
+  errorToResponse: (error: unknown) =>
+    Response.json(
+      { error: error instanceof Error ? error.message : "error" },
+      { status: 500 },
+    ),
+}));
+mock.module("@/lib/security/outbound-url", () => ({
+  assertSafeOutboundUrl: async () => undefined,
+}));
+mock.module("@/lib/config/containers-env", () => ({
+  containersEnv: {
+    warmPoolEnabled: () => false,
+    defaultAgentImage: () => "eliza-agent:test",
+  },
+}));
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: { claimWarmContainer },
+}));
+
+const { default: provisionRoute } = await import("./route");
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.route("/api/v1/eliza/agents/:agentId/provision", provisionRoute);
+  return app;
+}
+
+function post(query = "") {
+  return buildApp().request(
+    `/api/v1/eliza/agents/${AGENT_ID}/provision${query}`,
+    { method: "POST" },
+    ENV,
+  );
+}
+
+describe("POST /api/v1/eliza/agents/:id/provision sync identity", () => {
+  beforeEach(() => {
+    getAgentForWrite.mockClear();
+    provision.mockClear();
+    checkAgentCreditGate.mockClear();
+    enqueueAgentProvision.mockClear();
+    triggerImmediate.mockClear();
+    checkProvisioningWorkerHealth.mockClear();
+    claimWarmContainer.mockClear();
+  });
+
+  test.each(["", "?sync=", "?sync=false"])(
+    "accepts %s as async provision (already-running fast path)",
+    async (query) => {
+      const response = await post(query);
+      expect(response.status).toBe(200);
+      expect(getAgentForWrite).toHaveBeenCalledTimes(1);
+      expect(provision).not.toHaveBeenCalled();
+      expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    },
+  );
+
+  test("accepts sync=true as the blocking-fallback token (already-running)", async () => {
+    const response = await post("?sync=true");
+    expect(response.status).toBe(200);
+    expect(getAgentForWrite).toHaveBeenCalledTimes(1);
+    expect(provision).not.toHaveBeenCalled();
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+  });
+
+  test.each(["FALSE", "TRUE", "0", "1", "no", "yes", "foo", "1e2"])(
+    "rejects sync=%s before lookup, credit gate, provision, and enqueue",
+    async (token) => {
+      const response = await post(`?sync=${encodeURIComponent(token)}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid sync");
+      expect(getAgentForWrite).not.toHaveBeenCalled();
+      expect(checkAgentCreditGate).not.toHaveBeenCalled();
+      expect(provision).not.toHaveBeenCalled();
+      expect(enqueueAgentProvision).not.toHaveBeenCalled();
+      expect(checkProvisioningWorkerHealth).not.toHaveBeenCalled();
+      expect(triggerImmediate).not.toHaveBeenCalled();
+      expect(claimWarmContainer).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?sync=false&sync=true",
+    "?sync=true&sync=false",
+    "?sync=true&sync=true",
+    "?sync=&sync=false",
+  ])(
+    "rejects ambiguous duplicate query %s without side effects",
+    async (query) => {
+      const response = await post(query);
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({ error: "Invalid sync" });
+      expect(getAgentForWrite).not.toHaveBeenCalled();
+      expect(checkAgentCreditGate).not.toHaveBeenCalled();
+      expect(provision).not.toHaveBeenCalled();
+      expect(enqueueAgentProvision).not.toHaveBeenCalled();
+      expect(checkProvisioningWorkerHealth).not.toHaveBeenCalled();
+      expect(triggerImmediate).not.toHaveBeenCalled();
+      expect(claimWarmContainer).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.sync.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.sync.test.ts
@@ -34,6 +34,11 @@ const provision = mock(async () => ({
   success: true,
   bridgeUrl: "https://bridge.example.test",
   healthUrl: "https://health.example.test",
+  sandboxRecord: {
+    id: AGENT_ID,
+    agent_name: "provisioned-agent",
+    status: "running",
+  },
 }));
 const checkAgentCreditGate = mock(async () => ({
   allowed: true,
@@ -131,11 +136,22 @@ describe("POST /api/v1/eliza/agents/:id/provision sync identity", () => {
     },
   );
 
-  test("accepts sync=true as the blocking-fallback token (already-running)", async () => {
+  test("accepts sync=true and runs the blocking provision path", async () => {
+    getAgentForWrite.mockImplementationOnce(async () => ({
+      id: AGENT_ID,
+      organization_id: ORG_A,
+      agent_name: "needs-provisioning",
+      execution_tier: "dedicated-always",
+      status: "stopped",
+      bridge_url: null,
+      health_url: null,
+    }));
     const response = await post("?sync=true");
     expect(response.status).toBe(200);
     expect(getAgentForWrite).toHaveBeenCalledTimes(1);
-    expect(provision).not.toHaveBeenCalled();
+    expect(checkAgentCreditGate).toHaveBeenCalledTimes(1);
+    expect(provision).toHaveBeenCalledTimes(1);
+    expect(provision).toHaveBeenCalledWith(AGENT_ID, ORG_A);
     expect(enqueueAgentProvision).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
@@ -83,8 +83,32 @@ async function __hono_POST(
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
     const { agentId } = await params;
-    const syncRequested =
-      new URL(request.url).searchParams.get("sync") === "true";
+    // Agent-provision wait identity, leftover tax after agent-resume
+    // sync (#21099). sync=TRUE used to silently stay async (202 job)
+    // instead of the blocking fallback.
+    const syncValues = new URL(request.url).searchParams.getAll("sync");
+    const requestedSync = syncValues[0];
+    if (
+      syncValues.length > 1 ||
+      (requestedSync != null &&
+        requestedSync !== "" &&
+        requestedSync !== "true" &&
+        requestedSync !== "false")
+    ) {
+      return applyCorsHeaders(
+        Response.json(
+          {
+            success: false,
+            error: "Invalid sync",
+            message:
+              'sync must be specified at most once as "true" or "false".',
+          },
+          { status: 400 },
+        ),
+        CORS_METHODS,
+      );
+    }
+    const syncRequested = requestedSync === "true";
     const sync =
       syncRequested &&
       (process.env.NODE_ENV !== "production" ||


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on agent-provision
`sync` identity. Leftover tax after agent-resume sync (#21099). Not leftover
tax on agent-create autoProvision, approval-request public, ballot public,
x-feed connectionRole, voice-list includeInactive, analytics-export
includeMetadata, or prefix-coerced limit/offset.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. POST `sync` only on `/api/v1/eliza/agents/:id/provision`.
Omitted/empty/`false` still bind the async job path (today's default).
Exact `true` still selects the blocking fallback (existing production
allowlist unchanged). Unknown / uppercase / duplicate tokens 400 before
lookup, credit gate, warm-pool claim, provision, or enqueue.

# Background

## What does this PR do?

`POST /api/v1/eliza/agents/:id/provision` treated every non-exact `true`
token as async. `sync=TRUE` silently enqueued a 202 job instead of a 400.

- omitted / empty / `false` → async provision (200 already-running or 202 job)
- exact `true` → blocking-fallback token (existing production allowlist)
- `TRUE` / `1` / `yes` / `foo` / `1e2` / duplicate `sync` → **400** before
  lookup or enqueue

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers select the blocking provision fallback with `?sync=true`. A common
`sync=TRUE` after a client uppercases the flag must not silently stay async.
This is leftover tax after agent-resume sync (#21099), which left the
provision parser untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.sync.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/eliza/agents/[agentId]/provision/route.sync.test.ts
```

16 passed at this exact head (126 assertions), including the real blocking provision branch.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; agent-provision `sync` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; agent-provision `sync` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; agent-provision `sync` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real sync tokens and assert 400 before lookup or enqueue; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no provision write; illegal tokens 400 before lookup, credit gate, or enqueue.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`sync` tokens reject; omitted/canonical still bind the matching
async-or-blocking path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

Focused real-route suite: 16/16 tests, 126 assertions. Biome and diff checks pass. Package typecheck was attempted but this isolated sparse environment lacks the configured `@cloudflare/workers-types` type package (TS2688); no changed-code diagnostic was reached.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7aff4df2a8edc1a228f57f6b81f7b4732d881db1 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Maintainer validation

Validated after rebase on current `develop` at exact head `7aff4df2a8edc1a228f57f6b81f7b4732d881db1`: the route suite proves omitted/empty/false compatibility, exact `true` reaching the blocking provision call, strict rejection of eight malformed tokens, and duplicate-key rejection in every tested order before lookup, billing, provisioning, warm-pool, worker, or enqueue side effects.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@84b1bf2797a21a5cd629e13f639020d46e6b0c09
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@84b1bf2797a21a5cd629e13f639020d46e6b0c09"} -->