### PR TITLE
fix(core): make non-imperative leading word checks case-insensitive in lintDescriptionCompressed and add unit test suite

### DIFF
--- a/packages/core/src/utils/description-compressed-lint.test.ts
+++ b/packages/core/src/utils/description-compressed-lint.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for lintDescriptionCompressed in packages/core/src/utils/description-compressed-lint.ts.
+ * Exercises imperative starting verbs, case-insensitive leading word detection,
+ * banned phrases, banned words, empty inputs, and violation aggregation.
+ */
+import { describe, expect, it } from "vitest";
+import { lintDescriptionCompressed } from "./description-compressed-lint.js";
+
+describe("lintDescriptionCompressed", () => {
+	it("accepts clean imperative descriptions", () => {
+		const result = lintDescriptionCompressed(
+			"Search issues and pull requests by keyword or label",
+		);
+		expect(result.ok).toBe(true);
+		expect(result.violations).toHaveLength(0);
+	});
+
+	it("flags empty or whitespace-only inputs", () => {
+		expect(lintDescriptionCompressed("").ok).toBe(false);
+		expect(lintDescriptionCompressed("   ").ok).toBe(false);
+		expect(
+			lintDescriptionCompressed(null as unknown as string).violations[0],
+		).toContain("empty");
+	});
+
+	it("flags banned phrases", () => {
+		const result = lintDescriptionCompressed(
+			"Use this action in order to search data for the user",
+		);
+		expect(result.ok).toBe(false);
+		expect(result.violations.some((v) => v.includes("in order to"))).toBe(true);
+		expect(result.violations.some((v) => v.includes("use this action"))).toBe(
+			true,
+		);
+		expect(result.violations.some((v) => v.includes("the user"))).toBe(true);
+	});
+
+	it("flags banned words suggesting preferred abbreviations", () => {
+		const result = lintDescriptionCompressed(
+			"Fetch all messages and load configuration",
+		);
+		expect(result.ok).toBe(false);
+		expect(result.violations.some((v) => v.includes("messages"))).toBe(true);
+		expect(result.violations.some((v) => v.includes("configuration"))).toBe(
+			true,
+		);
+	});
+
+	it("flags non-imperative leading verbs across title-case, lower-case, and upper-case", () => {
+		const titleCase = lintDescriptionCompressed("Provides search results");
+		expect(titleCase.ok).toBe(false);
+		expect(titleCase.violations[0]).toContain("non-imperative");
+
+		const lowerCase = lintDescriptionCompressed("provides search results");
+		expect(lowerCase.ok).toBe(false);
+		expect(lowerCase.violations[0]).toContain("non-imperative");
+
+		const upperCase = lintDescriptionCompressed("PROVIDES search results");
+		expect(upperCase.ok).toBe(false);
+		expect(upperCase.violations[0]).toContain("non-imperative");
+
+		const helps = lintDescriptionCompressed("helps users find records");
+		expect(helps.ok).toBe(false);
+		expect(helps.violations[0]).toContain("non-imperative");
+	});
+});

--- a/packages/core/src/utils/description-compressed-lint.ts
+++ b/packages/core/src/utils/description-compressed-lint.ts
@@ -63,24 +63,24 @@ const BANNED_WORDS: ReadonlyArray<{
  * already be in imperative form, so we flag the rest of the family directly.
  */
 const NON_IMPERATIVE_LEADING_WORDS: ReadonlySet<string> = new Set([
-	"It",
-	"This",
-	"Helps",
-	"Allows",
-	"Should",
-	"Provides",
-	"Retrieves",
-	"Returns",
-	"Generates",
-	"Creates",
-	"Updates",
-	"Deletes",
-	"Sends",
-	"Extracts",
-	"Identifies",
-	"Summarizes",
-	"Compresses",
-	"Automatically",
+	"it",
+	"this",
+	"helps",
+	"allows",
+	"should",
+	"provides",
+	"retrieves",
+	"returns",
+	"generates",
+	"creates",
+	"updates",
+	"deletes",
+	"sends",
+	"extracts",
+	"identifies",
+	"summarizes",
+	"compresses",
+	"automatically",
 ]);
 
 export interface LintDescriptionCompressedResult {
@@ -127,7 +127,7 @@ export function lintDescriptionCompressed(
 	const firstWordMatch = value.trim().match(/^([A-Za-z][A-Za-z0-9_-]*)/);
 	if (firstWordMatch) {
 		const firstWord = firstWordMatch[1];
-		if (NON_IMPERATIVE_LEADING_WORDS.has(firstWord)) {
+		if (NON_IMPERATIVE_LEADING_WORDS.has(firstWord.toLowerCase())) {
 			violations.push(
 				`non-imperative: descriptionCompressed starts with "${firstWord}" — use an imperative verb (e.g. "Send", "Get", "List")`,
 			);


### PR DESCRIPTION
## Summary

1. In `packages/core/src/utils/description-compressed-lint.ts`, `NON_IMPERATIVE_LEADING_WORDS` used title-case strings and direct case-sensitive `.has(firstWord)` lookup. This permitted lowercase non-imperative words like `"provides"`, `"helps"`, `"allows"`, `"this"`, `"it"` to bypass the lint check without warning.
2. Normalized `NON_IMPERATIVE_LEADING_WORDS` to lowercase and checked `NON_IMPERATIVE_LEADING_WORDS.has(firstWord.toLowerCase())`.
3. Created a comprehensive unit test suite in `packages/core/src/utils/description-compressed-lint.test.ts`.

Closes #21244.

## Verification

Exact commit: `2f15e541de`.

- Focused unit test suite `packages/core/src/utils/description-compressed-lint.test.ts`: 5/5 tests passing (20 assertions).
- Biome format on `@elizaos/core`: 1292 files formatted, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - description compressed lint utility; no rendered UI changed.
- [x] N/A - description compressed lint utility; no rendered UI changed.
- [x] N/A - deterministic description compressed lint tests.
- [x] Focused test suite transcript:
```text
✓ lintDescriptionCompressed > accepts clean imperative descriptions [0.55ms]
✓ lintDescriptionCompressed > flags empty or whitespace-only inputs [0.08ms]
✓ lintDescriptionCompressed > flags banned phrases [0.19ms]
✓ lintDescriptionCompressed > flags banned words suggesting preferred abbreviations [0.06ms]
✓ lintDescriptionCompressed > flags non-imperative leading verbs across title-case, lower-case, and upper-case [0.10ms]
5 pass, 0 fail, 20 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza"} -->
