### PR TITLE
fix(shared): trim custom ELIZA_NAMESPACE and add unit test suite in ensureNamespaceDefaults

### DIFF
--- a/packages/shared/src/utils/namespace-defaults.test.ts
+++ b/packages/shared/src/utils/namespace-defaults.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for ensureNamespaceDefaults in packages/shared/src/utils/namespace-defaults.ts.
+ * Exercises default namespace assignment, whitespace trimming of custom namespaces,
+ * empty/whitespace fallbacks to "eliza", and non-object env handling.
+ */
+import { describe, expect, it } from "vitest";
+import { ensureNamespaceDefaults } from "./namespace-defaults.js";
+
+describe("ensureNamespaceDefaults", () => {
+  it("sets default 'eliza' namespace when ELIZA_NAMESPACE is undefined", () => {
+    const env: { ELIZA_NAMESPACE?: string } = {};
+    ensureNamespaceDefaults(env);
+    expect(env.ELIZA_NAMESPACE).toBe("eliza");
+  });
+
+  it("sets default 'eliza' namespace when ELIZA_NAMESPACE is empty string", () => {
+    const env = { ELIZA_NAMESPACE: "" };
+    ensureNamespaceDefaults(env);
+    expect(env.ELIZA_NAMESPACE).toBe("eliza");
+  });
+
+  it("sets default 'eliza' namespace when ELIZA_NAMESPACE is whitespace-only", () => {
+    const env = { ELIZA_NAMESPACE: "   \t\n  " };
+    ensureNamespaceDefaults(env);
+    expect(env.ELIZA_NAMESPACE).toBe("eliza");
+  });
+
+  it("trims and preserves custom namespace values", () => {
+    const env = { ELIZA_NAMESPACE: "  milady  " };
+    ensureNamespaceDefaults(env);
+    expect(env.ELIZA_NAMESPACE).toBe("milady");
+  });
+
+  it("preserves already clean custom namespace values", () => {
+    const env = { ELIZA_NAMESPACE: "custom-agent" };
+    ensureNamespaceDefaults(env);
+    expect(env.ELIZA_NAMESPACE).toBe("custom-agent");
+  });
+
+  it("safely handles null or non-object env arguments", () => {
+    expect(() =>
+      ensureNamespaceDefaults(null as unknown as undefined),
+    ).not.toThrow();
+    expect(() => ensureNamespaceDefaults(undefined)).not.toThrow();
+    expect(() =>
+      ensureNamespaceDefaults("string" as unknown as undefined),
+    ).not.toThrow();
+  });
+});

--- a/packages/shared/src/utils/namespace-defaults.ts
+++ b/packages/shared/src/utils/namespace-defaults.ts
@@ -21,11 +21,10 @@ export function ensureNamespaceDefaults(
     globalThis as { process?: { env?: NamespaceDefaultsEnv } }
   ).process?.env,
 ): void {
-  if (!env) return;
+  if (!env || typeof env !== "object") return;
 
-  if (!trimEnvValue(env.ELIZA_NAMESPACE)) {
-    env.ELIZA_NAMESPACE = "eliza";
-  }
+  const trimmed = trimEnvValue(env.ELIZA_NAMESPACE);
+  env.ELIZA_NAMESPACE = trimmed ?? "eliza";
 }
 
 ensureNamespaceDefaults();


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/namespace-defaults.ts`, `ensureNamespaceDefaults` checked `!trimEnvValue(env.ELIZA_NAMESPACE)` and assigned `"eliza"` only if empty, but failed to assign the trimmed value back when a custom namespace was provided with surrounding whitespace (e.g. `ELIZA_NAMESPACE=" milady "`).
2. Updated `ensureNamespaceDefaults` to assign `env.ELIZA_NAMESPACE = trimmed ?? "eliza"` to normalize namespaces in place.
3. Added non-object `env` guard.
4. Created a dedicated unit test suite in `packages/shared/src/utils/namespace-defaults.test.ts`.

Closes #21204.

## Verification

Exact commit: `76e04da611`.

- Focused unit test suite `packages/shared/src/utils/namespace-defaults.test.ts`: 6/6 tests passing (8 assertions).
- Biome format on `@elizaos/shared`: 409 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - namespace defaults helper; no rendered UI changed.
- [x] N/A - namespace defaults helper; no rendered UI changed.
- [x] N/A - deterministic namespace normalization tests.
- [x] Focused test suite transcript:
```text
✓ ensureNamespaceDefaults > sets default 'eliza' namespace when ELIZA_NAMESPACE is undefined [0.05ms]
✓ ensureNamespaceDefaults > sets default 'eliza' namespace when ELIZA_NAMESPACE is empty string [0.08ms]
✓ ensureNamespaceDefaults > sets default 'eliza' namespace when ELIZA_NAMESPACE is whitespace-only [0.04ms]
✓ ensureNamespaceDefaults > trims and preserves custom namespace values [0.03ms]
✓ ensureNamespaceDefaults > preserves already clean custom namespace values [0.03ms]
✓ ensureNamespaceDefaults > safely handles null or non-object env arguments [0.12ms]
6 pass, 0 fail, 8 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza"} -->
