### PR TITLE
fix(cloud): reject prefix-coerced admin-moderation list limit

### DIFF
--- a/packages/cloud/api/v1/admin/moderation/route.limit.test.ts
+++ b/packages/cloud/api/v1/admin/moderation/route.limit.test.ts
@@ -1,0 +1,127 @@
+/**
+ * GET /api/v1/admin/moderation `limit` is violations page-size identity.
+ * Stock develop used z.coerce.number(), which treated `1e2` / `007` /
+ * `0x10` as a page size instead of a 400. view / userId stay untouched.
+ * Missing / empty still means 100.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getRecentViolations = mock(async () => []);
+const getUsersFlaggedForReview = mock(async () => []);
+const getBannedUsers = mock(async () => []);
+const listAdmins = mock(async () => []);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireAdmin: async () => ({
+    user: { id: "admin-1", wallet_address: "0xadmin", organization_id: "org-1" },
+    role: "super_admin",
+  }),
+  requireUserOrApiKey: async () => ({ id: "admin-1" }),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  ApiError: class ApiError extends Error {
+    status = 500;
+    constructor(status: number, _code: string, message: string) {
+      super(message);
+      this.status = status;
+    }
+    toJSON() {
+      return { error: this.message };
+    }
+  },
+  ValidationError: (message: string) => {
+    const err = new Error(message);
+    err.name = "ValidationError";
+    return err;
+  },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    warn: () => undefined,
+    info: () => undefined,
+    error: () => undefined,
+  },
+}));
+mock.module("@/lib/services/admin", () => ({
+  adminService: {
+    getRecentViolations,
+    getUsersFlaggedForReview,
+    getBannedUsers,
+    listAdmins,
+    getUserDetails: mock(async () => ({})),
+  },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/", route);
+
+describe("GET /api/v1/admin/moderation limit identity", () => {
+  beforeEach(() => {
+    getRecentViolations.mockClear();
+  });
+
+  test.each(["?view=violations", "?view=violations&limit=", "?view=violations&limit"])(
+    "accepts %s as the default moderation violations page of 100",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(200);
+      expect(getRecentViolations).toHaveBeenCalledTimes(1);
+      expect(getRecentViolations).toHaveBeenCalledWith(100);
+    },
+  );
+
+  test("accepts limit=10 as an exact moderation violations page size", async () => {
+    const response = await app.request("/?view=violations&limit=10");
+    expect(response.status).toBe(200);
+    expect(getRecentViolations).toHaveBeenCalledWith(10);
+  });
+
+  test("rejects a canonical oversize limit before getRecentViolations", async () => {
+    const response = await app.request("/?view=violations&limit=1001");
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("Invalid limit");
+    expect(getRecentViolations).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    "1e2",
+    "12px",
+    "007",
+    "0",
+    "abc",
+    "-1",
+    "50abc",
+    " 10",
+    "10 ",
+    "0x10",
+  ])(
+    "rejects prefix-coerced limit=%s before getRecentViolations",
+    async (token) => {
+      const response = await app.request(
+        `/?view=violations&limit=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid limit");
+      expect(getRecentViolations).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?view=violations&limit=10&limit=10",
+    "?view=violations&limit=10&limit=20",
+    "?view=violations&limit=&limit=10",
+    "?view=violations&limit=foo&limit=10",
+  ])(
+    "rejects duplicate limit values in %s before getRecentViolations",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid limit");
+      expect(getRecentViolations).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/admin/moderation/route.ts
+++ b/packages/cloud/api/v1/admin/moderation/route.ts
@@ -51,7 +51,45 @@ type CombinableView = (typeof CombinableViews)[number];
 function isCombinableView(value: string): value is CombinableView {
   return (CombinableViews as readonly string[]).includes(value);
 }
-const LimitSchema = z.coerce.number().int().min(1).max(1000).default(100);
+const DEFAULT_MODERATION_LIMIT = 100;
+const MAX_MODERATION_LIMIT = 1000;
+
+class ModerationLimitError extends Error {
+  constructor(message = "Invalid limit") {
+    super(message);
+    this.name = "ModerationLimitError";
+  }
+}
+
+/**
+ * GET /api/v1/admin/moderation `limit` is violations page-size identity.
+ * Stock develop used z.coerce.number(), which treated `1e2` / `007` /
+ * `0x10` as a page size instead of a 400. view / userId stay untouched.
+ * Missing / empty still means 100. Exact integers above 1000 stay 400.
+ */
+function parseModerationLimitQuery(searchParams: URLSearchParams): number {
+  const requested = searchParams.getAll("limit");
+  if (requested.length > 1) {
+    throw new ModerationLimitError();
+  }
+  const raw = requested[0];
+  if (raw == null || raw === "") {
+    return DEFAULT_MODERATION_LIMIT;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new ModerationLimitError();
+  }
+  const parsed = Number(raw);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    parsed > MAX_MODERATION_LIMIT
+  ) {
+    throw new ModerationLimitError();
+  }
+  return parsed;
+}
+
 const AdminRoleSchema = z.enum(["super_admin", "moderator", "viewer"]);
 
 type AdminUserRecord = Awaited<
@@ -288,11 +326,17 @@ app.get("/", async (c) => {
 
   const rawView = c.req.query("view") ?? "overview";
 
-  const parsedLimit = LimitSchema.safeParse(c.req.query("limit"));
-  if (!parsedLimit.success) {
-    throw ValidationError("limit must be an integer from 1 to 1000");
+  let limit: number;
+  try {
+    limit = parseModerationLimitQuery(
+      new URL(c.req.url, "http://localhost").searchParams,
+    );
+  } catch (limitError) {
+    if (limitError instanceof ModerationLimitError) {
+      return c.json({ error: limitError.message }, 400);
+    }
+    throw limitError;
   }
-  const limit = parsedLimit.data;
   const userId = c.req.query("userId");
 
   // Multi-view path: comma-separated list of combinable views. user-detail is


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on cloud
admin-moderation violations `limit` identity. Page-size class, leftover
tax after admin redemption filters. Not a twin of those parsers — this
is `GET /api/v1/admin/moderation` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `limit` only on `/api/v1/admin/moderation`. Omitted/empty still
means 100. Exact positive integers still bind and stay 400 above 1000.
Prefix-coerced / unknown / duplicate tokens 400 before
`adminService.getRecentViolations`. view / userId stay untouched.

# Background

## What does this PR do?

`GET /api/v1/admin/moderation` used `z.coerce.number()`, which treated
`1e2` / `007` / `0x10` as a violations page size instead of a 400.

- omitted / empty → default page of 100
- exact `10` → page of 10
- exact `1001` → 400
- `1e2` / `12px` / `007` / `0x10` / `0` / `foo` / duplicates → **400** before `getRecentViolations`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Admins page moderation violations with `?limit=`. A common `limit=1e2`
or `007` after a client sends a numeric token must not silently become a
coerced page. Leftover tax after admin redemption network/status
filters. Disjoint files from those.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/admin/moderation/route.limit.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test "./v1/admin/moderation/route.limit.test.ts"
```

19 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; admin-moderation `limit` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; admin-moderation `limit` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; admin-moderation `limit` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real limit tokens and assert 400 before getRecentViolations; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before getRecentViolations.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`limit` tokens reject; omitted/canonical still bind the matching
moderation violations page size.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the admin-moderation
`limit` query only.

## Known gaps / failures

`bun run verify` was not run. Focused 19-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4644b834c5125f202b12638461cbde0dcafcc37f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
