### PR TITLE
fix(cloud): green onboarding coordinator and BlueBubbles dedupe suites

### DIFF
--- a/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
@@ -182,6 +182,7 @@ mock.module("@/lib/services/credits", () => ({
   },
   DEFAULT_OUTPUT_TOKENS: 500,
   InsufficientCreditsError: class extends Error {},
+  ReservationNotFoundError: class extends Error {},
 }));
 
 mock.module("@/lib/services/usage", () => ({

--- a/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
@@ -126,6 +126,7 @@ mock.module("@/lib/services/credits", () => ({
   },
   DEFAULT_OUTPUT_TOKENS: 500,
   InsufficientCreditsError: TestInsufficientCreditsError,
+  ReservationNotFoundError: class extends Error {},
 }));
 
 mock.module("@/lib/services/organization-inference-admission", () => ({

--- a/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
@@ -35,11 +35,14 @@ mock.module("../../shared/src/lib/services/eliza-app/user-service", () => ({
 }));
 
 mock.module("../../shared/src/lib/services/eliza-app/provisioning", () => ({
-  ensureElizaAppProvisioning: mock(async () => {
+  ensureElizaAppProvisioning: mock(async () => noProvisioning),
+  // Onboarding no longer provisions compute; the read-only status poll is the
+  // remaining fallible provisioning step inside an authenticated turn, so it
+  // is where a pre-commit outage is injected.
+  getElizaAppProvisioningStatus: mock(async () => {
     if (provisioningFailure) throw provisioningFailure;
     return noProvisioning;
   }),
-  getElizaAppProvisioningStatus: mock(async () => noProvisioning),
 }));
 
 const { OnboardingSessionCoordinator: OnboardingSessionCoordinatorValue } =
@@ -1232,8 +1235,9 @@ describe("OnboardingSessionCoordinator", () => {
           }),
         );
 
-      // The browser continuation binds the account in memory, then
-      // provisioning throws BEFORE the durable transaction commits. The turn
+      // The browser continuation binds the account in memory, then the
+      // provisioning status read throws BEFORE the durable transaction
+      // commits. The turn
       // fails and the greeting must not exist anywhere: the user would be
       // DMed "you're all set" for a sign-in that did not persist.
       provisioningFailure = new Error("transient provisioning outage");

--- a/packages/cloud/api/__tests__/stripe-event-clawback.test.ts
+++ b/packages/cloud/api/__tests__/stripe-event-clawback.test.ts
@@ -93,6 +93,7 @@ mock.module("@/lib/services/credits", () => ({
     clawbackCredits,
     refundCredits,
   },
+  ReservationNotFoundError: class extends Error {},
 }));
 mock.module("@/lib/services/discord", () => ({
   discordService: {},

--- a/packages/cloud/api/webhooks/bluebubbles/dedupe.test.ts
+++ b/packages/cloud/api/webhooks/bluebubbles/dedupe.test.ts
@@ -59,7 +59,14 @@ let closeDb: (() => Promise<void>) | undefined;
 let bbRoute: typeof import("./route").default;
 
 const SECRET = "bb-secret";
-const ENV = { BLUEBUBBLES_GATEWAY_SECRET: SECRET };
+// The legacy (secret-header) path requires an explicit gateway identity since
+// the fabricated org/phone defaults were removed; without these the route
+// returns 503 before the dedupe claim.
+const ENV = {
+  BLUEBUBBLES_GATEWAY_SECRET: SECRET,
+  BLUEBUBBLES_GATEWAY_ORG_ID: "org-1",
+  BLUEBUBBLES_GATEWAY_PHONE_NUMBER: "+14159611510",
+};
 
 function delivery(guid: string) {
   const app = new Hono();


### PR DESCRIPTION
## Summary

Greens the remaining red files in the cloud-api `bun test` lane (the release-blocking `bun run test` step, evidence run 32028487803, listed 8/354 failing files). #21309 already fixed the two workerd runtime miniflare suites and the coordinator-errors stub; this PR (rebased on top of it) fixes the other five. All were **test drift behind intentional product changes** — no product code changed, and the deliberate safety contracts (dedupe rollback, durable-commit-before-DM) remain pinned.

## Root causes

**1. `webhooks/bluebubbles/dedupe.test.ts` (3 failures, 503 instead of 200)**
c1d89b5a1861 ("close BlueBubbles identity and retry gaps") deliberately removed the fabricated `DEFAULT_GATEWAY_ORG_ID` / `DEFAULT_GATEWAY_PHONE_NUMBER` fallbacks: the legacy secret-header path now 503s ("BlueBubbles gateway is not configured") unless `BLUEBUBBLES_GATEWAY_ORG_ID` and `BLUEBUBBLES_GATEWAY_PHONE_NUMBER` are set — before the dedupe claim is ever reached. `route.test.ts` was updated in that commit; `dedupe.test.ts` was not. Fix: the dedupe suite's env now carries the legacy identity. The replay-dedupe and rollback-on-failure contracts are unchanged and still exercised against the real PGlite-backed `webhookEventsRepository`.

**2. `__tests__/onboarding-session-coordinator.test.ts` ("no false-success DM" test, 200 instead of 500)**
d58a80ab37bc ("stop onboarding from provisioning compute", #19799) removed the `ensureElizaAppProvisioning` call from the onboarding turn — provisioning is now an explicit lifecycle action and the turn only reads status. The test injected its pre-commit outage into `ensureElizaAppProvisioning`, which is no longer called, so the turn succeeded and the expected 500 never happened. Fix: the outage is now injected into the read-only `getElizaAppProvisioningStatus` poll — the remaining fallible provisioning step inside an authenticated turn, which runs after the in-memory account bind and before `store.save`. The guard is intact and still verified: a turn that fails before its durable commit never enqueues the proactive greeting, the retry enqueues exactly one, and a transport replay never re-enqueues.

**3. `__tests__/chat-cache-hotpath.test.ts`, `__tests__/chat-stream-credit-leak.test.ts`, `__tests__/stripe-event-clawback.test.ts` (module-link failure before any test ran)**
`credit-reservation.ts` now imports `ReservationNotFoundError` from `@/lib/services/credits` (20754, "fail closed in credits reconcile settlement"). These suites replace that module via `mock.module` with shapes that lacked the class, so bun failed linking with "Export named 'ReservationNotFoundError' not found". The mocks now export a stub class alongside their existing `creditsService` surface.

**Also checked (per lane report): `packages/cloud/shared/.../onboarding-proactive-greeting.test.ts`** — already green on develop; no change.

## Evidence

Every file runs via the package lane runner (`test/run-unit-isolated.mjs`, one bun process per file for `mock.module` isolation), rebased on 590f425c574c (#21309):

```
webhooks/bluebubbles/dedupe.test.ts                        3 pass / 0 fail
__tests__/onboarding-session-coordinator.test.ts          25 pass / 0 fail
__tests__/onboarding-coordinator-errors.miniflare.test.ts  1 pass / 0 fail   (fixed in #21309)
__tests__/chat-cache-hotpath.test.ts                       6 pass / 0 fail
__tests__/chat-stream-credit-leak.test.ts                  7 pass / 0 fail
__tests__/stripe-event-clawback.test.ts                    6 pass / 0 fail
__tests__/eliza-runtime-edge.miniflare.test.ts             pass              (fixed in #21309)
__tests__/shared-eliza-runtime.miniflare.test.ts           3 pass / 1 skip   (fixed in #21309; skip is the env-gated live web-search test)
cloud/shared onboarding-proactive-greeting.test.ts         2 pass / 0 fail   (already green)
```

- Full package lane `bun run --cwd packages/cloud/api test` (isolated, one bun process per file): **all 354 files pass** — previously 8/354 failed, matching the CI evidence run.
- `bun run --cwd packages/cloud/api typecheck` — clean (tsc + wrangler dry-run worker bundle).
- Biome on all touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
