### PR TITLE
fix(wallet): add timeout to birdeye makeApiRequest

### DIFF
--- a/plugins/plugin-wallet/src/analytics/birdeye/utils.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/utils.ts
@@ -403,6 +403,7 @@ export async function makeApiRequest<T>(
   try {
     const response = await fetch(url, {
       method,
+      signal: AbortSignal.timeout(10_000),
       headers: {
         "X-API-KEY": apiKey,
         "x-chain": chain,


### PR DESCRIPTION
Fix timeout for Birdeye utils fetch

Adds signal: AbortSignal.timeout(10_000) to makeApiRequest.

Evidence: grep before 0 hits, after 1 hit. tsc EXIT:0.

---
*AI provider/model: anthropic/claude-fable-5*
*Client / agent tooling: claude-code*
*Contribution skill revision: elizaOS/eliza@79949c086f4f8db894b901633ca5ef86ebb35560:packages/skills/skills/contribute-to-eliza*
<!-- {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/eliza@79949c086f4f8db894b901633ca5ef86ebb35560:packages/skills/skills/contribute-to-eliza"} -->