### PR TITLE
fix(wallet): add timeout to Meteora pools fetch

### DIFF
--- a/plugins/plugin-wallet/src/chains/solana/dex/meteora/services/MeteoraLpService.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/meteora/services/MeteoraLpService.ts
@@ -71,7 +71,7 @@ export class MeteoraLpService extends Service {
 
   public async getPools(tokenAMint?: string, tokenBMint?: string): Promise<PoolInfo[]> {
     try {
-      const response = await fetch(this.METEORA_API_URL);
+      const response = await fetch(this.METEORA_API_URL, { signal: AbortSignal.timeout(10_000) });
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Bug #2 on `develop` @ `cd41f99b` — `fetch(METEORA_API_URL)` with no timeout in `plugins/plugin-wallet/src/chains/solana/dex/meteora/services/MeteoraLpService.ts:74` (`getPools`). External Meteora API fetch could hang indefinitely. No existing issue; single-file signal fix. Mirrors `solana:543` / `erc8004:624` timeout idiom.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `cd41f99b` (origin/develop at task creation) with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` / package typecheck were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is self-reported provenance, not a request for chain-of-thought. Never include prompts containing secrets, tokens, private session IDs, or hidden reasoning. Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels (`Client / agent tooling`, `Skill revision` / `Contribution skill revision`, `Attribution status`). Duplicating those strings makes the scoring validator reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->` markers; only the human-readable prefixes changed. After filling these rows, append the standard footer once at the end of the PR body (do not repeat the visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@cd41f99b1a9b74b507e64060fc86ae82a459d7cd:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto `cd41f99b` (`origin/develop` at task base); zero conflicts. Current `origin/develop` is `cd41f99b` — this branch is based on `cd41f99b` (latest at task creation). Single-line isolated replacement, no conflicts expected.
- [x] `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json --skipLibCheck` passes post-sync; typecheck green (see Evidence). No `bun install` blocker for this file — `AbortSignal` is global, no new import.

# Risks

Low. Single-file change, 1 insertion / 1 deletion, no API or storage migration. Behaviour strictly adds a timeout: previously external `fetch(METEORA_API_URL)` could hang forever on a slow/unresponsive Meteora DLMM API; now bounded to 10s via `AbortSignal.timeout(10_000)`. Matches existing idiom in `uaid.ts:484` (`AbortController`), `health-connectors.ts:261` (`AbortSignal.timeout`), and `solana.ts:543` (`AbortSignal.timeout(10_000)`) just shipped. Risk only if Meteora API legitimately needs >10s — unlikely for pool metadata and desirable to fail fast; caller already handles errors by returning `[]`.

# Background

## What does this PR do?

Adds `signal: AbortSignal.timeout(10_000)` to the external pools `fetch` in `getPools` (`plugins/plugin-wallet/src/chains/solana/dex/meteora/services/MeteoraLpService.ts:74`).

Before (line 74):
```ts
const response = await fetch(this.METEORA_API_URL);
```
- No signal, no timeout — `fetch` on external Meteora DLMM API (`https://dlmm-api.meteora.ag/pair/all`) could hang indefinitely, blocking `getPools` and downstream callers (`removeLiquidity`, `getLpPositionDetails`, `getMarketDataForPools`).

After (line 74):
```ts
const response = await fetch(this.METEORA_API_URL, { signal: AbortSignal.timeout(10_000) });
```
- 10s timeout via global `AbortSignal.timeout` (no import needed). Mirrors `plugins/plugin-wallet/src/sdk/identity/uaid.ts:484`, `plugins/plugin-health/src/health-bridge/health-connectors.ts:261`, and `plugins/plugin-wallet/src/chains/solana/solana.ts:543` idiom.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

`getPools` is called during Meteora DLMM pool discovery and transitively by `removeLiquidity`, `getLpPositionDetails`, and `getMarketDataForPools`. The Meteora API is an external untrusted endpoint; a slow or hanging response could DoS the caller. No timeout idiom was present (`grep -n "signal|AbortSignal"` → 0 hits before, 1 after). The Solana `fetch` path and ERC-8004 `resolveAgentURI` (`PR #21154`) were just fixed with the same `AbortSignal.timeout` idiom — this Meteora path was the remaining open external `fetch` without a signal.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/chains/solana/dex/meteora/services/MeteoraLpService.ts` — `getPools` function, `fetch` call at line 74.

## Detailed testing steps

- Verify no signal before: `grep -n "signal\|AbortSignal" plugins/plugin-wallet/src/chains/solana/dex/meteora/services/MeteoraLpService.ts` → 0 hits on `cd41f99b` (see Evidence Details).
- Verify signal after: `grep -n "signal\|AbortSignal" plugins/plugin-wallet/src/chains/solana/dex/meteora/services/MeteoraLpService.ts` → `74:      const response = await fetch(this.METEORA_API_URL, { signal: AbortSignal.timeout(10_000) });` (see Evidence Details).
- Verify surrounding `grep -n "fetch|signal"` before/after shows 0→1 signal line.
- Typecheck: `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json --skipLibCheck` → `EXIT:0` (no new diagnostic on `MeteoraLpService.ts` — `AbortSignal.timeout` is DOM lib global).
- No dedicated `MeteoraLpService` unit test exists; no existing test breakage — single-line `fetch` option addition, error path already returns `[]`.
- Idiom check: `grep -n "AbortSignal.timeout" plugins/plugin-health/src/health-bridge/health-connectors.ts` → `261` hit confirms established pattern.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:77393cd620cf23088c95c3a184a6778838808664 -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the description or a comment), or write `N/A - <reason>` on the row. Do not leave evidence rows blank. Videos must be **MP4** (GitHub renders them inline); prefer **JPG over PNG** for screenshots. Do not commit evidence files to the repo.

<!-- evidence-row:frontend-video -->
- [x] Frontend video walkthrough is attached (MP4), or marked `N/A - <reason>`. → N/A — no frontend surface; `getPools` is a backend Solana DEX service, not a UI component.
<!-- evidence-row:frontend-screenshots -->
- [x] Before/after screenshots are attached (JPG preferred), or marked `N/A - <reason>`. → N/A — no rendered visual surface; single-line `fetch` signal addition in Meteora LP service.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`. → N/A — no frontend request/response; external `fetch` is server-side Meteora API call, not browser UI.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`. → N/A — `fetch` timeout fix, no LLM trajectory.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`. → N/A — no domain artifacts; `getPools` returns `PoolInfo[]` in-memory.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface. → N/A — no rendered visual surface.

# Evidence Details

**Before grep** (`MeteoraLpService.ts:74` on `cd41f99b`):
```
74:      const response = await fetch(this.METEORA_API_URL);
grep -n "signal|AbortSignal" → 0 hits
grep -n "fetch|signal" → 74:      const response = await fetch(this.METEORA_API_URL);
sed -n '70,80p':
  public async getPools(tokenAMint?: string, tokenBMint?: string): Promise<PoolInfo[]> {
    try {
      const response = await fetch(this.METEORA_API_URL);
      if (!response.ok) {
        throw new Error(`HTTP error! status: ${response.status}`);
      }
      const data = (await response.json()) as MeteoraPoolResponse[];
```

**After grep** (this PR):
```
74:      const response = await fetch(this.METEORA_API_URL, { signal: AbortSignal.timeout(10_000) });
grep -n "signal|AbortSignal" → 74:      const response = await fetch(this.METEORA_API_URL, { signal: AbortSignal.timeout(10_000) });
grep -n "fetch|signal" → 74:      const response = await fetch(this.METEORA_API_URL, { signal: AbortSignal.timeout(10_000) });
sed -n '70,80p':
  public async getPools(tokenAMint?: string, tokenBMint?: string): Promise<PoolInfo[]> {
    try {
      const response = await fetch(this.METEORA_API_URL, { signal: AbortSignal.timeout(10_000) });
      if (!response.ok) {
        throw new Error(`HTTP error! status: ${response.status}`);
      }
      const data = (await response.json()) as MeteoraPoolResponse[];
```

**Timeout proof** (mirrors existing idioms):
| File | Idiom |
|------|-------|
| `plugins/plugin-wallet/src/sdk/identity/uaid.ts:484` | `AbortController` timeout |
| `plugins/plugin-health/src/health-bridge/health-connectors.ts:261` | `AbortSignal.timeout(...)` |
| `plugins/plugin-wallet/src/chains/solana/solana.ts:543` | `AbortSignal.timeout(10_000)` — just shipped |
| This PR `MeteoraLpService.ts:74` | `AbortSignal.timeout(10_000)` — same |

**Typecheck**: `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json --skipLibCheck` → `EXIT:0` (no new diagnostic on `MeteoraLpService.ts`; `AbortSignal` is DOM global, no import needed).

**Diff stat**: `1 file changed, 1 insertion(+), 1 deletion(-)` — single-file scoped, rebased on `cd41f99b`.

---
AI provider/model: anthropic/claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/eliza@cd41f99b1a9b74b507e64060fc86ae82a459d7cd:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/eliza@cd41f99b1a9b74b507e64060fc86ae82a459d7cd:packages/skills/skills/contribute-to-eliza"} -->
