### PR TITLE
fix(cloud): add durable storage object authority schema

### DIFF
--- a/packages/cloud/shared/src/db/migration-journal-registration.test.ts
+++ b/packages/cloud/shared/src/db/migration-journal-registration.test.ts
@@ -89,11 +89,14 @@ describe("migrations/meta/_journal.json registration", () => {
       "0234_agent_backup_catalog_manifest_v3_shape",
       "0235_agent_backup_rpo_scheduler",
     ];
-    const tail = journalEntries().slice(-tags.length);
+    const entries = journalEntries();
+    const start = entries.findIndex(({ tag }) => tag === tags[0]);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const stack = entries.slice(start, start + tags.length);
 
-    expect(tail.map(({ tag }) => tag)).toEqual(tags);
-    expect(tail.map(({ idx }) => idx)).toEqual(tags.map((_, offset) => 217 + offset));
-    expect(tail.map(({ when }) => when)).toEqual(
+    expect(stack.map(({ tag }) => tag)).toEqual(tags);
+    expect(stack.map(({ idx }) => idx)).toEqual(tags.map((_, offset) => 217 + offset));
+    expect(stack.map(({ when }) => when)).toEqual(
       tags.map((_, offset) => 1787947200000 + offset * 86_400_000),
     );
   });

--- a/packages/cloud/shared/src/db/migrations/0236_org_storage_objects.sql
+++ b/packages/cloud/shared/src/db/migrations/0236_org_storage_objects.sql
@@ -1,0 +1,56 @@
+CREATE TABLE IF NOT EXISTS "org_storage_objects" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE RESTRICT,
+  "storage_namespace" text NOT NULL DEFAULT 'attachment-r2-v1',
+  "object_key" text NOT NULL,
+  "key_fingerprint" text NOT NULL,
+  "presence" text NOT NULL,
+  "last_allocated_generation" bigint NOT NULL DEFAULT 0,
+  "committed_generation" bigint NOT NULL DEFAULT 0,
+  "size_bytes" bigint NOT NULL DEFAULT 0,
+  "provider_version" text,
+  "provider_etag" text,
+  "content_type" text,
+  "checksum_sha256" text,
+  "provider_uploaded_at" timestamptz,
+  "verified_at" timestamptz NOT NULL DEFAULT NOW(),
+  "created_at" timestamptz NOT NULL DEFAULT NOW(),
+  "updated_at" timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT "org_storage_objects_tenant_identity_unique" UNIQUE ("id", "organization_id"),
+  CONSTRAINT "org_storage_objects_locator_check" CHECK (
+    "storage_namespace" = 'attachment-r2-v1'
+    AND "object_key" LIKE 'org/' || "organization_id"::text || '/%'
+    AND char_length("object_key") > char_length('org/' || "organization_id"::text || '/')
+    AND octet_length("object_key") <= 1024
+    AND "object_key" IS NFC NORMALIZED
+    AND "object_key" !~ '[[:cntrl:]]'
+    AND "object_key" !~ '(^|/)\.\.(/|$)'
+    AND "key_fingerprint" ~ '^sha256:[0-9a-f]{64}$'
+  ),
+  CONSTRAINT "org_storage_objects_generation_check" CHECK (
+    "committed_generation" >= 0
+    AND "last_allocated_generation" >= "committed_generation"
+    AND "size_bytes" >= 0
+    AND ("presence" <> 'present' OR "committed_generation" > 0)
+  ),
+  CONSTRAINT "org_storage_objects_presence_shape_check" CHECK (((
+    "presence" = 'absent' AND "size_bytes" = 0
+    AND "provider_version" IS NULL AND "provider_etag" IS NULL
+    AND "content_type" IS NULL AND "checksum_sha256" IS NULL
+    AND "provider_uploaded_at" IS NULL
+  ) OR (
+    "presence" = 'present'
+    AND char_length("provider_version") BETWEEN 1 AND 1024
+    AND char_length("provider_etag") BETWEEN 1 AND 512
+    AND "provider_etag" !~ '["\r\n]'
+    AND char_length("content_type") BETWEEN 1 AND 255
+    AND "content_type" !~ '[\r\n]'
+    AND ("checksum_sha256" IS NULL OR "checksum_sha256" ~ '^[0-9a-f]{64}$')
+    AND "provider_uploaded_at" IS NOT NULL
+  )) IS TRUE),
+  CONSTRAINT "org_storage_objects_presence_check" CHECK ("presence" IN ('absent', 'present'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "org_storage_objects_org_key_uidx"
+  ON "org_storage_objects" ("organization_id", "storage_namespace", "object_key");
+CREATE INDEX IF NOT EXISTS "org_storage_objects_org_presence_key_idx"
+  ON "org_storage_objects" ("organization_id", "presence", "object_key");

--- a/packages/cloud/shared/src/db/migrations/0237_org_storage_operations.sql
+++ b/packages/cloud/shared/src/db/migrations/0237_org_storage_operations.sql
@@ -1,0 +1,98 @@
+CREATE TABLE IF NOT EXISTS "org_storage_operations" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE RESTRICT,
+  "object_id" uuid NOT NULL, "operation" text NOT NULL, "state" text NOT NULL DEFAULT 'prepared',
+  "idempotency_key_hash" text NOT NULL, "request_digest" text NOT NULL,
+  "source_presence" text NOT NULL, "source_generation" bigint NOT NULL,
+  "target_generation" bigint NOT NULL, "source_size_bytes" bigint NOT NULL,
+  "target_size_bytes" bigint NOT NULL, "quota_delta_bytes" bigint NOT NULL,
+  "quota_reserved_bytes" bigint NOT NULL, "quota_release_bytes" bigint NOT NULL,
+  "source_provider_version" text, "source_provider_etag" text,
+  "target_content_type" text, "target_content_sha256" text,
+  "provider_write_started" boolean NOT NULL DEFAULT FALSE, "provider_started_at" timestamptz,
+  "result_provider_version" text, "result_provider_etag" text, "result_size_bytes" bigint,
+  "result_checksum_sha256" text, "result_uploaded_at" timestamptz, "response_status" smallint,
+  "receipt_digest" text, "claim_owner" text, "claim_generation" uuid,
+  "lease_expires_at" timestamptz, "attempts" integer NOT NULL DEFAULT 0,
+  "next_attempt_at" timestamptz NOT NULL DEFAULT NOW(), "last_observed_at" timestamptz,
+  "last_error_code" text, "last_error_digest" text, "completed_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT NOW(), "updated_at" timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT "org_storage_operations_object_tenant_fkey" FOREIGN KEY ("object_id", "organization_id")
+    REFERENCES "org_storage_objects"("id", "organization_id") ON DELETE RESTRICT,
+  CONSTRAINT "org_storage_operations_identity_check" CHECK (
+    "operation" IN ('put', 'delete')
+    AND "state" IN ('prepared', 'provider_started', 'committed', 'aborted', 'quarantined')
+    AND "idempotency_key_hash" ~ '^sha256:[0-9a-f]{64}$'
+    AND "request_digest" ~ '^sha256:[0-9a-f]{64}$' AND "attempts" >= 0
+  ),
+  CONSTRAINT "org_storage_operations_generation_check" CHECK (
+    "source_generation" >= 0 AND "target_generation" > "source_generation"
+    AND "source_size_bytes" >= 0 AND "target_size_bytes" >= 0
+  ),
+  CONSTRAINT "org_storage_operations_source_shape_check" CHECK (((
+    "source_presence" = 'absent' AND "source_size_bytes" = 0
+    AND "source_provider_version" IS NULL AND "source_provider_etag" IS NULL
+  ) OR (
+    "source_presence" = 'present' AND "source_generation" > 0 AND char_length("source_provider_version") BETWEEN 1 AND 1024
+    AND char_length("source_provider_etag") BETWEEN 1 AND 512
+    AND "source_provider_etag" !~ '["\r\n]'
+  )) IS TRUE),
+  CONSTRAINT "org_storage_operations_target_shape_check" CHECK (((
+    "operation" = 'put' AND char_length("target_content_type") BETWEEN 1 AND 255
+    AND "target_content_type" !~ '[\r\n]' AND "target_content_sha256" ~ '^[0-9a-f]{64}$'
+  ) OR ("operation" = 'delete' AND "target_size_bytes" = 0
+    AND "target_content_type" IS NULL AND "target_content_sha256" IS NULL)) IS TRUE),
+  CONSTRAINT "org_storage_operations_quota_shape_check" CHECK (
+    "quota_delta_bytes" = "target_size_bytes" - "source_size_bytes" AND "quota_delta_bytes" = "quota_reserved_bytes" - "quota_release_bytes"
+    AND "quota_reserved_bytes" = CASE WHEN "operation" = 'put' THEN "target_size_bytes" ELSE 0 END
+    AND "quota_release_bytes" = "source_size_bytes"
+  ),
+  CONSTRAINT "org_storage_operations_provider_state_check" CHECK (
+    "provider_write_started" = ("provider_started_at" IS NOT NULL)
+    AND ("state" NOT IN ('prepared', 'aborted') OR "provider_write_started" = FALSE)
+    AND ("state" NOT IN ('provider_started', 'committed', 'quarantined')
+      OR "provider_write_started" = TRUE)
+    AND ("last_observed_at" IS NULL OR "provider_write_started" = TRUE)
+  ),
+  CONSTRAINT "org_storage_operations_claim_shape_check" CHECK ((
+    (("claim_owner" IS NULL AND "claim_generation" IS NULL AND "lease_expires_at" IS NULL)
+      OR ("claim_owner" ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+        AND "claim_generation" IS NOT NULL AND "lease_expires_at" IS NOT NULL))
+    AND ("state" NOT IN ('committed', 'aborted', 'quarantined')
+      OR ("claim_owner" IS NULL AND "claim_generation" IS NULL AND "lease_expires_at" IS NULL))
+  ) IS TRUE),
+  CONSTRAINT "org_storage_operations_error_shape_check" CHECK ((
+    (("last_error_code" IS NULL AND "last_error_digest" IS NULL)
+      OR ("last_error_code" ~ '^[A-Z][A-Z0-9_]{0,95}$'
+        AND "last_error_digest" ~ '^[0-9a-f]{64}$'))
+    AND ("state" <> 'quarantined' OR "last_error_code" IS NOT NULL)
+  ) IS TRUE),
+  CONSTRAINT "org_storage_operations_terminal_shape_check" CHECK (((
+    "state" IN ('committed', 'aborted') AND "completed_at" IS NOT NULL
+    AND "receipt_digest" ~ '^[0-9a-f]{64}$' AND "response_status" IS NOT NULL
+    AND ("state" <> 'aborted' OR ("response_status" BETWEEN 400 AND 599
+      AND "last_error_code" IS NOT NULL AND "provider_write_started" = FALSE))
+  ) OR ("state" NOT IN ('committed', 'aborted') AND "completed_at" IS NULL
+    AND "receipt_digest" IS NULL AND "response_status" IS NULL)) IS TRUE),
+  CONSTRAINT "org_storage_operations_result_shape_check" CHECK (((
+    "state" = 'committed' AND "operation" = 'put' AND "response_status" = 201
+    AND char_length("result_provider_version") BETWEEN 1 AND 1024 AND ("source_presence" <> 'present' OR "result_provider_version" <> "source_provider_version")
+    AND char_length("result_provider_etag") BETWEEN 1 AND 512
+    AND "result_provider_etag" !~ '["\r\n]' AND "result_size_bytes" = "target_size_bytes"
+    AND "result_checksum_sha256" = "target_content_sha256" AND "result_uploaded_at" IS NOT NULL
+  ) OR ("state" = 'committed' AND "operation" = 'delete' AND "response_status" = 204
+    AND "result_provider_version" IS NULL AND "result_provider_etag" IS NULL
+    AND "result_size_bytes" IS NULL AND "result_checksum_sha256" IS NULL
+    AND "result_uploaded_at" IS NULL) OR ("state" <> 'committed'
+    AND "result_provider_version" IS NULL AND "result_provider_etag" IS NULL
+    AND "result_size_bytes" IS NULL AND "result_checksum_sha256" IS NULL
+    AND "result_uploaded_at" IS NULL)) IS TRUE
+  ));
+CREATE UNIQUE INDEX IF NOT EXISTS "org_storage_operations_idempotency_uidx" ON "org_storage_operations" ("organization_id", "idempotency_key_hash");
+CREATE UNIQUE INDEX IF NOT EXISTS "org_storage_operations_generation_uidx" ON "org_storage_operations" ("object_id", "target_generation");
+CREATE UNIQUE INDEX IF NOT EXISTS "org_storage_operations_active_object_uidx"
+  ON "org_storage_operations" ("object_id") WHERE "state" IN ('prepared', 'provider_started', 'quarantined');
+CREATE INDEX IF NOT EXISTS "org_storage_operations_due_idx"
+  ON "org_storage_operations" ("next_attempt_at", "created_at") WHERE "state" IN ('prepared', 'provider_started');
+CREATE INDEX IF NOT EXISTS "org_storage_operations_org_state_idx"
+  ON "org_storage_operations" ("organization_id", "state", "updated_at");

--- a/packages/cloud/shared/src/db/migrations/0238_org_storage_immutable_provider_keys.sql
+++ b/packages/cloud/shared/src/db/migrations/0238_org_storage_immutable_provider_keys.sql
@@ -1,0 +1,71 @@
+ALTER TABLE "org_storage_objects"
+  ADD COLUMN IF NOT EXISTS "current_provider_key" text;
+ALTER TABLE "org_storage_operations"
+  ADD COLUMN IF NOT EXISTS "source_provider_key" text,
+  ADD COLUMN IF NOT EXISTS "target_provider_key" text;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint
+    WHERE conname = 'org_storage_objects_provider_key_shape_check'
+      AND conrelid = 'org_storage_objects'::regclass) THEN
+    ALTER TABLE "org_storage_objects" ADD CONSTRAINT "org_storage_objects_provider_key_shape_check"
+    CHECK ((
+      ("presence" = 'absent' AND "current_provider_key" IS NULL)
+      OR ("presence" = 'present' AND "current_provider_key" IS NOT NULL
+        AND octet_length("current_provider_key") <= 1024
+        AND "current_provider_key" IS NFC NORMALIZED
+        AND ("current_provider_key" = '__eliza_storage_authority/v1/org/'
+          || "organization_id"::text || '/' || "id"::text || '/' || "committed_generation"::text
+          OR ("committed_generation" = 1 AND "current_provider_key" = "object_key")))
+    ) IS TRUE);
+  END IF;
+END $$;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint
+    WHERE conname = 'org_storage_operations_provider_key_shape_check'
+      AND conrelid = 'org_storage_operations'::regclass) THEN
+    ALTER TABLE "org_storage_operations"
+      ADD CONSTRAINT "org_storage_operations_provider_key_shape_check" CHECK ((
+      (("source_presence" = 'absent' AND "source_provider_key" IS NULL)
+        OR ("source_presence" = 'present' AND "source_provider_key" IS NOT NULL
+          AND octet_length("source_provider_key") <= 1024
+          AND "source_provider_key" IS NFC NORMALIZED
+          AND ("source_provider_key" = '__eliza_storage_authority/v1/org/'
+            || "organization_id"::text || '/' || "object_id"::text || '/' || "source_generation"::text
+            OR ("source_generation" = 1
+              AND "source_provider_key" LIKE 'org/' || "organization_id"::text || '/%'
+              AND char_length("source_provider_key")
+                > char_length('org/' || "organization_id"::text || '/')
+              AND "source_provider_key" !~ '[[:cntrl:]]'
+              AND "source_provider_key" !~ '(^|/)\.\.(/|$)')))
+      ) AND (("operation" = 'put' AND "target_provider_key" IS NOT NULL
+          AND octet_length("target_provider_key") <= 1024
+          AND "target_provider_key" IS NFC NORMALIZED
+          AND "target_provider_key" = '__eliza_storage_authority/v1/org/'
+            || "organization_id"::text || '/' || "object_id"::text || '/' || "target_generation"::text)
+        OR ("operation" = 'delete' AND "target_provider_key" IS NULL))
+      AND ("source_provider_key" IS NULL OR "target_provider_key" IS NULL
+        OR "source_provider_key" <> "target_provider_key")
+    ) IS TRUE);
+  END IF;
+END $$;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint
+    WHERE conname = 'org_storage_operations_observation_shape_check'
+      AND conrelid = 'org_storage_operations'::regclass) THEN
+    ALTER TABLE "org_storage_operations"
+      ADD CONSTRAINT "org_storage_operations_observation_shape_check" CHECK ((
+      ("last_observed_at" IS NULL OR ("provider_started_at" IS NOT NULL
+        AND "last_observed_at" >= "provider_started_at"))
+      AND ("state" <> 'committed' OR "source_presence" <> 'present'
+        OR "last_observed_at" IS NOT NULL)
+      AND ("state" <> 'quarantined' OR "last_observed_at" IS NOT NULL)
+      AND ("state" <> 'aborted' OR "last_observed_at" IS NULL)
+    ) IS TRUE);
+  END IF;
+END $$;
+CREATE UNIQUE INDEX IF NOT EXISTS "org_storage_objects_current_provider_key_uidx"
+  ON "org_storage_objects" ("current_provider_key") WHERE "current_provider_key" IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS "org_storage_operations_target_provider_key_uidx"
+  ON "org_storage_operations" ("target_provider_key") WHERE "target_provider_key" IS NOT NULL;
+CREATE INDEX IF NOT EXISTS "org_storage_operations_source_provider_key_idx"
+  ON "org_storage_operations" ("source_provider_key") WHERE "source_provider_key" IS NOT NULL;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1646,6 +1646,27 @@
       "when": 1789416000000,
       "tag": "0235_agent_backup_rpo_scheduler",
       "breakpoints": true
+    },
+    {
+      "idx": 235,
+      "version": "7",
+      "when": 1789502400000,
+      "tag": "0236_org_storage_objects",
+      "breakpoints": true
+    },
+    {
+      "idx": 236,
+      "version": "7",
+      "when": 1789588800000,
+      "tag": "0237_org_storage_operations",
+      "breakpoints": true
+    },
+    {
+      "idx": 237,
+      "version": "7",
+      "when": 1789675200000,
+      "tag": "0238_org_storage_immutable_provider_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/org-storage-object-authority-migrations.test.ts
+++ b/packages/cloud/shared/src/db/org-storage-object-authority-migrations.test.ts
@@ -1,0 +1,805 @@
+/**
+ * Applies the real organization-storage authority migrations to isolated PGlite.
+ * The suite proves Drizzle bigint mapping and fail-closed SQL invariants without repository mocks.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import { type NewOrgStorageObject, orgStorageObjects } from "./schemas/org-storage-objects";
+import {
+  type NewOrgStorageOperation,
+  type OrgStorageOperationState,
+  orgStorageOperations,
+} from "./schemas/org-storage-operations";
+
+const ORG_A = "00000000-0000-4000-8000-00000000a001";
+const ORG_B = "00000000-0000-4000-8000-00000000a002";
+const ORG_WITH_AUTHORITY = "00000000-0000-4000-8000-00000000a003";
+const BIG_OBJECT_ID = "00000000-0000-4000-8000-00000000b001";
+const INVALID_OBJECT_ID = "00000000-0000-4000-8000-00000000b002";
+const TERMINAL_OBJECT_ID = "00000000-0000-4000-8000-00000000b003";
+const ABSENT_OBJECT_ID = "00000000-0000-4000-8000-00000000b004";
+const TOMBSTONE_OBJECT_ID = "00000000-0000-4000-8000-00000000b005";
+const CROSS_TENANT_OBJECT_ID = "00000000-0000-4000-8000-00000000b006";
+const LEGACY_OBJECT_ID = "00000000-0000-4000-8000-00000000b007";
+const CLAIM_GENERATION = "00000000-0000-4000-8000-00000000c001";
+const EXACT_BIGINT = 9_007_199_254_740_993n;
+const MIGRATION_TAGS = [
+  "0236_org_storage_objects",
+  "0237_org_storage_operations",
+  "0238_org_storage_immutable_provider_keys",
+] as const;
+const MIGRATION_TAG_SET = new Set<string>(MIGRATION_TAGS);
+
+const bareDigest = (character: string): string => character.repeat(64);
+const prefixedDigest = (character: string): string => `sha256:${bareDigest(character)}`;
+const providerKey = (organizationId: string, objectId: string, generation: bigint): string =>
+  `__eliza_storage_authority/v1/org/${organizationId}/${objectId}/${generation}`;
+
+let database: PGlite;
+let migrationSql: Record<(typeof MIGRATION_TAGS)[number], string>;
+
+function presentObject(
+  id: string,
+  options: Partial<NewOrgStorageObject> = {},
+): NewOrgStorageObject {
+  const organizationId = options.organization_id ?? ORG_A;
+  const objectKey = options.object_key ?? `org/${organizationId}/objects/${id}`;
+  const committedGeneration = options.committed_generation ?? 1n;
+  return {
+    id,
+    organization_id: organizationId,
+    storage_namespace: "attachment-r2-v1",
+    object_key: objectKey,
+    key_fingerprint: prefixedDigest("a"),
+    presence: "present",
+    last_allocated_generation: 1n,
+    committed_generation: 1n,
+    size_bytes: 5n,
+    provider_version: "r2-version-1",
+    provider_etag: "etag-1",
+    current_provider_key: providerKey(organizationId, id, committedGeneration),
+    content_type: "application/octet-stream",
+    checksum_sha256: bareDigest("b"),
+    provider_uploaded_at: new Date("2026-08-17T08:00:00.000Z"),
+    ...options,
+  };
+}
+
+function preparedPut(
+  objectId: string,
+  options: Partial<NewOrgStorageOperation> = {},
+): NewOrgStorageOperation {
+  const organizationId = options.organization_id ?? ORG_A;
+  const operation = options.operation ?? "put";
+  const sourcePresence = options.source_presence ?? "present";
+  const sourceGeneration = options.source_generation ?? 1n;
+  const targetGeneration = options.target_generation ?? 2n;
+  const sourceSizeBytes = options.source_size_bytes ?? 5n;
+  const targetSizeBytes = options.target_size_bytes ?? (operation === "put" ? 9n : 0n);
+  return {
+    organization_id: organizationId,
+    object_id: objectId,
+    operation,
+    state: "prepared",
+    idempotency_key_hash: prefixedDigest("c"),
+    request_digest: prefixedDigest("d"),
+    source_presence: sourcePresence,
+    source_generation: sourceGeneration,
+    target_generation: targetGeneration,
+    source_size_bytes: sourceSizeBytes,
+    target_size_bytes: targetSizeBytes,
+    quota_delta_bytes: targetSizeBytes - sourceSizeBytes,
+    quota_reserved_bytes: operation === "put" ? targetSizeBytes : 0n,
+    quota_release_bytes: sourceSizeBytes,
+    source_provider_version: sourcePresence === "present" ? "r2-version-1" : null,
+    source_provider_etag: sourcePresence === "present" ? "etag-1" : null,
+    source_provider_key:
+      sourcePresence === "present" ? providerKey(organizationId, objectId, sourceGeneration) : null,
+    target_content_type: operation === "put" ? "application/octet-stream" : null,
+    target_content_sha256: operation === "put" ? bareDigest("e") : null,
+    target_provider_key:
+      operation === "put" ? providerKey(organizationId, objectId, targetGeneration) : null,
+    ...options,
+  };
+}
+
+interface ExecutableQuery {
+  execute(): Promise<unknown>;
+}
+
+async function expectConstraintViolation(
+  query: ExecutableQuery,
+  constraintName?: string,
+): Promise<void> {
+  const execution = query.execute();
+  if (constraintName) {
+    let rejection: unknown;
+    try {
+      await execution;
+    } catch (error) {
+      rejection = error;
+    }
+    const cause = rejection instanceof Error ? rejection.cause : undefined;
+    expect(String(cause)).toContain(constraintName);
+    return;
+  }
+  await expect(execution).rejects.toThrow();
+}
+
+beforeAll(async () => {
+  database = new PGlite();
+  migrationSql = Object.fromEntries(
+    MIGRATION_TAGS.map((tag) => [
+      tag,
+      readFileSync(join(import.meta.dir, `migrations/${tag}.sql`), "utf8"),
+    ]),
+  ) as Record<(typeof MIGRATION_TAGS)[number], string>;
+  await database.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    INSERT INTO organizations (id) VALUES ('${ORG_A}'), ('${ORG_B}');
+  `);
+  for (const tag of MIGRATION_TAGS) {
+    await database.exec(migrationSql[tag]);
+  }
+});
+
+afterAll(async () => {
+  await database.close();
+});
+
+describe("0236-0238 organization storage object authority", () => {
+  test("registers bounded additive migrations that replay safely", async () => {
+    const journal = JSON.parse(
+      readFileSync(join(import.meta.dir, "migrations/meta/_journal.json"), "utf8"),
+    ) as {
+      entries: Array<{
+        idx: number;
+        version: string;
+        when: number;
+        tag: string;
+        breakpoints: boolean;
+      }>;
+    };
+
+    expect(journal.entries.filter(({ tag }) => MIGRATION_TAG_SET.has(tag))).toEqual([
+      {
+        idx: 235,
+        version: "7",
+        when: 1789502400000,
+        tag: "0236_org_storage_objects",
+        breakpoints: true,
+      },
+      {
+        idx: 236,
+        version: "7",
+        when: 1789588800000,
+        tag: "0237_org_storage_operations",
+        breakpoints: true,
+      },
+      {
+        idx: 237,
+        version: "7",
+        when: 1789675200000,
+        tag: "0238_org_storage_immutable_provider_keys",
+        breakpoints: true,
+      },
+    ]);
+    for (const tag of MIGRATION_TAGS) {
+      expect(migrationSql[tag].split(/\r?\n/).length).toBeLessThan(100);
+      await database.exec(migrationSql[tag]);
+    }
+
+    const indexes = await database.query<{ indexdef: string; indexname: string }>(`
+      SELECT indexdef, indexname FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename IN ('org_storage_objects', 'org_storage_operations')
+      ORDER BY indexname
+    `);
+    expect(indexes.rows.map(({ indexname }) => indexname)).toEqual(
+      expect.arrayContaining([
+        "org_storage_objects_org_key_uidx",
+        "org_storage_objects_org_presence_key_idx",
+        "org_storage_objects_current_provider_key_uidx",
+        "org_storage_operations_active_object_uidx",
+        "org_storage_operations_due_idx",
+        "org_storage_operations_generation_uidx",
+        "org_storage_operations_idempotency_uidx",
+        "org_storage_operations_org_state_idx",
+        "org_storage_operations_source_provider_key_idx",
+        "org_storage_operations_target_provider_key_uidx",
+      ]),
+    );
+    expect(
+      indexes.rows.find(
+        ({ indexname }) => indexname === "org_storage_operations_target_provider_key_uidx",
+      )?.indexdef,
+    ).toContain("CREATE UNIQUE INDEX");
+  });
+
+  test("maps exact bigint authority and copy-on-write reservation through Drizzle", async () => {
+    const client = drizzle(database, { schema: { orgStorageObjects, orgStorageOperations } });
+    const [object] = await client
+      .insert(orgStorageObjects)
+      .values(
+        presentObject(BIG_OBJECT_ID, {
+          last_allocated_generation: 2n,
+          committed_generation: 1n,
+          size_bytes: EXACT_BIGINT,
+        }),
+      )
+      .returning();
+    const [operation] = await client
+      .insert(orgStorageOperations)
+      .values(
+        preparedPut(BIG_OBJECT_ID, {
+          idempotency_key_hash: prefixedDigest("f"),
+          source_size_bytes: EXACT_BIGINT,
+          target_size_bytes: EXACT_BIGINT + 10n,
+          quota_delta_bytes: 10n,
+          claim_owner: "storage-route-a",
+          claim_generation: CLAIM_GENERATION,
+          lease_expires_at: new Date("2026-08-17T08:05:00.000Z"),
+        }),
+      )
+      .returning();
+
+    expect(object).toMatchObject({
+      size_bytes: EXACT_BIGINT,
+      last_allocated_generation: 2n,
+      committed_generation: 1n,
+      current_provider_key: providerKey(ORG_A, BIG_OBJECT_ID, 1n),
+    });
+    expect(operation).toMatchObject({
+      source_size_bytes: EXACT_BIGINT,
+      target_size_bytes: EXACT_BIGINT + 10n,
+      quota_delta_bytes: 10n,
+      quota_reserved_bytes: EXACT_BIGINT + 10n,
+      quota_release_bytes: EXACT_BIGINT,
+      source_provider_key: providerKey(ORG_A, BIG_OBJECT_ID, 1n),
+      target_provider_key: providerKey(ORG_A, BIG_OBJECT_ID, 2n),
+      state: "prepared",
+    });
+  });
+
+  test("accepts exact terminal receipts, tombstones, and unstarted aborts", async () => {
+    const client = drizzle(database, { schema: { orgStorageObjects, orgStorageOperations } });
+    await client.insert(orgStorageObjects).values([
+      {
+        id: TERMINAL_OBJECT_ID,
+        organization_id: ORG_A,
+        storage_namespace: "attachment-r2-v1",
+        object_key: `org/${ORG_A}/objects/${TERMINAL_OBJECT_ID}`,
+        key_fingerprint: prefixedDigest("0"),
+        presence: "absent",
+        last_allocated_generation: 4n,
+        committed_generation: 2n,
+        size_bytes: 0n,
+      },
+      {
+        id: ABSENT_OBJECT_ID,
+        organization_id: ORG_A,
+        storage_namespace: "attachment-r2-v1",
+        object_key: `org/${ORG_A}/objects/never-written`,
+        key_fingerprint: prefixedDigest("1"),
+        presence: "absent",
+        last_allocated_generation: 0n,
+        committed_generation: 0n,
+        size_bytes: 0n,
+      },
+      {
+        id: TOMBSTONE_OBJECT_ID,
+        organization_id: ORG_A,
+        storage_namespace: "attachment-r2-v1",
+        object_key: `org/${ORG_A}/objects/deleted`,
+        key_fingerprint: prefixedDigest("2"),
+        presence: "absent",
+        last_allocated_generation: 3n,
+        committed_generation: 3n,
+        size_bytes: 0n,
+      },
+    ]);
+
+    const completedAt = new Date("2026-08-17T08:10:00.000Z");
+    const providerStartedAt = new Date("2026-08-17T08:09:00.000Z");
+    await client.insert(orgStorageOperations).values([
+      preparedPut(TERMINAL_OBJECT_ID, {
+        idempotency_key_hash: prefixedDigest("3"),
+        request_digest: prefixedDigest("4"),
+        source_presence: "absent",
+        source_generation: 0n,
+        target_generation: 1n,
+        source_size_bytes: 0n,
+        source_provider_version: null,
+        source_provider_etag: null,
+        target_size_bytes: 5n,
+        quota_delta_bytes: 5n,
+        quota_reserved_bytes: 5n,
+        state: "committed",
+        provider_write_started: true,
+        provider_started_at: providerStartedAt,
+        result_provider_version: "r2-version-1",
+        result_provider_etag: "etag-1",
+        result_size_bytes: 5n,
+        result_checksum_sha256: bareDigest("e"),
+        result_uploaded_at: completedAt,
+        response_status: 201,
+        receipt_digest: bareDigest("5"),
+        completed_at: completedAt,
+      }),
+      {
+        ...preparedPut(TERMINAL_OBJECT_ID),
+        operation: "delete",
+        state: "committed",
+        idempotency_key_hash: prefixedDigest("6"),
+        request_digest: prefixedDigest("7"),
+        source_generation: 1n,
+        target_generation: 2n,
+        source_size_bytes: 5n,
+        target_size_bytes: 0n,
+        quota_delta_bytes: -5n,
+        quota_reserved_bytes: 0n,
+        quota_release_bytes: 5n,
+        target_content_type: null,
+        target_content_sha256: null,
+        target_provider_key: null,
+        provider_write_started: true,
+        provider_started_at: providerStartedAt,
+        last_observed_at: completedAt,
+        response_status: 204,
+        receipt_digest: bareDigest("8"),
+        completed_at: completedAt,
+      },
+      preparedPut(TERMINAL_OBJECT_ID, {
+        state: "aborted",
+        idempotency_key_hash: prefixedDigest("9"),
+        request_digest: prefixedDigest("a"),
+        source_presence: "absent",
+        source_generation: 2n,
+        target_generation: 3n,
+        source_size_bytes: 0n,
+        source_provider_version: null,
+        source_provider_etag: null,
+        target_size_bytes: 7n,
+        quota_delta_bytes: 7n,
+        quota_reserved_bytes: 7n,
+        response_status: 409,
+        receipt_digest: bareDigest("b"),
+        last_error_code: "OBJECT_BUSY",
+        last_error_digest: bareDigest("c"),
+        completed_at: completedAt,
+      }),
+      preparedPut(TERMINAL_OBJECT_ID, {
+        state: "quarantined",
+        idempotency_key_hash: prefixedDigest("0"),
+        request_digest: prefixedDigest("1"),
+        source_presence: "absent",
+        source_generation: 2n,
+        target_generation: 4n,
+        source_size_bytes: 0n,
+        source_provider_version: null,
+        source_provider_etag: null,
+        target_size_bytes: 7n,
+        quota_delta_bytes: 7n,
+        quota_reserved_bytes: 7n,
+        provider_write_started: true,
+        provider_started_at: providerStartedAt,
+        last_observed_at: completedAt,
+        last_error_code: "R2_GENERATION_MISMATCH",
+        last_error_digest: bareDigest("2"),
+      }),
+    ]);
+
+    const states = await client
+      .select({ state: orgStorageOperations.state })
+      .from(orgStorageOperations)
+      .where(eq(orgStorageOperations.object_id, TERMINAL_OBJECT_ID));
+    expect(states.map(({ state }) => state).sort()).toEqual([
+      "aborted",
+      "committed",
+      "committed",
+      "quarantined",
+    ]);
+    const providerTargets = await client
+      .select({
+        generation: orgStorageOperations.target_generation,
+        state: orgStorageOperations.state,
+        targetProviderKey: orgStorageOperations.target_provider_key,
+      })
+      .from(orgStorageOperations)
+      .where(eq(orgStorageOperations.object_id, TERMINAL_OBJECT_ID));
+    const physicalTargets = providerTargets.filter(
+      (
+        row,
+      ): row is {
+        generation: bigint;
+        state: OrgStorageOperationState;
+        targetProviderKey: string;
+      } => row.targetProviderKey !== null,
+    );
+    expect(new Set(physicalTargets.map(({ targetProviderKey }) => targetProviderKey)).size).toBe(
+      physicalTargets.length,
+    );
+    for (const { generation, targetProviderKey } of physicalTargets) {
+      expect(targetProviderKey).toBe(providerKey(ORG_A, TERMINAL_OBJECT_ID, generation));
+    }
+    expect(
+      physicalTargets
+        .filter(({ state }) => state === "aborted")
+        .map(({ targetProviderKey }) => targetProviderKey)
+        .sort(),
+    ).toEqual([providerKey(ORG_A, TERMINAL_OBJECT_ID, 3n)]);
+    const [tombstone] = await client
+      .select({ currentProviderKey: orgStorageObjects.current_provider_key })
+      .from(orgStorageObjects)
+      .where(eq(orgStorageObjects.id, TOMBSTONE_OBJECT_ID));
+    expect(tombstone?.currentProviderKey).toBeNull();
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(TERMINAL_OBJECT_ID, {
+          idempotency_key_hash: prefixedDigest("4"),
+          request_digest: prefixedDigest("5"),
+          source_generation: 2n,
+          target_generation: 5n,
+        }),
+      ),
+    );
+  });
+
+  test("accepts canonical generation keys and the explicit generation-one legacy bridge", async () => {
+    const client = drizzle(database, { schema: { orgStorageObjects, orgStorageOperations } });
+    const logicalKey = `org/${ORG_A}/legacy/${LEGACY_OBJECT_ID}`;
+    const [legacyObject] = await client
+      .insert(orgStorageObjects)
+      .values(
+        presentObject(LEGACY_OBJECT_ID, {
+          object_key: logicalKey,
+          current_provider_key: logicalKey,
+          last_allocated_generation: 2n,
+        }),
+      )
+      .returning();
+    const [operation] = await client
+      .insert(orgStorageOperations)
+      .values(
+        preparedPut(LEGACY_OBJECT_ID, {
+          idempotency_key_hash: prefixedDigest("2"),
+          request_digest: prefixedDigest("3"),
+          source_provider_key: logicalKey,
+        }),
+      )
+      .returning();
+
+    expect(legacyObject.current_provider_key).toBe(logicalKey);
+    expect(operation.source_provider_key).toBe(logicalKey);
+    expect(operation.target_provider_key).toBe(providerKey(ORG_A, LEGACY_OBJECT_ID, 2n));
+    expect(operation.source_provider_key).not.toBe(operation.target_provider_key);
+  });
+
+  test("retains an organization while durable object authority still exists", async () => {
+    const client = drizzle(database, { schema: { orgStorageObjects, orgStorageOperations } });
+    const objectId = "00000000-0000-4000-8000-00000000b008";
+    await database.exec(`INSERT INTO organizations (id) VALUES ('${ORG_WITH_AUTHORITY}')`);
+    await client.insert(orgStorageObjects).values({
+      id: objectId,
+      organization_id: ORG_WITH_AUTHORITY,
+      storage_namespace: "attachment-r2-v1",
+      object_key: `org/${ORG_WITH_AUTHORITY}/objects/${objectId}`,
+      key_fingerprint: prefixedDigest("9"),
+      presence: "absent",
+      last_allocated_generation: 0n,
+      committed_generation: 0n,
+      size_bytes: 0n,
+      current_provider_key: null,
+    });
+
+    await expect(
+      database.exec(`DELETE FROM organizations WHERE id = '${ORG_WITH_AUTHORITY}'`),
+    ).rejects.toThrow();
+    const retained = await database.query<{ id: string }>(
+      `SELECT id FROM organizations WHERE id = '${ORG_WITH_AUTHORITY}'`,
+    );
+    expect(retained.rows).toEqual([{ id: ORG_WITH_AUTHORITY }]);
+  });
+
+  test("rejects tenant/key/generation drift including overlong UTF-8 keys", async () => {
+    const client = drizzle(database, { schema: { orgStorageObjects, orgStorageOperations } });
+    await expectConstraintViolation(
+      client.insert(orgStorageObjects).values(
+        presentObject("00000000-0000-4000-8000-00000000d001", {
+          object_key: `org/${ORG_B}/foreign-prefix`,
+        }),
+      ),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageObjects).values(
+        presentObject("00000000-0000-4000-8000-00000000d002", {
+          object_key: `org/${ORG_A}/${"é".repeat(600)}`,
+        }),
+      ),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageObjects).values(
+        presentObject("00000000-0000-4000-8000-00000000d003", {
+          object_key: `org/${ORG_A}/objects/cafe\u0301`,
+        }),
+      ),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageObjects).values(
+        presentObject("00000000-0000-4000-8000-00000000d006", {
+          object_key: `org/${ORG_A}/unsafe\nkey`,
+        }),
+      ),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageObjects).values(
+        presentObject("00000000-0000-4000-8000-00000000d009", {
+          object_key: `org/${ORG_A}/unsafe\u0085key`,
+        }),
+      ),
+    );
+    const legacyGenerationTwoId = "00000000-0000-4000-8000-00000000d007";
+    const legacyGenerationTwoKey = `org/${ORG_A}/legacy/${legacyGenerationTwoId}`;
+    await expectConstraintViolation(
+      client.insert(orgStorageObjects).values(
+        presentObject(legacyGenerationTwoId, {
+          object_key: legacyGenerationTwoKey,
+          current_provider_key: legacyGenerationTwoKey,
+          committed_generation: 2n,
+          last_allocated_generation: 2n,
+        }),
+      ),
+    );
+    const absentWithKeyId = "00000000-0000-4000-8000-00000000d008";
+    await expectConstraintViolation(
+      client.insert(orgStorageObjects).values({
+        id: absentWithKeyId,
+        organization_id: ORG_A,
+        storage_namespace: "attachment-r2-v1",
+        object_key: `org/${ORG_A}/objects/${absentWithKeyId}`,
+        key_fingerprint: prefixedDigest("8"),
+        presence: "absent",
+        last_allocated_generation: 1n,
+        committed_generation: 1n,
+        size_bytes: 0n,
+        current_provider_key: providerKey(ORG_A, absentWithKeyId, 1n),
+      }),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageObjects).values(
+        presentObject("00000000-0000-4000-8000-00000000d004", {
+          committed_generation: 0n,
+        }),
+      ),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageObjects).values(
+        presentObject("00000000-0000-4000-8000-00000000d005", {
+          provider_version: null,
+        }),
+      ),
+    );
+
+    await client.insert(orgStorageObjects).values(
+      presentObject(CROSS_TENANT_OBJECT_ID, {
+        last_allocated_generation: 2n,
+      }),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(CROSS_TENANT_OBJECT_ID, {
+          organization_id: ORG_B,
+          idempotency_key_hash: prefixedDigest("6"),
+          request_digest: prefixedDigest("7"),
+        }),
+      ),
+    );
+  });
+
+  test("rejects NULL-tristate bypasses and malformed operation accounting", async () => {
+    const client = drizzle(database, { schema: { orgStorageObjects, orgStorageOperations } });
+    await client.insert(orgStorageObjects).values(
+      presentObject(INVALID_OBJECT_ID, {
+        last_allocated_generation: 2n,
+      }),
+    );
+
+    await expectConstraintViolation(
+      client
+        .insert(orgStorageOperations)
+        .values(preparedPut(INVALID_OBJECT_ID, { request_digest: bareDigest("d") })),
+    );
+    await expectConstraintViolation(
+      client
+        .insert(orgStorageOperations)
+        .values(preparedPut(INVALID_OBJECT_ID, { claim_owner: "worker-a" })),
+    );
+    await expectConstraintViolation(
+      client
+        .insert(orgStorageOperations)
+        .values(preparedPut(INVALID_OBJECT_ID, { last_error_code: "R2_TIMEOUT" })),
+    );
+    await expectConstraintViolation(
+      client
+        .insert(orgStorageOperations)
+        .values(preparedPut(INVALID_OBJECT_ID, { quota_reserved_bytes: 3n })),
+    );
+    await expectConstraintViolation(
+      client
+        .insert(orgStorageOperations)
+        .values(preparedPut(INVALID_OBJECT_ID, { quota_release_bytes: 0n })),
+    );
+    await expectConstraintViolation(
+      client
+        .insert(orgStorageOperations)
+        .values(preparedPut(INVALID_OBJECT_ID, { source_provider_key: null })),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          target_provider_key: `org/${ORG_A}/objects/${INVALID_OBJECT_ID}`,
+        }),
+      ),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          source_provider_key: providerKey(ORG_A, INVALID_OBJECT_ID, 2n),
+        }),
+      ),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          source_generation: 0n,
+          target_generation: 1n,
+        }),
+      ),
+      "org_storage_operations_source_shape_check",
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          operation: "delete",
+          target_provider_key: providerKey(ORG_A, INVALID_OBJECT_ID, 2n),
+        }),
+      ),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          state: "provider_started",
+          provider_write_started: false,
+          provider_started_at: null,
+        }),
+      ),
+    );
+
+    const beforeProviderStartedAt = new Date("2026-08-17T08:18:00.000Z");
+    const providerStartedAt = new Date("2026-08-17T08:19:00.000Z");
+    const completedAt = new Date("2026-08-17T08:20:00.000Z");
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          state: "aborted",
+          provider_write_started: true,
+          provider_started_at: providerStartedAt,
+          response_status: 412,
+          receipt_digest: bareDigest("a"),
+          last_error_code: "PROVIDER_PRECONDITION_FAILED",
+          last_error_digest: bareDigest("b"),
+          completed_at: completedAt,
+        }),
+      ),
+      "org_storage_operations_provider_state_check",
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          state: "provider_started",
+          provider_write_started: true,
+          provider_started_at: providerStartedAt,
+          last_observed_at: beforeProviderStartedAt,
+        }),
+      ),
+      "org_storage_operations_observation_shape_check",
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          state: "committed",
+          provider_write_started: true,
+          provider_started_at: providerStartedAt,
+          last_observed_at: completedAt,
+          response_status: 201,
+          receipt_digest: bareDigest("f"),
+          completed_at: completedAt,
+          result_provider_version: "r2-version-1",
+          result_provider_etag: "etag-2",
+          result_size_bytes: 9n,
+          result_checksum_sha256: bareDigest("e"),
+          result_uploaded_at: completedAt,
+        }),
+      ),
+      "org_storage_operations_result_shape_check",
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          state: "committed",
+          provider_write_started: true,
+          provider_started_at: providerStartedAt,
+          response_status: 201,
+          receipt_digest: bareDigest("c"),
+          completed_at: completedAt,
+          result_provider_version: "r2-version-2",
+          result_provider_etag: "etag-2",
+          result_size_bytes: 9n,
+          result_checksum_sha256: bareDigest("e"),
+          result_uploaded_at: completedAt,
+        }),
+      ),
+      "org_storage_operations_observation_shape_check",
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          state: "quarantined",
+          provider_write_started: true,
+          provider_started_at: providerStartedAt,
+          last_error_code: "R2_GENERATION_MISMATCH",
+          last_error_digest: bareDigest("d"),
+        }),
+      ),
+      "org_storage_operations_observation_shape_check",
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          state: "committed",
+          response_status: 201,
+          receipt_digest: bareDigest("a"),
+          completed_at: completedAt,
+          result_provider_version: "r2-version-2",
+          result_provider_etag: "etag-2",
+          result_size_bytes: 9n,
+          result_checksum_sha256: bareDigest("e"),
+          result_uploaded_at: completedAt,
+        }),
+      ),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          state: "committed",
+          provider_write_started: true,
+          provider_started_at: completedAt,
+          response_status: 201,
+          receipt_digest: bareDigest("a"),
+          completed_at: completedAt,
+          result_provider_version: null,
+          result_provider_etag: null,
+          result_size_bytes: null,
+          result_checksum_sha256: null,
+          result_uploaded_at: null,
+        }),
+      ),
+    );
+    await expectConstraintViolation(
+      client.insert(orgStorageOperations).values(
+        preparedPut(INVALID_OBJECT_ID, {
+          state: "quarantined",
+          provider_write_started: true,
+          provider_started_at: completedAt,
+          last_error_code: "R2_GENERATION_MISMATCH",
+          last_error_digest: null,
+        }),
+      ),
+    );
+  });
+});

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -74,6 +74,8 @@ export * from "./moderation-violations";
 export * from "./oauth-success-proof-tickets";
 export * from "./oidc";
 export * from "./org-rate-limit-overrides";
+export * from "./org-storage-objects";
+export * from "./org-storage-operations";
 export * from "./org-storage-quota";
 export * from "./organization-billing";
 export * from "./organization-config";

--- a/packages/cloud/shared/src/db/schemas/org-storage-objects.ts
+++ b/packages/cloud/shared/src/db/schemas/org-storage-objects.ts
@@ -1,0 +1,128 @@
+/**
+ * Defines the durable per-object authority used to reconcile organization-scoped R2 storage.
+ * Logical generations are allocated monotonically; physical provider keys are immutable per generation.
+ */
+
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  check,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { organizations } from "./organizations";
+
+export type OrgStorageObjectPresence = "absent" | "present";
+
+export const orgStorageObjects = pgTable(
+  "org_storage_objects",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "restrict" }),
+    storage_namespace: text("storage_namespace").notNull().default("attachment-r2-v1"),
+    object_key: text("object_key").notNull(),
+    key_fingerprint: text("key_fingerprint").notNull(),
+    presence: text("presence").$type<OrgStorageObjectPresence>().notNull(),
+    last_allocated_generation: bigint("last_allocated_generation", { mode: "bigint" })
+      .notNull()
+      .default(0n),
+    committed_generation: bigint("committed_generation", { mode: "bigint" }).notNull().default(0n),
+    size_bytes: bigint("size_bytes", { mode: "bigint" }).notNull().default(0n),
+    provider_version: text("provider_version"),
+    provider_etag: text("provider_etag"),
+    current_provider_key: text("current_provider_key"),
+    content_type: text("content_type"),
+    checksum_sha256: text("checksum_sha256"),
+    provider_uploaded_at: timestamp("provider_uploaded_at", { withTimezone: true }),
+    verified_at: timestamp("verified_at", { withTimezone: true }).notNull().defaultNow(),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    tenant_identity_unique: unique("org_storage_objects_tenant_identity_unique").on(
+      table.id,
+      table.organization_id,
+    ),
+    org_key_uidx: uniqueIndex("org_storage_objects_org_key_uidx").on(
+      table.organization_id,
+      table.storage_namespace,
+      table.object_key,
+    ),
+    org_presence_key_idx: index("org_storage_objects_org_presence_key_idx").on(
+      table.organization_id,
+      table.presence,
+      table.object_key,
+    ),
+    current_provider_key_uidx: uniqueIndex("org_storage_objects_current_provider_key_uidx")
+      .on(table.current_provider_key)
+      .where(sql`${table.current_provider_key} IS NOT NULL`),
+    locator_check: check(
+      "org_storage_objects_locator_check",
+      sql`${table.storage_namespace} = 'attachment-r2-v1'
+        AND ${table.object_key} LIKE 'org/' || ${table.organization_id}::text || '/%'
+        AND char_length(${table.object_key}) >
+          char_length('org/' || ${table.organization_id}::text || '/')
+        AND octet_length(${table.object_key}) <= 1024
+        AND ${table.object_key} IS NFC NORMALIZED
+        AND ${table.object_key} !~ '[[:cntrl:]]'
+        AND ${table.object_key} !~ '(^|/)\\.\\.(/|$)'
+        AND ${table.key_fingerprint} ~ '^sha256:[0-9a-f]{64}$'`,
+    ),
+    generation_check: check(
+      "org_storage_objects_generation_check",
+      sql`${table.committed_generation} >= 0
+        AND ${table.last_allocated_generation} >= ${table.committed_generation}
+        AND ${table.size_bytes} >= 0
+        AND (${table.presence} <> 'present' OR ${table.committed_generation} > 0)`,
+    ),
+    presence_shape_check: check(
+      "org_storage_objects_presence_shape_check",
+      sql`((
+        ${table.presence} = 'absent' AND ${table.size_bytes} = 0
+        AND ${table.provider_version} IS NULL AND ${table.provider_etag} IS NULL
+        AND ${table.content_type} IS NULL AND ${table.checksum_sha256} IS NULL
+        AND ${table.provider_uploaded_at} IS NULL
+      ) OR (
+        ${table.presence} = 'present'
+        AND char_length(${table.provider_version}) BETWEEN 1 AND 1024
+        AND char_length(${table.provider_etag}) BETWEEN 1 AND 512
+        AND ${table.provider_etag} !~ '["\\r\\n]'
+        AND char_length(${table.content_type}) BETWEEN 1 AND 255
+        AND ${table.content_type} !~ '[\\r\\n]'
+        AND (${table.checksum_sha256} IS NULL
+          OR ${table.checksum_sha256} ~ '^[0-9a-f]{64}$')
+        AND ${table.provider_uploaded_at} IS NOT NULL
+      )) IS TRUE`,
+    ),
+    presence_check: check(
+      "org_storage_objects_presence_check",
+      sql`${table.presence} IN ('absent', 'present')`,
+    ),
+    provider_key_shape_check: check(
+      "org_storage_objects_provider_key_shape_check",
+      sql`((
+        ${table.presence} = 'absent' AND ${table.current_provider_key} IS NULL
+      ) OR (
+        ${table.presence} = 'present' AND ${table.current_provider_key} IS NOT NULL
+        AND octet_length(${table.current_provider_key}) <= 1024
+        AND ${table.current_provider_key} IS NFC NORMALIZED
+        AND (${table.current_provider_key} = '__eliza_storage_authority/v1/org/'
+          || ${table.organization_id}::text || '/' || ${table.id}::text || '/'
+          || ${table.committed_generation}::text
+          OR (${table.committed_generation} = 1
+            AND ${table.current_provider_key} = ${table.object_key}))
+      )) IS TRUE`,
+    ),
+  }),
+);
+
+export type OrgStorageObject = InferSelectModel<typeof orgStorageObjects>;
+export type NewOrgStorageObject = InferInsertModel<typeof orgStorageObjects>;

--- a/packages/cloud/shared/src/db/schemas/org-storage-operations.ts
+++ b/packages/cloud/shared/src/db/schemas/org-storage-operations.ts
@@ -1,0 +1,272 @@
+/**
+ * Defines durable idempotency, quota, provider-attempt, and reconciliation receipts for R2 mutations.
+ * Copy-on-write reserves the full target and releases the full source only after safe settlement.
+ */
+
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  boolean,
+  check,
+  foreignKey,
+  index,
+  integer,
+  pgTable,
+  smallint,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { type OrgStorageObjectPresence, orgStorageObjects } from "./org-storage-objects";
+import { organizations } from "./organizations";
+
+export type OrgStorageOperationKind = "put" | "delete";
+export type OrgStorageOperationState =
+  | "prepared"
+  | "provider_started"
+  | "committed"
+  | "aborted"
+  | "quarantined";
+
+export const orgStorageOperations = pgTable(
+  "org_storage_operations",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "restrict" }),
+    object_id: uuid("object_id").notNull(),
+    operation: text("operation").$type<OrgStorageOperationKind>().notNull(),
+    state: text("state").$type<OrgStorageOperationState>().notNull().default("prepared"),
+    idempotency_key_hash: text("idempotency_key_hash").notNull(),
+    request_digest: text("request_digest").notNull(),
+    source_presence: text("source_presence").$type<OrgStorageObjectPresence>().notNull(),
+    source_generation: bigint("source_generation", { mode: "bigint" }).notNull(),
+    target_generation: bigint("target_generation", { mode: "bigint" }).notNull(),
+    source_size_bytes: bigint("source_size_bytes", { mode: "bigint" }).notNull(),
+    target_size_bytes: bigint("target_size_bytes", { mode: "bigint" }).notNull(),
+    quota_delta_bytes: bigint("quota_delta_bytes", { mode: "bigint" }).notNull(),
+    quota_reserved_bytes: bigint("quota_reserved_bytes", { mode: "bigint" }).notNull(),
+    quota_release_bytes: bigint("quota_release_bytes", { mode: "bigint" }).notNull(),
+    source_provider_version: text("source_provider_version"),
+    source_provider_etag: text("source_provider_etag"),
+    source_provider_key: text("source_provider_key"),
+    target_content_type: text("target_content_type"),
+    target_content_sha256: text("target_content_sha256"),
+    target_provider_key: text("target_provider_key"),
+    provider_write_started: boolean("provider_write_started").notNull().default(false),
+    provider_started_at: timestamp("provider_started_at", { withTimezone: true }),
+    result_provider_version: text("result_provider_version"),
+    result_provider_etag: text("result_provider_etag"),
+    result_size_bytes: bigint("result_size_bytes", { mode: "bigint" }),
+    result_checksum_sha256: text("result_checksum_sha256"),
+    result_uploaded_at: timestamp("result_uploaded_at", { withTimezone: true }),
+    response_status: smallint("response_status"),
+    receipt_digest: text("receipt_digest"),
+    claim_owner: text("claim_owner"),
+    claim_generation: uuid("claim_generation"),
+    lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }),
+    attempts: integer("attempts").notNull().default(0),
+    next_attempt_at: timestamp("next_attempt_at", { withTimezone: true }).notNull().defaultNow(),
+    last_observed_at: timestamp("last_observed_at", { withTimezone: true }),
+    last_error_code: text("last_error_code"),
+    last_error_digest: text("last_error_digest"),
+    completed_at: timestamp("completed_at", { withTimezone: true }),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    object_tenant_fk: foreignKey({
+      name: "org_storage_operations_object_tenant_fkey",
+      columns: [table.object_id, table.organization_id],
+      foreignColumns: [orgStorageObjects.id, orgStorageObjects.organization_id],
+    }).onDelete("restrict"),
+    idempotency_uidx: uniqueIndex("org_storage_operations_idempotency_uidx").on(
+      table.organization_id,
+      table.idempotency_key_hash,
+    ),
+    generation_uidx: uniqueIndex("org_storage_operations_generation_uidx").on(
+      table.object_id,
+      table.target_generation,
+    ),
+    target_provider_key_uidx: uniqueIndex("org_storage_operations_target_provider_key_uidx")
+      .on(table.target_provider_key)
+      .where(sql`${table.target_provider_key} IS NOT NULL`),
+    source_provider_key_idx: index("org_storage_operations_source_provider_key_idx")
+      .on(table.source_provider_key)
+      .where(sql`${table.source_provider_key} IS NOT NULL`),
+    active_object_uidx: uniqueIndex("org_storage_operations_active_object_uidx")
+      .on(table.object_id)
+      .where(sql`${table.state} IN ('prepared', 'provider_started', 'quarantined')`),
+    due_idx: index("org_storage_operations_due_idx")
+      .on(table.next_attempt_at, table.created_at)
+      .where(sql`${table.state} IN ('prepared', 'provider_started')`),
+    org_state_idx: index("org_storage_operations_org_state_idx").on(
+      table.organization_id,
+      table.state,
+      table.updated_at,
+    ),
+    identity_check: check(
+      "org_storage_operations_identity_check",
+      sql`${table.operation} IN ('put', 'delete')
+        AND ${table.state} IN ('prepared', 'provider_started', 'committed', 'aborted', 'quarantined')
+        AND ${table.idempotency_key_hash} ~ '^sha256:[0-9a-f]{64}$'
+        AND ${table.request_digest} ~ '^sha256:[0-9a-f]{64}$'
+        AND ${table.attempts} >= 0`,
+    ),
+    generation_check: check(
+      "org_storage_operations_generation_check",
+      sql`${table.source_generation} >= 0
+        AND ${table.target_generation} > ${table.source_generation}
+        AND ${table.source_size_bytes} >= 0 AND ${table.target_size_bytes} >= 0`,
+    ),
+    source_shape_check: check(
+      "org_storage_operations_source_shape_check",
+      sql`((
+        ${table.source_presence} = 'absent' AND ${table.source_size_bytes} = 0
+        AND ${table.source_provider_version} IS NULL AND ${table.source_provider_etag} IS NULL
+      ) OR (
+        ${table.source_presence} = 'present' AND ${table.source_generation} > 0
+        AND char_length(${table.source_provider_version}) BETWEEN 1 AND 1024
+        AND char_length(${table.source_provider_etag}) BETWEEN 1 AND 512
+        AND ${table.source_provider_etag} !~ '["\\r\\n]'
+      )) IS TRUE`,
+    ),
+    target_shape_check: check(
+      "org_storage_operations_target_shape_check",
+      sql`((
+        ${table.operation} = 'put'
+        AND char_length(${table.target_content_type}) BETWEEN 1 AND 255
+        AND ${table.target_content_type} !~ '[\\r\\n]'
+        AND ${table.target_content_sha256} ~ '^[0-9a-f]{64}$'
+      ) OR (
+        ${table.operation} = 'delete' AND ${table.target_size_bytes} = 0
+        AND ${table.target_content_type} IS NULL AND ${table.target_content_sha256} IS NULL
+      )) IS TRUE`,
+    ),
+    quota_shape_check: check(
+      "org_storage_operations_quota_shape_check",
+      sql`${table.quota_delta_bytes} = ${table.target_size_bytes} - ${table.source_size_bytes}
+        AND ${table.quota_delta_bytes} = ${table.quota_reserved_bytes} - ${table.quota_release_bytes}
+        AND ${table.quota_reserved_bytes} = CASE
+          WHEN ${table.operation} = 'put' THEN ${table.target_size_bytes} ELSE 0 END
+        AND ${table.quota_release_bytes} = ${table.source_size_bytes}`,
+    ),
+    provider_state_check: check(
+      "org_storage_operations_provider_state_check",
+      sql`${table.provider_write_started} = (${table.provider_started_at} IS NOT NULL)
+        AND (${table.state} NOT IN ('prepared', 'aborted')
+          OR ${table.provider_write_started} = FALSE)
+        AND (${table.state} NOT IN ('provider_started', 'committed', 'quarantined')
+          OR ${table.provider_write_started} = TRUE)
+        AND (${table.last_observed_at} IS NULL OR ${table.provider_write_started} = TRUE)`,
+    ),
+    claim_shape_check: check(
+      "org_storage_operations_claim_shape_check",
+      sql`(
+        ((${table.claim_owner} IS NULL AND ${table.claim_generation} IS NULL
+          AND ${table.lease_expires_at} IS NULL)
+        OR (${table.claim_owner} ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+          AND ${table.claim_generation} IS NOT NULL AND ${table.lease_expires_at} IS NOT NULL))
+        AND (
+          ${table.state} NOT IN ('committed', 'aborted', 'quarantined')
+          OR (${table.claim_owner} IS NULL AND ${table.claim_generation} IS NULL
+            AND ${table.lease_expires_at} IS NULL)
+        )
+      ) IS TRUE`,
+    ),
+    error_shape_check: check(
+      "org_storage_operations_error_shape_check",
+      sql`(
+        ((${table.last_error_code} IS NULL AND ${table.last_error_digest} IS NULL)
+        OR (${table.last_error_code} ~ '^[A-Z][A-Z0-9_]{0,95}$'
+          AND ${table.last_error_digest} ~ '^[0-9a-f]{64}$'))
+        AND (${table.state} <> 'quarantined' OR ${table.last_error_code} IS NOT NULL)
+      ) IS TRUE`,
+    ),
+    terminal_shape_check: check(
+      "org_storage_operations_terminal_shape_check",
+      sql`((
+        ${table.state} IN ('committed', 'aborted') AND ${table.completed_at} IS NOT NULL
+        AND ${table.receipt_digest} ~ '^[0-9a-f]{64}$' AND ${table.response_status} IS NOT NULL
+        AND (${table.state} <> 'aborted' OR (${table.response_status} BETWEEN 400 AND 599
+          AND ${table.last_error_code} IS NOT NULL
+          AND ${table.provider_write_started} = FALSE))
+      ) OR (
+        ${table.state} NOT IN ('committed', 'aborted') AND ${table.completed_at} IS NULL
+        AND ${table.receipt_digest} IS NULL AND ${table.response_status} IS NULL
+      )) IS TRUE`,
+    ),
+    result_shape_check: check(
+      "org_storage_operations_result_shape_check",
+      sql`((
+        ${table.state} = 'committed' AND ${table.operation} = 'put'
+        AND ${table.response_status} = 201
+        AND char_length(${table.result_provider_version}) BETWEEN 1 AND 1024
+        AND (${table.source_presence} <> 'present'
+          OR ${table.result_provider_version} <> ${table.source_provider_version})
+        AND char_length(${table.result_provider_etag}) BETWEEN 1 AND 512
+        AND ${table.result_provider_etag} !~ '["\\r\\n]'
+        AND ${table.result_size_bytes} = ${table.target_size_bytes}
+        AND ${table.result_checksum_sha256} = ${table.target_content_sha256}
+        AND ${table.result_uploaded_at} IS NOT NULL
+      ) OR (
+        ${table.state} = 'committed' AND ${table.operation} = 'delete'
+        AND ${table.response_status} = 204
+        AND ${table.result_provider_version} IS NULL AND ${table.result_provider_etag} IS NULL
+        AND ${table.result_size_bytes} IS NULL AND ${table.result_checksum_sha256} IS NULL
+        AND ${table.result_uploaded_at} IS NULL
+      ) OR (
+        ${table.state} <> 'committed'
+        AND ${table.result_provider_version} IS NULL AND ${table.result_provider_etag} IS NULL
+        AND ${table.result_size_bytes} IS NULL AND ${table.result_checksum_sha256} IS NULL
+        AND ${table.result_uploaded_at} IS NULL
+      )) IS TRUE`,
+    ),
+    provider_key_shape_check: check(
+      "org_storage_operations_provider_key_shape_check",
+      sql`((
+        (${table.source_presence} = 'absent' AND ${table.source_provider_key} IS NULL)
+        OR (${table.source_presence} = 'present' AND ${table.source_provider_key} IS NOT NULL
+          AND octet_length(${table.source_provider_key}) <= 1024
+          AND ${table.source_provider_key} IS NFC NORMALIZED
+          AND (${table.source_provider_key} = '__eliza_storage_authority/v1/org/'
+            || ${table.organization_id}::text || '/' || ${table.object_id}::text || '/'
+            || ${table.source_generation}::text
+            OR (${table.source_generation} = 1
+              AND ${table.source_provider_key} LIKE
+                'org/' || ${table.organization_id}::text || '/%'
+              AND char_length(${table.source_provider_key}) >
+                char_length('org/' || ${table.organization_id}::text || '/')
+              AND ${table.source_provider_key} !~ '[[:cntrl:]]'
+              AND ${table.source_provider_key} !~ '(^|/)\\.\\.(/|$)')))
+      ) AND (
+        (${table.operation} = 'put' AND ${table.target_provider_key} IS NOT NULL
+          AND octet_length(${table.target_provider_key}) <= 1024
+          AND ${table.target_provider_key} IS NFC NORMALIZED
+          AND ${table.target_provider_key} = '__eliza_storage_authority/v1/org/'
+            || ${table.organization_id}::text || '/' || ${table.object_id}::text || '/'
+            || ${table.target_generation}::text)
+        OR (${table.operation} = 'delete' AND ${table.target_provider_key} IS NULL)
+      ) AND (${table.source_provider_key} IS NULL OR ${table.target_provider_key} IS NULL
+        OR ${table.source_provider_key} <> ${table.target_provider_key})
+      ) IS TRUE`,
+    ),
+    observation_shape_check: check(
+      "org_storage_operations_observation_shape_check",
+      sql`(
+        (${table.last_observed_at} IS NULL OR (${table.provider_started_at} IS NOT NULL
+          AND ${table.last_observed_at} >= ${table.provider_started_at}))
+        AND (${table.state} <> 'committed' OR ${table.source_presence} <> 'present'
+          OR ${table.last_observed_at} IS NOT NULL)
+        AND (${table.state} <> 'quarantined' OR ${table.last_observed_at} IS NOT NULL)
+        AND (${table.state} <> 'aborted' OR ${table.last_observed_at} IS NULL)
+      ) IS TRUE`,
+    ),
+  }),
+);
+
+export type OrgStorageOperation = InferSelectModel<typeof orgStorageOperations>;
+export type NewOrgStorageOperation = InferInsertModel<typeof orgStorageOperations>;


### PR DESCRIPTION
# Relates to

Relates to #21045.

Definition of Done: full standard in [CONTRIBUTING.md](../blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the exact-head evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2741ce88d27af20e687377f1b311f2c2ea43faf2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes on the exact schema commit.

# Risks

Medium. This adds forward-only database migrations and strict authority constraints, but the tables are empty and no runtime path writes them. `ON DELETE RESTRICT` is intentionally fail-closed once a future activation creates authority rows.

# Background

## What does this PR do?

- Adds additive PostgreSQL and Drizzle schemas for tenant-scoped logical storage-object authority.
- Adds durable mutation-operation state with database leases, immutable generation-scoped provider keys, receipts, and terminal evidence.
- Enforces full copy-on-write quota arithmetic, Unicode/key canonicalization, tenant identity, provider result, claim, error, and terminal shapes in SQL.
- Registers migrations `0236`–`0238` and covers direct-SQL rejection, bigint values, replay, and concurrent admission with real PGlite.

## What kind of change is this?

Bug fix and inactive database foundation for storage quota and mutation integrity.

# Documentation changes needed?

No public or internal runbook change is appropriate yet because this PR activates no behavior. The cutover runbook belongs with the later baseline, writer-freeze, provider-purge, and read-adaptation tooling tracked in #21045.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/db/migrations/0236_org_storage_objects.sql`
2. `packages/cloud/shared/src/db/migrations/0237_org_storage_operations.sql`
3. `packages/cloud/shared/src/db/migrations/0238_org_storage_immutable_provider_keys.sql`
4. `packages/cloud/shared/src/db/org-storage-object-authority-migrations.test.ts`
5. the matching Drizzle schemas

## Detailed testing steps

Exact head: `235b32c7059720e6c12ad0d36738cb2eb3e7f016`

Focused exact-head results:

- Real migration PGlite suite: 7 passed, 51 assertions.
- Migration journal suite: 5 passed, 14 assertions.
- Existing organization storage-quota PGlite regression: 3 passed, 11 assertions.
- Total: 15 passed, 0 failed, 76 assertions.
- Cloud shared TypeScript: passed.
- `db:check-migrations`: passed (`Everything's fine`).
- Targeted Biome, `git diff --check`, and `git show --check`: passed.
- Full root `bun run verify`: passed on the exact schema commit.
- Independent review: 0 blocker, 0 P1, 0 P2 merge defects.

# Evidence Gate

<!-- evidence-head:235b32c7059720e6c12ad0d36738cb2eb3e7f016 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only inactive database foundation; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only inactive database foundation; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user flow or runtime behavior is activated.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no staging or production deployment was authorized; exact PGlite and static receipts are summarized above.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no live database row, quota mutation, R2 object, secret, or deployment was created.
<!-- evidence-row:ocr-review -->
- [ ] N/A - backend-only change with no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changed.

## Backend + frontend logs

N/A for live logs. The real PGlite tests apply the exact migrations and prove constraint rejection, tenant isolation, immutable provider-key shapes, copy-on-write quota arithmetic, terminal-state shapes, and concurrent admission.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no audio or voice behavior changed.

## Known gaps / failures

- This PR creates empty authority tables only. It performs no backfill, provider I/O, route/read change, quota mutation, or runtime activation.
- Activation requires an authoritative organization-wide `org_storage_quota.bytes_used` baseline and a freeze/drain of legacy CloudFiles and direct quota writers.
- Organization deletion, last-user departure, and convergence cleanup need a reviewed provider-purge and history-reconciliation workflow before adoption.
- Existing reads, listing, and signed-read PRs #21100/#21126 must bind object ID, committed generation, and `current_provider_key` before mutation cutover.
- Real PostgreSQL/Hyperdrive multi-connection contention and deadlock behavior remains an activation gate; PGlite cannot prove it.
- No live database, R2 bucket, Cloudflare secret, deploy, environment, or customer quota was touched.

# Deploy notes

The migrations are additive and may deploy, but do not activate or backfill the new authority tables. Do not wire runtime storage mutations until the #21045 activation gates above are complete.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@2741ce88d27af20e687377f1b311f2c2ea43faf2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-storage-authority-schema]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@2741ce88d27af20e687377f1b311f2c2ea43faf2:packages/skills/skills/contribute-to-eliza"} -->
