### PR TITLE
fix(plugin-scheduling): reject unknown scheduled-tasks ownerVisibleOnly flag

### DIFF
--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.owner-visible.test.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.owner-visible.test.ts
@@ -1,0 +1,215 @@
+/**
+ * GET /api/lifeops/scheduled-tasks `ownerVisibleOnly` is list-filter
+ * identity, leftover tax after lifeops inbox bools (#20930). Stock
+ * develop treated every non-exact `1` token as list-all, so
+ * `ownerVisibleOnly=true` returned hidden tasks instead of a 400.
+ * kind / status / source / firedSince parsers stay untouched.
+ */
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import { describe, expect, it } from "vitest";
+import {
+  createAnchorRegistry,
+  createCompletionCheckRegistry,
+  createConsolidationRegistry,
+  createEscalationLadderRegistry,
+  createInMemoryScheduledTaskLogStore,
+  createInMemoryScheduledTaskStore,
+  createScheduledTaskRunner,
+  createTaskGateRegistry,
+  registerBuiltInCompletionChecks,
+  registerBuiltInGates,
+  registerDefaultEscalationLadders,
+  type ScheduledTaskRunnerHandle,
+  TestNoopScheduledTaskDispatcher,
+} from "../scheduled-task/index.js";
+import {
+  makeScheduledTasksRouteHandler,
+  type SchedulingRouteContext,
+} from "./scheduled-tasks.js";
+
+function makeRunner(): ScheduledTaskRunnerHandle {
+  const gates = createTaskGateRegistry();
+  registerBuiltInGates(gates);
+  const completionChecks = createCompletionCheckRegistry();
+  registerBuiltInCompletionChecks(completionChecks);
+  const ladders = createEscalationLadderRegistry();
+  registerDefaultEscalationLadders(ladders);
+  return createScheduledTaskRunner({
+    agentId: "test-agent",
+    store: createInMemoryScheduledTaskStore(),
+    logStore: createInMemoryScheduledTaskLogStore(),
+    gates,
+    completionChecks,
+    ladders,
+    anchors: createAnchorRegistry(),
+    consolidation: createConsolidationRegistry(),
+    ownerFacts: async () => ({}),
+    globalPause: { current: async () => ({ active: false }) },
+    activity: { hasSignalSince: () => false },
+    subjectStore: { wasUpdatedSince: () => false },
+    dispatcher: TestNoopScheduledTaskDispatcher,
+  });
+}
+
+interface MockResponse {
+  statusCode?: number;
+  body?: string;
+  ended: boolean;
+}
+
+function buildCtx(pathname: string): {
+  ctx: SchedulingRouteContext;
+  res: MockResponse;
+} {
+  const res: MockResponse = { ended: false };
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  const httpReq = new IncomingMessage(socket);
+  httpReq.method = "GET";
+  const httpRes = new ServerResponse(httpReq);
+  const ctx: SchedulingRouteContext = {
+    req: httpReq,
+    res: httpRes,
+    method: "GET",
+    pathname: new URL(`http://localhost${pathname}`).pathname,
+    url: new URL(`http://localhost${pathname}`),
+    json(_r, data, status = 200) {
+      res.statusCode = status;
+      res.body = JSON.stringify(data);
+      res.ended = true;
+    },
+    error(_r, message, status = 400) {
+      res.statusCode = status;
+      res.body = JSON.stringify({ error: message });
+      res.ended = true;
+    },
+    async readJsonBody<T extends object>(): Promise<T | null> {
+      return null;
+    },
+  };
+  return { ctx, res };
+}
+
+async function seed(runner: ScheduledTaskRunnerHandle) {
+  await runner.schedule({
+    kind: "reminder",
+    promptInstructions: "visible",
+    trigger: { kind: "manual" },
+    priority: "low",
+    respectsGlobalPause: true,
+    source: "user_chat",
+    createdBy: "x",
+    ownerVisible: true,
+  });
+  await runner.schedule({
+    kind: "reminder",
+    promptInstructions: "hidden",
+    trigger: { kind: "manual" },
+    priority: "low",
+    respectsGlobalPause: true,
+    source: "user_chat",
+    createdBy: "x",
+    ownerVisible: false,
+  });
+}
+
+describe("GET /api/lifeops/scheduled-tasks ownerVisibleOnly identity", () => {
+  it.each([
+    "/api/lifeops/scheduled-tasks",
+    "/api/lifeops/scheduled-tasks?ownerVisibleOnly=",
+  ])("accepts %s as list-all", async (pathname) => {
+    const runner = makeRunner();
+    await seed(runner);
+    let listed = 0;
+    const original = runner.list.bind(runner);
+    runner.list = async (filter) => {
+      listed += 1;
+      return original(filter);
+    };
+    const handler = makeScheduledTasksRouteHandler({
+      resolveRunner: async () => runner,
+    });
+    const { ctx, res } = buildCtx(pathname);
+    await handler(ctx);
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.body ?? "{}") as {
+      tasks: Array<{ promptInstructions: string }>;
+    };
+    expect(payload.tasks.map((t) => t.promptInstructions).sort()).toEqual([
+      "hidden",
+      "visible",
+    ]);
+    expect(listed).toBe(1);
+  });
+
+  it("accepts ownerVisibleOnly=1 as owner-visible-only list", async () => {
+    const runner = makeRunner();
+    await seed(runner);
+    const handler = makeScheduledTasksRouteHandler({
+      resolveRunner: async () => runner,
+    });
+    const { ctx, res } = buildCtx(
+      "/api/lifeops/scheduled-tasks?ownerVisibleOnly=1",
+    );
+    await handler(ctx);
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.body ?? "{}") as {
+      tasks: Array<{ promptInstructions: string }>;
+    };
+    expect(payload.tasks.map((t) => t.promptInstructions)).toEqual(["visible"]);
+  });
+
+  it.each(["true", "TRUE", "yes", "foo", "0", "false", "1e2"])(
+    "rejects ownerVisibleOnly=%s before list",
+    async (token) => {
+      const runner = makeRunner();
+      await seed(runner);
+      let listed = 0;
+      const original = runner.list.bind(runner);
+      runner.list = async (filter) => {
+        listed += 1;
+        return original(filter);
+      };
+      let resolved = 0;
+      const handler = makeScheduledTasksRouteHandler({
+        resolveRunner: async () => {
+          resolved += 1;
+          return runner;
+        },
+      });
+      const { ctx, res } = buildCtx(
+        `/api/lifeops/scheduled-tasks?ownerVisibleOnly=${encodeURIComponent(token)}`,
+      );
+      await handler(ctx);
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body ?? "{}")).toMatchObject({
+        error: 'ownerVisibleOnly must be specified at most once as "1".',
+      });
+      expect(resolved).toBe(0);
+      expect(listed).toBe(0);
+    },
+  );
+
+  it.each([
+    "/api/lifeops/scheduled-tasks?ownerVisibleOnly=1&ownerVisibleOnly=1",
+    "/api/lifeops/scheduled-tasks?ownerVisibleOnly=1&ownerVisibleOnly=0",
+    "/api/lifeops/scheduled-tasks?ownerVisibleOnly=&ownerVisibleOnly=1",
+    "/api/lifeops/scheduled-tasks?ownerVisibleOnly=foo&ownerVisibleOnly=1",
+  ])("rejects duplicate ownerVisibleOnly values in %s before list", async (pathname) => {
+    let resolved = 0;
+    const handler = makeScheduledTasksRouteHandler({
+      resolveRunner: async () => {
+        resolved += 1;
+        return makeRunner();
+      },
+    });
+    const { ctx, res } = buildCtx(pathname);
+    await handler(ctx);
+    expect(res.statusCode).toBe(400);
+    expect(resolved).toBe(0);
+  });
+});

--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
@@ -303,15 +303,36 @@ async function handleScheduledTasks(
 
   // List.
   if (method === "GET" && pathname === PATH_PREFIX) {
+    const url = ctx.url;
+    // Scheduled-task owner-visible list identity, leftover tax after
+    // lifeops inbox bools (#20930). ownerVisibleOnly=true used to
+    // silently list hidden tasks instead of a 400. kind / status /
+    // source / firedSince parsers stay untouched.
+    const requestedOwnerVisibleValues = url.searchParams.getAll(
+      "ownerVisibleOnly",
+    );
+    const requestedOwnerVisible = requestedOwnerVisibleValues[0];
+    if (
+      requestedOwnerVisibleValues.length > 1 ||
+      (requestedOwnerVisible != null &&
+        requestedOwnerVisible !== "" &&
+        requestedOwnerVisible !== "1")
+    ) {
+      error(
+        res,
+        'ownerVisibleOnly must be specified at most once as "1".',
+        400,
+      );
+      return true;
+    }
     const runner = await deps.resolveRunner(ctx);
     if (!runner) return true;
-    const url = ctx.url;
     const filterParse = scheduledTaskFilterSchema.safeParse({
       kind: url.searchParams.get("kind") ?? undefined,
       status: url.searchParams.get("status") ?? undefined,
       source: url.searchParams.get("source") ?? undefined,
       firedSince: url.searchParams.get("firedSince") ?? undefined,
-      ownerVisibleOnly: url.searchParams.get("ownerVisibleOnly") === "1",
+      ownerVisibleOnly: requestedOwnerVisible === "1",
     });
     if (!filterParse.success) {
       error(


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
scheduled-tasks `ownerVisibleOnly` identity. Life Ops list-filter
class, leftover tax after inbox bools (#20930). Not leftover tax on
groupByThread / missedOnly / sortByPriority, kind / status / source /
firedSince, or voice-models force.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `ownerVisibleOnly` only on `/api/lifeops/scheduled-tasks`.
Omitted/empty still list all tasks (today's default).
Exact `1` still filters to owner-visible rows.
Unknown / uppercase / `true` tokens 400 before `runner.list`.
kind / status / source / firedSince parsers stay untouched.

# Background

## What does this PR do?

`GET /api/lifeops/scheduled-tasks` treated any non-exact `1` token as
list-all. `ownerVisibleOnly=true` silently returned hidden tasks
instead of a 400.

- omitted / empty → list all tasks (200)
- exact `1` → owner-visible-only list
- `true` / `TRUE` / `0` / `false` / `yes` / `foo` / `1e2` → **400** before `runner.list`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers opt into an owner-visible-only list with
`?ownerVisibleOnly=1`. A common `ownerVisibleOnly=true` after a client
sends a boolean must not silently leak hidden tasks. This is leftover
tax after lifeops inbox bools (#20930), which left the scheduled-tasks
list parser untouched.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-scheduling/src/routes/scheduled-tasks.owner-visible.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-scheduling && bunx vitest run src/routes/scheduled-tasks.owner-visible.test.ts src/routes/scheduled-tasks.test.ts
```

14 new identity tests + 16 existing scheduled-tasks route tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; scheduled-tasks `ownerVisibleOnly` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; scheduled-tasks `ownerVisibleOnly` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; scheduled-tasks `ownerVisibleOnly` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real ownerVisibleOnly tokens and assert 400 before list; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before the list filter.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
`ownerVisibleOnly` tokens reject; omitted/canonical still bind the
matching list-all or owner-visible-only path.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file scheduled-tasks
ownerVisibleOnly parse with a green focused suite (14 new + 16
existing). Full monorepo verify is unrelated to this query grammar and
was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2250d300d8cd7a318013afeb0f865ab054244f22 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
