### PR TITLE
fix(plugin-calendar): reject unknown calendar feed forceSync flag

### DIFF
--- a/plugins/plugin-calendar/src/routes/calendar-routes.force-sync.test.ts
+++ b/plugins/plugin-calendar/src/routes/calendar-routes.force-sync.test.ts
@@ -1,0 +1,96 @@
+/**
+ * GET /api/lifeops/calendar/feed `forceSync` is refresh-now identity,
+ * leftover tax after LifeOps inbox flags (#20930). Stock develop accepted
+ * `1` / `TRUE` as force-sync via case-folded boolean identities, so a
+ * non-exact token changed the live connector pull instead of a 400.
+ * includeHiddenCalendars stays untouched.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  type CalendarRouteDeps,
+  type CalendarRouteService,
+  handleCalendarRoutes,
+} from "./calendar-routes.js";
+
+function harness(path: string) {
+  const getCalendarFeed = vi.fn(async () => ({ events: [] }));
+  const jsonCalls: Array<{ data: unknown; status?: number }> = [];
+  const deps: CalendarRouteDeps = {
+    method: "GET",
+    pathname: "/api/lifeops/calendar/feed",
+    url: new URL(`http://host${path}`),
+    runRoute: async (fn) => {
+      await fn({ getCalendarFeed } as unknown as CalendarRouteService);
+      return true;
+    },
+    rateLimit: () => false,
+    json: (data, status) => jsonCalls.push({ data, status }),
+    readJsonBody: async () => ({}) as never,
+    decodePathComponent: (raw) => raw,
+    parseConnectorMode: () => undefined,
+    parseConnectorSide: () => undefined,
+    parseBoolean: () => undefined,
+    serviceError: (status, message) =>
+      Object.assign(new Error(message), { status }),
+    mutationGateway: {} as CalendarRouteDeps["mutationGateway"],
+  };
+  return { deps, getCalendarFeed, jsonCalls };
+}
+
+describe("GET /api/lifeops/calendar/feed forceSync identity", () => {
+  it.each([
+    "/api/lifeops/calendar/feed",
+    "/api/lifeops/calendar/feed?forceSync=",
+  ])("accepts %s as no force-sync", async (path) => {
+    const { deps, getCalendarFeed, jsonCalls } = harness(path);
+    expect(await handleCalendarRoutes(deps)).toBe(true);
+    expect(getCalendarFeed).toHaveBeenCalledTimes(1);
+    const request = getCalendarFeed.mock.calls[0]?.[1] as { forceSync?: boolean };
+    expect(request.forceSync).toBeUndefined();
+    expect(jsonCalls[0]?.status).toBeUndefined();
+  });
+
+  it("accepts forceSync=true as a forced connector pull", async () => {
+    const { deps, getCalendarFeed } = harness(
+      "/api/lifeops/calendar/feed?forceSync=true",
+    );
+    expect(await handleCalendarRoutes(deps)).toBe(true);
+    expect(getCalendarFeed).toHaveBeenCalledTimes(1);
+    const request = getCalendarFeed.mock.calls[0]?.[1] as { forceSync?: boolean };
+    expect(request.forceSync).toBe(true);
+  });
+
+  it("accepts forceSync=false as no force-sync", async () => {
+    const { deps, getCalendarFeed } = harness(
+      "/api/lifeops/calendar/feed?forceSync=false",
+    );
+    expect(await handleCalendarRoutes(deps)).toBe(true);
+    expect(getCalendarFeed).toHaveBeenCalledTimes(1);
+    const request = getCalendarFeed.mock.calls[0]?.[1] as { forceSync?: boolean };
+    expect(request.forceSync).toBe(false);
+  });
+
+  it.each(["TRUE", "FALSE", "1", "0", "yes", "no", "foo", "1e2"])(
+    "rejects forceSync=%s before getCalendarFeed",
+    async (token) => {
+      const { deps, getCalendarFeed, jsonCalls } = harness(
+        `/api/lifeops/calendar/feed?forceSync=${encodeURIComponent(token)}`,
+      );
+      expect(await handleCalendarRoutes(deps)).toBe(true);
+      expect(getCalendarFeed).not.toHaveBeenCalled();
+      expect(jsonCalls).toEqual([{ data: { error: "Invalid forceSync" }, status: 400 }]);
+    },
+  );
+
+  it.each([
+    "/api/lifeops/calendar/feed?forceSync=true&forceSync=true",
+    "/api/lifeops/calendar/feed?forceSync=true&forceSync=false",
+    "/api/lifeops/calendar/feed?forceSync=&forceSync=true",
+    "/api/lifeops/calendar/feed?forceSync=foo&forceSync=true",
+  ])("rejects duplicate forceSync values in %s before getCalendarFeed", async (path) => {
+    const { deps, getCalendarFeed, jsonCalls } = harness(path);
+    expect(await handleCalendarRoutes(deps)).toBe(true);
+    expect(getCalendarFeed).not.toHaveBeenCalled();
+    expect(jsonCalls).toEqual([{ data: { error: "Invalid forceSync" }, status: 400 }]);
+  });
+});

--- a/plugins/plugin-calendar/src/routes/calendar-routes.ts
+++ b/plugins/plugin-calendar/src/routes/calendar-routes.ts
@@ -113,6 +113,39 @@ export interface CalendarRouteDeps {
   mutationGateway: CalendarOwnerMutationGateway;
 }
 
+class CalendarForceSyncError extends Error {
+  constructor(message = "Invalid forceSync") {
+    super(message);
+    this.name = "CalendarForceSyncError";
+  }
+}
+
+/**
+ * GET /api/lifeops/calendar/feed `forceSync` is refresh-now identity,
+ * leftover tax after LifeOps inbox flags (#20930). Stock develop accepted
+ * `1` / `TRUE` as force-sync via case-folded boolean identities, so a
+ * non-exact token changed the live connector pull instead of a 400.
+ * Missing / empty still means no force-sync. includeHiddenCalendars stays
+ * untouched.
+ */
+function parseForceSyncQuery(searchParams: URLSearchParams): boolean | undefined {
+  const requested = searchParams.getAll("forceSync");
+  if (requested.length > 1) {
+    throw new CalendarForceSyncError();
+  }
+  const raw = requested[0];
+  if (raw == null || raw === "") {
+    return undefined;
+  }
+  if (raw === "true") {
+    return true;
+  }
+  if (raw === "false") {
+    return false;
+  }
+  throw new CalendarForceSyncError();
+}
+
 /**
  * Handle a calendar route. Resolves to `true` when the request matched a
  * calendar path (and was served/short-circuited), or `false` when no calendar
@@ -146,6 +179,16 @@ export async function handleCalendarRoutes(
 
   if (method === "GET" && pathname === "/api/lifeops/calendar/feed") {
     if (deps.rateLimit("google_api_read")) return true;
+    let forceSync: boolean | undefined;
+    try {
+      forceSync = parseForceSyncQuery(q);
+    } catch (forceSyncError) {
+      if (forceSyncError instanceof CalendarForceSyncError) {
+        deps.json({ error: forceSyncError.message }, 400);
+        return true;
+      }
+      throw forceSyncError;
+    }
     return deps.runRoute(async (service) => {
       const request: GetLifeOpsCalendarFeedRequest = {
         mode: deps.parseConnectorMode(q.get("mode")),
@@ -158,7 +201,7 @@ export async function handleCalendarRoutes(
         timeMin: q.get("timeMin") ?? undefined,
         timeMax: q.get("timeMax") ?? undefined,
         timeZone: q.get("timeZone") ?? undefined,
-        forceSync: deps.parseBoolean(q.get("forceSync"), "forceSync"),
+        forceSync,
         grantId: q.get("grantId") ?? undefined,
       };
       deps.json(await service.getCalendarFeed(url, request));


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on calendar feed
`forceSync` identity. Refresh-now class, leftover tax after LifeOps inbox
flags (#20930). Not a twin of those inbox flags — this is
`GET /api/lifeops/calendar/feed` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `forceSync` only on `/api/lifeops/calendar/feed`. Omitted/empty
still means no force-sync (today's default). Exact `true` / `false` still
bind. Unknown / uppercase / `1` / `0` tokens 400 before `getCalendarFeed`.
`includeHiddenCalendars` stays untouched.

# Background

## What does this PR do?

`GET /api/lifeops/calendar/feed` accepted `1` / `TRUE` as force-sync via
case-folded boolean identities. `forceSync=TRUE` / `1` silently forced a
live connector pull instead of a 400.

- omitted / empty → no force-sync (200)
- exact `true` → forced connector pull
- exact `false` → no force-sync
- `TRUE` / `FALSE` / `1` / `0` / `yes` / `foo` / `1e2` / duplicates → **400** before `getCalendarFeed`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers opt into a live connector pull with `?forceSync=true`. A common
`forceSync=TRUE` or `1` after a client sends a boolean token must not
silently change the pull. Leftover tax after LifeOps inbox flags (#20930).
Disjoint from plugin-health sleep `includeNaps` (#21275).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-calendar/src/routes/calendar-routes.force-sync.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-calendar && bunx vitest run --config vitest.config.ts src/routes/calendar-routes.force-sync.test.ts
```

16 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; calendar feed `forceSync` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; calendar feed `forceSync` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; calendar feed `forceSync` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real forceSync tokens and assert 400 before getCalendarFeed; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before getCalendarFeed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
`forceSync` tokens reject; omitted/canonical still bind the matching
refresh-now filter.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the calendar feed
`forceSync` query only.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:22a77f64cc20038c0056cb98348368dd7fd07540 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
