### PR TITLE
fix(security): homepage security headers + gateway-discord internal auth (W1-028, W1-071)

### DIFF
--- a/packages/cloud/services/gateway-discord/AGENTS.md
+++ b/packages/cloud/services/gateway-discord/AGENTS.md
@@ -9,9 +9,13 @@ loaded as an Eliza plugin.
 ## Layout
 
 - `src/index.ts` — entrypoint. Boots the Hono HTTP server and a single
-  `GatewayManager`; exposes `/health` (liveness), `/ready` (readiness), `/drain`
-  (preStop graceful drain), `/metrics` (Prometheus text), and `/status`. Wires
-  `SIGTERM`/`SIGINT` to graceful shutdown.
+  `GatewayManager`; exposes `/health` (liveness) and `/ready` (readiness)
+  unauthenticated for probes, plus `/drain` (preStop graceful drain),
+  `/metrics` (Prometheus text), and `/status` behind the internal-secret
+  gate. Wires `SIGTERM`/`SIGINT` to graceful shutdown.
+- `src/internal-auth.ts` — `validateInternalSecret`, the constant-time
+  `X-Internal-Secret` gate for the operational endpoints; fails closed when
+  `GATEWAY_INTERNAL_SECRET` is unset.
 - `src/gateway-manager.ts` — the bulk of the service (`GatewayManager`): polls
   Redis for bot assignments, opens `discord.js` `Client` connections, heartbeats
   pod state, handles failover, and runs Eliza App system-bot leader election.
@@ -64,6 +68,9 @@ Connection / routing:
 - `ELIZA_CLOUD_URL` (falls back to `NEXT_PUBLIC_APP_URL`, then `https://api.eliza.app`)
 - `REDIS_URL` (or `KV_REST_API_URL`) and `KV_REST_API_TOKEN` — Redis/Upstash.
 - `AGENT_SERVER_SHARED_SECRET` — sent as `X-Server-Token` when forwarding to agent-servers.
+- `GATEWAY_INTERNAL_SECRET` — shared secret callers present as `X-Internal-Secret`
+  on `/internal/deliver`, `/drain`, `/status`, and `/metrics`. Those routes fail
+  closed (401) when it is unset; `/health` and `/ready` stay unauthenticated for probes.
 - `POD_NAME` — required in production (K8s downward API); falls back to `gateway-<hostname>`
   for local dev only, which can orphan connections on reschedule.
 - `PORT` (default 3000), `PROJECT` (log tag, default `cloud`).

--- a/packages/cloud/services/gateway-discord/CLAUDE.md
+++ b/packages/cloud/services/gateway-discord/CLAUDE.md
@@ -9,9 +9,13 @@ loaded as an Eliza plugin.
 ## Layout
 
 - `src/index.ts` — entrypoint. Boots the Hono HTTP server and a single
-  `GatewayManager`; exposes `/health` (liveness), `/ready` (readiness), `/drain`
-  (preStop graceful drain), `/metrics` (Prometheus text), and `/status`. Wires
-  `SIGTERM`/`SIGINT` to graceful shutdown.
+  `GatewayManager`; exposes `/health` (liveness) and `/ready` (readiness)
+  unauthenticated for probes, plus `/drain` (preStop graceful drain),
+  `/metrics` (Prometheus text), and `/status` behind the internal-secret
+  gate. Wires `SIGTERM`/`SIGINT` to graceful shutdown.
+- `src/internal-auth.ts` — `validateInternalSecret`, the constant-time
+  `X-Internal-Secret` gate for the operational endpoints; fails closed when
+  `GATEWAY_INTERNAL_SECRET` is unset.
 - `src/gateway-manager.ts` — the bulk of the service (`GatewayManager`): polls
   Redis for bot assignments, opens `discord.js` `Client` connections, heartbeats
   pod state, handles failover, and runs Eliza App system-bot leader election.
@@ -64,6 +68,9 @@ Connection / routing:
 - `ELIZA_CLOUD_URL` (falls back to `NEXT_PUBLIC_APP_URL`, then `https://api.eliza.app`)
 - `REDIS_URL` (or `KV_REST_API_URL`) and `KV_REST_API_TOKEN` — Redis/Upstash.
 - `AGENT_SERVER_SHARED_SECRET` — sent as `X-Server-Token` when forwarding to agent-servers.
+- `GATEWAY_INTERNAL_SECRET` — shared secret callers present as `X-Internal-Secret`
+  on `/internal/deliver`, `/drain`, `/status`, and `/metrics`. Those routes fail
+  closed (401) when it is unset; `/health` and `/ready` stay unauthenticated for probes.
 - `POD_NAME` — required in production (K8s downward API); falls back to `gateway-<hostname>`
   for local dev only, which can orphan connections on reschedule.
 - `PORT` (default 3000), `PROJECT` (log tag, default `cloud`).

--- a/packages/cloud/services/gateway-discord/README.md
+++ b/packages/cloud/services/gateway-discord/README.md
@@ -397,18 +397,21 @@ Expected response:
 #### 2. Check Gateway Status
 
 ```bash
-curl http://localhost:3000/status
+curl -H "X-Internal-Secret: $GATEWAY_INTERNAL_SECRET" http://localhost:3000/status
 ```
 
-Shows detailed information about all active connections.
+Shows detailed information about all active connections. Requires the
+`X-Internal-Secret` header (`GATEWAY_INTERNAL_SECRET`); unauthenticated
+requests are rejected with 401.
 
 #### 3. Check Prometheus Metrics
 
 ```bash
-curl http://localhost:3000/metrics
+curl -H "X-Internal-Secret: $GATEWAY_INTERNAL_SECRET" http://localhost:3000/metrics
 ```
 
-Returns metrics in Prometheus format for monitoring.
+Returns metrics in Prometheus format for monitoring. Requires the same
+`X-Internal-Secret` header as `/status`.
 
 #### 4. Watch the Logs
 
@@ -1041,12 +1044,13 @@ When a pod receives `SIGTERM` or `SIGINT`, it performs a graceful shutdown:
 
 ### Health Endpoints
 
-| Endpoint | Purpose | Returns 503 When |
-|----------|---------|------------------|
-| `/health` | Liveness probe (K8s restarts pod if 503) | `status === "unhealthy"` (control plane lost OR all bots disconnected) |
-| `/ready` | Readiness probe (K8s stops traffic if 503) | `status !== "healthy"` OR control plane unhealthy |
-| `/metrics` | Prometheus metrics scraping | Never (always returns metrics text) |
-| `/status` | Detailed debug information | Never (always returns JSON status) |
+| Endpoint | Purpose | Auth | Returns 503 When |
+|----------|---------|------|------------------|
+| `/health` | Liveness probe (K8s restarts pod if 503) | None (probes cannot attach headers) | `status === "unhealthy"` (control plane lost OR all bots disconnected) |
+| `/ready` | Readiness probe (K8s stops traffic if 503) | None (probes cannot attach headers) | `status !== "healthy"` OR control plane unhealthy |
+| `/metrics` | Prometheus metrics scraping | `X-Internal-Secret` required (401 otherwise) | Never (always returns metrics text) |
+| `/status` | Detailed debug information | `X-Internal-Secret` required (401 otherwise) | Never (always returns JSON status) |
+| `/drain` | Graceful drain before shutdown | `X-Internal-Secret` required (401 otherwise) | Never |
 
 ### Communication Summary
 

--- a/packages/cloud/services/gateway-discord/src/index.ts
+++ b/packages/cloud/services/gateway-discord/src/index.ts
@@ -13,6 +13,7 @@ import {
   createDiscordPublicKeyResolver,
 } from "./discord-event-webhook";
 import { GatewayManager } from "./gateway-manager";
+import { validateInternalSecret } from "./internal-auth";
 import { deliverInternalDiscordMessage } from "./internal-delivery";
 import { logger } from "./logger";
 
@@ -123,20 +124,32 @@ app.get("/ready", (c) => {
 
 // Drain endpoint - called by preStop hook before shutdown
 // Marks pod as draining to prevent new assignments while allowing existing bots to continue
-// This enables graceful failover without message loss
+// This enables graceful failover without message loss.
+// Gated on the internal secret: an unauthenticated drain lets anything that
+// reaches the pod IP force a fleet-wide Discord reconnect. /health and /ready
+// stay open because kubelet/Railway/Docker probes cannot attach headers.
 app.post("/drain", async (c) => {
+  if (!validateInternalSecret(c.req.raw)) {
+    return c.json({ success: false, error: "unauthorized" }, 401);
+  }
   await gatewayManager.startDraining();
   return c.json({ draining: true, podName });
 });
 
-// Metrics endpoint for Prometheus
+// Metrics endpoint for Prometheus (internal-secret gated like /drain)
 app.get("/metrics", (c) => {
+  if (!validateInternalSecret(c.req.raw)) {
+    return c.json({ success: false, error: "unauthorized" }, 401);
+  }
   const metrics = gatewayManager.getMetrics();
   return c.text(metrics, 200, { "Content-Type": "text/plain" });
 });
 
-// Status endpoint with detailed info
+// Status endpoint with detailed info (internal-secret gated like /drain)
 app.get("/status", (c) => {
+  if (!validateInternalSecret(c.req.raw)) {
+    return c.json({ success: false, error: "unauthorized" }, 401);
+  }
   const status = gatewayManager.getStatus();
   return c.json(status);
 });

--- a/packages/cloud/services/gateway-discord/src/internal-auth.ts
+++ b/packages/cloud/services/gateway-discord/src/internal-auth.ts
@@ -1,0 +1,73 @@
+/**
+ * Enforces the internal trust boundary for the gateway's operational
+ * endpoints (`/drain`, `/status`, `/metrics`). Anything able to reach the pod
+ * IP could otherwise force a fleet-wide Discord reconnect or read operational
+ * state. Mirrors the gateway-webhook verifier: same `GATEWAY_INTERNAL_SECRET`
+ * env var and `X-Internal-Secret` header that already gate `/internal/deliver`.
+ */
+import { timingSafeEqual } from "node:crypto";
+import { logger } from "./logger";
+
+/**
+ * Validates the X-Internal-Secret header against the configured internal
+ * secret using constant-time comparison to prevent timing attacks.
+ *
+ * The secret is read from process.env on each call (same pattern as
+ * AGENT_SERVER_SHARED_SECRET in server-router) so runtime config changes
+ * are picked up without a restart.
+ *
+ * Returns false (and logs at warn level) when:
+ * - GATEWAY_INTERNAL_SECRET env var is not configured (fail-closed)
+ * - Header is missing from the request
+ * - Header value does not match the secret
+ *
+ * The constant-time comparison always runs, even when the secret or
+ * header is empty, to prevent timing oracles from revealing whether
+ * the env var is configured. Both buffers are padded to equal length
+ * (minimum 1 byte) so timingSafeEqual never receives zero-length
+ * inputs and always runs for the same duration.
+ */
+export function validateInternalSecret(request: Request): boolean {
+  const secret = process.env.GATEWAY_INTERNAL_SECRET ?? "";
+  const header = request.headers.get("X-Internal-Secret") ?? "";
+
+  // Extract boolean flags before any buffer work so the constant-time
+  // comparison always runs regardless of empty inputs.
+  const secretMissing = !secret;
+  const headerMissing = !header;
+
+  // Logging here is intentional for operational visibility: operators need
+  // to know why requests are being rejected. The timing oracle concern is
+  // mitigated because timingSafeEqual always runs below (no early return).
+  if (secretMissing) {
+    logger.warn(
+      "Internal auth rejected: GATEWAY_INTERNAL_SECRET not configured",
+    );
+  } else if (headerMissing) {
+    logger.warn("Internal auth rejected: missing X-Internal-Secret header");
+  }
+
+  const a = Buffer.from(header);
+  const b = Buffer.from(secret);
+  const maxLen = Math.max(a.length, b.length, 1);
+  const aPadded = Buffer.alloc(maxLen);
+  const bPadded = Buffer.alloc(maxLen);
+  a.copy(aPadded);
+  b.copy(bPadded);
+
+  // Compare original lengths before using padded buffers so values like
+  // "secret\0\0" can never match "secret" after padding.
+  const lengthMatch = a.length === b.length;
+  // Pre-compute both conditions so the || below does not short-circuit and
+  // timingSafeEqual always executes regardless of length match.
+  const valueMatch = timingSafeEqual(aPadded, bPadded);
+
+  if (secretMissing || headerMissing || !lengthMatch || !valueMatch) {
+    if (!secretMissing && !headerMissing) {
+      logger.warn("Internal auth rejected: invalid secret");
+    }
+    return false;
+  }
+
+  return true;
+}

--- a/packages/cloud/services/gateway-discord/tests/internal-auth.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/internal-auth.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Exercises the internal-secret gate on the gateway's operational endpoints
+ * (`/drain`, `/status`, `/metrics`). The verifier tests drive the real
+ * `validateInternalSecret`; the contract tests pin the route wiring in
+ * `src/index.ts` so the guard cannot be dropped without failing CI.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { validateInternalSecret } from "../src/internal-auth";
+
+describe("validateInternalSecret", () => {
+  const originalSecret = process.env.GATEWAY_INTERNAL_SECRET;
+
+  beforeEach(() => {
+    process.env.GATEWAY_INTERNAL_SECRET = "test-internal-secret";
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.GATEWAY_INTERNAL_SECRET;
+    } else {
+      process.env.GATEWAY_INTERNAL_SECRET = originalSecret;
+    }
+  });
+
+  function makeRequest(secret?: string): Request {
+    const headers: Record<string, string> = {};
+    if (secret !== undefined) {
+      headers["X-Internal-Secret"] = secret;
+    }
+    return new Request("http://localhost/drain", { method: "POST", headers });
+  }
+
+  test("fails closed when GATEWAY_INTERNAL_SECRET env is empty", () => {
+    process.env.GATEWAY_INTERNAL_SECRET = "";
+    expect(validateInternalSecret(makeRequest("any-value"))).toBe(false);
+  });
+
+  test("fails closed when GATEWAY_INTERNAL_SECRET env is not set", () => {
+    delete process.env.GATEWAY_INTERNAL_SECRET;
+    expect(validateInternalSecret(makeRequest("any-value"))).toBe(false);
+  });
+
+  test("returns false when header is missing", () => {
+    expect(validateInternalSecret(makeRequest())).toBe(false);
+  });
+
+  test("returns false when header value is wrong", () => {
+    expect(validateInternalSecret(makeRequest("wrong-secret"))).toBe(false);
+  });
+
+  test("returns false when header does not match secret (length and value differ)", () => {
+    process.env.GATEWAY_INTERNAL_SECRET = "short";
+    expect(
+      validateInternalSecret(makeRequest("this-is-a-much-longer-secret-value")),
+    ).toBe(false);
+  });
+
+  test("returns false when the header is a prefix or extension of the secret", () => {
+    process.env.GATEWAY_INTERNAL_SECRET = "secret";
+    expect(validateInternalSecret(makeRequest("secret"))).toBe(true);
+    expect(validateInternalSecret(makeRequest("secre"))).toBe(false);
+    expect(validateInternalSecret(makeRequest("secret2"))).toBe(false);
+  });
+
+  test("returns true for multi-byte UTF-8 secret with matching encoding", () => {
+    process.env.GATEWAY_INTERNAL_SECRET = "café";
+    expect(validateInternalSecret(makeRequest("café"))).toBe(true);
+    expect(validateInternalSecret(makeRequest("cafe"))).toBe(false);
+  });
+
+  test("returns true when header matches GATEWAY_INTERNAL_SECRET", () => {
+    expect(validateInternalSecret(makeRequest("test-internal-secret"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("operational route auth wiring", () => {
+  const indexSource = async () =>
+    Bun.file(new URL("../src/index.ts", import.meta.url)).text();
+
+  test("/drain, /status, and /metrics require the internal secret", async () => {
+    const source = await indexSource();
+    for (const route of ['"/drain"', '"/metrics"', '"/status"']) {
+      const routeIndex = source.indexOf(route);
+      expect(routeIndex).toBeGreaterThan(-1);
+      const handler = source.slice(routeIndex, routeIndex + 400);
+      expect(handler).toContain("validateInternalSecret(c.req.raw)");
+      expect(handler).toContain("401");
+    }
+  });
+
+  test("/health and /ready stay unauthenticated for probes", async () => {
+    const source = await indexSource();
+    for (const route of ['"/health"', '"/ready"']) {
+      const routeIndex = source.indexOf(route);
+      expect(routeIndex).toBeGreaterThan(-1);
+      const handler = source.slice(routeIndex, routeIndex + 300);
+      expect(handler).not.toContain("validateInternalSecret");
+    }
+  });
+});

--- a/packages/homepage/public/_headers
+++ b/packages/homepage/public/_headers
@@ -1,3 +1,37 @@
+# Cloudflare Pages headers for the public Eliza homepage.
+# Format: https://developers.cloudflare.com/pages/configuration/headers/
+#
+# Cloudflare Pages drops headers larger than ~2000 bytes silently. Keep the CSP
+# line under ~1900 bytes; verify with `wc -L < public/_headers`.
+#
+# The /* security block mirrors the suite packages/app sets for the unified
+# deploy, scoped to what the homepage actually loads:
+# - script-src keeps the app's 'unsafe-eval'/'unsafe-inline'/'wasm-unsafe-eval'
+#   renderer posture and adds https://telegram.org, the one external script the
+#   /get-started Telegram login widget injects.
+# - style-src 'unsafe-inline' is required by the inline style attribute on the
+#   index.html <body>.
+# - frame-src/child-src allow https://oauth.telegram.org (the widget iframe);
+#   form-action allows it for the widget's auth POST.
+# - connect-src covers the canonical and legacy Eliza Cloud API origins
+#   (api.eliza.app default in src/lib/api/client.ts); Discord/Telegram/WhatsApp
+#   sign-in links are top-level navigations, not fetches.
+# frame-ancestors 'self' + X-Frame-Options deny cross-origin framing of the
+# onboarding/auth pages (clickjacking); no homepage route is a designed embed.
+#
+# There is deliberately NO Cache-Control on /*: multiple matching _headers rules
+# aggregate into one comma-joined value instead of overriding, so a global rule
+# would poison the durable per-path cache policies below.
+
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' 'wasm-unsafe-eval' https://telegram.org; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self' https://oauth.telegram.org; frame-ancestors 'self'; child-src 'self' blob: https://oauth.telegram.org; frame-src 'self' https://oauth.telegram.org; connect-src 'self' https://eliza.app https://*.eliza.app wss://*.eliza.app https://elizacloud.ai https://*.elizacloud.ai wss://*.elizacloud.ai; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' data: blob: https:
+  X-Frame-Options: SAMEORIGIN
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-XSS-Protection: 1; mode=block
+  Permissions-Policy: camera=(self), microphone=(self), geolocation=(self)
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+
 /assets/*
   Cache-Control: public, max-age=0, must-revalidate
 

--- a/packages/homepage/tests/smoke.node.test.mjs
+++ b/packages/homepage/tests/smoke.node.test.mjs
@@ -149,6 +149,66 @@ test("large visual assets receive a durable browser cache policy", () => {
   }
 });
 
+test("every response carries the defense-in-depth security header suite", () => {
+  const headers = readFileSync(headersPath, "utf8");
+  const globalBlock = headers.match(/^\/\*\n((?:[ \t]+\S.*\n)+)/m)?.[1] ?? "";
+  const headerLine = (name) => {
+    const line = globalBlock
+      .split("\n")
+      .find((candidate) => candidate.trimStart().startsWith(`${name}:`));
+    assert.ok(line, `missing ${name} in the /* block`);
+    return line.trimStart();
+  };
+
+  const csp = headerLine("Content-Security-Policy");
+  assert.ok(
+    csp.length < 1900,
+    `CSP must stay under the Cloudflare Pages header limit (${csp.length} bytes)`,
+  );
+  // Clickjacking defense for the onboarding/auth pages.
+  assert.match(csp, /frame-ancestors 'self'/);
+  assert.match(headerLine("X-Frame-Options"), /^X-Frame-Options: SAMEORIGIN$/);
+  // The CSP must reflect what the homepage really loads: the /get-started
+  // Telegram widget is the only external script and renders its
+  // oauth.telegram.org iframe; the index.html <body> carries an inline style;
+  // sign-in providers are top-level navigations, not fetches.
+  assert.match(
+    csp,
+    /script-src 'self' 'unsafe-eval' 'unsafe-inline' 'wasm-unsafe-eval' https:\/\/telegram\.org/,
+  );
+  assert.match(csp, /style-src 'self' 'unsafe-inline'/);
+  assert.match(csp, /frame-src 'self' https:\/\/oauth\.telegram\.org/);
+  assert.match(csp, /form-action 'self' https:\/\/oauth\.telegram\.org/);
+  assert.match(
+    csp,
+    /connect-src 'self' https:\/\/eliza\.app https:\/\/\*\.eliza\.app wss:\/\/\*\.eliza\.app/,
+  );
+  assert.match(csp, /object-src 'none'/);
+  assert.match(csp, /base-uri 'self'/);
+
+  assert.match(
+    headerLine("X-Content-Type-Options"),
+    /^X-Content-Type-Options: nosniff$/,
+  );
+  assert.match(
+    headerLine("Referrer-Policy"),
+    /^Referrer-Policy: strict-origin-when-cross-origin$/,
+  );
+  assert.match(
+    headerLine("Strict-Transport-Security"),
+    /^Strict-Transport-Security: max-age=63072000; includeSubDomains; preload$/,
+  );
+  assert.match(
+    headerLine("Permissions-Policy"),
+    /^Permissions-Policy: camera=\(self\), microphone=\(self\), geolocation=\(self\)$/,
+  );
+
+  // A global Cache-Control would aggregate with the per-path rules below
+  // (matching _headers rules join instead of overriding) and destroy the
+  // durable asset caching enforced by the previous test.
+  assert.doesNotMatch(globalBlock, /Cache-Control/);
+});
+
 test("preloaded image declares the MIME type of the referenced asset", () => {
   const indexHtml = readFileSync(indexHtmlPath, "utf8");
   const preloadTag = indexHtml.match(/<link(?=[^>]*rel="preload")[^>]*>/)?.[0];


### PR DESCRIPTION
## Summary

Two confirmed wave-1 security-audit findings, both in edge/header posture:

### W1-028 (MEDIUM) — homepage ships no security headers
`packages/homepage/public/_headers` carried only `Cache-Control` rules: no CSP, no framing protection, no `nosniff`, no HSTS for the public marketing/onboarding surface.

**Fix:** add a `/*` block mirroring the suite `packages/app/public/_headers` sets, scoped to what the homepage actually loads (verified against source):
- `script-src` keeps the app's renderer posture and adds `https://telegram.org` — the one external script the `/get-started` Telegram login widget injects; its `oauth.telegram.org` iframe and auth form POST are covered by `frame-src`/`child-src`/`form-action`.
- `style-src 'unsafe-inline'` is required by the inline `style` attribute on the `index.html` `<body>`.
- `connect-src` covers the canonical + legacy cloud API origins; Discord/Telegram/WhatsApp sign-in are top-level navigations, not fetches.
- `frame-ancestors 'self'` + `X-Frame-Options: SAMEORIGIN` deny cross-origin framing of the onboarding/auth pages; `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, and HSTS mirror the app.
- Deliberately **no** global `Cache-Control`: matching `_headers` rules aggregate into a comma-joined value instead of overriding, which would have poisoned the durable per-path asset caching pinned by the existing smoke test.

### W1-071 (LOW) — gateway-discord exposes unauthenticated operational endpoints
`POST /drain`, `GET /status`, and `GET /metrics` were unauthenticated on a server bound to all interfaces; anything able to reach the pod IP could force a graceful drain (availability impact across every hosted Discord bot) or read operational state.

**Fix:** new `src/internal-auth.ts` mirroring the sibling `gateway-webhook` verifier — same `GATEWAY_INTERNAL_SECRET` env var and `X-Internal-Secret` header that already gate `/internal/deliver` on this service, constant-time padded compare, fail-closed (401) when the secret is unset. `/health` and `/ready` intentionally stay unauthenticated: kubelet/Railway/Docker probes cannot attach headers and those routes expose only coarse health state. `GATEWAY_INTERNAL_SECRET` is already a required env on the Railway service per `railway.toml`; README/AGENTS/CLAUDE docs updated to match.

## Test evidence

- `bun test tests/internal-auth.test.ts` (gateway-discord): **10 pass / 0 fail** — verifier fail-closed when env unset/empty, missing/wrong header, prefix/extension mismatch, UTF-8 secret, plus source-contract tests pinning the guard on `/drain` `/status` `/metrics` and the open probes on `/health` `/ready`.
- `bun run --cwd packages/cloud/services/gateway-discord test`: **129 pass / 0 fail** across 19 files.
- `bun run --cwd packages/cloud/services/gateway-discord typecheck`: pass (after building `packages/shared`, a normal monorepo prerequisite; the pre-existing `dm-policy.ts` resolution error is environmental, not from this change).
- `bun run --cwd packages/cloud/services/gateway-discord lint`: clean.
- `node --test packages/homepage/tests/smoke.node.test.mjs`: **11 pass / 0 fail**, including the new security-suite test (CSP under the ~1900-byte Pages limit, framing/nosniff/referrer/HSTS/permissions headers present, no global Cache-Control) and the pre-existing durable-cache test.
- `bun run --cwd packages/homepage test` (full suite): pass.
- `bun run --cwd packages/homepage lint:check` and `typecheck`: pass.
- `bun run check:agents-claude`: PASS (155 pairs byte-identical).

## Risk notes

- **Deploy coupling (W1-071):** any Prometheus scrape of `/metrics` or lifecycle hook calling `/drain` must now send `X-Internal-Secret`. `railway.toml` already lists `GATEWAY_INTERNAL_SECRET` as a required secret for the service, and the repo contains no K8s manifest or scrape config for this deployment to update; operators with external scrapers need the header added.
- **CSP scope (W1-028):** the policy was derived from the homepage's actual script/style/frame/connect usage so the site renders unchanged; it is tighter than the app's only in dropped hosts the homepage never requests.
- Observation outside this PR's scope: the app-served `/get-started` route inherits `packages/app/public/_headers`, whose `script-src` does not list `telegram.org` — worth a follow-up check that the Telegram widget loads as intended under the unified deploy.

Ref: artifacts/security-audit/wave1-report.md (W1-028, W1-071)
