### PR TITLE
fix(agent): drop orphaned decodePathComponent from skills route injection

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -2569,7 +2569,6 @@ async function handleRequest(
         error,
         readJsonBody,
         readBody,
-        decodePathComponent,
         discoverSkills,
       })
     ) {


### PR DESCRIPTION
Two halves of the skills-route decoder change raced onto develop: 972cf5d injected `decodePathComponent` through `SkillsRouteContext`, then #21115 (344a0de) replaced that design with the shared `decodeUrlPathComponent` helper and removed the context field — but the server.ts call site kept passing it, breaking `packages/agent` + `packages/app-core` typecheck repo-wide (caught by transactional release run 32018432224).

Fix: remove the orphaned property from the injection site. `bun run --cwd packages/agent typecheck` and `bun run --cwd packages/app-core typecheck` both green; skills-routes tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)