### PR TITLE
fix(shared): trim reason in isCloudStatusReasonApiKeyOnly and add unit test suite

### DIFF
--- a/packages/shared/src/utils/cloud-status.test.ts
+++ b/packages/shared/src/utils/cloud-status.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for cloud-status helpers in packages/shared/src/utils/cloud-status.ts.
+ * Exercises API-key-only reason classification, whitespace trimming, non-string
+ * input handling, and cloud authenticated state determination.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isCloudStatusAuthenticated,
+  isCloudStatusReasonApiKeyOnly,
+} from "./cloud-status.js";
+
+describe("isCloudStatusReasonApiKeyOnly", () => {
+  it("identifies API-key-only reason codes", () => {
+    expect(
+      isCloudStatusReasonApiKeyOnly("api_key_present_not_authenticated"),
+    ).toBe(true);
+    expect(
+      isCloudStatusReasonApiKeyOnly("api_key_present_runtime_not_started"),
+    ).toBe(true);
+  });
+
+  it("handles reasons with surrounding whitespace", () => {
+    expect(
+      isCloudStatusReasonApiKeyOnly("  api_key_present_not_authenticated\n"),
+    ).toBe(true);
+    expect(
+      isCloudStatusReasonApiKeyOnly("api_key_present_runtime_not_started "),
+    ).toBe(true);
+  });
+
+  it("returns false for unknown reasons and non-string inputs", () => {
+    expect(isCloudStatusReasonApiKeyOnly("disconnected")).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly("")).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly(null)).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly(undefined)).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly(123 as unknown as string)).toBe(false);
+  });
+});
+
+describe("isCloudStatusAuthenticated", () => {
+  it("returns true when connected and reason is not API-key-only", () => {
+    expect(isCloudStatusAuthenticated(true, undefined)).toBe(true);
+    expect(isCloudStatusAuthenticated(true, null)).toBe(true);
+    expect(isCloudStatusAuthenticated(true, "ready")).toBe(true);
+  });
+
+  it("returns false when connected is true but reason is API-key-only", () => {
+    expect(
+      isCloudStatusAuthenticated(true, "api_key_present_not_authenticated"),
+    ).toBe(false);
+    expect(
+      isCloudStatusAuthenticated(true, "api_key_present_runtime_not_started"),
+    ).toBe(false);
+  });
+
+  it("returns false when connected is false", () => {
+    expect(isCloudStatusAuthenticated(false, undefined)).toBe(false);
+    expect(isCloudStatusAuthenticated(false, "ready")).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/cloud-status.ts
+++ b/packages/shared/src/utils/cloud-status.ts
@@ -11,14 +11,16 @@ const CLOUD_STATUS_API_KEY_ONLY_REASONS: ReadonlySet<string> = new Set([
 export function isCloudStatusReasonApiKeyOnly(
   reason: string | null | undefined,
 ): boolean {
-  return (
-    typeof reason === "string" && CLOUD_STATUS_API_KEY_ONLY_REASONS.has(reason)
-  );
+  if (typeof reason !== "string") {
+    return false;
+  }
+  const normalized = reason.trim();
+  return CLOUD_STATUS_API_KEY_ONLY_REASONS.has(normalized);
 }
 
 export function isCloudStatusAuthenticated(
   connected: boolean,
   reason: string | null | undefined,
 ): boolean {
-  return connected && !isCloudStatusReasonApiKeyOnly(reason);
+  return Boolean(connected) && !isCloudStatusReasonApiKeyOnly(reason);
 }


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/cloud-status.ts`, `isCloudStatusReasonApiKeyOnly` checked reason strings against `CLOUD_STATUS_API_KEY_ONLY_REASONS` without `.trim()`, failing to match reasons containing surrounding whitespace from YAML or JSON configurations.
2. Added `.trim()` normalization to `isCloudStatusReasonApiKeyOnly` and boolean coercion to `isCloudStatusAuthenticated`.
3. Created a comprehensive unit test suite in `packages/shared/src/utils/cloud-status.test.ts` covering API-key-only reason classification, whitespace handling, and authenticated state determination.

Closes #21183.

## Verification

Exact commit: `818589a87c`.

- Focused unit test suite `packages/shared/src/utils/cloud-status.test.ts`: 6/6 tests passing (16 assertions).
- Biome format on `@elizaos/shared`: 409 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - cloud status classifier; no rendered UI changed.
- [x] N/A - cloud status classifier; no rendered UI changed.
- [x] N/A - deterministic status classification tests.
- [x] Focused test suite transcript:
```text
✓ isCloudStatusReasonApiKeyOnly > identifies API-key-only reason codes [0.10ms]
✓ isCloudStatusReasonApiKeyOnly > handles reasons with surrounding whitespace [0.03ms]
✓ isCloudStatusReasonApiKeyOnly > returns false for unknown reasons and non-string inputs [0.06ms]
✓ isCloudStatusAuthenticated > returns true when connected and reason is not API-key-only [0.06ms]
✓ isCloudStatusAuthenticated > returns false when connected is true but reason is API-key-only [0.03ms]
✓ isCloudStatusAuthenticated > returns false when connected is false [0.03ms]
6 pass, 0 fail, 16 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@cd41f99b1ab65b1695f269a8da23ff3a699c2777:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@cd41f99b1ab65b1695f269a8da23ff3a699c2777:packages/skills/skills/contribute-to-eliza"} -->
