### PR TITLE
fix(cloud): reject prefix-coerced elevenlabs voices user limit

### DIFF
--- a/packages/cloud/api/elevenlabs/voices/user/route.limit.test.ts
+++ b/packages/cloud/api/elevenlabs/voices/user/route.limit.test.ts
@@ -1,0 +1,95 @@
+/**
+ * GET /api/elevenlabs/voices/user `limit` is voices-page size identity,
+ * leftover tax after files / gallery explore. Stock develop used
+ * z.coerce.number(), which treated `1e2` / `007` / `0x10` as a page
+ * size instead of a 400. includeInactive / cloneType / offset stay
+ * untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getUserVoices = mock(async () => []);
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: {
+      id: "user-1",
+      organization_id: "org-1",
+    },
+  }),
+}));
+mock.module("@/lib/api/errors", () => ({
+  getErrorStatusCode: () => 500,
+  getSafeErrorMessage: () => "error",
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn: () => undefined, info: () => undefined, error: () => undefined },
+}));
+mock.module("@/lib/services/voice-cloning", () => ({
+  voiceCloningService: { getUserVoices },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/", route);
+
+describe("GET /api/elevenlabs/voices/user limit identity", () => {
+  beforeEach(() => {
+    getUserVoices.mockClear();
+  });
+
+  test.each(["", "?limit=", "?limit"])(
+    "accepts %s as the default voices page of 50",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { limit: number };
+      expect(body.limit).toBe(50);
+      expect(getUserVoices).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test("accepts limit=10 as an exact voices page size", async () => {
+    const response = await app.request("/?limit=10");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { limit: number };
+    expect(body.limit).toBe(10);
+    expect(getUserVoices).toHaveBeenCalledTimes(1);
+  });
+
+  test("caps a canonical oversize limit at 100", async () => {
+    const response = await app.request("/?limit=101");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { limit: number };
+    expect(body.limit).toBe(100);
+    expect(getUserVoices).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["1e2", "12px", "007", "0", "abc", "-1", "50abc", " 10", "10 ", "0x10"])(
+    "rejects prefix-coerced limit=%s before voiceCloningService.getUserVoices",
+    async (token) => {
+      const response = await app.request(
+        `/?limit=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid limit");
+      expect(getUserVoices).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?limit=10&limit=10",
+    "?limit=10&limit=20",
+    "?limit=&limit=10",
+    "?limit=foo&limit=10",
+  ])(
+    "rejects duplicate limit values in %s before voiceCloningService.getUserVoices",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid limit");
+      expect(getUserVoices).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/elevenlabs/voices/user/route.ts
+++ b/packages/cloud/api/elevenlabs/voices/user/route.ts
@@ -7,13 +7,49 @@ import { voiceCloningService } from "@/lib/services/voice-cloning";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
+const DEFAULT_USER_VOICES_LIMIT = 50;
+const MAX_USER_VOICES_LIMIT = 100;
+
+class UserVoicesLimitError extends Error {
+  constructor(message = "Invalid limit") {
+    super(message);
+    this.name = "UserVoicesLimitError";
+  }
+}
+
+/**
+ * GET /api/elevenlabs/voices/user `limit` is voices-page size identity,
+ * leftover tax after files / gallery explore. Stock develop used
+ * z.coerce.number(), which treated `1e2` / `007` / `0x10` as a page
+ * size instead of a 400. includeInactive / cloneType / offset stay
+ * untouched. Missing / empty still means 50. Exact integers clamp at
+ * 100.
+ */
+function parseUserVoicesLimitQuery(searchParams: URLSearchParams): number {
+  const requested = searchParams.getAll("limit");
+  if (requested.length > 1) {
+    throw new UserVoicesLimitError();
+  }
+  const raw = requested[0];
+  if (raw == null || raw === "") {
+    return DEFAULT_USER_VOICES_LIMIT;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new UserVoicesLimitError();
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new UserVoicesLimitError();
+  }
+  return Math.min(parsed, MAX_USER_VOICES_LIMIT);
+}
+
 const userVoicesQuerySchema = z.object({
   includeInactive: z
     .enum(["true", "false"])
     .optional()
     .transform((value) => value === "true"),
   cloneType: z.enum(["instant", "professional"]).optional(),
-  limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
@@ -38,10 +74,18 @@ async function __hono_GET(request: Request) {
 
     // Parse query parameters with bounds validation
     const { searchParams } = new URL(request.url);
+    let limit: number;
+    try {
+      limit = parseUserVoicesLimitQuery(searchParams);
+    } catch (limitError) {
+      if (limitError instanceof UserVoicesLimitError) {
+        return Response.json({ error: limitError.message }, { status: 400 });
+      }
+      throw limitError;
+    }
     const parsedQuery = userVoicesQuerySchema.safeParse({
       includeInactive: searchParams.get("includeInactive") || undefined,
       cloneType: searchParams.get("cloneType") || undefined,
-      limit: searchParams.get("limit") || undefined,
       offset: searchParams.get("offset") || undefined,
     });
 
@@ -52,7 +96,7 @@ async function __hono_GET(request: Request) {
       );
     }
 
-    const { includeInactive, cloneType, limit, offset } = parsedQuery.data;
+    const { includeInactive, cloneType, offset } = parsedQuery.data;
 
     logger.info(`[User Voices API] Fetching voices for user ${user.id}`, {
       organizationId: user.organization_id!,


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on ElevenLabs
user-voices list `limit` identity. Page-size class, leftover tax after
files / gallery explore. Not a twin of those parsers — this is
`GET /api/elevenlabs/voices/user` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `limit` only on `/api/elevenlabs/voices/user`. Omitted/empty
still means 50 (today's default). Exact positive integers still bind and
clamp at 100. Prefix-coerced / unknown / duplicate tokens 400 before
`voiceCloningService.getUserVoices`. includeInactive / cloneType /
offset stay untouched.

# Background

## What does this PR do?

`GET /api/elevenlabs/voices/user` used `z.coerce.number()`, which treated
`1e2` / `007` / `0x10` as a page size instead of a 400.

- omitted / empty → 50 (200)
- exact `10` → page of 10
- exact `101` → clamped to 100
- `1e2` / `12px` / `007` / `0x10` / `0` / `foo` / duplicates → **400** before `voiceCloningService.getUserVoices`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers page org-owned cloned voices with `?limit=`. A common
`limit=1e2` or `007` after a client sends a numeric token must not
silently become a coerced page. Leftover tax after files / gallery
explore. Disjoint from voice-list `includeInactive` / `cloneType` and
from files / gallery explore `limit`.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/elevenlabs/voices/user/route.limit.test.ts`

## Detailed testing steps

```bash
bun test ./packages/cloud/api/elevenlabs/voices/user/route.limit.test.ts
```

19 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; ElevenLabs user-voices `limit` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; ElevenLabs user-voices `limit` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; ElevenLabs user-voices `limit` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real limit tokens and assert 400 before getUserVoices; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before getUserVoices.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`limit` tokens reject; omitted/canonical still bind the matching voices
page size.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the ElevenLabs
user-voices `limit` query only.

## Known gaps / failures

`bun run verify` was not run. Focused 19-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:cd4a793ba4e1f45c0c1cce25ee4887f602ba54c2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
