### PR TITLE
fix(agent): harden media store decode, GC sweep, and serving (W1-012/013/049/050)

### DIFF
--- a/packages/agent/src/api/chat-attachment-processing-lifecycle.test.ts
+++ b/packages/agent/src/api/chat-attachment-processing-lifecycle.test.ts
@@ -317,9 +317,14 @@ describe("chat attachment upload -> store -> processing lifecycle (#10714)", () 
       );
       expect(head.headers["X-Content-Type-Options"], mimeType).toBe("nosniff");
       const disposition = String(head.headers["Content-Disposition"]);
-      // Only image/audio/video/pdf render inline; text/* and application/json
-      // are forced to download (attachment) by the serve-path security policy.
-      if (mimeType.startsWith("text/") || mimeType === "application/json") {
+      // Only image/audio/video render inline; application/pdf, text/* and
+      // application/json are forced to download (attachment) by the serve-path
+      // security policy.
+      if (
+        mimeType.startsWith("text/") ||
+        mimeType === "application/json" ||
+        mimeType === "application/pdf"
+      ) {
         expect(disposition, mimeType).toContain("attachment");
       } else {
         expect(disposition, mimeType).toBe("inline");

--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -296,7 +296,11 @@ describe("media-store", () => {
     const out = get();
     expect(out.status).toBe(200);
     expect(out.headers["Content-Type"]).toBe("image/png");
-    expect(String(out.headers["Cache-Control"])).toContain("immutable");
+    const cacheControl = String(out.headers["Cache-Control"]);
+    expect(cacheControl).toContain("immutable");
+    // Pre-auth capability URLs must not be persisted by shared/proxy caches.
+    expect(cacheControl).toContain("private");
+    expect(cacheControl).not.toContain("public");
     expect(Number(out.headers["Content-Length"])).toBe(
       Buffer.from("served-bytes").length,
     );
@@ -367,6 +371,21 @@ describe("serve-path security headers (stored-XSS defence)", () => {
     expect(String(headers["Content-Disposition"])).toContain("attachment");
   });
 
+  it("forces PDF to download (attachment) — never inline-rendered", () => {
+    // Parity with SVG: inline plugin/viewer rendering of a pre-auth capability
+    // URL must never execute active content on this origin.
+    const { url, fileName } = persistMediaBytes(
+      Buffer.from("%PDF-1.4\nfake"),
+      "application/pdf",
+    );
+    expect(fileName.endsWith(".pdf")).toBe(true);
+    const { res, get } = makeRes();
+    serveMediaFile({ method: "HEAD", headers: {} } as never, res, url);
+    const { headers } = get();
+    expect(headers["Content-Type"]).toBe("application/pdf");
+    expect(String(headers["Content-Disposition"])).toContain("attachment");
+  });
+
   it("reconciles markup masquerading as a PNG → stored + served as a download", () => {
     // Bytes are really an SVG but the caller declared image/png.
     const { fileName } = persistMediaBytes(
@@ -388,7 +407,7 @@ describe("serve-path security headers (stored-XSS defence)", () => {
     expect(isInlineSafeMime("image/png")).toBe(true);
     expect(isInlineSafeMime("audio/mpeg")).toBe(true);
     expect(isInlineSafeMime("video/mp4")).toBe(true);
-    expect(isInlineSafeMime("application/pdf")).toBe(true);
+    expect(isInlineSafeMime("application/pdf")).toBe(false);
     expect(isInlineSafeMime("image/svg+xml")).toBe(false);
     expect(isInlineSafeMime("text/html")).toBe(false);
     expect(isInlineSafeMime("application/octet-stream")).toBe(false);
@@ -915,6 +934,18 @@ describe("readStoredMediaBytes fast-fail (#12265)", () => {
     expect(readStoredMediaBytes("../../etc/passwd")).toBeNull();
   });
 
+  it("returns null for a sibling ledger name that exists in the store dir", () => {
+    // background-pins.json / audio-redactions.json live next to the media
+    // objects and pass a bare dirname check; the strict name pattern must
+    // reject them before the helper ever resolves the path.
+    fs.writeFileSync(mediaPath("background-pins.json"), "[]");
+    try {
+      expect(readStoredMediaBytes("background-pins.json")).toBeNull();
+    } finally {
+      fs.rmSync(mediaPath("background-pins.json"), { force: true });
+    }
+  });
+
   it("throws MEDIA_STORE_READ_FAILED when a stored entry is unreadable", () => {
     // A directory sitting where the bytes should be makes readFileSync throw
     // EISDIR — a real I/O failure distinct from absence, and root-independent.
@@ -942,6 +973,15 @@ describe("writeStoredMediaFile fast-fail (#12265)", () => {
     expect(writeStoredMediaFile(name, Buffer.from("ok"))).toBe(true);
     expect(readStoredMediaBytes(name)?.toString()).toBe("ok");
     expect(writeStoredMediaFile("../escape.bin", Buffer.from("x"))).toBe(false);
+  });
+
+  it("returns false for a sibling ledger name without writing it", () => {
+    // audio-redactions.json lives next to the media objects and passes a bare
+    // dirname check; the strict name pattern must reject it before any write.
+    expect(
+      writeStoredMediaFile("audio-redactions.json", Buffer.from("{}")),
+    ).toBe(false);
+    expect(fs.existsSync(mediaPath("audio-redactions.json"))).toBe(false);
   });
 
   it.skipIf(typeof process.getuid === "function" && process.getuid() === 0)(

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -97,10 +97,13 @@ const MEDIA_URL_PREFIX = "/api/media/";
 
 /**
  * MIME types that are safe to render inline in a browser context. Everything
- * else — notably `image/svg+xml`, `text/html`, and unknown/active types — is
- * served with `Content-Disposition: attachment` so it can never execute script
- * on the dashboard origin (stored-XSS defence). SVG is deliberately excluded:
- * it is an XML document that can carry `<script>` and event handlers.
+ * else — notably `image/svg+xml`, `application/pdf`, `text/html`, and
+ * unknown/active types — is served with `Content-Disposition: attachment` so it
+ * can never execute script on the dashboard origin (stored-XSS defence). SVG is
+ * deliberately excluded: it is an XML document that can carry `<script>` and
+ * event handlers. PDF is excluded for parity: inline plugin/viewer rendering
+ * adds script surface the sandboxed CSP cannot fully confine, and these pre-auth
+ * capability URLs must never inline-execute active content.
  */
 export function isInlineSafeMime(mime: string): boolean {
   const m = (mime.split(";")[0] ?? "").trim().toLowerCase();
@@ -108,8 +111,7 @@ export function isInlineSafeMime(mime: string): boolean {
   return (
     (m.startsWith("image/") && m !== "image/svg+xml") ||
     m.startsWith("audio/") ||
-    m.startsWith("video/") ||
-    m === "application/pdf"
+    m.startsWith("video/")
   );
 }
 
@@ -159,7 +161,7 @@ export function sniffMarkupMime(buffer: Buffer): string | null {
  * Build the security headers for a served media response. Always sets
  * `X-Content-Type-Options: nosniff` (so a mislabelled image is never sniffed to
  * HTML) and a fully-sandboxed CSP (applies when the URL is navigated to as a
- * document). Inline-safe types render inline; everything else (SVG, HTML,
+ * document). Inline-safe types render inline; everything else (SVG, PDF, HTML,
  * unknown/active) is forced to download so it cannot execute on this origin.
  */
 function mediaSecurityHeaders(
@@ -345,10 +347,13 @@ export function persistMediaBytes(
 
 /**
  * Read a stored media file's raw bytes by its `<sha256>.<ext>` name, or null if
- * absent/unreadable. Path-traversal-safe (the resolved path must stay in the
- * store dir). Used by agent backup/export to bundle referenced media bytes.
+ * absent. Only the strict content-addressed name pattern is accepted — anything
+ * else (traversal segments, or a sibling ledger name like the GC-pin/redaction
+ * JSON files) is rejected before the path is even resolved. Used by agent
+ * backup/export to bundle referenced media bytes.
  */
 export function readStoredMediaBytes(fileName: string): Buffer | null {
+  if (!MEDIA_FILE_NAME.test(fileName)) return null;
   const filePath = path.join(mediaDir(), fileName);
   if (path.dirname(filePath) !== mediaDir()) return null;
   // Absence is a valid answer — the file may have been evicted/GC'd since it was
@@ -370,14 +375,18 @@ export function readStoredMediaBytes(fileName: string): Buffer | null {
 
 /**
  * Write raw bytes to a stored media file by its `<sha256>.<ext>` name (the name
- * is the content hash, so this is idempotent). Path-traversal-safe. Used by
- * agent restore/import to rehydrate the content-addressed media store.
+ * is the content hash, so this is idempotent). Only the strict content-addressed
+ * name pattern is accepted — anything else (traversal segments, or a sibling
+ * ledger name like the GC-pin/redaction JSON files) is rejected before the path
+ * is even resolved. Used by agent restore/import to rehydrate the
+ * content-addressed media store.
  */
 export function writeStoredMediaFile(fileName: string, bytes: Buffer): boolean {
+  // A pattern/traversal-rejecting name is invalid input, not a failure — return
+  // false so the caller skips it. A write that then fails (ENOSPC/EACCES) is a
+  // real failure and must not be swallowed into a silent "restored fewer files".
+  if (!MEDIA_FILE_NAME.test(fileName)) return false;
   const filePath = path.join(mediaDir(), fileName);
-  // A traversal-rejecting name is invalid input, not a failure — return false so
-  // the caller skips it. A write that then fails (ENOSPC/EACCES) is a real
-  // failure and must not be swallowed into a silent "restored fewer files".
   if (path.dirname(filePath) !== mediaDir()) return false;
   try {
     fs.mkdirSync(mediaDir(), { recursive: true });
@@ -819,7 +828,7 @@ export function handleMediaRouteRequest(
   }
   const headers: Record<string, string> = {
     "Content-Type": resolved.contentType,
-    "Cache-Control": "public, max-age=31536000, immutable",
+    "Cache-Control": "private, max-age=31536000, immutable",
     "Accept-Ranges": "bytes",
     ...mediaSecurityHeaders(resolved.name, resolved.contentType),
   };
@@ -877,7 +886,8 @@ export function handleMediaRouteRequest(
  * Serve a stored media file for `GET/HEAD /api/media/<name>`. Returns true when
  * the request was handled (including 404/400). Supports HTTP Range so `<video>`
  * / `<audio>` seeking works. Bytes are immutable (content-addressed) so they
- * carry a long immutable Cache-Control.
+ * carry a long immutable Cache-Control; `private` keeps shared/proxy caches
+ * from persisting bytes reachable through the pre-auth capability URL.
  */
 export function serveMediaFile(
   req: http.IncomingMessage,
@@ -900,7 +910,7 @@ export function serveMediaFile(
 
   const baseHeaders: Record<string, string | number> = {
     "Content-Type": contentType,
-    "Cache-Control": "public, max-age=31536000, immutable",
+    "Cache-Control": "private, max-age=31536000, immutable",
     "Accept-Ranges": "bytes",
     ...mediaSecurityHeaders(resolved.name, contentType),
   };

--- a/packages/agent/src/api/media-thumbnail.test.ts
+++ b/packages/agent/src/api/media-thumbnail.test.ts
@@ -1,15 +1,24 @@
 /**
  * Verifies generateThumbnailBytes (api/media-thumbnail.ts) downscales oversized
- * images to a ≤512px JPEG and returns null for in-bounds or non-thumbnailable
- * inputs, using real PNG encode + JPEG decode (pngjs / jpeg-js).
+ * images to a ≤512px JPEG, returns null for in-bounds or non-thumbnailable
+ * inputs, and rejects declared bomb dimensions from the container header before
+ * any decode runs. Uses real PNG/JPEG encode + decode (pngjs / jpeg-js).
  */
-import type { Buffer } from "node:buffer";
+import { Buffer } from "node:buffer";
 import { PNG } from "pngjs";
 import { describe, expect, it } from "vitest";
 import { generateThumbnailBytes } from "./media-thumbnail.ts";
 
 const jpegMod = await import("jpeg-js");
 const jpeg = (jpegMod as { default?: unknown }).default ?? jpegMod;
+
+interface JpegCodec {
+  decode: (b: Buffer) => { width: number; height: number };
+  encode: (
+    img: { width: number; height: number; data: Uint8Array },
+    quality?: number,
+  ) => { data: Buffer };
+}
 
 function makePng(width: number, height: number): Buffer {
   const png = new PNG({ width, height });
@@ -22,6 +31,31 @@ function makePng(width: number, height: number): Buffer {
   return PNG.sync.write(png);
 }
 
+function makeJpeg(width: number, height: number): Buffer {
+  const data = new Uint8Array(width * height * 4);
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = 0x33;
+    data[i + 1] = 0x66;
+    data[i + 2] = 0xcc;
+    data[i + 3] = 0xff;
+  }
+  return (jpeg as JpegCodec).encode({ width, height, data }, 80).data;
+}
+
+/** SOI + bare SOF0 segment declaring `width`×`height` — no real scan data. */
+function makeJpegHeaderOnly(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(15);
+  buf[0] = 0xff;
+  buf[1] = 0xd8; // SOI
+  buf[2] = 0xff;
+  buf[3] = 0xc0; // SOF0
+  buf.writeUInt16BE(11, 4); // segment length (self-inclusive)
+  buf[6] = 8; // sample precision
+  buf.writeUInt16BE(height, 7);
+  buf.writeUInt16BE(width, 9);
+  return buf;
+}
+
 describe("generateThumbnailBytes", () => {
   it("downscales a large PNG to a ≤512px JPEG", async () => {
     const png = makePng(1280, 960);
@@ -29,11 +63,7 @@ describe("generateThumbnailBytes", () => {
     expect(thumb).not.toBeNull();
     expect(thumb?.mimeType).toBe("image/jpeg");
     // Decode the JPEG result and confirm it was actually downscaled.
-    const decoded = (
-      jpeg as {
-        decode: (b: Buffer) => { width: number; height: number };
-      }
-    ).decode(thumb?.buffer as Buffer);
+    const decoded = (jpeg as JpegCodec).decode(thumb?.buffer as Buffer);
     expect(Math.max(decoded.width, decoded.height)).toBeLessThanOrEqual(512);
     // 1280×960 → longest 1280 scaled to 512 → width 512.
     expect(decoded.width).toBe(512);
@@ -50,5 +80,49 @@ describe("generateThumbnailBytes", () => {
     const png = makePng(1280, 960);
     expect(await generateThumbnailBytes(png, "image/webp")).toBeNull();
     expect(await generateThumbnailBytes(png, "application/pdf")).toBeNull();
+  });
+});
+
+describe("generateThumbnailBytes decode-dimension bounds", () => {
+  it("rejects a PNG whose IHDR declares bomb dimensions before decoding", async () => {
+    // Forge the IHDR of a real small PNG: the compressed bytes stay tiny, but
+    // decoding the declared 25000×25000 would allocate ~2.5 GB of RGBA.
+    const png = makePng(64, 64);
+    png.writeUInt32BE(25000, 16);
+    png.writeUInt32BE(25000, 20);
+    expect(await generateThumbnailBytes(png, "image/png")).toBeNull();
+  });
+
+  it("rejects a PNG over the total-pixel bound with each edge under the cap", async () => {
+    // 5000×5000 = 25 M px > 16 Mi px, yet both edges are ≤ 8192.
+    const png = makePng(64, 64);
+    png.writeUInt32BE(5000, 16);
+    png.writeUInt32BE(5000, 20);
+    expect(await generateThumbnailBytes(png, "image/png")).toBeNull();
+  });
+
+  it("rejects a JPEG whose SOF declares bomb dimensions", async () => {
+    expect(
+      await generateThumbnailBytes(
+        makeJpegHeaderOnly(25000, 25000),
+        "image/jpeg",
+      ),
+    ).toBeNull();
+  });
+
+  it("fails closed when the container header can't be parsed", async () => {
+    expect(
+      await generateThumbnailBytes(Buffer.from("not an image"), "image/png"),
+    ).toBeNull();
+  });
+
+  it("still thumbnails a valid in-bounds JPEG", async () => {
+    const thumb = await generateThumbnailBytes(
+      makeJpeg(1280, 960),
+      "image/jpeg",
+    );
+    expect(thumb?.mimeType).toBe("image/jpeg");
+    const decoded = (jpeg as JpegCodec).decode(thumb?.buffer as Buffer);
+    expect(decoded.width).toBe(512);
   });
 });

--- a/packages/agent/src/api/media-thumbnail.ts
+++ b/packages/agent/src/api/media-thumbnail.ts
@@ -17,6 +17,82 @@ import { logger } from "@elizaos/core";
 const THUMBNAIL_MAX_DIM = 512;
 const THUMBNAILABLE_MIME = /^image\/(png|jpe?g)$/i;
 
+/**
+ * Decode-time safety bounds. The pure-JS codecs allocate `width*height*4`
+ * bytes of RGBA with no guard of their own, and the upload validator caps only
+ * the *compressed* size — a tiny solid-color PNG can declare dimensions whose
+ * decode would allocate gigabytes and take the process down. Dimensions are
+ * read from the container header and rejected before any decode runs.
+ */
+const MAX_DECODE_EDGE_PX = 8192;
+const MAX_DECODE_PIXELS = 16_777_216; // 16 Mi px → ≤64 MiB RGBA
+
+interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+/** Dimensions from the PNG signature + IHDR header (BE u32 at bytes 16/20). */
+function readPngDimensions(source: Buffer): ImageDimensions | null {
+  if (source.length < 24) return null;
+  if (source.readUInt32BE(0) !== 0x89504e47) return null;
+  if (source.readUInt32BE(4) !== 0x0d0a1a0a) return null;
+  if (source.toString("ascii", 12, 16) !== "IHDR") return null;
+  return { width: source.readUInt32BE(16), height: source.readUInt32BE(20) };
+}
+
+/**
+ * Dimensions from the first JPEG SOFn segment. Walks the marker stream from
+ * the SOI: every segment is `FF <marker> <u16 length>` except the standalone
+ * markers (SOI/RSTn/TEM) that carry no length.
+ */
+function readJpegDimensions(source: Buffer): ImageDimensions | null {
+  if (source.length < 4 || source[0] !== 0xff || source[1] !== 0xd8) {
+    return null;
+  }
+  let offset = 2;
+  while (offset + 4 <= source.length) {
+    if (source[offset] !== 0xff) return null;
+    const marker = source[offset + 1];
+    if (
+      marker === 0xd8 ||
+      marker === 0x01 ||
+      (marker >= 0xd0 && marker <= 0xd7)
+    ) {
+      offset += 2;
+      continue;
+    }
+    const segmentLength = source.readUInt16BE(offset + 2);
+    if (segmentLength < 2 || offset + 2 + segmentLength > source.length) {
+      return null;
+    }
+    // SOF0–SOF15 carry the frame dimensions; exclude DHT (C4), JPG (C8), DAC (CC).
+    if (
+      marker >= 0xc0 &&
+      marker <= 0xcf &&
+      marker !== 0xc4 &&
+      marker !== 0xc8 &&
+      marker !== 0xcc
+    ) {
+      if (segmentLength < 7) return null;
+      return {
+        height: source.readUInt16BE(offset + 5),
+        width: source.readUInt16BE(offset + 7),
+      };
+    }
+    offset += 2 + segmentLength;
+  }
+  return null;
+}
+
+/** True when the declared dimensions stay within the decode-time bounds. */
+function withinDecodeBounds(dimensions: ImageDimensions): boolean {
+  const { width, height } = dimensions;
+  if (width <= 0 || height <= 0) return false;
+  if (width > MAX_DECODE_EDGE_PX || height > MAX_DECODE_EDGE_PX) return false;
+  return width * height <= MAX_DECODE_PIXELS;
+}
+
 const PNGJS_MODULE_ID = "pngjs";
 const JPEGJS_MODULE_ID = "jpeg-js";
 
@@ -110,8 +186,9 @@ function downscaleRGBA(
 
 /**
  * Downscale a PNG/JPEG buffer to a ≤512px JPEG thumbnail. Returns null when the
- * input isn't a supported raster, is already within bounds, the codecs are
- * unavailable, or decoding fails.
+ * input isn't a supported raster, is already within bounds, declares dimensions
+ * beyond the decode-time safety bounds, the codecs are unavailable, or decoding
+ * fails.
  */
 export async function generateThumbnailBytes(
   source: Buffer,
@@ -122,6 +199,13 @@ export async function generateThumbnailBytes(
   if (!loaded) return null;
   try {
     const isPng = /png/i.test(srcMimeType);
+    // Bound the decode before the codecs allocate width*height*4 bytes: a
+    // compressed input under the upload size cap can still declare bomb
+    // dimensions. Unparseable headers fail closed — decode would fail anyway.
+    const dimensions = isPng
+      ? readPngDimensions(source)
+      : readJpegDimensions(source);
+    if (!dimensions || !withinDecodeBounds(dimensions)) return null;
     const decoded: RawImage = isPng
       ? loaded.png.sync.read(source)
       : loaded.jpeg.decode(source, { useTArray: true, formatAsRGBA: true });

--- a/packages/core/src/runtime-get-all-memories.test.ts
+++ b/packages/core/src/runtime-get-all-memories.test.ts
@@ -3,7 +3,9 @@
  * recording adapter: the partition sweep must include every platform-owned
  * memory table — the media GC's referenced-set and clearAllAgentMemories both
  * depend on this list being complete (#14751: a partition missing here leaves
- * its media references invisible to the sweep).
+ * its media references invisible to the sweep) — and must paginate each
+ * partition to exhaustion rather than truncate at one bounded page (a
+ * truncated sweep makes the GC delete still-referenced media).
  */
 
 import { describe, expect, it } from "vitest";
@@ -46,5 +48,36 @@ describe("AgentRuntime.getAllMemories", () => {
 			"transcripts",
 		]);
 		expect(all).toContain(TRANSCRIPT_ROW);
+	});
+
+	it("paginates a partition to exhaustion instead of truncating at one page", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "get-all-memories-paging-test" } as Character,
+		});
+		const pageRow = (page: number, count: number): Memory[] =>
+			Array.from(
+				{ length: count },
+				(_, i) =>
+					({
+						id: `dddddddd-0000-0000-0000-${String(page * 10000 + i).padStart(12, "0")}`,
+					}) as Memory,
+			);
+		const requestedOffsets: number[] = [];
+		runtime.registerDatabaseAdapter({
+			getMemories: async (params: { tableName: string; offset?: number }) => {
+				if (params.tableName !== "messages") return [];
+				const offset = params.offset ?? 0;
+				requestedOffsets.push(offset);
+				// Two full pages then a short one: 20,007 rows in the partition.
+				if (offset === 0) return pageRow(0, 10000);
+				if (offset === 10000) return pageRow(1, 10000);
+				return pageRow(2, 7);
+			},
+		} as unknown as IDatabaseAdapter);
+
+		const all = await runtime.getAllMemories();
+
+		expect(requestedOffsets).toEqual([0, 10000, 20000]);
+		expect(all).toHaveLength(20007);
 	});
 });

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -374,6 +374,10 @@ const DEFAULT_FAST_ROOM_DRAIN_TIMEOUT_MS = 500;
 // recent and in-flight turns while bounding memory.
 const STATE_CACHE_LIMIT = 512;
 const PROVIDERS_PROMPT_MARKER = "__ELIZA_PROMPT_SEGMENT_PROVIDERS__";
+// Page size for the getAllMemories partition sweep. The sweep must be complete
+// — the media GC builds its referenced-set from it — so it paginates until a
+// short page instead of issuing one bounded read that silently truncates.
+const GET_ALL_MEMORIES_PAGE_SIZE = 10_000;
 
 type ProviderExecutionOutcome = "success" | "error" | "aborted";
 
@@ -11229,12 +11233,19 @@ ${section_end}`;
 		const allMemories: Memory[] = [];
 
 		for (const tableName of tables) {
-			const memories = await this.adapter.getMemories({
-				agentId: this.agentId,
-				tableName,
-				limit: 10000, // Get a large number to fetch all
-			});
-			allMemories.push(...memories);
+			// Paginate until a short page: a single 10k-bounded read silently
+			// truncates a larger partition, and the media GC would then delete
+			// files referenced only by rows past the cap as "orphaned".
+			for (let offset = 0; ; offset += GET_ALL_MEMORIES_PAGE_SIZE) {
+				const memories = await this.adapter.getMemories({
+					agentId: this.agentId,
+					tableName,
+					limit: GET_ALL_MEMORIES_PAGE_SIZE,
+					offset,
+				});
+				allMemories.push(...memories);
+				if (memories.length < GET_ALL_MEMORIES_PAGE_SIZE) break;
+			}
 		}
 
 		return allMemories;


### PR DESCRIPTION
## Summary

Four confirmed wave-1 security-audit findings against the content-addressed media store and its GC, all in the serving/decode housekeeping layer. Each fix is minimal and mapped to its finding ID.

- **W1-012 — thumbnail decode had no dimension cap.** `generateThumbnailBytes` decoded attacker-supplied PNG/JPEG bytes with the pure-JS codecs, which allocate `width*height*4` bytes with no guard. The upload validator caps only the compressed size, so an image with oversized declared dimensions could force a multi-GB allocation on the event loop. Dimensions are now parsed from the container header (PNG IHDR, JPEG SOFn) before any decode and rejected over sane bounds (8192 px per edge, 16 Mi px total ≈ ≤64 MiB RGBA); unparseable headers fail closed. Out-of-policy inputs degrade to the existing `null` path (callers serve the full image).
- **W1-013 — media GC reference scan truncated at 10k rows/partition.** `AgentRuntime.getAllMemories` issued a single `limit: 10000` read per partition; once a partition exceeded that, media referenced only by rows outside the window was treated as orphaned and deleted by the daily sweep. The sweep now paginates each partition until a short page, so the referenced-set is complete.
- **W1-049 — raw store helpers skipped the strict name pattern.** `readStoredMediaBytes`/`writeStoredMediaFile` enforced only `dirname === mediaDir()`, which the store's internal ledger files (`background-pins.json`, `audio-redactions.json`) also satisfy. Both helpers now apply the strict content-addressed `MEDIA_FILE_NAME` pattern first (defense in depth; all current callers already pre-validate — verified: `agent-export.ts`, `audio-redaction-store.ts`).
- **W1-050 — inline PDF + public caching on pre-auth capability URLs.** `application/pdf` leaves the inline-safe list (parity with SVG) so stored PDFs are served `Content-Disposition: attachment` and can never inline-execute on the origin, and both serve paths (HTTP + in-process/native) move from `Cache-Control: public` to `private` so shared caches don't persist bytes behind the unguessable capability URL.

No new file stores, no refcounting, no `fileId` — the single content-addressed store architecture is unchanged.

## Test evidence

Worktree on latest `origin/develop` (rebased, no conflicts; no upstream changes to the touched files):

- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/api/media-thumbnail.test.ts packages/agent/src/api/media-store.test.ts packages/agent/src/api/chat-attachment-processing-lifecycle.test.ts packages/agent/src/api/media-runtime.test.ts` — **102 passed** (new coverage: forged oversized PNG IHDR / JPEG SOF rejected pre-decode, over-pixel-cap rejection, fail-closed unparseable header, valid in-bounds JPEG still thumbnails; PDF served as attachment; `Cache-Control` private+immutable; ledger-name read/write rejection; GC worker sweep unchanged)
- `bunx vitest run --config packages/core/vitest.config.ts packages/core/src/runtime-get-all-memories.test.ts` — **2 passed** (new: partition paginated to exhaustion, offsets 0/10000/20000, 20,007 rows returned)
- `bun run --cwd packages/core typecheck` — **passes**
- `bun run --cwd packages/agent typecheck` — 2 errors, both **pre-existing on clean origin/develop** (verified by stashing my changes): `server.ts:2572` SkillsRouteContext drift and unbuilt `@elizaos/plugin-todos/edge` dist types in a light install; zero errors in touched files
- `bunx @biomejs/biome check` on all 7 changed files — **clean**

## Risk notes

- **PDF preview UX:** surfaces that render a stored PDF in an iframe (e.g. the knowledge-document reader) now get a download instead of an inline render. That is the intended security trade-off of this finding; follow-up UI work can route previews through a sandboxed viewer if desired.
- **GC pagination cost:** the daily sweep now reads every memory row in pages of 10k instead of stopping at the first page. This is the completeness the GC's referenced-set always assumed; duplicates from concurrent writes are harmless (set semantics, and `clearAllAgentMemories` deletes by id).
- **Dimension bounds:** legitimate images above 8192 px/edge or 16 Mi px no longer get server-side thumbnails (full image is served instead). Browser uploads are thumbnailed client-side already; the server path covers agent-generated/connector-ingested images, which are typically far below these bounds.
- **Caching:** `private` still allows browser caching of the immutable content-addressed bytes; only shared/proxy caches are excluded.