### PR TITLE
fix(core): trim and treat empty path env overrides as unset in paths helpers and add unit test suite

### DIFF
--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for paths resolution and caching in packages/core/src/utils/paths.ts.
+ * Exercises default directory resolution, environment variable overrides, fallback
+ * env keys, whitespace trimming, empty string fallback, and cache resets.
+ */
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	getAllElizaPaths,
+	getCharactersDir,
+	getDatabaseDir,
+	getDataDir,
+	getGeneratedDir,
+	getUploadsAgentsDir,
+	getUploadsChannelsDir,
+	resetPaths,
+} from "./paths.js";
+import { resolveStateDir } from "./state-dir.js";
+
+describe("paths", () => {
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		resetPaths();
+		delete process.env.ELIZA_DATA_DIR;
+		delete process.env.ELIZA_DATABASE_DIR;
+		delete process.env.PGLITE_DATA_DIR;
+		delete process.env.ELIZA_DATA_DIR_CHARACTERS;
+		delete process.env.ELIZA_DATA_DIR_GENERATED;
+		delete process.env.ELIZA_DATA_DIR_UPLOADS_AGENTS;
+		delete process.env.ELIZA_DATA_DIR_UPLOADS_CHANNELS;
+	});
+
+	afterEach(() => {
+		resetPaths();
+		process.env = { ...originalEnv };
+	});
+
+	it("resolves default directories relative to state dir and workspace", () => {
+		const expectedDataDir = join(resolveStateDir(), "workspace");
+		expect(getDataDir()).toBe(expectedDataDir);
+		expect(getDatabaseDir()).toBe(join(expectedDataDir, ".elizadb"));
+		expect(getCharactersDir()).toBe(
+			join(expectedDataDir, "data", "characters"),
+		);
+		expect(getGeneratedDir()).toBe(join(expectedDataDir, "data", "generated"));
+		expect(getUploadsAgentsDir()).toBe(
+			join(expectedDataDir, "data", "uploads", "agents"),
+		);
+		expect(getUploadsChannelsDir()).toBe(
+			join(expectedDataDir, "data", "uploads", "channels"),
+		);
+	});
+
+	it("honors and trims ELIZA_DATA_DIR override", () => {
+		process.env.ELIZA_DATA_DIR = "  /custom/workspace  ";
+		expect(getDataDir()).toBe("/custom/workspace");
+		expect(getCharactersDir()).toBe(
+			join("/custom/workspace", "data", "characters"),
+		);
+	});
+
+	it("honors ELIZA_DATABASE_DIR and fallback PGLITE_DATA_DIR", () => {
+		process.env.PGLITE_DATA_DIR = "/pglite/db";
+		expect(getDatabaseDir()).toBe("/pglite/db");
+
+		resetPaths();
+		process.env.ELIZA_DATABASE_DIR = "/eliza/db";
+		expect(getDatabaseDir()).toBe("/eliza/db");
+	});
+
+	it("treats empty or whitespace-only env overrides as unset", () => {
+		process.env.ELIZA_DATA_DIR = "   ";
+		process.env.ELIZA_DATABASE_DIR = "";
+		const expectedDataDir = join(resolveStateDir(), "workspace");
+		expect(getDataDir()).toBe(expectedDataDir);
+		expect(getDatabaseDir()).toBe(join(expectedDataDir, ".elizadb"));
+	});
+
+	it("returns all paths in getAllElizaPaths", () => {
+		const all = getAllElizaPaths();
+		expect(all).toHaveProperty("dataDir");
+		expect(all).toHaveProperty("databaseDir");
+		expect(all).toHaveProperty("charactersDir");
+		expect(all).toHaveProperty("generatedDir");
+		expect(all).toHaveProperty("uploadsAgentsDir");
+		expect(all).toHaveProperty("uploadsChannelsDir");
+	});
+});

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -10,7 +10,8 @@ import { resolveStateDir } from "./state-dir";
 
 function getEnvVar(key: string): string | undefined {
 	if (typeof process !== "undefined" && process.env) {
-		return process.env[key];
+		const raw = process.env[key]?.trim();
+		return raw && raw.length > 0 ? raw : undefined;
 	}
 	return undefined;
 }


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/paths.ts`, `getEnvVar` returned `process.env[key]` directly without `.trim()`. When path overrides were set to empty strings `""` or whitespace `" "`, `dir = envValue || ...` treated the whitespace string as truthy, corrupting directory resolution instead of falling back to defaults under `stateDir`/`dataDir`.
2. Updated `getEnvVar` to trim values and return `undefined` for empty/whitespace-only values.
3. Created a dedicated unit test suite in `packages/core/src/utils/paths.test.ts`.

Closes #21208.

## Verification

Exact commit: `41d97dec81`.

- Focused unit test suite `packages/core/src/utils/paths.test.ts`: 5/5 tests passing (18 assertions).
- Biome format/check on `@elizaos/core`: 1292 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - core paths helper; no rendered UI changed.
- [x] N/A - core paths helper; no rendered UI changed.
- [x] N/A - deterministic path resolution tests.
- [x] Focused test suite transcript:
```text
✓ paths > resolves default directories relative to state dir and workspace [1.66ms]
✓ paths > honors and trims ELIZA_DATA_DIR override [0.08ms]
✓ paths > honors ELIZA_DATABASE_DIR and fallback PGLITE_DATA_DIR [0.09ms]
✓ paths > treats empty or whitespace-only env overrides as unset [0.17ms]
✓ paths > returns all paths in getAllElizaPaths [0.18ms]
5 pass, 0 fail, 18 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza"} -->
