### PR TITLE
fix(shared): guard non-string inputs in quoteIdent and sqlLiteral and add unit test suite

### DIFF
--- a/packages/shared/src/utils/sql-compat.test.ts
+++ b/packages/shared/src/utils/sql-compat.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for SQL compatibility utilities in packages/shared/src/utils/sql-compat.ts.
+ * Exercises SQL identifier quoting, double-quote escaping, identifier sanitization,
+ * length bounds (128 chars), SQL string literal quoting/escaping, and non-string inputs.
+ */
+import { describe, expect, it } from "vitest";
+import { quoteIdent, sanitizeIdentifier, sqlLiteral } from "./sql-compat.js";
+
+describe("quoteIdent", () => {
+  it("quotes standard SQL identifiers with double quotes", () => {
+    expect(quoteIdent("users")).toBe('"users"');
+    expect(quoteIdent("created_at")).toBe('"created_at"');
+  });
+
+  it("escapes embedded double quotes by doubling them", () => {
+    expect(quoteIdent('user"table')).toBe('"user""table"');
+    expect(quoteIdent('a"b"c')).toBe('"a""b""c"');
+  });
+
+  it("safely handles null, undefined, or non-string inputs", () => {
+    expect(quoteIdent(null)).toBe('""');
+    expect(quoteIdent(undefined)).toBe('""');
+    expect(quoteIdent(123 as unknown as string)).toBe('""');
+  });
+});
+
+describe("sanitizeIdentifier", () => {
+  it("preserves alphanumeric and underscore characters", () => {
+    expect(sanitizeIdentifier("valid_table_123")).toBe("valid_table_123");
+    expect(sanitizeIdentifier("CamelCase_Name")).toBe("CamelCase_Name");
+  });
+
+  it("strips invalid characters and trims whitespace", () => {
+    expect(sanitizeIdentifier("  user-table.name;  ")).toBe("usertablename");
+    expect(sanitizeIdentifier('col"name$')).toBe("colname");
+  });
+
+  it("returns null when empty or stripped to empty", () => {
+    expect(sanitizeIdentifier("")).toBeNull();
+    expect(sanitizeIdentifier("   ")).toBeNull();
+    expect(sanitizeIdentifier("---;;;")).toBeNull();
+  });
+
+  it("returns null when exceeding 128 characters", () => {
+    const valid128 = "a".repeat(128);
+    expect(sanitizeIdentifier(valid128)).toBe(valid128);
+
+    const invalid129 = "a".repeat(129);
+    expect(sanitizeIdentifier(invalid129)).toBeNull();
+  });
+
+  it("returns null for non-string inputs", () => {
+    expect(sanitizeIdentifier(null)).toBeNull();
+    expect(sanitizeIdentifier(undefined)).toBeNull();
+    expect(sanitizeIdentifier(456 as unknown as string)).toBeNull();
+  });
+});
+
+describe("sqlLiteral", () => {
+  it("wraps strings in single quotes", () => {
+    expect(sqlLiteral("hello world")).toBe("'hello world'");
+  });
+
+  it("escapes embedded single quotes by doubling them", () => {
+    expect(sqlLiteral("it's a test")).toBe("'it''s a test'");
+    expect(sqlLiteral("O'Connor's")).toBe("'O''Connor''s'");
+  });
+
+  it("safely handles null, undefined, or non-string inputs", () => {
+    expect(sqlLiteral(null)).toBe("''");
+    expect(sqlLiteral(undefined)).toBe("''");
+    expect(sqlLiteral(789 as unknown as string)).toBe("''");
+  });
+});

--- a/packages/shared/src/utils/sql-compat.ts
+++ b/packages/shared/src/utils/sql-compat.ts
@@ -8,7 +8,8 @@ import type { AgentRuntime } from "@elizaos/core";
 const repairedRuntimes = new WeakSet<AgentRuntime>();
 const repairPromises = new WeakMap<AgentRuntime, Promise<void>>();
 
-export function quoteIdent(name: string): string {
+export function quoteIdent(name: string | null | undefined): string {
+  if (typeof name !== "string") return '""';
   return `"${name.replace(/"/g, '""')}"`;
 }
 
@@ -23,7 +24,8 @@ export function sanitizeIdentifier(
   return sanitized;
 }
 
-export function sqlLiteral(value: string): string {
+export function sqlLiteral(value: string | null | undefined): string {
+  if (typeof value !== "string") return "''";
   return `'${value.replace(/'/g, "''")}'`;
 }
 


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/sql-compat.ts`, `quoteIdent` and `sqlLiteral` called `.replace()` directly without validating `typeof === "string"`. When called with `null`, `undefined`, or non-string values, they threw an unhandled `TypeError: Cannot read properties of undefined (reading 'replace')`.
2. Added `typeof === "string"` guards to `quoteIdent` (returning `""`) and `sqlLiteral` (returning `''`).
3. Created a comprehensive unit test suite in `packages/shared/src/utils/sql-compat.test.ts` covering `quoteIdent`, `sanitizeIdentifier`, and `sqlLiteral` with normal, escaped, 128-char bound, and non-string inputs.

Closes #21215.

## Verification

Exact commit: `00ed9ea1b7`.

- Focused unit test suite `packages/shared/src/utils/sql-compat.test.ts`: 11/11 tests passing (25 assertions).
- Biome format on `@elizaos/shared`: 409 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - SQL compatibility helper; no rendered UI changed.
- [x] N/A - SQL compatibility helper; no rendered UI changed.
- [x] N/A - deterministic SQL formatting and quoting tests.
- [x] Focused test suite transcript:
```text
✓ quoteIdent > quotes standard SQL identifiers with double quotes [0.23ms]
✓ quoteIdent > escapes embedded double quotes by doubling them [0.03ms]
✓ quoteIdent > safely handles null, undefined, or non-string inputs [0.04ms]
✓ sanitizeIdentifier > preserves alphanumeric and underscore characters [0.11ms]
✓ sanitizeIdentifier > strips invalid characters and trims whitespace [0.03ms]
✓ sanitizeIdentifier > returns null when empty or stripped to empty [0.04ms]
✓ sanitizeIdentifier > returns null when exceeding 128 characters [0.04ms]
✓ sanitizeIdentifier > returns null for non-string inputs [0.03ms]
✓ sqlLiteral > wraps strings in single quotes [0.05ms]
✓ sqlLiteral > escapes embedded single quotes by doubling them [0.02ms]
✓ sqlLiteral > safely handles null, undefined, or non-string inputs [0.03ms]
11 pass, 0 fail, 25 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza"} -->
