### PR TITLE
fix(wallet): add timeout to Circle IRIS attestation poll fetch

### DIFF
--- a/plugins/plugin-wallet/src/sdk/bridge/attestation-fetch.test.ts
+++ b/plugins/plugin-wallet/src/sdk/bridge/attestation-fetch.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Verifies the shared Circle IRIS request boundary installs its production timeout signal.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CIRCLE_ATTESTATION_FETCH_TIMEOUT_MS,
+  fetchCircleAttestation,
+} from "./attestation-fetch";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("fetchCircleAttestation", () => {
+  it("passes a ten-second AbortSignal to fetch", async () => {
+    const signal = new AbortController().signal;
+    const timeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(signal);
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchCircleAttestation(
+      "https://iris.example.test/v2/messages/0/hash",
+    );
+
+    expect(timeout).toHaveBeenCalledExactlyOnceWith(
+      CIRCLE_ATTESTATION_FETCH_TIMEOUT_MS,
+    );
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+      "https://iris.example.test/v2/messages/0/hash",
+      {
+        headers: { Accept: "application/json" },
+        signal,
+      },
+    );
+  });
+});

--- a/plugins/plugin-wallet/src/sdk/bridge/attestation-fetch.ts
+++ b/plugins/plugin-wallet/src/sdk/bridge/attestation-fetch.ts
@@ -1,0 +1,13 @@
+/**
+ * Bounds Circle IRIS attestation HTTP requests shared by EVM and Solana bridge flows.
+ */
+
+export const CIRCLE_ATTESTATION_FETCH_TIMEOUT_MS = 10_000;
+
+export function fetchCircleAttestation(url: string): Promise<Response> {
+  // @duplicate-component-audit-allow Circle attestation polling is not an LLM generation call.
+  return fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(CIRCLE_ATTESTATION_FETCH_TIMEOUT_MS),
+  });
+}

--- a/plugins/plugin-wallet/src/sdk/bridge/client.ts
+++ b/plugins/plugin-wallet/src/sdk/bridge/client.ts
@@ -42,6 +42,7 @@ import {
   MessageTransmitterV2Abi,
   TokenMessengerV2Abi,
 } from "./abis.js";
+import { fetchCircleAttestation } from "./attestation-fetch.js";
 import type {
   BridgeChain,
   BridgeOptions,
@@ -371,10 +372,7 @@ export class BridgeModule {
         error?: string;
       };
       try {
-        // @duplicate-component-audit-allow Circle attestation polling is not an LLM generation call.
-        const res = await fetch(url, {
-          headers: { Accept: "application/json" },
-        });
+        const res = await fetchCircleAttestation(url);
         if (!res.ok) {
           if (res.status === 404) {
             await this.sleep(ATTESTATION_POLL_INTERVAL_MS);

--- a/plugins/plugin-wallet/src/sdk/bridge/solana.ts
+++ b/plugins/plugin-wallet/src/sdk/bridge/solana.ts
@@ -540,7 +540,7 @@ async function pollForAttestation(
     let response: { status: string; attestation?: Hex | null; error?: string };
     try {
       // @duplicate-component-audit-allow Circle attestation polling is not an LLM generation call.
-      const res = await fetch(url, { headers: { Accept: "application/json" } });
+      const res = await fetch(url, { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000) });
       if (!res.ok) {
         if (res.status === 404) {
           await sleep(ATTESTATION_POLL_INTERVAL_MS);

--- a/plugins/plugin-wallet/src/sdk/bridge/solana.ts
+++ b/plugins/plugin-wallet/src/sdk/bridge/solana.ts
@@ -37,6 +37,7 @@ import {
   MessageTransmitterV2Abi,
   TokenMessengerV2Abi,
 } from "./abis.js";
+import { fetchCircleAttestation } from "./attestation-fetch.js";
 import {
   ATTESTATION_POLL_INTERVAL_MS,
   CCTP_DOMAIN_IDS,
@@ -539,8 +540,7 @@ async function pollForAttestation(
   for (let attempt = 0; attempt < MAX_ATTESTATION_POLLS; attempt++) {
     let response: { status: string; attestation?: Hex | null; error?: string };
     try {
-      // @duplicate-component-audit-allow Circle attestation polling is not an LLM generation call.
-      const res = await fetch(url, { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000) });
+      const res = await fetchCircleAttestation(url);
       if (!res.ok) {
         if (res.status === 404) {
           await sleep(ATTESTATION_POLL_INTERVAL_MS);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Bug #3 on `develop` @ `a86033a127` — Circle IRIS attestation poll fetch without timeout in `plugins/plugin-wallet/src/sdk/bridge/solana.ts:543`. No existing issue; single-line timeout fix. Previous hunt fixes #21120 (DexScreener clamp) and #21123 (cloud-bootstrap clamp) left this `pollForAttestation` fetch path open with unbounded hang per attempt.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `a86033a127` (origin/develop at task creation) with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` / package typecheck were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is self-reported provenance, not a request for chain-of-thought. Never include prompts containing secrets, tokens, private session IDs, or hidden reasoning. Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels (`Client / agent tooling`, `Skill revision` / `Contribution skill revision`, `Attribution status`). Duplicating those strings makes the scoring validator reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->` markers; only the human-readable prefixes changed. After filling these rows, append the standard footer once at the end of the PR body (do not repeat the visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a86033a127198f11a4c81d60230d9b5b77fded87:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto `a86033a127` (`origin/develop` at task creation — also current `origin/develop`); zero conflicts. Single-line `signal` addition.
- [x] `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json` passes post-sync; typecheck green (see Evidence).

# Risks

Low. Single-file, single-line change, no API or storage migration. Adds `AbortSignal.timeout(10_000)` to bound each Circle IRIS `fetch` to 10s; on timeout the existing `catch` wraps it as `ATTESTATION_ERROR` (`Failed to reach Circle IRIS API`). Outer loop still respects `MAX_ATTESTATION_POLLS` and `ATTESTATION_POLL_INTERVAL_MS` on 404. No new imports (AbortSignal is global). Risk limited to fetch abort surfacing as attestation error — strictly tightens liveness vs prior indefinite hang.

# Background

## What does this PR do?

Adds `signal: AbortSignal.timeout(10_000)` to the Circle IRIS attestation poll `fetch` at `solana.ts:543`.

Before (line 543):
```ts
const res = await fetch(url, { headers: { Accept: "application/json" } });
```
A stalled TCP connection or unresponsive IRIS endpoint hangs this `await` indefinitely, blocking the entire `MAX_ATTESTATION_POLLS` loop iteration with no timeout. Each attempt can stall forever; `ATTESTATION_POLL_INTERVAL_MS` is never reached.

After (line 543):
```ts
const res = await fetch(url, { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000) });
```
Each fetch is bounded to 10s. Timeout triggers `AbortError` caught by the existing `catch (err)` → `ATTESTATION_ERROR: Failed to reach Circle IRIS API`. The `for` loop, `404 → sleep(ATTESTATION_POLL_INTERVAL_MS) → continue`, and `complete`/`error` response handling are untouched. Follows ranked hunt idiom.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Existing idioms in the same codebase use identical timeout patterns:
- `plugins/plugin-wallet/src/sdk/identity/uaid.ts:484` — `signal: controller.signal` with `AbortController` timeout.
- `plugins/plugin-health/src/health-bridge/health-connectors.ts:261` — `signal: AbortSignal.timeout(HEALTH_CONNECTOR_TIMEOUT_MS)`.

The hunt ranked `AbortSignal.timeout(10_000)` for this bridge path. Prior hunt fixes #21120 and #21123 addressed env-clamping; this #3 completes the triage by closing the unbounded-fetch liveness bug in the same `develop` branch.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/sdk/bridge/solana.ts` — `pollForAttestation()` at line 535, single changed line 543; loop still respects `MAX_ATTESTATION_POLLS` and `ATTESTATION_POLL_INTERVAL_MS`.

## Detailed testing steps

- Verify no signal before: `git show a86033a127:plugins/plugin-wallet/src/sdk/bridge/solana.ts | grep -n "fetch.*Accept.*json"` → `543: const res = await fetch(url, { headers: { Accept: "application/json" } });` (no `signal`).
- Verify signal after: `grep -n "fetch.*Accept.*json" plugins/plugin-wallet/src/sdk/bridge/solana.ts` → `543: ... signal: AbortSignal.timeout(10_000)`.
- Verify no extra import needed: `AbortSignal` is global (no import added).
- Verify loop intact: `grep -n "MAX_ATTESTATION_POLLS\|ATTESTATION_POLL_INTERVAL_MS" plugins/plugin-wallet/src/sdk/bridge/solana.ts` → lines 41,46,539,546,573,577 present.
- Package typecheck: `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json` → `EXIT:0`.
- No dedicated bridge `pollForAttestation` test file exists in this package; isolated single-line change does not alter control flow.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6ad119e60dcd3bed9c9ef72446298815658acc66 -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the description or a comment), or write `N/A - <reason>` on the row. Do not leave evidence rows blank. Videos must be **MP4** (GitHub renders them inline); prefer **JPG over PNG** for screenshots. Do not commit evidence files to the repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`. → N/A — backend bridge polling, no rendered UI surface. Before code grep attached in Evidence Details.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`. → N/A — same, no UI surface. After grep attached.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`. → N/A — no user flow; bridge attestation polling only.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`. → `tsc --noEmit` pass + grep evidence below; runtime path is `pollForAttestation` → Circle IRIS API.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`. → N/A — no frontend request/response.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`. → N/A — fetch timeout fix, no LLM trajectory.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`. → N/A — no domain artifacts; attestation polling is ephemeral network call.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface. → N/A — no rendered visual surface.

# Evidence Details

**Before grep** (`solana.ts:543` on `a86033a127`):
```
543:      const res = await fetch(url, { headers: { Accept: "application/json" } });
grep -n "signal" → no hits (confirms bug)
```

**After grep** (this PR `ed897f7d77`):
```
543:      const res = await fetch(url, { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000) });
grep -n "signal" → 543: signal: AbortSignal.timeout(10_000)
```

**Diff** (`1 file changed, 1 insertion(+), 1 deletion(-)`):
```diff
-      const res = await fetch(url, { headers: { Accept: "application/json" } });
+      const res = await fetch(url, { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000) });
```

**Typecheck**: `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json` → `EXIT:0`

**Idiom alignment**:
- `plugins/plugin-wallet/src/sdk/identity/uaid.ts:484` → `signal: controller.signal`
- `plugins/plugin-health/src/health-bridge/health-connectors.ts:261` → `signal: AbortSignal.timeout(HEALTH_CONNECTOR_TIMEOUT_MS)`

---
AI provider/model: anthropic/claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/eliza@a86033a127198f11a4c81d60230d9b5b77fded87:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/eliza@a86033a127198f11a4c81d60230d9b5b77fded87:packages/skills/skills/contribute-to-eliza"} -->


## Maintainer validation and repair

Validated exact head `6ad119e60dcd3bed9c9ef72446298815658acc66`, rebased onto current `develop`. The original one-line Solana fix left the identical live EVM `BridgeModule.waitForAttestation()` fetch unbounded. The maintainer repair introduces one shared Circle IRIS request boundary used by both EVM and Solana pollers, centralizes the 10-second timeout, and adds a deterministic test proving the exact timeout signal is passed to `fetch`.

- Focused production-helper test: 1/1 passed.
- Biome on all four changed files: passed.
- `git diff origin/develop...HEAD --check`: passed.
- Full wallet suite was attempted: 18 files / 75 tests passed, while 33 suites could not load because the isolated sparse clone lacks existing wallet dependencies including `@noble/hashes`, `@solana/web3.js`, `@elizaos/ui`, `lucide-react`, `bs58`, and `viem`; none reached a changed-file assertion.
- Package typecheck has the same sparse dependency-resolution blocker. The focused Vitest compiler loaded the new boundary without diagnostics.
- Current-develop/open-PR search found no overlapping timeout fix.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@41da41dae54a3c862efc366b795ba6e46e439d8c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@41da41dae54a3c862efc366b795ba6e46e439d8c:packages/skills/skills/contribute-to-eliza"} -->
