### PR TITLE
test(agent): exercise symlink escape guards on unprivileged Windows

### DIFF
--- a/packages/agent/src/api/provider-switch-config.test.ts
+++ b/packages/agent/src/api/provider-switch-config.test.ts
@@ -296,7 +296,11 @@ describe("clearPersistedFirstRunConfig (reset everything)", () => {
     const outside = mkdtempSync(path.join(tmpdir(), "eliza-reset-outside-"));
     const authRoot = path.join(isolatedElizaHome, "auth");
     mkdirSync(authRoot, { recursive: true });
-    symlinkSync(outside, path.join(authRoot, "openai-codex"), "dir");
+    symlinkSync(
+      outside,
+      path.join(authRoot, "openai-codex"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
     process.env.OPENAI_API_KEY = "must-survive";
     const config = buildFullyOnboardedConfig();
     const before = structuredClone(config);

--- a/packages/agent/src/runtime/load-plugin-from-directory.test.ts
+++ b/packages/agent/src/runtime/load-plugin-from-directory.test.ts
@@ -499,15 +499,19 @@ describe("loadPluginFromDirectory", () => {
   });
 
   it("rejects package entries that resolve through a symlink outside the plugin directory", async () => {
-    const outside = path.join(tmpDir, "outside.js");
-    await fsp.writeFile(outside, PREBUILT_PLUGIN_JS);
+    const outside = path.join(tmpDir, "outside-entry");
+    await fsp.mkdir(outside, { recursive: true });
+    await fsp.writeFile(path.join(outside, "index.js"), PREBUILT_PLUGIN_JS);
     const dir = await scaffold(
       "plugin-symlink-entry",
       { name: "@local/plugin-symlink-entry", main: "dist/index.js" },
       {},
     );
-    await fsp.mkdir(path.join(dir, "dist"), { recursive: true });
-    await fsp.symlink(outside, path.join(dir, "dist/index.js"));
+    await fsp.symlink(
+      outside,
+      path.join(dir, "dist"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
 
     const runtime = new AgentRuntime({ logLevel: "fatal" });
     await expect(


### PR DESCRIPTION
# Relates to

Closes #21303. Follow-up to #21288 and #21299. The remaining VFS symlink fixture is intentionally excluded because #21284 owns that file.

Definition of Done: full standard in [CONTRIBUTING.md](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] Frozen install, focused suites, exact-file Biome, and Agent lint/typecheck/build pass on the exact head.
- [x] The real 443-batch Windows entrypoint completed in a temporary local composition with #21288 and #21299; both repaired batches pass.
- [x] Root verify was run after final sync; exact unrelated blockers are recorded below.
- [x] The deterministic red/green and full-run receipts below let a reviewer confirm the change without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop@08bb08c0f7170be08b66927903d2d2da0322c289`; zero conflicts.
- [x] Exact head is one commit ahead / zero behind at publication.
- [x] `bun run verify` was rerun on the exact head; unrelated current-develop/Windows lint blockers are documented below.

# Risks

Low. This is a two-file test-fixture change. Production source, credential deletion behavior, plugin loading behavior, APIs, storage, packages, and deployments are unchanged. The tests still exercise a real path escape and retain the original error/no-mutation assertions. Unix continues to use directory symlinks; Windows uses unprivileged directory junctions.

# Background

## What does this PR do?

Two Agent security regressions could not reach their production assertions on ordinary Windows machines because fixture setup attempted privileged symbolic-link creation and failed with `EPERM` first.

This PR keeps the same escape topology without requiring Developer Mode or administrator rights:

1. The credential-reset test uses a directory junction on Windows and a directory symlink elsewhere, then still requires `AUTH_CREDENTIAL_PATH_ESCAPE` and verifies the config/environment remain unchanged.
2. The plugin-loader test puts `index.js` in an out-of-tree directory, links the plugin's complete `dist` directory to it, and still requires `entry must stay inside plugin directory`.

## What kind of change is this?

Test-infrastructure portability fix.

# Documentation changes needed?

No. Public behavior and documented commands are unchanged.

# Testing

## Where should a reviewer start?

Start with `packages/agent/src/api/provider-switch-config.test.ts` and `packages/agent/src/runtime/load-plugin-from-directory.test.ts`. Each fixture now reaches the same production containment guard on unprivileged Windows.

## Detailed testing steps

Exact head: `5c78d80bd9e203ff8a803eb908396fb1fb215046`

1. `bun install --frozen-lockfile --ignore-scripts`
   - PASS with pinned Bun 1.3.14; 3,809 installs checked across 4,090 packages.
2. Pre-fix focused matrix on current `develop`
   - RED: 2 files failed at fixture creation with Windows `EPERM`; 41 other tests passed.
3. `bun x vitest run packages/agent/src/api/provider-switch-config.test.ts packages/agent/src/runtime/load-plugin-from-directory.test.ts --config packages/agent/vitest.config.ts`
   - PASS on exact head: 2 files, 43 tests.
4. `bun x @biomejs/biome check packages/agent/src/api/provider-switch-config.test.ts packages/agent/src/runtime/load-plugin-from-directory.test.ts`
   - PASS on exact head: 2 files, no fixes.
5. `bun run --cwd packages/agent lint:check`
   - PASS on exact head: 931 files, no fixes.
6. `bun run --cwd packages/agent typecheck`
   - PASS on exact head after building the package's clean-worktree declaration prerequisites.
7. `bun run --cwd packages/agent build`
   - PASS on exact head: package-boundary audit, declarations/dist, and 196 NodeNext specifier rewrites.
8. Temporary local composition of candidate `40ad5f22b82e7c94938d82978dacf963a18e6f78` plus #21288 and #21299, then `bun run --cwd packages/agent test`
   - PASS for orchestration and this scope: 443 files discovered, 443 isolated batches completed, both repaired suites passed.
   - The overall lane exits 1 for seven unrelated Windows/upstream batches listed below, improving the prior composed baseline from nine to seven.
   - The final rebase from `590f425c57` to `08bb08c0f7` changed only Cloud/UI files; it did not touch `packages/agent`, `packages/core`, or `packages/shared`. Focused and all Agent package gates were rerun on final exact head `5c78d80b`.
   - The temporary composition branch was deleted and never pushed; this PR contains only the two fixture files.
9. `git diff --check origin/develop...HEAD`
   - PASS.
10. `bun run verify`
   - Rerun on final exact head; reaches Turbo typecheck/lint and stops on unchanged current-develop/Windows lint failures documented below.

# Evidence Gate

<!-- evidence-head:6e3a8cfa9851a1a2bf149de0b24dc9f9d63e88b7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only filesystem fixtures; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only filesystem fixtures; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic test and production-runner transcripts cover the complete changed surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service or request path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, console state, or network request changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action-selection, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Final-head Windows red/green plus ancestry-equivalent composed production-entrypoint transcript:
<details>
<summary>Unprivileged escape-fixture receipt</summary>

```text
Pre-fix focused: 2 failed files; both stopped at symlink creation with EPERM; 41 tests passed.
Final exact-head focused: 2 passed files; 43 passed tests; containment/no-mutation assertions executed.
[agent-test @ 40ad5f22 + #21288 + #21299] 443 files, 443 isolated batches, concurrency 4
[agent-test] progress 443/443
[agent-test] 7 unrelated batch(es) failed; both repaired batches passed (prior composition: 9).
Final rebase delta: Cloud/UI only; no packages/agent, packages/core, or packages/shared changes.
```
</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual-text surface changes.

# Evidence Details

## Domain artifact

```json
{
  "head": "5c78d80bd9e203ff8a803eb908396fb1fb215046",
  "composed_patch_head": "40ad5f22b82e7c94938d82978dacf963a18e6f78",
  "host": "Windows without privileged symlink creation",
  "focused_before": { "files_failed": 2, "tests_passed": 41, "failure": "EPERM" },
  "focused_after": { "files_passed": 2, "tests_passed": 43 },
  "composed_agent_runner": {
    "test_files_discovered": 443,
    "isolated_batches_completed": 443,
    "repaired_batches_failed": 0,
    "unrelated_batches_failed": 7,
    "previous_unrelated_batches_failed": 9
  }
}
```

## Real LLM-call trajectory

N/A - no provider/model/action path changed.

## Backend + frontend logs

N/A - deterministic test infrastructure only; no live service, credential, browser, or provider call.

## Screenshots / video / audio

N/A - no rendered, voice, TTS, or STT surface changed.

## Known gaps / failures

- The full Agent proof composes this test-only commit with #21288 and #21299 because those Windows runner/path fixes are still separate open PRs. The final PR branch itself is a clean one-commit branch from current `develop` and duplicates neither PR.
- The composed lane reaches 443/443 and leaves seven unrelated Windows/upstream batches: `media-store` (Unix read-only permission semantics), `server-helpers-swarm` (absolute path embedded in a directory name), `config-bind-mount-persistence` (POSIX mode assertion), `sandbox-character` (pre-existing config assertion), `e2b-capability-router.coding-remote-runner` (unavailable `sh`), `virtual-filesystem` (owned by #21284), and `cerebras-chat-flow-latency` (Windows-illegal newline filename).
- Exact-head root `bun run verify` passes guide/Biome-version/i18n/dependency/plugin-convention/alias/tsconfig pre-gates and reaches Turbo. It stops on unchanged formatting debt outside this diff, including Windows-generated Electrobun `src/preload.js`/`.generated/brand-config.json`, CRLF CSS in `packages/shared`/`packages/homepage`, and non-null assertions in `packages/core/src/truncation-suffix-reserve-2.test.ts`. Agent lint/typecheck/build pass independently.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-agent-windows-junction-escapes]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8e481051add0dd67f259057684cbb5e26ab26e52:packages/skills/skills/contribute-to-eliza"} -->

