### PR TITLE
fix(plugin-documents): reject unknown documents searchMode

### DIFF
--- a/plugins/plugin-documents/src/routes.search-mode.test.ts
+++ b/plugins/plugin-documents/src/routes.search-mode.test.ts
@@ -1,0 +1,143 @@
+/**
+ * GET /api/documents/search `searchMode` is retrieval-mode identity,
+ * leftover tax after notifications unreadOnly (#21220). Stock develop
+ * mapped every non-catalog token to undefined, so `searchMode=HYBRID`
+ * silently used the default search.
+ */
+import type { AccessContext, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { DocumentRouteContext } from "./routes.ts";
+import { handleDocumentsRoutes } from "./routes.ts";
+
+const searchDocuments = vi.fn(async () => []);
+
+vi.mock("@elizaos/shared", () => ({
+  parseClampedFloat: () => 0.3,
+  parsePositiveInteger: () => 20,
+}));
+
+vi.mock("@elizaos/agent/api/documents-service-loader", () => ({
+  getDocumentsService: vi.fn(async () => ({
+    service: {
+      searchDocuments,
+    },
+  })),
+  getDocumentsServiceTimeoutMs: vi.fn(() => 0),
+}));
+
+type MockResponse = {
+  statusCode?: number;
+  body?: unknown;
+  headers: Record<string, string>;
+  setHeader: (name: string, value: string | number | readonly string[]) => void;
+  end: (chunk?: string) => void;
+};
+
+const OWNER_ENTITY_ID = "00000000-0000-0000-0000-0000000000b1" as UUID;
+
+function buildCtx(path: string): {
+  ctx: DocumentRouteContext;
+  res: MockResponse;
+} {
+  const url = new URL(`http://localhost${path}`);
+  const res: MockResponse = {
+    headers: {},
+    setHeader(name, value) {
+      res.headers[name.toLowerCase()] = Array.isArray(value)
+        ? value.join(", ")
+        : String(value);
+    },
+    end(chunk) {
+      res.body = chunk ? JSON.parse(chunk) : undefined;
+    },
+  };
+
+  const ctx: DocumentRouteContext = {
+    req: { headers: {} } as DocumentRouteContext["req"],
+    res: res as DocumentRouteContext["res"],
+    method: "GET",
+    pathname: url.pathname,
+    url,
+    accessContext: {
+      requesterEntityId: OWNER_ENTITY_ID,
+      role: "OWNER",
+      isOwner: true,
+    } satisfies AccessContext,
+    runtime: {
+      agentId: "agent-id",
+      getSetting: () => undefined,
+      getMemoryById: vi.fn(),
+    } as DocumentRouteContext["runtime"],
+    json(response, data, status = 200) {
+      response.statusCode = status;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify(data));
+    },
+    error(response, message, status = 400) {
+      response.statusCode = status;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ error: message }));
+    },
+    async readJsonBody() {
+      return null;
+    },
+  };
+
+  return { ctx, res };
+}
+
+describe("GET /api/documents/search searchMode identity", () => {
+  it.each([
+    "/api/documents/search?q=notes",
+    "/api/documents/search?q=notes&searchMode=",
+  ])("accepts omitted/empty searchMode as the default search", async (path) => {
+    searchDocuments.mockClear();
+    const { ctx, res } = buildCtx(path);
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(searchDocuments).toHaveBeenCalledTimes(1);
+    expect(searchDocuments.mock.calls[0][2]).toBeUndefined();
+  });
+
+  it.each(["hybrid", "vector", "keyword"] as const)(
+    "accepts searchMode=%s as that retrieval mode",
+    async (token) => {
+      searchDocuments.mockClear();
+      const { ctx, res } = buildCtx(
+        `/api/documents/search?q=notes&searchMode=${token}`,
+      );
+      await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(searchDocuments).toHaveBeenCalledTimes(1);
+      expect(searchDocuments.mock.calls[0][2]).toBe(token);
+    },
+  );
+
+  it.each(["HYBRID", "VECTOR", "KEYWORD", "1", "true", "TRUE", "foo", "1e2"])(
+    "rejects searchMode=%s before searchDocuments",
+    async (token) => {
+      searchDocuments.mockClear();
+      const { ctx, res } = buildCtx(
+        `/api/documents/search?q=notes&searchMode=${encodeURIComponent(token)}`,
+      );
+      await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ error: "Invalid searchMode" });
+      expect(searchDocuments).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    "/api/documents/search?q=notes&searchMode=hybrid&searchMode=hybrid",
+    "/api/documents/search?q=notes&searchMode=hybrid&searchMode=vector",
+    "/api/documents/search?q=notes&searchMode=&searchMode=hybrid",
+    "/api/documents/search?q=notes&searchMode=foo&searchMode=hybrid",
+  ])("rejects duplicate searchMode values in %s", async (path) => {
+    searchDocuments.mockClear();
+    const { ctx, res } = buildCtx(path);
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid searchMode" });
+    expect(searchDocuments).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -244,10 +244,27 @@ export function resolveRouteActor(
   };
 }
 
+class DocumentsSearchModeError extends Error {
+  constructor(message = "Invalid searchMode") {
+    super(message);
+    this.name = "DocumentsSearchModeError";
+  }
+}
+
+/**
+ * GET /api/documents/search `searchMode` is retrieval-mode identity,
+ * leftover tax after notifications unreadOnly (#21220). Stock develop
+ * mapped every non-catalog token to undefined, so `searchMode=HYBRID` /
+ * `1` silently used the default search instead of a 400.
+ */
 function parseSearchMode(value: unknown): DocumentSearchMode | undefined {
-  return value === "hybrid" || value === "vector" || value === "keyword"
-    ? value
-    : undefined;
+  if (value == null || value === "") {
+    return undefined;
+  }
+  if (value === "hybrid" || value === "vector" || value === "keyword") {
+    return value;
+  }
+  throw new DocumentsSearchModeError();
 }
 
 function parseTimestampParam(value: unknown): number | undefined {
@@ -965,7 +982,21 @@ export async function handleDocumentsRoutes(
     });
     const limit = parsePositiveInteger(url.searchParams.get("limit"), 20);
     const filters = filtersFromSearchParams(url);
-    const searchMode = parseSearchMode(url.searchParams.get("searchMode"));
+    const requestedSearchMode = url.searchParams.getAll("searchMode");
+    if (requestedSearchMode.length > 1) {
+      error(res, "Invalid searchMode", 400);
+      return true;
+    }
+    let searchMode: DocumentSearchMode | undefined;
+    try {
+      searchMode = parseSearchMode(requestedSearchMode[0] ?? null);
+    } catch (searchModeError) {
+      if (searchModeError instanceof DocumentsSearchModeError) {
+        error(res, searchModeError.message, 400);
+        return true;
+      }
+      throw searchModeError;
+    }
     const searchMessage = buildRouteMessage({
       agentId,
       text: query.trim(),


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on documents
search `searchMode` identity. Retrieval-mode class, leftover tax after
notifications unreadOnly (#21220). Not leftover tax on sleep
`includeNaps` (#21275), workbench VFS `recursive` (#21276), or WhatsApp
`authScope`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `searchMode` only on `/api/documents/search`. Omitted/empty
still use the default search (today's fallback). Exact `hybrid` /
`vector` / `keyword` still bind. Unknown / uppercase / `1` tokens 400
before `searchDocuments`. threshold / limit / scope parsers stay
untouched.

# Background

## What does this PR do?

`GET /api/documents/search` mapped every non-catalog `searchMode` token
to undefined. `searchMode=HYBRID` silently used the default search
instead of a 400.

- omitted / empty → default search (200)
- exact `hybrid` / `vector` / `keyword` → that retrieval-mode identity
- `HYBRID` / `VECTOR` / `KEYWORD` / `1` / `true` / `TRUE` / `foo` / `1e2` / duplicates → **400** before `searchDocuments`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers opt into a retrieval mode with `?searchMode=hybrid`. A common
`searchMode=HYBRID` or `1` after a client sends a catalog token must not
silently change the search path. This is leftover tax after
notifications unreadOnly (#21220). Disjoint from sleep includeNaps
(#21275) and workbench VFS recursive (#21276).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-documents/src/routes.search-mode.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-documents && bunx vitest run src/routes.search-mode.test.ts
```

17 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; documents search `searchMode` query only.

- [x] N/A - no rendered UI change; documents search `searchMode` query only.

- [x] N/A - no rendered UI change; documents search `searchMode` query only.

- [x] N/A - focused route tests drive the real searchMode tokens and assert 400 before searchDocuments; no production log capture is required to see the contract.

- [x] N/A - no frontend request path in this proof.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.

- [x] N/A - no agent write; illegal tokens 400 before searchDocuments.

- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
`searchMode` tokens reject; omitted/canonical still bind the matching
retrieval mode.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the documents search
`searchMode` query only.

## Known gaps / failures

`bun run verify` was not run. This is a two-file searchMode parse with
a green focused suite (17). Full monorepo verify is unrelated to this
query grammar and was skipped to keep the proof tied to the changed
path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a07ff9fef4d41b76f3e151a56a7130e606212d4a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
