### PR TITLE
fix(orchestrator): judge content criteria against orchestrator-read file text

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/quick-app-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/quick-app-evidence.test.ts
@@ -17,6 +17,7 @@ import {
   detectCheckSurfaces,
   mineCandidatePaths,
   probeMappedUrls,
+  readFsVerifiedContents,
 } from "../services/quick-app-evidence.js";
 
 describe("mineCandidatePaths", () => {
@@ -153,5 +154,46 @@ describe("detectCheckSurfaces (dawn-mesa boundary)", () => {
     );
     expect(surfaces.test).toBe(true);
     expect(surfaces.typecheck).toBe(false);
+  });
+});
+
+describe("readFsVerifiedContents (reed-marsh content criteria)", () => {
+  it("reads real file text with caps, skipping binaries and traversal", () => {
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "content-"));
+    try {
+      const appDir = path.join(workdir, "data", "apps", "reed-marsh");
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(appDir, "style.css"),
+        "body { background: linear-gradient(#3aa8a0, #0f2f2c); }",
+      );
+      fs.writeFileSync(path.join(appDir, "big.css"), "x".repeat(5000));
+      fs.writeFileSync(path.join(appDir, "img.png"), "notreally");
+
+      const contents = readFsVerifiedContents(workdir, [
+        "data/apps/reed-marsh/style.css",
+        "data/apps/reed-marsh/big.css",
+        "data/apps/reed-marsh/img.png",
+        "../outside.css",
+      ]);
+      expect(contents.map((c) => c.path)).toEqual([
+        "data/apps/reed-marsh/style.css",
+        "data/apps/reed-marsh/big.css",
+      ]);
+      expect(contents[0]?.content).toContain("linear-gradient(#3aa8a0");
+      expect(contents[1]?.content).toContain("[truncated]");
+      expect(contents[1]?.content.length).toBeLessThan(2100);
+    } finally {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("unreadable files are absent, never fabricated", () => {
+    const contents = readFsVerifiedContents(
+      "/nonexistent-root",
+      ["a.css"],
+      () => undefined,
+    );
+    expect(contents).toEqual([]);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
@@ -130,6 +130,11 @@ export interface CompletionEvidenceBundle {
   /** Check classes runnable where the verified deliverable lives (tooling
    *  manifests observed in its own directories); absent = unknown. */
   checkSurfaces?: { typecheck: boolean; lint: boolean; test: boolean };
+  /** Capped contents of small fs-verified static files, READ BY THE
+   *  ORCHESTRATOR from the session workdir — so content criteria ("the CSS
+   *  includes …") are judged against the real file text instead of failing as
+   *  unproven narration (#20794 reed-marsh). */
+  fsVerifiedFileContents?: Array<{ path: string; content: string }>;
   /** Screenshot artifact paths found on the task/session. */
   screenshots: string[];
   /** Path to the persisted trajectory JSONL artifact for this completion. */
@@ -323,8 +328,12 @@ function renderUrlsSection(urls: readonly string[]): string {
   );
   const lines = ["## VERIFIED URLS (probed at completion)"];
   for (const url of unique) {
+    // Every URL here answered a probe the ORCHESTRATOR ran. A loopback hit is
+    // real local-serve evidence (the router/route mapping fronts it publicly),
+    // not an untrusted worker claim — the distrust label belongs to the
+    // MENTIONED section only, where nothing was probed.
     lines.push(
-      `- ${url}${isLoopbackUrl(url) ? " (LOOPBACK — not publicly reachable)" : ""}`,
+      `- ${url}${isLoopbackUrl(url) ? " (loopback probe — local serving confirmed by the orchestrator)" : ""}`,
     );
   }
   return lines.join("\n");
@@ -460,6 +469,21 @@ export function buildCompletionEvidenceString(
       [
         "## FS-VERIFIED FILES (stat-observed in the session workdir, modified after session start)",
         ...fsVerified.map((file) => `- ${file}`),
+      ].join("\n"),
+    );
+    hasRicherSection = true;
+  }
+
+  // The files' actual text, read by the orchestrator — content criteria are
+  // judged against this, not against the worker's description of it.
+  const fileContents = bundle.fsVerifiedFileContents ?? [];
+  if (fileContents.length > 0) {
+    sections.push(
+      [
+        "## FS-VERIFIED FILE CONTENTS (read by the orchestrator from the session workdir)",
+        ...fileContents.map(
+          (entry) => `--- ${entry.path} ---\n${entry.content}`,
+        ),
       ].join("\n"),
     );
     hasRicherSection = true;

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -204,6 +204,7 @@ import {
   detectCheckSurfaces,
   mineCandidatePaths,
   probeMappedUrls,
+  readFsVerifiedContents,
 } from "./quick-app-evidence.js";
 import {
   readSmithersDurableRunLink,
@@ -2518,6 +2519,17 @@ export class OrchestratorTaskService extends Service {
         : {}),
       ...(fsVerifiedFiles.length > 0 ? { fsVerifiedFiles } : {}),
       ...(checkSurfaces ? { checkSurfaces } : {}),
+      ...(fsVerifiedFiles.length > 0 && reportingSession?.workdir
+        ? (() => {
+            const fsVerifiedFileContents = readFsVerifiedContents(
+              reportingSession.workdir,
+              fsVerifiedFiles,
+            );
+            return fsVerifiedFileContents.length > 0
+              ? { fsVerifiedFileContents }
+              : {};
+          })()
+        : {}),
       screenshots: [...new Set(screenshots)],
     };
   }

--- a/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
@@ -231,3 +231,51 @@ export function detectCheckSurfaces(
       relativeFiles.some((file) => TEST_FILE_RE.test(file)),
   };
 }
+
+const MAX_CONTENT_FILES = 3;
+const MAX_CONTENT_CHARS = 2_000;
+/** Text-asset extensions worth showing the judge verbatim. */
+const TEXT_CONTENT_RE = /\.(?:html?|css|js|svg|md|txt|json)$/i;
+
+/**
+ * Read the (capped) contents of small fs-verified text files so content
+ * criteria are judged against the real file text. Same epistemic status as
+ * the stat probe: the orchestrator reads the bytes itself; worker narration
+ * never enters. Unreadable/oversized-beyond-cap files contribute a truncated
+ * or absent entry, never a fabricated one.
+ */
+export function readFsVerifiedContents(
+  workdir: string,
+  relativeFiles: readonly string[],
+  readImpl?: (absolutePath: string) => string | undefined,
+): Array<{ path: string; content: string }> {
+  const read =
+    readImpl ??
+    ((absolutePath: string): string | undefined => {
+      try {
+        return fs.readFileSync(absolutePath, "utf8");
+      } catch {
+        // error-policy:J3 an unreadable file is explicitly absent evidence
+        return undefined;
+      }
+    });
+  const root = path.resolve(workdir);
+  const out: Array<{ path: string; content: string }> = [];
+  for (const file of relativeFiles) {
+    if (out.length >= MAX_CONTENT_FILES) break;
+    if (!TEXT_CONTENT_RE.test(file)) continue;
+    const absolute = path.resolve(root, file);
+    const relative = path.relative(root, absolute);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) continue;
+    const content = read(absolute);
+    if (content === undefined) continue;
+    out.push({
+      path: relative,
+      content:
+        content.length > MAX_CONTENT_CHARS
+          ? `${content.slice(0, MAX_CONTENT_CHARS)}\n… [truncated]`
+          : content,
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
Last residual of the #20794 quick-app arc, from the reed-marsh live probe (09:47Z): check-class criteria now clear via #21133's surface detection, but CONTENT criteria ("CSS includes a gradient using muted teal…") still parked the task — judged "unproven" because the judge never sees the file, and the probe-verified URLs were discounted as "only claimed via loopback".

## What changed

1. **The judge gets the real file text.** `readFsVerifiedContents` reads small fs-verified TEXT assets (html/css/js/svg/md/txt/json; ≤3 files, 2KB cap each, traversal-guarded, unreadable = absent never fabricated) from the session workdir — the orchestrator reads the bytes itself, same epistemic status as the stat probe — and the bundle renders them as `## FS-VERIFIED FILE CONTENTS`. A content criterion is now judged against the actual stylesheet text (the literal `linear-gradient(...)`), not against the worker's description of it.
2. **Honest loopback labeling in the VERIFIED section.** Every URL there answered a probe the ORCHESTRATOR ran; a loopback hit is real local-serve evidence behind the route's public mapping, not an untrusted worker claim. The verified section now labels it "loopback probe — local serving confirmed by the orchestrator"; the distrust flag stays exactly where it belongs — the MENTIONED (unprobed claims) section, unchanged.

## Evidence

- 2 new real-filesystem tests (reed-marsh shape: gradient CSS read verbatim, oversize truncated at cap, binary and traversal skipped; unreadable → absent).
- Affected suites 113/113; plugin typecheck clean; Biome clean.
- Live re-proof: peer session re-runs the quick-app probe post-merge — expected: content criteria judged pass against the rendered file text, completing the #20794 close-out chain.

Also ledgered from the same round (separate lane items, not this PR): the APP/create-app flow (plugin-app-control) bypasses the shared_route_workdir residuals exemption (#20969 covered resolveSpawnWorkdir; that flow evidently doesn't route through it) and leaked an admin-stop notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)