### PR TITLE
fix(shared): guard non-function argument in createSerialise and add unit test suite

### DIFF
--- a/packages/shared/src/utils/serialise.test.ts
+++ b/packages/shared/src/utils/serialise.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for createSerialise in packages/shared/src/utils/serialise.ts.
+ * Exercises FIFO sequential promise execution, error isolation across tasks,
+ * concurrency serialization, and non-function argument rejection.
+ */
+import { describe, expect, it } from "vitest";
+import { createSerialise } from "./serialise.js";
+
+describe("createSerialise", () => {
+  it("executes async tasks in sequential FIFO order", async () => {
+    const serialise = createSerialise();
+    const order: number[] = [];
+
+    const p1 = serialise(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+      order.push(1);
+      return "res1";
+    });
+
+    const p2 = serialise(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      order.push(2);
+      return "res2";
+    });
+
+    const p3 = serialise(async () => {
+      order.push(3);
+      return "res3";
+    });
+
+    const results = await Promise.all([p1, p2, p3]);
+
+    expect(order).toEqual([1, 2, 3]);
+    expect(results).toEqual(["res1", "res2", "res3"]);
+  });
+
+  it("does not deadlock subsequent tasks when a prior task rejects", async () => {
+    const serialise = createSerialise();
+    const order: number[] = [];
+
+    const p1 = serialise(async () => {
+      order.push(1);
+      throw new Error("task 1 failed");
+    });
+
+    const p2 = serialise(async () => {
+      order.push(2);
+      return "recovered";
+    });
+
+    await expect(p1).rejects.toThrow("task 1 failed");
+    const res2 = await p2;
+
+    expect(res2).toBe("recovered");
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("ensures no overlapping execution between queued tasks", async () => {
+    const serialise = createSerialise();
+    let running = 0;
+    let maxRunning = 0;
+
+    const task = async () => {
+      running++;
+      maxRunning = Math.max(maxRunning, running);
+      await new Promise((r) => setTimeout(r, 10));
+      running--;
+    };
+
+    await Promise.all([
+      serialise(task),
+      serialise(task),
+      serialise(task),
+      serialise(task),
+    ]);
+
+    expect(maxRunning).toBe(1);
+    expect(running).toBe(0);
+  });
+
+  it("rejects immediately when fn is not a function", async () => {
+    const serialise = createSerialise();
+
+    await expect(
+      serialise(null as unknown as () => Promise<void>),
+    ).rejects.toThrow(TypeError);
+
+    await expect(
+      serialise(undefined as unknown as () => Promise<void>),
+    ).rejects.toThrow("createSerialise: fn must be a function");
+
+    await expect(
+      serialise(123 as unknown as () => Promise<void>),
+    ).rejects.toThrow(TypeError);
+  });
+});

--- a/packages/shared/src/utils/serialise.ts
+++ b/packages/shared/src/utils/serialise.ts
@@ -11,6 +11,11 @@
 export function createSerialise(): <T>(fn: () => Promise<T>) => Promise<T> {
   let lock: Promise<void> = Promise.resolve();
   return <T>(fn: () => Promise<T>): Promise<T> => {
+    if (typeof fn !== "function") {
+      return Promise.reject(
+        new TypeError("createSerialise: fn must be a function"),
+      );
+    }
     const prev = lock;
     let resolve: () => void;
     lock = new Promise<void>((r) => {


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/serialise.ts`, `createSerialise` chained async functions via `.then(fn)`. When passed a non-function value (`null`, `undefined`), `.then(fn)` silently resolved to `undefined` without executing or rejecting.
2. Added `typeof fn === "function"` validation to reject immediately with `TypeError("createSerialise: fn must be a function")`.
3. Created a comprehensive unit test suite in `packages/shared/src/utils/serialise.test.ts` covering FIFO execution order, rejection isolation (rejected task does not deadlock subsequent queue operations), execution concurrency, and invalid input rejection.

Closes #21157.

## Verification

Exact commit: `eeb2658bc7`.

- Focused unit test suite `packages/shared/src/utils/serialise.test.ts`: 4/4 tests passing (10 assertions).
- Biome format on `@elizaos/shared`: 409 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - promise serialization utility; no rendered UI changed.
- [x] N/A - promise serialization utility; no rendered UI changed.
- [x] N/A - deterministic promise queue execution tests.
- [x] Focused test suite transcript:
```text
✓ createSerialise > executes async tasks in sequential FIFO order [36.41ms]
✓ createSerialise > does not deadlock subsequent tasks when a prior task rejects [0.78ms]
✓ createSerialise > ensures no overlapping execution between queued tasks [49.53ms]
✓ createSerialise > rejects immediately when fn is not a function [0.28ms]
4 pass, 0 fail, 10 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@221508bd6de2e5cae1c7908b982631526ca3d8c1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@221508bd6de2e5cae1c7908b982631526ca3d8c1:packages/skills/skills/contribute-to-eliza"} -->
