### PR TITLE
fix(wallet): add timeout to DexScreener fetch

### DIFF
--- a/plugins/plugin-wallet/src/analytics/dexscreener/service.ts
+++ b/plugins/plugin-wallet/src/analytics/dexscreener/service.ts
@@ -100,7 +100,7 @@ export class DexScreenerService extends Service {
     if (params && Object.keys(params).length > 0) {
       url += `?${new URLSearchParams(params).toString()}`;
     }
-    const response = await fetch(url, { headers: this.defaultHeaders });
+    const response = await fetch(url, { headers: this.defaultHeaders, signal: AbortSignal.timeout(10_000) });
     if (!response.ok) {
       const errData = await response.json().catch(() => ({}));
       throw Object.assign(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Bug #3 on `develop` @ `cd41f99b` — `fetch(url, { headers })` with no timeout in `plugins/plugin-wallet/src/analytics/dexscreener/service.ts:103` (`private get<T>`). External DexScreener API fetch could hang indefinitely. No existing issue; single-file signal fix. Mirrors `solana:543` / `erc8004:624` / `Meteora:74` timeout idiom.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `cd41f99b` (origin/develop at task creation) with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` / package typecheck were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is self-reported provenance, not a request for chain-of-thought. Never include prompts containing secrets, tokens, private session IDs, or hidden reasoning. Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels (`Client / agent tooling`, `Skill revision` / `Contribution skill revision`, `Attribution status`). Duplicating those strings makes the scoring validator reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->` markers; only the human-readable prefixes changed. After filling these rows, append the standard footer once at the end of the PR body (do not repeat the visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@cd41f99b1a9b74b507e64060fc86ae82a459d7cd:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto `cd41f99b` (`origin/develop` at task base); zero conflicts. Current `origin/develop` is `cd41f99b` — this branch is based on `cd41f99b` (latest at task creation). Single-line isolated replacement, no conflicts expected.
- [x] `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json --skipLibCheck` passes post-sync; typecheck green (see Evidence). No `bun install` blocker for this file — `AbortSignal` is global, no new import.

# Risks

Low. Single-file change, 1 insertion / 1 deletion, no API or storage migration. Behaviour strictly adds a timeout: previously external `fetch(url, { headers })` on DexScreener API (`https://api.dexscreener.com`) could hang forever on a slow/unresponsive endpoint; now bounded to 10s via `AbortSignal.timeout(10_000)`. Matches existing idiom in `health-connectors.ts:261` (`AbortSignal.timeout`), `solana.ts:543` (`AbortSignal.timeout(10_000)`), `erc8004:624`, and `Meteora:74`. Rate-limit clamp from PR 21120 is untouched. Risk only if DexScreener legitimately needs >10s — unlikely for token/pair lookups and desirable to fail fast.

# Background

## What does this PR do?

Adds `signal: AbortSignal.timeout(10_000)` to the external fetch in `DexScreenerService.private get<T>` (`plugins/plugin-wallet/src/analytics/dexscreener/service.ts:103`).

Before (line 103):
```ts
const response = await fetch(url, { headers: this.defaultHeaders });
```
- No signal, no timeout — `fetch` on external DexScreener API could hang indefinitely, blocking all callers of the private `get` (token profiles, pair lookups, etc.).

After (line 103):
```ts
const response = await fetch(url, { headers: this.defaultHeaders, signal: AbortSignal.timeout(10_000) });
```
- 10s timeout via global `AbortSignal.timeout` (no import needed). Mirrors `plugins/plugin-health/src/health-bridge/health-connectors.ts:261` and `plugins/plugin-wallet/src/chains/solana/solana.ts:543` idiom.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

`DexScreenerService.get` is the sole HTTP path for all DexScreener queries. DexScreener is an external untrusted endpoint; a slow or hanging response could DoS the caller. No timeout was present (`grep -n "signal|AbortSignal"` → 0 hits before, 1 after). The rate-limit clamp (PR #21120) already merged but left this `fetch` bare. Fresh hunt ranked #1 `erc8004:624` landed PR 21154, #2 `Meteora:74` landed PR 21165 — this is #3.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/analytics/dexscreener/service.ts` — `private async get<T>` method, `fetch` call at line 103.

## Detailed testing steps

- Verify no signal before: `grep -n "signal\|AbortSignal" plugins/plugin-wallet/src/analytics/dexscreener/service.ts` → 0 hits on `cd41f99b` (see Evidence Details).
- Verify signal after: `grep -n "signal\|AbortSignal" plugins/plugin-wallet/src/analytics/dexscreener/service.ts` → `103:    const response = await fetch(url, { headers: this.defaultHeaders, signal: AbortSignal.timeout(10_000) });` (see Evidence Details).
- Verify surrounding `grep -n "fetch|signal"` before/after shows 0→1 signal line.
- Typecheck: `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json --skipLibCheck` → `EXIT:0` (no new diagnostic on `service.ts` — `AbortSignal.timeout` is DOM lib global).
- No dedicated `DexScreenerService` unit test breakage — single-line `fetch` option addition.
- Idiom check: `grep -n "AbortSignal.timeout" plugins/plugin-health/src/health-bridge/health-connectors.ts` → `261` hit confirms established pattern.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d3d35c2a01164326bcc00f5ec4815d3d4dca0c54 -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the description or a comment), or write `N/A - <reason>` on the row. Do not leave evidence rows blank. Videos must be **MP4** (GitHub renders them inline); prefer **JPG over PNG** for screenshots. Do not commit evidence files to the repo.

<!-- evidence-row:frontend-video -->
- [x] Frontend video walkthrough is attached (MP4), or marked `N/A - <reason>`. → N/A — no frontend surface; `DexScreenerService.get` is a backend analytics service, not a UI component.
<!-- evidence-row:frontend-screenshots -->
- [x] Before/after screenshots are attached (JPG preferred), or marked `N/A - <reason>`. → N/A — no rendered visual surface; single-line `fetch` signal addition in DexScreener service.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`. → N/A — no frontend request/response; external `fetch` is server-side DexScreener API call, not browser UI.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`. → N/A — `fetch` timeout fix, no LLM trajectory.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`. → N/A — no domain artifacts; `get<T>` returns parsed JSON in-memory.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface. → N/A — no rendered visual surface.

# Evidence Details

**Before grep** (`service.ts:103` on `cd41f99b`):
```
103:    const response = await fetch(url, { headers: this.defaultHeaders });
grep -n "signal|AbortSignal" → 0 hits
grep -n "fetch|signal" → 103:    const response = await fetch(url, { headers: this.defaultHeaders });
sed -n '100,110p':
    const response = await fetch(url, { headers: this.defaultHeaders });
    if (!response.ok) {
      const errData = await response.json().catch(() => ({}));
```

**After grep** (this PR):
```
103:    const response = await fetch(url, { headers: this.defaultHeaders, signal: AbortSignal.timeout(10_000) });
grep -n "signal|AbortSignal" → 103:    const response = await fetch(url, { headers: this.defaultHeaders, signal: AbortSignal.timeout(10_000) });
grep -n "fetch|signal" → 103:    const response = await fetch(url, { headers: this.defaultHeaders, signal: AbortSignal.timeout(10_000) });
sed -n '100,110p':
    const response = await fetch(url, { headers: this.defaultHeaders, signal: AbortSignal.timeout(10_000) });
    if (!response.ok) {
      const errData = await response.json().catch(() => ({}));
```

**Timeout proof** (mirrors existing idioms):
| File | Idiom |
|------|-------|
| `plugins/plugin-health/src/health-bridge/health-connectors.ts:261` | `AbortSignal.timeout(...)` |
| `plugins/plugin-elizacloud/src/cloud-setup.ts:69` | `AbortSignal.timeout(10_000)` |
| This PR `dexscreener/service.ts:103` | `AbortSignal.timeout(10_000)` — same |

**Typecheck**: `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json --skipLibCheck` → `EXIT:0` (no new diagnostic on `service.ts`; `AbortSignal` is DOM global, no import needed).

**Diff stat**: `1 file changed, 1 insertion(+), 1 deletion(-)` — single-file scoped, rebased on `cd41f99b`.

---
AI provider/model: anthropic/claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/eliza@cd41f99b1a9b74b507e64060fc86ae82a459d7cd:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/eliza@cd41f99b1a9b74b507e64060fc86ae82a459d7cd:packages/skills/skills/contribute-to-eliza"} -->
