### PR TITLE
fix(cloud): reject prefix-coerced discord-gateway assignments max

### DIFF
--- a/packages/cloud/api/internal/discord/gateway/assignments/route.max.test.ts
+++ b/packages/cloud/api/internal/discord/gateway/assignments/route.max.test.ts
@@ -1,0 +1,114 @@
+/**
+ * GET /api/internal/discord/gateway/assignments `max` is pod-capacity
+ * identity, leftover tax after cloud list `limit` leftover-tax. Stock
+ * develop used z.coerce.number(), which treated `1e2` / `007` / `0x10`
+ * as a capacity instead of a 400. current / pod stay untouched. Missing
+ * / empty still means 50.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getAssignmentsForPod = mock(async () => [{ id: "asg-1" }]);
+
+mock.module("../../../_auth", () => ({
+  requireInternalAuth: async () => ({
+    podName: "internal-secret",
+    service: "shared-secret",
+  }),
+}));
+mock.module("@/db/repositories/discord-connections", () => ({
+  discordConnectionsRepository: {
+    getAssignmentsForPod,
+  },
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_c: unknown, error: unknown) => {
+    throw error;
+  },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    warn: () => undefined,
+    info: () => undefined,
+    error: () => undefined,
+  },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/", route);
+
+describe("GET /api/internal/discord/gateway/assignments max identity", () => {
+  beforeEach(() => {
+    getAssignmentsForPod.mockClear();
+  });
+
+  test.each(["?pod=gw-1", "?pod=gw-1&max=", "?pod=gw-1&max"])(
+    "accepts %s as the default 50 assignment cap",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(200);
+      expect(getAssignmentsForPod).toHaveBeenCalledTimes(1);
+      expect(getAssignmentsForPod).toHaveBeenCalledWith("gw-1", true);
+    },
+  );
+
+  test("accepts max=10 as an exact assignment cap", async () => {
+    const response = await app.request("/?pod=gw-1&max=10&current=3");
+    expect(response.status).toBe(200);
+    expect(getAssignmentsForPod).toHaveBeenCalledWith("gw-1", true);
+  });
+
+  test("accepts max=10 with current=10 as at-capacity", async () => {
+    const response = await app.request("/?pod=gw-1&max=10&current=10");
+    expect(response.status).toBe(200);
+    expect(getAssignmentsForPod).toHaveBeenCalledWith("gw-1", false);
+  });
+
+  test("rejects a canonical oversize max before getAssignmentsForPod", async () => {
+    const response = await app.request("/?pod=gw-1&max=501");
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("Invalid max");
+    expect(getAssignmentsForPod).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    "1e2",
+    "12px",
+    "007",
+    "0",
+    "abc",
+    "-1",
+    "50abc",
+    " 10",
+    "10 ",
+    "0x10",
+  ])(
+    "rejects prefix-coerced max=%s before getAssignmentsForPod",
+    async (token) => {
+      const response = await app.request(
+        `/?pod=gw-1&max=${encodeURIComponent(token)}`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid max");
+      expect(getAssignmentsForPod).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    "?pod=gw-1&max=10&max=10",
+    "?pod=gw-1&max=10&max=20",
+    "?pod=gw-1&max=&max=10",
+    "?pod=gw-1&max=foo&max=10",
+  ])(
+    "rejects duplicate max values in %s before getAssignmentsForPod",
+    async (query) => {
+      const response = await app.request(`/${query}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid max");
+      expect(getAssignmentsForPod).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/internal/discord/gateway/assignments/route.ts
+++ b/packages/cloud/api/internal/discord/gateway/assignments/route.ts
@@ -14,10 +14,51 @@ const podNameSchema = z
   .max(253)
   .regex(/^[a-zA-Z0-9-]+$/);
 
+const MAX_ASSIGNMENTS_CAP = 500;
+const DEFAULT_ASSIGNMENTS_MAX = 50;
+
+class DiscordAssignmentsMaxError extends Error {
+  constructor(message = "Invalid max") {
+    super(message);
+    this.name = "DiscordAssignmentsMaxError";
+  }
+}
+
+/**
+ * GET /api/internal/discord/gateway/assignments `max` is pod-capacity
+ * identity, leftover tax after cloud list `limit` leftover-tax. Stock
+ * develop used z.coerce.number(), which treated `1e2` / `007` / `0x10`
+ * as a capacity instead of a 400. current / pod stay untouched.
+ * Missing / empty still means 50. Exact integers above 500 stay 400.
+ */
+function parseDiscordAssignmentsMaxQuery(
+  searchParams: URLSearchParams,
+): number {
+  const requested = searchParams.getAll("max");
+  if (requested.length > 1) {
+    throw new DiscordAssignmentsMaxError();
+  }
+  const raw = requested[0];
+  if (raw == null || raw === "") {
+    return DEFAULT_ASSIGNMENTS_MAX;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new DiscordAssignmentsMaxError();
+  }
+  const parsed = Number(raw);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    parsed > MAX_ASSIGNMENTS_CAP
+  ) {
+    throw new DiscordAssignmentsMaxError();
+  }
+  return parsed;
+}
+
 const querySchema = z.object({
   pod: podNameSchema,
   current: z.coerce.number().int().min(0).default(0),
-  max: z.coerce.number().int().min(1).max(500).default(50),
 });
 
 const app = new Hono<AppEnv>();
@@ -27,14 +68,25 @@ app.get("/", async (c) => {
     const auth = await requireInternalAuth(c);
     if (auth instanceof Response) return auth;
 
+    let max: number;
+    try {
+      max = parseDiscordAssignmentsMaxQuery(
+        new URL(c.req.url, "http://localhost").searchParams,
+      );
+    } catch (maxError) {
+      if (maxError instanceof DiscordAssignmentsMaxError) {
+        return c.json({ success: false, error: maxError.message }, 400);
+      }
+      throw maxError;
+    }
+
     const query = querySchema.parse({
       pod: c.req.query("pod"),
       current: c.req.query("current") ?? undefined,
-      max: c.req.query("max") ?? undefined,
     });
     const assignments = await discordConnectionsRepository.getAssignmentsForPod(
       query.pod,
-      query.current < query.max,
+      query.current < max,
     );
     return c.json({ assignments });
   } catch (err) {


### PR DESCRIPTION

# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on internal
discord-gateway assignments `max` identity. Capacity class, leftover
tax after cloud list `limit`. Not a twin of those parsers — this is
`GET /api/internal/discord/gateway/assignments` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `max` only on `/api/internal/discord/gateway/assignments`.
Omitted/empty still means the documented default (50). Exact positive
integers still bind and stay 400 above 500. Prefix-coerced / unknown /
duplicate tokens 400 before `getAssignmentsForPod`. current / pod stay
untouched.

# Background

## What does this PR do?

`GET /api/internal/discord/gateway/assignments` used `z.coerce.number()`,
which treated `1e2` / `007` / `0x10` as a pod capacity instead of a 400.

- omitted / empty → default 50
- exact `10` → cap 10
- exact `501` → 400
- `1e2` / `12px` / `007` / `0x10` / `0` / `foo` / duplicates → **400** before `getAssignmentsForPod`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Internal discord-gateway pods advertise capacity with `?max=`. A common
`max=1e2` or `007` after a client sends a numeric token must not silently
become a coerced capacity. Leftover tax after cloud list `limit`.
Disjoint files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/internal/discord/gateway/assignments/route.max.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test "./internal/discord/gateway/assignments/route.max.test.ts"
```

20 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; discord-gateway assignments `max` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; discord-gateway assignments `max` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; discord-gateway assignments `max` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real max tokens and assert 400 before getAssignmentsForPod; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before getAssignmentsForPod.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`max` tokens reject; omitted/canonical still bind the matching
assignment cap.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the discord-gateway
assignments `max` query only.

## Known gaps / failures

`bun run verify` was not run. Focused 20-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6cdfdf55dbc72c32e54a9adcc5c87995ec676d3c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
