### PR TITLE
fix(core): run npm pack verifier on Windows

### DIFF
--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type { BuildConfig, BunPlugin } from "bun";
+import { resolveNpmCliInvocation } from "./scripts/npm-cli";
 
 const execFileAsync = promisify(execFile);
 const RM_RECURSIVE_SCRIPT = fileURLToPath(
@@ -1323,11 +1324,17 @@ async function verifyPackedEdgeContract(): Promise<void> {
 		join(tmpdir(), "eliza-core-edge-package-"),
 	);
 	try {
-		const { stdout } = await execFileAsync(
-			"npm",
-			["pack", "--json", "--pack-destination", contractRoot, process.cwd()],
-			{ cwd: process.cwd(), maxBuffer: 10 * 1024 * 1024 },
-		);
+		const npmPack = resolveNpmCliInvocation([
+			"pack",
+			"--json",
+			"--pack-destination",
+			contractRoot,
+			process.cwd(),
+		]);
+		const { stdout } = await execFileAsync(npmPack.command, npmPack.args, {
+			cwd: process.cwd(),
+			maxBuffer: 10 * 1024 * 1024,
+		});
 		const packed = JSON.parse(stdout) as Array<{ filename?: unknown }>;
 		const filename = packed[0]?.filename;
 		if (typeof filename !== "string") {

--- a/packages/core/scripts/npm-cli.test.ts
+++ b/packages/core/scripts/npm-cli.test.ts
@@ -1,3 +1,4 @@
+/** Deterministic unit coverage validates Core's platform-specific npm CLI resolution. */
 import { describe, expect, it } from "vitest";
 import { resolveNpmCliInvocation } from "./npm-cli";
 

--- a/packages/core/scripts/npm-cli.test.ts
+++ b/packages/core/scripts/npm-cli.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { resolveNpmCliInvocation } from "./npm-cli";
+
+function windowsInstallation(root: string): Set<string> {
+	return new Set([
+		`${root}\\node.exe`,
+		`${root}\\npm.cmd`,
+		`${root}\\node_modules\\npm\\bin\\npm-cli.js`,
+	]);
+}
+
+describe("resolveNpmCliInvocation", () => {
+	it("keeps the existing direct npm command off Windows", () => {
+		expect(
+			resolveNpmCliInvocation(["pack", "package path"], {
+				platform: "linux",
+				pathValue: "",
+			}),
+		).toEqual({ command: "npm", args: ["pack", "package path"] });
+	});
+
+	it("uses node.exe plus npm-cli.js from a complete quoted PATH entry", () => {
+		const root = "C:\\Program Files\\nodejs";
+		const files = windowsInstallation(root);
+		const args = ["pack", "C:\\repo with spaces", "--json"];
+
+		expect(
+			resolveNpmCliInvocation(args, {
+				platform: "win32",
+				pathValue: `;"${root}";C:\\other`,
+				fileExists: (filePath) => files.has(filePath),
+			}),
+		).toEqual({
+			command: `${root}\\node.exe`,
+			args: [`${root}\\node_modules\\npm\\bin\\npm-cli.js`, ...args],
+		});
+	});
+
+	it("skips incomplete installs and selects the first complete one", () => {
+		const incomplete = "C:\\incomplete";
+		const complete = "D:\\node";
+		const files = windowsInstallation(complete);
+		files.add(`${incomplete}\\node.exe`);
+		files.add(`${incomplete}\\npm.cmd`);
+
+		expect(
+			resolveNpmCliInvocation(["--version"], {
+				platform: "win32",
+				pathValue: `${incomplete};${complete}`,
+				fileExists: (filePath) => files.has(filePath),
+			}),
+		).toEqual({
+			command: `${complete}\\node.exe`,
+			args: [`${complete}\\node_modules\\npm\\bin\\npm-cli.js`, "--version"],
+		});
+	});
+
+	it("falls back predictably when PATH has no complete npm installation", () => {
+		expect(
+			resolveNpmCliInvocation(["pack"], {
+				platform: "win32",
+				pathValue: ';"";C:\\missing',
+				fileExists: () => false,
+			}),
+		).toEqual({ command: "npm", args: ["pack"] });
+	});
+});

--- a/packages/core/scripts/npm-cli.ts
+++ b/packages/core/scripts/npm-cli.ts
@@ -1,3 +1,4 @@
+/** Resolves the npm CLI invocation used by Core build verification across supported platforms. */
 import { existsSync } from "node:fs";
 import path from "node:path";
 

--- a/packages/core/scripts/npm-cli.ts
+++ b/packages/core/scripts/npm-cli.ts
@@ -1,0 +1,68 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+export interface NpmCliInvocation {
+	command: string;
+	args: string[];
+}
+
+interface ResolveNpmCliOptions {
+	platform?: NodeJS.Platform;
+	pathValue?: string;
+	fileExists?: (filePath: string) => boolean;
+}
+
+function normalizePathEntry(entry: string): string {
+	const trimmed = entry.trim();
+	if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+/**
+ * Resolve npm without asking a Windows shell to interpret `npm.cmd`.
+ *
+ * Core's build runs under Bun, so `process.execPath` is not Node. Instead,
+ * inspect PATH for a complete Node distribution and execute npm's JavaScript
+ * entrypoint through that distribution's `node.exe`. Non-Windows platforms
+ * keep the existing direct `npm` invocation.
+ */
+export function resolveNpmCliInvocation(
+	args: readonly string[],
+	options: ResolveNpmCliOptions = {},
+): NpmCliInvocation {
+	const platform = options.platform ?? process.platform;
+	if (platform !== "win32") {
+		return { command: "npm", args: [...args] };
+	}
+
+	const fileExists = options.fileExists ?? existsSync;
+	const pathValue = options.pathValue ?? process.env.PATH ?? "";
+	for (const rawEntry of pathValue.split(";")) {
+		const entry = normalizePathEntry(rawEntry);
+		if (entry.length === 0) continue;
+
+		const nodeExecutable = path.win32.join(entry, "node.exe");
+		const npmCommand = path.win32.join(entry, "npm.cmd");
+		const npmCli = path.win32.join(
+			entry,
+			"node_modules",
+			"npm",
+			"bin",
+			"npm-cli.js",
+		);
+		if (
+			fileExists(nodeExecutable) &&
+			fileExists(npmCommand) &&
+			fileExists(npmCli)
+		) {
+			return {
+				command: nodeExecutable,
+				args: [npmCli, ...args],
+			};
+		}
+	}
+
+	return { command: "npm", args: [...args] };
+}


### PR DESCRIPTION
# Relates to

Closes #21185.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      Electrobun lint blocker is recorded below.
- [x] A reviewer can confirm the change from the deterministic resolver matrix
      and real full Core packed-edge build transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@79949c086f4f8db894b901633ca5ef86ebb35560`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated Electrobun lint
      blocker is documented in **Known gaps / failures**.

# Risks

Low. This changes only Core's build-time npm launcher. The existing pack
arguments, working directory, output parser, temp-tree cleanup, and non-Windows
`npm` command are unchanged. No runtime or public package export is added.

# Background

## What does this PR do?

Full Core builds finish by running `npm pack`, extracting the candidate package,
typechecking a NodeNext edge consumer, and importing the packed edge runtime.
The build runs under Bun, and `execFile("npm")` cannot execute Windows' usual
`npm.cmd`, so all bundles/declarations completed before the required verifier
failed with `ENOENT: uv_spawn 'npm'`.

This PR adds a shell-free resolver that scans Windows PATH entries for a complete
Node/npm installation (`node.exe`, `npm.cmd`, and
`node_modules/npm/bin/npm-cli.js`) and invokes the JavaScript CLI through that
installation's `node.exe`. It deliberately avoids `shell: true` and preserves
the direct `npm` invocation everywhere else.

## What kind of change is this?

Bug fix (cross-platform Core build verification).

# Documentation changes needed?

No. The documented Core build commands are unchanged; this makes the existing
full-build contract succeed on Windows.

# Testing

## Where should a reviewer start?

Start with `packages/core/scripts/npm-cli.test.ts`, then inspect the single
`verifyPackedEdgeContract` call-site change in `packages/core/build.ts`.

## Detailed testing steps

Exact head: `4ae66568a31178476b5350ffc9ec2e6e9a83c4a6`

1. `bun install --frozen-lockfile --ignore-scripts`
   - PASS: 3,809 installs / 4,090 packages, no changes.
2. `bun run --cwd packages/core test -- scripts/npm-cli.test.ts`
   - PASS: 1 file, 4 tests.
3. `bun x --no-install @biomejs/biome check packages/core/build.ts packages/core/scripts/npm-cli.ts packages/core/scripts/npm-cli.test.ts`
   - PASS: 3 files, no fixes.
4. `bun run --cwd packages/core typecheck`
   - PASS.
5. `bun run --cwd packages/core lint:check`
   - PASS (exit 0; seven pre-existing non-null-assertion warnings in
     `src/truncation-suffix-reserve-2.test.ts`).
6. `bun run --cwd packages/core build`
   - PASS: Node (12 outputs), browser (6), edge (2), testing (4), 507
     declaration files / 1,779 NodeNext specifier rewrites, and the final
     `Packed @elizaos/core/edge declarations and runtime import verified` gate.
7. Current-machine resolver probe:
   - PASS: resolved `C:\\Program Files\\nodejs\\node.exe` with
     `C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js`, not
     a shell or `npm.cmd` execution.
8. `git diff --check`
   - PASS.
9. `bun run verify`
   - Reaches Turbo package lint/typecheck fan-out, then stops at the unrelated
     Electrobun lint command described below.

# Evidence Gate

<!-- evidence-head:4ac3255ae86e63135f7da4fdeb44f6503a8b67db -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Core build infrastructure only; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Core build infrastructure only; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic tests and the real full build prove the complete flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service path changes; build output is included below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, network request, or UI state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action, prompt, provider, model, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] The real packed Core tarball was extracted, typechecked, and runtime-imported
      by the existing build verifier; its success transcript is included below.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual-text surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model path changes.

## Backend + frontend logs

N/A - build infrastructure only. Exact-head domain transcript:

```text
Built Node: 12 files
Built Browser: 6 files
Built Edge: 2 files
Built Testing: 4 files
Rewrote 1779 relative specifier(s) in 507 .d.ts file(s) for NodeNext ESM
All builds complete
Packed @elizaos/core/edge declarations and runtime import verified
```

## Screenshots (before / after) + video walkthrough

N/A - no rendered surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changes.

## Known gaps / failures

- Exact-head root `bun run verify` reaches Turbo and stops in the unrelated
  `@elizaos/electrobun#lint:check` package. Its script invokes Unix `find` from
  Windows, prints `File not found - *.tsx`, then scans generated `src/preload.js`
  and `.generated/brand-config.json`, yielding existing generated-code lint and
  format errors. The changed Core files are outside that package; Core focused
  tests, typecheck, lint:check, exact-file Biome, full multi-target build,
  packed-edge verifier, frozen install, and diff-check all pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-core-windows-npm]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza"} -->

