### PR TITLE
fix(cloud): reject prefix-coerced earnings-history list limit

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/earnings/history/route.limit.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/earnings/history/route.limit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * GET /api/v1/apps/[id]/earnings/history `limit` is ledger-page size
+ * identity, leftover tax after earnings `days` (#20672). Stock develop
+ * used z.coerce.number(), which treated `1e2` / `007` / `0x10` as a
+ * page size instead of a 400. offset / type stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getById = mock(async () => ({
+  id: "app-1",
+  organization_id: "org-1",
+}));
+const getTransactionHistory = mock(async () => []);
+const isAppKeyOutOfScope = mock(async () => false);
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKey: null,
+  }),
+}));
+mock.module("@/lib/auth/app-key-scope", () => ({
+  isAppKeyOutOfScope,
+}));
+mock.module("@/lib/services/apps", () => ({
+  appsService: { getById },
+}));
+mock.module("@/lib/services/app-earnings", () => ({
+  appEarningsService: { getTransactionHistory },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn: () => undefined, info: () => undefined, error: () => undefined },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id/earnings/history", route);
+
+describe("GET /api/v1/apps/[id]/earnings/history limit identity", () => {
+  beforeEach(() => {
+    getById.mockClear();
+    getTransactionHistory.mockClear();
+  });
+
+  test.each(["", "?limit=", "?limit"])(
+    "accepts %s as the default earnings-history page of 50",
+    async (query) => {
+      const response = await app.request(`/app-1/earnings/history${query}`);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        pagination: { limit: number };
+      };
+      expect(body.pagination.limit).toBe(50);
+      expect(getTransactionHistory).toHaveBeenCalledTimes(1);
+      expect(getTransactionHistory).toHaveBeenCalledWith(
+        "app-1",
+        expect.objectContaining({ limit: 50 }),
+      );
+    },
+  );
+
+  test("accepts limit=10 as an exact earnings-history page size", async () => {
+    const response = await app.request("/app-1/earnings/history?limit=10");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      pagination: { limit: number };
+    };
+    expect(body.pagination.limit).toBe(10);
+    expect(getTransactionHistory).toHaveBeenCalledWith(
+      "app-1",
+      expect.objectContaining({ limit: 10 }),
+    );
+  });
+
+  test("caps a canonical oversize limit at 100", async () => {
+    const response = await app.request("/app-1/earnings/history?limit=101");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      pagination: { limit: number };
+    };
+    expect(body.pagination.limit).toBe(100);
+    expect(getTransactionHistory).toHaveBeenCalledWith(
+      "app-1",
+      expect.objectContaining({ limit: 100 }),
+    );
+  });
+
+  test.each(["1e2", "12px", "007", "0", "abc", "-1", "50abc", " 10", "10 ", "0x10"])(
+    "rejects prefix-coerced limit=%s before getTransactionHistory",
+    async (token) => {
+      const response = await app.request(
+        `/app-1/earnings/history?limit=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid limit");
+      expect(getTransactionHistory).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?limit=10&limit=10",
+    "?limit=10&limit=20",
+    "?limit=&limit=10",
+    "?limit=foo&limit=10",
+  ])(
+    "rejects duplicate limit values in %s before getTransactionHistory",
+    async (query) => {
+      const response = await app.request(`/app-1/earnings/history${query}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid limit");
+      expect(getTransactionHistory).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/apps/[id]/earnings/history/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/earnings/history/route.ts
@@ -8,8 +8,45 @@ import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
+const DEFAULT_EARNINGS_HISTORY_LIMIT = 50;
+const MAX_EARNINGS_HISTORY_LIMIT = 100;
+
+class EarningsHistoryLimitError extends Error {
+  constructor(message = "Invalid limit") {
+    super(message);
+    this.name = "EarningsHistoryLimitError";
+  }
+}
+
+/**
+ * GET /api/v1/apps/[id]/earnings/history `limit` is ledger-page size
+ * identity, leftover tax after earnings `days` (#20672). Stock develop
+ * used z.coerce.number(), which treated `1e2` / `007` / `0x10` as a
+ * page size instead of a 400. offset / type stay untouched. Missing /
+ * empty still means 50. Exact integers clamp at 100.
+ */
+function parseEarningsHistoryLimitQuery(
+  searchParams: URLSearchParams,
+): number {
+  const requested = searchParams.getAll("limit");
+  if (requested.length > 1) {
+    throw new EarningsHistoryLimitError();
+  }
+  const raw = requested[0];
+  if (raw == null || raw === "") {
+    return DEFAULT_EARNINGS_HISTORY_LIMIT;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new EarningsHistoryLimitError();
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new EarningsHistoryLimitError();
+  }
+  return Math.min(parsed, MAX_EARNINGS_HISTORY_LIMIT);
+}
+
 const QuerySchema = z.object({
-  limit: z.coerce.number().int().positive().max(100).optional().default(50),
   offset: z.coerce.number().int().min(0).optional().default(0),
   type: z
     .enum(["inference_markup", "purchase_share", "withdrawal", "adjustment"])
@@ -41,11 +78,21 @@ async function __hono_GET(
 
     // Parse query params (filter out nulls to use defaults)
     const searchParams = new URL(request.url).searchParams;
+    let limit: number;
+    try {
+      limit = parseEarningsHistoryLimitQuery(searchParams);
+    } catch (limitError) {
+      if (limitError instanceof EarningsHistoryLimitError) {
+        return Response.json(
+          { success: false, error: limitError.message },
+          { status: 400 },
+        );
+      }
+      throw limitError;
+    }
     const queryInput: Record<string, string> = {};
-    const limitParam = searchParams.get("limit");
     const offsetParam = searchParams.get("offset");
     const typeParam = searchParams.get("type");
-    if (limitParam) queryInput.limit = limitParam;
     if (offsetParam) queryInput.offset = offsetParam;
     if (typeParam) queryInput.type = typeParam;
 
@@ -62,7 +109,7 @@ async function __hono_GET(
       );
     }
 
-    const { limit, offset, type } = queryResult.data;
+    const { offset, type } = queryResult.data;
 
     // Verify the app exists and belongs to the user's organization
     const app = await appsService.getById(id);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on cloud
app earnings-history list `limit` identity. Page-size class, leftover tax
after earnings `days` (#20672). Not a twin of that parser — this is
`GET /api/v1/apps/[id]/earnings/history` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `limit` only on `/api/v1/apps/[id]/earnings/history`. Omitted/empty
still means 50. Exact positive integers still bind and clamp at 100.
Prefix-coerced / unknown / duplicate tokens 400 before
`getTransactionHistory`. offset / type stay untouched.

# Background

## What does this PR do?

`GET /api/v1/apps/[id]/earnings/history` used `z.coerce.number()`, which
treated `1e2` / `007` / `0x10` as a page size instead of a 400.

- omitted / empty → default page of 50
- exact `10` → page of 10
- exact `101` → clamped to 100
- `1e2` / `12px` / `007` / `0x10` / `0` / `foo` / duplicates → **400** before `getTransactionHistory`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers page the app earnings ledger with `?limit=`. A common `limit=1e2`
or `007` after a client sends a numeric token must not silently become a
coerced page. Leftover tax after earnings `days` (#20672). Disjoint from
earnings `days`, files `limit`, gallery explore `limit`, and
payment-requests `limit`.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/apps/[id]/earnings/history/route.limit.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test "./v1/apps/[id]/earnings/history/route.limit.test.ts"
```

19 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; earnings-history list `limit` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; earnings-history list `limit` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; earnings-history list `limit` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real limit tokens and assert 400 before getTransactionHistory; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before getTransactionHistory.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`limit` tokens reject; omitted/canonical still bind the matching
earnings-history page size.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the earnings-history
list `limit` query only.

## Known gaps / failures

`bun run verify` was not run. Focused 19-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:81a7120f0aa2b9397e5cb52f4a56a80a8c44ba32 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
