### PR TITLE
fix(cloud): reject unknown agent-create sync flag

### DIFF
--- a/packages/cloud/api/v1/agents/route.sync.test.ts
+++ b/packages/cloud/api/v1/agents/route.sync.test.ts
@@ -1,0 +1,221 @@
+/**
+ * POST /api/v1/agents `sync` is service-create wait identity, leftover
+ * tax after agent-provision sync (#21136) and agent-resume sync (#21099).
+ * Stock develop treated any non-exact `true` token as async, so
+ * `sync=TRUE` still enqueued a 202 job instead of the blocking 201
+ * fallback. Character / credit / enqueue parsers stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const requireServiceKey = mock(async () => ({
+  organizationId: "service-org",
+  userId: "service-user",
+}));
+const findOrCreateUserByWalletAddress = mock(async (walletAddress: string) => ({
+  isNewAccount: true,
+  initialCreditsGranted: false,
+  initialFreeCreditsUsd: 0,
+  user: {
+    id: "agent-wallet-user",
+    organization_id: "agent-wallet-org",
+    wallet_address: walletAddress,
+  },
+}));
+const checkAgentCreditGate = mock(async () => ({
+  allowed: true,
+  balance: 5,
+}));
+const checkProvisioningWorkerHealth = mock(async () => ({ ok: true }));
+const findByTokenAddress = mock(async (): Promise<{ id: string } | null> => null);
+const findLatestByCharacterId = mock(
+  async (): Promise<{ id: string } | null> => null,
+);
+const createCharacter = mock(async (input: Record<string, unknown>) => ({
+  id: "character-1",
+  token_address: input.token_address,
+  token_chain: input.token_chain,
+  token_name: input.token_name,
+  token_ticker: input.token_ticker,
+}));
+const deleteCharacter = mock(async () => undefined);
+const createAgent = mock(async (input: Record<string, unknown>) => ({
+  agent: {
+    id: "cloud-agent-1",
+    input,
+  },
+}));
+const provisionAgent = mock(async () => ({
+  success: true,
+  sandboxRecord: {
+    id: "cloud-agent-1",
+    container_name: "container-worker",
+    sandbox_id: null,
+    bridge_url: "https://runtime.example.test",
+    status: "running",
+    last_heartbeat_at: null,
+    node_id: "node-1",
+    error_message: null,
+    database_status: "ready",
+    agent_config: {},
+  },
+}));
+const enqueueAgentProvision = mock(async () => ({ id: "job-1" }));
+
+class AgentImageNotAllowedError extends Error {
+  readonly image: string;
+  readonly reason: "not_allowlisted" | "not_digest_pinned";
+  constructor(image: string, reason: "not_allowlisted" | "not_digest_pinned") {
+    super(
+      `Docker image '${image}' is not in the managed-agent image allowlist.`,
+    );
+    this.name = "AgentImageNotAllowedError";
+    this.image = image;
+    this.reason = reason;
+  }
+}
+
+mock.module("@/lib/auth/service-key-hono-worker", () => ({
+  requireServiceKey,
+  validateServiceKey: requireServiceKey,
+}));
+mock.module("@/lib/services/wallet-signup", () => ({
+  findOrCreateUserByWalletAddress,
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth,
+  provisioningWorkerFailureBody: () => ({ error: "worker unavailable" }),
+}));
+mock.module("@/db/repositories/characters", () => ({
+  userCharactersRepository: { findByTokenAddress },
+}));
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: { findLatestByCharacterId },
+}));
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: { create: createCharacter, delete: deleteCharacter },
+}));
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  AgentImageNotAllowedError,
+  AgentQuotaExceededError: class AgentQuotaExceededError extends Error {},
+  elizaSandboxService: { createAgent, provision: provisionAgent },
+}));
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: { enqueueAgentProvision },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+const { default: app } = await import("./route");
+
+const VALID_BODY = {
+  tokenContractAddress: "0x0000000000000000000000000000000000000009",
+  chain: "bsc",
+  chainId: 56,
+  tokenName: "Waifu Smoke",
+  tokenTicker: "WSMOKE",
+  launchType: "native",
+  character: { name: "Smoke Agent" },
+  account: {
+    primaryWalletAddress: "0x0000000000000000000000000000000000000001",
+    chainType: "evm",
+  },
+  container: {
+    image: "registry.example.test/waifu-agent:latest",
+  },
+};
+
+function post(query = "") {
+  return app.fetch(
+    new Request(`https://api.example.test/${query}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Service-Key": "svc",
+      },
+      body: JSON.stringify(VALID_BODY),
+    }),
+    { WAIFU_SERVICE_KEY: "svc" },
+  );
+}
+
+describe("POST /api/v1/agents sync identity", () => {
+  beforeEach(() => {
+    requireServiceKey.mockClear();
+    findOrCreateUserByWalletAddress.mockClear();
+    checkAgentCreditGate.mockClear();
+    checkProvisioningWorkerHealth.mockClear();
+    findByTokenAddress.mockClear();
+    findLatestByCharacterId.mockClear();
+    createCharacter.mockClear();
+    deleteCharacter.mockClear();
+    createAgent.mockClear();
+    provisionAgent.mockClear();
+    enqueueAgentProvision.mockClear();
+  });
+
+  test.each(["", "?sync=", "?sync=false"])(
+    "accepts %s as async service create",
+    async (query) => {
+      const response = await post(query);
+      expect(response.status).toBe(202);
+      expect(requireServiceKey).toHaveBeenCalledTimes(1);
+      expect(createCharacter).toHaveBeenCalledTimes(1);
+      expect(createAgent).toHaveBeenCalledTimes(1);
+      expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
+      expect(provisionAgent).not.toHaveBeenCalled();
+    },
+  );
+
+  test("accepts sync=true as the blocking-fallback token", async () => {
+    const response = await post("?sync=true");
+    expect(response.status).toBe(201);
+    expect(requireServiceKey).toHaveBeenCalledTimes(1);
+    expect(provisionAgent).toHaveBeenCalledTimes(1);
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+  });
+
+  test.each(["FALSE", "TRUE", "0", "1", "no", "yes", "foo", "1e2"])(
+    "rejects sync=%s before lookup, credit gate, create, and enqueue",
+    async (token) => {
+      const response = await post(`?sync=${encodeURIComponent(token)}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid sync");
+      expect(findOrCreateUserByWalletAddress).not.toHaveBeenCalled();
+      expect(checkAgentCreditGate).not.toHaveBeenCalled();
+      expect(createCharacter).not.toHaveBeenCalled();
+      expect(createAgent).not.toHaveBeenCalled();
+      expect(provisionAgent).not.toHaveBeenCalled();
+      expect(enqueueAgentProvision).not.toHaveBeenCalled();
+      expect(checkProvisioningWorkerHealth).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?sync=false&sync=true",
+    "?sync=true&sync=false",
+    "?sync=true&sync=true",
+    "?sync=&sync=false",
+  ])(
+    "rejects ambiguous duplicate query %s without side effects",
+    async (query) => {
+      const response = await post(query);
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({ error: "Invalid sync" });
+      expect(findOrCreateUserByWalletAddress).not.toHaveBeenCalled();
+      expect(checkAgentCreditGate).not.toHaveBeenCalled();
+      expect(createCharacter).not.toHaveBeenCalled();
+      expect(createAgent).not.toHaveBeenCalled();
+      expect(provisionAgent).not.toHaveBeenCalled();
+      expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/agents/route.ts
+++ b/packages/cloud/api/v1/agents/route.ts
@@ -161,6 +161,30 @@ app.post("/", async (c) => {
   try {
     const identity = await requireServiceKey(c);
 
+    // Service-create wait identity, leftover tax after agent-provision
+    // sync (#21136) and agent-resume sync (#21099). sync=TRUE used to
+    // silently stay async (202 job) instead of the blocking 201 fallback.
+    const syncValues = c.req.queries("sync") ?? [];
+    const requestedSync = syncValues[0];
+    if (
+      syncValues.length > 1 ||
+      (requestedSync != null &&
+        requestedSync !== "" &&
+        requestedSync !== "true" &&
+        requestedSync !== "false")
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: "Invalid sync",
+          message:
+            'sync must be specified at most once as "true" or "false".',
+        },
+        400,
+      );
+    }
+    const sync = requestedSync === "true";
+
     const body = await c.req.json().catch(() => null);
     if (!body) throw ValidationError("Invalid JSON body");
 
@@ -172,7 +196,6 @@ app.post("/", async (c) => {
     }
 
     const p = parsed.data;
-    const sync = c.req.query("sync") === "true";
     const agentName = p.character?.name || p.tokenName;
     const characterConfig = recordFromUnknown(p.character?.config);
     const waifuAgentId = stringFromRecord(characterConfig, "waifuAgentId");


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on service
agent-create `sync` identity. Leftover tax after agent-provision sync
(#21136) and agent-resume sync (#21099). Not leftover tax on
agent-provision sync, resume sync, approval-request public, ballot
public, payment-request public, twitter-disconnect connectionRole,
x-dms-digest connectionRole, x-feed connectionRole, x-status
connectionRole, voice-list includeInactive, analytics-export
includeMetadata, or prefix-coerced limit/offset.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Query `sync` only on `POST /api/v1/agents`.
Omitted/empty/`false` still enqueue the async 202 job (today's default).
Exact `true` still takes the blocking 201 fallback.
Unknown / uppercase / numeric / duplicate tokens 400 before character
create, credit gate, provision, and enqueue.

# Background

## What does this PR do?

`POST /api/v1/agents` parsed `sync` with `=== "true"`. `sync=TRUE`
silently stayed async (202 job) instead of a 400.

- omitted / empty / `false` → async 202
- exact `true` → blocking 201 fallback
- `TRUE` / `1` / `yes` / `1e2` / duplicate `sync` → **400** before
  character create, credit gate, provision, or enqueue

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers opt into the blocking service-create fallback with `?sync=true`.
A common `sync=TRUE` after a client uppercases the flag must not silently
enqueue a 202 job. This is leftover tax after agent-provision sync
(#21136), which left the service-create parser untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/agents/route.sync.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/agents/route.sync.test.ts v1/agents/route.test.ts
```

16 new identity tests + 12 existing service-create tests passed at this head
(28 total).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; service agent-create `sync` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; service agent-create `sync` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; service agent-create `sync` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real sync tokens and assert 400 before create/enqueue; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before character create and enqueue.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`sync` tokens reject; omitted/canonical still bind the matching
async-or-blocking service-create path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file service-create sync
parse with a green focused suite (16 new + 12 existing). Full monorepo
verify is unrelated to this query grammar and was skipped to keep the
proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:50b65be97a691621b9a3094375739e75faf21058 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
