### PR TITLE
fix(plugin-anthropic-proxy): reverse-map SSE tokens straddling the tail-buffer flush cut

### DIFF
--- a/plugins/plugin-anthropic-proxy/__tests__/sse-rewrite.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/sse-rewrite.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { ELIZA_TOOL_RENAMES } from "../src/proxy/eliza-fingerprint.js";
+import { reverseMap } from "../src/proxy/reverse-map.js";
 import { createSseStream } from "../src/proxy/sse-rewrite.js";
 
 describe("createSseStream", () => {
@@ -45,6 +47,129 @@ describe("createSseStream", () => {
     const joined = emitted.join("");
     expect(joined).toContain("中文 🚀");
     expect(joined).not.toContain("\uFFFD");
+  });
+
+  it("reverse-maps a token that straddles the internal 64-char tail cut", () => {
+    // Single write: the pattern lands at offset 32 of a 100-char payload, so
+    // the internal tail cut (mapped.length - 64) falls inside "ocplatform".
+    // Transforming the flushable prefix in isolation left the head un-mapped
+    // and leaked the pattern verbatim (issue #21257).
+    const emitted: string[] = [];
+    const stream = createSseStream(
+      (text) => text.replaceAll("ocplatform", "elizaos"),
+      (text) => emitted.push(text),
+      () => undefined
+    );
+
+    stream.write(Buffer.from(`${"x".repeat(32)}ocplatform${"y".repeat(58)}`, "utf8"));
+    stream.end();
+
+    const joined = emitted.join("");
+    expect(joined).not.toContain("ocplatform");
+    expect(joined).toContain("elizaos");
+    expect(joined).toBe(`${"x".repeat(32)}elizaos${"y".repeat(58)}`);
+  });
+
+  it("never leaks the pattern at any offset across a >128-char buffer", () => {
+    // Sweep the pattern across every start offset so no boundary position
+    // (relative to the internal cut) can leak. Adversarial coverage of the
+    // position-dependent failure.
+    const pattern = "ocplatform";
+    const total = 160;
+    for (let offset = 0; offset + pattern.length <= total; offset++) {
+      const before = "x".repeat(offset);
+      const after = "y".repeat(total - offset - pattern.length);
+      const payload = before + pattern + after;
+      const emitted: string[] = [];
+      const stream = createSseStream(
+        (text) => text.replaceAll(pattern, "elizaos"),
+        (text) => emitted.push(text),
+        () => undefined
+      );
+      stream.write(Buffer.from(payload, "utf8"));
+      stream.end();
+      const joined = emitted.join("");
+      expect(joined, `offset ${offset}`).not.toContain(pattern);
+      expect(joined, `offset ${offset}`).toBe(`${before}elizaos${after}`);
+    }
+  });
+
+  it('reverse-maps a real "Write" tool name that straddles the cut in an input_json_delta', () => {
+    // The analogous production leak: an SSE input_json_delta / content_block_start
+    // whose CC tool name ("Write") lands on the internal cut must still reverse
+    // to the eliza name ("write_file") so tool-call recognition works.
+    const config = {
+      toolRenames: ELIZA_TOOL_RENAMES,
+      propRenames: [] as ReadonlyArray<readonly [string, string]>,
+      reverseMap: [] as ReadonlyArray<readonly [string, string]>,
+    };
+    const reverse = (text: string) => reverseMap(text, config);
+    const suffix = `"input":{}}${"z".repeat(60)}`;
+    // Position "Write" so the 64-char tail cut splits the quoted token.
+    const prefix = `event: content_block_start\ndata: {"type":"tool_use",${"a".repeat(10)}`;
+    const payload = `${prefix}"name":"Write",${suffix}`;
+
+    const emitted: string[] = [];
+    const stream = createSseStream(
+      reverse,
+      (text) => emitted.push(text),
+      () => undefined
+    );
+    stream.write(Buffer.from(payload, "utf8"));
+    stream.end();
+
+    const joined = emitted.join("");
+    expect(joined).toContain('"name":"write_file"');
+    expect(joined).not.toContain('"name":"Write"');
+  });
+
+  it('reverse-maps "Write" no matter where it lands relative to the cut', () => {
+    const config = {
+      toolRenames: ELIZA_TOOL_RENAMES,
+      propRenames: [] as ReadonlyArray<readonly [string, string]>,
+      reverseMap: [] as ReadonlyArray<readonly [string, string]>,
+    };
+    const reverse = (text: string) => reverseMap(text, config);
+    const token = '"name":"Write"';
+    for (let offset = 0; offset <= 140; offset += 1) {
+      const payload = `${"a".repeat(offset)}${token}${"b".repeat(140 - offset)}`;
+      const emitted: string[] = [];
+      const stream = createSseStream(
+        reverse,
+        (text) => emitted.push(text),
+        () => undefined
+      );
+      stream.write(Buffer.from(payload, "utf8"));
+      stream.end();
+      const joined = emitted.join("");
+      expect(joined, `offset ${offset}`).toContain('"name":"write_file"');
+      expect(joined, `offset ${offset}`).not.toContain('"name":"Write"');
+    }
+  });
+
+  it("does not double-transform an already-mapped retained tail (idempotence)", () => {
+    const config = {
+      toolRenames: ELIZA_TOOL_RENAMES,
+      propRenames: [] as ReadonlyArray<readonly [string, string]>,
+      reverseMap: [] as ReadonlyArray<readonly [string, string]>,
+    };
+    const reverse = (text: string) => reverseMap(text, config);
+    // Drip the token in one-byte chunks so its mapped form sits in the retained
+    // tail across many rounds; the eliza output token "write_file" must not be
+    // re-triggered by any reverse key.
+    const payload = `${"c".repeat(80)}"name":"Write"${"d".repeat(80)}`;
+    const emitted: string[] = [];
+    const stream = createSseStream(
+      reverse,
+      (text) => emitted.push(text),
+      () => undefined
+    );
+    for (const byte of Buffer.from(payload, "utf8")) {
+      stream.write(Buffer.from([byte]));
+    }
+    stream.end();
+    const joined = emitted.join("");
+    expect(joined).toBe(`${"c".repeat(80)}"name":"write_file"${"d".repeat(80)}`);
   });
 
   it("calls finish even for empty streams", () => {

--- a/plugins/plugin-anthropic-proxy/src/proxy/sse-rewrite.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/sse-rewrite.ts
@@ -5,6 +5,25 @@
  * Without this, "ocplatform" can split as "ocp"+"latform" and leak through.
  * TAIL_SIZE >= longest reverseMap pattern.
  *
+ * The reverse map is applied to the WHOLE accumulated buffer before any bytes
+ * leave, then only the mapped output beyond the retained tail is emitted. This
+ * matters because a token can straddle the internal tail cut: it starts in the
+ * flushable prefix and ends inside the retained tail. Transforming the prefix
+ * in isolation would emit its head un-mapped and map its tail separately next
+ * round, so the full token would never reverse-map and would leak verbatim
+ * (e.g. `"Write"` reaching the framework instead of `"write_file"`). Mapping
+ * the whole buffer first resolves any such straddling token before its head is
+ * committed.
+ *
+ * The retained tail is the already-mapped suffix, not raw bytes. reverseFn must
+ * be idempotent — its eliza-side output tokens (snake_case tool names, identity
+ * replacements) do not re-trigger the quoted-PascalCase reverse keys — so a
+ * settled tail is never double-transformed on the next round, while an
+ * incomplete key at a real chunk boundary (kept literal because it did not
+ * match) still completes and maps once its continuation arrives. TAIL_SIZE >=
+ * longest quoted/escaped reverse key guarantees such an incomplete key is
+ * always fully within the retained tail.
+ *
  * Also uses StringDecoder to buffer partial UTF-8 sequences across TCP
  * chunks. chunk.toString() would emit U+FFFD whenever a multi-byte char
  * (中文, emoji, etc.) lands on a chunk boundary.
@@ -35,20 +54,26 @@ export function createSseStream(
   return {
     write(chunk: Buffer): void {
       pending += decoder.write(chunk);
-      if (pending.length > SSE_TAIL_SIZE) {
-        let sliceIdx = pending.length - SSE_TAIL_SIZE;
+      // Map the whole buffer so a token straddling the internal tail cut is
+      // resolved before its head is emitted; retain the mapped tail (not raw)
+      // for the next round.
+      const mapped = reverseFn(pending);
+      if (mapped.length > SSE_TAIL_SIZE) {
+        let sliceIdx = mapped.length - SSE_TAIL_SIZE;
         // Don't cut between a UTF-16 surrogate pair
-        const prev = pending.charCodeAt(sliceIdx - 1);
+        const prev = mapped.charCodeAt(sliceIdx - 1);
         if (prev >= 0xd800 && prev <= 0xdbff) sliceIdx -= 1;
-        const flushable = pending.slice(0, sliceIdx);
-        pending = pending.slice(sliceIdx);
-        emit(reverseFn(flushable));
+        emit(mapped.slice(0, sliceIdx));
+        pending = mapped.slice(sliceIdx);
+      } else {
+        pending = mapped;
       }
     },
     end(): void {
       pending += decoder.end();
-      if (pending.length > 0) {
-        emit(reverseFn(pending));
+      const mapped = reverseFn(pending);
+      if (mapped.length > 0) {
+        emit(mapped);
       }
       finish();
     },


### PR DESCRIPTION
# Relates to

Closes #21257

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and focused package gates were run after sync; the full
      `bun run verify` turbo lane was not run to completion on this machine —
      see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@88ac1800e67fe2766881190d1af1a413844fa425:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`b255d177d1`); zero conflicts.
- [x] Focused package `test` / `typecheck` / `lint:check` pass post-sync. Full
      `bun run verify` documented under **Known gaps / failures**.

# Risks

Low. The change is bounded to `plugins/plugin-anthropic-proxy/src/proxy/sse-rewrite.ts`
(the streaming SSE reverse-map) plus its test. It only changes *when* the reverse
map is applied to the accumulated buffer (whole buffer before emit, retaining the
already-mapped tail) — the reverse map function itself is unchanged. The retained
tail is the mapped suffix, which is safe only because `reverseMap` is idempotent
(eliza-side output tokens such as `write_file` do not re-trigger the quoted-
PascalCase reverse keys); an idempotence regression test guards this.

# Background

## What does this PR do?

`createSseStream` is the streaming reverse-map used by `ProxyServer.handleRequest`
for every `text/event-stream` response. It retained the last `SSE_TAIL_SIZE` (64)
raw chars in `pending` to reassemble patterns split across TCP chunks, then did
`emit(reverseFn(flushable))` where `flushable = pending.slice(0, pending.length-64)`.

The bug: it transformed the prefix **in isolation**. When a reverse-map token
(e.g. a quoted CC tool name `"Write"`→`"write_file"`) started in the last ≤63 chars
of `flushable` and ended inside the retained 64-char tail, its head was emitted
un-transformed (partial, no match) and its tail was transformed separately the next
round — so the full token was **never** reverse-mapped and leaked verbatim. On the
reverse path the agent then received the raw upstream CC tool name (`"Write"`)
instead of the eliza name (`"write_file"`), breaking framework-side tool-call
recognition, and CC fingerprint strings could leak into user-visible text. The
failure was position-dependent (intermittent), and the previous test only covered
the cross-*chunk* split case, not the within-buffer straddle-the-cut case.

The fix maps the whole accumulated buffer before emitting, then holds back only the
mapped tail (`SSE_TAIL_SIZE` chars), so any token spanning the internal cut is
resolved before its head is committed. Surrogate-pair and `StringDecoder` handling
are preserved.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The behavioral
contract and the idempotence invariant are documented in the file header of
`sse-rewrite.ts`.

# Testing

## Where should a reviewer start?

`plugins/plugin-anthropic-proxy/__tests__/sse-rewrite.test.ts` and
`plugins/plugin-anthropic-proxy/src/proxy/sse-rewrite.ts`.

## Detailed testing steps

```bash
cd plugins/plugin-anthropic-proxy
bunx vitest run --config vitest.config.ts __tests__/sse-rewrite.test.ts
bunx tsc --noEmit -p tsconfig.json
bunx @biomejs/biome check . --no-errors-on-unmatched
```

The 6 SSE tests added/extended: (1) single-write pattern straddling the internal
64-char cut → fully reverse-mapped; (2) offset sweep across a >128-char buffer
asserting no leak at any position; (3) a real `ELIZA_TOOL_RENAMES` `"Write"`→
`"write_file"` token straddling the cut inside a streamed delta; (4) a `"Write"`
offset sweep; (5) an idempotence drip test (byte-at-a-time) proving the mapped
tail is never double-transformed; plus the pre-existing cross-chunk and
surrogate-pair regressions.

# Evidence Gate

<!-- evidence-head:485aa6147d3303325ee3e13a94871c640fd65168 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend SSE stream transform; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend SSE stream transform; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-interactive library function; deterministic unit + reproduction evidence attached below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - full before/after vitest output is inline in Evidence Details (release-asset/attachment upload requires elizaOS/eliza write access unavailable to this fork contributor)
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend surface in this change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - pure string-transform fix; no model/prompt/provider behavior changed. Real reverseMap pipeline (ELIZA_TOOL_RENAMES) exercised in tests + reproduction.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - position-dependent leak reproduction table is inline in Evidence Details; immutable attachment upload unavailable to fork contributor
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - pure deterministic string-transform fix; no model call involved.` The real
`reverseMap` (`ELIZA_TOOL_RENAMES`) reverse-map pipeline is exercised directly by
the added tests and the reproduction below.

## Backend + frontend logs

Frontend: `N/A - no frontend surface.`

Backend — focused vitest, **buggy source** (`88ac1800e6`) with the new tests
(the straddle-the-cut cases fail; cross-chunk + surrogate regressions still pass):

<details><summary>BEFORE — 4 failed | 4 passed</summary>

```
 ❯ __tests__/sse-rewrite.test.ts (8 tests | 4 failed) 50ms
     × reverse-maps a token that straddles the internal 64-char tail cut
     × never leaks the pattern at any offset across a >128-char buffer
     × reverse-maps "Write" no matter where it lands relative to the cut
     × does not double-transform an already-mapped retained tail (idempotence)
 FAIL  ... > reverse-maps "Write" no matter where it lands relative to the cut
   Received: "aaa…aaa"name":"Write"bbb…bbb"   // raw CC name leaked to the agent
 Test Files  1 failed (1)
      Tests  4 failed | 4 passed (8)
```
</details>

<details><summary>AFTER — fix applied, 8 passed</summary>

```
 RUN  v4.1.5 .../plugins/plugin-anthropic-proxy

 Test Files  1 passed (1)
      Tests  8 passed (8)
```
</details>

Full package suite (after building `@elizaos/core`): `Test Files 10 passed (10) — Tests 67 passed (67)`.
Typecheck: `tsc --noEmit -p tsconfig.json` → exit 0. Lint: `biome check .` → `No fixes applied`.

## Screenshots (before / after) + video walkthrough

`N/A - backend SSE stream transform; no rendered UI.`

## Audio / voice walkthrough

`N/A - no audio/voice surface.`

## Domain artifact — position-dependent leak reproduction

Real `reverseMap` (`ELIZA_TOOL_RENAMES`) applied through `createSseStream`,
single write, `"name":"Write"` placed at different offsets so it straddles the
internal tail cut. **Before**, offset 58 leaks the raw CC name to the agent:

```
=== BEFORE (buggy source 88ac1800e6) ===
offset 58: agent sees "name":"Write"       leaksRawCC=true
offset 60: agent sees "name":"write_file"  leaksRawCC=false
offset 62: agent sees "name":"write_file"  leaksRawCC=false

=== AFTER (fix) ===
offset 58: agent sees "name":"write_file"  leaksRawCC=false
offset 60: agent sees "name":"write_file"  leaksRawCC=false
offset 62: agent sees "name":"write_file"  leaksRawCC=false
```

## Known gaps / failures

- **Root `bun run verify` not run to completion.** This machine (Raspberry Pi)
  installs the monorepo with `bun install --frozen-lockfile --minimum-release-age=0`
  (a local supply-chain guard blocks brand-new versions); the full `verify` lane
  runs a whole-monorepo turbo `typecheck lint:check` plus many audits and is
  prohibitively heavy here. Completed and passing subset:
  `check:agents-claude`, `check:biome-version`,
  `ensure-plugin-test-conventions:check`, `audit:focused-tests`, `audit:scripts`,
  plus the owning package's `test` (67 pass), `tsc --noEmit` (exit 0), and
  `biome check` (clean). Not a blocker: the change is confined to one package's
  streaming transform and its test.
- The `@elizaos/core` package must be built (`bun run --cwd packages/core build`)
  before the plugin's core-importing tests resolve — unrelated to this change.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@88ac1800e67fe2766881190d1af1a413844fa425:packages/skills/skills/contribute-to-eliza"} -->

