### PR TITLE
fix(ui): isolate Cloud-only onboarding state

### DIFF
--- a/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
+++ b/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
@@ -119,11 +119,11 @@ export const ChoiceWidget = memo(function ChoiceWidget({
           className="h-auto min-h-10 w-full justify-center whitespace-normal rounded-md border border-white/30 bg-[#2c2f3a] px-4 py-2 text-[14px] font-semibold text-[#f0f2f7] transition-colors hover:bg-[#363a46] disabled:bg-[#2c2f3a] disabled:text-[#f0f2f7] disabled:opacity-100"
           onClick={() => handleChoose(soleOption)}
         >
-          <span className="inline-flex min-w-0 items-center justify-center gap-2">
+          <span className="flex w-full min-w-0 items-center justify-center gap-2">
             {isSelected ? (
               <Check className="h-4 w-4 shrink-0" aria-hidden />
             ) : null}
-            <span className="min-w-0 text-center [overflow-wrap:anywhere]">
+            <span className="min-w-0 flex-1 text-center [overflow-wrap:anywhere]">
               {soleOption.label}
             </span>
           </span>

--- a/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
+++ b/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
@@ -305,6 +305,13 @@ describe("ChoiceWidget — pick an option", () => {
     expect(signIn.parentElement?.className.split(/\s+/)).toContain(
       "max-w-[13.5rem]",
     );
+    const label = screen.getByText("Sign in to Eliza Cloud");
+    expect(label.parentElement?.className.split(/\s+/)).toEqual(
+      expect.arrayContaining(["flex", "w-full", "min-w-0"]),
+    );
+    expect(label.parentElement?.className.split(/\s+/)).not.toContain(
+      "inline-flex",
+    );
 
     // After the tap: locked but NOT washed out, with no redundant status line.
     fireEvent.click(signIn);

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -183,7 +183,7 @@ function AppProviderInner({
   }, [brandTheme, uiTheme]);
 
   // ── Lifecycle state (consolidated from 20+ useState hooks) ──
-  const lifecycle = useLifecycleState();
+  const lifecycle = useLifecycleState(brandingOverride?.cloudOnly);
 
   const {
     state: {

--- a/packages/ui/src/state/first-run-completion-persist.test.tsx
+++ b/packages/ui/src/state/first-run-completion-persist.test.tsx
@@ -3,6 +3,7 @@
 
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_BOOT_CONFIG, setBootConfig } from "../config/boot-config";
 import {
   hydratePersistedFirstRunCompleteFromNativeStore,
   loadPersistedFirstRunComplete,
@@ -27,9 +28,12 @@ import { useFirstRunState } from "./useFirstRunState";
  */
 
 const FIRST_RUN_COMPLETE_STORAGE_KEY = "eliza:first-run-complete";
+const CLOUD_ONLY_FIRST_RUN_COMPLETE_STORAGE_KEY =
+  "eliza:first-run-complete:cloud-only:v1";
 
 beforeEach(() => {
   window.localStorage.clear();
+  setBootConfig(DEFAULT_BOOT_CONFIG);
 });
 
 afterEach(() => {
@@ -60,6 +64,39 @@ describe("first-run completion durable flag survives a process restart", () => {
       window.localStorage.getItem(FIRST_RUN_COMPLETE_STORAGE_KEY),
     ).toBeNull();
   });
+
+  it("does not treat a local-capable build's completion as Cloud-only onboarding", () => {
+    window.localStorage.setItem(FIRST_RUN_COMPLETE_STORAGE_KEY, "1");
+    setBootConfig({
+      ...DEFAULT_BOOT_CONFIG,
+      branding: {
+        ...DEFAULT_BOOT_CONFIG.branding,
+        cloudOnly: true,
+      },
+    });
+
+    expect(loadPersistedFirstRunComplete()).toBe(false);
+  });
+
+  it("persists Cloud-only completion separately across a process restart", () => {
+    setBootConfig({
+      ...DEFAULT_BOOT_CONFIG,
+      branding: {
+        ...DEFAULT_BOOT_CONFIG.branding,
+        cloudOnly: true,
+      },
+    });
+
+    savePersistedFirstRunComplete(true);
+
+    expect(loadPersistedFirstRunComplete()).toBe(true);
+    expect(
+      window.localStorage.getItem(CLOUD_ONLY_FIRST_RUN_COMPLETE_STORAGE_KEY),
+    ).toBe("1");
+    expect(
+      window.localStorage.getItem(FIRST_RUN_COMPLETE_STORAGE_KEY),
+    ).toBeNull();
+  });
 });
 
 describe("useFirstRunState seeds the completion ref from durable storage", () => {
@@ -73,6 +110,14 @@ describe("useFirstRunState seeds the completion ref from durable storage", () =>
 
   it("a fresh mount with no prior onboarding starts uncommitted", () => {
     const { result } = renderHook(() => useFirstRunState());
+    expect(result.current.completionCommittedRef.current).toBe(false);
+  });
+
+  it("uses the explicit Cloud-only scope before global boot config is available", () => {
+    window.localStorage.setItem(FIRST_RUN_COMPLETE_STORAGE_KEY, "1");
+
+    const { result } = renderHook(() => useFirstRunState(true));
+
     expect(result.current.completionCommittedRef.current).toBe(false);
   });
 });

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -492,14 +492,28 @@ const LAST_NATIVE_TAB_STORAGE_KEY = "eliza:last-native-tab";
 /* ── First-run completion persistence ────────────────────────────────── */
 
 const FIRST_RUN_COMPLETE_STORAGE_KEY = "eliza:first-run-complete";
+const CLOUD_ONLY_FIRST_RUN_COMPLETE_STORAGE_KEY =
+  "eliza:first-run-complete:cloud-only:v1";
 
-export function loadPersistedFirstRunComplete(): boolean {
+/**
+ * Keep completion proof scoped to the onboarding contract that produced it.
+ * Desktop release channels intentionally share a WebKit container when their
+ * bundle id is the same, so an unscoped completion bit from a local-capable
+ * build must never suppress Cloud sign-in in a later cloud-only build.
+ */
+function firstRunCompleteStorageKey(cloudOnly?: boolean): string {
+  return (cloudOnly ?? getBootConfig().branding.cloudOnly) === true
+    ? CLOUD_ONLY_FIRST_RUN_COMPLETE_STORAGE_KEY
+    : FIRST_RUN_COMPLETE_STORAGE_KEY;
+}
+
+export function loadPersistedFirstRunComplete(cloudOnly?: boolean): boolean {
   if (typeof localStorage === "undefined") {
     return false;
   }
 
   try {
-    return localStorage.getItem(FIRST_RUN_COMPLETE_STORAGE_KEY) === "1";
+    return localStorage.getItem(firstRunCompleteStorageKey(cloudOnly)) === "1";
   } catch (err) {
     // error-policy:J3 an unreadable store reads as "first run not complete";
     // the native-store mirror (hydratePersistedFirstRunCompleteFromNativeStore)
@@ -520,6 +534,7 @@ export function loadPersistedFirstRunComplete(): boolean {
  * where Capacitor is unavailable. Mirrors the mobile-runtime-mode dual-write.
  */
 async function persistNativeFirstRunComplete(complete: boolean): Promise<void> {
+  const storageKey = firstRunCompleteStorageKey();
   try {
     const [{ Capacitor }, { Preferences }] = await Promise.all([
       import("@capacitor/core"),
@@ -528,11 +543,11 @@ async function persistNativeFirstRunComplete(complete: boolean): Promise<void> {
     if (!Capacitor.isNativePlatform()) return;
     if (complete) {
       await Preferences.set({
-        key: FIRST_RUN_COMPLETE_STORAGE_KEY,
+        key: storageKey,
         value: "1",
       });
     } else {
-      await Preferences.remove({ key: FIRST_RUN_COMPLETE_STORAGE_KEY });
+      await Preferences.remove({ key: storageKey });
     }
   } catch {
     // error-policy:J4 Capacitor Preferences is unavailable in web / unit-test
@@ -541,6 +556,7 @@ async function persistNativeFirstRunComplete(complete: boolean): Promise<void> {
 }
 
 export function savePersistedFirstRunComplete(complete: boolean): void {
+  const storageKey = firstRunCompleteStorageKey();
   void persistNativeFirstRunComplete(complete);
 
   if (typeof localStorage === "undefined") {
@@ -549,9 +565,9 @@ export function savePersistedFirstRunComplete(complete: boolean): void {
 
   try {
     if (complete) {
-      shellLocalStorage.setItem(FIRST_RUN_COMPLETE_STORAGE_KEY, "1");
+      shellLocalStorage.setItem(storageKey, "1");
     } else {
-      shellLocalStorage.removeItem(FIRST_RUN_COMPLETE_STORAGE_KEY);
+      shellLocalStorage.removeItem(storageKey);
     }
   } catch (err) {
     logger.warn(
@@ -564,7 +580,7 @@ export function savePersistedFirstRunComplete(complete: boolean): void {
  * Boot-time durability restore for the onboarding-complete flag (issue #11506).
  *
  * Android/iOS can clear a WebView's localStorage independently of the app's
- * Capacitor Preferences store, which would drop `eliza:first-run-complete` and
+ * Capacitor Preferences store, which would drop the scoped completion key and
  * re-show onboarding on the next launch even though the agent config on disk is
  * intact. Completion is mirrored into Preferences on save; on boot, when the
  * WebView lost the localStorage flag but the durable native store still has it,
@@ -580,6 +596,7 @@ export function savePersistedFirstRunComplete(complete: boolean): void {
 export async function hydratePersistedFirstRunCompleteFromNativeStore(): Promise<void> {
   if (typeof localStorage === "undefined") return;
   if (loadPersistedFirstRunComplete()) return;
+  const storageKey = firstRunCompleteStorageKey();
 
   try {
     const [{ Capacitor }, { Preferences }] = await Promise.all([
@@ -588,10 +605,10 @@ export async function hydratePersistedFirstRunCompleteFromNativeStore(): Promise
     ]);
     if (!Capacitor.isNativePlatform()) return;
     const { value } = await Preferences.get({
-      key: FIRST_RUN_COMPLETE_STORAGE_KEY,
+      key: storageKey,
     });
     if (value === "1") {
-      shellLocalStorage.setItem(FIRST_RUN_COMPLETE_STORAGE_KEY, "1");
+      shellLocalStorage.setItem(storageKey, "1");
     }
   } catch {
     // error-policy:J4 native store unavailable — localStorage remains

--- a/packages/ui/src/state/useFirstRunState.ts
+++ b/packages/ui/src/state/useFirstRunState.ts
@@ -249,7 +249,7 @@ export function useFirstRunState(cloudOnly?: boolean): FirstRunStateHook {
   // URL-scoped — dropping `?onboarding-replay=1` restores normal seeding on
   // the next load, and the durable flag itself is never written.
   const completionCommittedRef = useRef(
-    loadPersistedFirstRunComplete() && !isOnboardingReplayRequested(),
+    loadPersistedFirstRunComplete(cloudOnly) && !isOnboardingReplayRequested(),
   );
 
   return {

--- a/packages/ui/src/state/useLifecycleState.ts
+++ b/packages/ui/src/state/useLifecycleState.ts
@@ -40,29 +40,31 @@ export interface LifecycleState {
   systemWarnings: string[];
 }
 
-const INITIAL_LIFECYCLE_STATE: LifecycleState = {
-  connected: false,
-  agentStatus: null,
-  firstRunComplete: loadPersistedFirstRunComplete(),
-  firstRunUiRevealNonce: 0,
-  firstRunLoading: true,
-  startupError: null,
-  startupRetryNonce: 0,
-  authRequired: false,
-  actionNotice: null,
-  lifecycleBusy: false,
-  lifecycleAction: null,
-  pendingRestart: false,
-  pendingRestartReasons: [],
-  restartBannerDismissed: false,
-  backendConnection: {
-    state: "disconnected",
-    reconnectAttempt: 0,
-    maxReconnectAttempts: 15,
-    showDisconnectedUI: false,
-  },
-  systemWarnings: [],
-};
+function createInitialLifecycleState(cloudOnly?: boolean): LifecycleState {
+  return {
+    connected: false,
+    agentStatus: null,
+    firstRunComplete: loadPersistedFirstRunComplete(cloudOnly),
+    firstRunUiRevealNonce: 0,
+    firstRunLoading: true,
+    startupError: null,
+    startupRetryNonce: 0,
+    authRequired: false,
+    actionNotice: null,
+    lifecycleBusy: false,
+    lifecycleAction: null,
+    pendingRestart: false,
+    pendingRestartReasons: [],
+    restartBannerDismissed: false,
+    backendConnection: {
+      state: "disconnected",
+      reconnectAttempt: 0,
+      maxReconnectAttempts: 15,
+      showDisconnectedUI: false,
+    },
+    systemWarnings: [],
+  };
+}
 
 // ── Actions ────────────────────────────────────────────────────────────
 
@@ -220,10 +222,11 @@ export interface LifecycleStateHook {
   agentStatusRef: React.RefObject<AgentStatus | null>;
 }
 
-export function useLifecycleState(): LifecycleStateHook {
+export function useLifecycleState(cloudOnly?: boolean): LifecycleStateHook {
   const [state, dispatch] = useReducer(
     lifecycleReducer,
-    INITIAL_LIFECYCLE_STATE,
+    cloudOnly,
+    createInitialLifecycleState,
   );
 
   // Refs for synchronous checks (used by lifecycle actions to avoid race conditions)


### PR DESCRIPTION
# Relates to

Closes #21313

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the state-isolation behavior from the tests and real desktop reproduction described below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `590f425c574c0a7b474bd97dd0929c73b1ba3f7d`; zero conflicts.
- [x] `bun run verify` passes post-sync: 356/356 tasks successful.

# Risks

Low. The persistence change only scopes first-run completion for Cloud-only branding; local-capable builds retain the legacy key. Existing Cloud-only users who legitimately completed onboarding will see onboarding once after upgrading, then use the new scoped key. The CTA change only replaces an intrinsic-width inline flex wrapper with a shrinkable full-width flex row.

# Background

## What does this PR do?

- Gives Cloud-only builds a dedicated `eliza:first-run-complete:cloud-only:v1` persistence key.
- Keeps the legacy generic key for local-capable builds without migrating it into Cloud-only state.
- Threads the explicit Cloud-only mode through first-run and lifecycle initialization so module/global boot-config timing cannot leak legacy completion state.
- Prevents the narrow desktop-overlay Cloud sign-in CTA from clipping its label.
- Adds regressions for legacy-key isolation, Cloud-only persistence, explicit hook initialization, and the shrinkable CTA label wrapper.

## Root cause

Stable, canary, and local desktop builds can share the `ai.elizaos.app` WebKit profile. A prior local-capable build persisted `eliza:first-run-complete = "1"`; the Cloud-only renderer trusted that generic value and initialized `firstRunComplete=true`. That bypassed the first-run conductor and mounted the normal composer even though there was no Cloud session or embedded agent. The first send then attempted `POST /api/conversations` and failed.

Separately, the CTA's nested `inline-flex` label wrapper retained intrinsic width inside its compact `13.5rem` container, clipping both ends of the label in the narrow overlay.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the documented Cloud-only onboarding behavior without changing a public API.

# Testing

## Where should a reviewer start?

- `packages/ui/src/state/persistence.ts`
- `packages/ui/src/state/first-run-completion-persist.test.tsx`
- `packages/ui/src/components/chat/widgets/ChoiceWidget.tsx`

## Detailed testing steps

1. Leave the legacy `eliza:first-run-complete = "1"` value in the shared WebKit profile.
2. Build with `node packages/app-core/scripts/desktop-build.mjs package --cloud-only --env=canary`.
3. Launch the resulting macOS app while signed out.
4. Verify the in-chat “Sign in with Eliza Cloud” action appears and the normal composer is absent.
5. Verify the complete CTA label remains within its button at narrow overlay width.
6. Run:
   - `bun run --cwd packages/ui test -- src/components/chat/widgets/interaction-widgets.behavior.test.tsx src/state/first-run-completion-persist.test.tsx src/state/useLifecycleState.canRespond.test.tsx`
   - `bun run --cwd packages/ui typecheck`
   - `bun run --cwd packages/ui lint:check`
   - `bun run verify`

# Evidence Gate

<!-- evidence-head:6f8e2f9f9c78b7a356478125bab6e719de9d48ec -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshot: captured locally from the installed stale-profile build; pending inline upload to this draft PR.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshot: pending final evidence capture on the draft PR.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: pending final evidence capture on the draft PR.
<!-- evidence-row:backend-logs -->
- [x] N/A - the defect and fix are renderer persistence/layout paths; no backend request should fire before Cloud sign-in.
<!-- evidence-row:frontend-logs -->
- [x] Real renderer evidence: stale legacy key remained `"1"`, the Cloud-only scoped key was absent, and the rebuilt artifact exposed the Cloud sign-in button instead of the composer. No credentials or headers were captured.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Cloud-only macOS artifact built successfully at `packages/app-core/platforms/electrobun/build/canary-macos-arm64/Eliza-canary.app`; the original legacy storage value was deliberately left intact.
<!-- evidence-row:ocr-review -->
- [ ] OCR review: pending alongside the final screenshot evidence.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

Backend logs are N/A because the repaired pre-auth path intentionally remains local and must not call `/api/conversations`.

The real desktop run used the original shared WebKit profile without clearing storage. Before the fix, the ordinary composer mounted and first send attempted conversation creation. After the persistence fix, the rebuilt Cloud-only artifact exposed the accessible button `Sign in with Eliza Cloud` and did not expose the ordinary composer.

## Screenshots (before / after) + video walkthrough

Pending inline attachment to this draft PR. The supplied before capture shows the CTA label clipped at both edges. Final after/video/OCR evidence remains an explicit draft-completion item.

## Audio / voice walkthrough

N/A - no audio, transcript, TTS, STT, or voice behavior changed.

## Known gaps / failures

- `bun run --cwd packages/app audit:app`: 217/219 cases passed, `broken=0`. The aggregate command remains red because of unrelated existing failures: a LifeOps iPad view readiness timeout, three minimalism-ratchet debts in untouched built-in views, thirteen non-exempt needs-work verdicts in untouched plugin views, and existing hover-probe timeouts. No finding points to the onboarding state or ChoiceWidget changes.
- Final inline before/after/video/OCR media is still pending; this PR is intentionally opened as a draft.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-desktop]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"N/A - no repository contribution skill used"} -->
