### PR TITLE
fix(orchestrator): Codex refresh-token expiry lost its auth typing — plus lane test alignment

### DIFF
--- a/packages/auth/src/token-expiry.ts
+++ b/packages/auth/src/token-expiry.ts
@@ -14,6 +14,19 @@ export type CodingAuthFailureReason =
 
 const REFRESH_TOKEN_EXPIRED_PATTERN =
   /\brefresh[_ ]token[_ ](?:(?:has|is)[_ ])?expired\b/i;
+
+/**
+ * True for explicit REFRESH-token expiry language. A refresh-token expiry is a
+ * genuinely dead credential (the holder can no longer self-refresh), so it is
+ * auth-shaped but must NOT be treated as the benign injected-access-token
+ * "token_expired" recovery — callers use this to keep the failure typed as
+ * needs-reauth instead of dropping it entirely.
+ */
+export function isRefreshTokenExpiryText(
+  text: string | null | undefined,
+): boolean {
+  return !!text && REFRESH_TOKEN_EXPIRED_PATTERN.test(text);
+}
 const TOKEN_EXPIRED_PATTERN =
   /\b(?:token[_ ](?:(?:has|is)[_ ])?expired|expired[_ ]?token|(?:oauth|access)[_ ]token[_ ](?:(?:has|is)[_ ])?expired|jwt[_ ]expired|session[_ ]expired)\b/i;
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acceptance-criteria.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acceptance-criteria.test.ts
@@ -108,8 +108,15 @@ describe("staticAcceptanceCriteria", () => {
     expect(coding).not.toEqual(viewCreate);
     expect(appBuild).not.toEqual(viewCreate);
 
-    // app-build is the coding superset plus the live-URL check.
-    expect(appBuild).toEqual([...coding, "the live URL is reachable"]);
+    // app-build is serve-focused ON PURPOSE (#20794 live residual): a quick
+    // one-file app has no test/typecheck surface, so it no longer inherits the
+    // coding checks — it pins deliverable existence + live serving instead.
+    expect(appBuild).toEqual([
+      "the live URL is reachable",
+      "the deliverable file exists in the workdir",
+      "the page serves the requested content",
+    ]);
+    expect(appBuild.some((c) => coding.includes(c))).toBe(false);
     // view-create is its own distinct set (no overlap with coding's checks).
     expect(viewCreate.some((c) => coding.includes(c))).toBe(false);
   });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence.test.ts
@@ -71,7 +71,7 @@ describe("buildEvidenceStringFromInput (legacy signal-mining assembler)", () => 
     });
     expect(evidence).toContain("## VERIFIED URLS");
     expect(evidence).toMatch(
-      /http:\/\/localhost:3000\/app \(LOOPBACK — not publicly reachable\)/,
+      /http:\/\/localhost:3000\/app \(loopback probe — local serving confirmed by the orchestrator\)/,
     );
     expect(evidence).toContain("https://app.example.com");
     // The public URL line must NOT carry the loopback flag.
@@ -158,8 +158,12 @@ describe("buildEvidenceStringFromInput (legacy signal-mining assembler)", () => 
       })),
       artifacts: [{ artifactType: "screenshot", title: "s", ref: "/x.png" }],
     });
-    expect(evidence.length).toBeLessThanOrEqual(8_100);
-    expect(evidence).toContain("[evidence truncated]");
+    // #21240 raised MAX_EVIDENCE_CHARS to 24_000 (plus the truncation marker).
+    // Oversized individual fields are clamped per-section ("[truncated]")
+    // before the global "[evidence truncated]" cap can fire, so assert the
+    // bound plus the per-section marker this fixture actually trips.
+    expect(evidence.length).toBeLessThanOrEqual(24_100);
+    expect(evidence).toContain("[truncated]");
   });
 });
 
@@ -198,7 +202,7 @@ describe("buildCompletionEvidenceString (typed bundle, #8894)", () => {
     expect(evidence).toContain("0 errors");
     expect(evidence).toContain("## VERIFIED URLS");
     expect(evidence).toContain("https://app.example.com");
-    expect(evidence).toMatch(/http:\/\/localhost:3000 \(LOOPBACK/);
+    expect(evidence).toMatch(/http:\/\/localhost:3000 \(loopback probe/);
     expect(evidence).toContain("## ARTIFACTS");
     expect(evidence).toContain("[screenshot] screenshot — /tmp/shots/home.png");
     expect(evidence).toContain(
@@ -230,10 +234,12 @@ describe("buildCompletionEvidenceString (typed bundle, #8894)", () => {
   });
 
   it("keeps an oversized appended section inside the evidence cap", () => {
+    // #21240 raised MAX_EVIDENCE_CHARS to 24_000; oversize accordingly so the
+    // clamp is actually exercised.
     const evidence = appendCompletionEvidenceSection(
       "existing",
-      "x".repeat(20_000),
+      "x".repeat(40_000),
     );
-    expect(evidence.length).toBeLessThanOrEqual(8_000);
+    expect(evidence.length).toBeLessThanOrEqual(24_000);
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
@@ -79,14 +79,16 @@ describe("buildVerificationPrompt", () => {
   });
 
   it("truncates very long completion evidence to keep the prompt bounded", () => {
-    const longEvidence = "X".repeat(20_000);
+    // #21240 raised the verifier evidence budget to 28_000 chars; oversize
+    // beyond it so head+tail truncation actually fires.
+    const longEvidence = "X".repeat(40_000);
     const prompt = buildVerificationPrompt({
       goal: "X",
       acceptanceCriteria: ["c"],
       completionEvidence: longEvidence,
     });
     expect(prompt).toMatch(/\[…evidence truncated…\]/);
-    expect(prompt.length).toBeLessThan(20_000);
+    expect(prompt.length).toBeLessThan(40_000);
   });
 
   it("demands concrete proof per criterion and rejects unproven claims", () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -57,6 +57,7 @@ import {
   accountMetaFromSessionMetadata,
   type CodingAccountMeta,
   diagnoseCodingAccountFallback,
+  isRefreshTokenExpiryText,
   isTokenExpiryText,
   resolveCodingAccountStrategy,
   selectCodingAccount,
@@ -4570,7 +4571,13 @@ export class AcpService extends Service {
     // that dies with only expiry text would otherwise emit no failureKind at
     // all, defeating the typed signal. Recognize either.
     const expired = isTokenExpiryText(text);
-    if (!isAuthText(text) && !expired) return {};
+    // Refresh-token expiry is excluded from isTokenExpiryText on purpose (it
+    // is a genuinely dead credential, never the benign injected-token case),
+    // but it is still AUTH-shaped: without recognizing it here a Codex
+    // "refresh token has expired" run would emit no failureKind at all and
+    // the dead account would be respawned instead of marked needs-reauth.
+    const refreshExpired = isRefreshTokenExpiryText(text);
+    if (!isAuthText(text) && !expired && !refreshExpired) return {};
     // The `token_expired` reason drives a downstream recovery that keeps the
     // account HEALTHY and just re-injects a fresh token — valid ONLY for the
     // claude bare-token injection path (CLAUDE_CODE_OAUTH_TOKEN the third-party

--- a/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
@@ -9,7 +9,7 @@
  * behavior untouched.
  */
 
-import { isTokenExpiryText } from "@elizaos/auth";
+import { isRefreshTokenExpiryText, isTokenExpiryText } from "@elizaos/auth";
 import {
   type CodingAccountStrategy,
   type CodingAccountUsage,
@@ -289,7 +289,7 @@ export function classifyAccountFailure(
   return null;
 }
 
-export { isTokenExpiryText };
+export { isRefreshTokenExpiryText, isTokenExpiryText };
 
 /**
  * Best-effort: tell the pool a spawned account hit a rate-limit / needs reauth


### PR DESCRIPTION
## Summary

`bun run --cwd plugins/plugin-agent-orchestrator test` has 7 failures on develop tip. Six are drifted pins of recently merged contracts; the seventh caught a **real classifier regression**:

**Runtime bug:** `isTokenExpiryText` (in `@elizaos/auth`) deliberately excludes refresh-token expiry so a genuinely dead credential never takes the benign injected-token `token_expired` recovery — but `AcpService.authFailureFields` relied on that same predicate to mark the failure auth-shaped **at all**. Net effect: a Codex `refresh token has expired` run emits no `failureKind`, so the dead account is respawned forever instead of marked needs-reauth — precisely the outcome the method's own comment says must not happen. Fix: `@elizaos/auth` exports `isRefreshTokenExpiryText`, and `authFailureFields` recognizes it as auth-shaped (without the `token_expired` reason).

**Test alignment** (each verified deliberate at the source):
- `completion-evidence`: #21240 raised `MAX_EVIDENCE_CHARS` to 24 000 with per-section `[truncated]` markers; #21148 changed the loopback URL annotation phrasing.
- `goal-llm-verifier`: the verifier's evidence budget is 28 000 chars; the fixture now oversizes past it so head+tail truncation actually fires.
- `acceptance-criteria`: app-build is serve-focused **by design** (#20794 residual, documented in `DEFAULT_CRITERIA_TEMPLATES`) and no longer the coding superset.

## Verification (exact head)

```
plugin-agent-orchestrator full lane: 244 files, 2868 passed, 0 failed (was 7 failed)
packages/auth token-expiry suite: 31 passed | auth typecheck: clean
biome (touched files): clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)