### PR TITLE
fix(core): reject empty strings and non-finite values in getNumberEnv and add unit test suite

### DIFF
--- a/packages/core/src/utils/environment.test.ts
+++ b/packages/core/src/utils/environment.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Deterministic tests for environment detection, typed getters, and cache management.
+ * Each test restores only the environment keys it owns so concurrent suites retain
+ * the process environment object and unrelated values.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	detectEnvironment,
+	getBooleanEnv,
+	getEnv,
+	getEnvironment,
+	getNumberEnv,
+	hasEnv,
+	setEnv,
+} from "./environment.js";
+
+describe("environment utils", () => {
+	const testKeys = [
+		"TEST_CORE_ENV_VAR",
+		"TEST_CORE_BOOL_VAR",
+		"TEST_CORE_NUM_VAR",
+	] as const;
+	const originalValues = new Map(
+		testKeys.map((key) => [key, process.env[key]] as const),
+	);
+
+	beforeEach(() => {
+		getEnvironment().clearCache();
+		for (const key of testKeys) delete process.env[key];
+	});
+
+	afterEach(() => {
+		getEnvironment().clearCache();
+		for (const key of testKeys) {
+			const value = originalValues.get(key);
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	it("detects Node environment", () => {
+		expect(detectEnvironment()).toBe("node");
+		expect(getEnvironment().isNode()).toBe(true);
+		expect(getEnvironment().isBrowser()).toBe(false);
+	});
+
+	it("gets, sets, and checks environment variables", () => {
+		expect(hasEnv("TEST_CORE_ENV_VAR")).toBe(false);
+		expect(getEnv("TEST_CORE_ENV_VAR")).toBeUndefined();
+		expect(getEnv("TEST_CORE_ENV_VAR", "default_val")).toBe("default_val");
+
+		setEnv("TEST_CORE_ENV_VAR", "active_val");
+		expect(hasEnv("TEST_CORE_ENV_VAR")).toBe(true);
+		expect(getEnv("TEST_CORE_ENV_VAR")).toBe("active_val");
+	});
+
+	it("parses boolean environment variables", () => {
+		setEnv("TEST_CORE_BOOL_VAR", "true");
+		expect(getBooleanEnv("TEST_CORE_BOOL_VAR")).toBe(true);
+
+		setEnv("TEST_CORE_BOOL_VAR", "1");
+		expect(getBooleanEnv("TEST_CORE_BOOL_VAR")).toBe(true);
+
+		setEnv("TEST_CORE_BOOL_VAR", "false");
+		expect(getBooleanEnv("TEST_CORE_BOOL_VAR")).toBe(false);
+
+		setEnv("TEST_CORE_BOOL_VAR", "0");
+		expect(getBooleanEnv("TEST_CORE_BOOL_VAR")).toBe(false);
+
+		delete process.env.TEST_CORE_BOOL_VAR;
+		getEnvironment().clearCache();
+		expect(getBooleanEnv("TEST_CORE_BOOL_VAR", true)).toBe(true);
+		expect(getBooleanEnv("TEST_CORE_BOOL_VAR", false)).toBe(false);
+	});
+
+	it("parses number environment variables and rejects empty/non-finite values", () => {
+		setEnv("TEST_CORE_NUM_VAR", "4000");
+		expect(getNumberEnv("TEST_CORE_NUM_VAR")).toBe(4000);
+
+		setEnv("TEST_CORE_NUM_VAR", "  3.14  ");
+		expect(getNumberEnv("TEST_CORE_NUM_VAR")).toBe(3.14);
+
+		setEnv("TEST_CORE_NUM_VAR", "-50");
+		expect(getNumberEnv("TEST_CORE_NUM_VAR")).toBe(-50);
+
+		setEnv("TEST_CORE_NUM_VAR", "");
+		expect(getNumberEnv("TEST_CORE_NUM_VAR", 8080)).toBe(8080);
+
+		setEnv("TEST_CORE_NUM_VAR", "   ");
+		expect(getNumberEnv("TEST_CORE_NUM_VAR", 8080)).toBe(8080);
+
+		setEnv("TEST_CORE_NUM_VAR", "not_a_number");
+		expect(getNumberEnv("TEST_CORE_NUM_VAR", 8080)).toBe(8080);
+
+		setEnv("TEST_CORE_NUM_VAR", "Infinity");
+		expect(getNumberEnv("TEST_CORE_NUM_VAR", 8080)).toBe(8080);
+
+		setEnv("TEST_CORE_NUM_VAR", "-Infinity");
+		expect(getNumberEnv("TEST_CORE_NUM_VAR", 8080)).toBe(8080);
+	});
+});

--- a/packages/core/src/utils/environment.ts
+++ b/packages/core/src/utils/environment.ts
@@ -198,8 +198,12 @@ class Environment {
 		if (value === undefined) {
 			return defaultValue;
 		}
-		const parsed = Number(value);
-		return Number.isNaN(parsed) ? defaultValue : parsed;
+		const trimmed = value.trim();
+		if (!trimmed) {
+			return defaultValue;
+		}
+		const parsed = Number(trimmed);
+		return !Number.isFinite(parsed) ? defaultValue : parsed;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/environment.ts`, `getNumber` / `getNumberEnv` called `Number(value)` and checked `Number.isNaN`. In JavaScript, `Number("")` and `Number("   ")` coerce to `0` (which is not NaN), causing empty/whitespace-only environment variables to evaluate to `0` instead of falling back to `defaultValue`. Furthermore, `Number("Infinity")` was not guarded.
2. Added `.trim()` and empty checks, and validated parsed numbers using `Number.isFinite(parsed)`.
3. Created a dedicated unit test suite in `packages/core/src/utils/environment.test.ts` testing string, boolean, and number getters, cache management, and environment detection.

Closes #21227.

## Verification

Exact commit: `f93f30287f`.

- Focused unit test suite `packages/core/src/utils/environment.test.ts`: 4/4 tests passing (22 assertions).
- Biome format on `@elizaos/core`: 1292 files formatted, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - core environment variable abstraction; no rendered UI changed.
- [x] N/A - core environment variable abstraction; no rendered UI changed.
- [x] N/A - deterministic environment variable parsing tests.
- [x] Focused test suite transcript:
```text
✓ environment utils > detects Node environment [1.68ms]
✓ environment utils > gets, sets, and checks environment variables [0.29ms]
✓ environment utils > parses boolean environment variables [0.28ms]
✓ environment utils > parses number environment variables and rejects empty/non-finite values [1.08ms]
4 pass, 0 fail, 22 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza"} -->
