### PR TITLE
fix(plugin-agent-orchestrator): reject unknown issues state

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/issue-routes.state.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/issue-routes.state.test.ts
@@ -1,0 +1,130 @@
+/**
+ * GET /api/issues `state` is list-filter identity, leftover tax after
+ * orchestrator includeArchived (#21265). Stock develop cast any token
+ * through to listIssues, so `state=OPEN` / `foo` / `1` kept an unknown
+ * catalog value instead of a 400. labels / repo stay untouched.
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core/client-public", () => ({
+  resolveAliasedEnvValue: (key: string) => process.env[key],
+  isTruthyEnvValue: () => false,
+  isElizaSettingsDebugEnabled: () => false,
+  sanitizeForSettingsDebug: (value: unknown) => value,
+  settingsDebugCloudSummary: () => ({}),
+  sanitizeSpeechText: (value: string) => value,
+  formatError: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+}));
+
+import { handleIssueRoutes } from "../../src/api/issue-routes.js";
+import type { RouteContext } from "../../src/api/route-utils.js";
+
+const listIssues = vi.fn(async () => [{ number: 1, title: "one" }]);
+
+function ctxWithList(): RouteContext {
+  return {
+    runtime: {},
+    acpService: null,
+    workspaceService: { listIssues },
+  } as never;
+}
+
+function makeReq(url: string): IncomingMessage {
+  const stream = Readable.from([]);
+  return Object.assign(stream, {
+    method: "GET",
+    url,
+    headers: { host: "localhost" },
+  }) as unknown as IncomingMessage;
+}
+
+class CapturingResponse {
+  statusCode = 0;
+  body = "";
+  writeHead(status: number): this {
+    this.statusCode = status;
+    return this;
+  }
+  end(chunk?: string): this {
+    if (chunk !== undefined) this.body = chunk;
+    return this;
+  }
+  json(): Record<string, unknown> {
+    return this.body ? (JSON.parse(this.body) as Record<string, unknown>) : {};
+  }
+}
+
+async function list(query: string) {
+  const req = makeReq(`/api/issues?repo=acme/widgets${query}`);
+  const res = new CapturingResponse();
+  const matched = await handleIssueRoutes(
+    req,
+    res as unknown as ServerResponse,
+    "/api/issues",
+    ctxWithList(),
+  );
+  expect(matched).toBe(true);
+  return { status: res.statusCode, body: res.json() };
+}
+
+describe("GET /api/issues state identity", () => {
+  beforeEach(() => {
+    listIssues.mockClear();
+  });
+
+  it.each(["", "&state=", "&state=open"])(
+    "accepts %s as the open-issue list",
+    async (query) => {
+      const result = await list(query);
+      expect(result.status).toBe(200);
+      expect(listIssues).toHaveBeenCalledTimes(1);
+      expect(listIssues).toHaveBeenCalledWith("acme/widgets", {
+        state: "open",
+        labels: undefined,
+      });
+    },
+  );
+
+  it("accepts state=closed as the closed-issue list", async () => {
+    const result = await list("&state=closed");
+    expect(result.status).toBe(200);
+    expect(listIssues).toHaveBeenCalledWith("acme/widgets", {
+      state: "closed",
+      labels: undefined,
+    });
+  });
+
+  it("accepts state=all as the unfiltered list", async () => {
+    const result = await list("&state=all");
+    expect(result.status).toBe(200);
+    expect(listIssues).toHaveBeenCalledWith("acme/widgets", {
+      state: "all",
+      labels: undefined,
+    });
+  });
+
+  it.each(["OPEN", "CLOSED", "ALL", "1", "0", "true", "foo", "1e2"])(
+    "rejects state=%s before listIssues",
+    async (token) => {
+      const result = await list(`&state=${encodeURIComponent(token)}`);
+      expect(result.status).toBe(400);
+      expect(result.body).toEqual({ error: "Invalid state" });
+      expect(listIssues).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    "&state=open&state=open",
+    "&state=open&state=closed",
+    "&state=&state=open",
+    "&state=foo&state=open",
+  ])("rejects duplicate state values in %s before listIssues", async (query) => {
+    const result = await list(query);
+    expect(result.status).toBe(400);
+    expect(result.body).toEqual({ error: "Invalid state" });
+    expect(listIssues).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/api/issue-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/issue-routes.ts
@@ -18,6 +18,33 @@ import {
   sendJson,
 } from "./route-utils.js";
 
+const ISSUE_LIST_STATES = ["open", "closed", "all"] as const;
+type IssueListState = (typeof ISSUE_LIST_STATES)[number];
+
+/**
+ * GET /api/issues `state` is list-filter identity, leftover tax after
+ * orchestrator includeArchived (#21265). Stock develop cast any token
+ * through to listIssues, so `state=OPEN` / `foo` / `1` kept an unknown
+ * catalog value instead of a 400. labels / repo stay untouched.
+ * Missing / empty still means open (today's default).
+ */
+function parseIssuesStateQuery(
+  searchParams: URLSearchParams,
+): IssueListState | "invalid" {
+  const requested = searchParams.getAll("state");
+  if (requested.length > 1) {
+    return "invalid";
+  }
+  const raw = requested[0];
+  if (raw == null || raw === "") {
+    return "open";
+  }
+  if ((ISSUE_LIST_STATES as readonly string[]).includes(raw)) {
+    return raw as IssueListState;
+  }
+  return "invalid";
+}
+
 /**
  * Handle issue routes (/api/issues/*)
  * Returns true if the route was handled, false otherwise
@@ -44,18 +71,18 @@ export async function handleIssueRoutes(
         sendError(res, "repo query parameter required", 400);
         return true;
       }
-      const state = url.searchParams.get("state") as
-        | "open"
-        | "closed"
-        | "all"
-        | null;
+      const state = parseIssuesStateQuery(url.searchParams);
+      if (state === "invalid") {
+        sendError(res, "Invalid state", 400);
+        return true;
+      }
       const labelsParam = url.searchParams.get("labels");
       const labels = labelsParam
         ? labelsParam.split(",").map((s) => s.trim())
         : undefined;
 
       const issues = await ctx.workspaceService.listIssues(repo, {
-        state: state ?? "open",
+        state,
         labels,
       });
       sendJson(res, issues);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on issues `state`
identity. List-filter class, leftover tax after orchestrator includeArchived
(#21265). Not a twin of that archive flag — this is `GET /api/issues` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `state` only on `/api/issues`. Omitted/empty still means open
(today's default). Exact `open` / `closed` / `all` still bind. Unknown /
uppercase / `1` / `foo` / duplicates 400 before `listIssues`. labels / repo
stay untouched.

# Background

## What does this PR do?

`GET /api/issues` cast any `state` token through to `listIssues`.
`state=OPEN` / `foo` / `1` silently kept an unknown catalog value instead of
a 400.

- omitted / empty → open (200)
- exact `open` / `closed` / `all` → that list filter
- `OPEN` / `CLOSED` / `ALL` / `1` / `true` / `foo` / `1e2` / duplicates → **400** before `listIssues`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers filter GitHub issues with `?state=open|closed|all`. A common
`state=OPEN` or garbage token must not silently change the list or become a
500 from the GitHub client. Leftover tax after orchestrator includeArchived
(#21265). Disjoint from gallery explore `limit`.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-orchestrator/__tests__/unit/issue-routes.state.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-agent-orchestrator && bunx vitest run --config vitest.config.ts __tests__/unit/issue-routes.state.test.ts
```

17 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; issues `state` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; issues `state` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; issues `state` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real state tokens and assert 400 before listIssues; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before listIssues.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal `state`
tokens reject; omitted/canonical still bind the matching list filter.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the issues `state` query
only.

## Known gaps / failures

`bun run verify` was not run. Focused 17-test identity suite passed at this
head. Full-repo verify is the same unrelated cost as sibling leftover-tax
Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:17f9595e05b4a1a6b38d5299b901a9e14718bad3 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
