### PR TITLE
fix(cloud): reject prefix-coerced payment-requests list limit

### DIFF
--- a/packages/cloud/api/v1/payment-requests/route.limit.test.ts
+++ b/packages/cloud/api/v1/payment-requests/route.limit.test.ts
@@ -1,0 +1,102 @@
+/**
+ * GET /api/v1/payment-requests `limit` is list-page size identity,
+ * leftover tax after files / gallery explore. Stock develop used
+ * z.coerce.number(), which treated `1e2` / `007` / `0x10` as a page
+ * size instead of a 400. offset / status / provider / agentId stay
+ * untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const list = mock(async () => []);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_c: unknown, error: unknown) => {
+    throw error;
+  },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn: () => undefined, info: () => undefined, error: () => undefined },
+}));
+mock.module("@/lib/services/payment-requests-default", () => ({
+  getPaymentRequestsService: () => ({ list }),
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/", route);
+
+describe("GET /api/v1/payment-requests limit identity", () => {
+  beforeEach(() => {
+    list.mockClear();
+  });
+
+  test.each(["", "?limit=", "?limit"])(
+    "accepts %s as no caller-supplied list page size",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(200);
+      expect(list).toHaveBeenCalledTimes(1);
+      expect(list).toHaveBeenCalledWith(
+        "org-1",
+        expect.objectContaining({ limit: undefined }),
+      );
+    },
+  );
+
+  test("accepts limit=10 as an exact payment-requests page size", async () => {
+    const response = await app.request("/?limit=10");
+    expect(response.status).toBe(200);
+    expect(list).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ limit: 10 }),
+    );
+  });
+
+  test("caps a canonical oversize limit at 200", async () => {
+    const response = await app.request("/?limit=201");
+    expect(response.status).toBe(200);
+    expect(list).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ limit: 200 }),
+    );
+  });
+
+  test.each(["1e2", "12px", "007", "0", "abc", "-1", "50abc", " 10", "10 ", "0x10"])(
+    "rejects prefix-coerced limit=%s before payment-requests list",
+    async (token) => {
+      const response = await app.request(
+        `/?limit=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid limit");
+      expect(list).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?limit=10&limit=10",
+    "?limit=10&limit=20",
+    "?limit=&limit=10",
+    "?limit=foo&limit=10",
+  ])(
+    "rejects duplicate limit values in %s before payment-requests list",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid limit");
+      expect(list).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/payment-requests/route.ts
+++ b/packages/cloud/api/v1/payment-requests/route.ts
@@ -65,9 +65,46 @@ const ListQuerySchema = z.object({
   status: StatusSchema.optional(),
   provider: ProviderSchema.optional(),
   agentId: z.string().min(1).max(256).optional(),
-  limit: z.coerce.number().int().min(1).max(200).optional(),
   offset: z.coerce.number().int().min(0).optional(),
 });
+
+const MAX_PAYMENT_REQUESTS_LIMIT = 200;
+
+class PaymentRequestsLimitError extends Error {
+  constructor(message = "Invalid limit") {
+    super(message);
+    this.name = "PaymentRequestsLimitError";
+  }
+}
+
+/**
+ * GET /api/v1/payment-requests `limit` is list-page size identity,
+ * leftover tax after files / gallery explore. Stock develop used
+ * z.coerce.number(), which treated `1e2` / `007` / `0x10` as a page
+ * size instead of a 400. offset / status / provider / agentId stay
+ * untouched. Missing / empty still means no explicit limit. Exact
+ * integers clamp at 200.
+ */
+function parsePaymentRequestsLimitQuery(
+  searchParams: URLSearchParams,
+): number | undefined {
+  const requested = searchParams.getAll("limit");
+  if (requested.length > 1) {
+    throw new PaymentRequestsLimitError();
+  }
+  const raw = requested[0];
+  if (raw == null || raw === "") {
+    return undefined;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new PaymentRequestsLimitError();
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new PaymentRequestsLimitError();
+  }
+  return Math.min(parsed, MAX_PAYMENT_REQUESTS_LIMIT);
+}
 
 const app = new Hono<AppEnv>();
 
@@ -155,11 +192,20 @@ app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
+    let limit: number | undefined;
+    try {
+      limit = parsePaymentRequestsLimitQuery(new URL(c.req.url).searchParams);
+    } catch (limitError) {
+      if (limitError instanceof PaymentRequestsLimitError) {
+        return c.json({ error: limitError.message }, 400);
+      }
+      throw limitError;
+    }
+
     const parsed = ListQuerySchema.safeParse({
       status: c.req.query("status"),
       provider: c.req.query("provider"),
       agentId: c.req.query("agentId"),
-      limit: c.req.query("limit"),
       offset: c.req.query("offset"),
     });
     if (!parsed.success) {
@@ -178,7 +224,7 @@ app.get("/", async (c) => {
       status: parsed.data.status,
       provider: parsed.data.provider,
       agentId: parsed.data.agentId,
-      limit: parsed.data.limit,
+      limit,
       offset: parsed.data.offset,
     });
 


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on cloud
payment-requests list `limit` identity. Page-size class, leftover tax
after files / gallery explore. Not a twin of those parsers — this is
`GET /api/v1/payment-requests` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `limit` only on `/api/v1/payment-requests`. Omitted/empty still
means no caller-supplied limit (today's optional). Exact positive
integers still bind and clamp at 200. Prefix-coerced / unknown /
duplicate tokens 400 before `service.list`. offset / status / provider /
agentId stay untouched.

# Background

## What does this PR do?

`GET /api/v1/payment-requests` used `z.coerce.number()`, which treated
`1e2` / `007` / `0x10` as a page size instead of a 400.

- omitted / empty → no caller-supplied limit (200)
- exact `10` → page of 10
- exact `201` → clamped to 200
- `1e2` / `12px` / `007` / `0x10` / `0` / `foo` / duplicates → **400** before `service.list`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers page org payment requests with `?limit=`. A common `limit=1e2`
or `007` after a client sends a numeric token must not silently become a
coerced page. Leftover tax after files / gallery explore. Disjoint from
files `limit`, gallery explore `limit`, and payment-request `public`
(#20954, `[id]` route).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/payment-requests/route.limit.test.ts`

## Detailed testing steps

```bash
bun test ./packages/cloud/api/v1/payment-requests/route.limit.test.ts
```

19 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; payment-requests list `limit` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; payment-requests list `limit` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; payment-requests list `limit` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real limit tokens and assert 400 before service.list; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before service.list.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`limit` tokens reject; omitted/canonical still bind the matching
payment-requests page size.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the payment-requests
list `limit` query only.

## Known gaps / failures

`bun run verify` was not run. Focused 19-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ff601ee7dda943d97403cc8d6a15f6b7c5d0daee -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
