### PR TITLE
fix(cloud): reject unknown twitter-status connectionRole

### DIFF
--- a/packages/cloud/api/v1/twitter/status/route.connection-role.test.ts
+++ b/packages/cloud/api/v1/twitter/status/route.connection-role.test.ts
@@ -1,0 +1,86 @@
+/**
+ * GET /api/v1/twitter/status `connectionRole` is owner-vs-agent
+ * identity, leftover tax after twitter-disconnect (#21144) and
+ * x-status (#20945). Stock develop used a ternary that mapped every
+ * non-"agent" token onto the personal owner Twitter status. The
+ * documented default remains owner; garbage must 400 before
+ * getConnectionStatus.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getConnectionStatus = mock(async () => ({
+  connected: true,
+  username: "owner-acct",
+}));
+const isConfigured = mock(() => true);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+mock.module("@/lib/services/twitter-automation", () => ({
+  twitterAutomationService: { getConnectionStatus, isConfigured },
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>
+    c.json({ error: "internal_error" }, 500),
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/v1/twitter/status", route);
+
+function getStatus(query = "") {
+  return app.request(`/api/v1/twitter/status${query}`);
+}
+
+describe("GET /api/v1/twitter/status connectionRole identity", () => {
+  beforeEach(() => {
+    getConnectionStatus.mockClear();
+    isConfigured.mockClear();
+    isConfigured.mockReturnValue(true);
+  });
+
+  test.each([
+    ["", "owner"],
+    ["?connectionRole=", "owner"],
+    ["?connectionRole=owner", "owner"],
+    ["?connectionRole=agent", "agent"],
+  ])("accepts %s as %s", async (query, role) => {
+    const response = await getStatus(query);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { connectionRole: string };
+    expect(body.connectionRole).toBe(role);
+    expect(getConnectionStatus).toHaveBeenCalledTimes(1);
+    expect(getConnectionStatus).toHaveBeenCalledWith("org-1", role);
+  });
+
+  test.each(["AGENT", "Owner", "foo", "1e2", "agent ", "owner\n"])(
+    "rejects connectionRole=%s before status lookup",
+    async (token) => {
+      const response = await getStatus(
+        `?connectionRole=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toMatch(/connection_role|connectionRole/i);
+      expect(getConnectionStatus).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?connectionRole=agent&connectionRole=agent",
+    "?connectionRole=agent&connectionRole=owner",
+    "?connectionRole=&connectionRole=agent",
+    "?connectionRole=foo&connectionRole=owner",
+  ])(
+    "rejects duplicate role values in %s before status lookup",
+    async (query) => {
+      const response = await getStatus(query);
+      expect(response.status).toBe(400);
+      expect(getConnectionStatus).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/twitter/status/route.ts
+++ b/packages/cloud/api/v1/twitter/status/route.ts
@@ -10,8 +10,30 @@ const app = new Hono<AppEnv>();
 app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    const role =
-      c.req.query("connectionRole") === "agent" ? "agent" : ("owner" as const);
+    // Role identity leftover after twitter-disconnect (#21144) / x-status
+    // (#20945). The prior ternary mapped every non-"agent" token —
+    // including AGENT, owner-typos, and 1e2 — onto the personal owner
+    // Twitter status. Missing/empty still defaults to owner. Garbage
+    // 400s before getConnectionStatus.
+    const requestedRoleValues = c.req.queries("connectionRole") ?? [];
+    const requestedRole = requestedRoleValues[0];
+    if (
+      requestedRoleValues.length > 1 ||
+      (requestedRole !== undefined &&
+        requestedRole !== "" &&
+        requestedRole !== "agent" &&
+        requestedRole !== "owner")
+    ) {
+      return c.json(
+        {
+          error: "invalid_connection_role",
+          message:
+            'connectionRole must be specified at most once as "agent" or "owner".',
+        },
+        400,
+      );
+    }
+    const role = requestedRole === "agent" ? "agent" : ("owner" as const);
     const connectionId = `twitter:${user.organization_id}:${role}`;
 
     if (!twitterAutomationService.isConfigured()) {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on twitter-status
`connectionRole` identity. Leftover tax after twitter-disconnect
connectionRole (#21144) and x-status connectionRole (#20945). Not leftover
tax on twitter-disconnect connectionRole, x-dms-digest connectionRole,
x-feed connectionRole, approval-request public, ballot public,
payment-request public, agent-provision sync, resume sync, voice-list
includeInactive, analytics-export includeMetadata, or prefix-coerced
limit/offset.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `connectionRole` only on `/api/v1/twitter/status`.
Omitted/empty still bind the owner Twitter status (today's default).
Exact `agent` / `owner` still select that Twitter connection.
Unknown / uppercase / duplicate tokens 400 before `getConnectionStatus`.

# Background

## What does this PR do?

`GET /api/v1/twitter/status` treated every non-exact `agent` token as
the personal owner Twitter status. `connectionRole=AGENT` silently
reported the owner account instead of a 400.

- omitted / empty / `owner` → owner status
- exact `agent` → agent status
- `AGENT` / `Owner` / `foo` / `1e2` / duplicate `connectionRole` → **400**
  before `getConnectionStatus`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers select the agent Twitter connection with `?connectionRole=agent`. A
common `connectionRole=AGENT` after a client uppercases the flag must not
silently report the owner account. This is leftover tax after
twitter-disconnect connectionRole (#21144), which left the twitter-status
parser untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/twitter/status/route.connection-role.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/twitter/status/route.connection-role.test.ts
```

14 passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; twitter-status `connectionRole` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; twitter-status `connectionRole` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; twitter-status `connectionRole` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real role tokens and assert 400 before status lookup; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no status write; illegal tokens 400 before `getConnectionStatus`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`connectionRole` tokens reject; omitted/canonical still bind the matching
owner-or-agent status path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file twitter-status role
parse with a green focused suite (14 tests). Full monorepo verify is
unrelated to this query grammar and was skipped to keep the proof tied
to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7f835d9a8201de9f7deaf835f1caef12b638b87e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
