### PR TITLE
fix(shared): guard missing type and name properties in isDocumentImageFile and add unit test suite

### DIFF
--- a/packages/shared/src/utils/documents-upload-image.test.ts
+++ b/packages/shared/src/utils/documents-upload-image.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for documents upload image helpers in packages/shared/src/utils/documents-upload-image.ts.
+ * Exercises MIME type detection, extension fallbacks, size threshold skips,
+ * MAX_DOCUMENT_IMAGE_PROCESSING_BYTES export, and non-object inputs.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  MAX_DOCUMENT_IMAGE_PROCESSING_BYTES,
+  isDocumentImageFile,
+  maybeCompressDocumentUploadImage,
+} from "./documents-upload-image.js";
+
+describe("isDocumentImageFile", () => {
+  it("identifies image files by MIME type", () => {
+    expect(isDocumentImageFile({ name: "file", type: "image/png" })).toBe(true);
+    expect(isDocumentImageFile({ name: "doc", type: "image/jpeg" })).toBe(true);
+    expect(isDocumentImageFile({ name: "photo", type: "image/webp" })).toBe(
+      true,
+    );
+    expect(isDocumentImageFile({ name: "anim", type: "image/gif" })).toBe(true);
+  });
+
+  it("identifies image files by extension when MIME type is absent or generic", () => {
+    expect(isDocumentImageFile({ name: "photo.jpg", type: "" })).toBe(true);
+    expect(
+      isDocumentImageFile({
+        name: "photo.JPEG",
+        type: "application/octet-stream",
+      }),
+    ).toBe(true);
+    expect(isDocumentImageFile({ name: "image.png", type: "" })).toBe(true);
+    expect(isDocumentImageFile({ name: "graphic.webp", type: "" })).toBe(true);
+    expect(isDocumentImageFile({ name: "clip.gif", type: "" })).toBe(true);
+  });
+
+  it("returns false for non-image files", () => {
+    expect(
+      isDocumentImageFile({ name: "document.pdf", type: "application/pdf" }),
+    ).toBe(false);
+    expect(isDocumentImageFile({ name: "notes.txt", type: "text/plain" })).toBe(
+      false,
+    );
+    expect(
+      isDocumentImageFile({ name: "data.json", type: "application/json" }),
+    ).toBe(false);
+  });
+
+  it("safely handles null, undefined, and non-object inputs", () => {
+    expect(isDocumentImageFile(null)).toBe(false);
+    expect(isDocumentImageFile(undefined)).toBe(false);
+    expect(isDocumentImageFile(123 as unknown as undefined)).toBe(false);
+    expect(isDocumentImageFile({} as unknown as undefined)).toBe(false);
+  });
+});
+
+describe("MAX_DOCUMENT_IMAGE_PROCESSING_BYTES", () => {
+  it("exports the 5MB threshold", () => {
+    expect(MAX_DOCUMENT_IMAGE_PROCESSING_BYTES).toBe(5 * 1024 * 1024);
+  });
+});
+
+describe("maybeCompressDocumentUploadImage", () => {
+  it("skips non-image files without attempting compression", async () => {
+    const mockFile = {
+      name: "doc.pdf",
+      type: "application/pdf",
+      size: 10 * 1024 * 1024,
+    } as unknown as File;
+
+    const result = await maybeCompressDocumentUploadImage(mockFile);
+    expect(result.optimized).toBe(false);
+    expect(result.file).toBe(mockFile);
+  });
+
+  it("skips images within size threshold", async () => {
+    const mockFile = {
+      name: "photo.jpg",
+      type: "image/jpeg",
+      size: 2 * 1024 * 1024,
+    } as unknown as File;
+
+    const result = await maybeCompressDocumentUploadImage(mockFile);
+    expect(result.optimized).toBe(false);
+    expect(result.file).toBe(mockFile);
+  });
+});

--- a/packages/shared/src/utils/documents-upload-image.ts
+++ b/packages/shared/src/utils/documents-upload-image.ts
@@ -128,11 +128,17 @@ function cloneUploadFile(
 }
 
 export function isDocumentImageFile(
-  file: Pick<File, "name" | "type">,
+  file: Pick<File, "name" | "type"> | null | undefined,
 ): boolean {
-  if (file.type.startsWith("image/")) return true;
-  const lowerName = file.name.toLowerCase();
-  return IMAGE_EXTENSIONS.some((extension) => lowerName.endsWith(extension));
+  if (!file || typeof file !== "object") return false;
+  if (typeof file.type === "string" && file.type.startsWith("image/")) {
+    return true;
+  }
+  if (typeof file.name === "string") {
+    const lowerName = file.name.toLowerCase();
+    return IMAGE_EXTENSIONS.some((extension) => lowerName.endsWith(extension));
+  }
+  return false;
 }
 
 export async function maybeCompressDocumentUploadImage(


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/documents-upload-image.ts`, `isDocumentImageFile` called `file.type.startsWith("image/")` directly. When passed file objects where `type` was undefined/non-string or when called with nullish inputs, it threw an unhandled `TypeError: Cannot read properties of undefined (reading 'startsWith')`.
2. Added safe type guards for `file`, `file.type`, and `file.name`.
3. Created a dedicated unit test suite in `packages/shared/src/utils/documents-upload-image.test.ts`.

Closes #21223.

## Verification

Exact commit: `6193f9c849`.

- Focused unit test suite `packages/shared/src/utils/documents-upload-image.test.ts`: 7/7 tests passing (21 assertions).
- Biome format on `@elizaos/shared`: 409 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - document upload image helper; no rendered UI changed.
- [x] N/A - document upload image helper; no rendered UI changed.
- [x] N/A - deterministic document upload image tests.
- [x] Focused test suite transcript:
```text
✓ isDocumentImageFile > identifies image files by MIME type [0.16ms]
✓ isDocumentImageFile > identifies image files by extension when MIME type is absent or generic [0.20ms]
✓ isDocumentImageFile > returns false for non-image files [0.04ms]
✓ isDocumentImageFile > safely handles null, undefined, and non-object inputs [0.05ms]
✓ MAX_DOCUMENT_IMAGE_PROCESSING_BYTES > exports the 5MB threshold [0.01ms]
✓ maybeCompressDocumentUploadImage > skips non-image files without attempting compression [0.82ms]
✓ maybeCompressDocumentUploadImage > skips images within size threshold [0.23ms]
7 pass, 0 fail, 21 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza"} -->
