### PR TITLE
fix(cloud): catch PGlite test schemas up to the backup-activation migrations

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -2569,7 +2569,6 @@ async function handleRequest(
         error,
         readJsonBody,
         readBody,
-        decodePathComponent,
         discoverSkills,
       })
     ) {

--- a/packages/cloud/api/__tests__/eliza-agents-restore-body-guard.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-restore-body-guard.test.ts
@@ -94,8 +94,10 @@ beforeAll(async () => {
     const { organizations } = await import("@/db/schemas/organizations");
     const { users } = await import("@/db/schemas/users");
     const { userCharacters } = await import("@/db/schemas/user-characters");
-    const { agentSandboxes, agentSandboxBackups } = await import(
-      "@/db/schemas/agent-sandboxes"
+    const { agentSandboxes, agentSandboxBackups, agentBackupCatalogAuthorities } =
+      await import("@/db/schemas/agent-sandboxes");
+    const { agentBackupObjects } = await import(
+      "@/db/schemas/agent-backup-catalog"
     );
     const { pushSchema } = await import("@/db/push-schema-for-tests");
     const { apply } = await pushSchema(
@@ -105,6 +107,8 @@ beforeAll(async () => {
         userCharacters,
         agentSandboxes,
         agentSandboxBackups,
+        agentBackupCatalogAuthorities,
+        agentBackupObjects,
       } as never,
       dbWrite as never,
     );

--- a/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
@@ -237,11 +237,34 @@ export const PROVISIONING_JOB_TEST_TABLES: readonly string[] = [
   "replacement_cleanup_vpn_registration_started_at" timestamptz,
   "replacement_cleanup_allocation_counted" boolean,
   "replacement_cleanup_created_at" timestamptz,
+  "activation_generation" uuid,
+  "activation_lifecycle_revision" bigint,
+  "activation_phase" text,
+  "activation_receipt_hash" text,
+  "activation_container_id" text,
+  "activation_node_id" text,
+  "activation_image_digest" text,
+  "activation_boot_id" uuid,
+  "activation_authority_published_at" timestamptz,
+  "activation_dispatched_at" timestamptz,
+  "activation_completed_at" timestamptz,
+  "next_backup_at" timestamptz,
+  "backup_schedule_operation_id" uuid,
+  "backup_schedule_retry_at" timestamptz,
+  "backup_schedule_claim_owner" text,
+  "backup_schedule_claim_generation" uuid,
+  "backup_schedule_claim_expires_at" timestamptz,
+  "backup_schedule_attempts" integer NOT NULL DEFAULT 0,
+  "backup_schedule_last_error_code" text,
+  "backup_schedule_last_protected_at" timestamptz,
   "created_at" timestamptz NOT NULL DEFAULT now(),
   "updated_at" timestamptz NOT NULL DEFAULT now(),
   "deleted_at" timestamptz,
   PRIMARY KEY ("id")
 )`,
+  `CREATE INDEX IF NOT EXISTS "agent_sandboxes_activation_generation_idx"
+  ON "agent_sandboxes" ("activation_generation")
+  WHERE "activation_generation" IS NOT NULL`,
   `CREATE OR REPLACE FUNCTION advance_agent_sandbox_lifecycle_revision()
 RETURNS trigger
 LANGUAGE plpgsql


### PR DESCRIPTION
Release candidate run 32019534953 got through verify (post #21158) and then failed `bun run test`: every PGlite suite built on the provisioning-job DDL fixture or the restore-guard pushSchema subset died in setup with `column "activation_generation" ... does not exist` / `relation "agent_backup_catalog_authorities" does not exist`.

Migrations 0230–0235 added the activation authority columns, backup-scheduler columns, and catalog authority/object tables, but the test schemas were not extended (the fixture's contract is explicit: every selected Drizzle column must exist there so drift fails loudly — it did).

- `tier-upgrade-pglite-schema.ts`: adds the 11 `activation_*` columns, the partial activation-generation index, and the 9 backup-scheduler columns.
- `eliza-agents-restore-body-guard.test.ts`: pushes `agentBackupCatalogAuthorities` + `agentBackupObjects`, which its repository path now reads.

Evidence: all four previously failing suites green locally — delete-sandbox-branch 4/4, restore+bridge/stream guards 9/9, upgrade-tier 16/16. Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)