### PR TITLE
fix(plugin-health): reject unknown sleep includeNaps flag

### DIFF
--- a/plugins/plugin-health/src/routes/sleep.test.ts
+++ b/plugins/plugin-health/src/routes/sleep.test.ts
@@ -30,7 +30,7 @@ function createContext(path: string) {
 describe("createHealthSleepRouteHandler", () => {
   it("routes sleep history requests through the host service", async () => {
     const { ctx, responses } = createContext(
-      "/api/lifeops/sleep/history?windowDays=14&includeNaps=1",
+      "/api/lifeops/sleep/history?windowDays=14&includeNaps=true",
     );
     const getSleepHistory = vi.fn().mockResolvedValue({
       episodes: [],
@@ -80,6 +80,113 @@ describe("createHealthSleepRouteHandler", () => {
     expect(errors).toEqual([
       { message: "windowDays must be at least 1", status: 400 },
     ]);
+  });
+
+  it.each(["", undefined])(
+    "accepts omitted/empty includeNaps as the default nap filter",
+    async (token) => {
+      const path =
+        token === undefined
+          ? "/api/lifeops/sleep/history?windowDays=14"
+          : "/api/lifeops/sleep/history?windowDays=14&includeNaps=";
+      const { ctx } = createContext(path);
+      const getSleepHistory = vi.fn().mockResolvedValue({
+        episodes: [],
+        summary: {
+          cycleCount: 0,
+          averageDurationMin: null,
+          overnightCount: 0,
+          napCount: 0,
+          openCount: 0,
+        },
+        windowDays: 14,
+        includeNaps: false,
+      });
+      const handle = createHealthSleepRouteHandler({
+        createService: () => ({
+          getSleepHistory,
+          getSleepRegularity: vi.fn(),
+          getPersonalBaseline: vi.fn(),
+        }),
+      });
+      await expect(handle(ctx)).resolves.toBe(true);
+      expect(getSleepHistory).toHaveBeenCalledWith({
+        windowDays: 14,
+        includeNaps: undefined,
+      });
+    },
+  );
+
+  it("accepts includeNaps=false as exclude-naps", async () => {
+    const { ctx } = createContext(
+      "/api/lifeops/sleep/history?windowDays=14&includeNaps=false",
+    );
+    const getSleepHistory = vi.fn().mockResolvedValue({
+      episodes: [],
+      summary: {
+        cycleCount: 0,
+        averageDurationMin: null,
+        overnightCount: 0,
+        napCount: 0,
+        openCount: 0,
+      },
+      windowDays: 14,
+      includeNaps: false,
+    });
+    const handle = createHealthSleepRouteHandler({
+      createService: () => ({
+        getSleepHistory,
+        getSleepRegularity: vi.fn(),
+        getPersonalBaseline: vi.fn(),
+      }),
+    });
+    await expect(handle(ctx)).resolves.toBe(true);
+    expect(getSleepHistory).toHaveBeenCalledWith({
+      windowDays: 14,
+      includeNaps: false,
+    });
+  });
+
+  it.each(["TRUE", "1", "0", "FALSE", "yes", "no", "foo", "1e2"])(
+    "rejects includeNaps=%s before getSleepHistory",
+    async (token) => {
+      const { ctx, errors } = createContext(
+        `/api/lifeops/sleep/history?windowDays=14&includeNaps=${encodeURIComponent(token)}`,
+      );
+      const getSleepHistory = vi.fn();
+      const handle = createHealthSleepRouteHandler({
+        createService: () => ({
+          getSleepHistory,
+          getSleepRegularity: vi.fn(),
+          getPersonalBaseline: vi.fn(),
+        }),
+      });
+      await expect(handle(ctx)).resolves.toBe(true);
+      expect(getSleepHistory).not.toHaveBeenCalled();
+      expect(errors).toEqual([
+        { message: "Invalid includeNaps", status: 400 },
+      ]);
+    },
+  );
+
+  it.each([
+    "/api/lifeops/sleep/history?includeNaps=true&includeNaps=true",
+    "/api/lifeops/sleep/history?includeNaps=true&includeNaps=false",
+    "/api/lifeops/sleep/history?includeNaps=&includeNaps=true",
+    "/api/lifeops/sleep/history?includeNaps=foo&includeNaps=true",
+  ])("rejects duplicate includeNaps values in %s", async (path) => {
+    const { ctx, errors } = createContext(path);
+    const getSleepHistory = vi.fn();
+    const handle = createHealthSleepRouteHandler({
+      createService: () => ({
+        getSleepHistory,
+        getSleepRegularity: vi.fn(),
+        getPersonalBaseline: vi.fn(),
+      }),
+    });
+    await expect(handle(ctx)).resolves.toBe(true);
+    expect(getSleepHistory).not.toHaveBeenCalled();
+    expect(errors).toEqual([{ message: "Invalid includeNaps", status: 400 }]);
   });
 
   it("ignores non-sleep routes", async () => {

--- a/plugins/plugin-health/src/routes/sleep.ts
+++ b/plugins/plugin-health/src/routes/sleep.ts
@@ -84,21 +84,28 @@ function parseWindowDaysQuery(value: string | null): number | undefined {
   return parsed;
 }
 
-function parseIncludeNapsQuery(value: string | null): boolean | undefined {
-  if (value === null) {
+/**
+ * GET Life Ops sleep `includeNaps` is nap-row identity, leftover tax after
+ * notifications unreadOnly (#21220). Stock develop treated `1` / `TRUE` as
+ * include-naps, so a non-exact token changed the episode set instead of a
+ * 400. windowDays stays untouched.
+ */
+function parseIncludeNapsQuery(query: URLSearchParams): boolean | undefined {
+  const requested = query.getAll("includeNaps");
+  const raw = requested[0];
+  if (requested.length > 1) {
+    throw new HealthSleepRouteError(400, "Invalid includeNaps");
+  }
+  if (raw == null || raw === "") {
     return undefined;
   }
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "") {
-    return undefined;
-  }
-  if (normalized === "true" || normalized === "1") {
+  if (raw === "true") {
     return true;
   }
-  if (normalized === "false" || normalized === "0") {
+  if (raw === "false") {
     return false;
   }
-  throw new HealthSleepRouteError(400, "includeNaps must be a boolean");
+  throw new HealthSleepRouteError(400, "Invalid includeNaps");
 }
 
 function routeErrorStatus(error: unknown): number | null {
@@ -174,9 +181,7 @@ export function createHealthSleepRouteHandler<
         const windowDays = parseWindowDaysQuery(
           url.searchParams.get("windowDays"),
         );
-        const includeNaps = parseIncludeNapsQuery(
-          url.searchParams.get("includeNaps"),
-        );
+        const includeNaps = parseIncludeNapsQuery(url.searchParams);
         const response = await service.getSleepHistory({
           windowDays,
           includeNaps,
@@ -190,9 +195,7 @@ export function createHealthSleepRouteHandler<
         const windowDays = parseWindowDaysQuery(
           url.searchParams.get("windowDays"),
         );
-        const includeNaps = parseIncludeNapsQuery(
-          url.searchParams.get("includeNaps"),
-        );
+        const includeNaps = parseIncludeNapsQuery(url.searchParams);
         const response = await service.getSleepRegularity({
           windowDays,
           includeNaps,


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on Life Ops
sleep `includeNaps` identity. Nap-row filter class, leftover tax after
notifications unreadOnly (#21220). Not leftover tax on `windowDays` or
Life Ops inbox bools (#20930).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `includeNaps` only on `/api/lifeops/sleep/history` and
`/api/lifeops/sleep/regularity`. Omitted/empty still leave the nap
filter unset (today's default). Exact `true`/`false` still bind. Unknown
/ uppercase / `1` tokens 400 before `getSleepHistory` /
`getSleepRegularity`. windowDays stays untouched.

# Background

## What does this PR do?

`GET /api/lifeops/sleep/history` and `GET /api/lifeops/sleep/regularity`
treated `1` / `TRUE` as include-naps. `includeNaps=TRUE` silently
changed the episode set instead of a 400.

- omitted / empty → default nap filter (200)
- exact `true` / `false` → that nap-row identity
- `TRUE` / `1` / `0` / `FALSE` / `yes` / `foo` / `1e2` / duplicates → **400** before the sleep service

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers opt into nap rows with `?includeNaps=true`. A common
`includeNaps=TRUE` or `1` after a client sends a boolean must not
silently change the episode set. This is leftover tax after
notifications unreadOnly (#21220), which left the sleep nap-row parser
accepting `1`/`TRUE`. Different file from #20930 (`lifeops-routes.ts`).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-health/src/routes/sleep.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-health && bunx vitest run src/routes/sleep.test.ts
```

18 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; Life Ops sleep `includeNaps` query only.

- [x] N/A - no rendered UI change; Life Ops sleep `includeNaps` query only.

- [x] N/A - no rendered UI change; Life Ops sleep `includeNaps` query only.

- [x] N/A - focused route tests drive the real includeNaps tokens and assert 400 before getSleepHistory; no production log capture is required to see the contract.

- [x] N/A - no frontend request path in this proof.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.

- [x] N/A - no agent write; illegal tokens 400 before the sleep service.

- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
`includeNaps` tokens reject; omitted/canonical still bind the matching
nap-row filter.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the Life Ops sleep
`includeNaps` query only.

## Known gaps / failures

`bun run verify` was not run. This is a two-file includeNaps parse with
a green focused suite (18). Full monorepo verify is unrelated to this
query grammar and was skipped to keep the proof tied to the changed
path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0bda7a84dcf9afc4b014fc0effd927cd0b6d55a9 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
