### PR TITLE
fix(cloud): route storage HEAD through metadata path

### DIFF
--- a/packages/cloud/api/__tests__/storage-objects-head-routing.test.ts
+++ b/packages/cloud/api/__tests__/storage-objects-head-routing.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Exercises the real storage object Hono router to protect HEAD from Hono's
+ * automatic HEAD-to-GET dispatch. The suite proves metadata requests never
+ * enter the object-body path or use GET pricing.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const ORGANIZATION_ID = "00000000-0000-4000-8000-000000021045";
+const ROUTE_PREFIX = "/api/v1/apis/storage/objects";
+const ROUTE_MOUNT = `${ROUTE_PREFIX}/:*{.+}`;
+const OBJECT_PATH = "voice/message.ogg";
+const SCOPED_KEY = `org/${ORGANIZATION_ID}/${OBJECT_PATH}`;
+const HEAD_COST = 0.00007;
+const GET_COST = 0.00011;
+const OBJECT_BYTES = new TextEncoder().encode("asset");
+const MODIFIED_AT = new Date("2026-08-17T12:00:00.000Z");
+
+const requireUserOrApiKeyWithOrg = mock();
+const getR2StorageAdapter = mock();
+const getServiceMethodCost = mock();
+const deductCredits = mock();
+const exists = mock();
+const read = mock();
+const stat = mock();
+const write = mock();
+const remove = mock();
+const tryReserveBytes = mock();
+const releaseBytes = mock();
+const loggerError = mock();
+const failureResponse = mock((_context: unknown, error: unknown) =>
+  Response.json(
+    { error: error instanceof Error ? error.message : "Unexpected test error" },
+    { status: 500 },
+  ),
+);
+
+mock.module("@/db/repositories", () => ({
+  orgStorageQuotaRepository: { tryReserveBytes, releaseBytes },
+}));
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/credits", () => ({
+  creditsService: { deductCredits },
+}));
+
+mock.module("@/lib/services/proxy/pricing", () => ({
+  getServiceMethodCost,
+}));
+
+mock.module("@/lib/services/storage/r2-storage-adapter", () => ({
+  getR2StorageAdapter,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: loggerError },
+}));
+
+const storageObjectsRoute = (
+  await import("../v1/apis/storage/objects/[...key]/route")
+).default;
+const app = new Hono();
+app.route(ROUTE_MOUNT, storageObjectsRoute);
+
+function request(method: "GET" | "HEAD"): Response | Promise<Response> {
+  return app.request(`${ROUTE_PREFIX}/${OBJECT_PATH}`, { method });
+}
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockReset();
+  getR2StorageAdapter.mockReset();
+  getServiceMethodCost.mockReset();
+  deductCredits.mockReset();
+  exists.mockReset();
+  read.mockReset();
+  stat.mockReset();
+  write.mockReset();
+  remove.mockReset();
+  tryReserveBytes.mockReset();
+  releaseBytes.mockReset();
+  loggerError.mockReset();
+  failureResponse.mockClear();
+
+  requireUserOrApiKeyWithOrg.mockResolvedValue({
+    organization_id: ORGANIZATION_ID,
+  });
+  getR2StorageAdapter.mockReturnValue({ exists, read, stat, write, remove });
+  deductCredits.mockResolvedValue({ success: true });
+  exists.mockResolvedValue(true);
+  read.mockResolvedValue(OBJECT_BYTES);
+  stat.mockResolvedValue({
+    size: OBJECT_BYTES.byteLength,
+    contentType: "audio/ogg",
+    etag: "storage-etag",
+    modified: MODIFIED_AT,
+  });
+});
+
+describe("storage object HEAD routing", () => {
+  test("uses HEAD pricing and metadata without reading the object body", async () => {
+    getServiceMethodCost.mockResolvedValue(HEAD_COST);
+
+    const response = await request("HEAD");
+
+    expect(response.status).toBe(200);
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+    expect(response.headers.get("content-type")).toBe("audio/ogg");
+    expect(response.headers.get("content-length")).toBe(
+      String(OBJECT_BYTES.byteLength),
+    );
+    expect(response.headers.get("etag")).toBe("storage-etag");
+    expect(response.headers.get("last-modified")).toBe(
+      MODIFIED_AT.toUTCString(),
+    );
+
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+    expect(getR2StorageAdapter).toHaveBeenCalledTimes(1);
+    expect(getServiceMethodCost).toHaveBeenCalledTimes(1);
+    expect(getServiceMethodCost).toHaveBeenCalledWith("storage", "head");
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(deductCredits).toHaveBeenCalledWith({
+      organizationId: ORGANIZATION_ID,
+      amount: HEAD_COST,
+      description: "API proxy: storage — head",
+      metadata: {
+        type: "proxy_storage",
+        service: "storage",
+        method: "head",
+        key: OBJECT_PATH,
+      },
+    });
+    expect(exists).toHaveBeenCalledTimes(1);
+    expect(exists).toHaveBeenCalledWith(SCOPED_KEY);
+    expect(stat).toHaveBeenCalledTimes(1);
+    expect(stat).toHaveBeenCalledWith(SCOPED_KEY);
+    expect(read).not.toHaveBeenCalled();
+    expect(tryReserveBytes).not.toHaveBeenCalled();
+    expect(releaseBytes).not.toHaveBeenCalled();
+    expect(failureResponse).not.toHaveBeenCalled();
+  });
+
+  test("preserves the existing GET pricing and body path", async () => {
+    getServiceMethodCost.mockResolvedValue(GET_COST);
+
+    const response = await request("GET");
+
+    expect(response.status).toBe(200);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(OBJECT_BYTES);
+    expect(getServiceMethodCost).toHaveBeenCalledTimes(1);
+    expect(getServiceMethodCost).toHaveBeenCalledWith("storage", "get");
+    expect(deductCredits).toHaveBeenCalledWith({
+      organizationId: ORGANIZATION_ID,
+      amount: GET_COST,
+      description: "API proxy: storage — get",
+      metadata: {
+        type: "proxy_storage",
+        service: "storage",
+        method: "get",
+        key: OBJECT_PATH,
+      },
+    });
+    expect(exists).toHaveBeenCalledWith(SCOPED_KEY);
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(read).toHaveBeenCalledWith(SCOPED_KEY);
+    expect(stat).toHaveBeenCalledTimes(1);
+    expect(stat).toHaveBeenCalledWith(SCOPED_KEY);
+    expect(failureResponse).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts
+++ b/packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts
@@ -17,7 +17,7 @@
  * Pricing: per-request charge (and per-byte for PUT) deducted via creditsService.
  */
 
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { orgStorageQuotaRepository } from "@/db/repositories";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
@@ -193,6 +193,13 @@ app.put("/*", async (c) => {
 });
 
 app.get("/*", async (c) => {
+  // Hono dispatches HEAD through the matching GET route while preserving the
+  // original request method. Branch here so HEAD never enters the body-read
+  // path or uses GET pricing.
+  if (c.req.method === "HEAD") {
+    return handleLegacyStorageHead(c);
+  }
+
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const { organization_id } = user;
@@ -244,7 +251,7 @@ app.get("/*", async (c) => {
   }
 });
 
-app.on(["HEAD"], "/*", async (c) => {
+async function handleLegacyStorageHead(c: Context<AppEnv>) {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const { organization_id } = user;
@@ -289,7 +296,7 @@ app.on(["HEAD"], "/*", async (c) => {
   } catch (error) {
     return failureResponse(c, error);
   }
-});
+}
 
 app.delete("/*", async (c) => {
   try {


### PR DESCRIPTION
# Relates to

Relates to #21045.

Definition of Done: full standard in [CONTRIBUTING.md](../blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run on the exact tree.
- [x] A reviewer can confirm the change works without reading the code from the before/after regression evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2741ce88d27af20e687377f1b311f2c2ea43faf2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based directly on `origin/develop` `9f48a26bcfb7cded2887f0daea25f193a36450cb`; zero conflicts.
- [x] `bun run verify` passes on the exact tree.

# Risks

Medium. This actively corrects which existing storage path serves HEAD requests. It preserves the intended legacy HEAD response and billing contract, while eliminating object-body reads and GET pricing for HEAD.

# Background

## What does this PR do?

Pinned Hono 4.13.1 routes every incoming HEAD request through GET route matching and only strips the body after the handler returns. The later explicit HEAD registration in this route was therefore unreachable: HEAD used `storage.get` pricing, called `adapter.read`, and buffered the complete object.

This PR:

- branches on the original `c.req.method` at the start of the GET-registered handler;
- sends HEAD to the existing metadata-only logic;
- removes the unreachable method-specific HEAD registration;
- adds a real Hono regression using the exact generated production mount pattern;
- proves HEAD uses `storage.head`, `exists`, and `stat` without `read`, while GET remains unchanged.

## What kind of change is this?

Bug fix for storage billing selection and unnecessary object-body I/O.

# Documentation changes needed?

No. The public route and intended HEAD response contract are unchanged.

# Testing

## Where should a reviewer start?

1. `packages/cloud/api/__tests__/storage-objects-head-routing.test.ts`
2. `packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts`

## Detailed testing steps

Exact head: `8080bd892317f26f71751afdbaa5aa365adeb4aa`

- Discriminating baseline on unchanged `develop`: 1 passed / 1 failed, with HEAD receiving `getServiceMethodCost("storage", "get")` instead of the expected `"head"`; the GET control passed.
- Exact-head focused route suite: 2 passed, 31 assertions.
- Focused stress run: 20 passed, 310 assertions across ten repetitions.
- Isolated storage unit lane: 7 passed, 66 assertions.
- API TypeScript (`tsc` and `tsc6`): passed.
- Production Worker dry-run: passed; 26,034.52 KiB upload, 6,369.01 KiB gzip.
- Targeted Biome, `git diff --check`, `git show --check`, and clean-tree checks: passed.
- Full root `bun run verify`: 356/356 tasks passed; anti-larp scanned 8,560 test files with zero focused or orphaned skipped tests.
- Independent review: 0 blocker, 0 P1, 0 P2 findings.

# Evidence Gate

<!-- evidence-head:8080bd892317f26f71751afdbaa5aa365adeb4aa -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only routing fix; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only routing fix; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual user flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no live deployment was authorized; the exact before/after Hono test receipt is included above.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no live R2 object, pricing row, credit balance, quota, secret, or deployment was touched.
<!-- evidence-row:ocr-review -->
- [ ] N/A - backend-only change with no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changed.

## Backend + frontend logs

N/A for live logs. The hermetic route test proves the exact auth count, organization-scoped key, pricing method, debit metadata, provider calls, metadata headers, empty HEAD body, and unchanged GET bytes.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no audio or voice behavior changed.

## Known gaps / failures

- This PR deliberately does not change the legacy adapter, pricing fallback, debit-before-provider ordering, crash idempotency, quota accounting, native R2 catalog, or deployment configuration; those remain in #21045.
- Hono strips bodies from all HEAD responses, including JSON error responses. This is existing framework behavior and is unchanged.
- Seeded GET and HEAD prices are currently equal, but live pricing rows are mutable. No live pricing database was queried or changed.
- No live R2 binding, customer request, credit balance, secret, staging environment, or production deployment was touched.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@2741ce88d27af20e687377f1b311f2c2ea43faf2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-storage-head-dispatch-pr]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@2741ce88d27af20e687377f1b311f2c2ea43faf2:packages/skills/skills/contribute-to-eliza"} -->
