### PR TITLE
fix(cloud): push backup-catalog authority schema in wake-route suite

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-restore-body-guard.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-restore-body-guard.test.ts
@@ -94,8 +94,11 @@ beforeAll(async () => {
     const { organizations } = await import("@/db/schemas/organizations");
     const { users } = await import("@/db/schemas/users");
     const { userCharacters } = await import("@/db/schemas/user-characters");
-    const { agentSandboxes, agentSandboxBackups, agentBackupCatalogAuthorities } =
-      await import("@/db/schemas/agent-sandboxes");
+    const {
+      agentSandboxes,
+      agentSandboxBackups,
+      agentBackupCatalogAuthorities,
+    } = await import("@/db/schemas/agent-sandboxes");
     const { agentBackupObjects } = await import(
       "@/db/schemas/agent-backup-catalog"
     );

--- a/packages/cloud/api/__tests__/eliza-agents-wake-route.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-wake-route.test.ts
@@ -149,8 +149,13 @@ beforeAll(async () => {
     const { organizations } = await import("@/db/schemas/organizations");
     const { users } = await import("@/db/schemas/users");
     const { userCharacters } = await import("@/db/schemas/user-characters");
-    const { agentSandboxes, agentSandboxBackups } = await import(
-      "@/db/schemas/agent-sandboxes"
+    const {
+      agentSandboxes,
+      agentSandboxBackups,
+      agentBackupCatalogAuthorities,
+    } = await import("@/db/schemas/agent-sandboxes");
+    const { agentBackupObjects } = await import(
+      "@/db/schemas/agent-backup-catalog"
     );
     const { apiKeys } = await import("@/db/schemas/api-keys");
     const { generations } = await import("@/db/schemas/generations");
@@ -165,6 +170,8 @@ beforeAll(async () => {
       userCharacters,
       agentSandboxes,
       agentSandboxBackups,
+      agentBackupCatalogAuthorities,
+      agentBackupObjects,
       apiKeys,
       generations,
       jobs,


### PR DESCRIPTION
Final member of the #21258 drift class: eliza-agents-wake-route.test.ts pushes its own schema subset and the wake path now reads `agent_backup_catalog_authorities` (release candidate run 32023848726 failed its setup with the missing relation). Adds the authority/object schemas to the subset. Suite 17/17 locally; cloud-api Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)