### PR TITLE
fix(wallet): add timeout to birdeye fetchBirdeyeJson

### DIFF
--- a/plugins/plugin-wallet/src/analytics/birdeye/service.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/service.ts
@@ -165,6 +165,7 @@ export class BirdeyeService extends Service {
     const fetchOptions = this.getBirdeyeFetchOptions(chain);
     const response = await fetch(this.birdeyeUrl(suffix), {
       ...fetchOptions,
+      signal: AbortSignal.timeout(10_000),
       headers: {
         ...(fetchOptions.headers as Record<string, string>),
         ...(options.headers ?? {}),


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Bug on `develop` @ `79949c086f` — `await fetch(this.birdeyeUrl(suffix), { ...fetchOptions, headers })` with no timeout in `plugins/plugin-wallet/src/analytics/birdeye/service.ts:166` (`private fetchBirdeyeJson<T>`). External Birdeye API fetch could hang indefinitely, blocking all Birdeye callers (market data, security, trade data). No existing issue; single-file signal fix. Mirrors `dexscreener:103` / `solana:543` / `erc8004:624` / `Meteora:74` timeout idiom.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `79949c086f` (origin/develop at task creation) with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` / package typecheck were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is self-reported provenance, not a request for chain-of-thought. Never include prompts containing secrets, tokens, private session IDs, or hidden reasoning. Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels (`Client / agent tooling`, `Skill revision` / `Contribution skill revision`, `Attribution status`). Duplicating those strings makes the scoring validator reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->` markers; only the human-readable prefixes changed. After filling these rows, append the standard footer once at the end of the PR body (do not repeat the visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@79949c086f4f8db894b901633ca5ef86ebb35560:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto `79949c086f` (`origin/develop` at task base); zero conflicts. Current `origin/develop` is `79949c086f` — this branch is based on `79949c086f` (latest at task creation). Single-line isolated insertion, no conflicts expected.
- [x] `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json --skipLibCheck` passes post-sync; typecheck green (see Evidence). No `bun install` blocker for this file — `AbortSignal` is global, no new import.

# Risks

Low. Single-file change, 1 insertion, no API or storage migration. Behaviour strictly adds a timeout: previously external `fetch(this.birdeyeUrl(suffix), { ...fetchOptions, headers })` on Birdeye API (`https://public-api.birdeye.so`) could hang forever on a slow/unresponsive endpoint; now bounded to 10s via `AbortSignal.timeout(10_000)`. Matches existing idiom in `health-connectors.ts:261` (`AbortSignal.timeout`), `solana.ts:543` (`AbortSignal.timeout(10_000)`), `attestation-fetch.ts:11` (`AbortSignal.timeout(CIRCLE_ATTESTATION_FETCH_TIMEOUT_MS)`), and `wallet-routes.ts:1081` (`AbortSignal.timeout(15_000)`). Risk only if Birdeye legitimately needs >10s — unlikely for market data lookups and desirable to fail fast.

# Background

## What does this PR do?

Adds `signal: AbortSignal.timeout(10_000)` to the external fetch in `BirdeyeService.private fetchBirdeyeJson<T>` (`plugins/plugin-wallet/src/analytics/birdeye/service.ts:166`).

Before (line 166):
```ts
const response = await fetch(this.birdeyeUrl(suffix), {
  ...fetchOptions,
  headers: { ...(fetchOptions.headers as Record<string, string>), ...(options.headers ?? {}) },
});
```
- No signal, no timeout — `fetch` on external Birdeye API could hang indefinitely, blocking all callers of `fetchBirdeyeJson` (search, market data, security, trade data).

After (line 166):
```ts
const response = await fetch(this.birdeyeUrl(suffix), {
  ...fetchOptions,
  signal: AbortSignal.timeout(10_000),
  headers: { ...(fetchOptions.headers as Record<string, string>), ...(options.headers ?? {}) },
});
```
- 10s timeout via global `AbortSignal.timeout` (no import needed). Mirrors `plugins/plugin-health/src/health-bridge/health-connectors.ts:261` and `plugins/plugin-wallet/src/chains/solana/solana.ts:543` idiom.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

`BirdeyeService.fetchBirdeyeJson` is the sole HTTP path for all Birdeye queries (market data, security, trade data, search). Birdeye is an external untrusted endpoint; a slow or hanging response could DoS the caller. No timeout was present (`grep -n "signal|AbortSignal"` → 0 hits before, 1 after). Fresh hunt excluded already-shipped `#21154` (`erc8004:624`), `#21165` (`meteora:74`), `#21176` (`dexscreener:103`) — this is the next highest-ranked hang.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/analytics/birdeye/service.ts` — `private async fetchBirdeyeJson<T>` method, `fetch` call at line 166.

## Detailed testing steps

- Verify no signal before: `grep -n "signal\|AbortSignal" plugins/plugin-wallet/src/analytics/birdeye/service.ts` → 0 hits on `79949c086f` (see Evidence Details).
- Verify signal after: `grep -n "signal\|AbortSignal" plugins/plugin-wallet/src/analytics/birdeye/service.ts` → `168:      signal: AbortSignal.timeout(10_000),` (see Evidence Details).

## Linked issues / Covering tests / New tests

Bug on `develop` — verification is evidence-gated; see Evidence Gate. No new test harness; existing plugin-wallet typecheck is gate.

# Evidence Gate

| Check | Before | After |
|-------|--------|-------|
| `grep -n "signal\|AbortSignal" plugins/plugin-wallet/src/analytics/birdeye/service.ts` | 0 hits (no timeout — see Evidence Details) | 1 hit: `168:      signal: AbortSignal.timeout(10_000),` |
| `grep -n "await fetch" plugins/plugin-wallet/src/analytics/birdeye/service.ts` | `166:    const response = await fetch(this.birdeyeUrl(suffix), {` (bare) | same line with signal added |
| `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json --skipLibCheck` | — | `EXIT:0` |

# Evidence Details

Before — `grep -n "signal\|AbortSignal" plugins/plugin-wallet/src/analytics/birdeye/service.ts` on `79949c086f`:
```
(no output — 0 hits)
```

Before — `sed -n '152,170p' plugins/plugin-wallet/src/analytics/birdeye/service.ts` on `79949c086f`:
```
  private async fetchBirdeyeJson<T>(
    path: string,
    params: object = {},
    options: { headers?: Record<string, string> } = {},
  ): Promise<T> {
    const chain = options.headers?.["x-chain"] ?? "solana";
    const cleanParams = Object.fromEntries(
      Object.entries(params).filter(([, value]) => value !== undefined),
    );
    const query = new URLSearchParams(
      convertToStringParams(cleanParams),
    ).toString();
    const suffix = query ? `${path}?${query}` : path;
    const fetchOptions = this.getBirdeyeFetchOptions(chain);
    const response = await fetch(this.birdeyeUrl(suffix), {
      ...fetchOptions,
      headers: {
        ...(fetchOptions.headers as Record<string, string>),
        ...(options.headers ?? {}),
      },
    });
```

After — `grep -n "signal\|AbortSignal" plugins/plugin-wallet/src/analytics/birdeye/service.ts` on this branch:
```
168:      signal: AbortSignal.timeout(10_000),
```

After — `sed -n '152,175p' plugins/plugin-wallet/src/analytics/birdeye/service.ts` on this branch:
```
  private async fetchBirdeyeJson<T>(
    path: string,
    params: object = {},
    options: { headers?: Record<string, string> } = {},
  ): Promise<T> {
    const chain = options.headers?.["x-chain"] ?? "solana";
    const cleanParams = Object.fromEntries(
      Object.entries(params).filter(([, value]) => value !== undefined),
    );
    const query = new URLSearchParams(
      convertToStringParams(cleanParams),
    ).toString();
    const suffix = query ? `${path}?${query}` : path;
    const fetchOptions = this.getBirdeyeFetchOptions(chain);
    const response = await fetch(this.birdeyeUrl(suffix), {
      ...fetchOptions,
      signal: AbortSignal.timeout(10_000),
      headers: {
        ...(fetchOptions.headers as Record<string, string>),
        ...(options.headers ?? {}),
      },
    });
```

Diff stat: `plugins/plugin-wallet/src/analytics/birdeye/service.ts | 1 +`

```
 plugins/plugin-wallet/src/analytics/birdeye/service.ts | 1 +
 1 file changed, 1 insertion(+)
```

# Checklist

- [x] I have read and followed the guidance in `CONTRIBUTING.md`.
- [x] This change is covered by tests (evidence-gated) and `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json --skipLibCheck` passes.
- [x] I have verified the provenance block above describes exactly the assistance used (or human-only) and matches the footer.

---
*AI provider/model: anthropic/claude-fable-5*
*Client / agent tooling: claude-code*
*Contribution skill revision: elizaOS/eliza@79949c086f4f8db894b901633ca5ef86ebb35560:packages/skills/skills/contribute-to-eliza*
<!-- {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/eliza@79949c086f4f8db894b901633ca5ef86ebb35560:packages/skills/skills/contribute-to-eliza"} -->
