### PR TITLE
fix(release): accept fast-forwarded develop in source binding

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,6 +83,23 @@ jobs:
             exit 1
           fi
 
+          # The dispatch binds one commit: the run SHA, declared source SHA,
+          # and workflow SHA must be the same commit of refs/heads/develop.
+          # That commit does not have to still be the live head — under
+          # continuous merge traffic the queue delay would make an exact
+          # head pin unsatisfiable — but it must be genuine develop history
+          # (ancestor of the live head) and its release workflow must be
+          # byte-identical to the live head's, so a stale dispatch cannot
+          # run superseded release logic.
+          if [ "$OBSERVED_SOURCE_SHA" != "$OBSERVED_SHA" ]; then
+            echo "::error::Release source SHA is $OBSERVED_SOURCE_SHA, dispatch bound $OBSERVED_SHA."
+            exit 1
+          fi
+          if [ "$OBSERVED_WORKFLOW_SHA" != "$OBSERVED_SHA" ]; then
+            echo "::error::Release workflow SHA is $OBSERVED_WORKFLOW_SHA, dispatch bound $OBSERVED_SHA."
+            exit 1
+          fi
+
           protected_sha="$({
             curl --fail-with-body --silent --show-error \
               --header 'Accept: application/vnd.github+json' \
@@ -100,19 +117,52 @@ jobs:
             });
           ')"
           if [ "$OBSERVED_SHA" != "$protected_sha" ]; then
-            echo "::error::Release caller SHA is $OBSERVED_SHA, current protected develop is $protected_sha."
-            exit 1
+            ancestry_status="$({
+              curl --fail-with-body --silent --show-error \
+                --header 'Accept: application/vnd.github+json' \
+                --header "Authorization: Bearer $API_TOKEN" \
+                --header 'X-GitHub-Api-Version: 2022-11-28' \
+                "${GITHUB_API_URL}/repos/${EXPECTED_REPOSITORY}/compare/${OBSERVED_SHA}...${protected_sha}"
+            } | node -e '
+              let source = "";
+              process.stdin.setEncoding("utf8");
+              process.stdin.on("data", (chunk) => { source += chunk; });
+              process.stdin.on("end", () => {
+                const value = JSON.parse(source)?.status;
+                if (typeof value !== "string") process.exit(1);
+                process.stdout.write(value);
+              });
+            ')"
+            if [ "$ancestry_status" != "ahead" ] && [ "$ancestry_status" != "identical" ]; then
+              echo "::error::Release SHA $OBSERVED_SHA is not reachable from protected develop head $protected_sha (compare status: $ancestry_status)."
+              exit 1
+            fi
+            workflow_blob_at() {
+              curl --fail-with-body --silent --show-error \
+                --header 'Accept: application/vnd.github+json' \
+                --header "Authorization: Bearer $API_TOKEN" \
+                --header 'X-GitHub-Api-Version: 2022-11-28' \
+                "${GITHUB_API_URL}/repos/${EXPECTED_REPOSITORY}/contents/.github/workflows/release.yaml?ref=$1" \
+              | node -e '
+                let source = "";
+                process.stdin.setEncoding("utf8");
+                process.stdin.on("data", (chunk) => { source += chunk; });
+                process.stdin.on("end", () => {
+                  const value = JSON.parse(source)?.sha;
+                  if (typeof value !== "string" || !/^[0-9a-f]{40}$/.test(value)) process.exit(1);
+                  process.stdout.write(value);
+                });
+              '
+            }
+            dispatched_workflow_blob="$(workflow_blob_at "$OBSERVED_SHA")"
+            protected_workflow_blob="$(workflow_blob_at "$protected_sha")"
+            if [ "$dispatched_workflow_blob" != "$protected_workflow_blob" ]; then
+              echo "::error::Release workflow at $OBSERVED_SHA no longer matches protected develop head $protected_sha; re-dispatch from the current head."
+              exit 1
+            fi
           fi
-          if [ "$OBSERVED_SOURCE_SHA" != "$protected_sha" ]; then
-            echo "::error::Release source SHA is $OBSERVED_SOURCE_SHA, current protected develop is $protected_sha."
-            exit 1
-          fi
-          if [ "$OBSERVED_WORKFLOW_SHA" != "$protected_sha" ]; then
-            echo "::error::Release workflow SHA is $OBSERVED_WORKFLOW_SHA, current protected develop is $protected_sha."
-            exit 1
-          fi
-          echo "tooling_sha=$protected_sha" >> "$GITHUB_OUTPUT"
-          echo "Protected release tooling: $protected_sha" >> "$GITHUB_STEP_SUMMARY"
+          echo "tooling_sha=$OBSERVED_SHA" >> "$GITHUB_OUTPUT"
+          echo "Protected release tooling: $OBSERVED_SHA (develop head at verification: $protected_sha)" >> "$GITHUB_STEP_SUMMARY"
 
   candidate:
     name: Build immutable candidate

--- a/packages/scripts/__tests__/release-git.integration.test.ts
+++ b/packages/scripts/__tests__/release-git.integration.test.ts
@@ -199,10 +199,66 @@ describe("atomic release refs", () => {
         sourceRef: "refs/heads/missing",
         sourceSha: fixture.releaseSha,
       }),
-    ).toThrow("resolves to null");
+    ).toThrow("is missing on remote");
     expect(remoteRefs(fixture.repoRoot, fixture.remote)).not.toContain(
       "refs/tags/",
     );
+  });
+
+  test("accepts a source the ref fast-forwarded past and rejects divergent history", () => {
+    const fixture = makeScenario();
+    git(fixture.repoRoot, [
+      "push",
+      fixture.remote,
+      `${fixture.releaseSha}:refs/heads/develop`,
+    ]);
+    fs.writeFileSync(path.join(fixture.repoRoot, "later.txt"), "later\n");
+    git(fixture.repoRoot, ["add", "."]);
+    git(fixture.repoRoot, ["commit", "-m", "later merge traffic"]);
+    const laterSha = git(fixture.repoRoot, ["rev-parse", "HEAD"]);
+    git(fixture.repoRoot, [
+      "push",
+      fixture.remote,
+      `${laterSha}:refs/heads/develop`,
+    ]);
+    git(fixture.repoRoot, ["checkout", "--quiet", fixture.releaseSha]);
+    expect(
+      verifyReleaseSource({
+        repoRoot: fixture.repoRoot,
+        remote: fixture.remote,
+        repository: "elizaOS/eliza",
+        sourceRef: "refs/heads/develop",
+        sourceSha: fixture.releaseSha,
+      }),
+    ).toMatchObject({ sourceSha: fixture.releaseSha });
+
+    git(fixture.repoRoot, [
+      "checkout",
+      "--quiet",
+      "-b",
+      "divergent",
+      fixture.baseSha,
+    ]);
+    fs.writeFileSync(path.join(fixture.repoRoot, "divergent.txt"), "other\n");
+    git(fixture.repoRoot, ["add", "."]);
+    git(fixture.repoRoot, ["commit", "-m", "divergent history"]);
+    const divergentSha = git(fixture.repoRoot, ["rev-parse", "HEAD"]);
+    git(fixture.repoRoot, [
+      "push",
+      "--force",
+      fixture.remote,
+      `${divergentSha}:refs/heads/develop`,
+    ]);
+    git(fixture.repoRoot, ["checkout", "--quiet", fixture.releaseSha]);
+    expect(() =>
+      verifyReleaseSource({
+        repoRoot: fixture.repoRoot,
+        remote: fixture.remote,
+        repository: "elizaOS/eliza",
+        sourceRef: "refs/heads/develop",
+        sourceSha: fixture.releaseSha,
+      }),
+    ).toThrow("is not its descendant");
   }, 120_000);
 
   test("one rejected ref rejects the entire atomic push and no unrelated tag follows", () => {

--- a/packages/scripts/lib/release-git.mjs
+++ b/packages/scripts/lib/release-git.mjs
@@ -336,7 +336,12 @@ function assertRemoteCanonicalTag(
   return true;
 }
 
-/** Prove an exact checked-out source SHA is the tip of its named repository ref. */
+/**
+ * Prove an exact checked-out source SHA is genuine history of its named
+ * repository ref: either the ref's current tip, or — because merge traffic
+ * routinely advances the ref while a release run is queued — an ancestor the
+ * tip fast-forwarded away from. A SHA the ref cannot reach fails closed.
+ */
 export function verifyReleaseSource({
   repoRoot,
   remote,
@@ -358,10 +363,12 @@ export function verifyReleaseSource({
     runGit(repoRoot, ["ls-remote", "--", remote, expectedRef]),
   );
   const actualRefCommit = refs.get(expectedRef) || null;
+  if (!actualRefCommit) {
+    throw new Error(`Release source ref ${expectedRef} is missing on remote`);
+  }
   if (actualRefCommit !== expectedCommit) {
-    throw new Error(
-      `Release source ref ${expectedRef} resolves to ${actualRefCommit}, expected ${expectedCommit}`,
-    );
+    runGit(repoRoot, ["fetch", "--no-tags", "--quiet", remote, expectedRef]);
+    assertFastForward(repoRoot, expectedCommit, actualRefCommit);
   }
   return {
     repository: expectedRepository,


### PR DESCRIPTION
Follow-up to #21132. The authorize job now tolerates the ref advancing while a release run is queued, but `verifyReleaseSource` (the "Bind source ref and repository" step) still pinned the dispatched SHA to the exact remote tip — run 32015741469 passed authorize and then failed this binding minutes later when the next merge landed.

The binding now mirrors the existing `assertSourceStillReachable` idiom: if the ref moved, fetch and prove the source SHA is an ancestor of the new tip (`git merge-base --is-ancestor`); divergent or force-rewritten history still fails closed, as does a missing ref.

Evidence: release-git integration suite extended with both paths (fast-forwarded tip accepted, divergent tip rejected) — 11 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)