### PR TITLE
fix(personal-assistant): reject malformed graph route IDs

### DIFF
--- a/plugins/plugin-personal-assistant/src/routes/entities.ts
+++ b/plugins/plugin-personal-assistant/src/routes/entities.ts
@@ -167,13 +167,18 @@ export async function handleEntityRoutes(
     /^\/api\/lifeops\/entities\/([^/]+)\/identities$/,
   );
   if (method === "POST" && identitiesMatch) {
-    const store = makeStore(ctx);
-    if (!store) return true;
-    const entityId = decodeURIComponent(identitiesMatch[1] ?? "");
+    const entityId = ctx.decodePathComponent(
+      identitiesMatch[1] ?? "",
+      res,
+      "entity id",
+    );
+    if (entityId === null) return true;
     if (!entityId) {
       ctx.error(res, "entity id required", 400);
       return true;
     }
+    const store = makeStore(ctx);
+    if (!store) return true;
     const body = await readJsonBody<{
       platform?: unknown;
       handle?: unknown;
@@ -212,13 +217,18 @@ export async function handleEntityRoutes(
   // PATCH /api/lifeops/entities/:id
   const patchMatch = pathname.match(/^\/api\/lifeops\/entities\/([^/]+)$/);
   if (method === "PATCH" && patchMatch) {
-    const store = makeStore(ctx);
-    if (!store) return true;
-    const entityId = decodeURIComponent(patchMatch[1] ?? "");
+    const entityId = ctx.decodePathComponent(
+      patchMatch[1] ?? "",
+      res,
+      "entity id",
+    );
+    if (entityId === null) return true;
     if (!entityId) {
       ctx.error(res, "entity id required", 400);
       return true;
     }
+    const store = makeStore(ctx);
+    if (!store) return true;
     const existing = await store.get(entityId);
     if (!existing) {
       ctx.error(res, "entity not found", 404);
@@ -245,13 +255,18 @@ export async function handleEntityRoutes(
   // GET /api/lifeops/entities/:id
   const getOneMatch = pathname.match(/^\/api\/lifeops\/entities\/([^/]+)$/);
   if (method === "GET" && getOneMatch) {
-    const store = makeStore(ctx);
-    if (!store) return true;
-    const entityId = decodeURIComponent(getOneMatch[1] ?? "");
+    const entityId = ctx.decodePathComponent(
+      getOneMatch[1] ?? "",
+      res,
+      "entity id",
+    );
+    if (entityId === null) return true;
     if (!entityId) {
       ctx.error(res, "entity id required", 400);
       return true;
     }
+    const store = makeStore(ctx);
+    if (!store) return true;
     const entity = await store.get(entityId);
     if (!entity) {
       ctx.error(res, "entity not found", 404);

--- a/plugins/plugin-personal-assistant/src/routes/entity-relationship-route-encoding.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/entity-relationship-route-encoding.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Deterministic route-boundary coverage verifies malformed entity and
+ * relationship IDs fail with a structured 400 before knowledge-graph or body
+ * work, while valid encoded IDs still reach the real handler contract.
+ */
+
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import { decodePathComponent } from "@elizaos/agent/api/server-helpers";
+import type { AgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleEntityRoutes } from "./entities.js";
+import type { LifeOpsRouteContext } from "./lifeops-routes.js";
+import { handleRelationshipRoutes } from "./relationships.js";
+
+const graph = vi.hoisted(() => {
+  const entityStore = {
+    get: vi.fn(),
+    list: vi.fn(),
+    merge: vi.fn(),
+    observeIdentity: vi.fn(),
+    resolve: vi.fn(),
+    upsert: vi.fn(),
+  };
+  const relationshipStore = {
+    get: vi.fn(),
+    list: vi.fn(),
+    observe: vi.fn(),
+    retire: vi.fn(),
+    upsert: vi.fn(),
+  };
+  const service = {
+    getEntityStore: vi.fn(() => entityStore),
+    getRelationshipStore: vi.fn(() => relationshipStore),
+  };
+  return {
+    entityStore,
+    relationshipStore,
+    resolve: vi.fn(() => service),
+    service,
+  };
+});
+
+vi.mock("@elizaos/agent", () => ({
+  resolveKnowledgeGraphService: graph.resolve,
+}));
+
+interface CapturedResponse {
+  body: string;
+  ended: boolean;
+  statusCode: number;
+}
+
+function buildContext(options: {
+  body?: object;
+  method: string;
+  pathname: string;
+}): {
+  ctx: LifeOpsRouteContext;
+  readJsonBody: ReturnType<typeof vi.fn>;
+  response: CapturedResponse;
+} {
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", {
+    configurable: true,
+    value: "127.0.0.1",
+  });
+  const req = new IncomingMessage(socket);
+  req.method = options.method;
+  req.url = options.pathname;
+
+  const captured: CapturedResponse = {
+    body: "",
+    ended: false,
+    statusCode: 200,
+  };
+  const res = new ServerResponse(req);
+  res.end = function end(
+    this: ServerResponse,
+    chunk?: unknown,
+    encodingOrCallback?: BufferEncoding | (() => void),
+    callback?: () => void,
+  ): ServerResponse {
+    captured.body =
+      chunk === undefined
+        ? ""
+        : Buffer.isBuffer(chunk)
+          ? chunk.toString("utf8")
+          : String(chunk);
+    captured.ended = true;
+    captured.statusCode = this.statusCode;
+    const done =
+      typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+    done?.();
+    return this;
+  };
+
+  const readJsonBody = vi.fn(async () => options.body ?? {});
+  const ctx: LifeOpsRouteContext = {
+    req,
+    res,
+    method: options.method,
+    pathname: options.pathname,
+    url: new URL(options.pathname, "http://localhost"),
+    state: {
+      adminEntityId: null,
+      runtime: { agentId: "agent-1" } as unknown as AgentRuntime,
+    },
+    json(response, data, status = 200) {
+      response.statusCode = status;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify(data));
+    },
+    error(response, message, status = 400) {
+      response.statusCode = status;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ error: message }));
+    },
+    readJsonBody:
+      readJsonBody as unknown as LifeOpsRouteContext["readJsonBody"],
+    decodePathComponent,
+  };
+  return { ctx, readJsonBody, response: captured };
+}
+
+const routeCases = [
+  {
+    domain: "entity",
+    handle: handleEntityRoutes,
+    label: "entity id",
+    method: "POST",
+    path: (segment: string) => `/api/lifeops/entities/${segment}/identities`,
+  },
+  {
+    domain: "entity",
+    handle: handleEntityRoutes,
+    label: "entity id",
+    method: "PATCH",
+    path: (segment: string) => `/api/lifeops/entities/${segment}`,
+  },
+  {
+    domain: "entity",
+    handle: handleEntityRoutes,
+    label: "entity id",
+    method: "GET",
+    path: (segment: string) => `/api/lifeops/entities/${segment}`,
+  },
+  {
+    domain: "relationship",
+    handle: handleRelationshipRoutes,
+    label: "relationship id",
+    method: "POST",
+    path: (segment: string) => `/api/lifeops/relationships/${segment}/retire`,
+  },
+  {
+    domain: "relationship",
+    handle: handleRelationshipRoutes,
+    label: "relationship id",
+    method: "PATCH",
+    path: (segment: string) => `/api/lifeops/relationships/${segment}`,
+  },
+  {
+    domain: "relationship",
+    handle: handleRelationshipRoutes,
+    label: "relationship id",
+    method: "GET",
+    path: (segment: string) => `/api/lifeops/relationships/${segment}`,
+  },
+] as const;
+
+describe("entity and relationship item-route encoding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  for (const routeCase of routeCases) {
+    it.each(["%", "%E0%A4"])(
+      `rejects ${routeCase.method} ${routeCase.domain} segment %s before downstream work`,
+      async (segment) => {
+        const { ctx, readJsonBody, response } = buildContext({
+          method: routeCase.method,
+          pathname: routeCase.path(segment),
+        });
+
+        await expect(routeCase.handle(ctx)).resolves.toBe(true);
+
+        expect(response.statusCode).toBe(400);
+        expect(JSON.parse(response.body)).toEqual({
+          error: `Invalid ${routeCase.label}: malformed URL encoding`,
+        });
+        expect(graph.resolve).not.toHaveBeenCalled();
+        expect(graph.service.getEntityStore).not.toHaveBeenCalled();
+        expect(graph.service.getRelationshipStore).not.toHaveBeenCalled();
+        expect(readJsonBody).not.toHaveBeenCalled();
+      },
+    );
+  }
+
+  it("decodes a valid entity ID before entity lookup", async () => {
+    graph.entityStore.get.mockResolvedValueOnce({ entityId: "entity one" });
+    const { ctx, response } = buildContext({
+      method: "GET",
+      pathname: "/api/lifeops/entities/entity%20one",
+    });
+
+    await expect(handleEntityRoutes(ctx)).resolves.toBe(true);
+
+    expect(graph.entityStore.get).toHaveBeenCalledWith("entity one");
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      entity: { entityId: "entity one" },
+    });
+  });
+
+  it("decodes a valid relationship ID before relationship lookup", async () => {
+    graph.relationshipStore.get.mockResolvedValueOnce({
+      relationshipId: "relationship one",
+    });
+    const { ctx, response } = buildContext({
+      method: "GET",
+      pathname: "/api/lifeops/relationships/relationship%20one",
+    });
+
+    await expect(handleRelationshipRoutes(ctx)).resolves.toBe(true);
+
+    expect(graph.relationshipStore.get).toHaveBeenCalledWith(
+      "relationship one",
+    );
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      relationship: { relationshipId: "relationship one" },
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/routes/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.ts
@@ -13,6 +13,7 @@
 import type http from "node:http";
 import { TLSSocket } from "node:tls";
 import { handleConnectorAccountRoutes } from "@elizaos/agent/api/connector-account-routes";
+import { decodePathComponent } from "@elizaos/agent/api/server-helpers";
 import {
   ensureRouteAuthorized,
   ensureSessionForRequest,
@@ -55,19 +56,6 @@ function json(res: http.ServerResponse, data: unknown, status = 200): void {
 
 function error(res: http.ServerResponse, message: string, status = 400): void {
   httpSendJsonError(res, message, status);
-}
-
-function httpDecodePathComponent(
-  raw: string,
-  res: http.ServerResponse,
-  fieldName: string,
-): string | null {
-  try {
-    return decodeURIComponent(raw);
-  } catch {
-    httpSendJsonError(res, `Invalid ${fieldName}: malformed URL encoding`, 400);
-    return null;
-  }
 }
 
 function firstHeaderValue(value: string | string[] | undefined): string | null {
@@ -204,7 +192,7 @@ function buildLifeOpsContext(
     json,
     error,
     readJsonBody: httpReadJsonBody,
-    decodePathComponent: httpDecodePathComponent,
+    decodePathComponent,
   };
 }
 

--- a/plugins/plugin-personal-assistant/src/routes/relationships.ts
+++ b/plugins/plugin-personal-assistant/src/routes/relationships.ts
@@ -146,13 +146,18 @@ export async function handleRelationshipRoutes(
     /^\/api\/lifeops\/relationships\/([^/]+)\/retire$/,
   );
   if (method === "POST" && retireMatch) {
-    const store = makeStore(ctx);
-    if (!store) return true;
-    const relationshipId = decodeURIComponent(retireMatch[1] ?? "");
+    const relationshipId = ctx.decodePathComponent(
+      retireMatch[1] ?? "",
+      res,
+      "relationship id",
+    );
+    if (relationshipId === null) return true;
     if (!relationshipId) {
       ctx.error(res, "relationship id required", 400);
       return true;
     }
+    const store = makeStore(ctx);
+    if (!store) return true;
     const body = await readJsonBody<{ reason?: unknown }>(req, res);
     if (!body) return true;
     await store.retire(relationshipId, asString(body.reason, "manual_retire"));
@@ -163,13 +168,18 @@ export async function handleRelationshipRoutes(
   // PATCH /api/lifeops/relationships/:id
   const patchMatch = pathname.match(/^\/api\/lifeops\/relationships\/([^/]+)$/);
   if (method === "PATCH" && patchMatch) {
-    const store = makeStore(ctx);
-    if (!store) return true;
-    const relationshipId = decodeURIComponent(patchMatch[1] ?? "");
+    const relationshipId = ctx.decodePathComponent(
+      patchMatch[1] ?? "",
+      res,
+      "relationship id",
+    );
+    if (relationshipId === null) return true;
     if (!relationshipId) {
       ctx.error(res, "relationship id required", 400);
       return true;
     }
+    const store = makeStore(ctx);
+    if (!store) return true;
     const existing = await store.get(relationshipId);
     if (!existing) {
       ctx.error(res, "relationship not found", 404);
@@ -202,13 +212,18 @@ export async function handleRelationshipRoutes(
     /^\/api\/lifeops\/relationships\/([^/]+)$/,
   );
   if (method === "GET" && getOneMatch) {
-    const store = makeStore(ctx);
-    if (!store) return true;
-    const relationshipId = decodeURIComponent(getOneMatch[1] ?? "");
+    const relationshipId = ctx.decodePathComponent(
+      getOneMatch[1] ?? "",
+      res,
+      "relationship id",
+    );
+    if (relationshipId === null) return true;
     if (!relationshipId) {
       ctx.error(res, "relationship id required", 400);
       return true;
     }
+    const store = makeStore(ctx);
+    if (!store) return true;
     const relationship = await store.get(relationshipId);
     if (!relationship) {
       ctx.error(res, "relationship not found", 404);

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -82,6 +82,9 @@ const agentSourceJsToTsPlugin = {
     if (source === "@elizaos/agent/api/connector-account-routes") {
       return path.join(agentSourceRoot, "api", "connector-account-routes.ts");
     }
+    if (source === "@elizaos/agent/api/server-helpers") {
+      return path.join(agentSourceRoot, "api", "server-helpers.ts");
+    }
     if (source === "@elizaos/ui") {
       return path.join(lifeopsTestStubsRoot, "ui.ts");
     }
@@ -273,6 +276,10 @@ export default defineConfig({
           "api",
           "connector-account-routes.ts",
         ),
+      },
+      {
+        find: /^@elizaos\/agent\/api\/server-helpers$/,
+        replacement: path.join(agentSourceRoot, "api", "server-helpers.ts"),
       },
       {
         find: /^@elizaos\/app-core\/platform\/native-library-policy$/,


### PR DESCRIPTION
# Relates to

Closes #21116.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      Windows toolchain blocker is recorded below.
- [x] A reviewer can confirm the behavior from the deterministic route matrix
      and command results below without reverse-engineering the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@41da41dae54a3c862efc366b795ba6e46e439d8c`; zero conflicts.
- [x] `bun run verify` was run post-sync; the exact unrelated Turbo/Bun discovery
      blocker is documented in **Known gaps / failures**.

# Risks

Low. This changes only personal-assistant entity/relationship HTTP path decoding
and focused test resolution. Valid encoded IDs keep their existing behavior;
malformed percent encoding now receives a bounded 400 response before any graph
store or request-body work.

# Background

## What does this PR do?

- Reuses Agent's canonical `decodePathComponent` transport helper instead of a
  plugin-local decoder.
- Rejects malformed entity and relationship path IDs across all six dynamic
  route shapes before graph-service/store access or body parsing.
- Adds a 12-case malformed-encoding matrix (`%` and truncated UTF-8 for every
  route shape) plus valid encoded entity/relationship controls.
- Adds the exact Agent helper subpath to the personal-assistant Vitest resolver
  so tests exercise production decoding rather than the broad Agent test stub.

## What kind of change is this?

Bug fix (non-breaking validation hardening).

# Documentation changes needed?

No. This aligns malformed transport input with the existing Agent HTTP contract
and does not change a documented user workflow or public success response.

# Testing

## Where should a reviewer start?

`plugins/plugin-personal-assistant/src/routes/entity-relationship-route-encoding.test.ts`
contains the complete malformed/valid route matrix. The corresponding guards are
in `entities.ts` and `relationships.ts`; `plugin.ts` delegates to the canonical
Agent decoder.

## Detailed testing steps

Exact head: `3566eae7a3647efac48fc0f7fb567046747570e7`

1. `bun install --frozen-lockfile --ignore-scripts`
   - PASS: 3,809 installs / 4,090 packages, no changes.
2. `bun run test -- src/routes/entity-relationship-route-encoding.test.ts src/routes/entities-limit-query.test.ts src/routes/plugin.test.ts`
   - PASS: 3 files, 35 tests.
3. `bun run typecheck`
   - PASS.
4. `bun x --no-install @biomejs/biome check .`
   - PASS: 1,663 files, no fixes.
5. `bun x --no-install @biomejs/biome format .`
   - PASS: 1,662 files, no fixes.
6. `bun run build`
   - PASS: JS bundle and declaration build.
7. `git diff --check`
   - PASS.
8. `bun run verify`
   - Reaches repository preflight, dependency-reference, i18n, alias-read, and
     generated-source gates, then stops before package typecheck/lint fan-out
     because Turbo 2.10.8 cannot rediscover the workspace-bundled Windows Bun
     executable (`Unable to find package manager binary: cannot find binary path`).

# Evidence Gate

<!-- evidence-head:65858297df286da7a46735ba267fcd0241de0d98 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side route validation only; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side route validation only; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic HTTP handler behavior with no visual interaction.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend or credential is required; the real route handlers
      are exercised directly and assert that malformed input causes zero graph
      service/store/body work.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request state, or rendered surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, model, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - malformed requests are rejected before graph persistence; the proof
      is the deterministic route response/side-effect matrix above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no UI or visual-text surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model path changes.

## Backend + frontend logs

Deterministic backend-boundary result on the exact head:

```text
Test Files  3 passed (3)
Tests       35 passed (35)
```

The malformed matrix verifies exact 400 JSON and zero graph-service resolution,
store access, and request-body parsing. The valid controls verify decoded IDs
reach the entity and relationship stores.

Frontend logs: N/A - no frontend code path changes.

## Screenshots (before / after) + video walkthrough

N/A - server-side route validation only; no rendered surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changes.

## Known gaps / failures

- Exact-head root `bun run verify` cannot enter Turbo's package fan-out in this
  isolated Windows worktree because Turbo reports `Unable to find package manager
  binary: cannot find binary path` even though pinned Bun 1.3.14 runs the command
  and all pre-Turbo repository gates pass. The owning package's focused tests,
  typecheck, Biome checks, build, frozen install, and diff-check all pass.
- A broader personal-assistant suite on the identical change before the final
  base-only rebase reported 2,016 passing tests. Its remaining Windows failures
  were unrelated environment assumptions (`@elizaos/core/testing` resolution,
  symlink EPERM, and POSIX/file-URL fixtures); the changed route suite was green.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-pa-route-decoder]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza"} -->

