### PR TITLE
fix(cloud): add timeout to Fal image generation fetch (bound provider)

### DIFF
--- a/packages/cloud/shared/src/lib/providers/__tests__/fal-image-timeout.test.ts
+++ b/packages/cloud/shared/src/lib/providers/__tests__/fal-image-timeout.test.ts
@@ -1,39 +1,49 @@
-/**
- * Proves Fal image provider fetch timeout (rank 8 clone of atlas/openai batches).
- * Both fetches now have AbortSignal.timeout(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS) matching download sibling.
- */
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+/** Exercises Fal generation and download deadlines through an injected fetch boundary. */
+import { describe, expect, it, mock } from "bun:test";
 
-const falPath = new URL("../image/fal-image-generation.ts", import.meta.url).pathname;
-const atlasPath = new URL("../image/atlascloud-image-generation.ts", import.meta.url).pathname;
-const sunoPath = new URL("../audio/suno-audio-generation.ts", import.meta.url).pathname;
+mock.module("../language-model", () => ({
+  getAiProviderConfigurationError: () => "missing provider configuration",
+}));
 
-describe("fal image fetch timeout — bounded provider", () => {
-  test("generation fetch has AbortSignal.timeout", () => {
-    const src = readFileSync(falPath, "utf8");
-    expect(src).toContain('fetch(`${baseUrl}/${request.model}`');
-    expect(src).toContain("signal: AbortSignal.timeout(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS),");
-    const timeouts = (src.match(/AbortSignal\.timeout\(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS\)/g) || []).length;
-    expect(timeouts).toBeGreaterThanOrEqual(2); // download + generate
+const { generateFalImageWithFetch } = await import("../image/fal-image-generation");
+
+const request = {
+  model: "fal-ai/flux/dev",
+  prompt: "draw a bounded request",
+  apiKeys: { FAL_KEY: "test-key", FAL_RUN_BASE_URL: "https://fal.invalid" },
+};
+
+describe("Fal image request deadlines", () => {
+  it("aborts a stalled synchronous generation at the configured job deadline", async () => {
+    const fetchImpl: typeof fetch = async (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) throw new Error("expected generation abort signal");
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+
+    await expect(generateFalImageWithFetch(request, fetchImpl, 10)).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
   });
 
-  test("download already bounded sibling proves intent", () => {
-    const src = readFileSync(falPath, "utf8");
-    expect(src).toContain("const response = await fetch(url, { signal: AbortSignal.timeout(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS) });");
-  });
+  it("uses the injected fetch for both generation and image download", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      if (signals.length === 1) {
+        return Response.json({ images: [{ url: "https://images.invalid/result.png" }] });
+      }
+      return new Response(new Uint8Array([1, 2, 3]), {
+        headers: { "content-type": "image/png" },
+      });
+    };
 
-  test("no unbounded fetch remains in fal image provider", () => {
-    const src = readFileSync(falPath, "utf8");
-    const fetches = (src.match(/await fetch\(/g) || []).length;
-    const timeouts = (src.match(/AbortSignal\.timeout/g) || []).length;
-    expect(timeouts).toBe(fetches); // 2 == 2
-  });
+    const image = await generateFalImageWithFetch(request, fetchImpl, 1_000);
 
-  test("sibling correct — atlas and suno already bounded", () => {
-    const atlas = readFileSync(atlasPath, "utf8");
-    expect(atlas).toContain("AbortSignal.timeout");
-    const suno = readFileSync(sunoPath, "utf8");
-    expect(suno).toContain("AbortSignal.timeout");
+    expect(signals).toHaveLength(2);
+    expect(signals.every((signal) => !signal.aborted)).toBe(true);
+    expect(image.mimeType).toBe("image/png");
+    expect(image.bytes).toEqual(new Uint8Array([1, 2, 3]));
   });
 });

--- a/packages/cloud/shared/src/lib/providers/__tests__/fal-image-timeout.test.ts
+++ b/packages/cloud/shared/src/lib/providers/__tests__/fal-image-timeout.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Proves Fal image provider fetch timeout (rank 8 clone of atlas/openai batches).
+ * Both fetches now have AbortSignal.timeout(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS) matching download sibling.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const falPath = new URL("../image/fal-image-generation.ts", import.meta.url).pathname;
+const atlasPath = new URL("../image/atlascloud-image-generation.ts", import.meta.url).pathname;
+const sunoPath = new URL("../audio/suno-audio-generation.ts", import.meta.url).pathname;
+
+describe("fal image fetch timeout — bounded provider", () => {
+  test("generation fetch has AbortSignal.timeout", () => {
+    const src = readFileSync(falPath, "utf8");
+    expect(src).toContain('fetch(`${baseUrl}/${request.model}`');
+    expect(src).toContain("signal: AbortSignal.timeout(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS),");
+    const timeouts = (src.match(/AbortSignal\.timeout\(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS\)/g) || []).length;
+    expect(timeouts).toBeGreaterThanOrEqual(2); // download + generate
+  });
+
+  test("download already bounded sibling proves intent", () => {
+    const src = readFileSync(falPath, "utf8");
+    expect(src).toContain("const response = await fetch(url, { signal: AbortSignal.timeout(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS) });");
+  });
+
+  test("no unbounded fetch remains in fal image provider", () => {
+    const src = readFileSync(falPath, "utf8");
+    const fetches = (src.match(/await fetch\(/g) || []).length;
+    const timeouts = (src.match(/AbortSignal\.timeout/g) || []).length;
+    expect(timeouts).toBe(fetches); // 2 == 2
+  });
+
+  test("sibling correct — atlas and suno already bounded", () => {
+    const atlas = readFileSync(atlasPath, "utf8");
+    expect(atlas).toContain("AbortSignal.timeout");
+    const suno = readFileSync(sunoPath, "utf8");
+    expect(suno).toContain("AbortSignal.timeout");
+  });
+});

--- a/packages/cloud/shared/src/lib/providers/image/fal-image-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/image/fal-image-generation.ts
@@ -3,6 +3,7 @@ import { getAiProviderConfigurationError } from "../language-model";
 import type { GeneratedImage, ImageGenRequest, ImageProvider } from "./types";
 
 const FAL_IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000;
+const FAL_IMAGE_GENERATION_TIMEOUT_MS = 5 * 60_000;
 const FAL_IMAGE_MAX_BYTES = 20 * 1024 * 1024;
 
 function bytesToBase64(bytes: Uint8Array): string {
@@ -53,8 +54,14 @@ async function readImageWithLimit(response: Response): Promise<Uint8Array> {
   return bytes;
 }
 
-async function imageUrlToGeneratedImage(url: string, text = ""): Promise<GeneratedImage> {
-  const response = await fetch(url, { signal: AbortSignal.timeout(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS) });
+async function imageUrlToGeneratedImage(
+  url: string,
+  text = "",
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<GeneratedImage> {
+  const response = await fetchImpl(url, {
+    signal: AbortSignal.timeout(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`fal image download failed: ${response.status}`);
   }
@@ -81,7 +88,12 @@ function extractFalImageUrl(payload: Record<string, unknown>): { url: string; te
   return { url, text };
 }
 
-export async function generateFalImage(request: ImageGenRequest): Promise<GeneratedImage> {
+/** Runs Fal's synchronous generation request with a job-sized deadline. */
+export async function generateFalImageWithFetch(
+  request: ImageGenRequest,
+  fetchImpl: typeof fetch,
+  generationTimeoutMs = FAL_IMAGE_GENERATION_TIMEOUT_MS,
+): Promise<GeneratedImage> {
   const apiKey = request.apiKeys.FAL_KEY ?? request.apiKeys.FAL_API_KEY;
   if (!apiKey) {
     throw new Error(getAiProviderConfigurationError());
@@ -90,7 +102,7 @@ export async function generateFalImage(request: ImageGenRequest): Promise<Genera
   // Overridable for deterministic tests (same convention as OPENROUTER_BASE_URL
   // and the queue client's FAL_QUEUE_BASE_URL).
   const baseUrl = (request.apiKeys.FAL_RUN_BASE_URL ?? "https://fal.run").replace(/\/+$/, "");
-  const response = await fetch(`${baseUrl}/${request.model}`, {
+  const response = await fetchImpl(`${baseUrl}/${request.model}`, {
     method: "POST",
     headers: {
       Authorization: `Key ${apiKey}`,
@@ -102,7 +114,7 @@ export async function generateFalImage(request: ImageGenRequest): Promise<Genera
       ...(request.aspectRatio ? { aspect_ratio: request.aspectRatio } : {}),
       ...(request.size ? { image_size: request.size } : {}),
     }),
-    signal: AbortSignal.timeout(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS),
+    signal: AbortSignal.timeout(generationTimeoutMs),
   });
 
   const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
@@ -112,7 +124,11 @@ export async function generateFalImage(request: ImageGenRequest): Promise<Genera
   }
 
   const { url, text } = extractFalImageUrl(payload);
-  return await imageUrlToGeneratedImage(url, text);
+  return await imageUrlToGeneratedImage(url, text, fetchImpl);
+}
+
+export async function generateFalImage(request: ImageGenRequest): Promise<GeneratedImage> {
+  return generateFalImageWithFetch(request, globalThis.fetch);
 }
 
 export const falImageProvider: ImageProvider = {

--- a/packages/cloud/shared/src/lib/providers/image/fal-image-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/image/fal-image-generation.ts
@@ -102,6 +102,7 @@ export async function generateFalImage(request: ImageGenRequest): Promise<Genera
       ...(request.aspectRatio ? { aspect_ratio: request.aspectRatio } : {}),
       ...(request.size ? { image_size: request.size } : {}),
     }),
+    signal: AbortSignal.timeout(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS),
   });
 
   const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;


### PR DESCRIPTION
# Relates to

Fal synchronous image generation could wait forever, but the original patch reused the 30-second image-download budget for a request that stays open for the full inference job. This revision separates the two contracts.

# Summary

- Give synchronous `fal.run` inference a five-minute job deadline while retaining the existing 30-second finished-image download deadline.
- Inject `fetch` into a dependency-light helper so timeout and download behavior can be tested without live credentials or network access.
- Replace source-text assertions with behavior tests that observe cancellation of a stalled generation and exercise both fetch calls.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5; OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `claude-code; Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1e80e1ece2e48cc140abf2f945400ade1c065d5f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `1e80e1ece2e48cc140abf2f945400ade1c065d5f` with zero conflicts.
- [x] Exact candidate head: `83b2c9971c7ae8e5576256edf77a289b28c253cb`.
- [x] `git diff --check origin/develop...HEAD` is clean.

# Testing

Focused, credential-scrubbed validation on the exact rebased head:

```text
bun test packages/cloud/shared/src/lib/providers/__tests__/fal-image-timeout.test.ts
2 pass; 0 fail; 5 expect() calls

biome check fal-image-generation.ts fal-image-timeout.test.ts
Checked 2 files. No fixes applied.
```

# Evidence Gate

<!-- evidence-head:83b2c9971c7ae8e5576256edf77a289b28c253cb -->
<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only provider transport behavior with no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only provider transport behavior with no rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - deterministic timeout behavior is exercised directly by the focused test.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs:

  <details><summary>Exact-head focused validation</summary>

  ```text
  head: 83b2c9971c7ae8e5576256edf77a289b28c253cb
  bun test: stalled synchronous generation aborted at the configured 10ms test deadline
  bun test: injected fetch exercised for generation and image download; 2 passed, 0 failed
  biome: checked 2 touched files; no fixes applied; git diff --check clean
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend or browser request path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - the change bounds provider HTTP duration and does not alter prompts, model selection, or planner behavior.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - deterministic timeout behavior produces no persisted row or file; the observable cancellation and successful download are covered by focused tests.`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@1e80e1ece2e48cc140abf2f945400ade1c065d5f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [byt61-repair-a]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@1e80e1ece2e48cc140abf2f945400ade1c065d5f:packages/skills/skills/contribute-to-eliza"} -->
