### PR TITLE
fix(cloud): group-o e2e reuses the fixture org past the cutover delete guard

### DIFF
--- a/packages/cloud/api/test/e2e/group-o-console-pageload.test.ts
+++ b/packages/cloud/api/test/e2e/group-o-console-pageload.test.ts
@@ -81,15 +81,25 @@ async function seedSavedAgentInteraction(input: {
   userId: string;
 }): Promise<{ characterId: string }> {
   const suffix = crypto.randomUUID().slice(0, 8);
-  const anonOrgId = crypto.randomUUID();
   const anonUserId = crypto.randomUUID();
   const characterId = crypto.randomUUID();
 
   await withDb(async (client) => {
-    await client.query(
-      `INSERT INTO organizations (id, name, slug) VALUES ($1, $2, $3)`,
-      [anonOrgId, `E2E Saved Org ${suffix}`, `e2e-saved-org-${suffix}`],
+    // Reuse the persistent E2E fixture organization instead of minting one:
+    // the auto-top-up cutover guard (migration 0217) blocks ANY organizations
+    // DELETE while the control singleton is sealed, so a mint-and-delete org
+    // fails the whole suite in afterAll (same conversion as group-c,
+    // fe0822873b).
+    const fixtureOrganization = await client.query(
+      `SELECT id FROM organizations WHERE slug = $1`,
+      ["playwright-e2e-affiliate-org"],
     );
+    const anonOrgId: string | undefined = fixtureOrganization.rows[0]?.id;
+    if (!anonOrgId) {
+      throw new Error(
+        "Persistent E2E fixture organization playwright-e2e-affiliate-org is missing; run the e2e seed bootstrap",
+      );
+    }
     await client.query(
       `INSERT INTO users (id, email, steward_user_id, is_anonymous, organization_id)
        VALUES ($1, $2, $3, true, $4)`,
@@ -144,7 +154,10 @@ async function seedSavedAgentInteraction(input: {
 
   cleanup.push({ table: "agents", id: characterId });
   cleanup.push({ table: "user_characters", id: characterId });
-  cleanup.push({ table: "organizations", id: anonOrgId });
+  // Last: the seeded fixture-org user (after its user_characters row is gone).
+  // The fixture org keeps a permanent resident, so the last-user vacate guard
+  // never fires (same pattern as group-c).
+  cleanup.push({ table: "users", id: anonUserId });
   return { characterId };
 }
 


### PR DESCRIPTION
Unblocks the staging deploy train. Since #20879 (migration 0217, "seal auto-top-up behind durable cutover controls"), ANY `organizations` DELETE raises `auto_top_up_cutover_paused` while the control singleton is sealed — the intended production posture. Group-o's cleanup still minted and deleted its own org, so its `afterAll` dies on the guard ("(unnamed)" bun failure), the Worker-e2e deploy gate goes red, and every staging release since has failed at Deploy API Worker (runs 32019674306 et al.), pinning staging on the hours-old 78bd11ff build.

## What changed

The exact conversion group-c already received tonight (fe0822873b): `seedSavedAgentInteraction` reuses the persistent `playwright-e2e-affiliate-org` fixture instead of mint-and-delete, the org cleanup entry is gone, and the seeded fixture-org user is deleted LAST (after its user_characters row) — the fixture org keeps a permanent resident so the last-user vacate guard never fires, same as group-c's green pattern. Stan's guard itself is untouched: this is the e2e suite adapting to the sealed lifecycle, not a change to the payment cutover semantics.

@standujar FYI — group-o was the remaining mint-and-delete suite your #20879 seal exposed; if other groups still mint orgs they'll trip the same guard on their next run.

## Evidence

- CI receipt: run 32019674306 Deploy API Worker → Run Worker e2e → group-o 13/14 with the unnamed afterAll failure, PG error `constraint: auto_top_up_cutover_paused` from `guard_active_auto_top_up_organization_deletion()` line 8.
- cloud-api typecheck clean on the touched file; Biome clean. (Full e2e proof rides the next staging deploy run — the local harness needs the CI-injected Worker stack.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)