### PR TITLE
fix(plugin-whatsapp): reject unknown WhatsApp authScope

### DIFF
--- a/plugins/plugin-whatsapp/src/api/whatsapp-routes.auth-scope.test.ts
+++ b/plugins/plugin-whatsapp/src/api/whatsapp-routes.auth-scope.test.ts
@@ -1,0 +1,118 @@
+/**
+ * GET /api/whatsapp/status `authScope` is auth-dir identity, leftover tax
+ * after notifications unreadOnly (#21220). Stock develop mapped every
+ * non-exact `lifeops` token onto the platform auth dir.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  handleWhatsAppRoute,
+  type WhatsAppRouteDeps,
+  type WhatsAppRouteState,
+} from "./whatsapp-routes.js";
+
+function createHarness(path: string) {
+  const chunks: string[] = [];
+  const res = {
+    headersSent: false,
+    statusCode: 200,
+    setHeader: vi.fn(),
+    end: (body?: string) => {
+      if (body) chunks.push(body);
+    },
+  } as unknown as ServerResponse;
+  const req = {
+    url: path,
+    headers: { host: "localhost" },
+  } as IncomingMessage;
+  const whatsappAuthExists = vi.fn(() => false);
+  const state: WhatsAppRouteState = {
+    whatsappPairingSessions: new Map(),
+    config: {},
+    saveConfig: vi.fn(),
+    workspaceDir: "/tmp/whatsapp-auth-scope-test",
+  };
+  const deps: WhatsAppRouteDeps = {
+    sanitizeAccountId: (accountId) => accountId,
+    whatsappAuthExists,
+    whatsappLogout: vi.fn(async () => undefined),
+    createWhatsAppPairingSession: vi.fn(),
+  };
+  return { req, res, state, deps, chunks, whatsappAuthExists };
+}
+
+function parsed(chunks: string[]): { error?: string; authScope?: string } {
+  return JSON.parse(chunks.join("") || "{}") as {
+    error?: string;
+    authScope?: string;
+  };
+}
+
+describe("GET /api/whatsapp/status authScope identity", () => {
+  it.each(["/api/whatsapp/status", "/api/whatsapp/status?authScope="])(
+    "accepts omitted/empty authScope as the platform auth dir",
+    async (path) => {
+      const { req, res, state, deps, chunks, whatsappAuthExists } =
+        createHarness(path);
+      await expect(
+        handleWhatsAppRoute(req, res, "/api/whatsapp/status", "GET", state, deps),
+      ).resolves.toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(parsed(chunks).authScope).toBe("platform");
+      expect(whatsappAuthExists).toHaveBeenCalledWith(
+        state.workspaceDir,
+        "default",
+      );
+    },
+  );
+
+  it.each(["platform", "lifeops"] as const)(
+    "accepts authScope=%s as that auth dir",
+    async (token) => {
+      const { req, res, state, deps, chunks, whatsappAuthExists } =
+        createHarness(`/api/whatsapp/status?authScope=${token}`);
+      await expect(
+        handleWhatsAppRoute(req, res, "/api/whatsapp/status", "GET", state, deps),
+      ).resolves.toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(parsed(chunks).authScope).toBe(token);
+      if (token === "platform") {
+        expect(whatsappAuthExists).toHaveBeenCalled();
+      } else {
+        expect(whatsappAuthExists).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each(["LIFEOPS", "PLATFORM", "1", "0", "true", "TRUE", "foo", "1e2"])(
+    "rejects authScope=%s before auth-dir lookup",
+    async (token) => {
+      const { req, res, state, deps, chunks, whatsappAuthExists } =
+        createHarness(
+          `/api/whatsapp/status?authScope=${encodeURIComponent(token)}`,
+        );
+      await expect(
+        handleWhatsAppRoute(req, res, "/api/whatsapp/status", "GET", state, deps),
+      ).resolves.toBe(true);
+      expect(res.statusCode).toBe(400);
+      expect(parsed(chunks)).toEqual({ error: "Invalid authScope" });
+      expect(whatsappAuthExists).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    "/api/whatsapp/status?authScope=lifeops&authScope=lifeops",
+    "/api/whatsapp/status?authScope=lifeops&authScope=platform",
+    "/api/whatsapp/status?authScope=&authScope=lifeops",
+    "/api/whatsapp/status?authScope=foo&authScope=lifeops",
+  ])("rejects duplicate authScope values in %s", async (path) => {
+    const { req, res, state, deps, chunks, whatsappAuthExists } =
+      createHarness(path);
+    await expect(
+      handleWhatsAppRoute(req, res, "/api/whatsapp/status", "GET", state, deps),
+    ).resolves.toBe(true);
+    expect(res.statusCode).toBe(400);
+    expect(parsed(chunks)).toEqual({ error: "Invalid authScope" });
+    expect(whatsappAuthExists).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-whatsapp/src/api/whatsapp-routes.ts
+++ b/plugins/plugin-whatsapp/src/api/whatsapp-routes.ts
@@ -146,8 +146,45 @@ function shouldConfigurePlugin(body: WhatsAppAccountBody | null): boolean {
   return body?.configurePlugin !== false;
 }
 
+class WhatsAppAuthScopeError extends Error {
+  constructor(message = "Invalid authScope") {
+    super(message);
+    this.name = "WhatsAppAuthScopeError";
+  }
+}
+
+/**
+ * WhatsApp pairing `authScope` is auth-dir identity, leftover tax after
+ * notifications unreadOnly (#21220). Stock develop mapped every non-exact
+ * `lifeops` token onto the platform auth dir, so `authScope=LIFEOPS` /
+ * `1` silently used `whatsapp-auth/` instead of a 400.
+ */
 function resolveAuthScope(value: unknown): WhatsAppAuthScope {
-  return value === "lifeops" ? "lifeops" : "platform";
+  if (value == null || value === "") {
+    return "platform";
+  }
+  if (value === "lifeops") {
+    return "lifeops";
+  }
+  if (value === "platform") {
+    return "platform";
+  }
+  throw new WhatsAppAuthScopeError();
+}
+
+function parseAuthScopeOrReject(
+  res: ServerResponse,
+  value: unknown,
+): WhatsAppAuthScope | null {
+  try {
+    return resolveAuthScope(value);
+  } catch (error) {
+    if (error instanceof WhatsAppAuthScopeError) {
+      json(res, { error: error.message }, 400);
+      return null;
+    }
+    throw error;
+  }
 }
 
 function resolveSessionKey(authScope: WhatsAppAuthScope, accountId: string): string {
@@ -248,7 +285,10 @@ export async function handleWhatsAppRoute(
 
   if (method === "POST" && pathname === "/api/whatsapp/pair") {
     const body = await readJsonBody<WhatsAppAccountBody>(req, res);
-    const authScope = resolveAuthScope(body?.authScope);
+    const authScope = parseAuthScopeOrReject(res, body?.authScope);
+    if (authScope == null) {
+      return true;
+    }
     const configurePlugin = authScope === "platform" && shouldConfigurePlugin(body);
     let accountId: string;
     try {
@@ -341,7 +381,15 @@ export async function handleWhatsAppRoute(
       json(res, { error: (err as Error).message }, 400);
       return true;
     }
-    const authScope = resolveAuthScope(url.searchParams.get("authScope"));
+    const requested = url.searchParams.getAll("authScope");
+    if (requested.length > 1) {
+      json(res, { error: "Invalid authScope" }, 400);
+      return true;
+    }
+    const authScope = parseAuthScopeOrReject(res, requested[0] ?? null);
+    if (authScope == null) {
+      return true;
+    }
     const sessionKey = resolveSessionKey(authScope, accountId);
 
     const session = state.whatsappPairingSessions.get(sessionKey);
@@ -373,7 +421,10 @@ export async function handleWhatsAppRoute(
 
   if (method === "POST" && pathname === "/api/whatsapp/pair/stop") {
     const body = await readJsonBody<WhatsAppAccountBody>(req, res);
-    const authScope = resolveAuthScope(body?.authScope);
+    const authScope = parseAuthScopeOrReject(res, body?.authScope);
+    if (authScope == null) {
+      return true;
+    }
     let accountId: string;
     try {
       accountId = deps.sanitizeAccountId(
@@ -399,7 +450,10 @@ export async function handleWhatsAppRoute(
 
   if (method === "POST" && pathname === "/api/whatsapp/disconnect") {
     const body = await readJsonBody<WhatsAppAccountBody>(req, res);
-    const authScope = resolveAuthScope(body?.authScope);
+    const authScope = parseAuthScopeOrReject(res, body?.authScope);
+    if (authScope == null) {
+      return true;
+    }
     const configurePlugin = authScope === "platform" && shouldConfigurePlugin(body);
     let accountId: string;
     try {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on WhatsApp
pairing `authScope` identity. Auth-dir class, leftover tax after
notifications unreadOnly (#21220). Not leftover tax on sleep
`includeNaps` (#21275), workbench VFS `recursive` (#21276), or
documents `searchMode`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. `authScope` only on WhatsApp pair / status / stop / disconnect.
Omitted/empty still bind the platform auth dir (today's default). Exact
`lifeops` / `platform` still bind. Unknown / uppercase / `1` tokens 400
before auth-dir lookup. accountId / webhook parsers stay untouched.

# Background

## What does this PR do?

WhatsApp pairing `authScope` mapped every non-exact `lifeops` token onto
the platform auth dir. `authScope=LIFEOPS` silently used
`whatsapp-auth/` instead of a 400.

- omitted / empty → platform auth dir (200)
- exact `lifeops` / `platform` → that auth-dir identity
- `LIFEOPS` / `PLATFORM` / `1` / `0` / `true` / `TRUE` / `foo` / `1e2` / duplicates → **400** before auth-dir lookup

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers opt into the Life Ops WhatsApp auth dir with `?authScope=lifeops`.
A common `authScope=LIFEOPS` or `1` after a client sends a catalog token
must not silently switch auth directories. This is leftover tax after
notifications unreadOnly (#21220). Disjoint from sleep includeNaps
(#21275) and workbench VFS recursive (#21276).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-whatsapp/src/api/whatsapp-routes.auth-scope.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-whatsapp && bunx vitest run src/api/whatsapp-routes.auth-scope.test.ts
```

16 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; WhatsApp pairing `authScope` query only.

- [x] N/A - no rendered UI change; WhatsApp pairing `authScope` query only.

- [x] N/A - no rendered UI change; WhatsApp pairing `authScope` query only.

- [x] N/A - focused route tests drive the real authScope tokens and assert 400 before auth-dir lookup; no production log capture is required to see the contract.

- [x] N/A - no frontend request path in this proof.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.

- [x] N/A - no agent write; illegal tokens 400 before auth-dir lookup.

- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
`authScope` tokens reject; omitted/canonical still bind the matching
auth dir.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the WhatsApp pairing
`authScope` query only.

## Known gaps / failures

`bun run verify` was not run. This is a two-file authScope parse with
a green focused suite (16). Full monorepo verify is unrelated to this
query grammar and was skipped to keep the proof tied to the changed
path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2fe208c00995b449faae39c9d2d21280a12859eb -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
