### PR TITLE
fix(plugin-capacitor-bridge): reject unknown Android notifications unreadOnly flag

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -333,6 +333,38 @@ function isAndroidNotifier(
 	);
 }
 
+class AndroidUnreadOnlyError extends Error {
+	constructor(message = "Invalid unreadOnly") {
+		super(message);
+		this.name = "AndroidUnreadOnlyError";
+	}
+}
+
+/**
+ * GET /api/notifications `unreadOnly` on the Android UDS inbox is unread-row
+ * identity, leftover tax after agent notifications unreadOnly (#21220).
+ * Stock develop treated every non-exact `true` token as the full inbox, so
+ * `unreadOnly=TRUE` / `1` still listed read rows instead of a 400.
+ * Missing / empty still means the full inbox. limit stays untouched.
+ */
+function parseUnreadOnlyQuery(
+	raw: string | string[] | undefined,
+): boolean {
+	if (Array.isArray(raw)) {
+		throw new AndroidUnreadOnlyError();
+	}
+	if (raw == null || raw === "") {
+		return false;
+	}
+	if (raw === "true") {
+		return true;
+	}
+	if (raw === "false") {
+		return false;
+	}
+	throw new AndroidUnreadOnlyError();
+}
+
 /**
  * Serve the `/api/notifications` inbox surface over the Android UDS. These are
  * server-level routes (not plugin `runtime.routes`), so `dispatchRoute` never
@@ -406,8 +438,17 @@ async function directAndroidNotificationRoute(
 			parsedLimit >= 0
 				? Math.min(parsedLimit, 500)
 				: undefined;
+		let unreadOnly: boolean;
+		try {
+			unreadOnly = parseUnreadOnlyQuery(query.unreadOnly);
+		} catch (unreadError) {
+			if (unreadError instanceof AndroidUnreadOnlyError) {
+				return jsonResponse(400, { error: unreadError.message });
+			}
+			throw unreadError;
+		}
 		const notifications = service.list({
-			unreadOnly: queryValue("unreadOnly") === "true",
+			unreadOnly,
 			category: queryValue("category"),
 			limit,
 		});

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.unread-only.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.unread-only.test.ts
@@ -1,0 +1,114 @@
+/**
+ * GET /api/notifications `unreadOnly` on the Android UDS inbox is unread-row
+ * identity, leftover tax after agent notifications unreadOnly (#21220).
+ * Stock develop treated every non-exact `true` token as the full inbox, so
+ * `unreadOnly=TRUE` / `1` still listed read rows instead of a 400.
+ * limit stays untouched.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+	type AndroidDispatchRoute,
+	dispatchBufferedRequest,
+} from "./dispatch.ts";
+
+function notifierRuntime(
+	list: (query?: { unreadOnly?: boolean }) => unknown[],
+): IAgentRuntime {
+	return {
+		getService: (type: string) =>
+			type === "notification"
+				? {
+						list,
+						getUnreadCount: () => 0,
+						markRead: () => Promise.resolve(true),
+						markAllRead: () => Promise.resolve(0),
+						remove: () => Promise.resolve(true),
+						clear: () => Promise.resolve(),
+					}
+				: null,
+	} as unknown as IAgentRuntime;
+}
+
+const fallthrough: AndroidDispatchRoute = async () => null;
+
+describe("GET /api/notifications unreadOnly identity", () => {
+	it.each(["/api/notifications", "/api/notifications?unreadOnly="])(
+		"accepts %s as the full inbox",
+		async (path) => {
+			const calls: Array<{ unreadOnly?: boolean } | undefined> = [];
+			const runtime = notifierRuntime((query) => {
+				calls.push(query);
+				return [];
+			});
+			const response = await dispatchBufferedRequest(runtime, fallthrough, {
+				method: "GET",
+				path,
+			});
+			expect(response.status).toBe(200);
+			expect(calls).toEqual([{ unreadOnly: false, category: undefined, limit: undefined }]);
+		},
+	);
+
+	it("accepts unreadOnly=true as the unread-only inbox", async () => {
+		const calls: Array<{ unreadOnly?: boolean } | undefined> = [];
+		const runtime = notifierRuntime((query) => {
+			calls.push(query);
+			return [];
+		});
+		const response = await dispatchBufferedRequest(runtime, fallthrough, {
+			method: "GET",
+			path: "/api/notifications?unreadOnly=true",
+		});
+		expect(response.status).toBe(200);
+		expect(calls[0]?.unreadOnly).toBe(true);
+	});
+
+	it("accepts unreadOnly=false as the full inbox", async () => {
+		const calls: Array<{ unreadOnly?: boolean } | undefined> = [];
+		const runtime = notifierRuntime((query) => {
+			calls.push(query);
+			return [];
+		});
+		const response = await dispatchBufferedRequest(runtime, fallthrough, {
+			method: "GET",
+			path: "/api/notifications?unreadOnly=false",
+		});
+		expect(response.status).toBe(200);
+		expect(calls[0]?.unreadOnly).toBe(false);
+	});
+
+	it.each(["TRUE", "FALSE", "1", "0", "yes", "no", "foo", "1e2"])(
+		"rejects unreadOnly=%s before list",
+		async (token) => {
+			const list = () => {
+				throw new Error("list must not run");
+			};
+			const runtime = notifierRuntime(list);
+			const response = await dispatchBufferedRequest(runtime, fallthrough, {
+				method: "GET",
+				path: `/api/notifications?unreadOnly=${encodeURIComponent(token)}`,
+			});
+			expect(response.status).toBe(400);
+			expect(JSON.parse(response.body)).toEqual({ error: "Invalid unreadOnly" });
+		},
+	);
+
+	it.each([
+		"/api/notifications?unreadOnly=true&unreadOnly=true",
+		"/api/notifications?unreadOnly=true&unreadOnly=false",
+		"/api/notifications?unreadOnly=&unreadOnly=true",
+		"/api/notifications?unreadOnly=foo&unreadOnly=true",
+	])("rejects duplicate unreadOnly values in %s before list", async (path) => {
+		const list = () => {
+			throw new Error("list must not run");
+		};
+		const runtime = notifierRuntime(list);
+		const response = await dispatchBufferedRequest(runtime, fallthrough, {
+			method: "GET",
+			path,
+		});
+		expect(response.status).toBe(400);
+		expect(JSON.parse(response.body)).toEqual({ error: "Invalid unreadOnly" });
+	});
+});


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on Android UDS
notifications `unreadOnly` identity. Unread-row class, leftover tax after
agent notifications unreadOnly (#21220). Not a twin of that HTTP route —
this is the Capacitor Android inbox surface.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `unreadOnly` only on the Android UDS `/api/notifications` inbox.
Omitted/empty still means the full inbox (today's default). Exact `true` /
`false` still bind. Unknown / uppercase / `1` / `0` tokens 400 before
`NotificationService.list`. `limit` stays untouched.

# Background

## What does this PR do?

Android UDS `GET /api/notifications` treated every non-exact `true`
`unreadOnly` token as the full inbox. `unreadOnly=TRUE` / `1` silently
listed read rows instead of a 400.

- omitted / empty / `false` → full inbox (200)
- exact `true` → unread-only list
- `TRUE` / `FALSE` / `1` / `0` / `yes` / `foo` / `1e2` / duplicates → **400** before `list`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The dashboard notification center hydrates from this UDS inbox. A common
`unreadOnly=TRUE` or `1` after a client sends a boolean token must not
silently keep the full inbox. Leftover tax after agent notifications
unreadOnly (#21220). Disjoint files from that PR.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-capacitor-bridge/src/android/dispatch.unread-only.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-capacitor-bridge && bunx vitest run --config vitest.config.ts src/android/dispatch.unread-only.test.ts
```

16 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; Android UDS notifications `unreadOnly` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; Android UDS notifications `unreadOnly` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; Android UDS notifications `unreadOnly` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real unreadOnly tokens and assert 400 before list; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before NotificationService.list.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
`unreadOnly` tokens reject; omitted/canonical still bind the matching
inbox filter.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the Android UDS
notifications `unreadOnly` query only.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d705eea1fc41de17361b07a411faa4fe8ba23cfe -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
