### PR TITLE
fix(desktop): recover cloud auth and dev backend lifecycle

### DIFF
--- a/packages/app-core/scripts/dev-ui.mjs
+++ b/packages/app-core/scripts/dev-ui.mjs
@@ -34,6 +34,10 @@ import { createApiSupervisor } from "./lib/api-supervisor.mjs";
 import { relativeAppDir, resolveMainAppDir } from "./lib/app-dir.mjs";
 import { getBunVersionAdvisory } from "./lib/bun-version-guard.mjs";
 import { capacitorPluginsBuildNeeded } from "./lib/capacitor-plugin-build-needed.mjs";
+import {
+  createApiHealthWatchdog,
+  createParentExitGuard,
+} from "./lib/dev-process-lifecycle.mjs";
 import { isRedundantApiListenLine } from "./lib/dev-ui-log-filter.mjs";
 import { buildVisionDepsFailureMessage } from "./lib/dev-ui-vision.mjs";
 import { resolveViteCommand } from "./lib/dev-ui-vite.mjs";
@@ -859,6 +863,8 @@ let vitePluginBuildAttempted = false;
 let viteRestartCount = 0;
 let viteRestartTimer = null;
 let viteHealthTimer = null;
+let apiHealthWatchdog = null;
+let parentExitGuard = null;
 let viteStartedAt = 0;
 let viteReady = false;
 
@@ -888,6 +894,9 @@ function cleanup(exitCode = 0) {
     return;
   }
   shuttingDown = true;
+
+  parentExitGuard?.stop();
+  apiHealthWatchdog?.stop();
 
   if (sourceWatcher) {
     sourceWatcher.close();
@@ -929,6 +938,20 @@ process.on("SIGTERM", () => cleanup(0));
 if (process.platform !== "win32") {
   process.on("SIGHUP", () => cleanup(0));
 }
+
+parentExitGuard = createParentExitGuard({
+  initialPpid: process.ppid,
+  getPpid: () => process.ppid,
+  disabled:
+    process.platform === "win32" || process.env.ELIZA_DEV_ALLOW_ORPHAN === "1",
+  onParentExit: ({ initialPpid, currentPpid }) => {
+    console.error(
+      `[dev-ui] Parent process changed (${initialPpid} -> ${currentPpid}); shutting down orphaned dev stack. Set ELIZA_DEV_ALLOW_ORPHAN=1 only for an intentional daemon.`,
+    );
+    cleanup(0);
+  },
+});
+parentExitGuard.start();
 
 function buildCapacitorPluginsIfNeeded(childEnv) {
   const pkgPath = path.join(cwd, appDir, "package.json");
@@ -1297,6 +1320,16 @@ if (uiOnly) {
   });
 
   apiSupervisor.start();
+  apiHealthWatchdog = createApiHealthWatchdog({
+    check: () => isAgentReadyNow(API_PORT),
+    restart: () => {
+      console.error(
+        `\n  ${green(logPrefix)} API health failed 3 consecutive probes — restarting wedged child…`,
+      );
+      apiSupervisor.restart();
+    },
+    isShuttingDown: () => shuttingDown,
+  });
 
   // Start Vite before the source-watcher directory scan. The proxy has no
   // boot-time dependency on the API, and both children can warm their module
@@ -1383,6 +1416,7 @@ if (uiOnly) {
       console.log(
         `\r  ${green(logPrefix)} ${green(`Agent ready`)} ${dim(`(${elapsed}s)`)}          `,
       );
+      apiHealthWatchdog?.start();
     })
     .catch((err) => {
       clearInterval(dots);

--- a/packages/app-core/scripts/lib/dev-process-lifecycle.mjs
+++ b/packages/app-core/scripts/lib/dev-process-lifecycle.mjs
@@ -1,0 +1,96 @@
+/**
+ * Guards long-running development supervisors against orphaning and wedged API
+ * children that remain alive while their health endpoint stops responding.
+ */
+
+/**
+ * Watch the launcher PID that owns a development supervisor. A changed parent
+ * means the shell, task runner, or desktop session that requested the dev stack
+ * is gone, so the supervisor must drain its children instead of becoming a
+ * permanent PID-1 orphan.
+ */
+export function createParentExitGuard({
+  initialPpid,
+  getPpid,
+  onParentExit,
+  intervalMs = 2_000,
+  disabled = false,
+}) {
+  let timer = null;
+  let fired = false;
+
+  const check = () => {
+    if (disabled || fired) return;
+    const currentPpid = getPpid();
+    if (currentPpid === initialPpid) return;
+    fired = true;
+    if (timer) clearInterval(timer);
+    timer = null;
+    onParentExit({ initialPpid, currentPpid });
+  };
+
+  return {
+    start() {
+      if (disabled || timer || initialPpid <= 1) return;
+      timer = setInterval(check, intervalMs);
+      timer.unref?.();
+    },
+    stop() {
+      if (timer) clearInterval(timer);
+      timer = null;
+    },
+    checkNow: check,
+  };
+}
+
+/**
+ * Restart a supervised API child only after repeated failed health probes.
+ * Successful probes reset the streak so a transient busy event never bounces
+ * the runtime, while a live-but-wedged TCP listener repairs itself.
+ */
+export function createApiHealthWatchdog({
+  check,
+  restart,
+  isShuttingDown = () => false,
+  intervalMs = 5_000,
+  failureThreshold = 3,
+}) {
+  let timer = null;
+  let failures = 0;
+  let checkInFlight = false;
+
+  const checkNow = async () => {
+    if (checkInFlight || isShuttingDown()) return;
+    checkInFlight = true;
+    let healthy = false;
+    try {
+      healthy = (await check()) === true;
+    } catch {
+      healthy = false;
+    } finally {
+      checkInFlight = false;
+    }
+    if (healthy) {
+      failures = 0;
+      return;
+    }
+    failures += 1;
+    if (failures < failureThreshold) return;
+    failures = 0;
+    restart();
+  };
+
+  return {
+    start() {
+      if (timer) return;
+      timer = setInterval(() => void checkNow(), intervalMs);
+      timer.unref?.();
+    },
+    stop() {
+      if (timer) clearInterval(timer);
+      timer = null;
+      failures = 0;
+    },
+    checkNow,
+  };
+}

--- a/packages/app-core/scripts/lib/dev-process-lifecycle.test.mjs
+++ b/packages/app-core/scripts/lib/dev-process-lifecycle.test.mjs
@@ -1,0 +1,54 @@
+/** Verifies dev-process parent and health lifecycle guards deterministically. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createApiHealthWatchdog,
+  createParentExitGuard,
+} from "./dev-process-lifecycle.mjs";
+
+describe("createParentExitGuard", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("shuts down when the dev supervisor is reparented", () => {
+    let ppid = 42;
+    const onParentExit = vi.fn();
+    const guard = createParentExitGuard({
+      initialPpid: 42,
+      getPpid: () => ppid,
+      onParentExit,
+      intervalMs: 100,
+    });
+
+    guard.start();
+    vi.advanceTimersByTime(100);
+    expect(onParentExit).not.toHaveBeenCalled();
+
+    ppid = 1;
+    vi.advanceTimersByTime(100);
+    expect(onParentExit).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(500);
+    expect(onParentExit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createApiHealthWatchdog", () => {
+  it("restarts only after consecutive unhealthy probes", async () => {
+    const checks = [false, true, false, false, false];
+    const restart = vi.fn();
+    const watchdog = createApiHealthWatchdog({
+      check: async () => checks.shift() ?? true,
+      restart,
+      failureThreshold: 3,
+    });
+
+    await watchdog.checkNow();
+    await watchdog.checkNow();
+    await watchdog.checkNow();
+    await watchdog.checkNow();
+    expect(restart).not.toHaveBeenCalled();
+
+    await watchdog.checkNow();
+    expect(restart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -95,6 +95,7 @@ describe("App standalone chat-overlay wiring", () => {
     );
     expect(branch).toContain("<ChatOverlayShell />");
     expect(branch).toContain("<FirstRunConductorMount />");
+    expect(branch).toContain("<ShellOverlays actionNotice={actionNotice} />");
   });
 
   it("renders a header-less app shell", () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1832,7 +1832,8 @@ function ShellFoundationMount() {
       const shell = controllerRef.current;
       if (!shell) return;
       if (shell.authGate.gated) {
-        shell.requestSignIn();
+        if (shell.authGate.phase === "needs-auth") shell.requestSignIn();
+        else shell.startRecording("ptt");
         return;
       }
       if (shell.recording) {
@@ -1865,7 +1866,8 @@ function ShellFoundationMount() {
       if (detail.held) {
         if (fnHoldActiveRef.current || shell.recording) return;
         if (shell.authGate.gated) {
-          shell.requestSignIn();
+          if (shell.authGate.phase === "needs-auth") shell.requestSignIn();
+          else shell.startRecording("ptt");
           return;
         }
         fnHoldActiveRef.current = true;
@@ -1916,7 +1918,11 @@ function ShellFoundationMount() {
         onClose={controller.close}
         onHoldStart={() => {
           if (controller.authGate.gated) {
-            controller.requestSignIn();
+            if (controller.authGate.phase === "needs-auth") {
+              controller.requestSignIn();
+            } else {
+              controller.startRecording("ptt");
+            }
             return;
           }
           // Audible mic-open ping BEFORE capture spins up: the cue is the
@@ -2825,6 +2831,7 @@ function AppContent() {
           <FirstRunConductorMount />
           <ModelStatusConductorMount />
           <BootRecoveryConductorMount />
+          <ShellOverlays actionNotice={actionNotice} />
         </ShellControllerProvider>
         <BugReportModal />
       </BugReportProvider>

--- a/packages/ui/src/components/shell/__tests__/shell-auth-gate.test.ts
+++ b/packages/ui/src/components/shell/__tests__/shell-auth-gate.test.ts
@@ -66,7 +66,7 @@ describe("deriveShellAuthGate", () => {
     },
   );
 
-  it("keeps loading and server_unavailable on checking when a Cloud session exists", () => {
+  it("keeps loading on checking when a Cloud session exists", () => {
     expect(
       deriveShellAuthGate({
         cloudOnly: true,
@@ -74,13 +74,16 @@ describe("deriveShellAuthGate", () => {
         hasUsableCloudSession: true,
       }),
     ).toEqual({ gated: true, phase: "checking" });
+  });
+
+  it("surfaces server_unavailable distinctly when a Cloud session exists", () => {
     expect(
       deriveShellAuthGate({
         cloudOnly: true,
         authPhase: "server_unavailable",
         hasUsableCloudSession: true,
       }),
-    ).toEqual({ gated: true, phase: "checking" });
+    ).toEqual({ gated: true, phase: "unavailable" });
   });
 });
 
@@ -99,6 +102,19 @@ describe("deriveShellPhase", () => {
     expect(
       deriveShellPhase({ ...idleInputs, ready: true, authGate: "checking" }),
     ).toBe("booting");
+  });
+
+  it("keeps unavailable on booting until chat is opened", () => {
+    expect(deriveShellPhase({ ...idleInputs, authGate: "unavailable" })).toBe(
+      "booting",
+    );
+    expect(
+      deriveShellPhase({
+        ...idleInputs,
+        authGate: "unavailable",
+        isOpen: true,
+      }),
+    ).toBe("summoned");
   });
 
   it("surfaces needs-auth even before the agent proxy is up", () => {

--- a/packages/ui/src/components/shell/__tests__/useShellAuthGate.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellAuthGate.test.tsx
@@ -78,4 +78,13 @@ describe("useShellAuthGate", () => {
     act(() => clearStoredStewardToken());
     expect(result.current).toEqual({ gated: true, phase: "needs-auth" });
   });
+
+  it("distinguishes an unavailable backend from an in-flight auth check", () => {
+    writeStoredStewardToken("opaque-cloud-session");
+    __setAuthStatusForTests({ phase: "server_unavailable" });
+    const { result } = renderHook(() => useShellAuthGate(), {
+      wrapper: wrapperFor(true),
+    });
+    expect(result.current).toEqual({ gated: true, phase: "unavailable" });
+  });
 });

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -314,8 +314,16 @@ vi.mock("../../../voice/useWakeListenWindow", () => ({
 const authGateMock = vi.hoisted(() => ({
   value: {
     gated: false,
-    phase: "clear" as "checking" | "needs-auth" | "clear",
+    phase: "clear" as "checking" | "unavailable" | "needs-auth" | "clear",
   },
+}));
+
+const authStatusMock = vi.hoisted(() => ({
+  revalidate: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  revalidateAuthStatus: authStatusMock.revalidate,
 }));
 
 vi.mock("../useShellAuthGate", () => ({
@@ -338,6 +346,7 @@ afterEach(() => {
   appMock.serverTurnStatus = null;
   appMock.value.sendChatText.mockClear();
   appMock.value.setActionNotice.mockClear();
+  authStatusMock.revalidate.mockClear();
   appMock.value.agentStatus = { ...READY_STATUS };
   appMock.value.handleNewConversation = vi.fn(() => Promise.resolve());
   appMock.value.handleSelectConversation = vi.fn(() => Promise.resolve());
@@ -2505,6 +2514,45 @@ describe("useShellController cloud-only auth gate", () => {
     const { result } = renderHook(() => useShellController());
     expect(result.current.phase).toBe("booting");
     expect(result.current.authGate.gated).toBe(true);
+  });
+
+  it("opens chat while checking but keeps PTT closed and retries auth visibly", () => {
+    authGateMock.value = { gated: true, phase: "checking" };
+    const login = appMock.value.handleInteractiveCloudLogin;
+    login.mockClear();
+    const { result } = renderHook(() => useShellController());
+
+    act(() => result.current.open());
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.phase).toBe("summoned");
+
+    act(() => result.current.startRecording("ptt"));
+    expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+    expect(login).not.toHaveBeenCalled();
+    expect(authStatusMock.revalidate).toHaveBeenCalledTimes(1);
+    expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+      "Checking your Eliza Cloud session. Try push-to-talk again in a moment.",
+      "info",
+      4000,
+    );
+  });
+
+  it("opens chat while Cloud is unavailable and retries PTT with an error", () => {
+    authGateMock.value = { gated: true, phase: "unavailable" };
+    const { result } = renderHook(() => useShellController());
+
+    act(() => result.current.open());
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.phase).toBe("summoned");
+
+    act(() => result.current.startRecording("ptt"));
+    expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+    expect(authStatusMock.revalidate).toHaveBeenCalledTimes(1);
+    expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+      "Unable to reach Eliza Cloud. Retrying the connection.",
+      "error",
+      4000,
+    );
   });
 
   it("surfaces needs-auth and routes open + startRecording to sign-in", () => {

--- a/packages/ui/src/components/shell/shell-auth-gate.ts
+++ b/packages/ui/src/components/shell/shell-auth-gate.ts
@@ -11,7 +11,11 @@ import type { AuthStatusState } from "../../hooks/useAuthStatus";
 import type { ShellPhase } from "./shell-state";
 
 /** Discriminated rest-state of the cloud-only pill auth gate. */
-export type ShellAuthGatePhase = "checking" | "needs-auth" | "clear";
+export type ShellAuthGatePhase =
+  | "checking"
+  | "unavailable"
+  | "needs-auth"
+  | "clear";
 
 export interface ShellAuthGate {
   /** True while capture, overlay summon, and hotkeys must not run. */
@@ -59,6 +63,9 @@ export function deriveShellAuthGate(
   if (input.authPhase === "unauthenticated") {
     return { gated: true, phase: "needs-auth" };
   }
+  if (input.authPhase === "server_unavailable") {
+    return { gated: true, phase: "unavailable" };
+  }
   return { gated: true, phase: "checking" };
 }
 
@@ -74,7 +81,7 @@ export function deriveShellPhase(input: DeriveShellPhaseInput): ShellPhase {
     return "needs-auth";
   }
   if (
-    input.authGate === "checking" &&
+    (input.authGate === "checking" || input.authGate === "unavailable") &&
     !input.isOpen &&
     !input.recording &&
     !input.realtimeVoiceListening &&

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/snapshot.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/snapshot.test.ts
@@ -1,7 +1,11 @@
 /** Snapshot projection + coalescing equality. */
 import { describe, expect, it } from "vitest";
 import type { ShellMessage } from "../../shell-state";
-import { deriveShellControllerSnapshot, snapshotsEqual } from "../snapshot";
+import {
+  deriveShellControllerSnapshot,
+  parseShellControllerSnapshot,
+  snapshotsEqual,
+} from "../snapshot";
 import { baseSnapshot, makeFakeShellController } from "./fixtures";
 
 describe("deriveShellControllerSnapshot", () => {
@@ -22,6 +26,18 @@ describe("deriveShellControllerSnapshot", () => {
       hasNext: false,
       activeId: null,
       index: -1,
+    });
+  });
+});
+
+describe("parseShellControllerSnapshot", () => {
+  it("accepts the unavailable auth-recovery phase across desktop windows", () => {
+    const snapshot = baseSnapshot({
+      authGate: { gated: true, phase: "unavailable" },
+    });
+    expect(parseShellControllerSnapshot(snapshot)?.authGate).toEqual({
+      gated: true,
+      phase: "unavailable",
     });
   });
 });

--- a/packages/ui/src/components/shell/shell-controller-sync/snapshot.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/snapshot.ts
@@ -80,6 +80,7 @@ export function parseShellControllerSnapshot(
     typeof authGate.gated !== "boolean" ||
     !(
       authGate.phase === "checking" ||
+      authGate.phase === "unavailable" ||
       authGate.phase === "needs-auth" ||
       authGate.phase === "clear"
     ) ||

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -31,6 +31,7 @@ import {
   VOICE_CONTROL_EVENT,
   type VoiceControlEventDetail,
 } from "../../events";
+import { revalidateAuthStatus } from "../../hooks/useAuthStatus";
 import { useRealtimeVoiceMint } from "../../hooks/useRealtimeVoiceMint";
 import {
   isRealtimeVoiceFlagEnabled,
@@ -509,6 +510,20 @@ export function useShellController(): ShellController {
         setSigningIn(false);
       });
   }, [authGate.phase, handleInteractiveCloudLogin, setActionNotice]);
+  const recoverGatedCapture = React.useCallback(() => {
+    if (authGate.phase === "needs-auth") {
+      requestSignIn();
+      return;
+    }
+    void revalidateAuthStatus();
+    setActionNotice(
+      authGate.phase === "unavailable"
+        ? "Unable to reach Eliza Cloud. Retrying the connection."
+        : "Checking your Eliza Cloud session. Try push-to-talk again in a moment.",
+      authGate.phase === "unavailable" ? "error" : "info",
+      4000,
+    );
+  }, [authGate.phase, requestSignIn, setActionNotice]);
   // The wake phrase for transcript-mode inline replies follows the character
   // name (issue #9880); falls back to the running agent name, then "eliza".
   const wakeCharacterName =
@@ -1634,7 +1649,7 @@ export function useShellController(): ShellController {
 
   const toggleRecording = React.useCallback(() => {
     if (authGate.gated) {
-      requestSignIn();
+      recoverGatedCapture();
       return;
     }
     if (realtimeVoiceEnabled) {
@@ -1648,7 +1663,7 @@ export function useShellController(): ShellController {
     authGate.gated,
     realtimeVoiceEnabled,
     recording,
-    requestSignIn,
+    recoverGatedCapture,
     startCapture,
     stopCapture,
   ]);
@@ -1736,12 +1751,12 @@ export function useShellController(): ShellController {
   }, []);
 
   const open = React.useCallback(() => {
-    if (authGate.gated) {
+    if (authGate.phase === "needs-auth") {
       requestSignIn();
       return;
     }
     setIsOpen(true);
-  }, [authGate.gated, requestSignIn]);
+  }, [authGate.phase, requestSignIn]);
   const close = React.useCallback(() => {
     setIsOpen(false);
     setHandsFree(false);
@@ -2080,7 +2095,7 @@ export function useShellController(): ShellController {
   // both the mic and any in-flight reply.
   const toggleHandsFree = React.useCallback(() => {
     if (authGate.gated) {
-      requestSignIn();
+      recoverGatedCapture();
       return;
     }
     if (realtimeVoiceEnabled) {
@@ -2141,7 +2156,7 @@ export function useShellController(): ShellController {
     }
   }, [
     authGate.gated,
-    requestSignIn,
+    recoverGatedCapture,
     responding,
     startCapture,
     stopCapture,
@@ -2251,7 +2266,7 @@ export function useShellController(): ShellController {
   // as an attachment the user sends with their next message.
   const toggleTranscriptionMode = React.useCallback(async () => {
     if (authGateRef.current.gated) {
-      requestSignIn();
+      recoverGatedCapture();
       return;
     }
     if (transcriptionModeRef.current) {
@@ -2306,7 +2321,7 @@ export function useShellController(): ShellController {
     beginTranscriptSession,
     finalizeTranscriptSession,
     realtimeVoiceEnabled,
-    requestSignIn,
+    recoverGatedCapture,
   ]);
 
   // The mic button while transcribing: turn the mic (and thus transcript) fully
@@ -2612,19 +2627,19 @@ export function useShellController(): ShellController {
     wasCapturingAtSuspendRef.current = false;
     autoEngagedHandsFreeRef.current = true;
     if (captureRef.current) cancelCapture();
-    if (isOpen) setIsOpen(false);
+    if (authGate.phase === "needs-auth" && isOpen) setIsOpen(false);
     stopRealtimeVoiceRef.current();
-  }, [authGate.gated, cancelCapture, isOpen]);
+  }, [authGate.gated, authGate.phase, cancelCapture, isOpen]);
 
   const startRecording = React.useCallback(
     (intent?: CaptureIntent) => {
       if (authGate.gated) {
-        requestSignIn();
+        recoverGatedCapture();
         return;
       }
       startCapture(intent);
     },
-    [authGate.gated, requestSignIn, startCapture],
+    [authGate.gated, recoverGatedCapture, startCapture],
   );
 
   return {

--- a/packages/ui/src/first-run/first-run-runtime-flag.test.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.test.ts
@@ -62,6 +62,7 @@ describe("isRuntimeChooserEnabled", () => {
 
 describe("resolveRuntimeChooserEnabled", () => {
   const productionDefaults = {
+    isCloudOnlyBuild: false,
     isCloudLockedAndroid: false,
     override: null,
     isViteDev: false,
@@ -110,7 +111,20 @@ describe("resolveRuntimeChooserEnabled", () => {
   it("keeps a cloud-locked Android build disabled under every opt-in", () => {
     expect(
       resolveRuntimeChooserEnabled({
+        isCloudOnlyBuild: false,
         isCloudLockedAndroid: true,
+        override: true,
+        isViteDev: true,
+        isBuildEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps every cloud-only build disabled under every opt-in", () => {
+    expect(
+      resolveRuntimeChooserEnabled({
+        isCloudOnlyBuild: true,
+        isCloudLockedAndroid: false,
         override: true,
         isViteDev: true,
         isBuildEnabled: true,

--- a/packages/ui/src/first-run/first-run-runtime-flag.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.ts
@@ -65,6 +65,7 @@ function readBuildDefault(): boolean {
 
 /** Inputs to the environment-independent runtime-chooser policy. */
 export interface RuntimeChooserGateInputs {
+  isCloudOnlyBuild: boolean;
   isCloudLockedAndroid: boolean;
   override: boolean | null;
   isViteDev: boolean;
@@ -77,12 +78,13 @@ export interface RuntimeChooserGateInputs {
  * override wins over the development and build defaults.
  */
 export function resolveRuntimeChooserEnabled({
+  isCloudOnlyBuild,
   isCloudLockedAndroid,
   override,
   isViteDev,
   isBuildEnabled,
 }: RuntimeChooserGateInputs): boolean {
-  if (isCloudLockedAndroid) return false;
+  if (isCloudOnlyBuild || isCloudLockedAndroid) return false;
   if (override !== null) return override;
   return isViteDev || isBuildEnabled;
 }
@@ -97,8 +99,9 @@ export function resolveRuntimeChooserEnabled({
  * localStorage override; Android local sideloads no longer special-case the
  * production default.
  */
-export function isRuntimeChooserEnabled(): boolean {
+export function isRuntimeChooserEnabled(isCloudOnlyBuild = false): boolean {
   return resolveRuntimeChooserEnabled({
+    isCloudOnlyBuild,
     isCloudLockedAndroid: isAndroidCloudBuild(),
     override: readOverride(),
     isViteDev: readDevMode(),

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -137,6 +137,8 @@ vi.mock("../state/cloud-login-launch", async (importOriginal) => {
 });
 
 import type { ConversationMessage, LocalAgentBackupMetadata } from "../api";
+import { DEFAULT_BRANDING } from "../config/branding-base";
+import { BrandingContext } from "../config/branding-react.hooks";
 import { APP_RESUME_EVENT } from "../events";
 import { __setAppValueForTests } from "../state/app-store";
 import {
@@ -253,7 +255,7 @@ function seedAppStore(overrides: Record<string, unknown> = {}): AppStoreSpies {
  * seeded onboarding turns are observable exactly as the overlay would render
  * them. `setConversationMessages` applies functional updaters for real.
  */
-function renderConductor() {
+function renderConductor(options?: { cloudOnly?: boolean }) {
   const transcript: { current: ConversationMessage[] } = { current: [] };
   const value: ConversationMessagesValue = {
     conversationMessages: [],
@@ -265,7 +267,20 @@ function renderConductor() {
     },
   };
   const wrapper = ({ children }: { children: React.ReactNode }) =>
-    React.createElement(ConversationMessagesCtx.Provider, { value }, children);
+    React.createElement(
+      BrandingContext.Provider,
+      {
+        value: {
+          ...DEFAULT_BRANDING,
+          cloudOnly: options?.cloudOnly === true,
+        },
+      },
+      React.createElement(
+        ConversationMessagesCtx.Provider,
+        { value },
+        children,
+      ),
+    );
   const utils = renderHook(() => useFirstRunConductor(), { wrapper });
   const turn = (id: string): ConversationMessage | undefined =>
     transcript.current.find((message) => message.id === id);
@@ -339,6 +354,20 @@ function writeTestCookie(value: string): void {
 }
 
 describe("useFirstRunConductor", () => {
+  it("keeps cloud-only onboarding locked when a stale developer override enables the chooser", async () => {
+    localStorage.removeItem("steward_session_token");
+    localStorage.setItem("eliza:enable-runtime-chooser", "1");
+    seedAppStore({ elizaCloudConnected: false });
+    const { turn } = renderConductor({ cloudOnly: true });
+
+    const greeting = await waitForTurn(turn, "first-run:greeting");
+    expect(greeting.text).not.toContain("where should your agent run?");
+    const signIn = await waitForTurn(turn, "first-run:cloud-oauth");
+    expect(signIn.text).toContain("Sign in to Eliza Cloud");
+    expect(signIn.text).not.toContain("runtime:local");
+    expect(signIn.text).not.toContain("runtime:remote");
+  });
+
   it("drives the LOCAL path end to end: greeting → runtime → provider → tutorial → completeFirstRun, POSTing exactly once", async () => {
     const spies = seedAppStore();
     const { turn, unmount } = renderConductor();

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -72,6 +72,7 @@ import {
   getCloudAuthToken,
   refreshCloudStewardSession,
 } from "../api/client-cloud";
+import { useBranding } from "../config/branding";
 import { APP_RESUME_EVENT } from "../events";
 import { ACCENT_PRESETS, useAppSelectorShallow } from "../state";
 import { useConversationMessages } from "../state/ConversationMessagesContext.hooks";
@@ -336,7 +337,10 @@ const CLOUD_ONLY_ERROR_CHOICE = [
  * detail for context. The recovery framing tracks the runtime chooser: with the
  * chooser off there is no "different way to run" to offer.
  */
-function finishErrorMessage(message: string): string {
+function finishErrorMessage(
+  message: string,
+  runtimeChooserEnabled: boolean,
+): string {
   const detail = message.trim();
   const isTerse = /^(not found|failed to fetch|forbidden|unauthorized)$/i.test(
     detail,
@@ -344,7 +348,7 @@ function finishErrorMessage(message: string): string {
   const lead = isTerse
     ? `I couldn't finish setting up your agent (${detail}).`
     : `I couldn't finish setting up your agent: ${detail}`;
-  const recovery = isRuntimeChooserEnabled()
+  const recovery = runtimeChooserEnabled
     ? "You can try again, pick a different way to run your agent, or configure a model provider yourself in Settings."
     : "You can try again, or configure a model provider yourself in Settings.";
   return `${lead}\n\n${recovery}`;
@@ -407,14 +411,17 @@ interface FirstRunTurnWriter {
   replaceTurn(id: string, next: ConversationMessage): void;
 }
 
-export function surfaceCloudLoginRetryTurn(writer: FirstRunTurnWriter): void {
+export function surfaceCloudLoginRetryTurn(
+  writer: FirstRunTurnWriter,
+  runtimeChooserEnabled = isRuntimeChooserEnabled(),
+): void {
   // Replacing the turn re-parses its CHOICE block, so the re-offered runtime
   // buttons arrive unlocked even when an earlier pick locked the originals —
   // without this the "pick again" instruction is a dead end (every prior
   // runtime widget locked itself on first tap). In cloud-only mode there is no
   // runtime to re-pick: the retry turn re-offers the single sign-in button
   // (whose tap re-enters the cloud flow with a fresh user gesture).
-  const retryText = isRuntimeChooserEnabled()
+  const retryText = runtimeChooserEnabled
     ? `Sign in to Eliza Cloud to continue. You can also pick how to run your agent again.\n\n${runtimeChoiceBlock()}`
     : CLOUD_SIGN_IN_CHOICE;
   const connectTurn = makeTurn("first-run:cloud-oauth", retryText);
@@ -423,6 +430,8 @@ export function surfaceCloudLoginRetryTurn(writer: FirstRunTurnWriter): void {
 }
 
 export function useFirstRunConductor(): void {
+  const { cloudOnly } = useBranding();
+  const runtimeChooserEnabled = isRuntimeChooserEnabled(cloudOnly === true);
   const {
     firstRunComplete,
     firstRunName,
@@ -618,7 +627,7 @@ export function useFirstRunConductor(): void {
       },
       setTab,
       completeFirstRun: () => {
-        if (isRuntimeChooserEnabled()) {
+        if (runtimeChooserEnabled) {
           seedTutorial();
           return;
         }
@@ -649,6 +658,7 @@ export function useFirstRunConductor(): void {
       seedTutorial,
       completeCloudOnly,
       seedTurn,
+      runtimeChooserEnabled,
     ],
   );
   const portsRef = React.useRef(ports);
@@ -669,11 +679,11 @@ export function useFirstRunConductor(): void {
       seedTurn(
         makeTurn(
           `first-run:error:${Date.now()}`,
-          `${finishErrorMessage(message)}\n\n${isRuntimeChooserEnabled() ? ERROR_CHOICE : CLOUD_ONLY_ERROR_CHOICE}`,
+          `${finishErrorMessage(message, runtimeChooserEnabled)}\n\n${runtimeChooserEnabled ? ERROR_CHOICE : CLOUD_ONLY_ERROR_CHOICE}`,
         ),
       );
     },
-    [seedTurn],
+    [runtimeChooserEnabled, seedTurn],
   );
 
   // Explicit, non-finish escape hatch out of onboarding: flip the real gate and
@@ -701,7 +711,7 @@ export function useFirstRunConductor(): void {
       );
       // Cloud-only mode has no runtime to go back to; only offer the back
       // affordance when the chooser owns this flow.
-      if (isRuntimeChooserEnabled()) {
+      if (runtimeChooserEnabled) {
         lines.push(BACK_TO_RUNTIME_OPTION);
       }
       seedFreshChoiceTurn(
@@ -709,7 +719,7 @@ export function useFirstRunConductor(): void {
         `Which Eliza Cloud agent should I use?\n\n[CHOICE:first-run id=cloud-agent]\n${lines.join("\n")}\n[/CHOICE]`,
       );
     },
-    [seedFreshChoiceTurn],
+    [runtimeChooserEnabled, seedFreshChoiceTurn],
   );
 
   // Armed by a needs-cloud-login outcome; consumed by the auto-resume effect
@@ -737,7 +747,7 @@ export function useFirstRunConductor(): void {
           // provisioning's completeFirstRun port already ran the wrap-up
           // (tutorial offer, or the cloud-only real completion).
           if (!provisionedRef.current) {
-            if (isRuntimeChooserEnabled()) seedTutorial();
+            if (runtimeChooserEnabled) seedTutorial();
             else completeCloudOnly();
           }
           return;
@@ -749,7 +759,7 @@ export function useFirstRunConductor(): void {
           // Compatibility path for any legacy/stale picker outcome. The main
           // Cloud first-run path now binds the best healthy agent directly so
           // onboarding stays a single sign-in flow.
-          if (!isRuntimeChooserEnabled()) {
+          if (!runtimeChooserEnabled) {
             const first = outcome.agents[0]?.agent_id;
             if (outcome.agents.length === 1 && first) {
               bindCloudAgentByIdRef.current?.(first);
@@ -780,7 +790,10 @@ export function useFirstRunConductor(): void {
           // Asking for a sign-in ends a silent entry: the session turned out
           // not to be usable, so the flow is back to the visible ask path.
           silentCloudEntryRef.current = false;
-          surfaceCloudLoginRetryTurn({ seedTurn, replaceTurn });
+          surfaceCloudLoginRetryTurn(
+            { seedTurn, replaceTurn },
+            runtimeChooserEnabled,
+          );
           return;
         }
         case "error":
@@ -795,6 +808,7 @@ export function useFirstRunConductor(): void {
       seedTurn,
       replaceTurn,
       seedError,
+      runtimeChooserEnabled,
     ],
   );
 
@@ -1056,7 +1070,7 @@ export function useFirstRunConductor(): void {
       // can only be a stale widget from a chooser-mode transcript (or
       // garbage) — consume those untouched so they can't start a local/remote
       // flow (there is no runtime chooser to go "back" to).
-      if (!isRuntimeChooserEnabled()) {
+      if (!runtimeChooserEnabled) {
         if (
           group === "provider" ||
           group === "backup-restore" ||
@@ -1294,7 +1308,7 @@ export function useFirstRunConductor(): void {
           exitToSettings();
           return true;
         }
-        if (id === "restart" && isRuntimeChooserEnabled()) {
+        if (id === "restart" && runtimeChooserEnabled) {
           // Re-offer a FRESH (unlocked) runtime choice so the user can switch
           // how their agent runs after a failed finish — unwinding whatever
           // the failed local path committed first (#14390), so switching to
@@ -1355,6 +1369,7 @@ export function useFirstRunConductor(): void {
       startCloudProvisionFlow,
       startProviderFinish,
       setUiAccent,
+      runtimeChooserEnabled,
     ],
   );
   const handleActionRef = React.useRef(handleFirstRunAction);
@@ -1381,7 +1396,7 @@ export function useFirstRunConductor(): void {
             ? FIRST_RUN_TEXT_REPLY.wrapUp
             : erroredRef.current
               ? FIRST_RUN_TEXT_REPLY.error
-              : isRuntimeChooserEnabled()
+              : runtimeChooserEnabled
                 ? FIRST_RUN_TEXT_REPLY.choosing
                 : FIRST_RUN_TEXT_REPLY.signIn;
       textTurnSeqRef.current += 1;
@@ -1396,7 +1411,7 @@ export function useFirstRunConductor(): void {
       seedTurn(makeTurn(`first-run:reply:${seq}`, reply));
       return true;
     },
-    [seedTurn],
+    [runtimeChooserEnabled, seedTurn],
   );
   const handleTextRef = React.useRef(handleFirstRunText);
   handleTextRef.current = handleFirstRunText;
@@ -1445,7 +1460,7 @@ export function useFirstRunConductor(): void {
     // is needed — any stale chooser-mode marker is dropped. The local-backup
     // restore probe is skipped: restoring a local agent is a chooser-mode
     // concept.
-    if (!isRuntimeChooserEnabled()) {
+    if (!runtimeChooserEnabled) {
       clearCloudLoginPending();
       draftRef.current = {
         ...draftRef.current,
@@ -1622,6 +1637,7 @@ export function useFirstRunConductor(): void {
     seedRuntimeChoice,
     seedTurn,
     setConversationMessages,
+    runtimeChooserEnabled,
   ]);
 }
 

--- a/packages/ui/src/hooks/useAuthStatus.ts
+++ b/packages/ui/src/hooks/useAuthStatus.ts
@@ -295,6 +295,11 @@ export function subscribeAuthStatus(
   };
 }
 
+/** Force the shared auth probe to run now and publish its resolved state. */
+export function revalidateAuthStatus(): Promise<void> {
+  return fetchAuthStatus();
+}
+
 /**
  * Test/story seam for the #11084 auth gate: publish a synthetic status into the
  * shared snapshot (and to subscribers) so `useIsAuthenticated`-gated loaders


### PR DESCRIPTION
# Relates to

Follow-up to #21124. Fixes the logged-in auth-checking dead zone and prevents the generic runtime chooser from leaking into cloud-only desktop builds.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - local contribute-to-eliza workflow; external receipt path prohibited by repository instructions`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` not run; focused verification is listed below.

# Risks

Medium, scoped to cloud-only first-run/auth recovery and desktop chat/PTT routing. Microphone capture remains blocked until authentication is verified.

# Background

## What does this PR do?

- Splits short-lived auth checking from terminal backend unavailability.
- Allows the chat overlay to open while Cloud authentication is checking or unavailable.
- Keeps Fn, pill hold, and microphone controls blocked until auth is verified.
- Makes blocked PTT trigger auth revalidation and visible recovery feedback instead of silently returning.
- Mounts the existing action-notice surface in the detached chat overlay.
- Makes `cloudOnly` an absolute runtime-chooser lock, overriding stale developer localStorage/build flags.
- Prevents local and remote onboarding options from appearing anywhere in a cloud-only flow.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No external documentation change required. Source contracts and regression tests were updated.

# Testing

- 209 focused UI/auth/first-run tests passed after rebase.
- `packages/ui` typecheck passed.
- `packages/ui` lint passed with 8 pre-existing cookie warnings.
- Cloud-only macOS desktop build passed, build ID `bfd228f2a6ce`.
- Native Computer Use QA against the original unreachable-backend state:
  - pill click opens the chat overlay;
  - blocked microphone/PTT remains off and displays recovery feedback;
  - with `cloudOnly=true` and `eliza:enable-runtime-chooser=1`, no local/remote choices render;
  - signed-out surface is only `Sign in with Eliza Cloud`.

# Evidence Gate

<!-- evidence-head:725656403a -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshot captured in the originating task; pending GitHub upload.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots captured through native Computer Use; pending GitHub upload.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video not yet attached.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend behavior changed; the repro intentionally used an unreachable backend.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend state and accessible output inspected live; logs not yet attached.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no data/domain artifacts changed.
<!-- evidence-row:ocr-review -->
- [ ] Full visual audit was stopped at the operator's request; native accessible text verified directly.

# Known gaps / failures

- The repository visual audit reached 198 passing captures before the operator stopped the long run. It was not restarted after the final cloud-only chooser policy change.
- The five pre-existing untracked app asset files were not staged or modified by this PR.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - local workflow, repository-forbidden external receipt path omitted
Attribution status: self-reported
— codex-cloud-recovery
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex-desktop","skill_revision":"N/A-local-workflow"} -->
