### PR TITLE
fix(shared): reject non-string inputs in decodeUrlPathComponent

### DIFF
--- a/packages/shared/src/utils/path-component.test.ts
+++ b/packages/shared/src/utils/path-component.test.ts
@@ -30,4 +30,19 @@ describe("decodeUrlPathComponent", () => {
       value: "a%2Fb",
     });
   });
+
+  it("rejects non-string inputs as malformed encoding", () => {
+    expect(decodeUrlPathComponent(null)).toEqual({
+      ok: false,
+      reason: "malformed-encoding",
+    });
+    expect(decodeUrlPathComponent(undefined)).toEqual({
+      ok: false,
+      reason: "malformed-encoding",
+    });
+    expect(decodeUrlPathComponent(123 as unknown as string)).toEqual({
+      ok: false,
+      reason: "malformed-encoding",
+    });
+  });
 });

--- a/packages/shared/src/utils/path-component.ts
+++ b/packages/shared/src/utils/path-component.ts
@@ -8,7 +8,12 @@ export type PathComponentDecodeResult =
   | { ok: true; value: string }
   | { ok: false; reason: "malformed-encoding" };
 
-export function decodeUrlPathComponent(raw: string): PathComponentDecodeResult {
+export function decodeUrlPathComponent(
+  raw: string | null | undefined,
+): PathComponentDecodeResult {
+  if (typeof raw !== "string") {
+    return { ok: false, reason: "malformed-encoding" };
+  }
   try {
     return { ok: true, value: decodeURIComponent(raw) };
   } catch {


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/path-component.ts`, `decodeUrlPathComponent` passed `raw` directly to `decodeURIComponent(raw)`. When invoked with `null`, `undefined`, or non-string inputs from optional route parameters, `decodeURIComponent` coerced the argument to `"undefined"` or `"null"`, returning `{ ok: true, value: "undefined" }` or `{ ok: true, value: "null" }` instead of `{ ok: false, reason: "malformed-encoding" }`.
2. Added `typeof raw !== "string"` validation to safely return `{ ok: false, reason: "malformed-encoding" }`.
3. Added unit test cases in `packages/shared/src/utils/path-component.test.ts` for non-string inputs.

Closes #21179.

## Verification

Exact commit: `3e3696c38e`.

- Focused unit test suite `packages/shared/src/utils/path-component.test.ts`: 6/6 tests passing (10 assertions).
- Biome format on `@elizaos/shared`: 408 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - URL path component decoder; no rendered UI changed.
- [x] N/A - URL path component decoder; no rendered UI changed.
- [x] N/A - deterministic URL decoding tests.
- [x] Focused test suite transcript:
```text
✓ decodeUrlPathComponent > rejects malformed encoding % [0.20ms]
✓ decodeUrlPathComponent > rejects malformed encoding %2 [0.01ms]
✓ decodeUrlPathComponent > rejects malformed encoding %ZZ
✓ decodeUrlPathComponent > rejects malformed encoding %E0%A4
✓ decodeUrlPathComponent > decodes valid UTF-8 and leaves domain validation to the caller [0.05ms]
✓ decodeUrlPathComponent > rejects non-string inputs as malformed encoding [0.05ms]
6 pass, 0 fail, 10 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@cd41f99b1ab65b1695f269a8da23ff3a699c2777:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@cd41f99b1ab65b1695f269a8da23ff3a699c2777:packages/skills/skills/contribute-to-eliza"} -->
