### PR TITLE
fix(shared): guard non-function arguments in createSerialise and add unit test suite

### DIFF
--- a/packages/shared/src/utils/serialise.test.ts
+++ b/packages/shared/src/utils/serialise.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for createSerialise in packages/shared/src/utils/serialise.ts.
+ * Exercises sequential task execution, concurrency gating, failure recovery,
+ * synchronous exceptions, and non-function argument rejection.
+ */
+import { describe, expect, it } from "vitest";
+import { createSerialise } from "./serialise.js";
+
+describe("createSerialise", () => {
+  it("executes concurrent tasks strictly in order", async () => {
+    const run = createSerialise();
+    const executionOrder: number[] = [];
+
+    const task1 = run(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      executionOrder.push(1);
+      return "one";
+    });
+
+    const task2 = run(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      executionOrder.push(2);
+      return "two";
+    });
+
+    const task3 = run(async () => {
+      executionOrder.push(3);
+      return "three";
+    });
+
+    const results = await Promise.all([task1, task2, task3]);
+
+    expect(results).toEqual(["one", "two", "three"]);
+    expect(executionOrder).toEqual([1, 2, 3]);
+  });
+
+  it("continues processing subsequent tasks when a task fails", async () => {
+    const run = createSerialise();
+    const order: string[] = [];
+
+    const task1 = run(async () => {
+      order.push("task1-fail");
+      throw new Error("Task 1 error");
+    });
+
+    const task2 = run(async () => {
+      order.push("task2-success");
+      return "recovered";
+    });
+
+    await expect(task1).rejects.toThrow("Task 1 error");
+    const result2 = await task2;
+
+    expect(result2).toBe("recovered");
+    expect(order).toEqual(["task1-fail", "task2-success"]);
+  });
+
+  it("handles tasks that throw synchronously inside callback", async () => {
+    const run = createSerialise();
+
+    const task1 = run((() => {
+      throw new Error("sync throw");
+    }) as unknown as () => Promise<void>);
+
+    const task2 = run(async () => "after-sync-throw");
+
+    await expect(task1).rejects.toThrow("sync throw");
+    expect(await task2).toBe("after-sync-throw");
+  });
+
+  it("rejects non-function arguments with TypeError", async () => {
+    const run = createSerialise();
+
+    await expect(run(null as unknown as () => Promise<void>)).rejects.toThrow(
+      "Expected function for serialised execution",
+    );
+    await expect(
+      run(undefined as unknown as () => Promise<void>),
+    ).rejects.toThrow("Expected function for serialised execution");
+    await expect(
+      run("not-a-func" as unknown as () => Promise<void>),
+    ).rejects.toThrow("Expected function for serialised execution");
+  });
+});

--- a/packages/shared/src/utils/serialise.ts
+++ b/packages/shared/src/utils/serialise.ts
@@ -11,6 +11,11 @@
 export function createSerialise(): <T>(fn: () => Promise<T>) => Promise<T> {
   let lock: Promise<void> = Promise.resolve();
   return <T>(fn: () => Promise<T>): Promise<T> => {
+    if (typeof fn !== "function") {
+      return Promise.reject(
+        new TypeError("Expected function for serialised execution"),
+      );
+    }
     const prev = lock;
     let resolve: () => void;
     lock = new Promise<void>((r) => {


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/serialise.ts`, `createSerialise` accepted tasks without validating `typeof fn === "function"`.
2. Added `typeof fn !== "function"` check returning `Promise.reject(new TypeError("Expected function for serialised execution"))`.
3. Created a dedicated unit test suite in `packages/shared/src/utils/serialise.test.ts` covering sequential task ordering, failure recovery, synchronous errors, and input guards.

Closes #21232.

## Verification

Exact commit: `ae2e20724a`.

- Focused unit test suite `packages/shared/src/utils/serialise.test.ts`: 4/4 tests passing (10 assertions).
- Biome format on `@elizaos/shared`: 409 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - promise serialization helper; no rendered UI changed.
- [x] N/A - promise serialization helper; no rendered UI changed.
- [x] N/A - deterministic promise serialization queue tests.
- [x] Focused test suite transcript:
```text
✓ createSerialise > executes concurrent tasks strictly in order [26.66ms]
✓ createSerialise > continues processing subsequent tasks when a task fails [0.34ms]
✓ createSerialise > handles tasks that throw synchronously inside callback [0.20ms]
✓ createSerialise > rejects non-function arguments with TypeError [0.16ms]
4 pass, 0 fail, 10 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza"} -->
