### PR TITLE
fix(cloud): reject unknown vertex-assignments active flag

### DIFF
--- a/packages/cloud/api/training/vertex/assignments/route.active.test.ts
+++ b/packages/cloud/api/training/vertex/assignments/route.active.test.ts
@@ -1,0 +1,91 @@
+/**
+ * GET /api/training/vertex/assignments `active` is tuned-model
+ * active-row identity, leftover tax after vertex assignment scope
+ * (#20973) and vertex-jobs persisted (#21173). Stock develop treated
+ * every non-exact `false` token as active-only, so `active=TRUE` /
+ * `1` still listed only live assignments instead of a 400.
+ * scope / slot parsers stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { VertexModelRegistryService } from "@/lib/services/vertex-model-registry";
+
+type ListVisibleAssignmentsArgs = Parameters<
+  VertexModelRegistryService["listVisibleAssignments"]
+>;
+
+const listVisibleAssignments = mock(
+  async (..._args: ListVisibleAssignmentsArgs) => [{ id: "asg-1" }],
+);
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKey: null,
+  }),
+  requireAdmin: async () => ({ role: "super_admin" }),
+}));
+mock.module("@/lib/services/vertex-model-registry", () => ({
+  vertexModelRegistryService: {
+    listVisibleAssignments,
+    activateAssignment: mock(async () => ({})),
+    deactivateAssignment: mock(async () => 0),
+  },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/", route);
+
+describe("GET /api/training/vertex/assignments active identity", () => {
+  beforeEach(() => {
+    listVisibleAssignments.mockClear();
+  });
+
+  test.each(["", "?active=", "?active=true"])(
+    "accepts %s as the active-only assignment list",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { assignments: { id: string }[] };
+      expect(body.assignments).toEqual([{ id: "asg-1" }]);
+      expect(listVisibleAssignments).toHaveBeenCalledTimes(1);
+      const filter = listVisibleAssignments.mock.calls[0]?.[1];
+      expect(filter?.activeOnly).toBe(true);
+    },
+  );
+
+  test("accepts active=false as the full assignment list", async () => {
+    const response = await app.request("/?active=false");
+    expect(response.status).toBe(200);
+    expect(listVisibleAssignments).toHaveBeenCalledTimes(1);
+    const filter = listVisibleAssignments.mock.calls[0]?.[1];
+    expect(filter?.activeOnly).toBe(false);
+  });
+
+  test.each(["TRUE", "FALSE", "1", "0", "yes", "no", "foo", "1e2"])(
+    "rejects active=%s before listVisibleAssignments",
+    async (token) => {
+      const response = await app.request(`/?active=${encodeURIComponent(token)}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid active");
+      expect(listVisibleAssignments).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?active=true&active=true",
+    "?active=true&active=false",
+    "?active=&active=true",
+    "?active=foo&active=true",
+  ])(
+    "rejects duplicate active values in %s before listVisibleAssignments",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid active");
+      expect(listVisibleAssignments).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/training/vertex/assignments/route.ts
+++ b/packages/cloud/api/training/vertex/assignments/route.ts
@@ -26,6 +26,40 @@ function parseSlot(value: unknown): VertexTuningSlot | undefined {
     : undefined;
 }
 
+class VertexAssignmentActiveError extends Error {
+  constructor(message = "Invalid active") {
+    super(message);
+    this.name = "VertexAssignmentActiveError";
+  }
+}
+
+/**
+ * GET /api/training/vertex/assignments `active` is tuned-model
+ * active-row identity, leftover tax after vertex assignment scope
+ * (#20973) and vertex-jobs persisted (#21173). Stock develop treated
+ * every non-exact `false` token as active-only, so `active=TRUE` /
+ * `1` / `0` still listed only live assignments instead of a 400.
+ * Missing / empty still means active-only (today's default).
+ * scope / slot parsers stay untouched.
+ */
+function parseActiveOnlyQuery(searchParams: URLSearchParams): boolean {
+  const requested = searchParams.getAll("active");
+  if (requested.length > 1) {
+    throw new VertexAssignmentActiveError();
+  }
+  const raw = requested[0];
+  if (raw == null || raw === "") {
+    return true;
+  }
+  if (raw === "true") {
+    return true;
+  }
+  if (raw === "false") {
+    return false;
+  }
+  throw new VertexAssignmentActiveError();
+}
+
 async function ensureGlobalAccess(request: Request): Promise<void> {
   const admin = await requireAdmin(request);
   if (admin.role !== "super_admin") {
@@ -43,7 +77,7 @@ async function __hono_GET(request: Request) {
     // relationships-scope tax. parseScope maps unknown tokens to
     // organization, so scope=GLOBAL / USER listed org assignments.
     // Missing / empty still means unfiltered. Garbage 400s before
-    // listVisibleAssignments. POST/DELETE and slot/active untouched.
+    // listVisibleAssignments. POST/DELETE and slot stay untouched.
     const rawScope = searchParams.get("scope");
     if (
       rawScope !== null &&
@@ -57,7 +91,15 @@ async function __hono_GET(request: Request) {
     const scope = parseScope(rawScope);
     const rawSlot = searchParams.get("slot");
     const slot = parseSlot(rawSlot);
-    const activeOnly = searchParams.get("active") !== "false";
+    let activeOnly: boolean;
+    try {
+      activeOnly = parseActiveOnlyQuery(searchParams);
+    } catch (activeError) {
+      if (activeError instanceof VertexAssignmentActiveError) {
+        return Response.json({ error: activeError.message }, { status: 400 });
+      }
+      throw activeError;
+    }
 
     if (rawSlot && !slot) {
       return Response.json({ error: "Invalid slot." }, { status: 400 });


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on vertex
assignments `active` identity. Tuned-model active-row class, leftover
tax after vertex assignment scope (#20973) and vertex-jobs persisted
(#21173). Not leftover tax on discovery `activeOnly` (#21175) or
meetings `active`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `active` only on `/api/training/vertex/assignments`. Omitted/empty
still means active-only (today's default). Exact `true` / `false` still
bind. Unknown / uppercase / `1` / `0` tokens 400 before
`listVisibleAssignments`. scope / slot parsers stay untouched.

# Background

## What does this PR do?

`GET /api/training/vertex/assignments` treated every non-exact `false`
`active` token as active-only. `active=TRUE` / `1` silently listed only
live assignments instead of a 400.

- omitted / empty / `true` → active-only list (200)
- exact `false` → full assignment list
- `TRUE` / `FALSE` / `1` / `0` / `yes` / `foo` / `1e2` / duplicates → **400** before `listVisibleAssignments`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers opt out of the active-only filter with `?active=false`. A common
`active=TRUE` or `1` after a client sends a boolean token must not
silently keep the default filter. This is leftover tax after vertex
assignment scope (#20973). Disjoint from vertex-jobs persisted (#21173)
and discovery activeOnly (#21175).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/training/vertex/assignments/route.active.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test training/vertex/assignments/route.active.test.ts
```

16 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; vertex assignments `active` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; vertex assignments `active` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; vertex assignments `active` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real active tokens and assert 400 before listVisibleAssignments; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before listVisibleAssignments.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`active` tokens reject; omitted/canonical still bind the matching
active-only filter.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the vertex assignments
`active` query only.

## Known gaps / failures

`bun run verify` was not run. This is a two-file active parse with
a green focused suite (16). Full monorepo verify is unrelated to this
query grammar and was skipped to keep the proof tied to the changed
path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:fc5fd79934dbc227ac93dfc38531224cf4efb535 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
