### PR TITLE
fix(core): guard non-array items and non-function estimator in sliceToFitBudget

### DIFF
--- a/packages/core/src/utils/slice-to-fit-budget.test.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.test.ts
@@ -49,6 +49,22 @@ describe("sliceToFitBudget", () => {
 
 	it("returns empty for an empty input", () => {
 		expect(sliceToFitBudget([], byLength, 100)).toEqual([]);
+		expect(
+			sliceToFitBudget(undefined as unknown as string[], byLength, 100),
+		).toEqual([]);
+		expect(
+			sliceToFitBudget(null as unknown as string[], byLength, 100),
+		).toEqual([]);
+	});
+
+	it("throws TypeError if estimateChars is not a function", () => {
+		expect(() =>
+			sliceToFitBudget(
+				["a", "b"],
+				null as unknown as (item: string) => number,
+				100,
+			),
+		).toThrow(TypeError);
 	});
 
 	it("returns empty for a zero or negative budget", () => {

--- a/packages/core/src/utils/slice-to-fit-budget.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.ts
@@ -16,9 +16,12 @@ export function sliceToFitBudget<T>(
 	targetChars: number,
 	options?: { fromEnd?: boolean },
 ): T[] {
-	if (items.length === 0) return [];
+	if (!Array.isArray(items) || items.length === 0) return [];
 	// Zero, negative, or non-finite budget means no room - return empty array
 	if (!Number.isFinite(targetChars) || targetChars <= 0) return [];
+	if (typeof estimateChars !== "function") {
+		throw new TypeError("estimateChars must be a function");
+	}
 
 	const fromEnd = options?.fromEnd ?? false;
 	let total = 0;


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/slice-to-fit-budget.ts`, `sliceToFitBudget` accessed `items.length` and called `items.map()` directly. When invoked with non-array inputs (`null` or `undefined`), it threw an unhandled `TypeError: Cannot read properties of undefined (reading 'length')` instead of returning `[]`.
2. Added `!Array.isArray(items)` validation to safely return `[]`.
3. Added `typeof estimateChars !== "function"` validation to throw a clear `TypeError("estimateChars must be a function")`.
4. Added regression unit test cases in `packages/core/src/utils/slice-to-fit-budget.test.ts`.

Closes #21155.

## Verification

Exact commit: `bfdf01e7ba`.

- Focused unit test suite `packages/core/src/utils/slice-to-fit-budget.test.ts`: 18/18 tests passing (34 assertions).
- Biome format on `@elizaos/core`: 1291 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - budget slicing utility; no rendered UI changed.
- [x] N/A - budget slicing utility; no rendered UI changed.
- [x] N/A - deterministic budget estimation tests.
- [x] Focused test suite transcript:
```text
✓ sliceToFitBudget > returns everything when the whole set fits [1.69ms]
✓ sliceToFitBudget > keeps the running total within the budget [0.16ms]
✓ sliceToFitBudget > includes an item that exactly exhausts the budget [0.03ms]
✓ sliceToFitBudget > returns empty when the first item alone exceeds the budget [0.02ms]
✓ sliceToFitBudget > stops at the first item that does not fit rather than skipping it [0.02ms]
✓ sliceToFitBudget > returns empty for an empty input [0.04ms]
✓ sliceToFitBudget > throws TypeError if estimateChars is not a function [0.69ms]
✓ sliceToFitBudget > returns empty for a zero or negative budget [0.24ms]
✓ sliceToFitBudget > treats a zero budget as no room even for a zero-cost item [0.05ms]
✓ sliceToFitBudget > keeps zero-cost items when there is any budget at all [0.03ms]
✓ sliceToFitBudget > rejects invalid or negative estimator returns [0.20ms]
✓ sliceToFitBudget > fromEnd > keeps the newest items and preserves their original order [0.05ms]
✓ sliceToFitBudget > fromEnd > returns a contiguous suffix, never a gap [0.03ms]
✓ sliceToFitBudget > fromEnd > returns everything when the whole set fits [0.03ms]
✓ sliceToFitBudget > fromEnd > returns empty when the newest item alone exceeds the budget [0.03ms]
✓ sliceToFitBudget > estimates each item exactly once [0.07ms]
✓ sliceToFitBudget > does not mutate the input array [0.25ms]
✓ sliceToFitBudget > works with non-string items via their own estimator [0.08ms]
18 pass, 0 fail, 34 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@221508bd6de2e5cae1c7908b982631526ca3d8c1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@221508bd6de2e5cae1c7908b982631526ca3d8c1:packages/skills/skills/contribute-to-eliza"} -->
