### PR TITLE
fix(release): cap candidate turbo fan-out to fit hosted-runner memory

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -244,10 +244,16 @@ jobs:
 
       - name: Verify release source before first pack
         if: inputs.candidate_run_id == 0
+        env:
+          # verify's default typecheck fan-out (8 concurrent tsc processes)
+          # exceeds hosted-runner memory and gets the step SIGTERMed; cap it.
+          RUN_TURBO_CONCURRENCY: "3"
         run: bun run verify
 
       - name: Test release source before first pack
         if: inputs.candidate_run_id == 0
+        env:
+          RUN_TURBO_CONCURRENCY: "3"
         run: bun run test
 
       - name: Rebind source immediately before pack
@@ -265,6 +271,8 @@ jobs:
 
       - name: Build and pack once
         if: inputs.candidate_run_id == 0
+        env:
+          RUN_TURBO_CONCURRENCY: "3"
         run: >-
           node packages/scripts/release-candidate.mjs candidate
           --cohort packages/scripts/release-cohort.json

--- a/packages/cloud/api/v1/ballots/[id]/route.public-query.test.ts
+++ b/packages/cloud/api/v1/ballots/[id]/route.public-query.test.ts
@@ -14,8 +14,6 @@ const requireUserOrApiKeyWithOrg = mock(async () => ({
   id: "user-1",
   organization_id: "org-1",
 }));
-const getMock = mock(async (_id: string, _organizationId: string) => null);
-const getBallotMock = mock(async (_id: string) => null);
 
 const ballotRow = {
   id: BALLOT_ID,
@@ -31,6 +29,16 @@ const ballotRow = {
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
   metadata: { tokenHashByIdentity: { voter: "secret-hash" } },
 };
+
+const getMock = mock(
+  async (
+    _id: string,
+    _organizationId: string,
+  ): Promise<typeof ballotRow | null> => null,
+);
+const getBallotMock = mock(
+  async (_id: string): Promise<typeof ballotRow | null> => null,
+);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,


### PR DESCRIPTION
Release run 32017697287 passed authorize and source binding, then the candidate's `bun run verify` was SIGTERMed (exit 143) mid-typecheck: verify runs turbo at `--concurrency=8` with `--max-old-space-size=8192`, and eight parallel tsc processes exceed the hosted ubuntu runner's ~7GB. The verify/test/build steps now set `RUN_TURBO_CONCURRENCY=3`, the run-turbo.mjs override built for hosted-CI memory caps.

actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)