### PR TITLE
fix(plugin-imessage): reject prefix-coerced messages list limit

### DIFF
--- a/plugins/plugin-imessage/src/api/imessage-routes.limit.test.ts
+++ b/plugins/plugin-imessage/src/api/imessage-routes.limit.test.ts
@@ -1,0 +1,101 @@
+/**
+ * GET /api/imessage/messages `limit` is list pagination leftover tax after
+ * data-routes messages limit (#20855) and bluebubbles list limit.
+ * Stock develop treated `limit=1e2` as one row
+ * (`Number.parseInt("1e2", 10) === 1`) instead of a 400. chats /
+ * contacts / status parsers stay untouched.
+ */
+import type http from "node:http";
+import type { RouteHelpers } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleIMessageRoute } from "./imessage-routes.ts";
+
+function makeHelpers() {
+  const json = vi.fn();
+  const error = vi.fn();
+  const readJsonBody = vi.fn();
+  return { json, error, readJsonBody } as unknown as RouteHelpers & {
+    json: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+}
+
+async function call(
+  url: string,
+  limits: number[],
+): Promise<{ helpers: ReturnType<typeof makeHelpers> }> {
+  const helpers = makeHelpers();
+  const state = {
+    runtime: {
+      getService: (type: string) =>
+        type === "imessage"
+          ? {
+              isConnected: () => true,
+              getRecentMessages: async (limit?: number) => {
+                if (typeof limit === "number") limits.push(limit);
+                return [{ id: "msg-1", text: "hi", handle: "me", chatId: "c1" }];
+              },
+              getChats: async () => [],
+            }
+          : null,
+    },
+  };
+  const req = { url } as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  const handled = await handleIMessageRoute(
+    req,
+    res,
+    "/api/imessage/messages",
+    "GET",
+    state,
+    helpers,
+  );
+  expect(handled).toBe(true);
+  return { helpers };
+}
+
+describe("GET /api/imessage/messages limit identity", () => {
+  it("omitted limit defaults to 50 and reaches getRecentMessages", async () => {
+    const limits: number[] = [];
+    const { helpers } = await call("/api/imessage/messages", limits);
+    expect(helpers.error).not.toHaveBeenCalled();
+    expect(limits).toEqual([50]);
+  });
+
+  it("accepts empty limit as the default 50 page size", async () => {
+    const limits: number[] = [];
+    const { helpers } = await call("/api/imessage/messages?limit=", limits);
+    expect(helpers.error).not.toHaveBeenCalled();
+    expect(limits).toEqual([50]);
+  });
+
+  it("accepts canonical limit=10", async () => {
+    const limits: number[] = [];
+    const { helpers } = await call("/api/imessage/messages?limit=10", limits);
+    expect(helpers.error).not.toHaveBeenCalled();
+    expect(limits).toEqual([10]);
+  });
+
+  it("caps a canonical oversize limit at 500", async () => {
+    const limits: number[] = [];
+    await call("/api/imessage/messages?limit=501", limits);
+    expect(limits).toEqual([500]);
+  });
+
+  it.each(["1e2", "12px", "007", "0", "abc", "-1", "50abc", " 10", "10 ", "0x10"])(
+    "rejects prefix-coerced messages limit=%s before getRecentMessages",
+    async (token) => {
+      const limits: number[] = [];
+      const { helpers } = await call(
+        `/api/imessage/messages?limit=${encodeURIComponent(token)}`,
+        limits,
+      );
+      expect(helpers.error).toHaveBeenCalledWith(
+        expect.anything(),
+        "limit must be a positive integer",
+        400,
+      );
+      expect(limits).toEqual([]);
+    },
+  );
+});

--- a/plugins/plugin-imessage/src/api/imessage-routes.ts
+++ b/plugins/plugin-imessage/src/api/imessage-routes.ts
@@ -137,6 +137,29 @@ export interface IMessageRouteState {
 
 const IMESSAGE_SERVICE_NAME = "imessage";
 const MAX_BODY_BYTES = 256 * 1024; // Contacts payloads are tiny; cap aggressively.
+const DEFAULT_MESSAGES_LIMIT = 50;
+const MAX_MESSAGES_LIMIT = 500;
+
+/**
+ * Canonical iMessage messages page size. `Number.parseInt("1e2", 10) === 1`
+ * used to silently return one row instead of a 400. Leftover tax after
+ * data-routes messages limit (#20855) and bluebubbles list limit.
+ * chats / contacts / status parsers stay untouched. Missing / empty
+ * still means 50. Exact integers above 500 still cap at 500.
+ */
+function parseIMessageMessagesLimit(raw: string | null): number | null {
+  if (raw === null || raw === "") {
+    return DEFAULT_MESSAGES_LIMIT;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    return null;
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    return null;
+  }
+  return Math.min(parsed, MAX_MESSAGES_LIMIT);
+}
 
 function resolveService(state: IMessageRouteState): IMessageServiceLike | null {
   if (!state.runtime) return null;
@@ -202,8 +225,11 @@ export async function handleIMessageRoute(
       return true;
     }
     const url = new URL(req.url ?? pathname, "http://localhost");
-    const limitParam = url.searchParams.get("limit");
-    const limit = Math.min(Math.max(1, Number.parseInt(limitParam ?? "50", 10) || 50), 500);
+    const limit = parseIMessageMessagesLimit(url.searchParams.get("limit"));
+    if (limit === null) {
+      helpers.error(res, "limit must be a positive integer", 400);
+      return true;
+    }
     try {
       const messages = await service.getRecentMessages(limit);
       helpers.json(res, { messages, count: messages.length });


### PR DESCRIPTION

# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on plugin-imessage
messages list `limit` identity. Pagination class, leftover tax after
data-routes messages limit (#20855) and bluebubbles list limit (#21264).
Not a twin of those parsers — this is `GET /api/imessage/messages` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `limit` only on `/api/imessage/messages`. Omitted/empty still
means the documented default (50). Exact positive integers still bind
and cap at 500. Prefix-coerced / unknown tokens 400 before
`getRecentMessages`. chats / contacts / status stay untouched.

# Background

## What does this PR do?

`GET /api/imessage/messages` used `Number.parseInt`, which treated
`1e2` / `007` / `0x10` as a page size instead of a 400.

- omitted / empty → default 50
- exact `10` → page 10
- exact `501` → cap 500
- `1e2` / `12px` / `007` / `0x10` / `0` / `foo` → **400** before `getRecentMessages`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers page recent iMessage rows with `?limit=`. A common `limit=1e2`
or `007` after a client sends a numeric token must not silently become
one row. Leftover tax after data-routes messages limit and bluebubbles
list limit. Disjoint files from both.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-imessage/src/api/imessage-routes.limit.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-imessage && bunx vitest run --config vitest.config.ts src/api/imessage-routes.limit.test.ts
```

14 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; iMessage messages `limit` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; iMessage messages `limit` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; iMessage messages `limit` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real limit tokens and assert 400 before getRecentMessages; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before getRecentMessages.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
`limit` tokens reject; omitted/canonical still bind the matching
messages page size.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the iMessage
messages `limit` query only.

## Known gaps / failures

`bun run verify` was not run. Focused 14-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:2914ddd31e895caf539a2acb4e35a407d41ed376 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
