### PR TITLE
fix(build): run build:core entrypoint on Windows

### DIFF
--- a/packages/scripts/__tests__/build-core.test.ts
+++ b/packages/scripts/__tests__/build-core.test.ts
@@ -2,10 +2,11 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   BUILD_CORE_PREREQUISITE_SCRIPTS,
   buildCoreTurboArgs,
+  isBuildCoreEntrypoint,
 } from "../build-core.mjs";
 import { CORE_BUILD_PACKAGES } from "../build-core-packages.mjs";
 
@@ -129,6 +130,31 @@ describe("build-core package set (issue #10200)", () => {
     expect(body).toBe("node packages/scripts/build-core.mjs");
     // Guard against regressing to the hand-maintained inline flag wall.
     expect(body).not.toContain("--filter=");
+  });
+
+  test("direct execution compares canonical file URLs across platforms", () => {
+    const scriptPath = fileURLToPath(
+      new URL("../build-core.mjs", import.meta.url),
+    );
+
+    expect(
+      isBuildCoreEntrypoint(pathToFileURL(scriptPath).href, scriptPath),
+    ).toBe(true);
+  });
+
+  test("entrypoint detection handles URL-sensitive paths and rejects imports", () => {
+    const scriptPath = path.join(
+      REPO_ROOT,
+      "path with spaces",
+      "build-core #entry.mjs",
+    );
+    const scriptUrl = pathToFileURL(scriptPath).href;
+
+    expect(isBuildCoreEntrypoint(scriptUrl, scriptPath)).toBe(true);
+    expect(
+      isBuildCoreEntrypoint(scriptUrl, path.join(REPO_ROOT, "importer.mjs")),
+    ).toBe(false);
+    expect(isBuildCoreEntrypoint(scriptUrl, undefined)).toBe(false);
   });
 
   test("package-local core build prepares logger before core declarations", () => {

--- a/packages/scripts/build-core.mjs
+++ b/packages/scripts/build-core.mjs
@@ -20,12 +20,28 @@
  */
 import { spawnSync } from "node:child_process";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { CORE_BUILD_PACKAGES } from "./build-core-packages.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const RUN_TURBO = path.join(SCRIPT_DIR, "run-turbo.mjs");
-export const BUILD_CORE_PREREQUISITE_SCRIPTS = ["ensure-workspace-symlinks.mjs"];
+export const BUILD_CORE_PREREQUISITE_SCRIPTS = [
+  "ensure-workspace-symlinks.mjs",
+];
+
+/**
+ * Whether this module is the process entrypoint.
+ *
+ * `import.meta.url` is always a normalized file URL, while `process.argv[1]`
+ * is a platform-native filesystem path. Building a URL with string
+ * interpolation leaves Windows backslashes and drive-letter syntax intact,
+ * so the direct-execution guard silently fails there. Convert through Node's
+ * URL API instead, matching the representation used for `import.meta.url`.
+ */
+export function isBuildCoreEntrypoint(moduleUrl, argvPath) {
+  if (typeof argvPath !== "string" || argvPath.length === 0) return false;
+  return moduleUrl === pathToFileURL(path.resolve(argvPath)).href;
+}
 
 /** The exact `run-turbo.mjs` argv for the core build, plus any forwarded args. */
 export function buildCoreTurboArgs(extra = []) {
@@ -89,4 +105,4 @@ function main() {
   process.exit(result.status ?? 1);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+if (isBuildCoreEntrypoint(import.meta.url, process.argv[1])) main();


### PR DESCRIPTION
# Relates to

Closes #21145.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      Windows toolchain blocker is recorded below.
- [x] A reviewer can confirm the change from the canonical URL predicate matrix
      and deterministic real-entrypoint transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@221508bd6de9e374e8fba159e79f4e1397f3803a`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated Turbo/Bun discovery
      blocker is documented in **Known gaps / failures**.

# Risks

Low. The change affects only direct-execution detection for the root build-core
driver. Importing the module remains side-effect free, and package selection,
prerequisite ordering, forwarded arguments, and child failure propagation are
unchanged.

# Background

## What does this PR do?

`build:core` invokes `node packages/scripts/build-core.mjs`. The script compared
the normalized ESM `import.meta.url` with a hand-built `file://${process.argv[1]}`
string. On Windows, the latter retains backslashes and drive-letter path syntax,
so the guard was false and the command exited 0 without running prerequisites or
Turbo.

This PR converts the native path through Node's `path.resolve` and
`pathToFileURL`, matching the representation used by `import.meta.url`. Tests
cover the actual script path, URL-sensitive spaces/`#`, an unrelated importer,
and a missing argv path.

## What kind of change is this?

Bug fix (cross-platform build-infrastructure correctness).

# Documentation changes needed?

No. The documented `bun run build:core` command is unchanged; this makes its
existing Windows behavior match macOS/Linux instead of silently doing nothing.

# Testing

## Where should a reviewer start?

Start with `packages/scripts/__tests__/build-core.test.ts` at the two new
entrypoint tests, then inspect the bottom guard in `packages/scripts/build-core.mjs`.

## Detailed testing steps

Exact head: `4a91cda043fdf6107e70af379404a876321a55b7`

1. `bun install --frozen-lockfile --ignore-scripts`
   - PASS: 3,809 installs / 4,090 packages, no changes.
2. `bun test packages/scripts/__tests__/build-core.test.ts`
   - PASS: 10 tests, 18 assertions.
3. `node packages/scripts/audit-scripts.mjs`
   - PASS.
4. `bun x --no-install @biomejs/biome check packages/scripts/build-core.mjs packages/scripts/__tests__/build-core.test.ts`
   - PASS: 2 files, no fixes.
5. `git diff --check`
   - PASS.
6. Real driver boundary with the existing `RUN_TURBO_BIN` deterministic seam:
   - `node packages/scripts/build-core.mjs --force`
   - PASS: printed `[build-core] running ensure-workspace-symlinks.mjs`, then
     `[build-core] building 22 core packages via turbo`, and the fake Turbo
     received all 22 existing filters plus the forwarded `--force` argument.
     This exact command was a silent exit before the patch on Windows.
7. `bun run test:scripts`
   - Focused build-core file remains 10/10. The aggregate continues into broad
     unrelated Windows failures documented below.
8. `bun run verify`
   - Repository preflight, i18n, dependency-reference, alias-read, and generated
     source gates pass; it stops before package fan-out at the unrelated local
     Turbo/Bun discovery blocker documented below.

# Evidence Gate

<!-- evidence-head:e0f9ec461c4793219d5bd4f882d07b7e2bd3668a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - terminal build driver only; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - terminal build driver only; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic CLI and test transcript fully proves the change.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service path changes; CLI stdout is included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, network request, or UI state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, prompt, provider, model, or inference changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain data; the artifact is the build-driver argv transcript.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual-text surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model path changes.

## Backend + frontend logs

N/A - build infrastructure only. Deterministic terminal proof:

```text
[build-core] running ensure-workspace-symlinks.mjs
[build-core] building 22 core packages via turbo (extra args: --force)
[fake-turbo] ["--ui=stream","run","--log-order=stream","build",<22 unchanged filters>,"--force"]
```

## Screenshots (before / after) + video walkthrough

N/A - no rendered surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changes.

## Known gaps / failures

- Exact-head root `bun run verify` cannot enter Turbo's package fan-out in this
  isolated Windows worktree because Turbo 2.10.8 reports `Unable to find package
  manager binary: cannot find binary path` for the workspace-bundled Bun 1.3.14
  executable. All pre-Turbo repository gates pass, as do the focused test,
  scripts audit, exact-file Biome, frozen install, and diff-check.
- The full `test:scripts` inventory was run and exposes existing unrelated
  Windows assumptions: missing Bash, POSIX separator assertions, symlink EPERM,
  Windows `npm` spawn failures, and timing-sensitive lock fixtures. The changed
  `build-core.test.ts` suite is independently green 10/10; none of the aggregate
  failures names either changed file.
- The deterministic real-driver probe runs through the exact entrypoint and
  Turbo argv boundary. Windows sandbox policy prevents some optional workspace
  symlink repairs (EPERM), but the driver still reaches the fake Turbo and proves
  the regression is closed without performing the expensive build graph.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-build-core-windows]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza"} -->

