### PR TITLE
fix(plugin-local-inference): reject unknown voice-models force flag

### DIFF
--- a/plugins/plugin-local-inference/src/routes/voice-models-force.test.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-models-force.test.ts
@@ -1,0 +1,160 @@
+/**
+ * GET /api/local-inference/voice-models/check `force` is updater-walk
+ * identity, leftover tax after voice-profiles includeOwner (#21202).
+ * Stock develop treated every non-exact `1` token as a cached check, so
+ * `force=true` skipped the forced walk instead of a 400. pin /
+ * preferences / update parsers stay untouched.
+ */
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type * as http from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	handleVoiceModelsRoutes,
+	setVoiceModelsBundleVersionForTest,
+	setVoiceModelsUpdater,
+} from "./voice-models-routes";
+import type { VoiceModelStatus } from "../services/voice-model-updater";
+import { VoiceModelUpdater } from "../services/voice-model-updater";
+
+let tmpRoot: string;
+let prevStateDir: string | undefined;
+
+function makeReq(url: string): http.IncomingMessage {
+	const emitter = new EventEmitter();
+	(emitter as unknown as { method: string }).method = "GET";
+	(emitter as unknown as { url: string }).url = url;
+	(emitter as unknown as { headers: Record<string, string> }).headers = {};
+	(emitter as unknown as { socket: unknown }).socket = {
+		remoteAddress: "127.0.0.1",
+	};
+	return emitter as unknown as http.IncomingMessage;
+}
+
+interface CapturedResponse {
+	statusCode: number;
+	body: string;
+}
+
+function makeRes(): {
+	res: http.ServerResponse;
+	captured: CapturedResponse;
+} {
+	const captured: CapturedResponse = { statusCode: 200, body: "" };
+	const chunks: Buffer[] = [];
+	const res = {
+		statusCode: 200,
+		headersSent: false,
+		setHeader() {},
+		writeHead(code: number) {
+			captured.statusCode = code;
+		},
+		write(chunk: Buffer | string) {
+			chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+			return true;
+		},
+		end(chunk?: Buffer | string) {
+			if (chunk != null) {
+				chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+			}
+			captured.body = Buffer.concat(chunks).toString("utf8");
+			captured.statusCode = (res as unknown as { statusCode: number })
+				.statusCode;
+		},
+	};
+	return {
+		res: res as unknown as http.ServerResponse,
+		captured,
+	};
+}
+
+async function readJson(captured: CapturedResponse): Promise<unknown> {
+	await new Promise((r) => setTimeout(r, 0));
+	return JSON.parse(captured.body);
+}
+
+class CapturingUpdater {
+	readonly calls: Array<{ force?: boolean }> = [];
+	async check(
+		_install: unknown,
+		_pins: unknown,
+		options?: { force?: boolean },
+	): Promise<ReadonlyArray<VoiceModelStatus>> {
+		this.calls.push({ force: options?.force });
+		return [];
+	}
+}
+
+let updater: CapturingUpdater;
+
+beforeEach(() => {
+	tmpRoot = mkdtempSync(path.join(tmpdir(), "voice-models-force-"));
+	prevStateDir = process.env.ELIZA_STATE_DIR;
+	process.env.ELIZA_STATE_DIR = tmpRoot;
+	setVoiceModelsBundleVersionForTest("1.0.0");
+	updater = new CapturingUpdater();
+	setVoiceModelsUpdater(updater as unknown as VoiceModelUpdater);
+});
+
+afterEach(() => {
+	setVoiceModelsUpdater(null);
+	setVoiceModelsBundleVersionForTest(null);
+	if (prevStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+	else process.env.ELIZA_STATE_DIR = prevStateDir;
+	rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+async function call(pathname: string) {
+	const { res, captured } = makeRes();
+	const handled = await handleVoiceModelsRoutes(makeReq(pathname), res);
+	expect(handled).toBe(true);
+	return { status: captured.statusCode, body: await readJson(captured) };
+}
+
+describe("GET /api/local-inference/voice-models/check force identity", () => {
+	it.each([
+		"/api/local-inference/voice-models/check",
+		"/api/local-inference/voice-models/check?force=",
+	])("accepts %s as a cached updater walk", async (pathname) => {
+		const result = await call(pathname);
+		expect(result.status).toBe(200);
+		expect(result.body).toMatchObject({ statuses: [] });
+		expect(updater.calls).toEqual([{ force: false }]);
+	});
+
+	it("accepts force=1 as a forced updater walk", async () => {
+		const result = await call(
+			"/api/local-inference/voice-models/check?force=1",
+		);
+		expect(result.status).toBe(200);
+		expect(result.body).toMatchObject({ statuses: [] });
+		expect(updater.calls).toEqual([{ force: true }]);
+	});
+
+	it.each(["true", "TRUE", "yes", "foo", "0", "false", "1e2"])(
+		"rejects force=%s before updater.check",
+		async (token) => {
+			const result = await call(
+				`/api/local-inference/voice-models/check?force=${encodeURIComponent(token)}`,
+			);
+			expect(result.status).toBe(400);
+			expect(result.body).toMatchObject({
+				error: 'force must be specified at most once as "1".',
+			});
+			expect(updater.calls).toEqual([]);
+		},
+	);
+
+	it.each([
+		"/api/local-inference/voice-models/check?force=1&force=1",
+		"/api/local-inference/voice-models/check?force=1&force=0",
+		"/api/local-inference/voice-models/check?force=&force=1",
+		"/api/local-inference/voice-models/check?force=foo&force=1",
+	])("rejects duplicate force values in %s before updater.check", async (pathname) => {
+		const result = await call(pathname);
+		expect(result.status).toBe(400);
+		expect(updater.calls).toEqual([]);
+	});
+});

--- a/plugins/plugin-local-inference/src/routes/voice-models-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-models-routes.ts
@@ -485,6 +485,26 @@ export async function handleVoiceModelsRoutes(
 
 	// GET /api/local-inference/voice-models/check
 	if (method === "GET" && pathname === `${ROUTE_PREFIX}/check`) {
+		// Voice-models force-check identity, leftover tax after
+		// voice-profiles includeOwner (#21202). force=true used to
+		// silently skip a forced updater walk instead of a 400.
+		// pin / preferences / update parsers stay untouched.
+		const requestedForceValues = url.searchParams.getAll("force");
+		const requestedForce = requestedForceValues[0];
+		if (
+			requestedForceValues.length > 1 ||
+			(requestedForce != null &&
+				requestedForce !== "" &&
+				requestedForce !== "1")
+		) {
+			sendJsonError(
+				res,
+				'force must be specified at most once as "1".',
+				400,
+			);
+			return true;
+		}
+		const force = requestedForce === "1";
 		const [installed, pins] = await Promise.all([
 			resolveInstalledVersions(),
 			readPins(),
@@ -495,7 +515,7 @@ export async function handleVoiceModelsRoutes(
 			statuses = await updater.check(
 				{ installed, bundleVersion: resolveBundleVersion() },
 				{ pinned: pins },
-				{ force: url.searchParams.get("force") === "1" },
+				{ force },
 			);
 		} catch (err) {
 			logger.warn(


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
voice-models `force` identity. Local Voice Studio updater-walk class,
leftover tax after voice-profiles includeOwner (#21202). Not leftover
tax on includeOwner, includeInactive, catalogOnly/refresh, pin,
preferences, or update parsers.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `force` only on `/api/local-inference/voice-models/check`.
Omitted/empty still do a cached updater walk (today's default).
Exact `1` still forces a fresh walk.
Unknown / uppercase / `true` tokens 400 before `updater.check`.
pin / preferences / update parsers stay untouched.

# Background

## What does this PR do?

`GET /api/local-inference/voice-models/check` treated any non-exact `1`
token as a cached walk. `force=true` silently reused the last check
instead of a 400.

- omitted / empty → cached updater walk (200)
- exact `1` → forced updater walk
- `true` / `TRUE` / `0` / `false` / `yes` / `foo` / `1e2` → **400** before `updater.check`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers opt into a forced catalog walk with `?force=1`. A common
`force=true` after a client sends a boolean must not silently skip
that walk. This is leftover tax after voice-profiles includeOwner
(#21202), which left the voice-models force parser untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/src/routes/voice-models-force.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-local-inference && NODE_OPTIONS=--experimental-sqlite bunx vitest run src/routes/voice-models-force.test.ts __tests__/voice-models-routes.test.ts
```

14 new identity tests + 16 existing voice-models route tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; voice-models `force` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; voice-models `force` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; voice-models `force` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real force tokens and assert 400 before updater.check; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before the updater walk.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
`force` tokens reject; omitted/canonical still bind the matching
cached-or-forced updater path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the local updater
check query only.

## Known gaps / failures

`bun run verify` was not run. This is a two-file voice-models force
parse with a green focused suite (14 new + 16 existing). Full monorepo
verify is unrelated to this query grammar and was skipped to keep the
proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:091e62d6bc95e11746a68b5f2ceff3edb157c1c3 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
