### PR TITLE
fix(plugin-local-inference): reject unknown voice-profiles includeOwner flag

### DIFF
--- a/plugins/plugin-local-inference/src/routes/voice-profiles-include-owner.test.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-profiles-include-owner.test.ts
@@ -1,0 +1,182 @@
+/**
+ * DELETE /api/voice/profiles `includeOwner` is mass-delete owner identity,
+ * leftover tax after voice-list includeInactive (#21106). Stock develop
+ * treated every non-exact `true` token as spare-the-OWNER, so
+ * `includeOwner=TRUE` left the owner profile in place instead of a 400.
+ * Single-id DELETE / merge / bind parsers stay untouched.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import * as http from "node:http";
+import { Socket } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	type VoiceProfileAudioRef,
+	type VoiceProfileRecord,
+	VoiceProfileStore,
+} from "../services/voice/profile-store";
+import {
+	handleVoiceProfilesManagementRoutes,
+	setVoiceProfilesManagementStore,
+} from "./voice-profiles-management-routes";
+
+const OWNER_ENTITY_ID = "entity-owner";
+const JSON_BODY = Symbol.for("eliza.http.cachedJsonBody");
+
+let rootDir: string;
+let store: VoiceProfileStore;
+let owner: VoiceProfileRecord;
+let guest: VoiceProfileRecord;
+let previousOwnerEntityId: string | undefined;
+
+function unit(values: number[]): Float32Array {
+	const magnitude = Math.sqrt(
+		values.reduce((sum, value) => sum + value ** 2, 0),
+	);
+	return new Float32Array(values.map((value) => value / magnitude));
+}
+
+function sample(id: string): VoiceProfileAudioRef {
+	return {
+		sampleId: id,
+		wavSha256: `sha-${id}`,
+		durationMs: 1000,
+		recordedAt: "2026-08-01T00:00:00.000Z",
+	};
+}
+
+function request(method: string, pathname: string): http.IncomingMessage {
+	const req = new http.IncomingMessage(new Socket());
+	req.method = method;
+	req.url = pathname;
+	return req;
+}
+
+function response(): {
+	res: http.ServerResponse;
+	body: () => Record<string, unknown>;
+} {
+	let raw = "";
+	const req = new http.IncomingMessage(new Socket());
+	const res = new http.ServerResponse(req);
+	res.setHeader = () => res;
+	res.end = ((chunk?: string | Buffer) => {
+		if (typeof chunk === "string") raw += chunk;
+		else if (chunk) raw += chunk.toString("utf8");
+		return res;
+	}) as typeof res.end;
+	return {
+		res,
+		body: () => JSON.parse(raw) as Record<string, unknown>,
+	};
+}
+
+async function call(method: string, pathname: string) {
+	const out = response();
+	const handled = await handleVoiceProfilesManagementRoutes(
+		request(method, pathname),
+		out.res,
+	);
+	expect(handled).toBe(true);
+	return { status: out.res.statusCode, body: out.body() };
+}
+
+beforeEach(async () => {
+	previousOwnerEntityId = process.env.ELIZA_ADMIN_ENTITY_ID;
+	process.env.ELIZA_ADMIN_ENTITY_ID = OWNER_ENTITY_ID;
+	rootDir = mkdtempSync(path.join(tmpdir(), "voice-profile-include-owner-"));
+	store = new VoiceProfileStore({ rootDir });
+	await store.init();
+	owner = await store.createProfile({
+		centroid: unit([1, 0, 0, 0]),
+		embeddingModel: "test-speaker-model",
+		confidence: 0.9,
+		durationMs: 1000,
+		audioRef: sample("owner-a"),
+		entityId: OWNER_ENTITY_ID,
+		metadata: { displayName: "Owner", cohort: "owner" },
+	});
+	guest = await store.createProfile({
+		centroid: unit([0, 1, 0, 0]),
+		embeddingModel: "test-speaker-model",
+		confidence: 0.8,
+		durationMs: 1000,
+		audioRef: sample("guest-a"),
+		metadata: { displayName: "Guest" },
+	});
+	setVoiceProfilesManagementStore(store);
+});
+
+afterEach(() => {
+	setVoiceProfilesManagementStore(null);
+	if (previousOwnerEntityId === undefined) {
+		delete process.env.ELIZA_ADMIN_ENTITY_ID;
+	} else {
+		process.env.ELIZA_ADMIN_ENTITY_ID = previousOwnerEntityId;
+	}
+	rmSync(rootDir, { recursive: true, force: true });
+});
+
+describe("DELETE /api/voice/profiles includeOwner identity", () => {
+	it.each(["/api/voice/profiles", "/api/voice/profiles?includeOwner="])(
+		"accepts %s as spare-the-OWNER mass delete",
+		async (pathname) => {
+			const result = await call("DELETE", pathname);
+			expect(result.status).toBe(200);
+			expect(result.body).toEqual({ deleted: 1 });
+			expect(await store.get(owner.profileId)).not.toBeNull();
+			expect(await store.get(guest.profileId)).toBeNull();
+		},
+	);
+
+	it("accepts includeOwner=false as spare-the-OWNER mass delete", async () => {
+		const result = await call(
+			"DELETE",
+			"/api/voice/profiles?includeOwner=false",
+		);
+		expect(result.status).toBe(200);
+		expect(result.body).toEqual({ deleted: 1 });
+		expect(await store.get(owner.profileId)).not.toBeNull();
+		expect(await store.get(guest.profileId)).toBeNull();
+	});
+
+	it("accepts includeOwner=true as delete-including-OWNER", async () => {
+		const result = await call(
+			"DELETE",
+			"/api/voice/profiles?includeOwner=true",
+		);
+		expect(result.status).toBe(200);
+		expect(result.body).toEqual({ deleted: 2 });
+		expect(await store.get(owner.profileId)).toBeNull();
+		expect(await store.get(guest.profileId)).toBeNull();
+	});
+
+	it.each(["TRUE", "1", "yes", "foo", "1e2"])(
+		"rejects includeOwner=%s before mass delete",
+		async (token) => {
+			const result = await call(
+				"DELETE",
+				`/api/voice/profiles?includeOwner=${encodeURIComponent(token)}`,
+			);
+			expect(result.status).toBe(400);
+			expect(result.body).toMatchObject({
+				error: 'includeOwner must be specified at most once as "true" or "false".',
+			});
+			expect(await store.get(owner.profileId)).not.toBeNull();
+			expect(await store.get(guest.profileId)).not.toBeNull();
+		},
+	);
+
+	it.each([
+		"/api/voice/profiles?includeOwner=true&includeOwner=true",
+		"/api/voice/profiles?includeOwner=true&includeOwner=false",
+		"/api/voice/profiles?includeOwner=&includeOwner=true",
+		"/api/voice/profiles?includeOwner=foo&includeOwner=true",
+	])("rejects duplicate includeOwner values in %s before mass delete", async (pathname) => {
+		const result = await call("DELETE", pathname);
+		expect(result.status).toBe(400);
+		expect(await store.get(owner.profileId)).not.toBeNull();
+		expect(await store.get(guest.profileId)).not.toBeNull();
+	});
+});

--- a/plugins/plugin-local-inference/src/routes/voice-profiles-management-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-profiles-management-routes.ts
@@ -206,7 +206,27 @@ export async function handleVoiceProfilesManagementRoutes(
 	if (pathname === "/api/voice/profiles") {
 		if (method === "GET") return listProfiles(res);
 		if (method === "DELETE") {
-			return deleteAll(res, url.searchParams.get("includeOwner") === "true");
+			// Mass-delete owner identity, leftover tax after voice-list
+			// includeInactive (#21106). includeOwner=TRUE used to silently
+			// spare the OWNER profile instead of a 400. Single-id DELETE
+			// / merge / bind parsers stay untouched.
+			const requestedOwnerValues = url.searchParams.getAll("includeOwner");
+			const requestedOwner = requestedOwnerValues[0];
+			if (
+				requestedOwnerValues.length > 1 ||
+				(requestedOwner != null &&
+					requestedOwner !== "" &&
+					requestedOwner !== "true" &&
+					requestedOwner !== "false")
+			) {
+				sendJsonError(
+					res,
+					'includeOwner must be specified at most once as "true" or "false".',
+					400,
+				);
+				return true;
+			}
+			return deleteAll(res, requestedOwner === "true");
 		}
 		return false;
 	}


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on voice-profile
mass-delete `includeOwner` identity. Leftover tax after voice-list
includeInactive (#21106). Not leftover tax on discovery activeOnly,
vertex-jobs persisted, agent-create sync, agent-provision sync, resume
sync, approval-request public, ballot public, payment-request public,
twitter-status connectionRole, twitter-disconnect connectionRole,
x-dms-digest connectionRole, x-feed connectionRole, x-status
connectionRole, analytics-export includeMetadata, or github-oauth-complete
post_message.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Query `includeOwner` only on `DELETE /api/voice/profiles`.
Omitted/empty/`false` still spare the OWNER profile (today's default).
Exact `true` still deletes the OWNER profile with the rest.
Unknown / uppercase / numeric / duplicate tokens 400 before mass delete.
Single-id DELETE / merge / bind parsers stay untouched.

# Background

## What does this PR do?

`DELETE /api/voice/profiles` parsed `includeOwner` with `=== "true"`.
`includeOwner=TRUE` silently spared the OWNER profile instead of a 400.

- omitted / empty / `false` → delete guests only
- exact `true` → delete including OWNER
- `TRUE` / `1` / `yes` / `1e2` / duplicate `includeOwner` → **400** before
  mass delete

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Voice Studio mass-delete opts into removing the OWNER profile with
`?includeOwner=true`. A common `includeOwner=TRUE` after a client
uppercases the flag must not silently keep the owner row. This is leftover
tax after voice-list includeInactive (#21106), which left the local
voice-profile mass-delete parser untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/src/routes/voice-profiles-include-owner.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-local-inference && NODE_OPTIONS='--experimental-sqlite' bunx vitest run src/routes/voice-profiles-include-owner.test.ts src/routes/voice-profiles-management-routes.test.ts
```

13 new identity tests + 4 existing management tests passed at this head
(17 total).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; voice-profiles `includeOwner` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; voice-profiles `includeOwner` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; voice-profiles `includeOwner` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real includeOwner tokens and assert 400 before mass delete; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before mass delete.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
`includeOwner` tokens reject; omitted/canonical still bind the matching
spare-or-include OWNER path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file voice-profiles
includeOwner parse with a green focused suite (13 new + 4 existing). Full
monorepo verify is unrelated to this query grammar and was skipped to keep
the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4b0a926c38e4217ee5eec82bcf7399abb4d029a2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
