### PR TITLE
fix(shared): trim reason in isCloudStatusReasonApiKeyOnly and add unit test suite

### DIFF
--- a/packages/shared/src/utils/cloud-status.test.ts
+++ b/packages/shared/src/utils/cloud-status.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for cloud status classification utilities in packages/shared/src/utils/cloud-status.ts.
+ * Exercises API key only reason codes, whitespace trimming, disconnected states,
+ * and authenticated state logic.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isCloudStatusAuthenticated,
+  isCloudStatusReasonApiKeyOnly,
+} from "./cloud-status.js";
+
+describe("cloud status utilities", () => {
+  describe("isCloudStatusReasonApiKeyOnly", () => {
+    it("returns true for exact key-only reason strings", () => {
+      expect(
+        isCloudStatusReasonApiKeyOnly("api_key_present_not_authenticated"),
+      ).toBe(true);
+      expect(
+        isCloudStatusReasonApiKeyOnly("api_key_present_runtime_not_started"),
+      ).toBe(true);
+    });
+
+    it("trims whitespace from reason strings", () => {
+      expect(
+        isCloudStatusReasonApiKeyOnly("  api_key_present_not_authenticated  "),
+      ).toBe(true);
+      expect(
+        isCloudStatusReasonApiKeyOnly(
+          "\napi_key_present_runtime_not_started\t",
+        ),
+      ).toBe(true);
+    });
+
+    it("returns false for non-key-only reason strings", () => {
+      expect(isCloudStatusReasonApiKeyOnly("disconnected")).toBe(false);
+      expect(isCloudStatusReasonApiKeyOnly("invalid_credentials")).toBe(false);
+      expect(isCloudStatusReasonApiKeyOnly("")).toBe(false);
+      expect(isCloudStatusReasonApiKeyOnly("   ")).toBe(false);
+    });
+
+    it("returns false for nullish or non-string inputs", () => {
+      expect(isCloudStatusReasonApiKeyOnly(null)).toBe(false);
+      expect(isCloudStatusReasonApiKeyOnly(undefined)).toBe(false);
+      expect(isCloudStatusReasonApiKeyOnly(123 as unknown as string)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("isCloudStatusAuthenticated", () => {
+    it("returns true when connected and reason is not key-only", () => {
+      expect(isCloudStatusAuthenticated(true, undefined)).toBe(true);
+      expect(isCloudStatusAuthenticated(true, null)).toBe(true);
+      expect(isCloudStatusAuthenticated(true, "ready")).toBe(true);
+    });
+
+    it("returns false when connected but reason is key-only", () => {
+      expect(
+        isCloudStatusAuthenticated(true, "api_key_present_not_authenticated"),
+      ).toBe(false);
+      expect(
+        isCloudStatusAuthenticated(
+          true,
+          "  api_key_present_runtime_not_started  ",
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false when not connected regardless of reason", () => {
+      expect(isCloudStatusAuthenticated(false, undefined)).toBe(false);
+      expect(isCloudStatusAuthenticated(false, "ready")).toBe(false);
+      expect(
+        isCloudStatusAuthenticated(false, "api_key_present_not_authenticated"),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/utils/cloud-status.ts
+++ b/packages/shared/src/utils/cloud-status.ts
@@ -11,14 +11,15 @@ const CLOUD_STATUS_API_KEY_ONLY_REASONS: ReadonlySet<string> = new Set([
 export function isCloudStatusReasonApiKeyOnly(
   reason: string | null | undefined,
 ): boolean {
-  return (
-    typeof reason === "string" && CLOUD_STATUS_API_KEY_ONLY_REASONS.has(reason)
-  );
+  if (typeof reason !== "string") {
+    return false;
+  }
+  return CLOUD_STATUS_API_KEY_ONLY_REASONS.has(reason.trim());
 }
 
 export function isCloudStatusAuthenticated(
   connected: boolean,
   reason: string | null | undefined,
 ): boolean {
-  return connected && !isCloudStatusReasonApiKeyOnly(reason);
+  return connected === true && !isCloudStatusReasonApiKeyOnly(reason);
 }


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/cloud-status.ts`, `isCloudStatusReasonApiKeyOnly` checked `CLOUD_STATUS_API_KEY_ONLY_REASONS.has(reason)` without trimming, causing reason strings with whitespace padding to fail classification.
2. Added `.trim()` to reason string lookup.
3. Created a comprehensive unit test suite in `packages/shared/src/utils/cloud-status.test.ts`.

Closes #21255.

## Verification

Exact commit: `b6a3b77cae`.

- Focused unit test suite `packages/shared/src/utils/cloud-status.test.ts`: 7/7 tests passing (19 assertions).
- Biome format on `@elizaos/shared`: 409 files formatted, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - cloud status classification utility; no rendered UI changed.
- [x] N/A - cloud status classification utility; no rendered UI changed.
- [x] N/A - deterministic cloud status classification tests.
- [x] Focused test suite transcript:
```text
✓ cloud status utilities > isCloudStatusReasonApiKeyOnly > returns true for exact key-only reason strings [0.14ms]
✓ cloud status utilities > isCloudStatusReasonApiKeyOnly > trims whitespace from reason strings [0.06ms]
✓ cloud status utilities > isCloudStatusReasonApiKeyOnly > returns false for non-key-only reason strings [0.04ms]
✓ cloud status utilities > isCloudStatusReasonApiKeyOnly > returns false for nullish or non-string inputs [0.05ms]
✓ cloud status utilities > isCloudStatusAuthenticated > returns true when connected and reason is not key-only [0.07ms]
✓ cloud status utilities > isCloudStatusAuthenticated > returns false when connected but reason is key-only [0.03ms]
✓ cloud status utilities > isCloudStatusAuthenticated > returns false when not connected regardless of reason [0.03ms]
7 pass, 0 fail, 19 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza"} -->
