### PR TITLE
fix(cloud): reject prefix-coerced gallery explore limit

### DIFF
--- a/packages/cloud/api/v1/gallery/explore/route.limit.test.ts
+++ b/packages/cloud/api/v1/gallery/explore/route.limit.test.ts
@@ -1,0 +1,100 @@
+/**
+ * GET /api/v1/gallery/explore `limit` is explore-page size identity,
+ * leftover tax after v1 gallery list pagination. Stock develop used
+ * parseClampedLimit, which treated `1e2` / `12px` / `007` / `foo` as
+ * the default 20 instead of a 400. type / status stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const listRandomPublicImageSummaries = mock(async () => [
+  {
+    id: "gen-1",
+    type: "image",
+    storage_url: "https://cdn.example/1.png",
+    thumbnail_url: null,
+    prompt_preview: "a cat",
+    model: "flux",
+    status: "completed",
+    created_at: "2026-08-17T00:00:00.000Z",
+    completed_at: "2026-08-17T00:00:01.000Z",
+    dimensions: "512x512",
+    mime_type: "image/png",
+    file_size: 12,
+  },
+]);
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { AGGRESSIVE: {}, STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_c: unknown, error: unknown) => {
+    throw error;
+  },
+}));
+mock.module("@/lib/services/generations", () => ({
+  generationsService: {
+    listRandomPublicImageSummaries,
+  },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/", route);
+
+describe("GET /api/v1/gallery/explore limit identity", () => {
+  beforeEach(() => {
+    listRandomPublicImageSummaries.mockClear();
+  });
+
+  test.each(["", "?limit=", "?limit"])(
+    "accepts %s as the default explore page of 20",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(200);
+      expect(listRandomPublicImageSummaries).toHaveBeenCalledTimes(1);
+      expect(listRandomPublicImageSummaries).toHaveBeenCalledWith(20);
+    },
+  );
+
+  test("accepts limit=10 as an exact explore page size", async () => {
+    const response = await app.request("/?limit=10");
+    expect(response.status).toBe(200);
+    expect(listRandomPublicImageSummaries).toHaveBeenCalledWith(10);
+  });
+
+  test("caps a canonical oversize limit at 100", async () => {
+    const response = await app.request("/?limit=101");
+    expect(response.status).toBe(200);
+    expect(listRandomPublicImageSummaries).toHaveBeenCalledWith(100);
+  });
+
+  test.each(["1e2", "12px", "007", "0", "abc", "-1", "50abc", " 10", "10 "])(
+    "rejects prefix-coerced limit=%s before listRandomPublicImageSummaries",
+    async (token) => {
+      const response = await app.request(
+        `/?limit=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid limit");
+      expect(listRandomPublicImageSummaries).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?limit=10&limit=10",
+    "?limit=10&limit=20",
+    "?limit=&limit=10",
+    "?limit=foo&limit=10",
+  ])(
+    "rejects duplicate limit values in %s before listRandomPublicImageSummaries",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid limit");
+      expect(listRandomPublicImageSummaries).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/gallery/explore/route.ts
+++ b/packages/cloud/api/v1/gallery/explore/route.ts
@@ -7,7 +7,6 @@
  * Mirrors `_legacy_actions/gallery.ts → listExploreImages`.
  */
 
-import { parseClampedLimit } from "@elizaos/cloud-shared/lib/utils/clamp-limit";
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import {
@@ -17,13 +16,57 @@ import {
 import { generationsService } from "@/lib/services/generations";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
+const DEFAULT_EXPLORE_LIMIT = 20;
+const MAX_EXPLORE_LIMIT = 100;
+
+class GalleryExploreLimitError extends Error {
+  constructor(message = "Invalid limit") {
+    super(message);
+    this.name = "GalleryExploreLimitError";
+  }
+}
+
+/**
+ * GET /api/v1/gallery/explore `limit` is explore-page size identity,
+ * leftover tax after v1 gallery list pagination. Stock develop used
+ * parseClampedLimit, which treated `1e2` / `12px` / `007` / `foo` as
+ * the default 20 instead of a 400. type / status stay untouched.
+ * Missing / empty still means 20. Exact integers clamp at 100.
+ */
+function parseExploreLimitQuery(searchParams: URLSearchParams): number {
+  const requested = searchParams.getAll("limit");
+  if (requested.length > 1) {
+    throw new GalleryExploreLimitError();
+  }
+  const raw = requested[0];
+  if (raw == null || raw === "") {
+    return DEFAULT_EXPLORE_LIMIT;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new GalleryExploreLimitError();
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new GalleryExploreLimitError();
+  }
+  return Math.min(parsed, MAX_EXPLORE_LIMIT);
+}
+
 const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.AGGRESSIVE));
 
 app.get("/", async (c) => {
   try {
-    const limit = parseClampedLimit(c.req.query("limit"), 20, 100);
+    let limit: number;
+    try {
+      limit = parseExploreLimitQuery(new URL(c.req.url).searchParams);
+    } catch (limitError) {
+      if (limitError instanceof GalleryExploreLimitError) {
+        return c.json({ error: limitError.message }, 400);
+      }
+      throw limitError;
+    }
 
     const generations =
       await generationsService.listRandomPublicImageSummaries(limit);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on gallery explore
`limit` identity. Page-size class, leftover tax after v1 gallery list
pagination. Not a twin of that list parser — this is
`GET /api/v1/gallery/explore` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `limit` only on `/api/v1/gallery/explore`. Omitted/empty still
means 20 (today's default). Exact positive integers still bind and clamp at
100. Prefix-coerced / unknown / duplicate tokens 400 before
`listRandomPublicImageSummaries`. type / status stay untouched.

# Background

## What does this PR do?

`GET /api/v1/gallery/explore` used `parseClampedLimit`, which treated
`1e2` / `12px` / `007` / `foo` as the default 20 instead of a 400.

- omitted / empty → 20 (200)
- exact `10` → page of 10
- exact `101` → clamped to 100
- `1e2` / `12px` / `007` / `0` / `foo` / duplicates → **400** before `listRandomPublicImageSummaries`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers page the public explore gallery with `?limit=`. A common `limit=1e2`
or `12px` after a client sends a numeric token must not silently become the
default page. Leftover tax after v1 gallery list pagination. Disjoint from
issues `state`.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/gallery/explore/route.limit.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test ./v1/gallery/explore/route.limit.test.ts
```

18 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; gallery explore `limit` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; gallery explore `limit` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; gallery explore `limit` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real limit tokens and assert 400 before listRandomPublicImageSummaries; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before listRandomPublicImageSummaries.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal `limit`
tokens reject; omitted/canonical still bind the matching explore page size.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the gallery explore `limit`
query only.

## Known gaps / failures

`bun run verify` was not run. Focused 18-test identity suite passed at this
head. Full-repo verify is the same unrelated cost as sibling leftover-tax
Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9b4771749a38e37a6e73d6e60c7b4be1c938689d -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
