### PR TITLE
fix(cloud): reject unknown vertex-jobs persisted flag

### DIFF
--- a/packages/cloud/api/training/vertex/jobs/route.persisted.test.ts
+++ b/packages/cloud/api/training/vertex/jobs/route.persisted.test.ts
@@ -1,0 +1,114 @@
+/**
+ * GET /api/training/vertex/jobs `persisted` is Vertex persisted-list
+ * identity, leftover tax after voice-list includeInactive (#21106) and
+ * analytics-export includeMetadata (#21105). Stock develop treated any
+ * non-exact `true` token as the full remote+persisted list, so
+ * `persisted=TRUE` still called listTuningJobs instead of a 400.
+ * jobId / name / region parsers stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+  user: {
+    id: "user-1",
+    organization_id: "org-1",
+  },
+}));
+const listVisibleJobs = mock(async () => [{ id: "tracked-1" }]);
+const syncJobStatus = mock(async () => null);
+const listTuningJobs = mock(async () => [{ name: "remote-1" }]);
+const getTuningJobStatus = mock(async () => ({ name: "remote-1" }));
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg,
+}));
+mock.module("@/lib/services/vertex-model-registry", () => ({
+  vertexModelRegistryService: { listVisibleJobs, syncJobStatus },
+}));
+mock.module("@/lib/services/vertex-tuning", () => ({
+  listTuningJobs,
+  getTuningJobStatus,
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/training/vertex/jobs", route);
+
+function getJobs(query = "") {
+  return app.request(`/api/training/vertex/jobs${query}`);
+}
+
+describe("GET /api/training/vertex/jobs persisted identity", () => {
+  beforeEach(() => {
+    requireAuthOrApiKeyWithOrg.mockClear();
+    listVisibleJobs.mockClear();
+    syncJobStatus.mockClear();
+    listTuningJobs.mockClear();
+    getTuningJobStatus.mockClear();
+  });
+
+  test.each(["?projectId=proj", "?projectId=proj&persisted=", "?projectId=proj&persisted=false"])(
+    "accepts %s as the full remote+persisted Vertex list",
+    async (query) => {
+      const response = await getJobs(query);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        jobs: unknown[];
+        persistedJobs: unknown[];
+      };
+      expect(body.jobs).toEqual([{ name: "remote-1" }]);
+      expect(body.persistedJobs).toEqual([{ id: "tracked-1" }]);
+      expect(requireAuthOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+      expect(listVisibleJobs).toHaveBeenCalledTimes(1);
+      expect(listTuningJobs).toHaveBeenCalledTimes(1);
+      expect(syncJobStatus).not.toHaveBeenCalled();
+    },
+  );
+
+  test("accepts persisted=true as the persisted-only Vertex list", async () => {
+    const response = await getJobs("?persisted=true");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      persistedJobs: unknown[];
+      jobs?: unknown[];
+    };
+    expect(body.persistedJobs).toEqual([{ id: "tracked-1" }]);
+    expect(body.jobs).toBeUndefined();
+    expect(requireAuthOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+    expect(listVisibleJobs).toHaveBeenCalledTimes(1);
+    expect(listTuningJobs).not.toHaveBeenCalled();
+    expect(syncJobStatus).not.toHaveBeenCalled();
+  });
+
+  test.each(["FALSE", "TRUE", "0", "1", "no", "yes", "foo", "1e2"])(
+    "rejects persisted=%s before job lookup and remote list",
+    async (token) => {
+      const response = await getJobs(
+        `?persisted=${encodeURIComponent(token)}&jobId=tracked-1&projectId=proj`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid persisted");
+      expect(listVisibleJobs).not.toHaveBeenCalled();
+      expect(listTuningJobs).not.toHaveBeenCalled();
+      expect(syncJobStatus).not.toHaveBeenCalled();
+      expect(getTuningJobStatus).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?persisted=true&persisted=true",
+    "?persisted=true&persisted=false",
+    "?persisted=&persisted=true",
+    "?persisted=foo&persisted=true",
+  ])(
+    "rejects duplicate persisted values in %s before job lookup",
+    async (query) => {
+      const response = await getJobs(`${query}&projectId=proj`);
+      expect(response.status).toBe(400);
+      expect(listVisibleJobs).not.toHaveBeenCalled();
+      expect(listTuningJobs).not.toHaveBeenCalled();
+      expect(syncJobStatus).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/training/vertex/jobs/route.ts
+++ b/packages/cloud/api/training/vertex/jobs/route.ts
@@ -17,7 +17,29 @@ async function __hono_GET(request: Request) {
     const region = searchParams.get("region") || "us-central1";
     const jobName = searchParams.get("name");
     const jobId = searchParams.get("jobId");
-    const persistedOnly = searchParams.get("persisted") === "true";
+    // Vertex persisted-list identity, leftover tax after voice-list
+    // includeInactive (#21106) and analytics-export includeMetadata
+    // (#21105). persisted=TRUE used to silently list remote+persisted
+    // jobs instead of 400. jobId / name / region parsers stay untouched.
+    const requestedPersistedValues = searchParams.getAll("persisted");
+    const requestedPersisted = requestedPersistedValues[0];
+    if (
+      requestedPersistedValues.length > 1 ||
+      (requestedPersisted != null &&
+        requestedPersisted !== "" &&
+        requestedPersisted !== "true" &&
+        requestedPersisted !== "false")
+    ) {
+      return Response.json(
+        {
+          error: "Invalid persisted",
+          message:
+            'persisted must be specified at most once as "true" or "false".',
+        },
+        { status: 400 },
+      );
+    }
+    const persistedOnly = requestedPersisted === "true";
 
     const viewer = {
       organizationId: user.organization_id,


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on Vertex jobs
`persisted` identity. Leftover tax after voice-list includeInactive
(#21106) and analytics-export includeMetadata (#21105). Not leftover
tax on agent-create sync, agent-provision sync, resume sync,
approval-request public, ballot public, payment-request public,
twitter-status connectionRole, twitter-disconnect connectionRole,
x-dms-digest connectionRole, x-feed connectionRole, x-status
connectionRole, or prefix-coerced limit/offset.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Query `persisted` only on `GET /api/training/vertex/jobs`.
Omitted/empty/`false` still list remote+persisted jobs (today's default).
Exact `true` still returns the persisted-only list.
Unknown / uppercase / numeric / duplicate tokens 400 before
`listVisibleJobs`, `listTuningJobs`, and `syncJobStatus`.
jobId / name / region parsers stay untouched.

# Background

## What does this PR do?

`GET /api/training/vertex/jobs` parsed `persisted` with `=== "true"`.
`persisted=TRUE` silently listed remote+persisted jobs instead of a 400.

- omitted / empty / `false` → full remote+persisted list
- exact `true` → persisted-only list
- `TRUE` / `1` / `yes` / `1e2` / duplicate `persisted` → **400** before
  job lookup and remote list

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers opt into the persisted-only Vertex list with `?persisted=true`.
A common `persisted=TRUE` after a client uppercases the flag must not
silently fan out to `listTuningJobs`. This is leftover tax after
voice-list includeInactive (#21106), which left the Vertex jobs parser
untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/training/vertex/jobs/route.persisted.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test training/vertex/jobs/route.persisted.test.ts
```

16 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; Vertex jobs `persisted` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; Vertex jobs `persisted` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; Vertex jobs `persisted` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real persisted tokens and assert 400 before job lookup; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before Vertex job lookup.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`persisted` tokens reject; omitted/canonical still bind the matching
remote-or-persisted-only path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file Vertex jobs persisted
parse with a green focused suite (16 new). Full monorepo verify is
unrelated to this query grammar and was skipped to keep the proof tied
to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:abd0a56572cccb16eee80a11777ed76d9219f801 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
