### PR TITLE
fix(plugin-imessage): reject prefix-coerced bluebubbles list limit

### DIFF
--- a/plugins/plugin-imessage/src/api/bluebubbles-routes.limit.test.ts
+++ b/plugins/plugin-imessage/src/api/bluebubbles-routes.limit.test.ts
@@ -1,0 +1,173 @@
+/**
+ * GET /api/bluebubbles/chats|messages `limit`/`offset` is list pagination
+ * leftover tax after iMessage messages limit (#20855). Stock develop
+ * treated `limit=1e2` as one row (`Number.parseInt("1e2", 10) === 1`)
+ * instead of a 400. webhook / status parsers stay untouched.
+ */
+import type http from "node:http";
+import type { RouteHelpers } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleBlueBubblesRoute } from "./bluebubbles-routes.ts";
+
+interface ListCall {
+  kind: "chats" | "messages";
+  limit?: number;
+  offset?: number;
+  chatGuid?: string;
+}
+
+function makeHelpers() {
+  const json = vi.fn();
+  const error = vi.fn();
+  const readJsonBody = vi.fn();
+  return { json, error, readJsonBody } as unknown as RouteHelpers & {
+    json: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+}
+
+async function call(
+  url: string,
+  pathname: string,
+  calls: ListCall[],
+): Promise<{ helpers: ReturnType<typeof makeHelpers> }> {
+  const helpers = makeHelpers();
+  const client = {
+    listChats: async (limit?: number, offset?: number) => {
+      calls.push({ kind: "chats", limit, offset });
+      return [{ id: "chat-1" }];
+    },
+    getMessages: async (chatGuid: string, limit?: number, offset?: number) => {
+      calls.push({ kind: "messages", chatGuid, limit, offset });
+      return [{ id: "msg-1" }];
+    },
+  };
+  const state = {
+    runtime: {
+      getService: (type: string) =>
+        type === "bluebubbles"
+          ? {
+              isConnected: () => true,
+              getWebhookPath: () => "/webhooks/bluebubbles",
+              getClient: () => client,
+              handleWebhook: async () => undefined,
+            }
+          : null,
+    },
+  };
+  const req = { url } as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  const handled = await handleBlueBubblesRoute(
+    req,
+    res,
+    pathname,
+    "GET",
+    state,
+    helpers,
+  );
+  expect(handled).toBe(true);
+  return { helpers };
+}
+
+describe("GET /api/bluebubbles/chats limit identity", () => {
+  it("omitted limit defaults to 100 and reaches listChats", async () => {
+    const calls: ListCall[] = [];
+    const { helpers } = await call(
+      "/api/bluebubbles/chats",
+      "/api/bluebubbles/chats",
+      calls,
+    );
+    expect(helpers.error).not.toHaveBeenCalled();
+    expect(calls).toEqual([{ kind: "chats", limit: 100, offset: 0 }]);
+  });
+
+  it("accepts canonical limit=10", async () => {
+    const calls: ListCall[] = [];
+    const { helpers } = await call(
+      "/api/bluebubbles/chats?limit=10",
+      "/api/bluebubbles/chats",
+      calls,
+    );
+    expect(helpers.error).not.toHaveBeenCalled();
+    expect(calls).toEqual([{ kind: "chats", limit: 10, offset: 0 }]);
+  });
+
+  it("caps a canonical oversize limit at 500", async () => {
+    const calls: ListCall[] = [];
+    await call(
+      "/api/bluebubbles/chats?limit=501",
+      "/api/bluebubbles/chats",
+      calls,
+    );
+    expect(calls).toEqual([{ kind: "chats", limit: 500, offset: 0 }]);
+  });
+
+  it.each(["1e2", "12px", "007", "0", "abc", "-1", "50abc", " 10", "10 "])(
+    "rejects prefix-coerced chats limit=%s before listChats",
+    async (token) => {
+      const calls: ListCall[] = [];
+      const { helpers } = await call(
+        `/api/bluebubbles/chats?limit=${encodeURIComponent(token)}`,
+        "/api/bluebubbles/chats",
+        calls,
+      );
+      expect(helpers.error).toHaveBeenCalledWith(
+        expect.anything(),
+        "limit must be a positive integer",
+        400,
+      );
+      expect(calls).toEqual([]);
+    },
+  );
+
+  it.each(["1e2", "12px", "007", "-1", "0x10"])(
+    "rejects prefix-coerced chats offset=%s before listChats",
+    async (token) => {
+      const calls: ListCall[] = [];
+      const { helpers } = await call(
+        `/api/bluebubbles/chats?offset=${encodeURIComponent(token)}`,
+        "/api/bluebubbles/chats",
+        calls,
+      );
+      expect(helpers.error).toHaveBeenCalledWith(
+        expect.anything(),
+        "offset must be a non-negative integer",
+        400,
+      );
+      expect(calls).toEqual([]);
+    },
+  );
+});
+
+describe("GET /api/bluebubbles/messages limit identity", () => {
+  it("omitted limit defaults to 50 and reaches getMessages", async () => {
+    const calls: ListCall[] = [];
+    const { helpers } = await call(
+      "/api/bluebubbles/messages?chatGuid=chat-1",
+      "/api/bluebubbles/messages",
+      calls,
+    );
+    expect(helpers.error).not.toHaveBeenCalled();
+    expect(calls).toEqual([
+      { kind: "messages", chatGuid: "chat-1", limit: 50, offset: 0 },
+    ]);
+  });
+
+  it.each(["1e2", "12px", "007", "0", "foo"])(
+    "rejects prefix-coerced messages limit=%s before getMessages",
+    async (token) => {
+      const calls: ListCall[] = [];
+      const { helpers } = await call(
+        `/api/bluebubbles/messages?chatGuid=chat-1&limit=${encodeURIComponent(token)}`,
+        "/api/bluebubbles/messages",
+        calls,
+      );
+      expect(helpers.error).toHaveBeenCalledWith(
+        expect.anything(),
+        "limit must be a positive integer",
+        400,
+      );
+      expect(calls).toEqual([]);
+    },
+  );
+});

--- a/plugins/plugin-imessage/src/api/bluebubbles-routes.ts
+++ b/plugins/plugin-imessage/src/api/bluebubbles-routes.ts
@@ -46,6 +46,50 @@ function resolveService(state: BlueBubblesRouteState): BlueBubblesServiceLike | 
   return (raw as BlueBubblesServiceLike | null | undefined) ?? null;
 }
 
+const DEFAULT_CHATS_LIMIT = 100;
+const DEFAULT_MESSAGES_LIMIT = 50;
+const MAX_LIST_LIMIT = 500;
+
+/**
+ * Canonical BlueBubbles list page size. `Number.parseInt("1e2", 10) === 1`
+ * used to silently return one chat/message instead of a 400. chats default
+ * 100, messages default 50; webhook / status parsers stay untouched.
+ */
+function parseBlueBubblesLimit(
+  raw: string | null,
+  defaultValue: number,
+): number | null {
+  if (raw === null || raw === "") {
+    return defaultValue;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    return null;
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    return null;
+  }
+  return Math.min(parsed, MAX_LIST_LIMIT);
+}
+
+/**
+ * Canonical BlueBubbles list offset. Prefix-legal garbage must not coerce
+ * (`Number.parseInt("1e2", 10) === 1`) into `listChats` / `getMessages`.
+ */
+function parseBlueBubblesOffset(raw: string | null): number | null {
+  if (raw === null || raw === "") {
+    return 0;
+  }
+  if (!/^(?:0|[1-9]\d*)$/.test(raw)) {
+    return null;
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    return null;
+  }
+  return parsed;
+}
+
 export function resolveBlueBubblesWebhookPath(state: BlueBubblesRouteState): string {
   const service = resolveService(state);
   const configuredPath = service?.getWebhookPath();
@@ -105,11 +149,21 @@ export async function handleBlueBubblesRoute(
     }
 
     const url = new URL(req.url ?? pathname, "http://localhost");
-    const limit = Math.min(
-      Math.max(1, Number.parseInt(url.searchParams.get("limit") ?? "100", 10) || 100),
-      500
+    // BlueBubbles chats pagination leftover tax after iMessage messages
+    // limit (#20855). limit=1e2 used to silently return one chat.
+    const limit = parseBlueBubblesLimit(
+      url.searchParams.get("limit"),
+      DEFAULT_CHATS_LIMIT,
     );
-    const offset = Math.max(0, Number.parseInt(url.searchParams.get("offset") ?? "0", 10) || 0);
+    const offset = parseBlueBubblesOffset(url.searchParams.get("offset"));
+    if (limit === null) {
+      helpers.error(res, "limit must be a positive integer", 400);
+      return true;
+    }
+    if (offset === null) {
+      helpers.error(res, "offset must be a non-negative integer", 400);
+      return true;
+    }
 
     try {
       const chats = await client.listChats(limit, offset);
@@ -144,11 +198,19 @@ export async function handleBlueBubblesRoute(
       return true;
     }
 
-    const limit = Math.min(
-      Math.max(1, Number.parseInt(url.searchParams.get("limit") ?? "50", 10) || 50),
-      500
+    const limit = parseBlueBubblesLimit(
+      url.searchParams.get("limit"),
+      DEFAULT_MESSAGES_LIMIT,
     );
-    const offset = Math.max(0, Number.parseInt(url.searchParams.get("offset") ?? "0", 10) || 0);
+    const offset = parseBlueBubblesOffset(url.searchParams.get("offset"));
+    if (limit === null) {
+      helpers.error(res, "limit must be a positive integer", 400);
+      return true;
+    }
+    if (offset === null) {
+      helpers.error(res, "offset must be a non-negative integer", 400);
+      return true;
+    }
 
     try {
       const messages = await client.getMessages(chatGuid, limit, offset);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on BlueBubbles
list `limit`/`offset` prefix-coercion. iMessage HTTP list class, leftover
tax after data-routes messages limit (#20855). Not leftover tax on
webhook, status, iMessage `/api/imessage/messages`, or plugin-bluebubbles
data-routes.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `limit`/`offset` only on `/api/bluebubbles/chats` and
`/api/bluebubbles/messages`. Omitted/empty still use today's defaults
(chats 100, messages 50, offset 0). Canonical positive ints still page.
Prefix-legal garbage (`1e2`, `12px`, `007`) 400s before `listChats` /
`getMessages`. webhook / status parsers stay untouched.

# Background

## What does this PR do?

`GET /api/bluebubbles/chats` and `GET /api/bluebubbles/messages` used
`Number.parseInt` on `limit`/`offset`. `limit=1e2` silently returned one
row (`Number.parseInt("1e2", 10) === 1`) instead of a 400.

- omitted / empty limit → chats 100 / messages 50 (200)
- omitted / empty offset → 0
- exact canonical positive decimal → that page size, capped at 500
- `1e2` / `12px` / `007` / `0` / `abc` / `-1` → **400** before the client

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers page BlueBubbles chats/messages with `?limit=N`. A scientific or
unit-suffixed token must not silently coerce to a prefix integer and
return the wrong page. This is leftover tax after iMessage data-routes
messages limit (#20855), which left the BlueBubbles HTTP list parsers
untouched. Different file from #20855 (`data-routes.ts`) and different
plugin from #20818.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-imessage/src/api/bluebubbles-routes.limit.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-imessage && bunx vitest run --config vitest.config.ts src/api/bluebubbles-routes.limit.test.ts
```

23 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:ca7e78b37105d665f609ec996ca1d39f910113f4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; BlueBubbles list `limit`/`offset` query only.

- [x] N/A - no rendered UI change; BlueBubbles list `limit`/`offset` query only.

- [x] N/A - no rendered UI change; BlueBubbles list `limit`/`offset` query only.

- [x] N/A - focused route tests drive the real limit/offset tokens and assert 400 before listChats/getMessages; no production log capture is required to see the contract.

- [x] N/A - no frontend request path in this proof.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.

- [x] N/A - no agent write; illegal tokens 400 before the BlueBubbles client.

- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
`limit`/`offset` tokens reject; omitted/canonical still bind the matching
page.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the BlueBubbles list
query only.

## Known gaps / failures

`bun run verify` was not run. This is a two-file BlueBubbles list
parse with a green focused suite (23 new). Full monorepo verify is
unrelated to this query grammar and was skipped to keep the proof tied
to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
