### PR TITLE
fix(shared): guard non-string paths in asset-url utilities and add unit test suite

### DIFF
--- a/packages/shared/src/utils/asset-url.test.ts
+++ b/packages/shared/src/utils/asset-url.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for asset and API URL resolution in packages/shared/src/utils/asset-url.ts.
+ * Exercises relative asset normalization, absolute URL preservation, custom currentUrl/baseUrl options,
+ * boot-config CDN base resolution, and API base URL prefixing.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { setBootConfig } from "../config/boot-config-store.js";
+import { resolveApiUrl, resolveAppAssetUrl } from "./asset-url.js";
+
+describe("asset-url utilities", () => {
+  afterEach(() => {
+    setBootConfig({});
+  });
+
+  describe("resolveAppAssetUrl", () => {
+    it("returns empty string for empty or non-string inputs", () => {
+      expect(resolveAppAssetUrl("")).toBe("");
+      expect(resolveAppAssetUrl(null as unknown as string)).toBe("");
+      expect(resolveAppAssetUrl(undefined as unknown as string)).toBe("");
+    });
+
+    it("preserves already absolute URLs", () => {
+      expect(resolveAppAssetUrl("https://cdn.eliza.com/avatar.vrm")).toBe(
+        "https://cdn.eliza.com/avatar.vrm",
+      );
+      expect(resolveAppAssetUrl("http://localhost:3000/anim.glb")).toBe(
+        "http://localhost:3000/anim.glb",
+      );
+      expect(resolveAppAssetUrl("//assets.eliza.com/logo.png")).toBe(
+        "//assets.eliza.com/logo.png",
+      );
+      expect(resolveAppAssetUrl("file:///home/user/avatar.vrm")).toBe(
+        "file:///home/user/avatar.vrm",
+      );
+    });
+
+    it("normalizes and prepends root slash when runtime base is not available", () => {
+      expect(resolveAppAssetUrl("vrms/avatar.vrm")).toBe("/vrms/avatar.vrm");
+      expect(resolveAppAssetUrl("./vrms/avatar.vrm")).toBe("/vrms/avatar.vrm");
+      expect(resolveAppAssetUrl("/vrms/avatar.vrm")).toBe("/vrms/avatar.vrm");
+    });
+
+    it("resolves relative to currentUrl option", () => {
+      const resolved = resolveAppAssetUrl("vrms/1.vrm", {
+        currentUrl: "http://localhost:5173/chat",
+      });
+      expect(resolved).toBe("http://localhost:5173/vrms/1.vrm");
+    });
+
+    it("resolves against configured boot config assetBaseUrl", () => {
+      setBootConfig({ assetBaseUrl: "https://static.elizaos.com/dist" });
+      expect(resolveAppAssetUrl("models/agent.vrm")).toBe(
+        "https://static.elizaos.com/dist/models/agent.vrm",
+      );
+    });
+  });
+
+  describe("resolveApiUrl", () => {
+    it("returns empty string for non-string inputs", () => {
+      expect(resolveApiUrl(null as unknown as string)).toBe("");
+      expect(resolveApiUrl(undefined as unknown as string)).toBe("");
+    });
+
+    it("returns bare apiPath when no apiBase is set", () => {
+      expect(resolveApiUrl("/api/agents")).toBe("/api/agents");
+      expect(resolveApiUrl("api/status")).toBe("api/status");
+    });
+
+    it("prefixes apiBase from boot config and normalizes slashes", () => {
+      setBootConfig({ apiBase: "http://127.0.0.1:3000" });
+
+      expect(resolveApiUrl("/api/agents")).toBe(
+        "http://127.0.0.1:3000/api/agents",
+      );
+      expect(resolveApiUrl("api/agents")).toBe(
+        "http://127.0.0.1:3000/api/agents",
+      );
+    });
+
+    it("handles trailing slashes on apiBase without duplicate slashes", () => {
+      setBootConfig({ apiBase: "http://127.0.0.1:3000/" });
+
+      expect(resolveApiUrl("/api/agents")).toBe(
+        "http://127.0.0.1:3000/api/agents",
+      );
+    });
+  });
+});

--- a/packages/shared/src/utils/asset-url.ts
+++ b/packages/shared/src/utils/asset-url.ts
@@ -94,7 +94,7 @@ export function resolveAppAssetUrl(
   assetPath: string,
   options?: AssetUrlResolveOptions,
 ): string {
-  if (!assetPath) return assetPath;
+  if (typeof assetPath !== "string" || !assetPath) return assetPath || "";
   if (isAlreadyAbsolute(assetPath)) return assetPath;
 
   const normalized = stripLeadingPathMarkers(assetPath);
@@ -153,6 +153,9 @@ function readSessionStorageApiBase(): string | undefined {
  * storage remains a compatibility fallback when no boot config exists yet.
  */
 export function resolveApiUrl(apiPath: string): string {
+  if (typeof apiPath !== "string") {
+    return "";
+  }
   const apiBaseRaw = getElizaApiBase()?.trim();
   const apiBase = apiBaseRaw && apiBaseRaw.length > 0 ? apiBaseRaw : undefined;
   const stored = readSessionStorageApiBase();


### PR DESCRIPTION
## Summary

1. In `packages/shared/src/utils/asset-url.ts`, `resolveApiUrl` and `resolveAppAssetUrl` called string methods on path inputs without verifying `typeof === "string"`, throwing unhandled TypeErrors on non-string inputs.
2. Added safe `typeof !== "string"` checks returning empty string/default.
3. Created a comprehensive unit test suite in `packages/shared/src/utils/asset-url.test.ts`.

Closes #21270.

## Verification

Exact commit: `b2352d4ed5`.

- Focused unit test suite `packages/shared/src/utils/asset-url.test.ts`: 9/9 tests passing (19 assertions).
- Biome format on `@elizaos/shared`: 409 files formatted, 0 errors.
- `git diff --check`: clean.
- `bun run check:agents-claude`: 155 tracked CLAUDE.md/AGENTS.md pairs byte-identical.

## Evidence

- [x] N/A - asset url resolution utility; no rendered UI changed.
- [x] N/A - asset url resolution utility; no rendered UI changed.
- [x] N/A - deterministic asset URL resolution tests.
- [x] Focused test suite transcript:
```text
✓ asset-url utilities > resolveAppAssetUrl > returns empty string for empty or non-string inputs [0.47ms]
✓ asset-url utilities > resolveAppAssetUrl > preserves already absolute URLs [0.23ms]
✓ asset-url utilities > resolveAppAssetUrl > normalizes and prepends root slash when runtime base is not available [0.29ms]
✓ asset-url utilities > resolveAppAssetUrl > resolves relative to currentUrl option [0.18ms]
✓ asset-url utilities > resolveAppAssetUrl > resolves against configured boot config assetBaseUrl [0.06ms]
✓ asset-url utilities > resolveApiUrl > returns empty string for non-string inputs [0.15ms]
✓ asset-url utilities > resolveApiUrl > returns bare apiPath when no apiBase is set [0.18ms]
✓ asset-url utilities > resolveApiUrl > prefixes apiBase from boot config and normalizes slashes [0.20ms]
✓ asset-url utilities > resolveApiUrl > handles trailing slashes on apiBase without duplicate slashes [0.21ms]
9 pass, 0 fail, 19 expect() calls
```
- [x] N/A - no frontend code changed.
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
- [x] N/A - no database, memory, wallet, or generated artifact is written.
- [x] N/A - no rendered surface changed.

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@262f64ece98fe6175e1a38fbbeee21cb9eaec7dc:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@262f64ece98fe6175e1a38fbbeee21cb9eaec7dc:packages/skills/skills/contribute-to-eliza"} -->
