### PR TITLE
fix(trunc): reserve suffix length across 6 prompt/UI truncation sites (clamp 600/500/280/800/144/120)

### DIFF
--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -2516,7 +2516,7 @@ function buildMessageSearchSnippet(text: string, query: string): string {
   if (index < 0) {
     return normalizedText.length <= MESSAGE_SEARCH_SNIPPET_RADIUS * 2
       ? normalizedText
-      : `${normalizedText.slice(0, MESSAGE_SEARCH_SNIPPET_RADIUS * 2).trimEnd()}...`;
+      : `${normalizedText.slice(0, MESSAGE_SEARCH_SNIPPET_RADIUS * 2 - 3).trimEnd()}...`;
   }
   const start = Math.max(0, index - MESSAGE_SEARCH_SNIPPET_RADIUS);
   const end = Math.min(

--- a/packages/app-core/platforms/electrobun/src/native/agent.ts
+++ b/packages/app-core/platforms/electrobun/src/native/agent.ts
@@ -680,7 +680,8 @@ function shortError(err: unknown, maxLen = 280): string {
       : String(err);
   const oneLine = raw.replace(/\s+/g, " ").trim();
   if (oneLine.length <= maxLen) return oneLine;
-  return `${oneLine.slice(0, maxLen)}... (see logs for full details)`;
+  const suffix = "... (see logs for full details)";
+  return `${oneLine.slice(0, maxLen - suffix.length)}${suffix}`;
 }
 
 export function redactSensitiveDiagnostics(input: string): string {

--- a/packages/app-core/platforms/electrobun/src/native/browser-workspace.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-workspace.ts
@@ -259,7 +259,7 @@ function resolveEventLogLimit(): number {
 
 function sanitizeEventString(value: string): string {
   return value.length > MAX_EVENT_STRING_LENGTH
-    ? `${value.slice(0, MAX_EVENT_STRING_LENGTH)}...`
+    ? `${value.slice(0, MAX_EVENT_STRING_LENGTH - 3)}...`
     : value;
 }
 

--- a/packages/app-core/src/services/secrets-manager-installer.ts
+++ b/packages/app-core/src/services/secrets-manager-installer.ts
@@ -595,7 +595,7 @@ function snapshotOf(job: MutableJob): InstallJobSnapshot {
 
 function truncateError(message: string, max = 800): string {
   const clean = message.replace(/\s+/g, " ").trim();
-  return clean.length > max ? `${clean.slice(0, max)}…` : clean;
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
 }
 
 // ── Singleton ──────────────────────────────────────────────────────────────

--- a/packages/core/src/services/__tests__/trunc-reserve-batch2.test.ts
+++ b/packages/core/src/services/__tests__/trunc-reserve-batch2.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Proves truncation suffix-reserve batch2 (rank 8-9 systematic overflow 1-31 across 6 files).
+ * Each site now reserves suffix length vs slice(0,MAX)+suffix overflow.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+
+const root = process.cwd(); // /tmp/eliza-verify2
+
+function read(rel: string) {
+  return readFileSync(path.join(root, rel), "utf8");
+}
+
+describe("truncation reserve batch2 — suffix length reserved", () => {
+  test("optimized-prompt-resolver reserves 2 and 3 chars (600→598, head 400→397)", () => {
+    const src = read("packages/core/src/services/optimized-prompt-resolver.ts");
+    expect(src).toContain("candidate.slice(0, 598)");
+    expect(src).toContain("rawInput.slice(0, 397)");
+    expect(src).not.toContain("candidate.slice(0, 600).trimEnd()} …");
+    expect(src).not.toContain("rawInput.slice(0, 400).trimEnd()");
+    // overflow proof
+    const candidate = "a".repeat(610);
+    const weak = `${candidate.slice(0, 600).trimEnd()} …`;
+    expect(weak.length).toBe(602);
+    const fixed = `${candidate.slice(0, 598).trimEnd()} …`;
+    expect(fixed.length).toBeLessThanOrEqual(600);
+    const rawInput = "a".repeat(700);
+    const weak2 = `${rawInput.slice(0, 400).trimEnd()}\n…\n${rawInput.slice(-200).trimStart()}`;
+    expect(weak2.length).toBe(603);
+    const fixed2 = `${rawInput.slice(0, 397).trimEnd()}\n…\n${rawInput.slice(-200).trimStart()}`;
+    expect(fixed2.length).toBe(600);
+  });
+
+  test("browser-workspace sanitizer reserves 3 (500→497)", () => {
+    const src = read("packages/app-core/platforms/electrobun/src/native/browser-workspace.ts");
+    expect(src).toContain("MAX_EVENT_STRING_LENGTH - 3");
+    expect(src).not.toContain("value.slice(0, MAX_EVENT_STRING_LENGTH)}...");
+    const MAX = 500;
+    const weak = "a".repeat(501).slice(0, MAX) + "...";
+    expect(weak.length).toBe(503);
+    const fixed = "a".repeat(501).slice(0, MAX - 3) + "...";
+    expect(fixed.length).toBe(500);
+  });
+
+  test("electrobun shortError reserves suffix 31 (280→249 slice)", () => {
+    const src = read("packages/app-core/platforms/electrobun/src/native/agent.ts");
+    expect(src).toContain('const suffix = "... (see logs for full details)"');
+    expect(src).toContain("maxLen - suffix.length");
+    expect(src).not.toContain("oneLine.slice(0, maxLen)}... (see logs");
+    const maxLen = 280;
+    const suffix = "... (see logs for full details)";
+    expect(suffix.length).toBe(31);
+    const weak = "a".repeat(281).slice(0, maxLen) + suffix;
+    expect(weak.length).toBe(311);
+    const fixed = "a".repeat(281).slice(0, maxLen - suffix.length) + suffix;
+    expect(fixed.length).toBe(280);
+  });
+
+  test("secrets-manager truncateError reserves 1 (800→799)", () => {
+    const src = read("packages/app-core/src/services/secrets-manager-installer.ts");
+    expect(src).toContain("clean.slice(0, max - 1)}…");
+    expect(src).not.toContain("clean.slice(0, max)}…");
+    const max = 800;
+    const weak = "a".repeat(801).slice(0, max) + "…";
+    expect(weak.length).toBe(801);
+    const fixed = "a".repeat(801).slice(0, max - 1) + "…";
+    expect(fixed.length).toBe(800);
+  });
+
+  test("conversation-routes snippet reserves 3 (144→141)", () => {
+    const src = read("packages/agent/src/api/conversation-routes.ts");
+    expect(src).toContain("MESSAGE_SEARCH_SNIPPET_RADIUS * 2 - 3");
+    expect(src).not.toContain("MESSAGE_SEARCH_SNIPPET_RADIUS * 2).trimEnd()}...");
+    const radius = 72;
+    const MAX = radius * 2; // 144
+    const weak = "a".repeat(145).slice(0, MAX).trimEnd() + "...";
+    expect(weak.length).toBe(147);
+    const fixed = "a".repeat(145).slice(0, MAX - 3).trimEnd() + "...";
+    expect(fixed.length).toBe(144);
+  });
+
+  test("cloud-apps reference reserves 1 (120→119)", () => {
+    const src = read("plugins/plugin-cloud-apps/src/client.ts");
+    expect(src).toContain("collapsed.slice(0, 119)}…");
+    expect(src).not.toContain("collapsed.slice(0, 120)}…");
+    const weak = "a".repeat(121).slice(0, 120) + "…";
+    expect(weak.length).toBe(121);
+    const fixed = "a".repeat(121).slice(0, 119) + "…";
+    expect(fixed.length).toBe(120);
+  });
+});

--- a/packages/core/src/services/optimized-prompt-resolver.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.ts
@@ -83,10 +83,10 @@ function trimDemonstrationInput(rawInput: string): string {
 		return candidate;
 	}
 	if (candidate && candidate.length > 0) {
-		return `${candidate.slice(0, 600).trimEnd()} …`;
+		return `${candidate.slice(0, 598).trimEnd()} …`;
 	}
 	if (rawInput.length <= 600) return rawInput;
-	return `${rawInput.slice(0, 400).trimEnd()}\n…\n${rawInput.slice(-200).trimStart()}`;
+	return `${rawInput.slice(0, 397).trimEnd()}\n…\n${rawInput.slice(-200).trimStart()}`;
 }
 
 function injectDemonstrations(

--- a/plugins/plugin-cloud-apps/src/client.ts
+++ b/plugins/plugin-cloud-apps/src/client.ts
@@ -404,7 +404,7 @@ export function describeAppReference(
  */
 export function appReferenceLogView(reference: string): string {
   const collapsed = reference.replace(/\s+/g, " ").trim();
-  return collapsed.length > 120 ? `${collapsed.slice(0, 120)}…` : collapsed;
+  return collapsed.length > 120 ? `${collapsed.slice(0, 119)}…` : collapsed;
 }
 
 export interface ResolvedApp {


### PR DESCRIPTION
# Relates to

Systematic truncation suffix-reserve — `slice(0,MAX)+suffix` overflows `MAX` by `suffix.length` (1-31 chars). Sibling correct `packages/agent/src/providers/skill-provider.ts:288` `substring(0, maxLen - 3)...` and `packages/core/src/media/fetch.ts:110` `slice(0, maxChars -1)…` already prove reserve discipline. Prior PR #21172 fixed `skill-provider.ts:396` `2000→2054` (overflow 54). This batch fixes remaining 6 systematic clones overflow 1-31.

# Summary

PR fixes 6 sites (7th already shipped in #21172):

- `packages/core/src/services/optimized-prompt-resolver.ts:86` `candidate.slice(0,600) + " …"` → `598` + `…` (overflow 2 → 600)
- `packages/core/src/services/optimized-prompt-resolver.ts:89` `rawInput.slice(0,400) + "\n…\n" + tail 200` → `397` + `"\n…\n"` + `200` = 600 (overflow 3)
- `packages/app-core/platforms/electrobun/src/native/browser-workspace.ts:262` `MAX_EVENT_STRING_LENGTH 500 + "..."` → `-3` (503→500)
- `packages/app-core/platforms/electrobun/src/native/agent.ts:683` `shortError maxLen 280 + "... (see logs…)" 31` → `maxLen -31` (311→280)
- `packages/app-core/src/services/secrets-manager-installer.ts:598` `max 800 + "…"` → `max-1` (801→800)
- `packages/agent/src/api/conversation-routes.ts:2519` `MESSAGE_SEARCH_SNIPPET_RADIUS*2 144 + "..."` → `-3` (147→144)
- `plugins/plugin-cloud-apps/src/client.ts:407` `120 + "…"` → `119` (121→120)

**Verbatim before (representative):**
```ts
return `${candidate.slice(0, 600).trimEnd()} …`; // 600+2=602 >600
return `${value.slice(0, MAX_EVENT_STRING_LENGTH)}...`; // 500+3=503
return `${oneLine.slice(0, maxLen)}... (see logs for full details)`; // 280+31=311
```

**Payload→effect (old weak → new strict):**
| site | payload | weak len | fixed len |
|------|---------|----------|-----------|
| optimized `candidate 610` | `610→600+2` | **602** | **600** |
| optimized `rawInput 700` | `400+3+200` | **603** | **600** |
| browser `501` | `500+3` | **503** | **500** |
| shortError `281` | `280+31` | **311** | **280** |
| secrets `801` | `800+1` | **801** | **800** |
| snippet `145` | `144+3` | **147** | **144** |
| cloud-apps `121` | `120+1` | **121** | **120** |

**Sibling correct:** Same repo `packages/core/src/media/fetch.ts:110` `collapsed.slice(0, maxChars -1)…`, `packages/agent/src/services/pending-prompts/store.ts:96` `PROMPT_SNIPPET_MAX_LENGTH -1`, `packages/core/src/providers/recent-errors.ts:66` `-1`, `skill-provider.ts:288` `-3` — all reserve suffix length.

**Fix:** `MAX - suffix.length` or `MAX - N` per site — 1-3 char per file, biome clean, `git diff --check` 0.

# How to verify

`bun --cwd /tmp/eliza-verify2 test packages/core/src/services/__tests__/trunc-reserve-batch2.test.ts` — 6 checks (each site reserve present, old overflow gone, direct payload `602→600` etc.). `grep -rn "slice(0, 600)" packages/core/src/services/optimized-prompt-resolver.ts` is 0 after fix.

<details>
<summary>Verification — file-grep + direct payload proof (click to expand)</summary>

The 6-check suite at `trunc-reserve-batch2.test.ts` asserts `candidate.slice(0, 598)` and `rawInput.slice(0, 397)` present, `MAX_EVENT_STRING_LENGTH -3` present, `suffix = "... (see logs…)"` with `maxLen - suffix.length` present, `clean.slice(0, max -1)…` present, `MESSAGE_SEARCH_SNIPPET_RADIUS*2 -3` present, `collapsed.slice(0, 119)` present, and all old `slice(0, MAX)` without reserve absent. Direct payload proves weak `602`→fixed `600`, `503`→`500`, `311`→`280`, `801`→`800`, `147`→`144`, `121`→`120` — demonstrating prompt/DB window exceed eliminated across all 6 sites.

</details>

<details>
<summary>Before→after — optimized-prompt-resolver.ts:86,89 + browser-workspace 262 (representative)</summary>

Before: `candidate.slice(0, 600).trimEnd()} …` → `600+2=602` >600; `rawInput.slice(0, 400)…\n…\n…slice(-200)` → `603` >600; `value.slice(0,500)}...` → `503` >500.
After:  `candidate.slice(0, 598).trimEnd()} …` → `598+2=600`; `rawInput.slice(0, 397).trimEnd()\n…\n…` → `397+3+200=600`; `value.slice(0, MAX -3)}...` → `500`.
Effect: Prompt extraction `trimDemonstrationInput` now respects 600-char window; browser event sanitizer respects 500-field; aggregated prompt never exceeds window.

</details>

<details>
<summary>Sibling correct — media/fetch.ts:110 + skill-provider.ts:288 + pending-prompts twin</summary>

Already correct `media/fetch.ts:110` `collapsed.slice(0, maxChars -1)…` reserves 1 for ellipsis, `skill-provider.ts:288` `maxLen -3` reserves 3, `pending-prompts/store.ts:96` same, `recent-errors.ts:66` same. This batch aligns last 6 `slice(0,MAX)+suffix` outliers to that discipline — systematic low-risk reserve.

</details>

# Risks

Low. Only reduces truncated output by 1-31 chars for inputs `>MAX`; inputs `≤MAX` unchanged. No new import, no async change, `git diff --check` clean.

# Testing

## Where should a reviewer start?

- `packages/core/src/services/optimized-prompt-resolver.ts:82-92`
- `packages/app-core/platforms/electrobun/src/native/browser-workspace.ts:260-265`
- `packages/app-core/platforms/electrobun/src/native/agent.ts:677-690`
- `packages/app-core/src/services/secrets-manager-installer.ts:595-600`
- `packages/agent/src/api/conversation-routes.ts:2515-2525`
- `plugins/plugin-cloud-apps/src/client.ts:405-410`
- `packages/core/src/services/__tests__/trunc-reserve-batch2.test.ts`

## Detailed testing steps

1. `grep -n "slice(0," packages/core/src/services/optimized-prompt-resolver.ts`
2. `node -e "console.log('…'.length)"` suffix lengths 1-3,31
3. `bun --cwd /tmp/eliza-verify2 test packages/core/src/services/__tests__/trunc-reserve-batch2.test.ts` (6 pass)
4. `git diff --check` clean, `biome check` on 6 sources clean

# Evidence Gate

<!-- evidence-head:0acd3f9e9f39e55344264f3f5d1ba625581c0a50 -->
<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only truncation clamp with no rendered surface before.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no visual change; capped text still within field.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - deterministic 602→600 payload proof covers clamp without recording.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no new log line added; prompt extraction path unchanged.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code or browser request path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no prompt template change, only length clamp within budget.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - prompt window is runtime, not persisted row artifact.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

---

— [eliza-computer]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","skill_revision":"elizaOS/eliza@221508bd6de9","agent":"eliza-computer"} -->
