### PR TITLE
fix(orchestrator): evidence caps, changeset baselines, near-dup slug veto

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/changeset-baseline.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/changeset-baseline.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Contract for shared-workdir changeset baseline subtraction (velvet-moth
+ * live park: another app's pre-existing diff rendered as this session's
+ * changeset). Deterministic — pure function over a captured change set.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  subtractChangeSetBaseline,
+  type WorkspaceChangeSet,
+} from "../services/workspace-diff.js";
+
+const changeSet: WorkspaceChangeSet = {
+  changedFiles: [
+    "data/apps/velvet-moth/index.html",
+    "data/apps/color-pop/index.html",
+    "data/apps/dad-jokes/script.js",
+  ],
+  diffStat: [
+    " data/apps/velvet-moth/index.html | 120 ++++",
+    " data/apps/color-pop/index.html   |  40 +-",
+    " data/apps/dad-jokes/script.js    |  12 +-",
+  ].join("\n"),
+  diff: [
+    "diff --git a/data/apps/velvet-moth/index.html b/data/apps/velvet-moth/index.html\n+<moth/>\n",
+    "diff --git a/data/apps/color-pop/index.html b/data/apps/color-pop/index.html\n+<pop/>\n",
+    "diff --git a/data/apps/dad-jokes/script.js b/data/apps/dad-jokes/script.js\n+lol()\n",
+  ].join(""),
+  truncated: false,
+  capturedAt: 1755400000000,
+};
+
+describe("subtractChangeSetBaseline", () => {
+  it("drops baseline files from the list, diffstat, and diff hunks", () => {
+    const out = subtractChangeSetBaseline(changeSet, [
+      "data/apps/color-pop/index.html",
+      "data/apps/dad-jokes/script.js",
+    ]);
+    expect(out.changedFiles).toEqual(["data/apps/velvet-moth/index.html"]);
+    expect(out.diff).toContain("velvet-moth");
+    expect(out.diff).not.toContain("color-pop");
+    expect(out.diff).not.toContain("dad-jokes");
+    expect(out.diffStat).toContain("velvet-moth");
+    expect(out.diffStat).not.toContain("color-pop");
+  });
+
+  it("no baseline overlap returns the identical change set", () => {
+    const out = subtractChangeSetBaseline(changeSet, ["unrelated/file.ts"]);
+    expect(out).toBe(changeSet);
+  });
+
+  it("empty baselines are a no-op", () => {
+    expect(subtractChangeSetBaseline(changeSet, [])).toBe(changeSet);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/near-dup-slug-veto.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/near-dup-slug-veto.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Slug-identity veto for the near-duplicate spawn guard (live false positive:
+ * "tide-glass" blocked against a parked "ember-tide" on the shared "tide"
+ * boilerplate token). Deterministic — pure text functions.
+ */
+
+import { describe, expect, it } from "vitest";
+import { goalSimilarity, hasDistinctSlugIdentity } from "../actions/tasks.js";
+
+const BOILER = "build a one-file page in the shared route workdir called";
+
+describe("hasDistinctSlugIdentity", () => {
+  it("distinct slugs veto despite boilerplate similarity crossing the threshold", () => {
+    const a = `${BOILER} tide-glass`;
+    const b = `${BOILER} ember-tide`;
+    expect(goalSimilarity(a, b)).toBeGreaterThanOrEqual(0.6);
+    expect(hasDistinctSlugIdentity(a, b)).toBe(true);
+  });
+
+  it("a shared slug is NOT vetoed — a genuine re-ask still matches", () => {
+    expect(
+      hasDistinctSlugIdentity(`${BOILER} ember-tide`, `${BOILER} ember-tide`),
+    ).toBe(false);
+  });
+
+  it("texts without slugs never veto (guard behavior unchanged)", () => {
+    expect(
+      hasDistinctSlugIdentity(
+        "fix the flaky scheduler test",
+        "fix the scheduler flake",
+      ),
+    ).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/quick-app-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/quick-app-evidence.test.ts
@@ -167,7 +167,7 @@ describe("readFsVerifiedContents (reed-marsh content criteria)", () => {
         path.join(appDir, "style.css"),
         "body { background: linear-gradient(#3aa8a0, #0f2f2c); }",
       );
-      fs.writeFileSync(path.join(appDir, "big.css"), "x".repeat(5000));
+      fs.writeFileSync(path.join(appDir, "big.css"), "x".repeat(9000));
       fs.writeFileSync(path.join(appDir, "img.png"), "notreally");
 
       const contents = readFsVerifiedContents(workdir, [
@@ -182,7 +182,15 @@ describe("readFsVerifiedContents (reed-marsh content criteria)", () => {
       ]);
       expect(contents[0]?.content).toContain("linear-gradient(#3aa8a0");
       expect(contents[1]?.content).toContain("[truncated]");
-      expect(contents[1]?.content.length).toBeLessThan(2100);
+      expect(contents[1]?.content.length).toBeLessThan(8200);
+      // A typical 6-8KB quick-app file must survive whole (velvet-moth park).
+      const typical = path.join(appDir, "typical.js");
+      fs.writeFileSync(typical, "y".repeat(7000));
+      const [whole] = readFsVerifiedContents(workdir, [
+        "data/apps/reed-marsh/typical.js",
+      ]);
+      expect(whole?.content).toHaveLength(7000);
+      expect(whole?.content).not.toContain("[truncated]");
     } finally {
       fs.rmSync(workdir, { recursive: true, force: true });
     }

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -2920,6 +2920,28 @@ export function goalSimilarity(a: string, b: string): number {
 
 const DUPLICATE_SPAWN_SIMILARITY_THRESHOLD = 0.6;
 
+const SLUG_TOKEN_RE = /\b[a-z0-9]+(?:-[a-z0-9]+)+\b/g;
+
+/**
+ * Distinct hyphenated slugs veto a near-duplicate match. Quick-app requests
+ * share nearly all their phrasing ("build a one-file page in the shared route
+ * workdir called <slug>") so token containment crosses the threshold on
+ * boilerplate alone — live: "tide-glass" matched a parked "ember-tide" on the
+ * shared "tide" token. When BOTH texts name slugs and NEITHER text mentions
+ * any of the other's, they are different deliverables, not a re-ask.
+ */
+export function hasDistinctSlugIdentity(a: string, b: string): boolean {
+  const slugsA = new Set(a.toLowerCase().match(SLUG_TOKEN_RE) ?? []);
+  const slugsB = new Set(b.toLowerCase().match(SLUG_TOKEN_RE) ?? []);
+  if (slugsA.size === 0 || slugsB.size === 0) return false;
+  // Boilerplate carries shared hyphenated tokens ("one-file"), so the veto
+  // requires each side to name a slug the other lacks — a mutual exclusive
+  // identity, not full disjointness.
+  const aOnly = [...slugsA].some((slug) => !slugsB.has(slug));
+  const bOnly = [...slugsB].some((slug) => !slugsA.has(slug));
+  return aOnly && bOnly;
+}
+
 /**
  * Cross-request near-duplicate guard for create/spawn. The per-origin spawn cap
  * only anchors ONE user request; a status-shaped follow-up ("so is my site
@@ -2946,6 +2968,7 @@ async function findNearDuplicateInFlightWork(args: {
       for (const task of tasks) {
         if (!IN_FLIGHT_TASK_STATUSES.has(task.status)) continue;
         const existingText = `${task.title} ${task.originalRequest ?? ""}`;
+        if (hasDistinctSlugIdentity(candidateText, existingText)) continue;
         if (
           goalSimilarity(candidateText, existingText) >=
           DUPLICATE_SPAWN_SIMILARITY_THRESHOLD
@@ -2969,6 +2992,7 @@ async function findNearDuplicateInFlightWork(args: {
             ? session.metadata.initialTask
             : "";
         const existingText = `${label ?? ""} ${initialTask}`;
+        if (hasDistinctSlugIdentity(candidateText, existingText)) continue;
         if (
           goalSimilarity(candidateText, existingText) >=
           DUPLICATE_SPAWN_SIMILARITY_THRESHOLD

--- a/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
@@ -143,7 +143,7 @@ export interface CompletionEvidenceBundle {
 
 /** Total cap for the assembled evidence string. Sits under the verifier's own
  *  {@link trimEvidence} budget so the section structure survives intact. */
-const MAX_EVIDENCE_CHARS = 8_000;
+const MAX_EVIDENCE_CHARS = 24_000;
 const MAX_DIFF_CHARS = 3_000;
 const MAX_DELIVERABLE_CHARS = 1_500;
 const MAX_REPLY_CHARS = 1_500;

--- a/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
@@ -299,7 +299,10 @@ const EMPTY_EVIDENCE_SUMMARY =
 const MALFORMED_RESPONSE_SUMMARY =
   "Verifier returned a response that could not be parsed; defaulting to fail.";
 
-const MAX_EVIDENCE_CHARS = 12_000;
+// Sized to admit the full evidence bundle (24KB cap) — trimming the middle
+// of it was cutting FS-VERIFIED FILE CONTENTS exactly where content criteria
+// were judged (velvet-moth live park).
+const MAX_EVIDENCE_CHARS = 28_000;
 
 function trimEvidence(evidence: string): string {
   if (evidence.length <= MAX_EVIDENCE_CHARS) return evidence;

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -237,7 +237,11 @@ import {
   ensureTaskWorkdir,
   resolveAllowedWorkdir,
 } from "./workdir-validation.js";
-import { captureChangeSet, type WorkspaceChangeSet } from "./workspace-diff.js";
+import {
+  captureChangeSet,
+  subtractChangeSetBaseline,
+  type WorkspaceChangeSet,
+} from "./workspace-diff.js";
 import { getCodingWorkspaceService } from "./workspace-service.js";
 
 /**
@@ -2392,7 +2396,32 @@ export class OrchestratorTaskService extends Service {
       (message) => message.sessionId === sessionId,
     );
 
-    const changeSet = await this.resolveCompletionChangeSet(sessionId, doc);
+    const rawChangeSet = await this.resolveCompletionChangeSet(sessionId, doc);
+    // Shared-workdir captures include OTHER apps' pre-existing dirty files;
+    // subtract the spawn-time baselines so the evidence shows the session's
+    // own work (velvet-moth live: an unrelated app's diff read as
+    // contradictory evidence).
+    const baselineSession = doc.sessions.find(
+      (session) => session.sessionId === sessionId,
+    );
+    const baselineMeta = isRecord(baselineSession?.metadata)
+      ? baselineSession.metadata
+      : undefined;
+    const baselinePaths = [
+      ...(Array.isArray(baselineMeta?.codingBaselineDirty)
+        ? baselineMeta.codingBaselineDirty.filter(
+            (entry): entry is string => typeof entry === "string",
+          )
+        : []),
+      ...(Array.isArray(baselineMeta?.codingBaselineUntracked)
+        ? baselineMeta.codingBaselineUntracked.filter(
+            (entry): entry is string => typeof entry === "string",
+          )
+        : []),
+    ];
+    const changeSet = rawChangeSet
+      ? subtractChangeSetBaseline(rawChangeSet, baselinePaths)
+      : rawChangeSet;
     const diffSummary =
       changeSet && changeSet.changedFiles.length > 0
         ? renderChangeSetBody(changeSet)

--- a/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
@@ -233,7 +233,9 @@ export function detectCheckSurfaces(
 }
 
 const MAX_CONTENT_FILES = 3;
-const MAX_CONTENT_CHARS = 2_000;
+// Typical quick-app files run 6-8KB; a 2KB cap cut them exactly where the
+// judged content lived (velvet-moth live park). 8KB covers the class whole.
+const MAX_CONTENT_CHARS = 8_000;
 /** Text-asset extensions worth showing the judge verbatim. */
 const TEXT_CONTENT_RE = /\.(?:html?|css|js|svg|md|txt|json)$/i;
 

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
@@ -560,3 +560,49 @@ export function summarizeChangeSet(
     : "";
   return `Changed ${count} ${noun}: ${shown}${more}${verifiedSuffix}`;
 }
+
+/**
+ * Remove spawn-time baseline paths from a captured change set. In a SHARED
+ * route workdir the git diff sees every pre-existing dirty file from other
+ * apps (months-old edits included), so the completion evidence attributed
+ * unrelated changes to the session (live: velvet-moth's changeset rendered a
+ * different app's diff and the judge called the evidence contradictory). The
+ * baselines are the orchestrator-stamped codingBaselineDirty/Untracked lists
+ * (#20969's residuals inputs) — subtracting them leaves the session's OWN
+ * work. Diff hunks and diffstat lines for baseline paths are dropped with the
+ * file list so the rendered body matches.
+ */
+export function subtractChangeSetBaseline(
+  changeSet: WorkspaceChangeSet,
+  baselinePaths: readonly string[],
+): WorkspaceChangeSet {
+  if (baselinePaths.length === 0) return changeSet;
+  const baseline = new Set(baselinePaths.map((p) => p.trim()).filter(Boolean));
+  if (baseline.size === 0) return changeSet;
+  const changedFiles = changeSet.changedFiles.filter(
+    (file) => !baseline.has(file),
+  );
+  if (changedFiles.length === changeSet.changedFiles.length) return changeSet;
+
+  const keptHunks = changeSet.diff
+    .split(/^(?=diff --git )/m)
+    .filter((hunk) => {
+      const match = /^diff --git a\/(\S+) b\//.exec(hunk);
+      if (!match) return true;
+      return !baseline.has(match[1] ?? "");
+    })
+    .join("");
+  const keptStat = changeSet.diffStat
+    .split("\n")
+    .filter((line) => {
+      const name = line.split("|")[0]?.trim();
+      return !name || !baseline.has(name);
+    })
+    .join("\n");
+  return {
+    ...changeSet,
+    changedFiles,
+    diff: keptHunks,
+    diffStat: keptStat,
+  };
+}


### PR DESCRIPTION
Three precise residuals from the velvet-moth live probe (post-#21148 chain), each pinned to its receipt:

1. **Content caps cut the judged content.** Typical quick-app files run 6–8KB; the 2KB per-file cap truncated velvet-moth's source "exactly where the moth animation implementation begins" (judge's words). Per-file cap → 8KB; bundle budget → 24KB; the verifier's own trim budget → 28KB so it admits the full bundle instead of cutting the middle out of FS-VERIFIED FILE CONTENTS.
2. **Shared-workdir changesets attributed other apps' work.** The capture in the shared route workdir picked up months-old dirty files from unrelated apps ("provided changeset is for an unrelated app"). New `subtractChangeSetBaseline` removes the orchestrator-stamped spawn-time baseline paths (#20969's residuals inputs) from the changed-file list, the diffstat, and the diff hunks, so the evidence shows the session's OWN work.
3. **Near-duplicate spawn guard false-positived across different apps.** Quick-app requests share almost all their phrasing, so token containment crossed the threshold on boilerplate ("tide-glass" blocked against a parked "ember-tide" via the shared "tide" token — live receipt). New slug-identity veto: when each text names a hyphenated slug the other lacks (mutual exclusivity — shared boilerplate slugs like "one-file" don't defeat it), they are different deliverables and the guard stands down. Same-slug re-asks still match; slugless goals unchanged.

## Evidence

- 6 new tests (changeset subtraction incl. hunk/diffstat filtering and no-op identity; slug veto incl. the live tide-glass/ember-tide pair proven ≥0.6 similar yet vetoed, same-slug and slugless negative cases) + cap test updated to pin that a 7KB file survives whole.
- Affected suites 119/119; plugin typecheck clean; Biome clean.
- Live re-proof: next box rebuild re-runs the probe — expected: full file text in evidence, session-only changeset, and no spurious duplicate blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)