### PR TITLE
fix(shared): preserve PKCE storage fallback when sessionStorage throws

### DIFF
--- a/packages/shared/src/steward-session-client/steward-oauth-pkce.test.ts
+++ b/packages/shared/src/steward-session-client/steward-oauth-pkce.test.ts
@@ -10,6 +10,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   buildStewardOAuthAuthorizeUrl,
+  consumeStewardPkceVerifier,
   createStewardPkceChallenge,
   createStewardPkcePair,
   generateStewardOAuthState,
@@ -101,5 +102,47 @@ describe("steward-oauth-pkce", () => {
       JSON.stringify({ verifier: "v", expiresAt: Date.now() + 60_000 }),
     );
     expect(peekStewardOAuthState()).toBeNull();
+  });
+
+  it("peeks state and consumes the verifier from local storage when session storage is unavailable", () => {
+    const previousWindow = globalThis.window;
+    const stored = JSON.stringify({
+      verifier: "local-verifier",
+      state: "local-state",
+      expiresAt: Date.now() + 60_000,
+    });
+    let removed = false;
+    const localStorage = {
+      getItem: () => (removed ? null : stored),
+      removeItem: () => {
+        removed = true;
+      },
+    };
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: Object.create(null),
+    });
+    Object.defineProperty(globalThis.window, "sessionStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("Access denied", "SecurityError");
+      },
+    });
+    Object.defineProperty(globalThis.window, "localStorage", {
+      configurable: true,
+      value: localStorage,
+    });
+
+    try {
+      expect(peekStewardOAuthState()).toBe("local-state");
+      expect(removed).toBe(false);
+      expect(consumeStewardPkceVerifier()).toBe("local-verifier");
+      expect(removed).toBe(true);
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: previousWindow,
+      });
+    }
   });
 });

--- a/packages/shared/src/steward-session-client/steward-oauth-pkce.ts
+++ b/packages/shared/src/steward-session-client/steward-oauth-pkce.ts
@@ -96,8 +96,10 @@ export function storeStewardPkceVerifier(
 
 export function consumeStewardPkceVerifier(): string | null {
   if (typeof window === "undefined") return null;
-  const sessionVerifier = consumeStoredPkceVerifier(window.sessionStorage);
-  const localVerifier = consumeStoredPkceVerifier(window.localStorage);
+  const sessionVerifier = consumeStoredPkceVerifier(
+    () => window.sessionStorage,
+  );
+  const localVerifier = consumeStoredPkceVerifier(() => window.localStorage);
   return sessionVerifier ?? localVerifier;
 }
 
@@ -109,13 +111,14 @@ export function consumeStewardPkceVerifier(): string | null {
  */
 export function peekStewardOAuthState(): string | null {
   if (typeof window === "undefined") return null;
-  const sessionRecord = readStoredPkceRecord(window.sessionStorage);
-  const localRecord = readStoredPkceRecord(window.localStorage);
+  const sessionRecord = readStoredPkceRecord(() => window.sessionStorage);
+  const localRecord = readStoredPkceRecord(() => window.localStorage);
   return sessionRecord?.state ?? localRecord?.state ?? null;
 }
 
-function consumeStoredPkceVerifier(storage: Storage): string | null {
+function consumeStoredPkceVerifier(getStorage: () => Storage): string | null {
   try {
+    const storage = getStorage();
     const verifier = storage.getItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY);
     storage.removeItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY);
     return parseStoredPkceVerifier(verifier);
@@ -125,8 +128,11 @@ function consumeStoredPkceVerifier(storage: Storage): string | null {
   }
 }
 
-function readStoredPkceRecord(storage: Storage): StoredPkceVerifier | null {
+function readStoredPkceRecord(
+  getStorage: () => Storage,
+): StoredPkceVerifier | null {
   try {
+    const storage = getStorage();
     const value = storage.getItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY);
     if (!value) return null;
     try {


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
- AI assistance: Yes - initial author assistance plus maintainer review and remediation
<!-- attribution-row:models -->
- Models: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client/tooling: Codex CLI, Claude Code, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - the contribution skill was not used for this maintainer review and remediation
<!-- attribution-row:status -->
- Provenance status: self-reported

AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: re-ran the full mutation check myself from a clean revert of just the source fix (confirmed red, then restored and confirmed green), re-ran lint/typecheck myself, independently confirmed the pre-existing `index.test.ts` failures reproduce identically with this fix's two files fully `git stash`ed out (not caused by this change), and traced the reachability chain into the real login component.

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low. Changes only how `consumeStewardPkceVerifier`'s internal helper acquires each storage backend (a lazy getter instead of a call-site property access), so a throwing access now falls through to the try/catch it was always supposed to be inside. Normal storage access (no throw) is unaffected.

# Background

## What does this PR do?

`consumeStewardPkceVerifier()` accessed `window.sessionStorage` and `window.localStorage` as call-site arguments to `consumeStoredPkceVerifier`, before entering that helper's `try/catch`. In browsers where a Web Storage property getter itself throws `SecurityError` (restricted or opaque storage contexts - third-party iframes, some privacy modes), the function threw instead of falling back to the other storage backend. The hosted login callback calls this helper and passes its result as `codeVerifier` to `exchangeStewardCodeViaApi`, so the OAuth exchange could fail despite a valid verifier sitting in `localStorage`.

Before fix:
```text
THREW SecurityError: Access denied
```

After fix:
```text
FINAL_REPRO_RESULT valid-verifier
```

Sibling function `storeStewardPkceVerifier` already got this right (its `window.sessionStorage.setItem(...)` call is one expression fully inside its own try/catch) - this fix brings `consumeStewardPkceVerifier` in line with that existing pattern by passing a lazy `() => window.sessionStorage` getter into the guarded helper instead of evaluating the property at the call site.

## What kind of change is this?

Bug fix — no new capability, no schema change.

# Documentation changes needed?

No.

# Testing

New test `falls back to localStorage when sessionStorage is unavailable` in `packages/shared/src/steward-session-client/steward-oauth-pkce.test.ts`, installing a throwing `sessionStorage` getter via `Object.defineProperty` and a working `localStorage` mock, restoring `globalThis.window` in a `finally`.

# Evidence Gate

<!-- evidence-head:f353572ccbd9abaa2b5d53b94ec0ba17c4132a2c -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend/shared logic fix, no UI surface
- <!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual behavior changed

## Known gaps / failures

The touched package's full test run has **pre-existing, unrelated** failures in `src/steward-session-client/index.test.ts` (3 failures: `fails fast without publishing when canonical storage mutations fail`, `does not disguise a failed canonical read as a missing session`, and one more) - these expect Bun's built-in `localStorage` mock to throw when unavailable, but the test runner instead reports `localStorage is not available because --localstorage-file was not provided`. I independently confirmed these reproduce identically with this PR's two changed files fully `git stash`ed out - not caused by this change. Neither touched file appears in that failure.

## Reachability

`packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx` calls `consumeStewardPkceVerifier()` on the OAuth callback when a `code` query parameter is present (`const codeVerifier = consumeStewardPkceVerifier() ?? undefined;`). The returned verifier is passed through to `exchangeStewardCodeViaApi`. The same component creates and stores the verifier before redirecting to Steward, so the failing storage-getter path is reachable with real login input.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic focused regression tests are documented in the Testing section and produce no persistent backend log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by this logic change

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered interface changed
