### PR TITLE
fix(agent): run subscription CLI bootstrap on Windows

### DIFF
--- a/packages/agent/src/api/accounts-routes.subscription-cli.test.ts
+++ b/packages/agent/src/api/accounts-routes.subscription-cli.test.ts
@@ -5,13 +5,18 @@
  * package lifecycle scripts never execute), a structured
  * prerequisite error when installation is impossible, no guaranteed-to-fail
  * reinstall on every OAuth attempt (cooldown-cached failure), and the tools
- * bin dir made visible to the later bare `spawn("codex"|"claude")`.
+ * bin dir made visible to the later CLI launch.
  */
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { ElizaError } from "@elizaos/core";
-import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveSubscriptionCliNpmInvocation,
+  runSubscriptionCliNpm,
+  subscriptionCliCommandAvailable,
+} from "../internal/subscription-cli-process.ts";
 import {
   __clearSubscriptionCliInstallFailures,
   ensureSubscriptionCli,
@@ -213,5 +218,117 @@ describe("ensureSubscriptionCli (#16518)", () => {
       }),
     ).resolves.toBeUndefined();
     expect(installs).toBe(3);
+  });
+});
+
+describe("subscription CLI Windows process boundary (#21224)", () => {
+  it("finds npm-installed .cmd shims using PATHEXT", () => {
+    const binDir = path.join(stateDir, "windows-cli-bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(path.join(binDir, "codex.cmd"), "@echo off\r\n");
+
+    expect(
+      subscriptionCliCommandAvailable("codex", {
+        env: { PATH: binDir, PATHEXT: ".EXE;.CMD" },
+        platform: "win32",
+      }),
+    ).toBe(true);
+    expect(
+      subscriptionCliCommandAvailable("claude", {
+        env: { PATH: binDir, PATHEXT: ".EXE;.CMD" },
+        platform: "win32",
+      }),
+    ).toBe(false);
+  });
+
+  it("uses a complete Node/npm layout and skips incomplete PATH entries", () => {
+    const incomplete = path.join(stateDir, "incomplete node");
+    const complete = path.join(stateDir, "complete node");
+    const npmCli = path.join(
+      complete,
+      "node_modules",
+      "npm",
+      "bin",
+      "npm-cli.js",
+    );
+    mkdirSync(incomplete, { recursive: true });
+    mkdirSync(path.dirname(npmCli), { recursive: true });
+    writeFileSync(path.join(incomplete, "node.exe"), "fixture");
+    writeFileSync(path.join(complete, "node.exe"), "fixture");
+    writeFileSync(npmCli, "fixture");
+
+    const invocation = resolveSubscriptionCliNpmInvocation(
+      ["install", "package-fixture"],
+      {
+        env: {
+          PATH: `"${incomplete}"${path.delimiter}"${complete}"`,
+        },
+        platform: "win32",
+      },
+    );
+
+    expect(invocation).toEqual({
+      command: path.join(complete, "node.exe"),
+      args: [npmCli, "install", "package-fixture"],
+    });
+  });
+
+  it("rejects an incomplete Windows npm layout before starting a child", () => {
+    const incomplete = path.join(stateDir, "npm-without-node");
+    const npmCli = path.join(
+      incomplete,
+      "node_modules",
+      "npm",
+      "bin",
+      "npm-cli.js",
+    );
+    mkdirSync(path.dirname(npmCli), { recursive: true });
+    writeFileSync(npmCli, "fixture");
+
+    expect(() =>
+      resolveSubscriptionCliNpmInvocation(["install"], {
+        env: { PATH: incomplete },
+        platform: "win32",
+      }),
+    ).toThrow("No complete Windows Node.js/npm installation");
+  });
+
+  it("keeps the direct npm command on Unix", () => {
+    expect(
+      resolveSubscriptionCliNpmInvocation(["install", "package-fixture"], {
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: "npm",
+      args: ["install", "package-fixture"],
+    });
+  });
+
+  it("passes the resolved Windows argv and timeout to the executor", async () => {
+    const nodeDir = path.join(stateDir, "executable node");
+    const npmCli = path.join(
+      nodeDir,
+      "node_modules",
+      "npm",
+      "bin",
+      "npm-cli.js",
+    );
+    mkdirSync(path.dirname(npmCli), { recursive: true });
+    writeFileSync(path.join(nodeDir, "node.exe"), "fixture");
+    writeFileSync(npmCli, "fixture");
+    const execute = vi.fn(async () => undefined);
+
+    await runSubscriptionCliNpm(["install", "package-fixture"], {
+      env: { PATH: nodeDir },
+      execute,
+      platform: "win32",
+      timeout: 1234,
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      path.join(nodeDir, "node.exe"),
+      [npmCli, "install", "package-fixture"],
+      { timeout: 1234 },
+    );
   });
 });

--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -25,11 +25,9 @@
  * Per-strategy knobs live beside it in `accountStrategySettings`.
  */
 
-import { execFile } from "node:child_process";
 import nodeCrypto from "node:crypto";
-import { access, mkdir } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
 import {
   type AccountCredentialRecord,
   assertCanonicalAccountId,
@@ -73,28 +71,16 @@ import {
 } from "@elizaos/shared";
 import * as zod from "zod";
 import type { ElizaConfig } from "../config/types.eliza.ts";
+import {
+  runSubscriptionCliNpm,
+  subscriptionCliCommandAvailable,
+} from "../internal/subscription-cli-process.ts";
 import { getAgentHostBridge } from "../runtime/host-bridge.ts";
 
 const z = (zod as typeof zod & { z?: typeof zod }).z ?? zod;
-const execFileAsync = promisify(execFile);
 
 function accountStoragePolicy() {
   return createRuntimeAccountStoragePolicy(resolveStateDir());
-}
-
-async function commandAvailable(command: string): Promise<boolean> {
-  const executablePath = process.env.PATH;
-  if (!executablePath) return false;
-  for (const dir of executablePath.split(path.delimiter)) {
-    if (!dir) continue;
-    try {
-      await access(path.join(dir, command));
-      return true;
-    } catch {
-      // Continue through PATH.
-    }
-  }
-  return false;
 }
 
 const SUBSCRIPTION_CLI_INSTALL_TIMEOUT_MS = 2 * 60 * 1000;
@@ -143,11 +129,14 @@ export async function ensureSubscriptionCli(
   } = {},
 ): Promise<void> {
   const command = providerId === "openai-codex" ? "codex" : "claude";
-  const isAvailable = deps.isAvailable ?? commandAvailable;
+  const isAvailable =
+    deps.isAvailable ??
+    ((candidate: string) =>
+      Promise.resolve(subscriptionCliCommandAvailable(candidate)));
   const now = deps.now ?? Date.now;
 
   // A prior per-user install must stay visible to this check AND to the later
-  // bare `spawn("codex"|"claude")` in the login flows — including after a
+  // CLI launch in the login flows — including after a
   // process restart, where the parent PATH doesn't carry the tools dir.
   const binDir = path.join(
     subscriptionCliInstallPrefix(),
@@ -186,7 +175,7 @@ export async function ensureSubscriptionCli(
   const runInstall =
     deps.runInstall ??
     ((args: string[]) =>
-      execFileAsync("npm", args, {
+      runSubscriptionCliNpm(args, {
         timeout: SUBSCRIPTION_CLI_INSTALL_TIMEOUT_MS,
       }));
   try {

--- a/packages/agent/src/internal/subscription-cli-process.ts
+++ b/packages/agent/src/internal/subscription-cli-process.ts
@@ -1,3 +1,8 @@
+/**
+ * Resolves and launches the npm-installed subscription CLIs across platforms.
+ * Windows uses real executable boundaries for npm and PATHEXT-aware probes.
+ */
+
 import { execFile } from "node:child_process";
 import { statSync } from "node:fs";
 import path from "node:path";
@@ -25,11 +30,7 @@ interface RunSubscriptionCliNpmOptions extends SubscriptionCliProcessOptions {
 }
 
 function isFile(filePath: string): boolean {
-  try {
-    return statSync(filePath).isFile();
-  } catch {
-    return false;
-  }
+  return statSync(filePath, { throwIfNoEntry: false })?.isFile() === true;
 }
 
 function pathEntries(env: NodeJS.ProcessEnv): string[] {

--- a/packages/agent/src/internal/subscription-cli-process.ts
+++ b/packages/agent/src/internal/subscription-cli-process.ts
@@ -1,0 +1,131 @@
+import { execFile } from "node:child_process";
+import { statSync } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface SubscriptionCliProcessOptions {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+}
+
+export interface SubscriptionCliNpmInvocation {
+  args: string[];
+  command: string;
+}
+
+interface RunSubscriptionCliNpmOptions extends SubscriptionCliProcessOptions {
+  execute?: (
+    command: string,
+    args: string[],
+    options: { timeout: number },
+  ) => Promise<unknown>;
+  timeout: number;
+}
+
+function isFile(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function pathEntries(env: NodeJS.ProcessEnv): string[] {
+  const pathValue = env.PATH ?? env.Path ?? "";
+  return pathValue
+    .split(path.delimiter)
+    .map((entry) => entry.trim().replace(/^"(.*)"$/u, "$1"))
+    .filter(Boolean);
+}
+
+function uniquePathEntries(
+  entries: readonly string[],
+  platform: NodeJS.Platform,
+): string[] {
+  const seen = new Set<string>();
+  return entries.filter((entry) => {
+    const key = platform === "win32" ? entry.toLowerCase() : entry;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/**
+ * Resolve a CLI on PATH using the executable suffixes Windows actually runs.
+ * npm writes device-login shims as `.cmd`, so treating the extensionless
+ * companion file as executable would make the later child process fail.
+ */
+export function subscriptionCliCommandAvailable(
+  command: string,
+  options: SubscriptionCliProcessOptions = {},
+): boolean {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const names =
+    platform === "win32" && path.extname(command) === ""
+      ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+          .split(";")
+          .map((extension) => extension.trim().toLowerCase())
+          .filter(Boolean)
+          .map((extension) => `${command}${extension}`)
+      : [command];
+
+  return pathEntries(env).some((directory) =>
+    names.some((name) => isFile(path.join(directory, name))),
+  );
+}
+
+/**
+ * Resolve npm without routing the user-controlled state-directory prefix
+ * through a command shell. Standard Windows Node installations keep
+ * `node.exe`, `npm.cmd`, and `node_modules/npm/bin/npm-cli.js` together; call
+ * the JavaScript entrypoint through Node so spaces and shell metacharacters in
+ * the prefix remain ordinary argv data.
+ */
+export function resolveSubscriptionCliNpmInvocation(
+  args: string[],
+  options: SubscriptionCliProcessOptions = {},
+): SubscriptionCliNpmInvocation {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") {
+    return { command: "npm", args };
+  }
+
+  const candidateDirectories = uniquePathEntries(pathEntries(env), platform);
+
+  for (const directory of candidateDirectories) {
+    const nodeExecutable = path.join(directory, "node.exe");
+    const npmCli = path.join(
+      directory,
+      "node_modules",
+      "npm",
+      "bin",
+      "npm-cli.js",
+    );
+    if (isFile(nodeExecutable) && isFile(npmCli)) {
+      return { command: nodeExecutable, args: [npmCli, ...args] };
+    }
+  }
+
+  throw new Error(
+    "No complete Windows Node.js/npm installation was found on PATH",
+  );
+}
+
+export async function runSubscriptionCliNpm(
+  args: string[],
+  options: RunSubscriptionCliNpmOptions,
+): Promise<unknown> {
+  const invocation = resolveSubscriptionCliNpmInvocation(args, options);
+  const execute =
+    options.execute ??
+    ((command, commandArgs, execOptions) =>
+      execFileAsync(command, commandArgs, execOptions));
+  return execute(invocation.command, invocation.args, {
+    timeout: options.timeout,
+  });
+}

--- a/packages/auth/src/codex-device.test.ts
+++ b/packages/auth/src/codex-device.test.ts
@@ -25,7 +25,10 @@ vi.mock("node:fs", async (importOriginal) => {
   return { ...actual, rmSync: rmSyncMock };
 });
 
-import { startCodexDeviceLogin } from "./codex-device.ts";
+import {
+  codexDeviceLoginUsesShell,
+  startCodexDeviceLogin,
+} from "./codex-device.ts";
 
 interface FakeChild {
   process: EventEmitter;
@@ -84,6 +87,12 @@ afterEach(() => {
 });
 
 describe("startCodexDeviceLogin", () => {
+  it("uses the command shell only for the Windows npm shim", () => {
+    expect(codexDeviceLoginUsesShell("win32")).toBe(true);
+    expect(codexDeviceLoginUsesShell("linux")).toBe(false);
+    expect(codexDeviceLoginUsesShell("darwin")).toBe(false);
+  });
+
   it("rejects when the CLI closes successfully before emitting the prompt", async () => {
     const child = mockChild();
     const start = startCodexDeviceLogin();
@@ -173,6 +182,14 @@ describe("startCodexDeviceLogin", () => {
     const child = mockChild();
     const start = startCodexDeviceLogin();
     const codexHome = spawnedCodexHome();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "codex",
+      ["login", "--device-auth"],
+      expect.objectContaining({
+        shell: process.platform === "win32",
+      }),
+    );
 
     child.process.emit("spawn");
     child.process.emit("exit", 0, null);

--- a/packages/auth/src/codex-device.ts
+++ b/packages/auth/src/codex-device.ts
@@ -59,6 +59,12 @@ export interface CodexDeviceFlow {
   close: () => void;
 }
 
+export function codexDeviceLoginUsesShell(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === "win32";
+}
+
 function expiryFromJwt(token: string): number {
   try {
     const payload = JSON.parse(
@@ -83,6 +89,10 @@ export function startCodexDeviceLogin(): Promise<CodexDeviceFlow> {
   const codexHome = mkdtempSync(path.join(os.tmpdir(), "eliza-codex-device-"));
   const child = spawn("codex", ["login", "--device-auth"], {
     env: { ...process.env, CODEX_HOME: codexHome, NO_COLOR: "1" },
+    // npm installs Codex as a `.cmd` shim on Windows. The command and its
+    // arguments are static, so the shell is used only to make that shim
+    // executable; Unix keeps the direct child process and signal behavior.
+    shell: codexDeviceLoginUsesShell(),
     stdio: ["ignore", "pipe", "pipe"],
   });
 


### PR DESCRIPTION
# Relates to

Closes #21224.

Definition of Done: full standard in [CONTRIBUTING.md](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Frozen install, focused route/process tests, package typechecks, package builds, and full Agent/Auth source Biome checks pass on the exact head.
- [x] Root verify was run after sync; its unrelated Electrobun generated-file lint blocker is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@88ac1800e67fe2766881190d1af1a413844fa425`; zero conflicts.
- [x] Exact head is one commit ahead / zero behind.

# Risks

Low to moderate. The changed runtime path is limited to subscription CLI bootstrap and Codex device-process launch. Package names and Codex arguments are static. Windows npm execution is deliberately shell-free, and Unix keeps the existing direct `npm` / `codex` processes. Install prefix, cooldown, coalescing, typed errors, account persistence, and OAuth protocol code are unchanged.

# Background

## What does this PR do?

The Agent bootstrap previously called `execFile("npm", ...)`, but a normal Windows Node installation exposes `npm.cmd`, which `execFile` cannot start. Even if installation succeeded, the availability probe looked only for extensionless `codex` / `claude` files, then the headless Codex flow tried to launch bare `codex` without the Windows shell.

This PR closes the whole Windows process boundary:

1. Resolve a complete Node/npm installation from PATH and invoke `npm-cli.js` through that installation's `node.exe`. The user-controlled state-directory prefix remains ordinary argv and is never interpolated into a shell command.
2. Probe installed CLIs with PATHEXT semantics, deliberately ignoring the non-runnable extensionless npm companion on Windows.
3. Use the command shell only for the static Windows `codex login --device-auth` shim; Unix child/signal behavior stays direct.

## What kind of change is this?

Bug fix (Windows subscription/device-login bootstrap).

# Documentation changes needed?

No. Existing account-login commands and UI flow are unchanged; this makes that documented flow runnable on Windows.

# Testing

## Where should a reviewer start?

Start with `packages/agent/src/internal/subscription-cli-process.ts`, then inspect its single Agent call site and the `shell` option in `packages/auth/src/codex-device.ts`.

## Detailed testing steps

Exact head: `3f9e23cbae644f570f85733cd22e5b1644cc646a`

1. `bun install --frozen-lockfile --ignore-scripts`
   - PASS: 3,809 installs / 4,090 packages, no changes.
2. Focused accounts + Codex boundary:
   - `bun x --no-install vitest run packages/agent/src/api/accounts-routes.test.ts packages/agent/test/api/accounts-routes.test.ts packages/agent/src/api/accounts-routes.subscription-cli.test.ts packages/auth/src/codex-device.test.ts`
   - PASS: 4 files, 63 tests.
3. `bun x --no-install @biomejs/biome check packages/agent/src packages/auth/src`
   - PASS: 956 files, no fixes.
4. `bun run --cwd packages/auth typecheck` - PASS.
5. `bun run --cwd packages/agent typecheck` - PASS.
6. `bun run --cwd packages/auth build` - PASS.
7. `bun run --cwd packages/agent build` - PASS: package boundary audit, declarations/dist, 196 NodeNext specifier rewrites.
8. Current Windows resolver probe - PASS: `C:\Program Files\nodejs\node.exe` + `C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js`.
9. `git diff --check origin/develop...HEAD` - PASS.
10. `bun run verify` - reaches the Turbo typecheck/lint fan-out and stops at the unrelated Electrobun generated-artifact lint failure documented below.

# Evidence Gate

<!-- evidence-head:faeea0e488da27e5fbbabacc02d1c083eb15ba11 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - process-launch boundary only; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - process-launch boundary only; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic argv/spawn tests cover the complete changed boundary.
<!-- evidence-row:backend-logs -->
- [x] Production accounts-route coverage passes, including the typed 503 prerequisite path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action-selection, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head resolver matrix plus the real Windows Node/npm path probe are recorded below.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual-text surface changes.

# Evidence Details

## Domain artifact

```json
{
  "command": "C:\\Program Files\\nodejs\\node.exe",
  "args": [
    "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
    "--version"
  ]
}
```

The 63-test route/process matrix proves quoted and spaced PATH entries; incomplete Node/npm rejection; `.cmd` discovery through PATHEXT; shell-free npm argv and timeout forwarding; Unix direct npm behavior; Windows-only Codex shell selection; and the existing prefix/cooldown/coalescing/typed-failure behavior.

## Real LLM-call trajectory

N/A - no provider/model/action path changed.

## Backend + frontend logs

No live credential or provider call was used. The production route handler and mocked child-process boundary passed 63/63 deterministic tests; no secret or external CLI installation was required.

## Screenshots / video / audio

N/A - no rendered, voice, TTS, or STT surface changed.

## Known gaps / failures

- Exact-head root `bun run verify` passes guide/Biome-version/i18n/dependency/plugin-convention/alias/tsconfig pre-gates and reaches Turbo. It stops in unrelated `@elizaos/electrobun#lint:check`: the Windows package script scans generated `src/preload.js` and `.generated/brand-config.json`, producing existing generated-code lint and format errors. None of the five changed files are in that package.
- The full Auth suite passes 162/171 on this Windows host. The nine failures are existing Windows filesystem-policy tests that require symlink privilege or Unix permission-bit behavior; the changed `codex-device.test.ts` passes in the focused matrix.
- The full Agent batch runner cannot launch any Windows batch because it executes bare `spawn("bunx")` while the pinned distribution exposes `bunx.cmd`. The complete changed accounts-route surface was therefore run directly (63/63), and Agent typecheck, build, and all-source Biome pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-agent-windows-subscription-cli]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza"} -->

