### PR TITLE
fix(cloud): reject unknown github-oauth-complete post_message flag

### DIFF
--- a/packages/cloud/api/v1/eliza/github-oauth-complete/route.post-message.test.ts
+++ b/packages/cloud/api/v1/eliza/github-oauth-complete/route.post-message.test.ts
@@ -1,0 +1,124 @@
+/**
+ * GET /api/v1/eliza/github-oauth-complete `post_message` is popup-return
+ * identity, leftover tax after lifeops github-complete target (#21058).
+ * Stock develop treated every non-exact `1` token as a dashboard
+ * redirect, so `post_message=true` skipped the postMessage landing page
+ * instead of a 400. github_connected / return_url parsers stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const createLifeOpsGithubReturnResponse = mock(() => new Response("popup"));
+const findByIdAndOrg = mock(async () => null);
+const connectAgent = mock(async () => ({ restarted: false }));
+const getConnection = mock(async () => null);
+const readManagedAgentGithubBinding = mock(() => null);
+
+mock.module("@/lib/services/agent-github-return", () => ({
+  createLifeOpsGithubReturnResponse,
+}));
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: { findByIdAndOrg },
+}));
+mock.module("@/lib/services/agent-managed-github", () => ({
+  managedAgentGithubService: { connectAgent },
+}));
+mock.module("@/lib/services/eliza-agent-config", () => ({
+  readManagedAgentGithubBinding,
+}));
+mock.module("@/lib/services/oauth", () => ({
+  oauthService: { getConnection },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    warn: mock(),
+    error: mock(),
+    info: mock(),
+  },
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono<AppEnv>();
+app.route("/api/v1/eliza/github-oauth-complete", route);
+
+const ENV = {
+  NEXT_PUBLIC_APP_URL: "https://app.example.test",
+} as unknown as AppEnv["Bindings"];
+
+function complete(query = "") {
+  return app.request(
+    `/api/v1/eliza/github-oauth-complete${query}`,
+    {},
+    ENV,
+  );
+}
+
+describe("GET /api/v1/eliza/github-oauth-complete post_message identity", () => {
+  beforeEach(() => {
+    createLifeOpsGithubReturnResponse.mockClear();
+    findByIdAndOrg.mockClear();
+    connectAgent.mockClear();
+    getConnection.mockClear();
+    readManagedAgentGithubBinding.mockClear();
+  });
+
+  test.each(["", "?post_message="])(
+    "accepts %s as the dashboard-redirect completion path",
+    async (query) => {
+      const response = await complete(query);
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toContain(
+        "/cloud/settings?tab=agents",
+      );
+      expect(createLifeOpsGithubReturnResponse).not.toHaveBeenCalled();
+      expect(findByIdAndOrg).not.toHaveBeenCalled();
+      expect(connectAgent).not.toHaveBeenCalled();
+    },
+  );
+
+  test("accepts post_message=1 as the popup postMessage completion path", async () => {
+    const response = await complete("?post_message=1");
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("popup");
+    expect(createLifeOpsGithubReturnResponse).toHaveBeenCalledTimes(1);
+    const args = createLifeOpsGithubReturnResponse.mock.calls[0]?.[0] as {
+      postMessage: boolean;
+    };
+    expect(args.postMessage).toBe(true);
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    expect(connectAgent).not.toHaveBeenCalled();
+  });
+
+  test.each(["true", "TRUE", "0", "false", "yes", "foo", "1e2"])(
+    "rejects post_message=%s before GitHub linking",
+    async (token) => {
+      const response = await complete(
+        `?post_message=${encodeURIComponent(token)}&agent_id=agent-1&org_id=org-1&user_id=user-1&connection_id=conn-1&github_connected=true`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid post_message");
+      expect(createLifeOpsGithubReturnResponse).not.toHaveBeenCalled();
+      expect(findByIdAndOrg).not.toHaveBeenCalled();
+      expect(connectAgent).not.toHaveBeenCalled();
+      expect(getConnection).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?post_message=1&post_message=1",
+    "?post_message=1&post_message=0",
+    "?post_message=&post_message=1",
+    "?post_message=foo&post_message=1",
+  ])(
+    "rejects duplicate post_message values in %s before GitHub linking",
+    async (query) => {
+      const response = await complete(`${query}&agent_id=agent-1`);
+      expect(response.status).toBe(400);
+      expect(createLifeOpsGithubReturnResponse).not.toHaveBeenCalled();
+      expect(findByIdAndOrg).not.toHaveBeenCalled();
+      expect(connectAgent).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/eliza/github-oauth-complete/route.ts
+++ b/packages/cloud/api/v1/eliza/github-oauth-complete/route.ts
@@ -39,7 +39,29 @@ app.get("/", async (c) => {
   const connectionId = c.req.query("connection_id") ?? null;
   const githubConnected = c.req.query("github_connected") ?? null;
   const githubError = c.req.query("github_error") ?? null;
-  const postMessage = c.req.query("post_message") === "1";
+  // Popup-return identity, leftover tax after lifeops github-complete
+  // target (#21058). post_message=true used to silently skip the
+  // postMessage landing page and fall through to a dashboard redirect.
+  // github_connected / target / return_url parsers stay untouched.
+  const requestedPostMessageValues = new URL(c.req.url).searchParams.getAll(
+    "post_message",
+  );
+  const requestedPostMessage = requestedPostMessageValues[0];
+  if (
+    requestedPostMessageValues.length > 1 ||
+    (requestedPostMessage != null &&
+      requestedPostMessage !== "" &&
+      requestedPostMessage !== "1")
+  ) {
+    return c.json(
+      {
+        error: "Invalid post_message",
+        message: 'post_message must be specified at most once as "1".',
+      },
+      400,
+    );
+  }
+  const postMessage = requestedPostMessage === "1";
   const returnUrl = c.req.query("return_url") ?? null;
 
   const respond = (args: {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on GitHub OAuth
complete `post_message` identity. Leftover tax after lifeops github-complete
target (#21058). Not leftover tax on discovery activeOnly, vertex-jobs
persisted, agent-create sync, agent-provision sync, resume sync,
approval-request public, ballot public, payment-request public,
twitter-status connectionRole, twitter-disconnect connectionRole,
x-dms-digest connectionRole, x-feed connectionRole, x-status
connectionRole, voice-list includeInactive, or analytics-export
includeMetadata.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Query `post_message` only on `GET /api/v1/eliza/github-oauth-complete`.
Omitted/empty still use the dashboard redirect (today's default).
Exact `1` still opens the popup postMessage landing page.
Unknown / uppercase / numeric / duplicate tokens 400 before GitHub linking.
github_connected / return_url parsers stay untouched.

# Background

## What does this PR do?

`GET /api/v1/eliza/github-oauth-complete` parsed `post_message` with
`=== "1"`. `post_message=true` silently skipped the popup landing page
and redirected to the dashboard instead of a 400.

- omitted / empty → dashboard redirect
- exact `1` → popup postMessage page
- `true` / `TRUE` / `0` / `yes` / `1e2` / duplicate `post_message` → **400**
  before GitHub linking

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The OAuth completion popup sends `?post_message=1`. A common
`post_message=true` after a client stringifies a boolean must not silently
drop the opener handshake. This is leftover tax after lifeops
github-complete target (#21058), which left the managed-agent
`post_message` parser untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/eliza/github-oauth-complete/route.post-message.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/eliza/github-oauth-complete/route.post-message.test.ts
```

14 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; github-oauth-complete `post_message` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; github-oauth-complete `post_message` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; github-oauth-complete `post_message` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real post_message tokens and assert 400 before GitHub linking; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before GitHub linking.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`post_message` tokens reject; omitted/canonical still bind the matching
redirect-or-popup path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file github-oauth-complete
post_message parse with a green focused suite (14 passed). Full monorepo
verify is unrelated to this query grammar and was skipped to keep the
proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f06c26ca92628e0b7f4ffb1a7b247cd587fb50ab -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
