### PR TITLE
fix(shared): trim model string in modelLooksLikeElizaCloudHosted and add unit test suite

### DIFF
--- a/packages/shared/src/utils/eliza-cloud-model-route.test.ts
+++ b/packages/shared/src/utils/eliza-cloud-model-route.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for modelLooksLikeElizaCloudHosted in packages/shared/src/utils/eliza-cloud-model-route.ts.
+ * Exercises Kimi, Moonshot, and Eliza Cloud model name matching, case-insensitivity,
+ * whitespace trimming, non-hosted model rejections, and nullish/non-string inputs.
+ */
+import { describe, expect, it } from "vitest";
+import { modelLooksLikeElizaCloudHosted } from "./eliza-cloud-model-route.js";
+
+describe("modelLooksLikeElizaCloudHosted", () => {
+  it("returns true for Kimi models", () => {
+    expect(modelLooksLikeElizaCloudHosted("kimi-k1.5")).toBe(true);
+    expect(modelLooksLikeElizaCloudHosted("Kimi-Chat-32k")).toBe(true);
+    expect(modelLooksLikeElizaCloudHosted("  kimi  ")).toBe(true);
+  });
+
+  it("returns true for Moonshot models", () => {
+    expect(modelLooksLikeElizaCloudHosted("moonshot-v1-8k")).toBe(true);
+    expect(modelLooksLikeElizaCloudHosted("MOONSHOT-v1-128k")).toBe(true);
+  });
+
+  it("returns true for models containing both eliza and cloud", () => {
+    expect(modelLooksLikeElizaCloudHosted("eliza-cloud-deepseek-r1")).toBe(
+      true,
+    );
+    expect(modelLooksLikeElizaCloudHosted("ElizaCloud/llama-3.3-70b")).toBe(
+      true,
+    );
+  });
+
+  it("returns false for models containing only eliza or only cloud", () => {
+    expect(modelLooksLikeElizaCloudHosted("eliza-local-v1")).toBe(false);
+    expect(modelLooksLikeElizaCloudHosted("google-cloud-vertex")).toBe(false);
+  });
+
+  it("returns false for non-hosted external models", () => {
+    expect(modelLooksLikeElizaCloudHosted("gpt-4o")).toBe(false);
+    expect(modelLooksLikeElizaCloudHosted("claude-3-5-sonnet")).toBe(false);
+    expect(modelLooksLikeElizaCloudHosted("gemini-2.0-flash")).toBe(false);
+  });
+
+  it("returns false for empty, null, undefined, or non-string inputs", () => {
+    expect(modelLooksLikeElizaCloudHosted("")).toBe(false);
+    expect(modelLooksLikeElizaCloudHosted("   ")).toBe(false);
+    expect(modelLooksLikeElizaCloudHosted(null)).toBe(false);
+    expect(modelLooksLikeElizaCloudHosted(undefined)).toBe(false);
+    expect(modelLooksLikeElizaCloudHosted(123 as unknown as string)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/shared/src/utils/eliza-cloud-model-route.ts
+++ b/packages/shared/src/utils/eliza-cloud-model-route.ts
@@ -1,9 +1,10 @@
 /** Heuristic: SSE `estimatedUsage.model` for Eliza Cloud–hosted Kimi / moonshot routes. */
 export function modelLooksLikeElizaCloudHosted(
-  model: string | undefined,
+  model: string | null | undefined,
 ): boolean {
   if (!model || typeof model !== "string") return false;
-  const m = model.toLowerCase();
+  const m = model.trim().toLowerCase();
+  if (!m) return false;
   return (
     m.includes("kimi") ||
     m.includes("moonshot") ||


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/eliza-cloud-model-route.ts`, `modelLooksLikeElizaCloudHosted` checked model strings without `.trim()`.
2. Widened parameter type to `string | null | undefined` and added `.trim()` check.
3. Created a dedicated unit test suite in `packages/shared/src/utils/eliza-cloud-model-route.test.ts`.

Closes #21218.

## Verification

Exact commit: `af9777f8d6`.

- Focused unit test suite `packages/shared/src/utils/eliza-cloud-model-route.test.ts`: 6/6 tests passing (17 assertions).
- Biome format on `@elizaos/shared`: 409 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - cloud model route classifier; no rendered UI changed.
- [x] N/A - cloud model route classifier; no rendered UI changed.
- [x] N/A - deterministic cloud model route classification tests.
- [x] Focused test suite transcript:
```text
✓ modelLooksLikeElizaCloudHosted > returns true for Kimi models [0.15ms]
✓ modelLooksLikeElizaCloudHosted > returns true for Moonshot models [0.04ms]
✓ modelLooksLikeElizaCloudHosted > returns true for models containing both eliza and cloud [0.03ms]
✓ modelLooksLikeElizaCloudHosted > returns false for models containing only eliza or only cloud [0.04ms]
✓ modelLooksLikeElizaCloudHosted > returns false for non-hosted external models [0.03ms]
✓ modelLooksLikeElizaCloudHosted > returns false for empty, null, undefined, or non-string inputs [0.05ms]
6 pass, 0 fail, 17 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza"} -->
