### PR TITLE
fix(app-control): scaffold new apps outside the running agent's checkout

### DIFF
--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -30,6 +30,7 @@ import type { InstalledAppInfo } from "../types.js";
 import {
 	findAsyncCodingDelegationActionName,
 	preflightCodingDispatch,
+	resolveAppsLandingRoot,
 	resolveScaffoldTemplateDir,
 	templateMissingGuidance,
 } from "./scaffold-env.js";
@@ -190,10 +191,12 @@ async function copyTemplate(
 }
 
 async function findFreeWorkdir(
-	repoRoot: string,
 	baseName: string,
 ): Promise<{ workdir: string; appDirName: string }> {
-	const baseDir = path.join(repoRoot, APPS_RELATIVE_PATH);
+	// Landing is env-explicit or the state dir — NEVER the cwd-fallback repo
+	// root, which is the running agent's own checkout (see
+	// resolveAppsLandingRoot).
+	const baseDir = resolveAppsLandingRoot();
 	let appDirName = `app-${baseName}`;
 	let candidate = path.join(baseDir, appDirName);
 	let suffix = 2;
@@ -701,6 +704,8 @@ async function locateInstalledAppWorkdir(
 ): Promise<string | null> {
 	const basename = app.pluginName.replace(/^@[^/]+\//, "").trim();
 	const candidates = [
+		path.join(resolveAppsLandingRoot(), basename),
+		path.join(resolveAppsLandingRoot(), basename.replace(/^app-/, "")),
 		path.join(repoRoot, APPS_RELATIVE_PATH, basename),
 		path.join(repoRoot, APPS_RELATIVE_PATH, basename.replace(/^app-/, "")),
 		path.join(repoRoot, "eliza", "plugins", basename),
@@ -765,7 +770,7 @@ async function createNewApp({
 		};
 	}
 
-	const { workdir, appDirName } = await findFreeWorkdir(repoRoot, name);
+	const { workdir, appDirName } = await findFreeWorkdir(name);
 
 	await copyTemplate(templateSrc, workdir, {
 		[NAME_PLACEHOLDER]: name,

--- a/plugins/plugin-app-control/src/actions/scaffold-env.test.ts
+++ b/plugins/plugin-app-control/src/actions/scaffold-env.test.ts
@@ -19,6 +19,7 @@ import {
 	findCodingCliOnPath,
 	hasVendoredOpencodeShim,
 	preflightCodingDispatch,
+	resolveAppsLandingRoot,
 	resolvePluginScaffoldBaseDir,
 	resolveScaffoldTemplateDir,
 	templateMissingGuidance,
@@ -301,5 +302,42 @@ describe("hasVendoredOpencodeShim", () => {
 
 	it("returns false for an empty root list", () => {
 		expect(hasVendoredOpencodeShim([])).toBe(false);
+	});
+});
+
+describe("resolveAppsLandingRoot (lantern-row live incident)", () => {
+	const saved = new Map(
+		["ELIZA_REPO_ROOT", "ELIZA_WORKSPACE_DIR", "ELIZA_STATE_DIR"].map((k) => [
+			k,
+			process.env[k],
+		]),
+	);
+	afterEach(() => {
+		for (const [k, v] of saved) {
+			if (v === undefined) delete process.env[k];
+			else process.env[k] = v;
+		}
+	});
+
+	it("an explicit absolute repo root keeps the checkout-relative layout", () => {
+		process.env.ELIZA_REPO_ROOT = "/srv/eliza-checkout";
+		delete process.env.ELIZA_WORKSPACE_DIR;
+		expect(resolveAppsLandingRoot()).toBe("/srv/eliza-checkout/eliza/apps");
+	});
+
+	it("no explicit root lands in the state dir, never the cwd checkout", () => {
+		delete process.env.ELIZA_REPO_ROOT;
+		delete process.env.ELIZA_WORKSPACE_DIR;
+		process.env.ELIZA_STATE_DIR = "/var/lib/eliza-state";
+		const landing = resolveAppsLandingRoot();
+		expect(landing).toBe("/var/lib/eliza-state/apps");
+		expect(landing.startsWith(process.cwd())).toBe(false);
+	});
+
+	it("a relative env value is ignored like the cwd fallback", () => {
+		process.env.ELIZA_REPO_ROOT = "relative/path";
+		delete process.env.ELIZA_WORKSPACE_DIR;
+		process.env.ELIZA_STATE_DIR = "/var/lib/eliza-state";
+		expect(resolveAppsLandingRoot()).toBe("/var/lib/eliza-state/apps");
 	});
 });

--- a/plugins/plugin-app-control/src/actions/scaffold-env.ts
+++ b/plugins/plugin-app-control/src/actions/scaffold-env.ts
@@ -325,3 +325,23 @@ export async function preflightCodingDispatch(
 
 	return { ok: guidance.length === 0, guidance };
 }
+
+/**
+ * Where NEW app scaffolds land. An operator-configured root (absolute
+ * ELIZA_REPO_ROOT / ELIZA_WORKSPACE_DIR) keeps the checkout-relative
+ * `eliza/apps` layout. When the repo root was only the process-cwd FALLBACK,
+ * scaffolding into it would plant the app inside the RUNNING agent's own
+ * checkout — charging that repo's entire git state (dirty files, unpushed
+ * carries) to the build task's completion residuals and risking the live tree
+ * (observed: app-lantern-row scaffolded into the live checkout and parked on
+ * "33 commits not pushed"). Fallback landings go to the state dir instead.
+ */
+export function resolveAppsLandingRoot(): string {
+	const explicit =
+		process.env.ELIZA_REPO_ROOT?.trim() ||
+		process.env.ELIZA_WORKSPACE_DIR?.trim();
+	if (explicit && path.isAbsolute(explicit)) {
+		return path.join(explicit, "eliza", "apps");
+	}
+	return path.join(resolveStateDir(), "apps");
+}


### PR DESCRIPTION
Live incident (lantern-row, task 2c2011a2, box record pulled by the live-box session): the APP create flow scaffolded a new app INSIDE the running agent's own checkout — `defaultRepoRoot()` falls back to `process.cwd()` when no absolute `ELIZA_REPO_ROOT`/`ELIZA_WORKSPACE_DIR` is configured, and `findFreeWorkdir` landed the scaffold at `<live-checkout>/eliza/apps/app-lantern-row`. Consequences observed live: the build task's completion residuals charged the LIVE repo's entire git state to the task ("33 commits not pushed" — the box's carry history) and parked a working build; the scaffold also risks the live tree itself (the known live-checkout workdir hazard).

## What changed

`resolveAppsLandingRoot()` splits scaffold LANDING from template RESOLUTION (which legitimately keeps the cwd fallback — templates ship in the checkout):
- An operator-configured absolute `ELIZA_REPO_ROOT` / `ELIZA_WORKSPACE_DIR` keeps the exact current checkout-relative `eliza/apps` layout — explicit config is untouched.
- The cwd FALLBACK case (the live incident) now lands scaffolds at `<state dir>/apps` (core `resolveStateDir()`), never inside the checkout the agent happens to run from. A relative env value is treated like the fallback.
- Edit lookups check the landing root first, then the legacy checkout-relative candidates, so existing scaffolded apps keep resolving.

Downstream is location-agnostic (dispatch carries the absolute workdir with `lockWorkdir`; verification/registry/publish operate on the path), and a state-dir scaffold has no enclosing git repo, so residuals judge only the app's own state.

## Evidence

- 3 new tests: explicit-root layout preserved, fallback lands in the state dir and provably NOT under `process.cwd()`, relative env treated as fallback.
- `scaffold-env` + `app` suites 36/36; plugin typecheck clean; Biome clean.
- Live re-proof: next box rebuild + a create-app ask should scaffold under `~/.milady/apps` (the box's state dir) with residuals judging only that directory.

Remaining from the same incident (separate follow-up, not this PR): app-control sessions bypass `markSessionAdministrativelyStopped`, so a swarm-synthesis "stopped before completion" line leaked to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)