### PR TITLE
fix(cloud): reject unknown discovery activeOnly flag

### DIFF
--- a/packages/cloud/api/v1/discovery/route.active-only.test.ts
+++ b/packages/cloud/api/v1/discovery/route.active-only.test.ts
@@ -1,0 +1,115 @@
+/**
+ * GET /api/v1/discovery `activeOnly` is catalog-liveness identity,
+ * leftover tax after voice-list includeInactive (#21106). Stock
+ * develop treated any non-exact `true` token as include-inactive, so
+ * `activeOnly=TRUE` inverted the default live-only filter instead of
+ * a 400. x402Only / types / limit parsers stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const listPublicAgents = mock(async () => []);
+const listPublicMcps = mock(async () => []);
+const cacheGet = mock(async () => null);
+const cacheSet = mock(async () => undefined);
+
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: {
+    listPublic: listPublicAgents,
+    countPublicCatalog: mock(async () => 0),
+  },
+}));
+mock.module("@/lib/services/user-mcps", () => ({
+  userMcpsService: {
+    listPublic: listPublicMcps,
+    countPublic: mock(async () => 0),
+    getPublicProxyUrl: mock(() => "https://app.example.test/mcp"),
+  },
+}));
+mock.module("@/lib/cache/client", () => ({
+  cache: { get: cacheGet, set: cacheSet },
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_context: unknown, next: () => Promise<void>) =>
+    next(),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(),
+    error: mock(),
+    info: mock(),
+    warn: mock(),
+  },
+}));
+
+const discoveryModule = await import("./route");
+const app = new Hono<AppEnv>();
+app.route("/api/v1/discovery", discoveryModule.default);
+
+const ENV = {
+  NODE_ENV: "test",
+  NEXT_PUBLIC_APP_URL: "https://app.example.test",
+} as unknown as AppEnv["Bindings"];
+
+function discover(query = "") {
+  return app.request(`/api/v1/discovery${query}`, {}, ENV);
+}
+
+describe("GET /api/v1/discovery activeOnly identity", () => {
+  beforeEach(() => {
+    listPublicAgents.mockClear();
+    listPublicMcps.mockClear();
+    cacheGet.mockClear();
+    cacheSet.mockClear();
+  });
+
+  test.each(["", "?activeOnly=", "?activeOnly=true"])(
+    "accepts %s as the live discovery catalog",
+    async (query) => {
+      const response = await discover(query);
+      expect(response.status).toBe(200);
+      expect(listPublicAgents).toHaveBeenCalledTimes(1);
+      expect(listPublicMcps).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test("accepts activeOnly=false as the full discovery catalog", async () => {
+    const response = await discover("?activeOnly=false");
+    expect(response.status).toBe(200);
+    expect(listPublicAgents).toHaveBeenCalledTimes(1);
+    expect(listPublicMcps).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["FALSE", "TRUE", "0", "1", "no", "yes", "foo", "1e2"])(
+    "rejects activeOnly=%s before catalog lookup",
+    async (token) => {
+      const response = await discover(
+        `?activeOnly=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid activeOnly");
+      expect(listPublicAgents).not.toHaveBeenCalled();
+      expect(listPublicMcps).not.toHaveBeenCalled();
+      expect(cacheGet).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?activeOnly=true&activeOnly=true",
+    "?activeOnly=true&activeOnly=false",
+    "?activeOnly=&activeOnly=true",
+    "?activeOnly=foo&activeOnly=true",
+  ])(
+    "rejects duplicate activeOnly values in %s before catalog lookup",
+    async (query) => {
+      const response = await discover(query);
+      expect(response.status).toBe(400);
+      expect(listPublicAgents).not.toHaveBeenCalled();
+      expect(listPublicMcps).not.toHaveBeenCalled();
+      expect(cacheGet).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/discovery/route.ts
+++ b/packages/cloud/api/v1/discovery/route.ts
@@ -163,11 +163,13 @@ const querySchema = z
       .string()
       .transform((s) => s === "true")
       .optional(),
+    // Catalog-liveness identity, leftover tax after voice-list
+    // includeInactive (#21106). activeOnly=TRUE used to silently invert
+    // the default live-only filter. x402Only parser stays untouched.
     activeOnly: z
-      .string()
-      .transform((s) => s === "true")
+      .union([z.enum(["true", "false"]), z.literal("")])
       .optional()
-      .default(true),
+      .transform((value) => value !== "false"),
     limit: z.coerce.number().int().min(1).max(200).optional().default(50),
     offset: z.coerce
       .number()
@@ -203,6 +205,24 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 app.get("/", async (c) => {
   try {
     const url = new URL(c.req.url);
+    const requestedActiveValues = url.searchParams.getAll("activeOnly");
+    const requestedActive = requestedActiveValues[0];
+    if (
+      requestedActiveValues.length > 1 ||
+      (requestedActive !== undefined &&
+        requestedActive !== "" &&
+        requestedActive !== "true" &&
+        requestedActive !== "false")
+    ) {
+      return c.json(
+        {
+          error: "Invalid activeOnly",
+          message:
+            'activeOnly must be specified at most once as "true" or "false".',
+        },
+        400,
+      );
+    }
     const rawParams = Object.fromEntries(url.searchParams);
 
     const parseResult = querySchema.safeParse(rawParams);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on discovery
`activeOnly` identity. Leftover tax after voice-list includeInactive
(#21106) and analytics-export includeMetadata (#21105). Not leftover
tax on agent-create sync, agent-provision sync, resume sync,
approval-request public, ballot public, payment-request public,
twitter-status connectionRole, twitter-disconnect connectionRole,
x-dms-digest connectionRole, x-feed connectionRole, x-status
connectionRole, Vertex jobs persisted, or prefix-coerced limit/offset.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Query `activeOnly` only on `GET /api/v1/discovery`.
Omitted/empty/`true` still keep the live-only catalog (today's default).
Exact `false` still includes inactive rows.
Unknown / uppercase / numeric / duplicate tokens 400 before catalog
lookup and cache. x402Only / types / limit parsers stay untouched.

# Background

## What does this PR do?

`GET /api/v1/discovery` parsed `activeOnly` with `=== "true"` (default
true). `activeOnly=TRUE` silently inverted the live-only filter instead
of a 400.

- omitted / empty / `true` → live catalog
- exact `false` → include inactive
- `TRUE` / `1` / `yes` / `1e2` / duplicate `activeOnly` → **400** before
  catalog lookup

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers keep the default live-only discovery catalog, or opt out with
`?activeOnly=false`. A common `activeOnly=TRUE` after a client
uppercases the flag must not silently include inactive rows. This is
leftover tax after voice-list includeInactive (#21106), which left the
discovery parser untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/discovery/route.active-only.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/discovery/route.active-only.test.ts __tests__/discovery-supported-types.test.ts
```

16 new identity tests + 10 existing supported-type tests passed at this
head (26 total).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; discovery `activeOnly` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; discovery `activeOnly` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; discovery `activeOnly` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real activeOnly tokens and assert 400 before catalog lookup; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before catalog lookup.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`activeOnly` tokens reject; omitted/canonical still bind the matching
live-or-full catalog path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file discovery activeOnly
parse with a green focused suite (16 new + 10 existing). Full monorepo
verify is unrelated to this query grammar and was skipped to keep the
proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e5bc461762450e7a4d67954b88495a329452f519 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
