### PR TITLE
fix(cloud): type ballots public-query test mocks for their resolved rows

### DIFF
--- a/packages/cloud/api/v1/ballots/[id]/route.public-query.test.ts
+++ b/packages/cloud/api/v1/ballots/[id]/route.public-query.test.ts
@@ -14,8 +14,6 @@ const requireUserOrApiKeyWithOrg = mock(async () => ({
   id: "user-1",
   organization_id: "org-1",
 }));
-const getMock = mock(async (_id: string, _organizationId: string) => null);
-const getBallotMock = mock(async (_id: string) => null);
 
 const ballotRow = {
   id: BALLOT_ID,
@@ -31,6 +29,16 @@ const ballotRow = {
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
   metadata: { tokenHashByIdentity: { voter: "secret-hash" } },
 };
+
+const getMock = mock(
+  async (
+    _id: string,
+    _organizationId: string,
+  ): Promise<typeof ballotRow | null> => null,
+);
+const getBallotMock = mock(
+  async (_id: string): Promise<typeof ballotRow | null> => null,
+);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,


### PR DESCRIPTION
cloud-api typecheck is red on develop again — v1/ballots/[id]/route.public-query.test.ts types its repository mocks as returning `null`, so `mockResolvedValue(ballotRow)` is a TS2345. Caught by the transactional release candidate's verify gate (run 32016803044). Same class as #21113; mocks now declare `Promise<typeof ballotRow | null>`.

Evidence: `bun run --cwd packages/cloud/api typecheck` green; the test file passes 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)