### PR TITLE
fix(shared): guard empty name args and expose cache reset in getLogPrefix and add unit test suite

### DIFF
--- a/packages/shared/src/utils/log-prefix.test.ts
+++ b/packages/shared/src/utils/log-prefix.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for getLogPrefix in packages/shared/src/utils/log-prefix.ts.
+ * Exercises prefix precedence (APP_CLI_NAME, npm_package_name, --name flag, cwd),
+ * empty name argument handling, cache retention, and cache reset helper.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getLogPrefix, resetLogPrefixCacheForTesting } from "./log-prefix.js";
+
+describe("getLogPrefix", () => {
+  const originalEnv = { ...process.env };
+  const originalArgv = [...process.argv];
+
+  beforeEach(() => {
+    resetLogPrefixCacheForTesting();
+    delete process.env.APP_CLI_NAME;
+    delete process.env.npm_package_name;
+    process.argv = ["node", "app.js"];
+  });
+
+  afterEach(() => {
+    resetLogPrefixCacheForTesting();
+    process.env = { ...originalEnv };
+    process.argv = [...originalArgv];
+  });
+
+  it("prioritizes APP_CLI_NAME environment variable", () => {
+    process.env.APP_CLI_NAME = "custom-cli";
+    expect(getLogPrefix()).toBe("[custom-cli]");
+  });
+
+  it("extracts package name from scoped npm_package_name", () => {
+    process.env.npm_package_name = "@elizaos/plugin-browser";
+    expect(getLogPrefix()).toBe("[plugin-browser]");
+
+    resetLogPrefixCacheForTesting();
+    process.env.npm_package_name = "@elizaos/eliza-core";
+    expect(getLogPrefix()).toBe("[eliza]");
+
+    resetLogPrefixCacheForTesting();
+    process.env.npm_package_name = "@elizaos/core";
+    expect(getLogPrefix()).toBe("[core]");
+  });
+
+  it("extracts name from --name= CLI flag", () => {
+    process.argv = ["node", "app.js", "--name=worker-agent"];
+    expect(getLogPrefix()).toBe("[worker-agent]");
+  });
+
+  it("ignores empty --name= CLI flag and falls back", () => {
+    process.argv = ["node", "app.js", "--name="];
+    expect(getLogPrefix()).toBe("[eliza]");
+  });
+
+  it("caches the computed prefix until reset", () => {
+    process.env.APP_CLI_NAME = "cached-cli";
+    expect(getLogPrefix()).toBe("[cached-cli]");
+
+    // Change env without reset - should remain cached
+    process.env.APP_CLI_NAME = "different-cli";
+    expect(getLogPrefix()).toBe("[cached-cli]");
+
+    // Reset clears cache
+    resetLogPrefixCacheForTesting();
+    expect(getLogPrefix()).toBe("[different-cli]");
+  });
+});

--- a/packages/shared/src/utils/log-prefix.ts
+++ b/packages/shared/src/utils/log-prefix.ts
@@ -5,6 +5,10 @@
  */
 let cachedPrefix: string | null = null;
 
+export function resetLogPrefixCacheForTesting(): void {
+  cachedPrefix = null;
+}
+
 type RuntimeProcess = {
   argv?: string[];
   cwd?: () => string;
@@ -45,13 +49,15 @@ export function getLogPrefix(): string {
     return cachedPrefix;
   }
 
-  const nameArgMatch = runtimeProcess?.argv?.find((a) =>
-    a.startsWith("--name="),
+  const nameArgMatch = runtimeProcess?.argv?.find(
+    (a) => typeof a === "string" && a.startsWith("--name="),
   );
   if (nameArgMatch) {
-    const name = nameArgMatch.split("=")[1];
-    cachedPrefix = `[${name}]`;
-    return cachedPrefix;
+    const name = nameArgMatch.split("=")[1]?.trim();
+    if (name) {
+      cachedPrefix = `[${name}]`;
+      return cachedPrefix;
+    }
   }
 
   const cwd =


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/log-prefix.ts`, `getLogPrefix` checked `a.startsWith("--name=")` without ensuring the split value was non-empty, leading to `[]` when `--name=` was passed.
2. Added `.trim()` and empty check to `--name=` flag extraction.
3. Exported `resetLogPrefixCacheForTesting()` to allow test fixtures and environment transitions to clear the cached prefix.
4. Created a dedicated unit test suite in `packages/shared/src/utils/log-prefix.test.ts`.

Closes #21235.

## Verification

Exact commit: `748cf12a92`.

- Focused unit test suite `packages/shared/src/utils/log-prefix.test.ts`: 5/5 tests passing (9 assertions).
- Biome format on `@elizaos/shared`: 409 files checked, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - log prefix utility; no rendered UI changed.
- [x] N/A - log prefix utility; no rendered UI changed.
- [x] N/A - deterministic log prefix tests.
- [x] Focused test suite transcript:
```text
✓ getLogPrefix > prioritizes APP_CLI_NAME environment variable [0.43ms]
✓ getLogPrefix > extracts package name from scoped npm_package_name [0.27ms]
✓ getLogPrefix > extracts name from --name= CLI flag [0.13ms]
✓ getLogPrefix > ignores empty --name= CLI flag and falls back [0.04ms]
✓ getLogPrefix > caches the computed prefix until reset [0.05ms]
5 pass, 0 fail, 9 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza"} -->
