### PR TITLE
fix(agent): serialize VFS quota-checked writes

### DIFF
--- a/packages/agent/src/services/virtual-filesystem.test.ts
+++ b/packages/agent/src/services/virtual-filesystem.test.ts
@@ -124,6 +124,26 @@ describe("VirtualFilesystemService", () => {
     });
   });
 
+  it("serializes concurrent writes so quota cannot be exceeded", async () => {
+    const first = service({ quotaBytes: 10, maxFileBytes: 10 });
+    const second = service({ quotaBytes: 10, maxFileBytes: 10 });
+    await first.initialize();
+
+    const results = await Promise.allSettled([
+      first.writeFile("a.txt", "12345678"),
+      second.writeFile("b.txt", "12345678"),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    const rejected = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    expect(rejected?.reason).toMatchObject({ code: "QUOTA_EXCEEDED" });
+    await expect(first.quota()).resolves.toMatchObject({ usedBytes: 8 });
+  });
+
   it("creates snapshots and diffs current changes", async () => {
     const vfs = service();
     await vfs.initialize();

--- a/packages/agent/src/services/virtual-filesystem.ts
+++ b/packages/agent/src/services/virtual-filesystem.ts
@@ -21,6 +21,7 @@ import { resolveStateDir } from "../config/paths.ts";
 
 const DEFAULT_QUOTA_BYTES = 50 * 1024 * 1024;
 const DEFAULT_MAX_FILE_BYTES = 10 * 1024 * 1024;
+const writeLocks = new Map<string, Promise<void>>();
 
 export type VirtualFilesystemDiffStatus = "added" | "modified" | "deleted";
 
@@ -136,34 +137,49 @@ export class VirtualFilesystemService {
     virtualPath: string,
     contents: string | Uint8Array,
   ): Promise<VirtualFilesystemEntry> {
-    const data =
-      typeof contents === "string"
-        ? Buffer.from(contents)
-        : Buffer.from(contents);
-    if (data.byteLength > this.maxFileBytes) {
-      throw new VirtualFilesystemError(
-        `File exceeds max file size of ${this.maxFileBytes} bytes`,
-        "QUOTA_EXCEEDED",
-      );
+    const previous = writeLocks.get(this.projectRoot) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.then(() => current);
+    writeLocks.set(this.projectRoot, queued);
+    await previous;
+    try {
+      const data =
+        typeof contents === "string"
+          ? Buffer.from(contents)
+          : Buffer.from(contents);
+      if (data.byteLength > this.maxFileBytes) {
+        throw new VirtualFilesystemError(
+          `File exceeds max file size of ${this.maxFileBytes} bytes`,
+          "QUOTA_EXCEEDED",
+        );
+      }
+
+      const target = this.resolvePath(virtualPath);
+      await this.ensureSafeParentDirectory(target);
+      await this.rejectSymlinkIfExists(target);
+
+      const existingSize = await this.fileSizeIfExists(target);
+      const current = await this.measureFiles();
+      const nextBytes = current.bytes - existingSize + data.byteLength;
+      if (nextBytes > this.quotaBytes) {
+        throw new VirtualFilesystemError(
+          `Project quota exceeded: ${nextBytes}/${this.quotaBytes} bytes`,
+          "QUOTA_EXCEEDED",
+        );
+      }
+
+      await fsp.mkdir(path.dirname(target), { recursive: true, mode: 0o700 });
+      await fsp.writeFile(target, data, { mode: 0o600 });
+      return this.entryFor(target);
+    } finally {
+      release();
+      if (writeLocks.get(this.projectRoot) === queued) {
+        writeLocks.delete(this.projectRoot);
+      }
     }
-
-    const target = this.resolvePath(virtualPath);
-    await this.ensureSafeParentDirectory(target);
-    await this.rejectSymlinkIfExists(target);
-
-    const existingSize = await this.fileSizeIfExists(target);
-    const current = await this.measureFiles();
-    const nextBytes = current.bytes - existingSize + data.byteLength;
-    if (nextBytes > this.quotaBytes) {
-      throw new VirtualFilesystemError(
-        `Project quota exceeded: ${nextBytes}/${this.quotaBytes} bytes`,
-        "QUOTA_EXCEEDED",
-      );
-    }
-
-    await fsp.mkdir(path.dirname(target), { recursive: true, mode: 0o700 });
-    await fsp.writeFile(target, data, { mode: 0o600 });
-    return this.entryFor(target);
   }
 
   async readFile(


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
- AI assistance: Yes - initial author assistance plus maintainer review and remediation
<!-- attribution-row:models -->
- Models: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client/tooling: Codex CLI, Claude Code, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - the contribution skill was not used for this maintainer review and remediation
<!-- attribution-row:status -->
- Provenance status: self-reported

AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: re-ran the mutation check myself 3x against the reverted source (consistently red, not flaky) and 5x against the restored fix (consistently green), re-ran the full touched test file and biome myself, independently confirmed the pre-existing typecheck failures (19 errors, 7 unrelated files) reproduce identically with this fix's two files fully `git stash`ed out, and traced the reachability chain into the real workbench route, confirming `openProject()` does construct a fresh `VirtualFilesystemService` per request (the reason the fix needs module-level, not instance-level, state).

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low-to-moderate (concurrency fix, reviewed with extra scrutiny). The lock is a self-cleaning promise-chain queue keyed by `projectRoot`: a queued caller's `finally` block only deletes the map entry if it's still the map's current entry (reference-equality check), so a later queued write correctly keeps its own queue node live instead of being clobbered by an earlier writer's cleanup. Different projects don't block each other (keyed by root, not global). Errors thrown mid-write (e.g. quota exceeded) still release the lock via `finally`, so a rejected write doesn't wedge subsequent queued writers.

# Background

## What does this PR do?

`VirtualFilesystemService.writeFile` measured the current project size and then wrote the file with no coordination between concurrent writers - a classic check-then-act race. Two writes against the same project could both observe the pre-write size, both pass the quota check, and leave the project over quota.

Before fix (two concurrent 8-byte writes under a 10-byte quota):
```text
both fulfilled; quota() reports usedBytes: 16
```

After fix: writes are serialized through a module-level promise queue keyed by `projectRoot`, shared across separate `VirtualFilesystemService` instances (necessary because the live workbench route constructs a new service per request via `openProject(projectId)`). Exactly one write fulfills; the other rejects with the existing `QUOTA_EXCEEDED` error; final usage stays within quota.

## What kind of change is this?

Bug fix — no new capability, no schema change.

# Documentation changes needed?

No.

# Testing

New test `serializes concurrent writes so quota cannot be exceeded` in `packages/agent/src/services/virtual-filesystem.test.ts`, racing two separate service instances against the same project root under a tight 10-byte quota with two 8-byte writes.

# Evidence Gate

<!-- evidence-head:bf523a9c8f187cd53e2bee97a936afb45243b6dd -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend logic fix, no UI surface
- <!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual behavior changed

## Known gaps / failures

Package `typecheck` has **pre-existing, unrelated** failures: 19 errors across 7 files (`src/api/__tests__/stdio-envelope-child.ts`, `dispatch-route-binary-response.test.ts`, `dispatch-route-partial-write.test.ts`, `src/api/server.ts`, `capacitor-bridge-shim-parity.test.ts`, `optional-plugin-imports.generated.ts`, `../cloud/shared/src/db/repositories/users.ts`) - all `TS2307: Cannot find module` for optional plugin packages (`@elizaos/plugin-capacitor-bridge`, `@elizaos/plugin-wallet`, `@elizaos/plugin-video`, `@elizaos/plugin-vision`, `@elizaos/plugin-notes`, `@elizaos/plugin-todos`) not installed in this environment. I independently confirmed these reproduce identically with this PR's two changed files fully `git stash`ed out - not caused by this change. Neither touched file appears in the failure list.

## Reachability

`packages/agent/src/api/workbench-vfs-routes.ts`'s authenticated `PUT` handler calls `openProject(projectId)` (which constructs a **fresh** `VirtualFilesystemService` via `createVirtualFilesystemService` + `initialize()` on every call - confirmed directly in `openProject`'s implementation) and then `vfs.writeFile(parsed.data.path, data)` with request-controlled path and content. Concurrent requests targeting the same project therefore reach the race with real, non-hardcoded input. VFS shell append and plugin compiler paths also call `writeFile`; the workbench HTTP route is the direct concurrent boundary.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic focused regression tests are documented in the Testing section and produce no persistent backend log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by this logic change

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered interface changed
