### PR TITLE
fix(agent): respect quoted separators in vfs shell script splitting

### DIFF
--- a/packages/agent/src/services/vfs-builtin-shell.test.ts
+++ b/packages/agent/src/services/vfs-builtin-shell.test.ts
@@ -117,4 +117,18 @@ describe("runVfsBuiltinShell", () => {
     expect(files.stdout).toContain("src/a.ts");
     expect(files.stdout).toContain("src/nested/b.ts");
   });
+
+  it("keeps command separators inside quoted arguments", async () => {
+    const result = await runVfsBuiltinShell({
+      cwdUri: "vfs://quoted/",
+      command: "sh",
+      args: ["-c", `echo "alpha;beta" && echo 'gamma&&delta'`],
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      stdout: "alpha;beta\ngamma&&delta\n",
+      stderr: "",
+    });
+  });
 });

--- a/packages/agent/src/services/vfs-builtin-shell.ts
+++ b/packages/agent/src/services/vfs-builtin-shell.ts
@@ -108,8 +108,7 @@ async function runScript(
   cwd: string,
   script: string,
 ): Promise<VfsBuiltinCommandResult> {
-  const segments = script
-    .split(/&&|;/)
+  const segments = splitScriptSegments(script)
     .map((segment) => segment.trim())
     .filter(Boolean);
   let stdout = "";
@@ -123,6 +122,40 @@ async function runScript(
     }
   }
   return { exitCode: 0, stdout, stderr };
+}
+
+function splitScriptSegments(script: string): string[] {
+  const segments: string[] = [];
+  let start = 0;
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < script.length; index += 1) {
+    const character = script[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = quote === character ? null : (quote ?? character);
+      continue;
+    }
+    if (quote !== null) continue;
+
+    const separatorLength =
+      character === ";" ? 1 : script.startsWith("&&", index) ? 2 : 0;
+    if (separatorLength === 0) continue;
+    segments.push(script.slice(start, index));
+    index += separatorLength - 1;
+    start = index + 1;
+  }
+
+  segments.push(script.slice(start));
+  return segments;
 }
 
 async function runScriptSegment(


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
- AI assistance: Yes - initial author assistance plus maintainer review and remediation
<!-- attribution-row:models -->
- Models: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client/tooling: Codex CLI, Claude Code, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - the contribution skill was not used for this maintainer review and remediation
<!-- attribution-row:status -->
- Provenance status: self-reported

AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: re-ran the full mutation check myself from a clean revert of just the source fix (confirmed red, then restored and confirmed green), re-ran the focused test and biome myself, and independently confirmed the report's honest "no current production caller" reachability claim by grepping the whole repo for `vfs://` construction sites (found only a prefix-check in `capability-broker.ts`, not a constructor).

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low. Replaces a regex-based script split with a quote/escape-aware scanner used only inside `runScript`'s existing sequential-execution loop. Unquoted scripts split identically to before; only scripts containing `;`/`&&` inside quoted arguments change behavior (from incorrectly splitting to correctly not splitting).

# Background

## What does this PR do?

`runScript` in `packages/agent/src/services/vfs-builtin-shell.ts` split `sh -c` scripts with `script.split(/&&|;/)`, so a `;` or `&&` inside a quoted argument was incorrectly treated as a command boundary.

Before fix (`sh -c 'echo "alpha;beta"'`):
```json
{"exitCode": 127, "stdout": "\"alpha\n", "stderr": "[vfs-shell] unsupported command: beta\"\n"}
```

After fix: the whole quoted string is treated as one command's argument, as expected.

Adds a quote- and escape-aware `splitScriptSegments` scanner: tracks single/double quote state, treats backslash as an escape everywhere except inside single quotes (POSIX semantics — backslash is literal in `'...'`), and only splits on `;`/`&&` outside any quote.

## What kind of change is this?

Bug fix — no new capability, no schema change.

# Documentation changes needed?

No.

# Testing

New test `keeps command separators inside quoted arguments` in `packages/agent/src/services/vfs-builtin-shell.test.ts`, covering both double-quoted (`;`) and single-quoted (`&&`) separators via the real `runVfsBuiltinShell` entry point.

# Evidence Gate

<!-- evidence-head:7a6d9855e02258915ea2ab087731b91cdd4032f6 -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend logic fix, no UI surface
- <!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual behavior changed

## Known gaps / failures

Package-wide `typecheck` is blocked by **pre-existing, unrelated** missing-optional-module errors (`@elizaos/plugin-capacitor-bridge/*`, `@elizaos/plugin-wallet/diagnostic`, `@elizaos/plugin-video`, `@elizaos/plugin-vision`, `@elizaos/plugin-notes/plugin`), and the package-wide aggregate test lane hits unrelated pre-existing failures (`@elizaos/plugin-meetings` unresolved, a `listen EPERM` sandbox restriction). Neither is caused by this change; the focused test suite for the touched files passes cleanly (3/3) and `biome check` is clean.

## Reachability

`runShell` in `packages/agent/src/services/shell-execution-router.ts` detects `vfs://` cwd values and calls `runVfsBuiltinShell` when no SandboxManager is available on the local-safe/iOS fallback path. `runVfsBuiltinShell` is also exported from the agent package. I independently confirmed, repo-wide, that no current non-test caller constructs a `vfs://` cwd value (only a prefix-check exists in `capability-broker.ts`, not a constructor) - so this is a real defect on a live exported/public path and router branch, but not currently exercised by any known production call site. Worth fixing regardless: it's public API and the router explicitly special-cases this URI scheme, so it's clearly intended to be reachable.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic focused regression tests are documented in the Testing section and produce no persistent backend log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by this logic change

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered interface changed
