### PR TITLE
fix(cloud): close cloud API authorization and disclosure gaps (wave-1 security audit)

### DIFF
--- a/packages/cloud/api/health/operational/route.test.ts
+++ b/packages/cloud/api/health/operational/route.test.ts
@@ -1,8 +1,11 @@
 /**
  * Exercises /api/health/operational route behavior against mocked OAuth
- * diagnostics. bun-test does not resolve `@/lib/*` path aliases, so all
- * dependencies are mocked; the `getProviderEnvDiagnostics` return value
- * is controlled to verify the route serializes it correctly.
+ * diagnostics and a mocked platform-admin gate. bun-test does not resolve
+ * `@/lib/*` path aliases, so all dependencies are mocked; the
+ * `getProviderEnvDiagnostics` return value is controlled to verify the route
+ * serializes it correctly. The unauthenticated payload must stay collapsed to
+ * `{ status, timestamp }` so backend configuration state is not disclosed;
+ * per-check detail is admin-only.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
@@ -31,11 +34,20 @@ const defaultDiagnostics = [
 let mockDiagnostics = defaultDiagnostics.map((entry) => ({ ...entry }));
 const getProviderEnvDiagnostics = mock(() => mockDiagnostics);
 
+let requireAdminBehavior: () => Promise<unknown> = async () => {
+  throw new Error("Admin access required");
+};
+const requireAdmin = mock(() => requireAdminBehavior());
+
 mock.module("@/lib/api/cloud-worker-errors", () => ({
   failureResponse: (c: unknown, error: unknown) => {
     const ctx = c as { json: (body: unknown, status?: number) => Response };
     return ctx.json({ error: String(error) }, 500);
   },
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireAdmin,
 }));
 
 mock.module("@/lib/runtime/cloud-bindings", () => ({
@@ -61,9 +73,58 @@ function buildApp() {
   return app;
 }
 
-describe("GET /api/health/operational — OAuth providers", () => {
+describe("GET /api/health/operational — public payload", () => {
   beforeEach(() => {
     mockDiagnostics = defaultDiagnostics.map((entry) => ({ ...entry }));
+    requireAdminBehavior = async () => {
+      throw new Error("Admin access required");
+    };
+  });
+
+  test("unauthenticated callers receive only status and timestamp", async () => {
+    const res = await buildApp().request("/");
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("ok");
+    expect(typeof body.timestamp).toBe("number");
+    expect(body.checks).toBeUndefined();
+    expect(body.oauth_providers).toBeUndefined();
+    expect(body.region).toBeUndefined();
+  });
+
+  test("a missing deployment-required provider degrades the public status without revealing which", async () => {
+    mockDiagnostics = defaultDiagnostics.map((entry) =>
+      entry.id === "google"
+        ? {
+            ...entry,
+            configured: false,
+            missingEnvVars: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+          }
+        : { ...entry },
+    );
+
+    const res = await buildApp().request("/");
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body.status).toBe("degraded");
+    expect(body.checks).toBeUndefined();
+    expect(body.oauth_providers).toBeUndefined();
+  });
+
+  test("response is never cached", async () => {
+    const res = await buildApp().request("/");
+    expect(res.headers.get("cache-control")).toBe("no-store, max-age=0");
+  });
+});
+
+describe("GET /api/health/operational — platform-admin payload", () => {
+  beforeEach(() => {
+    mockDiagnostics = defaultDiagnostics.map((entry) => ({ ...entry }));
+    requireAdminBehavior = async () => ({
+      user: { id: "admin-1", organization_id: "org-ops" },
+      role: "super_admin",
+    });
   });
 
   test("response includes oauth_providers array with per-provider status", async () => {
@@ -107,7 +168,7 @@ describe("GET /api/health/operational — OAuth providers", () => {
     );
   });
 
-  test("a missing deployment-required provider degrades health", async () => {
+  test("a missing deployment-required provider degrades health with admin detail", async () => {
     mockDiagnostics = defaultDiagnostics.map((entry) =>
       entry.id === "google"
         ? {
@@ -131,7 +192,7 @@ describe("GET /api/health/operational — OAuth providers", () => {
     });
   });
 
-  test("response is never cached", async () => {
+  test("admin response is never cached", async () => {
     const res = await buildApp().request("/");
     expect(res.headers.get("cache-control")).toBe("no-store, max-age=0");
   });

--- a/packages/cloud/api/health/operational/route.ts
+++ b/packages/cloud/api/health/operational/route.ts
@@ -1,14 +1,19 @@
 /**
  * GET /api/health/operational
  *
- * Operational health check for monitoring. Returns boolean flags for the
- * subsystems whose silent misconfiguration would degrade or break the
- * monetization / payout / sandbox flows. No sensitive data (balances, keys,
- * wallet addresses) is exposed — that surface stays on the user-facing
- * `/api/v1/redemptions/status` (existing) and the admin endpoints.
+ * Operational health check for monitoring. The public, unauthenticated
+ * payload is intentionally collapsed to `{ status, timestamp }` so backend
+ * configuration state (which payout/cron/Steward/OAuth subsystems are live or
+ * misconfigured) is not disclosed to the internet. The per-check detail —
+ * boolean flags for the subsystems whose silent misconfiguration would
+ * degrade or break the monetization / payout / sandbox flows — is returned
+ * only to platform admins. No sensitive data (balances, keys, wallet
+ * addresses) is exposed in either variant — that surface stays on the
+ * user-facing `/api/v1/redemptions/status` (existing) and the admin
+ * endpoints.
  *
  * Intended caller: uptime monitors, ops dashboards, on-call runbooks.
- * Lightweight (no live RPC calls), unauthed.
+ * Lightweight (no live RPC calls).
  *
  * `status` flips from `ok` to `degraded` when any required-for-production
  * check fails so a single boolean grep is enough for alerts.
@@ -16,6 +21,7 @@
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { requireAdmin } from "@/lib/auth/workers-hono-auth";
 import { getCloudAwareEnv } from "@/lib/runtime/cloud-bindings";
 import { getProviderEnvDiagnostics } from "@/lib/services/oauth/provider-registry";
 import { isStewardPlatformConfigured } from "@/lib/services/steward-platform-users";
@@ -34,7 +40,7 @@ interface PayoutCheckResult {
 
 const app = new Hono<AppEnv>();
 
-app.get("/", (c) => {
+app.get("/", async (c) => {
   try {
     const env = getCloudAwareEnv();
 
@@ -88,9 +94,24 @@ app.get("/", (c) => {
       crons.configured &&
       oauthProvidersCheck.configured;
 
+    const status = allOk ? "ok" : "degraded";
+    const cacheHeaders = { "Cache-Control": "no-store, max-age=0" };
+
+    let isPlatformAdmin = false;
+    try {
+      await requireAdmin(c);
+      isPlatformAdmin = true;
+    } catch {
+      // error-policy:J1 route boundary — a failed admin resolution is not an error for a health probe; the caller receives the collapsed public payload below.
+    }
+
+    if (!isPlatformAdmin) {
+      return c.json({ status, timestamp: Date.now() }, 200, cacheHeaders);
+    }
+
     return c.json(
       {
-        status: allOk ? "ok" : "degraded",
+        status,
         timestamp: Date.now(),
         region: (env as { CF_REGION?: string }).CF_REGION ?? "unknown",
         checks: {
@@ -102,7 +123,7 @@ app.get("/", (c) => {
         oauth_providers: oauthProviders,
       },
       200,
-      { "Cache-Control": "no-store, max-age=0" },
+      cacheHeaders,
     );
   } catch (error) {
     // error-policy:J1 translate an operational-health boundary failure into the shared API error shape.

--- a/packages/cloud/api/v1/agent-tokens/route.test.ts
+++ b/packages/cloud/api/v1/agent-tokens/route.test.ts
@@ -11,13 +11,14 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
 
-class MockApiError extends Error {
-  constructor(
-    public readonly status: number,
-    message: string,
-  ) {
-    super(message);
+// Mirrors the real ApiError, which extends Hono's HTTPException, so an
+// uncaught rethrow surfaces with its own status through Hono's default
+// error handling exactly as the production global onError would translate it.
+class MockApiError extends HTTPException {
+  constructor(status: 401 | 403 | 503, message: string) {
+    super(status, { message });
     this.name = "ApiError";
   }
 }
@@ -207,6 +208,21 @@ describe("agent-tokens route — human-leg tenant binding", () => {
     });
     const res = await post({}, {});
     expect(res.status).toBe(400);
+    expect(mintAgentToken).not.toHaveBeenCalled();
+  });
+
+  test("a 5xx platform-admin infrastructure failure is not masked as an auth denial", async () => {
+    requireAdminBehavior = async () => {
+      throw new MockApiError(
+        503,
+        "API key validation is temporarily unavailable. Please retry.",
+      );
+    };
+
+    const res = await post({});
+    expect(res.status).toBe(503);
+    expect(getCurrentUser).not.toHaveBeenCalled();
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
     expect(mintAgentToken).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/agent-tokens/route.test.ts
+++ b/packages/cloud/api/v1/agent-tokens/route.test.ts
@@ -1,9 +1,10 @@
 /**
  * Agent-token minting route — service-secret compare must be constant-time
- * (#12227 M1). The route mints Steward agent JWTs for any `agentId`, so a
- * timing oracle on the service-secret compare could recover
- * ELIZA_CLOUD_SERVICE_TOKEN / AGENT_TOKEN_SERVICE_TOKEN and forge tokens. The
- * `===` was replaced with `timingSafeEqualSecret`; these drive the real route.
+ * (#12227 M1) and the human leg must be bound to platform or owning-org
+ * authority: an org "admin" is a per-organization role, so minting for an
+ * agentId outside the caller's org must 403 without minting. The `===` was
+ * replaced with `timingSafeEqualSecret`; these drive the real route with
+ * mocked auth/repository edges.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -11,14 +12,40 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { Hono } from "hono";
 
+class MockApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
 const mintAgentToken = mock(async (agentId: string) => ({
   token: `jwt-for-${agentId}`,
   expiresAt: "2026-01-01T00:00:00Z",
 }));
-const getCurrentUser = mock(async () => null);
+let currentUser: Record<string, unknown> | null = null;
+const getCurrentUser = mock(async () => currentUser);
+let requireAdminBehavior: () => Promise<unknown> = async () => {
+  throw new MockApiError(401, "Authentication required");
+};
+const requireAdmin = mock(() => requireAdminBehavior());
+let sandboxForOrg: Record<string, unknown> | undefined;
+const findByIdAndOrg = mock(async () => sandboxForOrg);
 
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  ApiError: MockApiError,
+}));
 mock.module("@/lib/auth/agent-token", () => ({ mintAgentToken }));
-mock.module("@/lib/auth/workers-hono-auth", () => ({ getCurrentUser }));
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  getCurrentUser,
+  requireAdmin,
+}));
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: { findByIdAndOrg },
+}));
 mock.module("@/lib/utils/logger", () => ({
   logger: {
     info: mock(() => undefined),
@@ -33,14 +60,17 @@ const { default: agentTokensRoute } = await import("./route");
 const SECRET = "super-secret-service-token-value";
 const ENV = { ELIZA_CLOUD_SERVICE_TOKEN: SECRET };
 
-function post(headers: Record<string, string>) {
+function post(
+  headers: Record<string, string>,
+  body: Record<string, unknown> = { agentId: "agent-xyz" },
+) {
   const app = new Hono();
   app.route("/api/v1/agent-tokens", agentTokensRoute);
   return app.fetch(
     new Request("https://api.example.test/api/v1/agent-tokens", {
       method: "POST",
       headers: { "content-type": "application/json", ...headers },
-      body: JSON.stringify({ agentId: "agent-xyz" }),
+      body: JSON.stringify(body),
     }),
     ENV,
   );
@@ -50,6 +80,13 @@ describe("agent-tokens route — constant-time service-secret gate (M1)", () => 
   beforeEach(() => {
     mintAgentToken.mockClear();
     getCurrentUser.mockClear();
+    requireAdmin.mockClear();
+    findByIdAndOrg.mockClear();
+    currentUser = null;
+    sandboxForOrg = undefined;
+    requireAdminBehavior = async () => {
+      throw new MockApiError(401, "Authentication required");
+    };
   });
 
   test("the source has no plain === / !== secret comparison", () => {
@@ -87,6 +124,89 @@ describe("agent-tokens route — constant-time service-secret gate (M1)", () => 
   test("an absent token is rejected 401", async () => {
     const res = await post({});
     expect(res.status).toBe(401);
+    expect(mintAgentToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("agent-tokens route — human-leg tenant binding", () => {
+  beforeEach(() => {
+    mintAgentToken.mockClear();
+    getCurrentUser.mockClear();
+    requireAdmin.mockClear();
+    findByIdAndOrg.mockClear();
+    currentUser = null;
+    sandboxForOrg = undefined;
+    requireAdminBehavior = async () => {
+      throw new MockApiError(401, "Authentication required");
+    };
+  });
+
+  test("a platform admin mints for any agentId", async () => {
+    requireAdminBehavior = async () => ({
+      user: { id: "admin-1", organization_id: "org-ops" },
+      role: "super_admin",
+    });
+    const res = await post({});
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      token: "jwt-for-agent-xyz",
+    });
+    expect(mintAgentToken).toHaveBeenCalledTimes(1);
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+  });
+
+  test("an org admin mints for an agent owned by their organization", async () => {
+    requireAdminBehavior = async () => {
+      throw new MockApiError(403, "Admin access required");
+    };
+    currentUser = { id: "user-1", role: "admin", organization_id: "org-1" };
+    sandboxForOrg = { id: "agent-xyz", organization_id: "org-1" };
+
+    const res = await post({});
+    expect(res.status).toBe(200);
+    expect(findByIdAndOrg).toHaveBeenCalledWith("agent-xyz", "org-1");
+    expect(mintAgentToken).toHaveBeenCalledTimes(1);
+  });
+
+  test("an org admin is denied for another tenant's agentId and mints nothing", async () => {
+    requireAdminBehavior = async () => {
+      throw new MockApiError(403, "Admin access required");
+    };
+    currentUser = { id: "user-1", role: "admin", organization_id: "org-1" };
+    sandboxForOrg = undefined;
+
+    const res = await post({});
+    expect(res.status).toBe(403);
+    expect(findByIdAndOrg).toHaveBeenCalledWith("agent-xyz", "org-1");
+    expect(mintAgentToken).not.toHaveBeenCalled();
+  });
+
+  test("an authenticated non-admin user is denied 403", async () => {
+    requireAdminBehavior = async () => {
+      throw new MockApiError(403, "Admin access required");
+    };
+    currentUser = { id: "user-2", role: "member", organization_id: "org-1" };
+
+    const res = await post({});
+    expect(res.status).toBe(403);
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    expect(mintAgentToken).not.toHaveBeenCalled();
+  });
+
+  test("a service token still wins over a failing human leg", async () => {
+    const res = await post({ authorization: `Bearer ${SECRET}` });
+    expect(res.status).toBe(200);
+    expect(requireAdmin).not.toHaveBeenCalled();
+    expect(getCurrentUser).not.toHaveBeenCalled();
+  });
+
+  test("agentId is still required after the human leg authorizes", async () => {
+    requireAdminBehavior = async () => ({
+      user: { id: "admin-1", organization_id: "org-ops" },
+      role: "super_admin",
+    });
+    const res = await post({}, {});
+    expect(res.status).toBe(400);
     expect(mintAgentToken).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/agent-tokens/route.ts
+++ b/packages/cloud/api/v1/agent-tokens/route.ts
@@ -2,15 +2,20 @@
  * POST /api/v1/agent-tokens
  * Mints a short-lived, RS256 Steward agent JWT for a cloud-provisioned agent.
  *
- * Auth: service-account bearer/header token, or an authenticated admin user.
+ * Auth: service-account bearer/header token (any agentId), a platform admin
+ * (any agentId), or an organization admin whose organization owns the agent.
+ * The human mint is bound to the caller's authority so one tenant cannot
+ * impersonate another tenant's agent at Steward.
  * Body: { agentId: string; ttl?: number }
  * Response: { token, expiresAt }
  */
 
 import { Hono } from "hono";
+import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
 import { mintAgentToken } from "@/lib/auth/agent-token";
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
-import { getCurrentUser } from "@/lib/auth/workers-hono-auth";
+import { getCurrentUser, requireAdmin } from "@/lib/auth/workers-hono-auth";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -43,41 +48,108 @@ function hasServiceAccountAuth(c: AppContext): boolean {
   return timingSafeEqualSecret(supplied, expected);
 }
 
-async function hasAdminAuth(c: AppContext): Promise<boolean> {
-  const existing = c.get("user");
-  if (existing?.role === "admin") return true;
-  const user = await getCurrentUser(c).catch(() => null);
-  return user?.role === "admin";
+type HumanMintAuth =
+  | {
+      ok: true;
+      actor: string;
+      actorUserId: string;
+      actorOrganizationId: string | null;
+    }
+  | { ok: false; status: 401 | 403; error: string };
+
+/**
+ * Human callers hold no service secret, so the mint must be tied to their
+ * platform or org authority: platform admins mint for any agentId, while an
+ * org "admin" (a per-organization role on the users row, not a platform role)
+ * mints only for an agent owned by their own organization.
+ */
+async function authorizeHumanMint(
+  c: AppContext,
+  agentId: string,
+): Promise<HumanMintAuth> {
+  try {
+    const { user } = await requireAdmin(c);
+    return {
+      ok: true,
+      actor: "platform-admin",
+      actorUserId: user.id,
+      actorOrganizationId: user.organization_id,
+    };
+  } catch (error) {
+    // error-policy:J1 route boundary — a 401/403 platform-admin denial is not final here; the org-scoped check below produces the structured denial. Infrastructure failures (e.g. 503 storage outage) propagate to the global onError translator instead of being masked as auth failures.
+    if (
+      error instanceof ApiError &&
+      error.status !== 401 &&
+      error.status !== 403
+    ) {
+      throw error;
+    }
+  }
+
+  const user = await getCurrentUser(c);
+  if (!user) {
+    return {
+      ok: false,
+      status: 401,
+      error: "admin or container service-account auth required",
+    };
+  }
+  if (agentId && user.role === "admin" && user.organization_id) {
+    const sandbox = await agentSandboxesRepository.findByIdAndOrg(
+      agentId,
+      user.organization_id,
+    );
+    if (sandbox) {
+      return {
+        ok: true,
+        actor: "org-admin",
+        actorUserId: user.id,
+        actorOrganizationId: user.organization_id,
+      };
+    }
+  }
+  return {
+    ok: false,
+    status: 403,
+    error:
+      "platform admin or owning-organization admin required for this agentId",
+  };
 }
 
 app.post("/", async (c) => {
   const serviceAccount = hasServiceAccountAuth(c);
-  const admin = serviceAccount ? false : await hasAdminAuth(c);
-  if (!serviceAccount && !admin) {
-    return c.json(
-      {
-        success: false,
-        error: "admin or container service-account auth required",
-      },
-      401,
-    );
-  }
 
   const body = (await c.req.json().catch(() => ({}))) as {
     agentId?: unknown;
     ttl?: unknown;
   };
-  const agentId = typeof body.agentId === "string" ? body.agentId : "";
-  if (!agentId.trim()) {
+  const agentId = typeof body.agentId === "string" ? body.agentId.trim() : "";
+
+  let actor = "service-account";
+  let actorUserId: string | null = null;
+  let actorOrganizationId: string | null = null;
+  if (!serviceAccount) {
+    const authz = await authorizeHumanMint(c, agentId);
+    if (!authz.ok) {
+      return c.json({ success: false, error: authz.error }, authz.status);
+    }
+    actor = authz.actor;
+    actorUserId = authz.actorUserId;
+    actorOrganizationId = authz.actorOrganizationId;
+  }
+
+  if (!agentId) {
     return c.json({ success: false, error: "agentId is required" }, 400);
   }
 
   try {
     const minted = await mintAgentToken(agentId, body.ttl);
     logger.info("[agent-token] minted Steward JWT", {
-      agentId: agentId.trim(),
+      agentId,
       expiresAt: minted.expiresAt,
-      actor: serviceAccount ? "service-account" : "admin",
+      actor,
+      actorUserId: actorUserId ?? undefined,
+      actorOrganizationId: actorOrganizationId ?? undefined,
     });
     return c.json(minted);
   } catch (error) {

--- a/packages/cloud/api/v1/x402/settle/route.test.ts
+++ b/packages/cloud/api/v1/x402/settle/route.test.ts
@@ -1,0 +1,136 @@
+/**
+ * x402 settle route — facilitator failures must not leak internal error text
+ * (upstream RPC endpoints, account addresses, provider detail) to
+ * unauthenticated callers: the boundary collapses every throw to the constant
+ * `errorReason: "internal_error"` and keeps the detail in server logs. The
+ * facilitator edge is mocked; the real route drives the response shape.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const SENSITIVE_MESSAGE =
+  "RPC https://mainnet.infura.io/v3/abc123 failed for account 0xDEADBEEF: nonce too low";
+
+let settleBehavior: () => Promise<unknown> = async () => ({
+  success: true,
+  transaction: "0xtx",
+  network: "base",
+});
+const settle = mock(() => settleBehavior());
+const errorLog = mock((..._args: unknown[]) => undefined);
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/x402-facilitator", () => ({
+  x402FacilitatorService: { settle },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: errorLog,
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: settleRoute } = await import("./route");
+
+function post(body: Record<string, unknown>) {
+  const app = new Hono();
+  app.route("/api/v1/x402/settle", settleRoute);
+  return app.fetch(
+    new Request("https://api.example.test/api/v1/x402/settle", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    {},
+  );
+}
+
+const VALID_BODY = {
+  paymentPayload: { scheme: "exact" },
+  paymentRequirements: { network: "base" },
+};
+
+describe("x402 settle route — internal error collapse", () => {
+  beforeEach(() => {
+    settle.mockClear();
+    errorLog.mockClear();
+    settleBehavior = async () => ({
+      success: true,
+      transaction: "0xtx",
+      network: "base",
+    });
+  });
+
+  test("a facilitator throw returns the constant internal_error reason", async () => {
+    settleBehavior = async () => {
+      throw new Error(SENSITIVE_MESSAGE);
+    };
+
+    const res = await post(VALID_BODY);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({
+      success: false,
+      transaction: "",
+      network: "",
+      errorReason: "internal_error",
+    });
+    expect(JSON.stringify(body)).not.toContain("infura");
+    expect(JSON.stringify(body)).not.toContain("0xDEADBEEF");
+  });
+
+  test("the internal detail is still logged server-side", async () => {
+    settleBehavior = async () => {
+      throw new Error(SENSITIVE_MESSAGE);
+    };
+
+    await post(VALID_BODY);
+    expect(errorLog).toHaveBeenCalledTimes(1);
+    const logged = String(errorLog.mock.calls[0]?.[0]);
+    expect(logged).toContain(SENSITIVE_MESSAGE);
+  });
+
+  test("a non-Error throw collapses the same way", async () => {
+    settleBehavior = async () => {
+      throw "string failure with https://rpc.internal/detail";
+    };
+
+    const res = await post(VALID_BODY);
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.errorReason).toBe("internal_error");
+    expect(JSON.stringify(body)).not.toContain("rpc.internal");
+  });
+
+  test("a successful settle passes the facilitator result through", async () => {
+    const res = await post(VALID_BODY);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      success: true,
+      transaction: "0xtx",
+    });
+  });
+
+  test("a facilitator failure result keeps its own 400 payload", async () => {
+    settleBehavior = async () => ({
+      success: false,
+      transaction: "",
+      network: "base",
+      errorReason: "insufficient_funds",
+    });
+
+    const res = await post(VALID_BODY);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      errorReason: "insufficient_funds",
+    });
+  });
+});

--- a/packages/cloud/api/v1/x402/settle/route.ts
+++ b/packages/cloud/api/v1/x402/settle/route.ts
@@ -57,6 +57,9 @@ app.post("/", async (c) => {
 
     return c.json(result, result.success ? 200 : 400);
   } catch (err) {
+    // error-policy:J1 route boundary — settlement failures return a constant
+    // reason to unauthenticated callers; upstream RPC/provider detail stays in
+    // server logs only.
     const msg = err instanceof Error ? err.message : String(err);
     logger.error(`[x402-settle] Settlement error: ${msg}`);
     return c.json(
@@ -64,7 +67,7 @@ app.post("/", async (c) => {
         success: false,
         transaction: "",
         network: "",
-        errorReason: `internal_error: ${msg}`,
+        errorReason: "internal_error",
       },
       500,
     );

--- a/packages/cloud/api/v1/x402/verify/route.test.ts
+++ b/packages/cloud/api/v1/x402/verify/route.test.ts
@@ -1,0 +1,100 @@
+/**
+ * x402 verify route — facilitator failures must not leak internal error text
+ * (upstream RPC endpoints, account addresses, provider detail) to
+ * unauthenticated callers: the boundary collapses every throw to the constant
+ * `invalidReason: "internal_error"` and keeps the detail in server logs. The
+ * facilitator edge is mocked; the real route drives the response shape.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const SENSITIVE_MESSAGE =
+  "RPC https://mainnet.infura.io/v3/abc123 failed for account 0xDEADBEEF: nonce too low";
+
+let verifyBehavior: () => Promise<unknown> = async () => ({ isValid: true });
+const verify = mock(() => verifyBehavior());
+const errorLog = mock((..._args: unknown[]) => undefined);
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/x402-facilitator", () => ({
+  x402FacilitatorService: { verify },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: errorLog,
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: verifyRoute } = await import("./route");
+
+function post(body: Record<string, unknown>) {
+  const app = new Hono();
+  app.route("/api/v1/x402/verify", verifyRoute);
+  return app.fetch(
+    new Request("https://api.example.test/api/v1/x402/verify", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    {},
+  );
+}
+
+const VALID_BODY = {
+  paymentPayload: { scheme: "exact" },
+  paymentRequirements: { network: "base" },
+};
+
+describe("x402 verify route — internal error collapse", () => {
+  beforeEach(() => {
+    verify.mockClear();
+    errorLog.mockClear();
+    verifyBehavior = async () => ({ isValid: true });
+  });
+
+  test("a facilitator throw returns the constant internal_error reason", async () => {
+    verifyBehavior = async () => {
+      throw new Error(SENSITIVE_MESSAGE);
+    };
+
+    const res = await post(VALID_BODY);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({ isValid: false, invalidReason: "internal_error" });
+    expect(JSON.stringify(body)).not.toContain("infura");
+    expect(JSON.stringify(body)).not.toContain("0xDEADBEEF");
+  });
+
+  test("the internal detail is still logged server-side", async () => {
+    verifyBehavior = async () => {
+      throw new Error(SENSITIVE_MESSAGE);
+    };
+
+    await post(VALID_BODY);
+    expect(errorLog).toHaveBeenCalledTimes(1);
+    const logged = String(errorLog.mock.calls[0]?.[0]);
+    expect(logged).toContain(SENSITIVE_MESSAGE);
+  });
+
+  test("a facilitator invalid result keeps its own 400 payload", async () => {
+    verifyBehavior = async () => ({
+      isValid: false,
+      invalidReason: "insufficient_funds",
+    });
+
+    const res = await post(VALID_BODY);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      invalidReason: "insufficient_funds",
+    });
+  });
+});

--- a/packages/cloud/api/v1/x402/verify/route.ts
+++ b/packages/cloud/api/v1/x402/verify/route.ts
@@ -48,12 +48,12 @@ app.post("/", async (c) => {
 
     return c.json(result, result.isValid ? 200 : 400);
   } catch (err) {
+    // error-policy:J1 route boundary — verification failures return a constant
+    // reason to unauthenticated callers; upstream RPC/provider detail stays in
+    // server logs only.
     const msg = err instanceof Error ? err.message : String(err);
     logger.error(`[x402-verify] Verification error: ${msg}`);
-    return c.json(
-      { isValid: false, invalidReason: `internal_error: ${msg}` },
-      500,
-    );
+    return c.json({ isValid: false, invalidReason: "internal_error" }, 500);
   }
 });
 

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.local-dev-admin.test.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.local-dev-admin.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The local-dev-admin bypass must fail closed in production at BOTH layers:
+ * the global middleware's isLocalDevAdminRequest already refuses when
+ * NODE_ENV=production, and the requireAdmin-side isLocalDevAdminEnabled in
+ * this module must do the same so a stray ELIZA_CLOUD_LOCAL_DEV_ADMIN /
+ * LOCAL_DEV=true in a production deployment cannot mint a super_admin on a
+ * loopback Host. Services are mocked; the real module under test decides.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("hono/cookie", () => ({
+  getCookie: mock(() => null),
+}));
+
+mock.module("../services/api-keys", () => ({
+  apiKeysService: {
+    validateApiKey: mock(async () => null),
+    incrementUsageDebounced: mock(async () => undefined),
+  },
+}));
+
+mock.module("../services/users", () => ({
+  usersService: {
+    getWithOrganization: mock(async () => null),
+    getByStewardId: mock(async () => null),
+  },
+}));
+
+mock.module("../services/admin", () => ({
+  adminService: {
+    getAdminStatusForUser: mock(async () => ({ isAdmin: false, role: null })),
+  },
+}));
+
+mock.module("./steward-client", () => ({
+  isStagingSessionTokenCandidate: () => false,
+  verifyStewardTokenCached: mock(async () => null),
+}));
+
+mock.module("./playwright-test-session", () => ({
+  PLAYWRIGHT_TEST_SESSION_COOKIE_NAME: "pw-test-session",
+  verifyPlaywrightTestSessionToken: mock(() => null),
+}));
+
+const errorLog = mock(() => undefined);
+mock.module("../utils/logger", () => ({
+  logger: {
+    error: errorLog,
+    warn: mock(() => undefined),
+  },
+}));
+
+const { requireAdmin } = await import("./workers-hono-auth");
+
+function loopbackContext(env: Record<string, unknown>) {
+  const state = new Map<string, unknown>();
+  return {
+    env,
+    executionCtx: { waitUntil: mock(() => undefined) },
+    req: {
+      url: "http://localhost:8787/api/v1/admin/users",
+      header: () => null,
+    },
+    get: (key: string) => state.get(key),
+    set: (key: string, value: unknown) => state.set(key, value),
+  };
+}
+
+beforeEach(() => {
+  errorLog.mockClear();
+});
+
+describe("isLocalDevAdminEnabled production hard-fail", () => {
+  test("NODE_ENV=production refuses the explicit dev-admin flag and never grants super_admin", async () => {
+    const c = loopbackContext({
+      NODE_ENV: "production",
+      ELIZA_CLOUD_LOCAL_DEV_ADMIN: "true",
+    });
+    await expect(requireAdmin(c as never)).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(errorLog).toHaveBeenCalledTimes(1);
+  });
+
+  test("NODE_ENV=production refuses the LOCAL_DEV dev-mode flag", async () => {
+    const c = loopbackContext({
+      NODE_ENV: "production",
+      LOCAL_DEV: "true",
+    });
+    await expect(requireAdmin(c as never)).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(errorLog).toHaveBeenCalledTimes(1);
+  });
+
+  test("outside production the loopback dev-admin bypass still works", async () => {
+    const c = loopbackContext({
+      NODE_ENV: "development",
+      ELIZA_CLOUD_LOCAL_DEV_ADMIN: "true",
+    });
+    const { user, role } = await requireAdmin(c as never);
+    expect(role).toBe("super_admin");
+    expect(user.email).toBe("local-dev-admin@localhost");
+  });
+});

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -50,6 +50,17 @@ function isLoopbackHostname(hostname: string): boolean {
 }
 
 function isLocalDevAdminEnabled(c: AppContext): boolean {
+  // Hard fail in production, mirroring isLocalDevAdminRequest in the global
+  // middleware: NEVER grant the dev-admin bypass regardless of env vars, so
+  // both layers fail closed identically (SOC2 CC6.1).
+  if (c.env.NODE_ENV === "production") {
+    if (c.env.ELIZA_CLOUD_LOCAL_DEV_ADMIN === "true" || c.env.LOCAL_DEV === "true") {
+      logger.error("[Auth] Refusing dev-admin bypass in production — env var ignored", {
+        path: new URL(c.req.url).pathname,
+      });
+    }
+    return false;
+  }
   const explicit = c.env.ELIZA_CLOUD_LOCAL_DEV_ADMIN === "true";
   const devMode = c.env.NODE_ENV !== "production" && c.env.LOCAL_DEV === "true";
   if (!explicit && !devMode) return false;


### PR DESCRIPTION
## Summary

Four confirmed wave-1 security-audit findings in the cloud API, each fixed minimally with regression tests.

### W1-003 (HIGH) — agent token minting authorized org role, not platform admin

`POST /api/v1/agent-tokens` treated the per-organization `users.role` value `admin` as sufficient authority and minted Steward agent JWTs for any caller-supplied `agentId`, with no org-ownership binding — enabling cross-tenant agent impersonation by any org admin.

- Human leg now requires platform admin (`requireAdmin`) for arbitrary `agentId` mints.
- An org admin may still mint, but only for an agent owned by their own organization (`agentSandboxesRepository.findByIdAndOrg`); mismatch is a 403 before any token is minted.
- Service-account leg unchanged (container token refresh keeps working).
- Mint logs now record actor kind, actor user id, and organization id.
- Authenticated-but-unauthorized callers now get 403 (was 401); unauthenticated stays 401.

### W1-029 (LOW) — unauthenticated operational health discloses backend config

`GET /api/health/operational` is public and returned per-subsystem configuration state (payout keys, cron secret presence, Steward platform keys, named missing OAuth providers). The public payload is collapsed to `{ status, timestamp }` so uptime monitors keep their ok/degraded signal; per-check detail is returned only to platform admins.

### W1-031 (LOW) — dev-admin bypass missing production hard-fail

`isLocalDevAdminEnabled` in cloud-shared honored `ELIZA_CLOUD_LOCAL_DEV_ADMIN`/`LOCAL_DEV` even with `NODE_ENV=production`, unlike the global middleware's variant which refuses outright. Both layers now fail closed identically: production returns false (logging the ignored env vars) before any loopback check.

### W1-032 (LOW) — x402 settle leaks internal error text

The settle boundary reflected raw exception messages (which can embed upstream endpoints/addresses/provider detail) to unauthenticated callers. It now returns the constant `errorReason: "internal_error"`; detail stays in server logs.

## Test evidence

- `bun test v1/agent-tokens/route.test.ts` — 11 pass (platform admin mints; org admin mints own-org agent; cross-tenant org admin denied 403, no mint; non-admin 403; service-account leg unchanged; constant-time gate retained)
- `bun test health/operational/route.test.ts` — 7 pass (public payload has no `checks`/`oauth_providers`/`region`; degraded status still signaled publicly; admin payload unchanged)
- `bun test src/lib/auth/workers-hono-auth.local-dev-admin.test.ts` (new) — 3 pass (production refuses both flags; non-production loopback bypass still works)
- `bun test v1/x402/settle/route.test.ts` (new) — 5 pass (constant reason, no internal text in body; detail still logged; success/400 paths unchanged)
- `node scripts/run-bun-tests.mjs src/lib/auth/` (cloud-shared) — 64 pass, 0 fail
- `bun run typecheck` — exit 0 in both `packages/cloud/api` and `packages/cloud/shared`
- `biome check` clean on all changed files
- Full cloud-api unit sweep (`node test/run-unit-isolated.mjs`): all touched areas pass; 12 unrelated files fail identically with these changes stashed (pre-existing PGlite/miniflare environment failures in a fresh worktree)

## Risk notes

- Org admins previously able to mint tokens for arbitrary agents are now scoped to their own org's agents; the platform service-account path used by containers is untouched.
- Any unauthenticated consumer parsing the detailed health/operational fields will now only see `status`/`timestamp` — no in-repo consumers do (verified by search); ops dashboards should use a platform-admin session for detail.
- Out of scope, flagged for follow-up: `v1/x402/verify/route.ts` reflects internal error text in `invalidReason` the same way settle did.
