### PR TITLE
fix(plugin-mcp): reject prefix-coerced marketplace search limit

### DIFF
--- a/plugins/plugin-mcp/__tests__/routes-mcp.test.ts
+++ b/plugins/plugin-mcp/__tests__/routes-mcp.test.ts
@@ -126,13 +126,12 @@ describe("handleMcpRoutes", () => {
   });
 
   it.each([
-    ["10junk", 30],
-    ["999", 50],
-    ["0", 1],
+    ["", 30],
     ["12", 12],
-  ])("sanitizes marketplace search limit %s to %s", async (rawLimit, expectedLimit) => {
+    ["999", 50],
+  ])("accepts marketplace search limit %s as %s", async (rawLimit, expectedLimit) => {
     const ctx = makeCtx("GET", "/api/mcp/marketplace/search", {
-      query: `?q=files&limit=${encodeURIComponent(rawLimit)}`,
+      query: rawLimit === "" ? "?q=files" : `?q=files&limit=${encodeURIComponent(rawLimit)}`,
     });
 
     await expect(handleMcpRoutes(ctx)).resolves.toBe(true);
@@ -143,6 +142,37 @@ describe("handleMcpRoutes", () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
     expect(ctx.response).toEqual({ status: 200, body: { ok: true, results: [] } });
+  });
+
+  it.each(["10junk", "1e2", "12px", "007", "0x10", "0", "-1", "foo", "Infinity"])(
+    "rejects marketplace search limit %s before the registry",
+    async (rawLimit) => {
+      const ctx = makeCtx("GET", "/api/mcp/marketplace/search", {
+        query: `?q=files&limit=${encodeURIComponent(rawLimit)}`,
+      });
+
+      await expect(handleMcpRoutes(ctx)).resolves.toBe(true);
+
+      expect(searchMcpMarketplace).not.toHaveBeenCalled();
+      expect(ctx.response).toEqual({
+        status: 400,
+        body: { ok: false, error: "Invalid limit" },
+      });
+    }
+  );
+
+  it("rejects duplicate marketplace search limit values before the registry", async () => {
+    const ctx = makeCtx("GET", "/api/mcp/marketplace/search", {
+      query: "?q=files&limit=12&limit=12",
+    });
+
+    await expect(handleMcpRoutes(ctx)).resolves.toBe(true);
+
+    expect(searchMcpMarketplace).not.toHaveBeenCalled();
+    expect(ctx.response).toEqual({
+      status: 400,
+      body: { ok: false, error: "Invalid limit" },
+    });
   });
 
   it("rejects oversized marketplace search queries before hitting the registry", async () => {

--- a/plugins/plugin-mcp/src/routes-mcp.ts
+++ b/plugins/plugin-mcp/src/routes-mcp.ts
@@ -62,13 +62,9 @@ export interface McpRouteConfig {
   };
 }
 
-interface ParseClampedIntegerOptions {
-  min?: number;
-  max?: number;
-  fallback?: number;
-}
-
 const MCP_MARKETPLACE_QUERY_MAX_LENGTH = 200;
+const DEFAULT_MARKETPLACE_LIMIT = 30;
+const MAX_MARKETPLACE_LIMIT = 50;
 const MCP_MARKETPLACE_SERVER_NAME_MAX_LENGTH = 200;
 const MCP_MARKETPLACE_DETAILS_PREFIX = "/api/mcp/marketplace/details/";
 const MCP_MARKETPLACE_DIRECT_DETAILS_PREFIX = "/api/mcp/marketplace/";
@@ -140,25 +136,37 @@ function createRequestAbortTracker(
   };
 }
 
-function parseClampedInteger(
-  value: string | null | undefined,
-  options: ParseClampedIntegerOptions = {}
-): number | undefined {
-  const raw = value == null ? "" : value.trim();
-  if (!raw) return Number.isFinite(options.fallback) ? options.fallback : undefined;
-
-  if (!/^[+-]?\d+$/.test(raw)) {
-    return Number.isFinite(options.fallback) ? options.fallback : undefined;
+class McpMarketplaceLimitError extends Error {
+  constructor(message = "Invalid limit") {
+    super(message);
+    this.name = "McpMarketplaceLimitError";
   }
+}
 
+/**
+ * GET /api/mcp/marketplace/search `limit` is registry page-size identity,
+ * leftover tax after gallery explore / inbox limits. Stock develop used
+ * parseClampedInteger, which treated `1e2` / `12px` / `10junk` as the
+ * default 30 instead of a 400. Missing / empty still means 30. Exact
+ * integers clamp at 50. q stays untouched.
+ */
+function parseMarketplaceLimitQuery(searchParams: URLSearchParams): number {
+  const requested = searchParams.getAll("limit");
+  if (requested.length > 1) {
+    throw new McpMarketplaceLimitError();
+  }
+  const raw = requested[0];
+  if (raw == null || raw === "") {
+    return DEFAULT_MARKETPLACE_LIMIT;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new McpMarketplaceLimitError();
+  }
   const parsed = Number(raw);
-  if (!Number.isSafeInteger(parsed)) {
-    return Number.isFinite(options.fallback) ? options.fallback : undefined;
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new McpMarketplaceLimitError();
   }
-
-  if (options.min !== undefined && parsed < options.min) return options.min;
-  if (options.max !== undefined && parsed > options.max) return options.max;
-  return parsed;
+  return Math.min(parsed, MAX_MARKETPLACE_LIMIT);
 }
 
 function normalizeBoundedString(value: string, maxLength: number, label: string): string {
@@ -197,8 +205,16 @@ export async function handleMcpRoutes(ctx: McpRouteContext): Promise<boolean> {
       error(res, err instanceof Error ? err.message : String(err), 400);
       return true;
     }
-    const limitStr = url.searchParams.get("limit");
-    const limit = limitStr ? parseClampedInteger(limitStr, { min: 1, max: 50, fallback: 30 }) : 30;
+    let limit: number;
+    try {
+      limit = parseMarketplaceLimitQuery(url.searchParams);
+    } catch (limitError) {
+      if (limitError instanceof McpMarketplaceLimitError) {
+        error(res, limitError.message, 400);
+        return true;
+      }
+      throw limitError;
+    }
     const abortTracker = createRequestAbortTracker(req, res, "MCP marketplace search");
     // error-policy:J1 marketplace boundary failures are translated to a 502 response.
     try {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on MCP marketplace
search `limit` identity. Page-size class, leftover tax after gallery explore
/ inbox limits. Not a twin of those parsers — this is
`GET /api/mcp/marketplace/search` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `limit` only on `/api/mcp/marketplace/search`. Omitted/empty still
means 30 (today's default). Exact positive integers still bind and clamp at
50. Prefix-coerced / unknown / duplicate tokens 400 before
`searchMcpMarketplace`. `q` stays untouched.

# Background

## What does this PR do?

`GET /api/mcp/marketplace/search` used `parseClampedInteger`, which treated
`1e2` / `12px` / `10junk` as the default 30 instead of a 400.

- omitted / empty → 30 (200)
- exact `10` → page of 10
- exact oversize → clamped to 50
- `1e2` / `12px` / `10junk` / `007` / `0` / `foo` / duplicates → **400** before `searchMcpMarketplace`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers page the MCP marketplace with `?limit=`. A common `limit=1e2` or
`10junk` after a client sends a numeric token must not silently become the
default page. Leftover tax after gallery explore / inbox limits. Disjoint
from gallery explore `limit` and issues `state`.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-mcp/__tests__/routes-mcp.test.ts`

## Detailed testing steps

```bash
bunx vitest run --config vitest.config.ts plugins/plugin-mcp/__tests__/routes-mcp.test.ts
```

25 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; marketplace search `limit` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; marketplace search `limit` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; marketplace search `limit` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real limit tokens and assert 400 before searchMcpMarketplace; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before searchMcpMarketplace.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal `limit`
tokens reject; omitted/canonical still bind the matching marketplace page size.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the marketplace search
`limit` query only.

## Known gaps / failures

`bun run verify` was not run. Focused 25-test identity suite passed at this
head. Full-repo verify is the same unrelated cost as sibling leftover-tax
Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:5239b9237f02518ce68b006910c0b819ca3ce970 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
