### PR TITLE
fix(agent): serialize push token hydration

### DIFF
--- a/packages/agent/src/services/push/push-token-registry.test.ts
+++ b/packages/agent/src/services/push/push-token-registry.test.ts
@@ -2,13 +2,17 @@
  * Covers the push-token registry: register/list/count/unregister, idempotent
  * upsert, moving a token between platforms, whitespace trimming and empty-token
  * rejection, platform filtering, cache-backed persistence with rehydration, and
- * dropping malformed records on hydrate. Backed by a Map-backed mock runtime
- * cache — no real storage.
+ * dropping malformed records on hydrate, concurrent first-use hydration, and
+ * serialized persistence. Backed by a Map-backed mock runtime cache — no real
+ * storage.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { createMockRuntime } from "@elizaos/core/testing";
 import { beforeEach, describe, expect, it } from "vitest";
-import { PushTokenRegistry } from "./push-token-registry.ts";
+import {
+  type PushTokenRecord,
+  PushTokenRegistry,
+} from "./push-token-registry.ts";
 
 function createRuntime(): {
   runtime: IAgentRuntime;
@@ -100,5 +104,86 @@ describe("PushTokenRegistry", () => {
     const fresh = new PushTokenRegistry(ctx.runtime);
     const list = await fresh.list();
     expect(list.map((r) => r.token)).toEqual(["good"]);
+  });
+
+  it("preserves registrations made while first-use hydration is in flight", async () => {
+    const cache = new Map<string, unknown>();
+    const cacheReads: Array<(value: unknown) => void> = [];
+    const runtime = createMockRuntime({
+      agentId: "00000000-0000-0000-0000-0000000000aa",
+      getCache: <T>(): Promise<T | undefined> =>
+        new Promise((resolve) => {
+          cacheReads.push(resolve as (value: unknown) => void);
+        }),
+      setCache: async <T>(key: string, value: T): Promise<boolean> => {
+        cache.set(key, value);
+        return true;
+      },
+    });
+    const concurrentRegistry = new PushTokenRegistry(runtime);
+
+    const first = concurrentRegistry.register("ios", "ios-token");
+    const second = concurrentRegistry.register("android", "android-token");
+    await Promise.resolve();
+    expect(cacheReads).toHaveLength(1);
+
+    cacheReads[0]([]);
+    await first;
+    await second;
+
+    expect(
+      (await concurrentRegistry.list()).map((record) => record.token).sort(),
+    ).toEqual(["android-token", "ios-token"]);
+  });
+
+  it("serializes concurrent mutations so persisted tokens cannot regress", async () => {
+    let persisted: PushTokenRecord[] = [];
+    const pendingWrites: Array<() => void> = [];
+    const snapshots: PushTokenRecord[][] = [];
+    let firstWriteStarted!: () => void;
+    let secondWriteStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      firstWriteStarted = resolve;
+    });
+    const secondStarted = new Promise<void>((resolve) => {
+      secondWriteStarted = resolve;
+    });
+    const runtime = createMockRuntime({
+      agentId: "00000000-0000-0000-0000-0000000000aa",
+      getCache: async <T>(): Promise<T | undefined> => persisted as T,
+      setCache: <T>(_key: string, value: T): Promise<boolean> => {
+        const snapshot = value as PushTokenRecord[];
+        snapshots.push(snapshot);
+        (snapshots.length === 1 ? firstWriteStarted : secondWriteStarted)();
+        return new Promise((resolve) => {
+          pendingWrites.push(() => {
+            persisted = snapshot;
+            resolve(true);
+          });
+        });
+      },
+    });
+    const concurrentRegistry = new PushTokenRegistry(runtime);
+
+    const first = concurrentRegistry.register("ios", "ios-token");
+    const second = concurrentRegistry.register("android", "android-token");
+    await firstStarted;
+    expect(snapshots).toHaveLength(1);
+
+    pendingWrites[0]();
+    await first;
+    await secondStarted;
+    expect(snapshots[1]?.map((record) => record.token).sort()).toEqual([
+      "android-token",
+      "ios-token",
+    ]);
+    pendingWrites[1]();
+    await second;
+
+    const fresh = new PushTokenRegistry(runtime);
+    expect((await fresh.list()).map((record) => record.token).sort()).toEqual([
+      "android-token",
+      "ios-token",
+    ]);
   });
 });

--- a/packages/agent/src/services/push/push-token-registry.ts
+++ b/packages/agent/src/services/push/push-token-registry.ts
@@ -33,6 +33,8 @@ const cacheKeyFor = (agentId: string): string => `push-tokens:${agentId}`;
 export class PushTokenRegistry {
   private tokens = new Map<string, PushTokenRecord>();
   private hydrated = false;
+  private hydrationPromise: Promise<void> | null = null;
+  private mutationTail: Promise<void> = Promise.resolve();
 
   constructor(private readonly runtime: IAgentRuntime) {}
 
@@ -43,6 +45,21 @@ export class PushTokenRegistry {
   /** Load persisted tokens from the DB-backed cache. Idempotent. */
   async hydrate(): Promise<void> {
     if (this.hydrated) return;
+    if (!this.hydrationPromise) {
+      this.hydrationPromise = this.loadPersistedTokens();
+    }
+    const hydrationPromise = this.hydrationPromise;
+    try {
+      await hydrationPromise;
+    } catch (error) {
+      if (this.hydrationPromise === hydrationPromise) {
+        this.hydrationPromise = null;
+      }
+      throw error;
+    }
+  }
+
+  private async loadPersistedTokens(): Promise<void> {
     const stored = await this.runtime.getCache<PushTokenRecord[]>(
       this.cacheKey,
     );
@@ -60,6 +77,17 @@ export class PushTokenRegistry {
     await this.runtime.setCache(this.cacheKey, [...this.tokens.values()]);
   }
 
+  private enqueueMutation<T>(mutation: () => Promise<T>): Promise<T> {
+    const pending = this.mutationTail.then(mutation);
+    // error-policy:J5 the caller observes `pending`; this recovery keeps one
+    // failed persistence attempt from poisoning every later registry mutation.
+    this.mutationTail = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    return pending;
+  }
+
   /**
    * Register (upsert) a device token. Re-registering an existing token under a
    * new platform moves it to that platform and refreshes `createdAt`.
@@ -69,23 +97,27 @@ export class PushTokenRegistry {
     if (!trimmed) {
       throw new Error("[PushTokenRegistry] token is required");
     }
-    await this.hydrate();
-    this.tokens.set(trimmed, {
-      token: trimmed,
-      platform,
-      createdAt: Date.now(),
+    await this.enqueueMutation(async () => {
+      await this.hydrate();
+      this.tokens.set(trimmed, {
+        token: trimmed,
+        platform,
+        createdAt: Date.now(),
+      });
+      await this.persist();
     });
-    await this.persist();
   }
 
   /** Unregister a device token. Returns true if it existed. */
   async unregister(token: string): Promise<boolean> {
-    await this.hydrate();
-    const removed = this.tokens.delete(token.trim());
-    if (removed) {
-      await this.persist();
-    }
-    return removed;
+    return this.enqueueMutation(async () => {
+      await this.hydrate();
+      const removed = this.tokens.delete(token.trim());
+      if (removed) {
+        await this.persist();
+      }
+      return removed;
+    });
   }
 
   /** List every registered token record. */


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
- AI assistance: Yes - initial author assistance plus maintainer review and remediation
<!-- attribution-row:models -->
- Models: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client/tooling: Codex CLI, Claude Code, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - the contribution skill was not used for this maintainer review and remediation
<!-- attribution-row:status -->
- Provenance status: self-reported

AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: traced the full `hydrate()`/`register()` interaction by hand to confirm the fix actually closes the race (not just the symptom the regression test exercises) - both concurrent registrations now block on the same single `loadPersistedTokens()` call before either mutates the shared `Map`, so no data is lost regardless of resume order. Re-ran the mutation check myself 3x against the reverted source (consistently red - deterministic, the test controls timing explicitly) and 3x against the restored fix (consistently green, 9/9), re-ran biome myself, independently confirmed the pre-existing typecheck failures (19 errors, same 7 unrelated files as a prior round's check) reproduce identically with this fix's two files fully `git stash`ed out, and traced the reachability chain into the real route dispatcher.

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low-to-moderate (concurrency fix, reviewed with extra scrutiny). Shares one in-flight hydration `Promise` across concurrent `hydrate()` callers instead of a boolean guard. The error-reset path clears `hydrationPromise` only if it's still reference-equal to the promise that just rejected, so an older failed attempt's cleanup can't clobber a newer retry already in flight - same reference-equality safety pattern as a prior concurrency fix in this codebase (`virtual-filesystem.ts`'s write-lock queue). Normal (non-concurrent, non-failing) hydration is unaffected.

# Background

## What does this PR do?

`PushTokenRegistry.hydrate()` used only a boolean `hydrated` guard. Two concurrent first-use calls - e.g. two devices registering before the registry's first cache load completes - could both pass that guard and start independent cache reads. `loadPersistedTokens()` unconditionally replaces `this.tokens` with a fresh `Map` built from the cache read; if a caller's own `register()` had already written into the first `Map` instance before the second read's replacement lands, that registration was silently deleted.

Before fix: two concurrent registrations (iOS, then Android) resolve their cache reads in sequence; only the Android token survives - the iOS registration is silently lost.

After fix: both registrations share the single hydration read; both survive.

## What kind of change is this?

Bug fix — no new capability, no schema change.

# Documentation changes needed?

No.

# Testing

New test `preserves registrations made while first-use hydration is in flight` in `packages/agent/src/services/push/push-token-registry.test.ts`, using a controllable mock cache to deterministically sequence the two concurrent cache-read completions.

# Evidence Gate

<!-- evidence-head:9516b40be1ebbff5b48e1cadd4345f5d86399c36 -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend logic fix, no UI surface
- <!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual behavior changed

## Known gaps / failures

Package `typecheck` has **pre-existing, unrelated** failures: 19 errors across 7 files, all `TS2307: Cannot find module` for optional plugin packages (`@elizaos/plugin-capacitor-bridge`, `@elizaos/plugin-wallet`, `@elizaos/plugin-video`, `@elizaos/plugin-vision`, `@elizaos/plugin-notes`, `@elizaos/plugin-todos`) not installed in this environment. Independently confirmed these reproduce identically with this PR's two changed files fully `git stash`ed out - not caused by this change. The package-wide test lane also hits unrelated pre-existing `listen EPERM` sandbox loopback-bind restrictions in a different test file. Neither touched file appears in either failure set.

## Reachability

- `packages/agent/src/runtime/eliza-plugin.ts` registers `NotificationPushService` in the normal agent service set.
- `packages/agent/src/api/server-route-dispatch.ts` dispatches real HTTP requests under `/api/notifications/push-tokens` to `handlePushTokenRoute`.
- `POST /api/notifications/push-tokens` (`packages/agent/src/api/push-token-routes.ts`) accepts device-supplied iOS/Android tokens and calls `registry.register()`, which resolves the registry via `NotificationPushService.getRegistry()`.
- Two devices registering concurrently before the registry's first cache load completes reach this race with real, non-hardcoded input.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic focused regression tests are documented in the Testing section and produce no persistent backend log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by this logic change

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered interface changed
