### PR TITLE
style(cloud): format restore-guard schema imports

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-restore-body-guard.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-restore-body-guard.test.ts
@@ -94,8 +94,11 @@ beforeAll(async () => {
     const { organizations } = await import("@/db/schemas/organizations");
     const { users } = await import("@/db/schemas/users");
     const { userCharacters } = await import("@/db/schemas/user-characters");
-    const { agentSandboxes, agentSandboxBackups, agentBackupCatalogAuthorities } =
-      await import("@/db/schemas/agent-sandboxes");
+    const {
+      agentSandboxes,
+      agentSandboxBackups,
+      agentBackupCatalogAuthorities,
+    } = await import("@/db/schemas/agent-sandboxes");
     const { agentBackupObjects } = await import(
       "@/db/schemas/agent-backup-catalog"
     );


### PR DESCRIPTION
Follow-up to #21258: the widened import block wasn't Biome-formatted, failing cloud-api `lint:check` in release candidate run 32023183837. `bunx biome check .` in packages/cloud/api now clean (1165 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)