### PR TITLE
test(agent): make native path contracts portable on Windows

### DIFF
--- a/packages/agent/src/api/model-catalog.test.ts
+++ b/packages/agent/src/api/model-catalog.test.ts
@@ -4,6 +4,7 @@
  * merge semantics, and the designed static fallback on a corrupt/absent cache.
  * Deterministic — filesystem reads are injected, no live provider is touched.
  */
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { buildModelCatalog, CODING_MODEL_DEFAULTS } from "./model-catalog";
 
@@ -138,15 +139,16 @@ describe("codex models_cache.json parse + merge", () => {
   });
 
   it("resolves the cache path from CODEX_HOME", () => {
+    const codexHome = path.resolve(path.sep, "opt", "codex");
     let seen = "";
     buildModelCatalog({
       readFile: (p) => {
         seen = p;
         return cache;
       },
-      env: { CODEX_HOME: "/opt/codex" } as NodeJS.ProcessEnv,
+      env: { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
     });
-    expect(seen).toBe("/opt/codex/models_cache.json");
+    expect(seen).toBe(path.join(codexHome, "models_cache.json"));
   });
 });
 

--- a/packages/agent/src/api/views-registry.package-resolution.test.ts
+++ b/packages/agent/src/api/views-registry.package-resolution.test.ts
@@ -9,6 +9,7 @@
  * end to end.
  */
 
+import path from "node:path";
 import type { Plugin } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -150,6 +151,11 @@ describe("registerPluginViews directory binding", () => {
   });
 
   it("uses the directory bound to an imported plugin object", async () => {
+    const fixtureDir = path.resolve(
+      path.sep,
+      "tmp",
+      "generated-plugin-fixture",
+    );
     const plugin: Plugin = {
       name: PLUGIN_NAME,
       description: "directory-loaded plugin fixture",
@@ -161,13 +167,13 @@ describe("registerPluginViews directory binding", () => {
         },
       ],
     } as Plugin;
-    bindPluginPackageDirectory(plugin, "/tmp/generated-plugin-fixture");
+    bindPluginPackageDirectory(plugin, fixtureDir);
 
     await registerPluginViews(plugin);
 
     const entry = listViews({ includeAllKinds: true }).find(
       (view) => view.id === "generated-view-resolution-fixture",
     );
-    expect(entry?.pluginDir).toBe("/tmp/generated-plugin-fixture");
+    expect(entry?.pluginDir).toBe(fixtureDir);
   });
 });

--- a/packages/agent/src/runtime/canonical-file-boot.test.ts
+++ b/packages/agent/src/runtime/canonical-file-boot.test.ts
@@ -11,7 +11,7 @@
 import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -42,6 +42,10 @@ function sha256(s: string): string {
   return createHash("sha256").update(s, "utf8").digest("hex");
 }
 
+function absoluteFixturePath(...segments: string[]): string {
+  return resolve(sep, ...segments);
+}
+
 const ENV_KEYS = [CANONICAL_BOOT_ROOT_ENV, CANONICAL_BOOT_MANIFEST_ENV];
 let savedEnv: Record<string, string | undefined>;
 
@@ -64,27 +68,30 @@ describe("resolveCanonicalManifest", () => {
   });
 
   it("resolves the default manifest under ELIZA_CANONICAL_BOOT_ROOT", () => {
+    const root = absoluteFixturePath("srv", "ws");
     const manifest = resolveCanonicalManifest(
-      { [CANONICAL_BOOT_ROOT_ENV]: "/srv/ws" },
+      { [CANONICAL_BOOT_ROOT_ENV]: root },
       fakeFs({}),
     );
     expect(manifest).not.toBeNull();
     expect(manifest?.length).toBe(DEFAULT_CANONICAL_MANIFEST.length);
     const soul = manifest?.find((e) => e.label === "SOUL.md");
-    expect(soul?.path).toBe("/srv/ws/SOUL.md");
+    expect(soul?.path).toBe(join(root, "SOUL.md"));
     expect(soul?.required).toBe(true);
     const handoff = manifest?.find((e) => e.label === "memory/HANDOFF.md");
-    expect(handoff?.path).toBe("/srv/ws/memory/HANDOFF.md");
+    expect(handoff?.path).toBe(join(root, "memory", "HANDOFF.md"));
     expect(handoff?.required).toBe(false);
   });
 
   it("resolves an explicit JSON manifest with its own root + required flags", () => {
-    const manifestPath = "/cfg/manifest.json";
+    const manifestPath = absoluteFixturePath("cfg", "manifest.json");
+    const root = absoluteFixturePath("data", "agent");
+    const absoluteEntryPath = absoluteFixturePath("etc", "agent", "extra.md");
     const manifestJson = JSON.stringify({
-      root: "/data/agent",
+      root,
       files: [
         { label: "SOUL", path: "soul.md", required: true },
-        { label: "ABS", path: "/etc/agent/extra.md" },
+        { label: "ABS", path: absoluteEntryPath },
       ],
     });
     const manifest = resolveCanonicalManifest(
@@ -94,11 +101,11 @@ describe("resolveCanonicalManifest", () => {
     expect(manifest).toHaveLength(2);
     expect(manifest?.[0]).toEqual({
       label: "SOUL",
-      path: "/data/agent/soul.md",
+      path: join(root, "soul.md"),
       required: true,
     });
     // absolute path passes through unchanged
-    expect(manifest?.[1].path).toBe("/etc/agent/extra.md");
+    expect(manifest?.[1].path).toBe(absoluteEntryPath);
     expect(manifest?.[1].required).toBe(false);
   });
 
@@ -208,12 +215,7 @@ describe("applyCanonicalFileBootToConfig", () => {
   });
 
   it("appends composed files onto the existing primary system prompt", () => {
-    const fs = fakeFs({
-      "/ws/SOUL.md": "SYNTHETIC SOUL canary=APPEND-OK",
-      "/ws/IDENTITY.md": "SYNTHETIC IDENTITY",
-      "/ws/AGENTS.md": "SYNTHETIC AGENTS",
-      "/ws/USER.md": "SYNTHETIC USER",
-    });
+    const root = absoluteFixturePath("ws");
     const config: ElizaConfig = {
       agents: {
         list: [{ id: "main", default: true, name: "X", system: "BASE-PROMPT" }],
@@ -221,14 +223,14 @@ describe("applyCanonicalFileBootToConfig", () => {
     } as unknown as ElizaConfig;
 
     // use an explicit manifest of only the 4 required-ish synthetic files
-    const manifestPath = "/cfg/m.json";
+    const manifestPath = absoluteFixturePath("cfg", "m.json");
     const fsWithManifest = fakeFs({
-      "/ws/SOUL.md": "SYNTHETIC SOUL canary=APPEND-OK",
-      "/ws/IDENTITY.md": "SYNTHETIC IDENTITY",
-      "/ws/AGENTS.md": "SYNTHETIC AGENTS",
-      "/ws/USER.md": "SYNTHETIC USER",
+      [join(root, "SOUL.md")]: "SYNTHETIC SOUL canary=APPEND-OK",
+      [join(root, "IDENTITY.md")]: "SYNTHETIC IDENTITY",
+      [join(root, "AGENTS.md")]: "SYNTHETIC AGENTS",
+      [join(root, "USER.md")]: "SYNTHETIC USER",
       [manifestPath]: JSON.stringify({
-        root: "/ws",
+        root,
         files: [
           { label: "SOUL.md", path: "SOUL.md", required: true },
           { label: "USER.md", path: "USER.md", required: true },
@@ -245,15 +247,15 @@ describe("applyCanonicalFileBootToConfig", () => {
     expect(sys.startsWith("BASE-PROMPT")).toBe(true);
     expect(sys).toContain("canary=APPEND-OK");
     expect(sys).toContain("SYNTHETIC USER");
-    void fs; // (kept for parity with sibling tests; unused directly)
   });
 
   it("creates a primary entry when none exists", () => {
-    const manifestPath = "/cfg/m.json";
+    const manifestPath = absoluteFixturePath("cfg", "m.json");
+    const root = absoluteFixturePath("ws");
     const fs = fakeFs({
-      "/ws/SOUL.md": "SYNTHETIC SOUL",
+      [join(root, "SOUL.md")]: "SYNTHETIC SOUL",
       [manifestPath]: JSON.stringify({
-        root: "/ws",
+        root,
         files: [{ label: "SOUL.md", path: "SOUL.md", required: true }],
       }),
     });

--- a/packages/agent/src/runtime/plugin-resolver-staging-cache.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver-staging-cache.test.ts
@@ -103,6 +103,20 @@ function coldStageParams(installPath: string, packageName: string) {
   };
 }
 
+async function canonicalPath(filePath: string): Promise<string> {
+  return fsp.realpath(filePath);
+}
+
+function isWithinPath(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return (
+    relative === "" ||
+    (!path.isAbsolute(relative) &&
+      relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`))
+  );
+}
+
 describe("workspace in-place fast-path", () => {
   it("dist-less workspace plugin imports in place with NO staging", async () => {
     // A workspace tree: root node_modules farm + plugins/<pkg> source package.
@@ -126,8 +140,8 @@ describe("workspace in-place fast-path", () => {
 
     expect(mod.marker).toBe("ws-inplace");
     // Loaded from the real workspace location, not a staged copy.
-    expect(fileURLToPath(mod.moduleUrl)).toBe(
-      path.join(installPath, "index.mjs"),
+    await expect(canonicalPath(fileURLToPath(mod.moduleUrl))).resolves.toBe(
+      await canonicalPath(path.join(installPath, "index.mjs")),
     );
     expect(await listStagingEntries(name)).toEqual([]);
   });
@@ -152,9 +166,11 @@ describe("workspace in-place fast-path", () => {
     };
 
     expect(mod.marker).toBe("ws-bare");
-    expect(fileURLToPath(mod.moduleUrl)).not.toBe(
-      path.join(installPath, "index.mjs"),
+    const canonicalInstallPath = await canonicalPath(installPath);
+    const canonicalModulePath = await canonicalPath(
+      fileURLToPath(mod.moduleUrl),
     );
+    expect(isWithinPath(canonicalInstallPath, canonicalModulePath)).toBe(false);
     const entries = await listStagingEntries(name);
     expect(entries.filter((e) => e.startsWith("content-"))).toHaveLength(1);
   });

--- a/packages/agent/src/runtime/plugin-resolver-staging-cache.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver-staging-cache.test.ts
@@ -11,6 +11,7 @@ import { spawn } from "node:child_process";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -125,7 +126,9 @@ describe("workspace in-place fast-path", () => {
 
     expect(mod.marker).toBe("ws-inplace");
     // Loaded from the real workspace location, not a staged copy.
-    expect(mod.moduleUrl).toContain(installPath);
+    expect(fileURLToPath(mod.moduleUrl)).toBe(
+      path.join(installPath, "index.mjs"),
+    );
     expect(await listStagingEntries(name)).toEqual([]);
   });
 
@@ -149,7 +152,9 @@ describe("workspace in-place fast-path", () => {
     };
 
     expect(mod.marker).toBe("ws-bare");
-    expect(mod.moduleUrl).not.toContain(installPath);
+    expect(fileURLToPath(mod.moduleUrl)).not.toBe(
+      path.join(installPath, "index.mjs"),
+    );
     const entries = await listStagingEntries(name);
     expect(entries.filter((e) => e.startsWith("content-"))).toHaveLength(1);
   });

--- a/packages/agent/src/services/permissions/probers/probers.test.ts
+++ b/packages/agent/src/services/permissions/probers/probers.test.ts
@@ -140,17 +140,11 @@ describe("permission probers", () => {
   });
 
   it("resolves the native bridge sealed into an Electrobun app", () => {
-    const execPath = path.join(
-      "/Applications",
-      "Eliza.app",
-      "Contents",
-      "MacOS",
-      "bun",
-    );
+    const appRoot = path.resolve(path.sep, "Applications", "Eliza.app");
+    const execPath = path.join(appRoot, "Contents", "MacOS", "bun");
     expect(resolvePackagedNativePermissionsDylib(execPath)).toBe(
       path.join(
-        "/Applications",
-        "Eliza.app",
+        appRoot,
         "Contents",
         "Resources",
         "app",

--- a/packages/agent/src/services/registry-client-local.test.ts
+++ b/packages/agent/src/services/registry-client-local.test.ts
@@ -36,24 +36,34 @@ afterEach(async () => {
 
 describe("applyLocalWorkspaceApps", () => {
   it("does not treat an implicit hidden worktree container as a workspace", () => {
+    const repoRoot = path.resolve(path.sep, "repo");
+    const worktreeRoot = path.join(repoRoot, ".worktrees", "feature");
     const roots = resolveWorkspaceRootsForDiscovery({
-      moduleDir: "/repo/.worktrees/feature/packages/agent/src/services",
-      cwd: "/repo/.worktrees/feature",
+      moduleDir: path.join(
+        worktreeRoot,
+        "packages",
+        "agent",
+        "src",
+        "services",
+      ),
+      cwd: worktreeRoot,
     });
 
-    expect(roots).toContain("/repo/.worktrees/feature");
-    expect(roots).not.toContain("/repo/.worktrees");
-    expect(roots).toContain("/repo");
+    expect(roots).toContain(worktreeRoot);
+    expect(roots).not.toContain(path.join(repoRoot, ".worktrees"));
+    expect(roots).toContain(repoRoot);
   });
 
   it("honors an explicitly configured hidden workspace root", () => {
+    const repoRoot = path.resolve(path.sep, "repo");
+    const hiddenRoot = path.join(repoRoot, ".workspaces");
     expect(
       resolveWorkspaceRootsForDiscovery({
-        moduleDir: "/repo/packages/agent/src/services",
-        cwd: "/repo",
-        envRoot: "/repo/.workspaces",
+        moduleDir: path.join(repoRoot, "packages", "agent", "src", "services"),
+        cwd: repoRoot,
+        envRoot: hiddenRoot,
       }),
-    ).toEqual(["/repo/.workspaces"]);
+    ).toEqual([hiddenRoot]);
   });
 
   it("reports and rejects one malformed candidate while preserving valid peers", async () => {


### PR DESCRIPTION
# Relates to

Closes #21292. Follow-up to #21288.

Definition of Done: full standard in [CONTRIBUTING.md](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Frozen install, six focused suites, Agent typecheck/build/lint, and exact-file Biome pass on the exact head.
- [x] The real 443-batch Windows entrypoint was run in a temporary local composition with #21288; every repaired batch passes.
- [x] Root verify was run after sync; unrelated Windows/generated-file blockers are recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop@9f48a26bcfb7cded2887f0daea25f193a36450cb`; zero conflicts.
- [x] Exact head is one commit ahead / zero behind.

# Risks

Low. This is test-only. It replaces synthetic POSIX path literals with host-native absolute fixtures and decodes imported `file:` URLs before filesystem comparison. Production source, runtime behavior, package exports, storage, APIs, and deployment code are unchanged. The assertions still pin the same semantics: exact cache location, package-directory identity, canonical-file firewall, staging-vs-in-place import selection, packaged macOS bundle layout, and hidden-worktree ancestry.

# Background

## What does this PR do?

Once #21288 made the official Agent test orchestrator runnable on Windows, six suites exposed a shared fixture defect: they passed POSIX-only strings into host-native `node:path` operations, or compared a `file:` URL directly to a Windows path. Production returned correct native paths; the tests expected a different representation.

This PR makes those fixtures platform-neutral:

1. Model cache, view registry, permission prober, and registry-discovery tests construct native absolute paths with `path.resolve(path.sep, ...)` and compare with `path.join`.
2. Canonical-file boot tests use the same resolved paths in environment inputs, manifest data, fake-filesystem keys, and assertions, preserving byte/firewall behavior rather than weakening it.
3. Plugin staging tests decode `import.meta.url` with `fileURLToPath()` before comparing the exact source/staged filesystem location. This also makes the former negative assertion non-vacuous on Windows.

## What kind of change is this?

Test-infrastructure portability fix.

# Documentation changes needed?

No. Public behavior and documented commands are unchanged.

# Testing

## Where should a reviewer start?

Start with `canonical-file-boot.test.ts` and `plugin-resolver-staging-cache.test.ts`; they contain the most important path-identity and non-vacuous staging assertions. The other four files apply the same host-native fixture principle at smaller boundaries.

## Detailed testing steps

Exact head: `e9a4d6385bf74caf19babc89ae105172005380bc`

1. `bun install --frozen-lockfile --ignore-scripts`
   - PASS: 7,084 packages installed with pinned Bun 1.3.14.
2. Pre-fix six-suite matrix on current `develop`
   - RED: 6 files failed, 10 relevant path assertions failed (plus one separate `spawn bun` caused by an intentionally unextended shell PATH in that first probe).
3. Exact-head focused matrix:
   - `bun x vitest run <six files> --config packages/agent/vitest.config.ts`
   - PASS: 6 files, 72 tests, including the real two-process staging race.
4. `bun x @biomejs/biome check <six files>`
   - PASS: 6 files, no fixes.
5. `bun run --cwd packages/agent lint:check`
   - PASS: 931 files, no fixes.
6. `bun run --cwd packages/agent typecheck`
   - PASS after building the package's clean-worktree declaration prerequisites.
7. `bun run --cwd packages/agent build`
   - PASS: package-boundary audit, declarations/dist, 196 NodeNext specifier rewrites.
8. Temporary local composition of this commit plus #21288, then `bun run --cwd packages/agent test`
   - PASS for orchestration and this scope: 443 files discovered, 443 isolated batches completed, all six repaired suites passed.
   - The overall lane exits 1 for 9 unrelated Windows assertion batches listed below.
   - The temporary composition branch was deleted and was never pushed; this PR contains only the six test files.
9. `git diff --check origin/develop...HEAD`
   - PASS.
10. `bun run verify`
   - Reaches the Turbo typecheck/lint fan-out and stops on unchanged homepage/Electrobun Windows/generated-file lint failures documented below.

# Evidence Gate

<!-- evidence-head:2b1e0cb20117c232d93aa380afe117d6f3f5ca01 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only path fixtures; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only path fixtures; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic test and production-runner transcripts cover the complete changed surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service or request path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, console state, or network request changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action-selection, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head Windows matrix and composed production-entrypoint transcript:
<details>
<summary>Path-contract receipt</summary>

```text
Focused pre-fix: 6 failed files; 10 relevant path assertion failures.
Focused exact head: 6 passed files; 72 passed tests.
[agent-test] 443 file(s), 443 isolated batch(es), concurrency 4
[agent-test] progress 443/443
[agent-test] 9 unrelated batch(es) failed; all six repaired batches passed.
```
</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual-text surface changes.

# Evidence Details

## Domain artifact

```json
{
  "head": "e9a4d6385bf74caf19babc89ae105172005380bc",
  "host": "Windows",
  "focused_before": { "files_failed": 6, "path_assertions_failed": 10 },
  "focused_after": { "files_passed": 6, "tests_passed": 72 },
  "composed_agent_runner": {
    "test_files_discovered": 443,
    "isolated_batches_completed": 443,
    "repaired_batches_failed": 0,
    "unrelated_batches_failed": 9
  }
}
```

## Real LLM-call trajectory

N/A - no provider/model/action path changed.

## Backend + frontend logs

N/A - this is deterministic test infrastructure with no live service, credential, browser, or provider call.

## Screenshots / video / audio

N/A - no rendered, voice, TTS, or STT surface changed.

## Known gaps / failures

- The full Agent lane proof composes this test-only commit with #21288 because the Windows runner repair is not yet merged into `develop`. The final PR branch itself is a clean one-commit branch from current `develop` and does not duplicate #21288.
- The composed lane reaches 443/443 and leaves 9 unrelated Windows batches: Unix permission behavior (`media-store`, `config-bind-mount-persistence`); symlink privilege (`provider-switch-config`, `load-plugin-from-directory`, `virtual-filesystem`); malformed absolute-path fixture (`server-helpers-swarm`); relative-path fixture (`sandbox-character`); unavailable `sh` (`e2b-capability-router.coding-remote-runner`); and Windows-illegal newline filename (`cerebras-chat-flow-latency`).
- Exact-head root `bun run verify` passes guide/Biome-version/i18n/dependency/plugin-convention/alias/tsconfig pre-gates and reaches Turbo. It stops on unchanged Windows checkout/generated-file lint failures: `packages/homepage/src/index.css` is checked out with CRLF, while Electrobun's shell-style lint command selects generated `src/preload.js` and tracked `.generated/brand-config.json` on Windows. None of those files are touched here.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-agent-windows-native-paths]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza"} -->

