### PR TITLE
feat(registry): add @wzrd_sol/plugin-trustgate

### DIFF
--- a/packages/registry/entries/third-party/wzrd_sol__plugin-trustgate.json
+++ b/packages/registry/entries/third-party/wzrd_sol__plugin-trustgate.json
@@ -1,0 +1,18 @@
+{
+  "package": "@wzrd_sol/plugin-trustgate",
+  "repository": "github:twzrd-sol/twzrd-trust",
+  "kind": "plugin",
+  "description": "Buyer-side x402 reputation gate for elizaOS: free TWZRD ReadinessCard preflight before spend, opt-in canSpendSafely enforcement, and an optional facilitator onBeforeSettle hook. No keys or auto-spend.",
+  "homepage": "https://github.com/twzrd-sol/twzrd-trust/tree/main/plugin-trustgate",
+  "version": "0.3.4",
+  "directory": "plugin-trustgate",
+  "tags": [
+    "x402",
+    "trust",
+    "payments",
+    "solana",
+    "spend-guard",
+    "preflight",
+    "reputation"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1040,6 +1040,53 @@
       "registryKind": "plugin",
       "directory": "elizaos-plugin"
     },
+    "@wzrd_sol/plugin-trustgate": {
+      "git": {
+        "repo": "twzrd-sol/twzrd-trust",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@wzrd_sol/plugin-trustgate",
+        "v0": null,
+        "v1": null,
+        "v2": "0.3.4"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Buyer-side x402 reputation gate for elizaOS: free TWZRD ReadinessCard preflight before spend, opt-in canSpendSafely enforcement, and an optional facilitator onBeforeSettle hook. No keys or auto-spend.",
+      "homepage": "https://github.com/twzrd-sol/twzrd-trust/tree/main/plugin-trustgate",
+      "topics": [
+        "x402",
+        "trust",
+        "payments",
+        "solana",
+        "spend-guard",
+        "preflight",
+        "reputation"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": "plugin-trustgate"
+    },
     "@xynqai/plugin-eliza": {
       "git": {
         "repo": "visionsXBT/xynq",


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Community listing per [`packages/registry/README.md`](https://github.com/elizaOS/eliza/blob/develop/packages/registry/README.md). No linked issue — this is a two-file third-party registry add, same path as #18019 / #20605.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Full-monorepo `bun install` / `bun run verify` were **not** run. This is a sparse checkout of `packages/registry` only (the documented listing path). Package checks that *were* run: `bun run --cwd packages/registry validate` (47 entries) and `bun run --cwd packages/registry generate` twice with zero diff. No `packages/registry/bun.lock` was created or committed.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xAI/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Build TUI
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@08bb08c0f7170be08b66927903d2d2da0322c289:packages/registry/README.md
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts. Branch cut from `08bb08c0f7170be08b66927903d2d2da0322c289`.
- [x] `bun run verify` was not run (sparse checkout, metadata-only listing). Unrelated blocker: full verify needs the whole monorepo and is not required for a two-file registry add (same as #20605).

# Risks

Low. Additive third-party registry metadata only. No runtime, plugin, or app code in this repo changes. Worst case of a bad listing is a discoverability row pointing at a public npm package.

# Background

## What does this PR do?

Adds `@wzrd_sol/plugin-trustgate@0.3.4` to the community registry.

The package is a **provider-only** buyer-side x402 spend guard:

- `TWZRD_TRUST_GATE` injects the seller's free ReadinessCard (`allow` / `warn` / `block`) into agent context.
- `canSpendSafely(payTo)` is an **opt-in** enforcement call the payment action must invoke before signing. The plugin does not hold keys and does not intercept signatures.
- Optional `onBeforeSettle` hook for facilitators that choose to wire it.

Honest scope (tested against the published 0.3.4 tarball, not a wishlist):

- This package scores via **free preflight only**. It does **not** call `GET /v1/intel/merchant_card` and does **not** auto-refuse on `wash_flagged`. That sequence lives in `@wzrd_sol/eliza-plugin` / `twzrd-x402-gate`.
- Fail-closed by default (`failOpen: false`): a preflight outage blocks rather than silently approving.

## What kind of change is this?

Features (non-breaking change which adds functionality) — community registry listing.

# Documentation changes needed?

My changes do not require a change to the project documentation. The listing follows `packages/registry/README.md`.

# Testing

## Where should a reviewer start?

1. Confirm the two-file diff: `entries/third-party/wzrd_sol__plugin-trustgate.json` + regenerated `generated-registry.json`.
2. Re-run `bun run --cwd packages/registry validate` and `generate` and confirm zero further diff.
3. Use the **Verify without installing** curls below. They exercise the same host and path the published plugin calls.

## Detailed testing steps

### Package / repo (reviewer install check)

```bash
npm view @wzrd_sol/plugin-trustgate@0.3.4 version repository homepage peerDependencies
# 0.3.4
# { type: 'git', url: 'git+https://github.com/twzrd-sol/twzrd-trust.git', directory: 'plugin-trustgate' }
# https://github.com/twzrd-sol/twzrd-trust/tree/main/plugin-trustgate#readme
# { '@elizaos/core': '>=1.0.0' }
```

Public source: https://github.com/twzrd-sol/twzrd-trust/tree/main/plugin-trustgate
npm: https://www.npmjs.com/package/@wzrd_sol/plugin-trustgate/v/0.3.4

Filename is `wzrd_sol__plugin-trustgate.json` (`@` dropped, `/` → `__`). Trailing newline present. `@elizaos/*` not used.

### Verify without installing

The plugin's `checkTrust()` is `POST https://intel.twzrd.xyz/v1/intel/preflight` with `{ seller_wallet }`. No auth.

Owned refuse fixture (synthetic TWZRD hard-block; not a third-party brand judgment):

```bash
curl -sS -X POST https://intel.twzrd.xyz/v1/intel/preflight \
  -H 'content-type: application/json' \
  -d '{"seller_wallet":"CnTmHDXVEafkc8sFSzNky9w5zwk63Bk2mHZZodorjhvR","price_usdc":0.05,"agent_intent":"registry-review"}'
```

Captured 2026-08-17 from this checkout: `preflight_id=628528`, `readiness_card.decision=block`, `trust_score=30`, `can_spend=false`.

WARN control (minifetch payTo from the public skill):

```bash
curl -sS -X POST https://intel.twzrd.xyz/v1/intel/preflight \
  -H 'content-type: application/json' \
  -d '{"seller_wallet":"46vMcwuC4sK11sB3gkLhyA7J7GEwfkhn5rFyDtihBwqe","price_usdc":0.002,"agent_intent":"registry-review"}'
```

Captured 2026-08-17: `preflight_id=628529`, `readiness_card.decision=warn`, `trust_score=53.9`, `can_spend=true`.

Same published tarball, no eliza runtime required:

```text
@wzrd_sol/plugin-trustgate@0.3.4 checkTrust
  CnTmHDXV…  decision=block  canSpendSafely=false  preflightId=628530  gateAvailable=true
  46vMcwuC…  decision=warn   canSpendSafely=true   preflightId=628531  gateAvailable=true
```

### Compatibility

- Default export is `{ name, description, providers }` — the 2.x `Plugin` shape in `@elizaos/core@2.0.3-beta.7` (`providers?: Provider[]`).
- Provider is `{ name, description, dynamic, get(runtime, message, state) }` — same `Provider.get` contract on 2.0.3-beta.7. **No evaluators** (the 1.x → 2.x break this listing is most likely to get wrong).
- Peer is `@elizaos/core >= 1.0.0`. I type-checked the shape against `2.0.3-beta.7` and ran the published JS against the live preflight. I did **not** boot a full 2.x agent process.

### Registry commands run here

```text
bun run --cwd packages/registry validate
[registry] 47 third-party entries validated

bun run --cwd packages/registry generate
Generated …/generated-registry.json (47 third-party entries)

# second generate: identical bytes
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:aae07a34269184ae379111d5c4753bc102b02f10 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - registry metadata only; no rendered UI changed
<!-- evidence-row:after-screenshots -->
- [x] N/A - registry metadata only; no rendered UI changed
<!-- evidence-row:walkthrough-video -->
- [x] N/A - registry metadata only; no interactive flow
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime behavior in this repo changed
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend files or behavior changed
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, model, prompt, provider, or action behavior in this repo changed (listing only)
<!-- evidence-row:domain-artifacts -->
- [x] Live preflight ids above (628528 block / 628529 warn) plus published-package `checkTrust` ids 628530 / 628531. npm `@wzrd_sol/plugin-trustgate@0.3.4` is the installable artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - metadata-only registry listing; no agent/action/provider/prompt/model code in this repository changed.

## Backend + frontend logs

N/A - no elizaOS backend or frontend path is modified.

## Screenshots (before / after) + video walkthrough

### Before

N/A - registry metadata only; no rendered UI changed

### After

N/A - registry metadata only; no rendered UI changed

### Walkthrough video

N/A - registry metadata only; no interactive flow

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT surface.

## Known gaps / failures

- Full `bun run verify` not run (sparse `packages/registry` checkout). Package-local `validate` + deterministic `generate` were run.
- Public GitHub tree `plugin-trustgate` was one patch behind npm (package.json said 0.3.3). Synced to the published 0.3.4 tarball in twzrd-sol/twzrd-trust#30 and merged to `main` before this PR so the clicked repo matches the listed version.
- I did not boot a full elizaOS 2.x agent with this plugin loaded. Compatibility claim is: published JS matches the current `Plugin` / `Provider.get` types, and the gate core works against the live preflight the provider calls.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Build TUI
Contribution skill revision: elizaOS/eliza@08bb08c0f7170be08b66927903d2d2da0322c289:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Build TUI","skill_revision":"elizaOS/eliza@08bb08c0f7170be08b66927903d2d2da0322c289:packages/skills/skills/contribute-to-eliza"} -->
