### PR TITLE
fix(logger): treat empty and whitespace-only env values as unset in getEnv and add unit test suite

### DIFF
--- a/packages/logger/src/env.test.ts
+++ b/packages/logger/src/env.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for getEnv in packages/logger/src/env.ts.
+ * Exercises environment variable reading, whitespace trimming, empty string fallback
+ * to defaultValue, and invalid key handling.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getEnv } from "./env.js";
+
+describe("getEnv", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.TEST_LOGGER_VAR;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("reads and trims an existing environment variable", () => {
+    process.env.TEST_LOGGER_VAR = "  debug  ";
+    expect(getEnv("TEST_LOGGER_VAR")).toBe("debug");
+  });
+
+  it("returns undefined when variable is unset and no default is given", () => {
+    expect(getEnv("TEST_LOGGER_VAR")).toBeUndefined();
+  });
+
+  it("returns defaultValue when variable is unset", () => {
+    expect(getEnv("TEST_LOGGER_VAR", "info")).toBe("info");
+  });
+
+  it("returns defaultValue when variable is set to empty string", () => {
+    process.env.TEST_LOGGER_VAR = "";
+    expect(getEnv("TEST_LOGGER_VAR", "info")).toBe("info");
+  });
+
+  it("returns defaultValue when variable is set to whitespace only", () => {
+    process.env.TEST_LOGGER_VAR = "   \t\n  ";
+    expect(getEnv("TEST_LOGGER_VAR", "info")).toBe("info");
+  });
+
+  it("returns defaultValue for invalid or missing keys", () => {
+    expect(getEnv("", "fallback")).toBe("fallback");
+    expect(getEnv(null as unknown as string, "fallback")).toBe("fallback");
+    expect(getEnv(undefined as unknown as string, "fallback")).toBe("fallback");
+  });
+});

--- a/packages/logger/src/env.ts
+++ b/packages/logger/src/env.ts
@@ -26,9 +26,17 @@ const isNode =
 
 /** Read an environment variable as a string, or `undefined` when unset. */
 export function getEnv(key: string, defaultValue?: string): string | undefined {
-  if (isNode) {
-    return process.env[key] ?? defaultValue;
+  if (!key || typeof key !== "string") {
+    return defaultValue;
   }
-  const value = browserEnvBag()[key];
-  return value !== undefined ? String(value) : defaultValue;
+  if (isNode) {
+    const raw = process.env[key]?.trim();
+    return raw && raw.length > 0 ? raw : defaultValue;
+  }
+  const raw = browserEnvBag()[key];
+  if (raw === undefined || raw === null) {
+    return defaultValue;
+  }
+  const str = String(raw).trim();
+  return str.length > 0 ? str : defaultValue;
 }


### PR DESCRIPTION
## Summary

1. In `packages/logger/src/env.ts`, `getEnv` used `process.env[key] ?? defaultValue` without trimming or checking for empty strings. When an environment variable was set to `""` or whitespace-only (e.g. `LOG_TIMESTAMPS=""`), it returned `""` rather than falling back to `defaultValue`.
2. Added `.trim()` normalization and empty string checks against `defaultValue`.
3. Added missing `key` type validation.
4. Created a dedicated unit test suite in `packages/logger/src/env.test.ts`.

Closes #21199.

## Verification

Exact commit: `83a3fe4aef`.

- Focused unit test suite `packages/logger/src/env.test.ts`: 6/6 tests passing.
- Package test suite `bun run --cwd packages/logger test`: 24/24 tests passing across 2 files.
- Biome check on `@elizaos/logger`: 5 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - logger environment helper; no rendered UI changed.
- [x] N/A - logger environment helper; no rendered UI changed.
- [x] N/A - deterministic environment resolution tests.
- [x] Focused test suite transcript:
```text
RUN  v4.1.5 /home/deepanshu/os/eliza/packages/logger

Test Files  2 passed (2)
     Tests  24 passed (24)
  Duration  294ms
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza"} -->
