### PR TITLE
fix(meetings): bound Zoom participant pagination

### DIFF
--- a/plugins/plugin-meetings/src/platforms/zoom/__tests__/cloud-import.test.ts
+++ b/plugins/plugin-meetings/src/platforms/zoom/__tests__/cloud-import.test.ts
@@ -160,6 +160,87 @@ describe("Zoom cloud import", () => {
     });
   });
 
+  it("rejects a repeated participant pagination token", async () => {
+    let participantCalls = 0;
+    const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+      const url = String(input);
+      if (url.includes("/participants")) {
+        participantCalls += 1;
+        if (participantCalls > 2) {
+          throw new Error("participant pagination did not terminate");
+        }
+        return json({ participants: [], next_page_token: "stuck-token" });
+      }
+      if (url.includes("/recordings")) {
+        return json({ recording_files: [] });
+      }
+      return json({ uuid: "meeting-repeated-token" });
+    };
+
+    await expect(
+      importZoomCloudMeeting({
+        meetingId: "meeting-repeated-token",
+        accessToken: TOKEN,
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject<Partial<ZoomCloudImportError>>({
+      code: "invalid_response",
+      status: 502,
+    });
+    expect(participantCalls).toBe(2);
+  });
+
+  it("rejects a non-adjacent participant pagination cycle", async () => {
+    const tokens = ["token-a", "token-b", "token-a"];
+    let participantCalls = 0;
+    const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+      if (String(input).includes("/participants")) {
+        const nextPageToken = tokens[participantCalls];
+        participantCalls += 1;
+        return json({ participants: [], next_page_token: nextPageToken });
+      }
+      return json({ uuid: "meeting-token-cycle" });
+    };
+
+    await expect(
+      importZoomCloudMeeting({
+        meetingId: "meeting-token-cycle",
+        accessToken: TOKEN,
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject<Partial<ZoomCloudImportError>>({
+      code: "invalid_response",
+      status: 502,
+    });
+    expect(participantCalls).toBe(3);
+  });
+
+  it("stops before requesting a 101st participant page", async () => {
+    let participantCalls = 0;
+    const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+      if (String(input).includes("/participants")) {
+        participantCalls += 1;
+        return json({
+          participants: [],
+          next_page_token: `unique-token-${participantCalls}`,
+        });
+      }
+      return json({ uuid: "meeting-page-limit" });
+    };
+
+    await expect(
+      importZoomCloudMeeting({
+        meetingId: "meeting-page-limit",
+        accessToken: TOKEN,
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject<Partial<ZoomCloudImportError>>({
+      code: "invalid_response",
+      status: 502,
+    });
+    expect(participantCalls).toBe(100);
+  });
+
   it("fails closed when a streamed recording exceeds its byte quota", async () => {
     const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
       const url = String(input);

--- a/plugins/plugin-meetings/src/platforms/zoom/cloud-import.ts
+++ b/plugins/plugin-meetings/src/platforms/zoom/cloud-import.ts
@@ -22,6 +22,7 @@ const ZOOM_API_BASE = "https://api.zoom.us/v2";
 const DEFAULT_JSON_LIMIT = 8 * 1024 * 1024;
 const DEFAULT_FILE_LIMIT = 256 * 1024 * 1024;
 const DEFAULT_TOTAL_LIMIT = 512 * 1024 * 1024;
+const MAX_PARTICIPANT_PAGES = 100;
 
 type FetchLike = (
   input: RequestInfo | URL,
@@ -255,8 +256,18 @@ async function requestAllParticipants(
   },
 ): Promise<ZoomParticipantResponse[]> {
   const participants: ZoomParticipantResponse[] = [];
+  const seenTokens = new Set<string>();
   let token: string | undefined;
+  let pageCount = 0;
   do {
+    pageCount += 1;
+    if (pageCount > MAX_PARTICIPANT_PAGES) {
+      throw new ZoomCloudImportError(
+        "invalid_response",
+        `Zoom participants pagination exceeded ${MAX_PARTICIPANT_PAGES} pages.`,
+        502,
+      );
+    }
     const url = new URL(
       `${ZOOM_API_BASE}/past_meetings/${encodedId}/participants`,
     );
@@ -273,6 +284,14 @@ async function requestAllParticipants(
       ),
     );
     token = page.next_page_token?.trim() || undefined;
+    if (token && seenTokens.has(token)) {
+      throw new ZoomCloudImportError(
+        "invalid_response",
+        "Zoom participants pagination repeated a page token.",
+        502,
+      );
+    }
+    if (token) seenTokens.add(token);
   } while (token);
   return participants;
 }


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
- AI assistance: Yes - initial author assistance plus maintainer review and remediation
<!-- attribution-row:models -->
- Models: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client/tooling: Codex CLI, Claude Code, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - the contribution skill was not used for this maintainer review and remediation
<!-- attribution-row:status -->
- Provenance status: self-reported

AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: re-ran the full mutation check myself from a clean revert of just the source fix (confirmed red, then restored and confirmed green), re-ran the full package test/lint/typecheck myself, confirmed the `ZoomCloudImportError` constructor usage and `invalid_response` error code against the actual source, and independently traced the reachability chain from the registered route through to the importer.

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low. Adds a page counter and a seen-tokens set local to `requestAllParticipants`. Normal pagination (each page returning a distinct token, or an empty/undefined token on the last page, within 100 pages) is unaffected — only a token that repeats, or pagination that exceeds 100 pages, now throws a typed error instead of looping.

# Background

## What does this PR do?

`requestAllParticipants` in the Zoom cloud-import path trusted Zoom's provider-controlled `next_page_token` with no cycle detection or page limit. If Zoom returns the same non-empty token on successive pages, the authenticated cloud import repeatedly fetches the same participant page, accumulates duplicate rows, and never completes unless the transport eventually fails.

Before fix (transport that throws after 6 calls, standing in for "would loop forever otherwise"):
```text
Zoom request failed before a response was received.
participantCalls=6
```

After fix: a repeated token is rejected as a typed `invalid_response` error after exactly 2 participant requests, and pagination is separately capped at 100 pages as a second line of defense against an endless stream of unique tokens.

## What kind of change is this?

Bug fix — no new capability, no schema change.

# Documentation changes needed?

No.

# Testing

New test `rejects a repeated participant pagination token` in `plugins/plugin-meetings/src/platforms/zoom/__tests__/cloud-import.test.ts`, following the file's existing mock-fetch conventions, with a fail-safe assertion (`participant pagination did not terminate`) if the guard doesn't fire.

# Evidence Gate

<!-- evidence-head:1e9a4317217a8a74b2c96d4a16dccc0186c1197f -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend logic fix, no UI surface
- <!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual behavior changed

## Known gaps / failures

None found. Full package test/lint/typecheck all clean.

## Reachability

- `POST /api/meetings/import/zoom` is a registered private raw-path route in `plugins/plugin-meetings/src/routes/meetings-routes.ts`, accepting a real `meetingId` and optional short-lived OAuth `accessToken`.
- Its handler calls `MeetingService.importZoomMeeting`, which resolves the request token or configured Zoom token and calls the injected production `importZoomCloudMeeting` implementation.
- `importZoomCloudMeeting` calls `requestAllParticipants`; its `next_page_token` values come directly from Zoom API JSON responses and are not hardcoded-safe.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic focused regression tests are documented in the Testing section and produce no persistent backend log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by this logic change

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered interface changed
