### PR TITLE
fix(plugins): close messaging-connector security gaps (pairing defaults, credential persistence, loopback binding, log hygiene)

### DIFF
--- a/plugins/plugin-bluebubbles/AGENTS.md
+++ b/plugins/plugin-bluebubbles/AGENTS.md
@@ -77,7 +77,7 @@ bun run --cwd plugins/plugin-bluebubbles typecheck
 | `BLUEBUBBLES_PASSWORD` | yes | — | BlueBubbles server password |
 | `BLUEBUBBLES_WEBHOOK_SECRET` | recommended | — | Shared secret validated on every POST to `/webhooks/bluebubbles` (header `X-BlueBubbles-Webhook-Secret`). Webhook requests are rejected without it. |
 | `BLUEBUBBLES_WEBHOOK_PATH` | no | `/webhooks/bluebubbles` | Override inbound webhook path |
-| `BLUEBUBBLES_DM_POLICY` | no | `pairing` | `open` \| `pairing` \| `allowlist` \| `disabled` |
+| `BLUEBUBBLES_DM_POLICY` | no | `pairing` | `open` \| `pairing` \| `allowlist` \| `disabled` — `pairing` holds unknown senders through the core PairingService code handshake; it never defaults open |
 | `BLUEBUBBLES_GROUP_POLICY` | no | `allowlist` | `open` \| `allowlist` \| `disabled` |
 | `BLUEBUBBLES_ALLOW_FROM` | no | — | Comma-separated allowlist for DM senders |
 | `BLUEBUBBLES_GROUP_ALLOW_FROM` | no | — | Comma-separated allowlist for group senders |
@@ -120,6 +120,13 @@ blocks under `character.settings.bluebubbles.accounts.<id>`.
 - **Webhook secret is enforced.** Every POST to `/webhooks/bluebubbles` is
   rejected with 401 if `BLUEBUBBLES_WEBHOOK_SECRET` is not set. Configure it
   in both the BlueBubbles server app and the agent env.
+- **DM `pairing` uses the core PairingService.** The connector has no pairing
+  handshake of its own; unknown DM senders get a one-time pairing code and
+  are held until the owner approves. An empty `BLUEBUBBLES_ALLOW_FROM` never
+  means "allow everyone".
+- **No credentials in stored attachment URLs.** Memories carry the bare
+  `/api/v1/attachment/<guid>` capability URL; the server password is appended
+  only at fetch time via `BlueBubblesClient.getAttachmentUrl()`.
 - **Private API required for edit/unsend.** `BlueBubblesClient.editMessage()`
   and `.unsendMessage()` require the BlueBubbles Private API to be enabled.
   Check `probeResult.privateApiEnabled` before using those paths.

--- a/plugins/plugin-bluebubbles/CLAUDE.md
+++ b/plugins/plugin-bluebubbles/CLAUDE.md
@@ -77,7 +77,7 @@ bun run --cwd plugins/plugin-bluebubbles typecheck
 | `BLUEBUBBLES_PASSWORD` | yes | — | BlueBubbles server password |
 | `BLUEBUBBLES_WEBHOOK_SECRET` | recommended | — | Shared secret validated on every POST to `/webhooks/bluebubbles` (header `X-BlueBubbles-Webhook-Secret`). Webhook requests are rejected without it. |
 | `BLUEBUBBLES_WEBHOOK_PATH` | no | `/webhooks/bluebubbles` | Override inbound webhook path |
-| `BLUEBUBBLES_DM_POLICY` | no | `pairing` | `open` \| `pairing` \| `allowlist` \| `disabled` |
+| `BLUEBUBBLES_DM_POLICY` | no | `pairing` | `open` \| `pairing` \| `allowlist` \| `disabled` — `pairing` holds unknown senders through the core PairingService code handshake; it never defaults open |
 | `BLUEBUBBLES_GROUP_POLICY` | no | `allowlist` | `open` \| `allowlist` \| `disabled` |
 | `BLUEBUBBLES_ALLOW_FROM` | no | — | Comma-separated allowlist for DM senders |
 | `BLUEBUBBLES_GROUP_ALLOW_FROM` | no | — | Comma-separated allowlist for group senders |
@@ -120,6 +120,13 @@ blocks under `character.settings.bluebubbles.accounts.<id>`.
 - **Webhook secret is enforced.** Every POST to `/webhooks/bluebubbles` is
   rejected with 401 if `BLUEBUBBLES_WEBHOOK_SECRET` is not set. Configure it
   in both the BlueBubbles server app and the agent env.
+- **DM `pairing` uses the core PairingService.** The connector has no pairing
+  handshake of its own; unknown DM senders get a one-time pairing code and
+  are held until the owner approves. An empty `BLUEBUBBLES_ALLOW_FROM` never
+  means "allow everyone".
+- **No credentials in stored attachment URLs.** Memories carry the bare
+  `/api/v1/attachment/<guid>` capability URL; the server password is appended
+  only at fetch time via `BlueBubblesClient.getAttachmentUrl()`.
 - **Private API required for edit/unsend.** `BlueBubblesClient.editMessage()`
   and `.unsendMessage()` require the BlueBubbles Private API to be enabled.
   Check `probeResult.privateApiEnabled` before using those paths.

--- a/plugins/plugin-bluebubbles/README.md
+++ b/plugins/plugin-bluebubbles/README.md
@@ -86,9 +86,13 @@ In the BlueBubbles server app → Webhooks, add an entry:
 | Policy | Behavior |
 |---|---|
 | `open` | Accept messages from any sender |
-| `pairing` (default for DMs) | Accept messages only from handles in `BLUEBUBBLES_ALLOW_FROM`; if the list is empty, accept all |
+| `pairing` (default for DMs) | Accept handles in `BLUEBUBBLES_ALLOW_FROM` immediately; unknown senders are held through the core PairingService handshake — they receive a one-time pairing code and are admitted once the owner approves it (`pairing approve imessage <code>` or the pairing UI) |
 | `allowlist` (default for groups) | Accept only from handles in the allow list |
 | `disabled` | Reject all messages of this type |
+
+Attachment URLs stored on inbound memories are bare capability URLs. The
+BlueBubbles server password is appended only at fetch time inside
+`BlueBubblesClient.getAttachmentUrl`, never persisted in the message store.
 
 ## API routes
 

--- a/plugins/plugin-bluebubbles/__tests__/environment.test.ts
+++ b/plugins/plugin-bluebubbles/__tests__/environment.test.ts
@@ -204,9 +204,20 @@ describe("isHandleAllowed", () => {
 		).toBe(true);
 	});
 
-	it("keeps disabled and empty allowlist policies restrictive except pairing", () => {
+	it("fails closed for disabled, allowlist, and pairing policies with an empty allow list", () => {
 		expect(isHandleAllowed("+14155552671", [], "disabled")).toBe(false);
 		expect(isHandleAllowed("+14155552671", [], "allowlist")).toBe(false);
-		expect(isHandleAllowed("+14155552671", [], "pairing")).toBe(true);
+		// Pairing must not default-open: unpaired first contact is gated by the
+		// service through the core PairingService handshake instead.
+		expect(isHandleAllowed("+14155552671", [], "pairing")).toBe(false);
+	});
+
+	it("treats pairing like allowlist for statically approved handles", () => {
+		expect(isHandleAllowed("+14155552671", ["+14155552671"], "pairing")).toBe(
+			true,
+		);
+		expect(isHandleAllowed("+14155559999", ["+14155552671"], "pairing")).toBe(
+			false,
+		);
 	});
 });

--- a/plugins/plugin-bluebubbles/__tests__/inbound-policy.test.ts
+++ b/plugins/plugin-bluebubbles/__tests__/inbound-policy.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Covers the inbound DM policy gate and attachment persistence: the default
+ * "pairing" policy holds unknown senders through the core PairingService code
+ * handshake instead of defaulting open, statically allowlisted and
+ * pairing-approved senders pass, and attachment URLs persisted on memories
+ * never carry the BlueBubbles server password. Uses a stub runtime with a
+ * mocked PairingService and message service — no live server.
+ */
+import { type IAgentRuntime, ServiceType, type UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { BlueBubblesService } from "../src/service";
+import type { BlueBubblesHandle, BlueBubblesMessage } from "../src/types";
+
+const SERVER_URL = "http://localhost:1234";
+const SERVER_PASSWORD = "super-secret";
+
+function makeRuntime(
+	settings: Record<string, unknown>,
+	options: { pairingAllowed: boolean; pairingRequestCreated?: boolean },
+) {
+	const pairingService = {
+		isAllowed: vi.fn(async () => options.pairingAllowed),
+		upsertRequest: vi.fn(async () => ({
+			code: "PAIRCODE1",
+			created: options.pairingRequestCreated ?? true,
+		})),
+	};
+	const handleMessage = vi.fn(async () => undefined);
+	const createMemory = vi.fn(async () => undefined);
+	const runtime = {
+		agentId: "agent-1" as UUID,
+		character: { name: "Test Agent", settings: {} },
+		getSetting: (key: string) => settings[key],
+		getService: (serviceType: string) =>
+			serviceType === ServiceType.PAIRING ? pairingService : null,
+		getEntityById: vi.fn(async () => null),
+		createEntity: vi.fn(async () => undefined),
+		ensureConnection: vi.fn(async () => undefined),
+		createMemory,
+		getRoom: vi.fn(async () => ({ id: "room-1" as UUID })),
+		messageService: { handleMessage },
+		reportError: vi.fn(),
+	} as unknown as IAgentRuntime;
+	return { runtime, pairingService, createMemory, handleMessage };
+}
+
+function makeHandle(address: string): BlueBubblesHandle {
+	return {
+		address,
+		service: "iMessage",
+		country: null,
+		originalROWID: 1,
+		uncanonicalizedId: null,
+	};
+}
+
+function makeMessage(
+	overrides: Partial<BlueBubblesMessage> = {},
+): BlueBubblesMessage {
+	const handle = makeHandle("+1 (415) 555-2671");
+	return {
+		guid: "msg-1",
+		text: "hello",
+		subject: null,
+		country: null,
+		handle,
+		handleId: 1,
+		otherHandle: 0,
+		chats: [
+			{
+				guid: "iMessage;-;+14155552671",
+				chatIdentifier: "+14155552671",
+				displayName: "Alice",
+				participants: [handle],
+				lastMessage: null,
+				style: 45,
+				isArchived: false,
+				isFiltered: false,
+				isPinned: false,
+				hasUnreadMessages: false,
+			},
+		],
+		attachments: [],
+		expressiveSendStyleId: null,
+		dateCreated: 1710969600000,
+		dateRead: null,
+		dateDelivered: null,
+		isFromMe: false,
+		isDelayed: false,
+		isAutoReply: false,
+		isSystemMessage: false,
+		isServiceMessage: false,
+		isForward: false,
+		isArchived: false,
+		hasDdResults: false,
+		hasPayloadData: false,
+		threadOriginatorGuid: null,
+		threadOriginatorPart: null,
+		associatedMessageGuid: null,
+		associatedMessageType: null,
+		balloonBundleId: null,
+		dateEdited: null,
+		error: 0,
+		itemType: 0,
+		groupTitle: null,
+		groupActionType: 0,
+		payloadData: null,
+		...overrides,
+	};
+}
+
+function baseSettings(overrides: Record<string, unknown> = {}) {
+	return {
+		BLUEBUBBLES_SERVER_URL: SERVER_URL,
+		BLUEBUBBLES_PASSWORD: SERVER_PASSWORD,
+		BLUEBUBBLES_SEND_READ_RECEIPTS: "false",
+		...overrides,
+	};
+}
+
+describe("BlueBubbles inbound DM pairing gate", () => {
+	it("holds an unpaired sender and sends the pairing-code reply", async () => {
+		const { runtime, pairingService, createMemory, handleMessage } =
+			makeRuntime(baseSettings(), { pairingAllowed: false });
+		const service = new BlueBubblesService(runtime);
+		const sendMessage = vi
+			.spyOn(service, "sendMessage")
+			.mockResolvedValue({ guid: "reply-1", dateCreated: 1 });
+
+		await service.handleWebhook({
+			type: "new-message",
+			data: makeMessage(),
+		});
+
+		expect(pairingService.isAllowed).toHaveBeenCalledWith(
+			"imessage",
+			"+14155552671",
+		);
+		expect(pairingService.upsertRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				channel: "imessage",
+				senderId: "+14155552671",
+			}),
+		);
+		expect(sendMessage).toHaveBeenCalledTimes(1);
+		expect(sendMessage.mock.calls[0]?.[0]).toBe("iMessage;-;+14155552671");
+		expect(sendMessage.mock.calls[0]?.[1]).toContain("PAIRCODE1");
+		expect(createMemory).not.toHaveBeenCalled();
+		expect(handleMessage).not.toHaveBeenCalled();
+	});
+
+	it("does not re-send the pairing code for an already-pending sender", async () => {
+		const { runtime, createMemory } = makeRuntime(baseSettings(), {
+			pairingAllowed: false,
+			pairingRequestCreated: false,
+		});
+		const service = new BlueBubblesService(runtime);
+		const sendMessage = vi.spyOn(service, "sendMessage");
+
+		await service.handleWebhook({
+			type: "new-message",
+			data: makeMessage(),
+		});
+
+		expect(sendMessage).not.toHaveBeenCalled();
+		expect(createMemory).not.toHaveBeenCalled();
+	});
+
+	it("admits a pairing-approved sender and persists bare attachment URLs", async () => {
+		const { runtime, pairingService, createMemory, handleMessage } =
+			makeRuntime(baseSettings(), { pairingAllowed: true });
+		const service = new BlueBubblesService(runtime);
+
+		await service.handleWebhook({
+			type: "new-message",
+			data: makeMessage({
+				attachments: [
+					{
+						guid: "att-1",
+						originalROWID: 1,
+						uti: "public.png",
+						mimeType: "image/png",
+						transferName: "photo.png",
+						totalBytes: 128,
+						isOutgoing: false,
+						hideAttachment: false,
+						isSticker: false,
+						hasLivePhoto: false,
+						height: null,
+						width: null,
+						metadata: null,
+					},
+				],
+			}),
+		});
+
+		expect(pairingService.isAllowed).toHaveBeenCalledWith(
+			"imessage",
+			"+14155552671",
+		);
+		expect(pairingService.upsertRequest).not.toHaveBeenCalled();
+		expect(createMemory).toHaveBeenCalledTimes(1);
+		const memory = createMemory.mock.calls[0]?.[0] as {
+			content: { attachments?: Array<{ url: string }> };
+		};
+		expect(memory.content.attachments).toHaveLength(1);
+		expect(memory.content.attachments?.[0]?.url).toBe(
+			`${SERVER_URL}/api/v1/attachment/att-1`,
+		);
+		expect(memory.content.attachments?.[0]?.url).not.toContain("password");
+		expect(memory.content.attachments?.[0]?.url).not.toContain(SERVER_PASSWORD);
+		expect(handleMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it("admits a statically allowlisted sender without consulting pairing", async () => {
+		const { runtime, pairingService, createMemory } = makeRuntime(
+			baseSettings({ BLUEBUBBLES_ALLOW_FROM: "+14155552671" }),
+			{ pairingAllowed: false },
+		);
+		const service = new BlueBubblesService(runtime);
+
+		await service.handleWebhook({
+			type: "new-message",
+			data: makeMessage(),
+		});
+
+		expect(pairingService.isAllowed).not.toHaveBeenCalled();
+		expect(createMemory).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the allowlist policy closed without creating pairing requests", async () => {
+		const { runtime, pairingService, createMemory } = makeRuntime(
+			baseSettings({ BLUEBUBBLES_DM_POLICY: "allowlist" }),
+			{ pairingAllowed: false },
+		);
+		const service = new BlueBubblesService(runtime);
+
+		await service.handleWebhook({
+			type: "new-message",
+			data: makeMessage(),
+		});
+
+		expect(pairingService.isAllowed).not.toHaveBeenCalled();
+		expect(pairingService.upsertRequest).not.toHaveBeenCalled();
+		expect(createMemory).not.toHaveBeenCalled();
+	});
+});

--- a/plugins/plugin-bluebubbles/__tests__/inbound-policy.test.ts
+++ b/plugins/plugin-bluebubbles/__tests__/inbound-policy.test.ts
@@ -1,10 +1,11 @@
 /**
  * Covers the inbound DM policy gate and attachment persistence: the default
  * "pairing" policy holds unknown senders through the core PairingService code
- * handshake instead of defaulting open, statically allowlisted and
- * pairing-approved senders pass, and attachment URLs persisted on memories
- * never carry the BlueBubbles server password. Uses a stub runtime with a
- * mocked PairingService and message service — no live server.
+ * handshake instead of defaulting open (and fails closed when that service is
+ * not registered), statically allowlisted and pairing-approved senders pass,
+ * and attachment URLs persisted on memories never carry the BlueBubbles
+ * server password. Uses a stub runtime with a mocked PairingService and
+ * message service — no live server.
  */
 import { type IAgentRuntime, ServiceType, type UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
@@ -16,7 +17,11 @@ const SERVER_PASSWORD = "super-secret";
 
 function makeRuntime(
 	settings: Record<string, unknown>,
-	options: { pairingAllowed: boolean; pairingRequestCreated?: boolean },
+	options: {
+		pairingAllowed: boolean;
+		pairingRequestCreated?: boolean;
+		pairingService?: boolean;
+	},
 ) {
 	const pairingService = {
 		isAllowed: vi.fn(async () => options.pairingAllowed),
@@ -32,7 +37,9 @@ function makeRuntime(
 		character: { name: "Test Agent", settings: {} },
 		getSetting: (key: string) => settings[key],
 		getService: (serviceType: string) =>
-			serviceType === ServiceType.PAIRING ? pairingService : null,
+			serviceType === ServiceType.PAIRING && options.pairingService !== false
+				? pairingService
+				: null,
 		getEntityById: vi.fn(async () => null),
 		createEntity: vi.fn(async () => undefined),
 		ensureConnection: vi.fn(async () => undefined),
@@ -243,5 +250,30 @@ describe("BlueBubbles inbound DM pairing gate", () => {
 		expect(pairingService.isAllowed).not.toHaveBeenCalled();
 		expect(pairingService.upsertRequest).not.toHaveBeenCalled();
 		expect(createMemory).not.toHaveBeenCalled();
+	});
+
+	it("fails closed and reports when the PairingService is not registered", async () => {
+		const { runtime, createMemory, handleMessage } = makeRuntime(
+			baseSettings(),
+			{ pairingAllowed: false, pairingService: false },
+		);
+		const service = new BlueBubblesService(runtime);
+		const sendMessage = vi
+			.spyOn(service, "sendMessage")
+			.mockResolvedValue({ guid: "reply-1", dateCreated: 1 });
+
+		await service.handleWebhook({
+			type: "new-message",
+			data: makeMessage(),
+		});
+
+		// A missing PairingService under the "pairing" policy is a host
+		// misconfiguration: the sender is denied, the runtime error reporter
+		// fires, and only the static "temporarily unavailable" reply goes out.
+		expect(runtime.reportError).toHaveBeenCalled();
+		expect(createMemory).not.toHaveBeenCalled();
+		expect(handleMessage).not.toHaveBeenCalled();
+		expect(sendMessage).toHaveBeenCalledTimes(1);
+		expect(sendMessage.mock.calls[0]?.[1]).not.toContain("PAIRCODE1");
 	});
 });

--- a/plugins/plugin-bluebubbles/src/client.ts
+++ b/plugins/plugin-bluebubbles/src/client.ts
@@ -85,6 +85,15 @@ export class BlueBubblesClient {
 	}
 
 	/**
+	 * Returns the authenticated fetch URL for an attachment. The server
+	 * password is appended only here, at fetch time — attachment URLs persisted
+	 * on memories are bare capability URLs without the credential.
+	 */
+	getAttachmentUrl(attachmentGuid: string): string {
+		return `${this.baseUrl}/api/v1/attachment/${encodeURIComponent(attachmentGuid)}?password=${encodeURIComponent(this.password)}`;
+	}
+
+	/**
 	 * Sends a text message
 	 */
 	async sendMessage(

--- a/plugins/plugin-bluebubbles/src/environment.ts
+++ b/plugins/plugin-bluebubbles/src/environment.ts
@@ -171,11 +171,10 @@ export function isHandleAllowed(
 	}
 
 	if (policy === "pairing" || policy === "allowlist") {
-		if (allowList.length === 0 && policy === "pairing") {
-			// Pairing mode with empty allow list allows first contact
-			return true;
-		}
-
+		// "pairing" has no connector-local handshake, so it must fail closed
+		// here: an empty allow list means "no statically approved senders", not
+		// "allow first contact". Unpaired first contact is gated by the service
+		// through the core PairingService code handshake.
 		const normalizedHandle = normalizeHandle(handle);
 		return allowList.some(
 			(allowed) => normalizeHandle(allowed) === normalizedHandle,

--- a/plugins/plugin-bluebubbles/src/service.ts
+++ b/plugins/plugin-bluebubbles/src/service.ts
@@ -14,6 +14,7 @@ import {
 	ChannelType,
 	type Content,
 	type ContentType,
+	checkPairingAllowed,
 	createMessageMemory,
 	createUniqueUuid,
 	type Entity,
@@ -438,8 +439,11 @@ function blueBubblesMessageToMemory({
 		message.chats[0]?.participants.length > 1 || chatGuid.includes(";+;");
 	const attachments = message.attachments.map((attachment) => ({
 		id: attachment.guid,
+		// Bare capability URL only — the server password is appended at fetch
+		// time inside BlueBubblesClient so stored memories never persist the
+		// credential (see BlueBubblesClient.getAttachmentUrl).
 		url: config
-			? `${config.serverUrl}/api/v1/attachment/${encodeURIComponent(attachment.guid)}?password=${encodeURIComponent(config.password)}`
+			? `${config.serverUrl}/api/v1/attachment/${encodeURIComponent(attachment.guid)}`
 			: "",
 		title: attachment.transferName,
 		description: attachment.mimeType ?? undefined,
@@ -1180,17 +1184,30 @@ export class BlueBubblesService extends Service {
 				return;
 			}
 		} else {
-			if (
-				!isHandleAllowed(
+			const dmPolicy = config.dmPolicy ?? "pairing";
+			const staticallyAllowed = isHandleAllowed(
+				senderHandle,
+				config.allowFrom ?? [],
+				dmPolicy === "pairing" ? "allowlist" : dmPolicy,
+			);
+			if (!staticallyAllowed) {
+				if (dmPolicy !== "pairing") {
+					logger.debug(
+						`Ignoring message from ${senderHandle} - not in DM allowlist`,
+					);
+					return;
+				}
+				// "pairing" policy: this connector has no handshake of its own, so
+				// an unknown sender is held through the core PairingService code
+				// flow (same as WhatsApp/Discord) instead of allowed by default.
+				const pairingApproved = await this.checkDmPairing(
 					senderHandle,
-					config.allowFrom ?? [],
-					config.dmPolicy ?? "pairing",
-				)
-			) {
-				logger.debug(
-					`Ignoring message from ${senderHandle} - not in DM allowlist`,
+					chat.guid,
+					message,
 				);
-				return;
+				if (!pairingApproved) {
+					return;
+				}
 			}
 		}
 
@@ -1215,7 +1232,10 @@ export class BlueBubblesService extends Service {
 			: undefined;
 		const attachments = message.attachments.map((att) => ({
 			id: att.guid,
-			url: `${config.serverUrl}/api/v1/attachment/${encodeURIComponent(att.guid)}?password=${encodeURIComponent(config.password)}`,
+			// Bare capability URL only — the server password is appended at fetch
+			// time inside BlueBubblesClient so stored memories never persist the
+			// credential (see BlueBubblesClient.getAttachmentUrl).
+			url: `${config.serverUrl}/api/v1/attachment/${encodeURIComponent(att.guid)}`,
 			title: att.transferName,
 			description: att.mimeType ?? undefined,
 			contentType: (att.mimeType ?? "application/octet-stream") as ContentType,
@@ -1301,6 +1321,43 @@ export class BlueBubblesService extends Service {
 		}
 
 		await this.processMessage(memory, room, chat.guid);
+	}
+
+	/**
+	 * Gates an unpaired DM sender through the core PairingService. Returns true
+	 * when the sender is already approved; otherwise a pairing request is
+	 * created (or refreshed) and, when a new code was issued, the pairing reply
+	 * is sent so the sender can ask the owner for approval.
+	 */
+	private async checkDmPairing(
+		senderHandle: string,
+		chatGuid: string,
+		message: BlueBubblesMessage,
+	): Promise<boolean> {
+		const pairing = await checkPairingAllowed(this.runtime, {
+			channel: "imessage",
+			senderId: normalizeHandle(senderHandle),
+			metadata: { name: message.handle?.address ?? senderHandle },
+		});
+		if (pairing.allowed) {
+			return true;
+		}
+
+		logger.debug(
+			`Ignoring message from ${senderHandle} - pairing not approved`,
+		);
+		if (pairing.replyMessage) {
+			try {
+				await this.sendMessage(chatGuid, pairing.replyMessage);
+			} catch (error) {
+				// error-policy:J7 a failed pairing-code reply must not fail webhook
+				// ingestion; the pending request remains visible for owner approval.
+				logger.warn(
+					`Failed to send BlueBubbles pairing reply to ${senderHandle}: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/plugins/plugin-imessage/AGENTS.md
+++ b/plugins/plugin-imessage/AGENTS.md
@@ -91,7 +91,7 @@ All read via `runtime.getSetting(key)` with `process.env[key]` fallback. None re
 | `IMESSAGE_DB_PATH` | `~/Library/Messages/chat.db` | Override chat.db path |
 | `IMESSAGE_POLL_INTERVAL_MS` | `5000` | How often (ms) to poll chat.db for new rows; `0` disables polling |
 | `IMESSAGE_HEARTBEAT_INTERVAL_MS` | `60000` | How often (ms) to run the heartbeat health check against chat.db |
-| `IMESSAGE_DM_POLICY` | `"pairing"` | `open` / `pairing` / `allowlist` / `disabled` |
+| `IMESSAGE_DM_POLICY` | `"pairing"` | `open` / `pairing` / `allowlist` / `disabled` — `pairing` holds unknown senders through the core PairingService code handshake; it never defaults open |
 | `IMESSAGE_GROUP_POLICY` | `"allowlist"` | `open` / `allowlist` / `disabled` |
 | `IMESSAGE_ALLOW_FROM` | `""` | Comma-separated E.164 phones or iCloud emails for allowlist |
 | `IMESSAGE_ENABLED` | `"true"` | Set to `"false"` to disable |
@@ -141,6 +141,7 @@ Config block in character settings:
 - **Bun:sqlite / node:sqlite dual runtime.** `chatdb-reader.ts` tries `bun:sqlite` first, then `node:sqlite`. Neither runtime ships both. If chat.db can't be opened, the service degrades silently (logs a warning, returns send-only status).
 - **Single macOS account model.** `DEFAULT_ACCOUNT_ID = "default"`. `assertLocalIMessageAccount` throws if a caller passes any other accountId. `accounts.ts` exposes connector-account inventory and config merging for the local Messages account; run separate agent processes for separate macOS user sessions.
 - **Polling reentrancy guard.** `pollInFlight` prevents concurrent ticks from racing on the same cursor. If dispatch takes longer than `IMESSAGE_POLL_INTERVAL_MS`, ticks are dropped (not queued). This is intentional.
+- **DM `pairing` uses the core PairingService.** The connector has no pairing handshake of its own; unknown DM senders are held until the owner approves their pairing code. The pairing-code reply is an autonomous outbound text, so it is only sent when `IMESSAGE_AUTO_REPLY=true` (the same consent gate as agent-generated replies); pending requests are always visible in the pairing UI.
 - **Message chunking.** Messages over 4000 chars (`MAX_IMESSAGE_MESSAGE_LENGTH`) are split at newlines or spaces and sent as sequential AppleScript calls.
 - **BlueBubbles support.** `src/api/bluebubbles-routes.ts` exports a webhook handler for BlueBubbles (a third-party iMessage relay). It is exported from the plugin index but not auto-registered as a `Route[]`; the agent must mount it manually.
 - **No npm build deps.** Only `@elizaos/core` and `zod` at runtime. The build uses `build.ts` (not a tsdown config file) invoked via `bun run build.ts`.

--- a/plugins/plugin-imessage/CLAUDE.md
+++ b/plugins/plugin-imessage/CLAUDE.md
@@ -91,7 +91,7 @@ All read via `runtime.getSetting(key)` with `process.env[key]` fallback. None re
 | `IMESSAGE_DB_PATH` | `~/Library/Messages/chat.db` | Override chat.db path |
 | `IMESSAGE_POLL_INTERVAL_MS` | `5000` | How often (ms) to poll chat.db for new rows; `0` disables polling |
 | `IMESSAGE_HEARTBEAT_INTERVAL_MS` | `60000` | How often (ms) to run the heartbeat health check against chat.db |
-| `IMESSAGE_DM_POLICY` | `"pairing"` | `open` / `pairing` / `allowlist` / `disabled` |
+| `IMESSAGE_DM_POLICY` | `"pairing"` | `open` / `pairing` / `allowlist` / `disabled` — `pairing` holds unknown senders through the core PairingService code handshake; it never defaults open |
 | `IMESSAGE_GROUP_POLICY` | `"allowlist"` | `open` / `allowlist` / `disabled` |
 | `IMESSAGE_ALLOW_FROM` | `""` | Comma-separated E.164 phones or iCloud emails for allowlist |
 | `IMESSAGE_ENABLED` | `"true"` | Set to `"false"` to disable |
@@ -141,6 +141,7 @@ Config block in character settings:
 - **Bun:sqlite / node:sqlite dual runtime.** `chatdb-reader.ts` tries `bun:sqlite` first, then `node:sqlite`. Neither runtime ships both. If chat.db can't be opened, the service degrades silently (logs a warning, returns send-only status).
 - **Single macOS account model.** `DEFAULT_ACCOUNT_ID = "default"`. `assertLocalIMessageAccount` throws if a caller passes any other accountId. `accounts.ts` exposes connector-account inventory and config merging for the local Messages account; run separate agent processes for separate macOS user sessions.
 - **Polling reentrancy guard.** `pollInFlight` prevents concurrent ticks from racing on the same cursor. If dispatch takes longer than `IMESSAGE_POLL_INTERVAL_MS`, ticks are dropped (not queued). This is intentional.
+- **DM `pairing` uses the core PairingService.** The connector has no pairing handshake of its own; unknown DM senders are held until the owner approves their pairing code. The pairing-code reply is an autonomous outbound text, so it is only sent when `IMESSAGE_AUTO_REPLY=true` (the same consent gate as agent-generated replies); pending requests are always visible in the pairing UI.
 - **Message chunking.** Messages over 4000 chars (`MAX_IMESSAGE_MESSAGE_LENGTH`) are split at newlines or spaces and sent as sequential AppleScript calls.
 - **BlueBubbles support.** `src/api/bluebubbles-routes.ts` exports a webhook handler for BlueBubbles (a third-party iMessage relay). It is exported from the plugin index but not auto-registered as a `Route[]`; the agent must mount it manually.
 - **No npm build deps.** Only `@elizaos/core` and `zod` at runtime. The build uses `build.ts` (not a tsdown config file) invoked via `bun run build.ts`.

--- a/plugins/plugin-imessage/README.md
+++ b/plugins/plugin-imessage/README.md
@@ -122,7 +122,7 @@ iMessage supports multiple target types:
 | Policy | Description |
 |--------|-------------|
 | `open` | Accept DMs from anyone |
-| `pairing` | Accept DMs and remember senders |
+| `pairing` (default) | Accept senders in `IMESSAGE_ALLOW_FROM` immediately; hold unknown senders through the core PairingService handshake — they are admitted once the owner approves their pairing code (`pairing approve imessage <code>` or the pairing UI). The pairing-code reply is only texted to the sender when `IMESSAGE_AUTO_REPLY=true` |
 | `allowlist` | Only accept from IMESSAGE_ALLOW_FROM list |
 | `disabled` | Don't accept any DMs |
 

--- a/plugins/plugin-imessage/__tests__/dm-policy.test.ts
+++ b/plugins/plugin-imessage/__tests__/dm-policy.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Covers the DM access gate for the "pairing" policy: unknown senders are
+ * held through the core PairingService handshake (a request is created and the
+ * one-time code is returned for the consent-gated reply) instead of being
+ * silently allowed, pairing-approved senders and static allowlist entries
+ * pass, a missing PairingService fails closed, and open/allowlist/disabled
+ * policies keep their existing semantics. Runs the real IMessageService
+ * against a stub runtime with a mocked PairingService — no chat.db or macOS
+ * bridge.
+ */
+import { type IAgentRuntime, ServiceType, type UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { IMessageService } from "../src/service.js";
+import type { IMessageSettings } from "../src/types.js";
+
+type DmAccess = { allowed: boolean; pairingReplyMessage?: string };
+type ServiceInternals = {
+  settings: IMessageSettings | null;
+  checkDmAccess(handle: string): Promise<DmAccess>;
+  isAutoReplyEnabled(): boolean;
+};
+
+function makeSettings(overrides: Partial<IMessageSettings> = {}): IMessageSettings {
+  return {
+    cliPath: "imsg",
+    pollIntervalMs: 5000,
+    heartbeatIntervalMs: 60000,
+    dmPolicy: "pairing",
+    groupPolicy: "allowlist",
+    allowFrom: [],
+    enabled: true,
+    ...overrides,
+  };
+}
+
+function makeService(
+  settings: IMessageSettings,
+  options: {
+    pairingAllowed?: boolean;
+    pairingService?: boolean;
+    settings?: Record<string, unknown>;
+  } = {}
+) {
+  const pairingService = {
+    isAllowed: vi.fn(async () => options.pairingAllowed ?? false),
+    upsertRequest: vi.fn(async () => ({ code: "PAIRCODE1", created: true })),
+  };
+  const runtime = {
+    agentId: "agent-1" as UUID,
+    getSetting: (key: string) => options.settings?.[key],
+    getService: (serviceType: string) =>
+      serviceType === ServiceType.PAIRING && options.pairingService !== false
+        ? pairingService
+        : null,
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime;
+  const service = new IMessageService(runtime);
+  const internals = service as unknown as ServiceInternals;
+  internals.settings = settings;
+  return { service, internals, runtime, pairingService };
+}
+
+describe("iMessage DM pairing gate", () => {
+  it("holds an unknown sender and returns the pairing-code reply message", async () => {
+    const { internals, pairingService } = makeService(makeSettings());
+
+    const access = await internals.checkDmAccess("+14155552671");
+
+    expect(access.allowed).toBe(false);
+    expect(access.pairingReplyMessage).toContain("PAIRCODE1");
+    expect(pairingService.isAllowed).toHaveBeenCalledWith("imessage", "+14155552671");
+    expect(pairingService.upsertRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "imessage",
+        senderId: "+14155552671",
+      })
+    );
+  });
+
+  it("admits a pairing-approved sender without a reply message", async () => {
+    const { internals, pairingService } = makeService(makeSettings(), {
+      pairingAllowed: true,
+    });
+
+    const access = await internals.checkDmAccess("+14155552671");
+
+    expect(access).toEqual({ allowed: true });
+    expect(pairingService.upsertRequest).not.toHaveBeenCalled();
+  });
+
+  it("admits a statically allowlisted sender without consulting pairing", async () => {
+    const { internals, pairingService } = makeService(
+      makeSettings({ allowFrom: ["+14155552671"] })
+    );
+
+    const access = await internals.checkDmAccess("+14155552671");
+
+    expect(access).toEqual({ allowed: true });
+    expect(pairingService.isAllowed).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the PairingService is not registered", async () => {
+    const { internals, runtime } = makeService(makeSettings(), {
+      pairingService: false,
+    });
+
+    const access = await internals.checkDmAccess("+14155552671");
+
+    expect(access.allowed).toBe(false);
+    expect(runtime.reportError).toHaveBeenCalled();
+  });
+
+  it("keeps open, allowlist, and disabled policy semantics", async () => {
+    const open = makeService(makeSettings({ dmPolicy: "open" }));
+    expect(await open.internals.checkDmAccess("+14155559999")).toEqual({
+      allowed: true,
+    });
+
+    const allowlist = makeService(
+      makeSettings({
+        dmPolicy: "allowlist",
+        allowFrom: ["alice@example.com"],
+      })
+    );
+    expect(await allowlist.internals.checkDmAccess("ALICE@example.com")).toEqual({ allowed: true });
+    expect(await allowlist.internals.checkDmAccess("+14155559999")).toEqual({
+      allowed: false,
+    });
+
+    const disabled = makeService(makeSettings({ dmPolicy: "disabled" }));
+    expect(await disabled.internals.checkDmAccess("+14155552671")).toEqual({
+      allowed: false,
+    });
+  });
+
+  it("gates autonomous replies on IMESSAGE_AUTO_REPLY", () => {
+    const off = makeService(makeSettings());
+    expect(off.internals.isAutoReplyEnabled()).toBe(false);
+
+    const on = makeService(makeSettings(), {
+      settings: { IMESSAGE_AUTO_REPLY: "true" },
+    });
+    expect(on.internals.isAutoReplyEnabled()).toBe(true);
+
+    const passive = makeService(makeSettings(), {
+      settings: {
+        IMESSAGE_AUTO_REPLY: "true",
+        ELIZA_LIFEOPS_PASSIVE_CONNECTORS: "true",
+      },
+    });
+    expect(passive.internals.isAutoReplyEnabled()).toBe(false);
+  });
+});

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -10,6 +10,7 @@ import {
   ChannelType,
   type Content,
   ContentType,
+  checkPairingAllowed,
   createUniqueUuid,
   type Entity,
   type EventPayload,
@@ -1429,8 +1430,23 @@ export class IMessageService extends Service implements IIMessageService {
         continue;
       }
 
-      // Policy gate: DM allowlist, group allowlist, disabled, etc.
-      if (!this.isAllowed(row.handle)) {
+      // Policy gate: DM allowlist, pairing handshake, disabled, etc.
+      const dmAccess = await this.checkDmAccess(row.handle);
+      if (!dmAccess.allowed) {
+        // A fresh pairing request carries a code for the owner-approval
+        // handshake. Delivering it is an autonomous outbound text, so it
+        // follows the same IMESSAGE_AUTO_REPLY consent gate as agent replies.
+        if (dmAccess.pairingReplyMessage && this.isAutoReplyEnabled()) {
+          const sendResult = await this.sendViaAppleScript(
+            row.handle,
+            dmAccess.pairingReplyMessage
+          );
+          if (!sendResult.success) {
+            logger.warn(
+              `[imessage] Pairing reply send failed for handle=${row.handle}: ${sendResult.error}`
+            );
+          }
+        }
         continue;
       }
 
@@ -1771,12 +1787,7 @@ export class IMessageService extends Service implements IIMessageService {
     // auto-generates a reply when IMESSAGE_AUTO_REPLY is explicitly enabled —
     // default-off prevents the runtime from speaking on the user's behalf to
     // real iMessage contacts.
-    const autoReplyRaw = this.runtime.getSetting("IMESSAGE_AUTO_REPLY");
-    const autoReply =
-      !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
-      (autoReplyRaw === true || autoReplyRaw === "true");
-
-    if (!autoReply) {
+    if (!this.isAutoReplyEnabled()) {
       // Persist the inbound memory so LifeOps and history views still see it.
       try {
         await this.runtime.createMemory(memory, "messages");
@@ -1872,27 +1883,69 @@ export class IMessageService extends Service implements IIMessageService {
     }
   }
 
-  private isAllowed(handle: string): boolean {
-    if (!this.settings) {
+  /**
+   * Whether the connector may autonomously send iMessages on the user's
+   * behalf. Default-off: requires IMESSAGE_AUTO_REPLY=true and LifeOps
+   * passive connectors disabled. Gates both agent-generated replies and the
+   * pairing-code reply sent to unpaired DM senders.
+   */
+  private isAutoReplyEnabled(): boolean {
+    if (!this.runtime) {
       return false;
+    }
+    const autoReplyRaw = this.runtime.getSetting("IMESSAGE_AUTO_REPLY");
+    return (
+      !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
+      (autoReplyRaw === true || autoReplyRaw === "true")
+    );
+  }
+
+  /**
+   * Evaluates the DM access policy for an inbound sender handle. The
+   * "pairing" policy has no connector-local handshake, so it delegates to the
+   * core PairingService: approved senders pass, everyone else is held with a
+   * pairing request (the reply message carries the one-time code when a new
+   * request was created) instead of being silently allowed through.
+   */
+  private async checkDmAccess(
+    handle: string
+  ): Promise<{ allowed: boolean; pairingReplyMessage?: string }> {
+    if (!this.settings) {
+      return { allowed: false };
     }
 
     if (this.settings.dmPolicy === "open") {
-      return true;
+      return { allowed: true };
     }
 
     if (this.settings.dmPolicy === "disabled") {
-      return false;
+      return { allowed: false };
     }
+
+    const inStaticAllowlist = this.settings.allowFrom.some(
+      (allowed) => allowed.toLowerCase() === handle.toLowerCase()
+    );
 
     if (this.settings.dmPolicy === "allowlist") {
-      return this.settings.allowFrom.some(
-        (allowed) => allowed.toLowerCase() === handle.toLowerCase()
-      );
+      return { allowed: inStaticAllowlist };
     }
 
-    // pairing - allow and track
-    return true;
+    // pairing — static allowlist entries pass directly, otherwise the core
+    // PairingService code handshake decides.
+    if (inStaticAllowlist) {
+      return { allowed: true };
+    }
+    if (!this.runtime) {
+      return { allowed: false };
+    }
+    const pairing = await checkPairingAllowed(this.runtime, {
+      channel: "imessage",
+      senderId: handle,
+    });
+    return {
+      allowed: pairing.allowed,
+      ...(pairing.replyMessage ? { pairingReplyMessage: pairing.replyMessage } : {}),
+    };
   }
 
   /**

--- a/plugins/plugin-telegram/src/standalone/handler.test.ts
+++ b/plugins/plugin-telegram/src/standalone/handler.test.ts
@@ -2,7 +2,7 @@
  * Exercises standalone Telegram identity and redelivery behavior with a
  * deterministic runtime double and no network transport.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, logger } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveTelegramRuntimeEntityId } from "../identity";
 import { handleTelegramStandaloneMessage } from "./handler";
@@ -117,5 +117,22 @@ describe("standalone Telegram durable identity", () => {
       expect.any(Error),
       { accountId: "default", chatId: "111" },
     );
+  });
+
+  it("keeps inbound message content out of production logs", async () => {
+    const { runtime } = makeRuntime();
+    const infoSpy = vi.spyOn(logger, "info");
+    const update = context(111, 9);
+    (update as { message: { text: string } }).message.text =
+      "secret hunter2 passphrase";
+
+    await handleTelegramStandaloneMessage(runtime, update as never);
+
+    // The receipt is still logged at info — just without the content.
+    expect(infoSpy).toHaveBeenCalled();
+    const logged = infoSpy.mock.calls.flat().join(" ");
+    expect(logged).not.toContain("hunter2");
+    expect(logged).not.toContain("passphrase");
+    infoSpy.mockRestore();
   });
 });

--- a/plugins/plugin-telegram/src/standalone/handler.ts
+++ b/plugins/plugin-telegram/src/standalone/handler.ts
@@ -161,7 +161,7 @@ export async function handleTelegramStandaloneMessage(
     }
 
     logger.info(
-      `[telegram-standalone] Telegram message from @${username}: ${text.substring(0, 80)}`,
+      `[telegram-standalone] Telegram message from @${username} chat=${chatId} length=${text.length}`,
     );
 
     if (!runtime.messageService) {

--- a/plugins/plugin-wechat/AGENTS.md
+++ b/plugins/plugin-wechat/AGENTS.md
@@ -124,10 +124,18 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
 - **Login flow.** On first start (or after session expiry), `WechatChannel`
   polls for QR-code login. `displayQRUrl` prints the URL; the user must scan it
   via the WeChat mobile app within `loginTimeoutMs` (default 5 min).
-- **Webhook port.** The local HTTP server (`src/callback-server.ts`) listens on
-  `ELIZA_WECHAT_WEBHOOK_PORT` → `config.webhookPort` → `18790`. In multi-account
-  mode, accounts sharing a port share one server; each gets its own URL path
-  (`/webhook/wechat/<accountId>`). Port conflicts throw at startup.
+- **Webhook port.** The local HTTP server (`src/callback-server.ts`) binds
+  `127.0.0.1` only and listens on `ELIZA_WECHAT_WEBHOOK_PORT` →
+  `config.webhookPort` → `18790`. The proxy registers a
+  `http://127.0.0.1:<port>` webhook URL, so it must run on the same host; the
+  static API key travels over plaintext HTTP and loopback binding keeps it off
+  the LAN. In multi-account mode, accounts sharing a port share one server;
+  each gets its own URL path (`/webhook/wechat/<accountId>`). Port conflicts
+  throw at startup.
+- **Proxy vouches for sender identity.** The proxy operator holds the API key
+  and its webhook payloads are trusted as delivered, so owner-pairing over
+  WeChat extends full OWNER trust to the proxy operator — see the README
+  security model.
 - **Webhook fail-closed.** Malformed percent-encoding in an account path returns
   404. A present `data` field is authoritative and must be a plain object; it
   never falls through to the flattened format. Only an actually absent

--- a/plugins/plugin-wechat/CLAUDE.md
+++ b/plugins/plugin-wechat/CLAUDE.md
@@ -124,10 +124,18 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
 - **Login flow.** On first start (or after session expiry), `WechatChannel`
   polls for QR-code login. `displayQRUrl` prints the URL; the user must scan it
   via the WeChat mobile app within `loginTimeoutMs` (default 5 min).
-- **Webhook port.** The local HTTP server (`src/callback-server.ts`) listens on
-  `ELIZA_WECHAT_WEBHOOK_PORT` → `config.webhookPort` → `18790`. In multi-account
-  mode, accounts sharing a port share one server; each gets its own URL path
-  (`/webhook/wechat/<accountId>`). Port conflicts throw at startup.
+- **Webhook port.** The local HTTP server (`src/callback-server.ts`) binds
+  `127.0.0.1` only and listens on `ELIZA_WECHAT_WEBHOOK_PORT` →
+  `config.webhookPort` → `18790`. The proxy registers a
+  `http://127.0.0.1:<port>` webhook URL, so it must run on the same host; the
+  static API key travels over plaintext HTTP and loopback binding keeps it off
+  the LAN. In multi-account mode, accounts sharing a port share one server;
+  each gets its own URL path (`/webhook/wechat/<accountId>`). Port conflicts
+  throw at startup.
+- **Proxy vouches for sender identity.** The proxy operator holds the API key
+  and its webhook payloads are trusted as delivered, so owner-pairing over
+  WeChat extends full OWNER trust to the proxy operator — see the README
+  security model.
 - **Webhook fail-closed.** Malformed percent-encoding in an account path returns
   404. A present `data` field is authoritative and must be a plain object; it
   never falls through to the flattened format. Only an actually absent

--- a/plugins/plugin-wechat/README.md
+++ b/plugins/plugin-wechat/README.md
@@ -69,7 +69,8 @@ npx elizaos plugins add @elizaos/plugin-wechat
 ## How it works
 
 1. On agent startup the plugin reads config, spins up a local HTTP webhook
-   server (default port 18790), and connects to the proxy.
+   server (default port 18790, bound to `127.0.0.1` only), and connects to the
+   proxy.
 2. If the WeChat session is not active, it fetches a QR-code login URL and
    prints it to the terminal. Scan it with the WeChat mobile app.
 3. Once logged in, the proxy pushes inbound messages to the webhook server.
@@ -78,4 +79,17 @@ npx elizaos plugins add @elizaos/plugin-wechat
 4. Outgoing replies are chunked at 2 000 characters and sent back via the proxy.
 5. A background health check runs every 60 seconds and re-initiates login if
    the session expires.
+
+## Security model
+
+- The webhook receiver binds `127.0.0.1` and registers a
+  `http://127.0.0.1:<port>/webhook/wechat/<accountId>` URL with the proxy, so
+  the proxy must run on the same host. The static API key authenticates
+  webhook POSTs but travels over plaintext HTTP — loopback binding keeps it
+  off the LAN.
+- The proxy operator holds the API key and vouches for sender identities:
+  sender wxids in webhook payloads are trusted as delivered. Pairing your
+  owner account over WeChat therefore extends full OWNER trust to the proxy
+  operator — a forged POST naming the owner's wxid produces OWNER-role turns.
+  Only pair owners over WeChat with a proxy you control.
 

--- a/plugins/plugin-wechat/src/callback-server.test.ts
+++ b/plugins/plugin-wechat/src/callback-server.test.ts
@@ -153,6 +153,29 @@ describe("webhook server malformed-path handling (#19060)", () => {
     closers.length = 0;
   });
 
+  it("binds loopback only so the plaintext-HTTP API key stays off the LAN", async () => {
+    const received: WechatMessageContext[] = [];
+    const handle = await startCallbackServer({
+      port: 0,
+      accounts: [{ accountId: "main", apiKey: "key-main" }],
+      onMessage: (_accountId, msg) => {
+        received.push(msg);
+      },
+    });
+    closers.push(handle.close);
+
+    expect(handle.host).toBe("127.0.0.1");
+    const res = await requestRaw(handle.port, "/webhook/wechat/main", {
+      headers: {
+        "x-api-key": "key-main",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(basePayload()),
+    });
+    expect(res.status).toBe(200);
+    expect(received).toHaveLength(1);
+  });
+
   async function startServer(
     received: WechatMessageContext[],
     accounts = [

--- a/plugins/plugin-wechat/src/callback-server.ts
+++ b/plugins/plugin-wechat/src/callback-server.ts
@@ -2,8 +2,10 @@
  * Local HTTP webhook server that receives inbound messages POSTed by the WeChat
  * proxy service, authenticates them (constant-time token compare), and
  * normalizes the raw proxy payloads into `WechatMessageContext` for the bot.
- * `WECHAT_TYPE_MAP` translates the proxy's numeric message types into the
- * plugin's message-type + private/group scope.
+ * Binds loopback only — the proxy registers a 127.0.0.1 webhook URL and the
+ * static API key travels over plaintext HTTP. `WECHAT_TYPE_MAP` translates the
+ * proxy's numeric message types into the plugin's message-type + private/group
+ * scope.
  */
 import { timingSafeEqual } from "node:crypto";
 import {
@@ -34,6 +36,14 @@ const WECHAT_TYPE_MAP: Record<
 
 const DEFAULT_MAX_REQUEST_BODY_BYTES = 1024 * 1024;
 
+/**
+ * The proxy registers a `http://127.0.0.1:<port>` webhook URL (channel.ts),
+ * so the receiver only ever serves same-host callers. Binding loopback keeps
+ * the static API key — which travels over plaintext HTTP — off every LAN and
+ * external interface.
+ */
+const WEBHOOK_BIND_HOST = "127.0.0.1";
+
 export interface CallbackServerOptions {
   port: number;
   accounts: Array<{ accountId: string; apiKey: string }>;
@@ -51,6 +61,7 @@ export async function startCallbackServer(
 ): Promise<{
   close: () => Promise<void>;
   port: number;
+  host: string;
 }> {
   const {
     port,
@@ -163,12 +174,14 @@ export async function startCallbackServer(
 
     server.once("listening", handleListening);
     server.once("error", handleError);
-    server.listen(port);
+    server.listen(port, WEBHOOK_BIND_HOST);
   });
 
   const address = server.address() as AddressInfo | null;
   const listeningPort = address?.port ?? port;
-  console.log(`[wechat] Webhook server listening on port ${listeningPort}`);
+  console.log(
+    `[wechat] Webhook server listening on ${WEBHOOK_BIND_HOST}:${listeningPort}`,
+  );
 
   server.on("error", (err: Error) => {
     if ((err as NodeJS.ErrnoException).code === "EADDRINUSE") {
@@ -193,6 +206,7 @@ export async function startCallbackServer(
   return {
     close: () => closeServer(server),
     port: listeningPort,
+    host: WEBHOOK_BIND_HOST,
   };
 }
 

--- a/plugins/plugin-wechat/src/channel.ts
+++ b/plugins/plugin-wechat/src/channel.ts
@@ -114,7 +114,10 @@ export class WechatChannel {
 
       // Login flow
       await this.ensureLoggedIn(account.id, client);
-      const webhookUrl = `http://localhost:${account.webhookPort}/webhook/wechat/${account.id}`;
+      // The callback server binds 127.0.0.1; register the literal IPv4
+      // loopback so a same-host proxy never resolves localhost to ::1 and
+      // misses the listener.
+      const webhookUrl = `http://127.0.0.1:${account.webhookPort}/webhook/wechat/${account.id}`;
 
       try {
         await client.registerWebhook(webhookUrl);


### PR DESCRIPTION
## Summary

Security-hardening fixes for four messaging plugins, mapped to the wave-1 audit findings they resolve. Each fix is scoped to one plugin and ships with contract tests.

- **W1-016 / W1-054 — `plugin-bluebubbles`, `plugin-imessage`: the default `pairing` DM policy had no handshake behind it and defaulted open.** Unknown DM senders are now held through the core `PairingService` code handshake (the same flow WhatsApp/Discord use): statically allowlisted and pairing-approved senders pass; everyone else is held with a pairing request until the owner approves. On iMessage the pairing-code reply is treated as an autonomous outbound text and is only sent under the existing `IMESSAGE_AUTO_REPLY=true` consent gate (that gate is now shared via `isAutoReplyEnabled()`); BlueBubbles mirrors the WhatsApp behavior and texts the one-time code once per new request. Empty allow lists now fail closed instead of allowing first contact.
- **W1-017 — `plugin-bluebubbles`: inbound attachment URLs persisted the BlueBubbles server password (the whole REST API credential) into the message store.** Memories now carry the bare `/api/v1/attachment/<guid>` capability URL; the password is appended only at fetch time via the new `BlueBubblesClient.getAttachmentUrl()`. See risk notes for previously persisted rows.
- **W1-055 — `plugin-wechat`: the webhook receiver bound every interface while authenticating with a static API key over plaintext HTTP.** It now binds `127.0.0.1` only, and the webhook URL registered with the proxy uses literal IPv4 loopback so a same-host proxy never resolves `localhost` to `::1` and misses the listener. The README gains a security-model section documenting that the proxy vouches for sender identities, so owner-pairing over WeChat extends full OWNER trust to the proxy operator.
- **W1-057 — `plugin-telegram`: the standalone handler logged the first 80 characters of every inbound message at info level.** The receipt log now records only sender, chat id, and text length, matching the peer-connector convention (content at debug or not at all).
- **W1-056 — `plugin-x` loopback OAuth state:** already fixed upstream on `develop` (#20508); no change needed.

Docs: each plugin's README + AGENTS/CLAUDE now describe the new pairing semantics and the WeChat trust model; `AGENTS.md`/`CLAUDE.md` parity verified with `bun run check:agents-claude` (155 pairs pass).

## Test evidence

All run on the rebased branch (origin/develop @ 303b66dc9bf1):

| Package | Command | Result |
|---|---|---|
| plugin-bluebubbles | `bun run test` | 59/59 pass (7 files), incl. new `__tests__/inbound-policy.test.ts` (5 tests: pairing hold + one-time code reply, no re-send for pending senders, approved-sender ingest with bare attachment URLs, static allowlist bypass, allowlist stays closed) |
| plugin-bluebubbles | `bun run typecheck` / `lint:check` | PASS |
| plugin-imessage | `bun run test` | 153/153 pass (12 files), incl. new `__tests__/dm-policy.test.ts` (6 tests: pairing hold + code, approved pass, static allowlist, fail-closed without PairingService, open/allowlist/disabled semantics, auto-reply consent gate) |
| plugin-imessage | `bun run typecheck` / `lint:check` | PASS |
| plugin-wechat | `bun run test` | 35/35 pass (3 files), incl. new loopback-binding test against a real listener |
| plugin-wechat | `bun run typecheck` / `lint:check` | PASS |
| plugin-telegram | `bun run test` | 177/177 pass (21 files), incl. new test asserting inbound content never reaches the info log |
| plugin-telegram | `bun run typecheck` / `lint:check` | PASS |

## Risk notes

- **Behavior change (intended):** with the default `pairing` DM policy, BlueBubbles and iMessage no longer ingest/respond to unknown senders; first contact is held for owner approval (`pairing approve imessage <code>` or the pairing UI). Operators who want the old behavior can set `*_DM_POLICY=open` explicitly. On iMessage, unknown-sender DMs were previously ingested read-only; they are now dropped until paired.
- **W1-017 remediation scope:** previously stored memories still contain credential-bearing attachment URLs; this PR stops new writes. Rotating the BlueBubbles server password invalidates the persisted copies and is the recommended remediation (noted rather than automated — a store sweep would require scanning the full messages table).
- **WeChat:** deployments running the proxy on a *different* host were already broken in practice (the registered webhook URL was loopback); this change makes the loopback-only model explicit rather than adding a new restriction.
- No changes outside the four plugin workspaces; no core API changes.