### PR TITLE
fix(ui): anchor the chat-overlay shell entry keyframes to the centering transform

### DIFF
--- a/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
@@ -408,6 +408,164 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
         skipVisible: true,
       });
 
+    // Resting-state transform lock: the settled panel's computed transform
+    // must be EXACTLY the shell's centering transform — asserting the
+    // anchored keyframes end state and that the Tailwind utility `translate`
+    // path stays cancelled.
+    const readRestingTransform = () =>
+      harness.eval<{
+        matrix: string;
+        width: number;
+      }>(`(() => {
+        const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
+        if (!(panel instanceof HTMLElement)) throw new Error('panel missing');
+        return {
+          matrix: getComputedStyle(panel).transform,
+          width: panel.getBoundingClientRect().width,
+        };
+      })()`);
+    // Poll until the entry animation has fully settled: its translateY term
+    // must reach exactly 0 before the one-shot snapshot is asserted.
+    await expect
+      .poll(async () => {
+        const current = await readRestingTransform();
+        const match = /^matrix\(([^)]+)\)$/.exec(current.matrix.trim());
+        return match
+          ? Number.parseFloat(match[1].split(",")[5]?.trim() ?? "NaN")
+          : Number.NaN;
+      })
+      .toBe(0);
+    const resting = await readRestingTransform();
+    const matrixMatch = /^matrix\(([^)]+)\)$/.exec(resting.matrix.trim());
+    expect(matrixMatch).toBeTruthy();
+    const matrixTerms = (matrixMatch?.[1] ?? "")
+      .split(",")
+      .map((term) => Number.parseFloat(term.trim()));
+    // identity scale terms and a pure X translation of exactly -width/2
+    expect(matrixTerms[0]).toBe(1);
+    expect(matrixTerms[1]).toBe(0);
+    expect(matrixTerms[2]).toBe(0);
+    expect(matrixTerms[3]).toBe(1);
+    expect(matrixTerms[5]).toBe(0);
+    expect(Math.abs(matrixTerms[4] + resting.width / 2)).toBeLessThanOrEqual(1);
+
+    // Mid-entry centering probe (#20063, follow-up to #20496): the resting
+    // assertions above wait out the 220ms entry animation, so they pass even
+    // if the animation replaces the centering transform (the residual finding
+    // from the #20496 review: the base `shell-overlay-in` keyframes animate
+    // `translateY(...)` alone, dropping the shell's `translateX(-50%)` for
+    // the entry). Deterministically RESTART the entry animation, flush
+    // styles, pause at the 110ms midpoint, and assert the panel is
+    // horizontally centered THERE, where un-anchored keyframes would place it
+    // ~half its width off-center. A computed animationName alone is NOT
+    // evidence the animation is still running (it stays declared after
+    // finish), and a finished animation ignores animationDelay/playState
+    // changes — hence the explicit restart.
+    {
+      const midEntry = await harness.eval<{
+        skipped: boolean;
+        reason?: string;
+        animationName: string;
+        left: number;
+        width: number;
+        viewportWidth: number;
+      }>(`(() => {
+        const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
+        if (!(panel instanceof HTMLElement)) throw new Error('panel missing');
+        // The ONLY legitimate skip: the runner itself suppresses animations.
+        // (animation-name is NOT a valid detector — the shell rule sets it
+        // unconditionally, even when motion-safe utilities are withheld.)
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+          return { skipped: true, reason: 'prefers-reduced-motion' };
+        }
+        const cs = getComputedStyle(panel);
+        if (cs.animationName !== 'shell-overlay-in-anchored') {
+          // The shell rule must select the anchored keyframes; anything else
+          // is a regression, not a skip.
+          throw new Error(
+            'shell rule no longer selects shell-overlay-in-anchored (got ' +
+              cs.animationName + ')',
+          );
+        }
+        // Capture the utility-declared shorthand so restoration is exact.
+        const declared = {
+          name: cs.animationName,
+          duration: cs.animationDuration,
+          timing: cs.animationTimingFunction,
+          delay: cs.animationDelay,
+          iteration: cs.animationIterationCount,
+          direction: cs.animationDirection,
+          fill: cs.animationFillMode,
+          play: cs.animationPlayState,
+        };
+        // Validate the duration BEFORE any inline mutation so the guard
+        // throws leave the panel untouched (the restore finally sits outside
+        // this eval round-trip; ordering makes the no-leak guarantee
+        // unconditional).
+        const durationMs =
+          Number.parseFloat(declared.duration) *
+          (declared.duration.endsWith("ms") ? 1 : 1000);
+        if (!(durationMs > 0)) {
+          throw new Error(
+            'entry animation duration is not positive (got ' +
+              declared.duration + '); motion-safe utility not applied',
+          );
+        }
+        // Restart: cancel any in-flight/finished animation, cancel the
+        // inline override, then re-declare the shorthand so a NEW
+        // CSSAnimation starts from time zero.
+        for (const anim of panel.getAnimations()) anim.cancel();
+        panel.style.animation = 'none';
+        void panel.offsetWidth; // force style flush
+        panel.style.animation = [
+          declared.duration, declared.timing, '0ms', declared.iteration,
+          declared.direction, declared.fill, 'paused', declared.name,
+        ].join(' ');
+        void panel.offsetWidth; // flush so the paused animation exists
+        // Seek to the midpoint of the duration via currentTime. A
+        // zero/negative duration means the motion-safe utility was withheld
+        // and seeking would sample time zero — a silent false pass.
+        const anim = panel.getAnimations()[0];
+        if (!(anim instanceof CSSAnimation)) {
+          throw new Error('no CSSAnimation running after restart');
+        }
+        anim.currentTime = durationMs / 2;
+        void panel.offsetWidth; // flush the seeked frame
+        const rect = panel.getBoundingClientRect();
+        return {
+          skipped: false,
+          animationName: cs.animationName,
+          left: rect.left,
+          width: rect.width,
+          viewportWidth: window.innerWidth,
+        };
+      })()`);
+      try {
+        if (!midEntry.skipped) {
+          expect(midEntry.animationName).toBe("shell-overlay-in-anchored");
+          const midOffset = Math.abs(
+            midEntry.left + midEntry.width / 2 - midEntry.viewportWidth / 2,
+          );
+          expect(midOffset).toBeLessThanOrEqual(4);
+        } else {
+          // Surface the skip for traceability, matching the file's
+          // established annotation pattern for unavailable-evidence paths.
+          testInfo.annotations.push({
+            type: "entry-probe-unavailable",
+            description: `mid-entry centering probe skipped: ${midEntry.reason ?? "unspecified"}`,
+          });
+        }
+      } finally {
+        // Restoration must run even when an assertion throws (so the inline
+        // animation override never leaks into later probes).
+        await harness.eval(
+          `(() => {
+            const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
+            if (panel instanceof HTMLElement) panel.style.animation = '';
+          })()`,
+        );
+      }
+    }
     await harness.eval(
       `document.querySelector('[aria-label="Close assistant"]')?.click()`,
     );

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -735,6 +735,29 @@ body.pwa-standalone * {
   }
 }
 
+/*
+ * Chat-overlay-shell variant of the panel entry animation (#20063): the
+ * shell rule centers the panel via `transform: translateX(-50%)`, and a CSS
+ * animation REPLACES the transform property wholesale for its duration —
+ * so animating `translateY(...)` alone (the base keyframes above) drops the
+ * centering term and the panel flies in ~half its width off-center for the
+ * 220ms entry before snapping back. These keyframes carry the centering
+ * term through every frame instead. Selected by the
+ * `html.eliza-chat-overlay-shell` rule in styles.css, which overrides the
+ * utility-picked animation-name; durations/easing still come from the
+ * `motion-safe:animate-[shell-overlay-in_220ms_ease-out]` utility.
+ */
+@keyframes shell-overlay-in-anchored {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(8%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
 /* A freshly-arrived chat turn fades + lifts in. Subtler than shell-overlay-in
    (a single bubble, not the whole panel). Applied via
    `motion-safe:animate-[chat-turn-in_...]` on the message <article>, scoped to

--- a/packages/ui/src/styles/shell-overlay-anchoring.test.ts
+++ b/packages/ui/src/styles/shell-overlay-anchoring.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Gate asserting the chat-overlay shell entry-animation anchoring contract
+ * (#20063 follow-up to #20496). Reads the stylesheets, no runtime.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard for the transient off-center fly-in lalalune confirmed as
+ * the one residual finding from the #20496 review.
+ *
+ * The chat-overlay desktop shell centers its panel with
+ * `transform: translateX(-50%)` (styles.css shell rule), and a CSS animation
+ * REPLACES the transform property wholesale for its duration. The base
+ * `shell-overlay-in` keyframes (used by the flex-centered login card, which
+ * has NO translateX term to preserve) animate `translateY(...)` alone — so
+ * when the shell's panel runs them, the centering term is dropped for the
+ * whole 220ms entry and the panel flies in ~half its width off-center before
+ * snapping back.
+ *
+ * The contract: base.css declares an `-anchored` variant carrying
+ * `translateX(-50%)` through EVERY keyframe, and the shell rule in styles.css
+ * overrides `animation-name` to select it (duration/easing still come from the
+ * utility). The login page keeps the base keyframes (its card is centered via
+ * flex `my-auto`, no translateX) and MUST stay unaffected: the override lives
+ * only inside the `html.eliza-chat-overlay-shell` scoped rule.
+ */
+function readStyle(name: string): string {
+  const raw = readFileSync(
+    fileURLToPath(new URL(`./${name}`, import.meta.url)),
+    "utf8",
+  );
+  // Strip CSS comments so their prose can't confuse brace matching below.
+  return raw.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/** Extract the declaration block body for the first rule matching `selector`. */
+function ruleBlock(css: string, selector: string): string {
+  const at = css.indexOf(selector);
+  if (at === -1) throw new Error(`selector not found: ${selector}`);
+  const open = css.indexOf("{", at);
+  const close = css.indexOf("}", open);
+  return css.slice(open + 1, close);
+}
+
+/** Extract the declaration block body between a keyframes selector's braces. */
+function keyframesBlock(css: string, name: string): string {
+  // The trailing whitespace boundary keeps "shell-overlay-in" from prefix-
+  // matching "shell-overlay-in-anchored" (both blocks live in base.css).
+  const marker = `@keyframes ${name} `;
+  const at = css.indexOf(marker);
+  if (at === -1) throw new Error(`@keyframes ${name} not found`);
+  const open = css.indexOf("{", at);
+  let depth = 1;
+  let i = open + 1;
+  while (i < css.length && depth > 0) {
+    if (css[i] === "{") depth += 1;
+    if (css[i] === "}") depth -= 1;
+    i += 1;
+  }
+  return css.slice(open + 1, i - 1);
+}
+
+describe("chat-overlay shell entry-animation anchoring (#20063)", () => {
+  const baseCss = readStyle("base.css");
+  const stylesCss = readStyle("styles.css");
+
+  it("declares shell-overlay-in-anchored keyframes carrying translateX(-50%) in every keyframe", () => {
+    const anchored = keyframesBlock(baseCss, "shell-overlay-in-anchored");
+    const frames = anchored.match(/transform:\s*([^;]+);/g) ?? [];
+    expect(frames.length).toBeGreaterThanOrEqual(2);
+    for (const frame of frames) {
+      expect(frame).toContain("translateX(-50%)");
+    }
+  });
+
+  it("keeps the base shell-overlay-in keyframes translateY-only for the login card", () => {
+    const base = keyframesBlock(baseCss, "shell-overlay-in");
+    const frames = base.match(/transform:\s*([^;]+);/g) ?? [];
+    expect(frames.length).toBeGreaterThanOrEqual(2);
+    for (const frame of frames) {
+      expect(frame).not.toContain("translateX");
+    }
+  });
+
+  it("overrides animation-name to the anchored variant only inside the chat-overlay shell rule", () => {
+    const shell = ruleBlock(
+      stylesCss,
+      "html.eliza-chat-overlay-shell .shell-assistant-overlay-panel",
+    );
+    expect(shell).toContain("animation-name: shell-overlay-in-anchored");
+    // The override must be scoped: the unscoped stylesheet outside the shell
+    // rule must not re-declare the animation name anywhere else.
+    const otherRules = stylesCss.replace(
+      /html\.eliza-chat-overlay-shell \.shell-assistant-overlay-panel\s*\{[^}]*\}/,
+      "",
+    );
+    expect(otherRules).not.toContain("shell-overlay-in-anchored");
+    // base.css owns the keyframes themselves and nothing else: a second
+    // reference there (e.g. an animation shorthand on an unrelated rule)
+    // would leak the X-carrying keyframes to a non-centered element.
+    const baseOccurrences = baseCss.match(/shell-overlay-in-anchored/g);
+    expect(baseOccurrences?.length).toBe(1);
+  });
+
+  it("keeps the shell's centering transform and translate reset intact (#20105)", () => {
+    const shell = ruleBlock(
+      stylesCss,
+      "html.eliza-chat-overlay-shell .shell-assistant-overlay-panel",
+    );
+    expect(shell).toContain("translate: none !important");
+    expect(shell).toContain("transform: translateX(-50%)");
+  });
+});

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -181,6 +181,13 @@ html.eliza-chat-overlay-shell .shell-assistant-overlay-panel {
   /* biome-ignore lint/complexity/noImportantStyles: cross-asset Tailwind reset */
   translate: none !important;
   transform: translateX(-50%);
+  /* The entry keyframes must not drop the centering transform: CSS animations
+     replace `transform` wholesale, so the utility-picked
+     `shell-overlay-in` (translateY-only) would un-center the panel for the
+     220ms entry. Override only the name — duration/easing still come from the
+     `motion-safe:animate-[shell-overlay-in_220ms_ease-out]` utility (the
+     `-anchored` keyframes are declared in base.css next to the base ones). */
+  animation-name: shell-overlay-in-anchored;
   border-radius: 1.5rem;
   border-color: rgb(255 255 255 / 20%);
 }


### PR DESCRIPTION
# Relates to

- Follow-up to #20496 (closed as superseded by #20105): implements the one residual entry-drift finding maintainer @lalalune's closing review invited as a standalone PR.
- Issue #20063 was resolved by #20105; this PR fixes the transient animation regression that remained after it.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (rebased onto `9f48a26bcf` = current tip immediately before push).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker. (Scoped gates run — see Known gaps: full-repo `bun run verify` not run; scoped equivalents for the touched surfaces all green, remaining lane reds reproduced identically on a clean develop-tip control.)
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3` (implementation + verification), `openai/gpt-5.6-sol` (independent RepoPrompt CE review agent, APPROVE with zero must-fix)
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below. (See Known gaps: full-repo verify not run in this session; scoped gates green, three pre-existing packages/ui lane reds reproduced identically at develop tip.)

# Risks

Low. CSS-only production change confined to two keyframes declarations + one longhand inside the already-scoped `html.eliza-chat-overlay-shell .shell-assistant-overlay-panel` rule; the second keyframes consumer (flex-centered login card) is provably unaffected (the override requires both the shell html class and the panel class). Tests are additive.

# Background

## What does this PR do?

The desktop chat-overlay shell centers its panel with `transform: translateX(-50%)` (styles.css shell rule, the #20105 cascade reset). A CSS animation **replaces** the `transform` property wholesale for its duration, and the base `shell-overlay-in` keyframes animate `translateY(...)` alone — so for the whole 220ms entry the panel dropped its centering term and flew in ~half its width (280px on the packaged 600px panel) off-center before snapping back.

This PR adds `shell-overlay-in-anchored` keyframes (`base.css`) that carry `translateX(-50%)` through every keyframe, and selects them from the shell rule by overriding `animation-name` only — duration/easing still come from the `motion-safe:animate-[shell-overlay-in_220ms_ease-out]` utility. Exactly the shape lalalune's closing comment invited: no hook, no conditional-class restructure, the #20105 cascade reset untouched.

This is the extraction of the reviewed round-1 finding from #20496 (closed as superseded): that PR's reviewer reproduced the drift in Chromium (`left=320..880` in a 640px viewport mid-animation). This PR carries the same anchored keyframes + shell override, plus the deterministic mid-entry probe from that PR's round-3 hardening.

## Why

The cascade reset from #20105 pins the resting state, but the entry animation still transiently un-centers the panel on every summon in the packaged desktop chat-overlay window — a visible flash of a half-off-screen panel on each open.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

None — pure CSS/test change; no documented surface changes.

# Testing

## Where should a reviewer start?

The **mid-entry probe table** in the evidence below: develop's panel sits 280px off-center at the 110ms midpoint; this branch's sits at 0.0px. Screenshots show the drift in the pixels; the OCR readout of the before-capture even shows the panel text clipped at the viewport edge.

## Detailed testing steps

1. `bun run --cwd packages/ui vitest run src/styles/shell-overlay-anchoring.test.ts` — 4/4 pass; against develop's stylesheets 2/4 fail (control-red).
2. Live real-browser probe (Playwright Chromium, real shell fixture + compiled theme + the hand-authored styles.css shell rule, `eliza-chat-overlay-shell` html class, 640px viewport): restart-seek the entry animation to its 110ms midpoint and measure. Results in the evidence table below.
3. `bun run --cwd packages/ui typecheck` — pass (after `core` + `cloud/routing` builds). Single-file tsc on the changed spec: zero new errors vs develop control. Biome clean on all four files.

# Evidence Gate
Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:2dbe31502e6511bbd41b876890f79ef096031539 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] develop mid-entry (panel 280px off-center): ![develop mid-entry](https://github.com/user-attachments/assets/f5de2e03-7be0-492b-b59e-e38987404c4d)
- [x] develop settled (centered at rest — the bug is the 220ms transient): ![develop settled](https://github.com/user-attachments/assets/c919e41c-2406-4b48-82c5-435dcf49385c)
<!-- evidence-row:after-screenshots -->
- [x] this branch mid-entry (offset 0.0px, anchored keyframes): ![head mid-entry](https://github.com/user-attachments/assets/2759f125-dcd5-4b72-939b-d4ffa83ee9d4)
- [x] this branch settled: ![head settled](https://github.com/user-attachments/assets/64f73c05-7bf3-4dd3-bb65-0f842196e1c8)
<!-- evidence-row:walkthrough-video -->
- [x] develop control recording: https://github.com/user-attachments/assets/c9d1536f-14e5-4a9f-adfe-f940c992ecb2
- [x] this branch recording: https://github.com/user-attachments/assets/8adf295c-03a4-47a4-8b20-c7104facf15b
<!-- evidence-row:backend-logs -->
- [ ] N/A - CSS keyframes + stylesheet contract test transcript inline in Evidence Details
<!-- evidence-row:frontend-logs -->
- [ ] N/A - probe console readouts inline in Evidence Details (mid-entry + settled measurements)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - CSS keyframes + tests only; no agent, prompt, provider, or model behavior change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - CSS keyframes + tests only; no domain artifacts.
<!-- evidence-row:ocr-review -->
- [x] OCR of the develop mid-entry capture (reads the clipped "capture the scree!" text at the viewport edge): [ocr-before-mid.txt](https://github.com/user-attachments/files/31145428/ocr-before-mid.txt)
- [x] OCR of this branch mid-entry capture: [ocr-after-mid.txt](https://github.com/user-attachments/files/31145429/ocr-after-mid.txt)
- [x] OCR of this branch settled capture: [ocr-after.txt](https://github.com/user-attachments/files/31145431/ocr-after.txt)

# Evidence Details

## Real LLM-call trajectory

N/A — CSS keyframes + tests only; no agent/action/provider/prompt/model change.

## Backend + frontend logs

<details>
<summary>Stylesheet contract test — HEAD vs develop control (control-red proof)</summary>

```text
$ bun run --cwd packages/ui vitest run src/styles/shell-overlay-anchoring.test.ts   # HEAD
Test Files  1 passed (1)
     Tests  4 passed (4)

$ git checkout origin/develop -- packages/ui/src/styles/base.css packages/ui/src/styles/styles.css
$ bun run --cwd packages/ui vitest run src/styles/shell-overlay-anchoring.test.ts   # CONTROL (develop tip css)
 ❯ src/styles/shell-overlay-anchoring.test.ts (4 tests | 2 failed)
     × declares shell-overlay-in-anchored keyframes carrying translateX(-50%) in every keyframe
     × overrides animation-name to the anchored variant only inside the chat-overlay shell rule
      Tests  2 failed | 2 passed (4)
```

</details>

<details>
<summary>Probe console readouts (real-browser, 640px viewport, seek to 110ms midpoint)</summary>

```text
[develop] mid-entry: {"skipped":false,"animationName":"shell-overlay-in","durationMs":220,"left":320,"width":560,"viewportWidth":640,"centerOffset":280}
[develop] settled:   {"left":40,"width":560,"viewportWidth":640,"centerOffset":0,"animationName":"shell-overlay-in","transform":"matrix(1, 0, 0, 1, -280, 0)"}

[head]    mid-entry: {"skipped":false,"animationName":"shell-overlay-in-anchored","durationMs":220,"left":40,"width":560,"viewportWidth":640,"centerOffset":0}
[head]    settled:   {"left":40,"width":560,"viewportWidth":640,"centerOffset":0,"animationName":"shell-overlay-in-anchored","transform":"matrix(1, 0, 0, 1, -280, 0)"}
```

develop mid-entry: panel LEFT edge at x=320 = viewport center — the panel body extends a full half-width past center. head mid-entry: offset 0.0px (panel edges at x=40/x=600 in a 640px viewport). Both settled states identical (the bug is transient).

</details>

## Screenshots (before / after) + video walkthrough

All captures: the REAL bottom-bar shell fixture (HomePill + AssistantOverlay + ChatSurface) over the compiled `@elizaos/ui` theme plus the hand-authored `styles.css` shell rule, `html class="dark eliza-chat-overlay-shell"`, 640×680 viewport (packaged-window aspect), Playwright Chromium, deviceScaleFactor 2. The mid-entry frame freezes the animation at its 110ms midpoint via the same restart-seek technique the packaged spec uses.

### Before

develop tip (`9f48a26bcf`): mid-entry, panel shifted a full half-width right — content visibly runs to the screen edge (OCR reads the clipped text "capture the scree!").

develop tip: settled state (correctly centered — the bug is the 220ms transient).

### After

This branch: mid-entry, panel centered (offset 0.0px, `shell-overlay-in-anchored`).

This branch: settled state.

### Walkthrough video

Two probe-run recordings (develop control, then this branch) showing the open flow and the seek-frozen midpoint state.

## Audio / voice walkthrough

N/A - no voice surface changed.

## Known gaps / failures

- Full-repo `bun run verify` was not run this session (time-boxed worker); scoped gates for every touched surface were run instead: packages/ui typecheck pass, changed-file tsc delta zero vs develop control, biome clean, stylesheet contract test 4/4 with control-red proof.
- Full packages/ui vitest lane on this branch: 10764 passed / 3 failed / 7 skipped — all three failures (hardcoded-color-ratchet, builtin-view-action-ratchet, NotificationsHomeCenter hydration-retry) reproduce **identically** on a clean origin/develop control worktree (frozen-lockfile install + core build), i.e. pre-existing develop-tip reds, none touching the changed files.
- The packaged Electrobun spec self-skips without a packaged launcher; its first full run will be in CI (the probe was built and hardened through three review rounds on #20496; the same restart-seek technique is proven live in the real-browser probe above).

## Review trail

- Recovered from the #20496 round-3-hardened branch (RP rounds 1-3 on that PR already converged on the anchored-keyframes shape); re-verified at exact head `664a8a442a` on 2026-08-17.
- **RP review (opus, exact-bytes payload, session `1E261391`): APPROVE — zero must-fix.** Independent cascade analysis confirmed the shell rule wins on both specificity (0,2,1 vs 0,1,0) and layering (unlayered author CSS beats `@layer utilities`), that the login-card leak is impossible (override needs both html class + panel class), and that every probe failure mode is loud. Its four cheap hardenings (keyframes-name boundary, guard-before-mutation ordering, reduced-motion annotation, single-occurrence pin) are all implemented in this head.

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza"} -->