### PR TITLE
fix(shared): guard empty name argument, export reset helper, and add unit test suite in log-prefix

### DIFF
--- a/packages/shared/src/utils/log-prefix.test.ts
+++ b/packages/shared/src/utils/log-prefix.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for getLogPrefix and resetLogPrefixForTesting in packages/shared/src/utils/log-prefix.ts.
+ * Exercises env resolution (APP_CLI_NAME, npm_package_name), CLI argv flags (--name=),
+ * empty name argument fallbacks, caching behavior, and test cache reset.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getLogPrefix, resetLogPrefixForTesting } from "./log-prefix.js";
+
+describe("log-prefix", () => {
+  const originalEnv = { ...process.env };
+  const originalArgv = [...process.argv];
+
+  beforeEach(() => {
+    resetLogPrefixForTesting();
+    delete process.env.APP_CLI_NAME;
+    delete process.env.npm_package_name;
+    process.argv = ["node", "script.js"];
+  });
+
+  afterEach(() => {
+    resetLogPrefixForTesting();
+    process.env = { ...originalEnv };
+    process.argv = [...originalArgv];
+  });
+
+  it("prioritizes APP_CLI_NAME when present in env", () => {
+    process.env.APP_CLI_NAME = "custom-app";
+    expect(getLogPrefix()).toBe("[custom-app]");
+  });
+
+  it("resolves log prefix from npm_package_name", () => {
+    process.env.npm_package_name = "elizaos";
+    expect(getLogPrefix()).toBe("[eliza]");
+
+    resetLogPrefixForTesting();
+    process.env.npm_package_name = "@elizaos/core";
+    expect(getLogPrefix()).toBe("[core]");
+
+    resetLogPrefixForTesting();
+    process.env.npm_package_name = "my-worker";
+    expect(getLogPrefix()).toBe("[my-worker]");
+  });
+
+  it("resolves log prefix from --name= argument", () => {
+    process.argv = ["node", "script.js", "--name=worker-node"];
+    expect(getLogPrefix()).toBe("[worker-node]");
+  });
+
+  it("ignores empty --name= and falls back to default prefix", () => {
+    process.argv = ["node", "script.js", "--name="];
+    expect(getLogPrefix()).toBe("[eliza]");
+  });
+
+  it("caches the computed prefix until reset", () => {
+    process.env.APP_CLI_NAME = "first-name";
+    expect(getLogPrefix()).toBe("[first-name]");
+
+    process.env.APP_CLI_NAME = "second-name";
+    // Should still return cached value
+    expect(getLogPrefix()).toBe("[first-name]");
+
+    resetLogPrefixForTesting();
+    expect(getLogPrefix()).toBe("[second-name]");
+  });
+});

--- a/packages/shared/src/utils/log-prefix.ts
+++ b/packages/shared/src/utils/log-prefix.ts
@@ -49,9 +49,11 @@ export function getLogPrefix(): string {
     a.startsWith("--name="),
   );
   if (nameArgMatch) {
-    const name = nameArgMatch.split("=")[1];
-    cachedPrefix = `[${name}]`;
-    return cachedPrefix;
+    const name = nameArgMatch.slice("--name=".length).trim();
+    if (name) {
+      cachedPrefix = `[${name}]`;
+      return cachedPrefix;
+    }
   }
 
   const cwd =
@@ -63,4 +65,8 @@ export function getLogPrefix(): string {
 
   cachedPrefix = "[eliza]";
   return cachedPrefix;
+}
+
+export function resetLogPrefixForTesting(): void {
+  cachedPrefix = null;
 }


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/log-prefix.ts`, `getLogPrefix` matched CLI argument `--name=` without verifying that the value was non-empty, causing empty `--name=` flags to cache `[]` as the log prefix.
2. Guarded `--name=` parsing to require trimmed non-empty values before setting `[${name}]`.
3. Exported `resetLogPrefixForTesting()` to allow test suites to reset the cached singleton prefix.
4. Created a comprehensive unit test suite in `packages/shared/src/utils/log-prefix.test.ts` covering `APP_CLI_NAME`, `npm_package_name`, `--name=` flags, and cache reset behavior.

Closes #21164.

## Verification

Exact commit: `823238b8f2`.

- Focused unit test suite `packages/shared/src/utils/log-prefix.test.ts`: 5/5 tests passing (9 assertions).
- Biome format on `@elizaos/shared`: 409 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - log prefix utility; no rendered UI changed.
- [x] N/A - log prefix utility; no rendered UI changed.
- [x] N/A - deterministic log prefix resolution tests.
- [x] Focused test suite transcript:
```text
✓ log-prefix > prioritizes APP_CLI_NAME when present in env [0.32ms]
✓ log-prefix > resolves log prefix from npm_package_name [0.15ms]
✓ log-prefix > resolves log prefix from --name= argument [0.10ms]
✓ log-prefix > ignores empty --name= and falls back to default prefix [0.03ms]
✓ log-prefix > caches the computed prefix until reset [0.04ms]
5 pass, 0 fail, 9 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@cd41f99b1ab65b1695f269a8da23ff3a699c2777:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@cd41f99b1ab65b1695f269a8da23ff3a699c2777:packages/skills/skills/contribute-to-eliza"} -->
