### PR TITLE
fix(shared): guard non-string inputs in normalizeOpenAICallbackInput and add unit test suite

### DIFF
--- a/packages/shared/src/utils/subscription-auth.test.ts
+++ b/packages/shared/src/utils/subscription-auth.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for subscription auth helpers in packages/shared/src/utils/subscription-auth.ts.
+ * Exercises error formatting, OpenAI OAuth callback URL parsing, raw authorization
+ * code handling, URL prefix normalization, validation rejections, and non-string inputs.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  formatSubscriptionRequestError,
+  normalizeOpenAICallbackInput,
+} from "./subscription-auth.js";
+
+describe("formatSubscriptionRequestError", () => {
+  it("extracts message from Error instances", () => {
+    expect(formatSubscriptionRequestError(new Error("auth failed"))).toBe(
+      "auth failed",
+    );
+  });
+
+  it("converts non-Error values to string", () => {
+    expect(formatSubscriptionRequestError("custom error")).toBe("custom error");
+    expect(formatSubscriptionRequestError(404)).toBe("404");
+  });
+});
+
+describe("normalizeOpenAICallbackInput", () => {
+  it("accepts valid full callback URLs from localhost and 127.0.0.1", () => {
+    const res1 = normalizeOpenAICallbackInput(
+      "http://localhost:1455/auth/callback?code=secret_code_123",
+    );
+    expect(res1).toEqual({
+      ok: true,
+      code: "http://localhost:1455/auth/callback?code=secret_code_123",
+    });
+
+    const res2 = normalizeOpenAICallbackInput(
+      "http://127.0.0.1:1455/auth/callback?code=secret_code_456",
+    );
+    expect(res2).toEqual({
+      ok: true,
+      code: "http://127.0.0.1:1455/auth/callback?code=secret_code_456",
+    });
+  });
+
+  it("normalizes localhost and 127.0.0.1 urls lacking the http scheme", () => {
+    const res = normalizeOpenAICallbackInput(
+      "localhost:1455/auth/callback?code=secret_code_789",
+    );
+    expect(res).toEqual({
+      ok: true,
+      code: "http://localhost:1455/auth/callback?code=secret_code_789",
+    });
+  });
+
+  it("accepts raw authorization codes without URL scheme", () => {
+    const res = normalizeOpenAICallbackInput("raw_auth_code_xyz");
+    expect(res).toEqual({
+      ok: true,
+      code: "raw_auth_code_xyz",
+    });
+  });
+
+  it("rejects excessively long raw codes", () => {
+    const longCode = "a".repeat(4097);
+    const res = normalizeOpenAICallbackInput(longCode);
+    expect(res).toEqual({
+      ok: false,
+      error: "subscriptionstatus.CallbackCodeTooLong",
+    });
+  });
+
+  it("rejects callback URLs with invalid host, port, or path", () => {
+    expect(
+      normalizeOpenAICallbackInput(
+        "http://example.com:1455/auth/callback?code=abc",
+      ),
+    ).toEqual({
+      ok: false,
+      error: "subscriptionstatus.ExpectedCallbackUrl",
+    });
+
+    expect(
+      normalizeOpenAICallbackInput(
+        "http://localhost:8080/auth/callback?code=abc",
+      ),
+    ).toEqual({
+      ok: false,
+      error: "subscriptionstatus.ExpectedCallbackUrl",
+    });
+
+    expect(
+      normalizeOpenAICallbackInput("http://localhost:1455/other?code=abc"),
+    ).toEqual({
+      ok: false,
+      error: "subscriptionstatus.ExpectedCallbackUrl",
+    });
+  });
+
+  it("rejects callback URLs missing code search parameter", () => {
+    expect(
+      normalizeOpenAICallbackInput("http://localhost:1455/auth/callback"),
+    ).toEqual({
+      ok: false,
+      error: "subscriptionstatus.CallbackUrlMissingCode",
+    });
+  });
+
+  it("rejects empty, null, undefined, or non-string inputs", () => {
+    expect(normalizeOpenAICallbackInput("")).toEqual({
+      ok: false,
+      error: "subscriptionstatus.PasteCallbackUrlFromLocalhost",
+    });
+    expect(normalizeOpenAICallbackInput("   ")).toEqual({
+      ok: false,
+      error: "subscriptionstatus.PasteCallbackUrlFromLocalhost",
+    });
+    expect(normalizeOpenAICallbackInput(null)).toEqual({
+      ok: false,
+      error: "subscriptionstatus.PasteCallbackUrlFromLocalhost",
+    });
+    expect(normalizeOpenAICallbackInput(undefined)).toEqual({
+      ok: false,
+      error: "subscriptionstatus.PasteCallbackUrlFromLocalhost",
+    });
+    expect(normalizeOpenAICallbackInput(123 as unknown as string)).toEqual({
+      ok: false,
+      error: "subscriptionstatus.PasteCallbackUrlFromLocalhost",
+    });
+  });
+});

--- a/packages/shared/src/utils/subscription-auth.ts
+++ b/packages/shared/src/utils/subscription-auth.ts
@@ -10,7 +10,7 @@ export function formatSubscriptionRequestError(err: unknown): string {
   return String(err);
 }
 
-export function normalizeOpenAICallbackInput(input: string):
+export function normalizeOpenAICallbackInput(input: string | null | undefined):
   | {
       ok: true;
       code: string;
@@ -19,6 +19,13 @@ export function normalizeOpenAICallbackInput(input: string):
       ok: false;
       error: string;
     } {
+  if (typeof input !== "string") {
+    return {
+      ok: false,
+      error: "subscriptionstatus.PasteCallbackUrlFromLocalhost",
+    };
+  }
+
   const trimmed = input.trim();
   if (!trimmed) {
     return {


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/subscription-auth.ts`, `normalizeOpenAICallbackInput` called `input.trim()` directly. When passed `null`, `undefined`, or non-string inputs from uninitialized form states, it threw an unhandled `TypeError: Cannot read properties of undefined (reading 'trim')` instead of returning `{ ok: false, error: "subscriptionstatus.PasteCallbackUrlFromLocalhost" }`.
2. Added `typeof input !== "string"` guard safely returning `{ ok: false, error: "subscriptionstatus.PasteCallbackUrlFromLocalhost" }`.
3. Created a comprehensive unit test suite in `packages/shared/src/utils/subscription-auth.test.ts` covering error string formatting, full OAuth callback URL validation, raw authorization code extraction, port/path matching, and non-string inputs.

Closes #21189.

## Verification

Exact commit: `82484e1afe`.

- Focused unit test suite `packages/shared/src/utils/subscription-auth.test.ts`: 9/9 tests passing (17 assertions).
- Biome format on `@elizaos/shared`: 409 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - subscription OAuth callback normalizer; no rendered UI changed.
- [x] N/A - subscription OAuth callback normalizer; no rendered UI changed.
- [x] N/A - deterministic callback normalization tests.
- [x] Focused test suite transcript:
```text
✓ formatSubscriptionRequestError > extracts message from Error instances [0.12ms]
✓ formatSubscriptionRequestError > converts non-Error values to string [0.04ms]
✓ normalizeOpenAICallbackInput > accepts valid full callback URLs from localhost and 127.0.0.1 [9.01ms]
✓ normalizeOpenAICallbackInput > normalizes localhost and 127.0.0.1 urls lacking the http scheme [0.11ms]
✓ normalizeOpenAICallbackInput > accepts raw authorization codes without URL scheme [0.03ms]
✓ normalizeOpenAICallbackInput > rejects excessively long raw codes [0.06ms]
✓ normalizeOpenAICallbackInput > rejects callback URLs with invalid host, port, or path [0.05ms]
✓ normalizeOpenAICallbackInput > rejects callback URLs missing code search parameter [0.02ms]
✓ normalizeOpenAICallbackInput > rejects empty, null, undefined, or non-string inputs [0.04ms]
9 pass, 0 fail, 17 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@cd41f99b1ab65b1695f269a8da23ff3a699c2777:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@cd41f99b1ab65b1695f269a8da23ff3a699c2777:packages/skills/skills/contribute-to-eliza"} -->
