### PR TITLE
fix(shared): guard non-string inputs in normalizeOpenAICallbackInput and add unit test suite

### DIFF
--- a/packages/shared/src/utils/subscription-auth.test.ts
+++ b/packages/shared/src/utils/subscription-auth.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for subscription and OAuth authentication utilities in packages/shared/src/utils/subscription-auth.ts.
+ * Exercises callback input normalization, raw code validation, localhost/127.0.0.1 port and path checks,
+ * non-string handling, and error formatting.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  formatSubscriptionRequestError,
+  normalizeOpenAICallbackInput,
+} from "./subscription-auth.js";
+
+describe("subscription auth utilities", () => {
+  describe("formatSubscriptionRequestError", () => {
+    it("extracts message from Error instance", () => {
+      expect(
+        formatSubscriptionRequestError(new Error("Connection reset by peer")),
+      ).toBe("Connection reset by peer");
+    });
+
+    it("stringifies non-Error values", () => {
+      expect(formatSubscriptionRequestError("Internal Server Error")).toBe(
+        "Internal Server Error",
+      );
+      expect(formatSubscriptionRequestError(500)).toBe("500");
+    });
+  });
+
+  describe("normalizeOpenAICallbackInput", () => {
+    it("returns error on non-string or empty inputs", () => {
+      expect(normalizeOpenAICallbackInput(null)).toEqual({
+        ok: false,
+        error: "subscriptionstatus.PasteCallbackUrlFromLocalhost",
+      });
+      expect(normalizeOpenAICallbackInput(undefined)).toEqual({
+        ok: false,
+        error: "subscriptionstatus.PasteCallbackUrlFromLocalhost",
+      });
+      expect(normalizeOpenAICallbackInput("   ")).toEqual({
+        ok: false,
+        error: "subscriptionstatus.PasteCallbackUrlFromLocalhost",
+      });
+    });
+
+    it("accepts valid raw authorization code", () => {
+      expect(normalizeOpenAICallbackInput("oa_code_987654321")).toEqual({
+        ok: true,
+        code: "oa_code_987654321",
+      });
+    });
+
+    it("rejects excessively long raw codes", () => {
+      const longCode = "a".repeat(4097);
+      expect(normalizeOpenAICallbackInput(longCode)).toEqual({
+        ok: false,
+        error: "subscriptionstatus.CallbackCodeTooLong",
+      });
+    });
+
+    it("normalizes localhost and 127.0.0.1 callback URLs", () => {
+      const fullUrl = "http://localhost:1455/auth/callback?code=secret_code_1";
+      expect(normalizeOpenAICallbackInput(fullUrl)).toEqual({
+        ok: true,
+        code: fullUrl,
+      });
+
+      const schemaLessLocalhost =
+        "localhost:1455/auth/callback?code=secret_code_2";
+      expect(normalizeOpenAICallbackInput(schemaLessLocalhost)).toEqual({
+        ok: true,
+        code: "http://localhost:1455/auth/callback?code=secret_code_2",
+      });
+
+      const ipUrl = "http://127.0.0.1:1455/auth/callback?code=secret_code_3";
+      expect(normalizeOpenAICallbackInput(ipUrl)).toEqual({
+        ok: true,
+        code: ipUrl,
+      });
+    });
+
+    it("rejects URLs with incorrect host, port, or path", () => {
+      expect(
+        normalizeOpenAICallbackInput(
+          "http://attacker.com:1455/auth/callback?code=123",
+        ),
+      ).toEqual({
+        ok: false,
+        error: "subscriptionstatus.ExpectedCallbackUrl",
+      });
+
+      expect(
+        normalizeOpenAICallbackInput(
+          "http://localhost:8080/auth/callback?code=123",
+        ),
+      ).toEqual({
+        ok: false,
+        error: "subscriptionstatus.ExpectedCallbackUrl",
+      });
+
+      expect(
+        normalizeOpenAICallbackInput(
+          "http://localhost:1455/other/callback?code=123",
+        ),
+      ).toEqual({
+        ok: false,
+        error: "subscriptionstatus.ExpectedCallbackUrl",
+      });
+    });
+
+    it("rejects callback URLs missing code parameter", () => {
+      expect(
+        normalizeOpenAICallbackInput("http://localhost:1455/auth/callback"),
+      ).toEqual({
+        ok: false,
+        error: "subscriptionstatus.CallbackUrlMissingCode",
+      });
+    });
+  });
+});

--- a/packages/shared/src/utils/subscription-auth.ts
+++ b/packages/shared/src/utils/subscription-auth.ts
@@ -10,7 +10,7 @@ export function formatSubscriptionRequestError(err: unknown): string {
   return String(err);
 }
 
-export function normalizeOpenAICallbackInput(input: string):
+export function normalizeOpenAICallbackInput(input: string | null | undefined):
   | {
       ok: true;
       code: string;
@@ -19,6 +19,13 @@ export function normalizeOpenAICallbackInput(input: string):
       ok: false;
       error: string;
     } {
+  if (typeof input !== "string") {
+    return {
+      ok: false,
+      error: "subscriptionstatus.PasteCallbackUrlFromLocalhost",
+    };
+  }
+
   const trimmed = input.trim();
   if (!trimmed) {
     return {


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/subscription-auth.ts`, `normalizeOpenAICallbackInput` invoked `input.trim()` directly without validating that `input` is a string, which caused unhandled TypeErrors on nullish or non-string inputs.
2. Added `typeof input !== "string"` guard and widened input type.
3. Created a comprehensive unit test suite in `packages/shared/src/utils/subscription-auth.test.ts`.

Closes #21252.

## Verification

Exact commit: `3a04eee011`.

- Focused unit test suite `packages/shared/src/utils/subscription-auth.test.ts`: 8/8 tests passing (15 assertions).
- Biome format on `@elizaos/shared`: 409 files formatted, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - subscription auth callback utility; no rendered UI changed.
- [x] N/A - subscription auth callback utility; no rendered UI changed.
- [x] N/A - deterministic subscription callback normalization tests.
- [x] Focused test suite transcript:
```text
✓ subscription auth utilities > formatSubscriptionRequestError > extracts message from Error instance [0.15ms]
✓ subscription auth utilities > formatSubscriptionRequestError > stringifies non-Error values [0.05ms]
✓ subscription auth utilities > normalizeOpenAICallbackInput > returns error on non-string or empty inputs [0.20ms]
✓ subscription auth utilities > normalizeOpenAICallbackInput > accepts valid raw authorization code [0.05ms]
✓ subscription auth utilities > normalizeOpenAICallbackInput > rejects excessively long raw codes [0.05ms]
✓ subscription auth utilities > normalizeOpenAICallbackInput > normalizes localhost and 127.0.0.1 callback URLs [0.12ms]
✓ subscription auth utilities > normalizeOpenAICallbackInput > rejects URLs with incorrect host, port, or path [0.04ms]
✓ subscription auth utilities > normalizeOpenAICallbackInput > rejects callback URLs missing code parameter [0.02ms]
8 pass, 0 fail, 15 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza"} -->
