### PR TITLE
fix(cloud): green the workerd runtime miniflare suites

### DIFF
--- a/packages/cloud/api/__tests__/eliza-runtime-edge.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/eliza-runtime-edge.miniflare.test.ts
@@ -39,6 +39,7 @@ describe("Eliza runtime Cloudflare entry", () => {
       new URL("../test/fixtures/eliza-runtime-edge-worker.ts", import.meta.url),
     );
     const outputPath = join(buildDirectory, "worker.mjs");
+    const coreEdgeArtifact = join(coreDirectory, "dist/edge/index.edge.js");
     const buildProcess = Bun.spawn({
       cmd: [
         process.execPath,
@@ -51,6 +52,18 @@ describe("Eliza runtime Cloudflare entry", () => {
 					conditions: ["worker"],
 					external: ["node:*"],
 					minify: true,
+					plugins: [{
+						name: "eliza-core-edge-boundary",
+						setup(build) {
+							// Pin the published edge artifact this suite just built. Without
+							// the pin, the cloud tsconfig "paths" alias resolves
+							// @elizaos/core/edge to core src, whose node-oriented feature
+							// graph (fs-extra and friends) cannot even evaluate in Workerd.
+							build.onResolve({ filter: /^@elizaos\\/core\\/edge$/ }, () => ({
+								path: process.env.ELIZA_CORE_EDGE_ARTIFACT,
+							}));
+						},
+					}],
 				});
 				if (!result.success) {
 					for (const log of result.logs) console.error(log);
@@ -63,6 +76,7 @@ describe("Eliza runtime Cloudflare entry", () => {
       cwd: coreDirectory,
       env: {
         ...process.env,
+        ELIZA_CORE_EDGE_ARTIFACT: coreEdgeArtifact,
         ELIZA_EDGE_ENTRY: entrypoint,
         ELIZA_EDGE_OUTPUT: outputPath,
       },
@@ -92,7 +106,7 @@ describe("Eliza runtime Cloudflare entry", () => {
         },
       ],
     });
-  });
+  }, 120_000);
 
   afterAll(async () => {
     await miniflare?.dispose();

--- a/packages/cloud/api/__tests__/onboarding-coordinator-errors.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-coordinator-errors.miniflare.test.ts
@@ -132,6 +132,9 @@ describe("onboarding coordinator error integration", () => {
               loader: "ts",
               contents: `export async function launchManagedElizaAgent() {
                 throw new Error("launch is outside this authorization test");
+              }
+              export async function readManagedElizaAgentConnection() {
+                throw new Error("connection reads are outside this authorization test");
               }`,
             }));
             build.onLoad(

--- a/packages/cloud/api/__tests__/shared-eliza-runtime.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/shared-eliza-runtime.miniflare.test.ts
@@ -622,7 +622,7 @@ describe("Shared Eliza runtime in Workerd", () => {
       scheduledTasks: Array<Record<string, unknown>>;
     };
     expect(payload.result).toMatchObject({
-      reply: "i'll remind you in two minutes",
+      reply: "Got it — I'll remind you in 2 minutes: stretch",
       degraded: false,
     });
     expect(payload.result.actionResults).toHaveLength(1);
@@ -648,7 +648,11 @@ describe("Shared Eliza runtime in Workerd", () => {
         },
       },
     });
-    expect(modelRequests.length - requestsBefore).toBe(3);
+    // Two model calls only: triage plus the REMINDERS tool call. The action's
+    // deterministic acknowledgement completes the turn, so no finish
+    // round-trip happens (plugin-scheduling shared-reminders acknowledgement
+    // contract).
+    expect(modelRequests.length - requestsBefore).toBe(2);
   }, 120_000);
 
   test.skipIf(process.env.SHARED_ELIZA_LIVE_WEB_SEARCH !== "1")(


### PR DESCRIPTION
## Problem

The cloud-api workerd/miniflare suites have been red in the `bun run test` lane (blocking the transactional npm release — see evidence run 32028487803). Reproduced locally via the lane's own runner (`node test/run-unit-isolated.mjs miniflare`): three of the four miniflare files failed.

## Root causes and fixes

### 1. `eliza-runtime-edge.miniflare.test.ts` — `Cannot read properties of undefined (reading 'native')`

The suite builds `@elizaos/core` with `--edge-only` (producing `dist/edge/index.edge.js`) and then bundles the worker fixture with a nested `Bun.build`. But `Bun.build` honors the cloud tsconfig `paths` alias (`"@elizaos/core/edge": ["../../../packages/core/src/index.edge.ts"]`, added for typecheck), so the bundle was built from core **source** instead of the just-built dist artifact. The from-source graph (`index.edge.ts → runtime.ts → features/basic-capabilities/index.ts → features barrel → plugin-manager/coreManagerService.ts`) eagerly evaluates `import fs from "fs-extra"`; under `target: "browser"` Bun shims bare `fs` to an empty module, so graceful-fs's module-scope `fs.realpath.native` read kills the isolate before any user code runs. Core's own edge build avoids this via its `edgeRuntimeSourcesPlugin` swap — which the nested test build never had.

**Fix:** pin `@elizaos/core/edge` to the freshly built `dist/edge/index.edge.js` with the same `eliza-core-edge-boundary` resolve plugin the sibling `shared-eliza-runtime` suite already uses (also more production-faithful: wrangler resolves the package export, not the tsconfig alias). Also give `beforeAll` the explicit `120_000` timeout the shared suite already carries — the CI runner spawns plain `bun test <file>`, whose default 5s hook timeout can't cover the core edge build, so the suite flipped between the hook timeout and the `.native` crash depending on build speed.

### 2. `shared-eliza-runtime.miniflare.test.ts` — REMINDERS assertion drift

d3fc4dc4ce98 (`fix(scheduling): keep reminder acknowledgements user-facing`) intentionally made the REMINDERS action emit a deterministic, user-facing acknowledgement (`Got it — I'll remind you in 2 minutes: stretch`) that completes the turn (`turnComplete: true`). It aligned `packages/cloud/shared/.../shared-eliza-runtime.test.ts` but missed this workerd suite, which still expected the model-composed `i'll remind you in two minutes` finish reply and 3 model calls. Aligned the reply expectation and the model-call count to 2 (triage + tool call; the finish round-trip no longer happens — the mock's finish stage is now dead by design).

### 3. `onboarding-coordinator-errors.miniflare.test.ts` — nested bundle build failure (found en route, same lane)

`onboarding-chat.ts` now imports `readManagedElizaAgentConnection` from `eliza-managed-launch` (iMessage onboarding return work), but the test's managed-launch boundary stub only exported `launchManagedElizaAgent`, so the nested `Bun.build` failed with `No matching export`. Added the new symbol to the stub with the same out-of-scope throw.

## Evidence

All four cloud-api miniflare files green via the lane's own runner:

```
$ node test/run-unit-isolated.mjs miniflare
[cloud-api unit] running 4 file(s) isolated (one bun process each)
...
[cloud-api unit] all 4 file(s) passed (isolated)
```

(9 pass, 1 skip — the skip is the env-gated `SHARED_ELIZA_LIVE_WEB_SEARCH` live-search test.)

- `bun run --cwd packages/cloud/api typecheck` (tsc + `check:worker-bundle` wrangler dry-run): green
- Biome on the three touched files: clean

Production code is untouched: cause 1 is a test-bundling resolution defect, causes 2 and 3 align tests with intentional product changes (d3fc4dc4ce98 and the onboarding managed-connection read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)