### PR TITLE
fix(skills): close symlink-escape sibling-prefix bypass in manifest scanner

### DIFF
--- a/plugins/plugin-agent-skills/src/security/manifest-scanner.test.ts
+++ b/plugins/plugin-agent-skills/src/security/manifest-scanner.test.ts
@@ -1,10 +1,19 @@
 /**
- * In-memory skill-manifest builder tests for the security scanner.
- * The manifest records byte lengths for text and binary payloads so integrity checks do not confuse character count with UTF-8 size.
+ * In-memory skill-manifest builder and symlink-escape classification tests for
+ * the security scanner. The builder cases prove byte lengths for text and
+ * binary payloads so integrity checks do not confuse character count with UTF-8
+ * size. The scanManifest cases pin the separator-aware boundary of the blocking
+ * `symlink-escape` rule so a sibling directory that shares a string prefix
+ * cannot masquerade as an internal (non-blocking) symlink. Deterministic; no
+ * disk, no mocks — scanManifest is pure over synthetic manifest entries.
  */
 
 import { describe, expect, it } from "vitest";
-import { buildManifestEntriesFromMemory } from "./manifest-scanner";
+import type { ManifestFileEntry } from "./manifest-scanner";
+import {
+  buildManifestEntriesFromMemory,
+  scanManifest,
+} from "./manifest-scanner";
 
 describe("buildManifestEntriesFromMemory", () => {
   it("returns an empty manifest for no files", () => {
@@ -37,5 +46,61 @@ describe("buildManifestEntriesFromMemory", () => {
   it("marks every entry as a non-symlink", () => {
     const files = new Map([["x", { content: "y", isText: true }]]);
     expect(buildManifestEntriesFromMemory(files).every((e) => e.isSymlink === false)).toBe(true);
+  });
+});
+
+describe("scanManifest symlink-escape boundary", () => {
+  const SKILL_DIR = "/base/skills/myskill";
+
+  function symlinkFinding(target: string, skillDir = SKILL_DIR) {
+    const entries: ManifestFileEntry[] = [
+      { relativePath: "SKILL.md", sizeBytes: 10, isSymlink: false },
+      { relativePath: "link", sizeBytes: 0, isSymlink: true, symlinkTarget: target },
+    ];
+    const finding = scanManifest(entries, skillDir).find((f) =>
+      f.ruleId.startsWith("symlink-"),
+    );
+    if (!finding) throw new Error("expected a symlink finding");
+    return finding;
+  }
+
+  it("blocks a sibling-prefix target that only shares a string prefix", () => {
+    // Regression for #21213: /base/skills/myskill-evil resolves OUTSIDE
+    // /base/skills/myskill despite the shared prefix and must not be treated
+    // as internal.
+    const finding = symlinkFinding("/base/skills/myskill-evil/secret.env");
+    expect(finding.ruleId).toBe("symlink-escape");
+    expect(finding.severity).toBe("critical");
+  });
+
+  it("blocks a target fully outside the skill directory", () => {
+    const finding = symlinkFinding("/etc/passwd");
+    expect(finding.ruleId).toBe("symlink-escape");
+    expect(finding.severity).toBe("critical");
+  });
+
+  it("treats a genuinely nested target as an internal warning", () => {
+    const finding = symlinkFinding("/base/skills/myskill/sub/x");
+    expect(finding.ruleId).toBe("symlink-internal");
+    expect(finding.severity).toBe("warn");
+  });
+
+  it("treats a target equal to the skill directory as internal", () => {
+    const finding = symlinkFinding("/base/skills/myskill");
+    expect(finding.ruleId).toBe("symlink-internal");
+    expect(finding.severity).toBe("warn");
+  });
+
+  it("classifies identically when the skill dir carries a trailing slash", () => {
+    expect(
+      symlinkFinding("/base/skills/myskill-evil/secret.env", "/base/skills/myskill/")
+        .ruleId,
+    ).toBe("symlink-escape");
+    expect(symlinkFinding("/etc/passwd", "/base/skills/myskill/").ruleId).toBe(
+      "symlink-escape",
+    );
+    expect(
+      symlinkFinding("/base/skills/myskill/sub/x", "/base/skills/myskill/").ruleId,
+    ).toBe("symlink-internal");
   });
 });

--- a/plugins/plugin-agent-skills/src/security/manifest-scanner.ts
+++ b/plugins/plugin-agent-skills/src/security/manifest-scanner.ts
@@ -57,6 +57,26 @@ function hasHiddenComponent(filePath: string): boolean {
 		.some((p) => p.startsWith(".") && !ALLOWED_DOTFILES.has(p));
 }
 
+/**
+ * Separator-aware containment test for the symlink-escape gate. A raw
+ * `target.startsWith(dir)` check would treat a sibling directory that merely
+ * shares a string prefix (e.g. `/base/skills/myskill-evil` for skill dir
+ * `/base/skills/myskill`) as internal, letting an escaping symlink bypass the
+ * blocking rule. Requiring an exact match or a trailing path separator closes
+ * that boundary. `symlinkTarget` is a realpath-resolved, absolute, canonical
+ * path, so only the skill dir needs its trailing separator stripped to accept
+ * dirs passed with or without a trailing slash.
+ */
+function isInsideDir(target: string, dir: string): boolean {
+	const normalizedDir = dir.replace(/[/\\]+$/, "");
+	if (normalizedDir === "") return true;
+	if (target === normalizedDir) return true;
+	return (
+		target.startsWith(`${normalizedDir}/`) ||
+		target.startsWith(`${normalizedDir}\\`)
+	);
+}
+
 export interface ManifestFileEntry {
 	relativePath: string;
 	sizeBytes: number;
@@ -90,7 +110,7 @@ export function scanManifest(
 		if (entry.isSymlink) {
 			if (
 				entry.symlinkTarget &&
-				!entry.symlinkTarget.startsWith(skillDirPath)
+				!isInsideDir(entry.symlinkTarget, skillDirPath)
 			) {
 				findings.push({
 					ruleId: "symlink-escape",


### PR DESCRIPTION
# Relates to

Closes #21213

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and focused package gates were run after sync; the repo-wide `bun run verify` blocker is recorded under **Known gaps** below.
- [x] A reviewer can confirm the change works without reading the code, from the before/after reproduction and failing-then-passing test evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@79949c086f4f8db894b901633ca5ef86ebb35560:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`88ac1800e6`); zero conflicts.
- [ ] `bun run verify` — not completed on this machine; see **Known gaps**. Focused package test, typecheck, and lint all pass.

# Risks

Low. The change tightens a security containment test in one pure function
(`scanManifest`). It makes the blocking `symlink-escape` rule fire in a case it
previously missed (sibling-prefix targets) and preserves the existing internal
(warn) classification for genuinely-nested symlinks. No public type or export
changes. Worst case is a symlink that was previously wrongly allowed is now
correctly blocked — the intended security behavior.

# Background

## What does this PR do?

Fixes a boundary bypass in the skill security scanner. The blocking
`symlink-escape` rule (one of three `BLOCKING_RULE_IDS` that force
`status:"blocked"` → delete skill + throw) decided whether a realpath-resolved
symlink target escaped the skill directory with a raw string prefix test:

```ts
!entry.symlinkTarget.startsWith(skillDirPath)
```

Because the check has no path-separator boundary, a symlink whose target is
**outside** the skill dir but shares a string prefix — e.g.
`/base/skills/myskill-evil/secret.env` when the skill dir is
`/base/skills/myskill` — was misclassified as the non-blocking
`symlink-internal` (warn). The escaping symlink survived the scan and the skill
installed instead of being blocked and deleted, defeating a control whose whole
purpose is to reject out-of-tree symlinks that `loadFile`/`readReference`/
`readScript` later follow via `readFileSync`.

The fix replaces the prefix test with a separator-aware `isInsideDir(target, dir)`
helper: a target is internal only when it equals the (trailing-separator
stripped) skill dir or begins with that dir plus a path separator. It stays a
pure string helper (no static `node:path` import) so the module remains
bundle-safe for the in-memory `scanSkillPackage` path.

## What kind of change is this?

Bug fix (non-breaking change which fixes a security-control bypass).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior of a
security rule is corrected to match its documented intent; no public API or docs
surface changes.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-skills/src/security/manifest-scanner.ts` (`isInsideDir` +
its single call site in `scanManifest`) and the new parametrized regression
suite in `plugins/plugin-agent-skills/src/security/manifest-scanner.test.ts`.

## Detailed testing steps

Automated tests are authoritative here — `scanManifest` is pure. The new
`scanManifest symlink-escape boundary` suite fails on `develop` and passes with
the fix. Reproduction and command output are inline below.

# Evidence Gate

<!-- evidence-head:896b2ecb115bc26ece41c9d84816fcc650e44c9d -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; change is a pure server-side security scanner function.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; change is a pure server-side security scanner function.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user flow; behavior is a pure function reproduced via tsx probe below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - scanManifest is pure and logs nothing; the tsx reproduction below is the equivalent real-path proof.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact — real `scanManifest` classification (before/after) and the failing-then-passing regression run, pasted below.

<details><summary>scanManifest classification output + regression run (real source)</summary>

```
skillDir = /base/skills/myskill   (manifest: SKILL.md + one symlink entry)

BEFORE (origin/develop, raw startsWith prefix test)
  true-outside (/etc/passwd):     ["symlink-escape"]
  sibling-prefix (myskill-evil):  ["symlink-internal"]   <- bug: escaping symlink allowed
  legit inside:                   ["symlink-internal"]
  exact dir:                      ["symlink-internal"]

AFTER (fix, separator-aware isInsideDir containment)
  true-outside (/etc/passwd):     ["symlink-escape"]
  sibling-prefix (myskill-evil):  ["symlink-escape"]     <- fixed: now blocked
  legit inside:                   ["symlink-internal"]
  exact dir:                      ["symlink-internal"]

Regression test on origin/develop (fix reverted):
  FAIL scanManifest symlink-escape boundary > blocks a sibling-prefix target
  AssertionError: expected 'symlink-internal' to be 'symlink-escape'
  Tests  1 failed | 8 passed (9)

Regression test with the fix applied:
  Tests  9 passed (9)

Full package suite with the fix applied:
  Test Files  17 passed (17)
  Tests  83 passed (83)
```

</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - `scanManifest` is a pure function that emits no logs. The real-source
reproduction (below) runs the actual scanner via `tsx` and is the equivalent
end-to-end proof of the code path.

### Reproduction (real source, no mocks) — before vs after

Ran the real `scanManifest` export through `tsx` with a two-entry manifest
(a `SKILL.md` plus one symlink), for skill dir `/base/skills/myskill`:

```
=== BEFORE (develop) ===
true-outside (/etc/passwd):     ["symlink-escape"]
sibling-prefix (myskill-evil):  ["symlink-internal"]   <- BUG: escaping symlink not blocked
legit inside:                   ["symlink-internal"]
exact dir:                      ["symlink-internal"]

=== AFTER (fix) ===
true-outside (/etc/passwd):     ["symlink-escape"]
sibling-prefix (myskill-evil):  ["symlink-escape"]     <- FIXED: now blocked
legit inside:                   ["symlink-internal"]
exact dir:                      ["symlink-internal"]
```

The sibling-prefix case flips from `["symlink-internal"]` (warn, non-blocking)
to `["symlink-escape"]` (critical, blocking), matching the `/etc/passwd` case.
Genuinely-nested and exact-dir targets remain `symlink-internal`.

### New regression test: fails on develop, passes with fix

Failing on `develop` (fix stashed):

```
 FAIL  src/security/manifest-scanner.test.ts > scanManifest symlink-escape boundary > blocks a sibling-prefix target that only shares a string prefix
AssertionError: expected 'symlink-internal' to be 'symlink-escape'
Expected: "symlink-escape"
 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)
```

Passing with the fix + full package suite green:

```
 RUN  v4.1.5 plugins/plugin-agent-skills
 Test Files  1 passed (1)
      Tests  9 passed (9)      # manifest-scanner.test.ts

$ bun run --cwd plugins/plugin-agent-skills test
 Test Files  17 passed (17)
      Tests  83 passed (83)
```

Typecheck and lint (focused package):

```
$ bun run --cwd plugins/plugin-agent-skills typecheck   # tsc --noEmit -> clean
$ bun run --cwd plugins/plugin-agent-skills lint        # biome check -> Checked 54 files, no fixes applied
```

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice/audio change.

## Known gaps / failures

- Repo-wide `bun run verify` was not run to completion on this Raspberry Pi
  environment (memory/time-bounded; it fans out builds across every workspace).
  Instead the owning package's `test`, `typecheck`, and `lint` were run and are
  green, plus the real-source `tsx` reproduction above. `bun install` succeeded.
- All evidence rows marked `N/A` are genuinely inapplicable: the change is a
  pure server-side function with no UI, no logs, no agent/model interaction.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@79949c086f4f8db894b901633ca5ef86ebb35560:packages/skills/skills/contribute-to-eliza"} -->
