### PR TITLE
fix(plugin-wallet): reject prefix-coerced wallet-router slippageBps

### DIFF
--- a/plugins/plugin-wallet/src/types/wallet-router.slippage.test.ts
+++ b/plugins/plugin-wallet/src/types/wallet-router.slippage.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Wallet-router `slippageBps` is swap-tolerance identity, leftover tax
+ * after cloud list `limit` leftover-tax. Stock develop used
+ * z.coerce.number(), which treated string `1e2` / `007` / `0x10` as a
+ * slippage instead of a parse failure. support / dryRun / amount stay
+ * untouched. Missing still means the chain default.
+ */
+import { describe, expect, it } from "vitest";
+import { parseWalletRouterParams } from "./wallet-router.ts";
+
+function parse(slippageBps?: unknown) {
+  const input: Record<string, unknown> = { subaction: "swap" };
+  if (arguments.length > 0) {
+    input.slippageBps = slippageBps;
+  }
+  return parseWalletRouterParams(input);
+}
+
+describe("wallet-router slippageBps identity", () => {
+  it("accepts omitted slippageBps as the chain-default tolerance", () => {
+    const params = parse();
+    expect(params.subaction).toBe("swap");
+    expect(params.slippageBps).toBeUndefined();
+  });
+
+  it("accepts slippageBps=50 as an exact swap tolerance", () => {
+    expect(parse(50).slippageBps).toBe(50);
+  });
+
+  it("accepts slippageBps=0 as a legal zero-slippage quote", () => {
+    expect(parse(0).slippageBps).toBe(0);
+    expect(parse("0").slippageBps).toBe(0);
+  });
+
+  it("accepts canonical string slippageBps=250", () => {
+    expect(parse("250").slippageBps).toBe(250);
+  });
+
+  it("rejects a canonical oversize slippageBps before routing", () => {
+    expect(() => parse(10001)).toThrow();
+    expect(() => parse("10001")).toThrow();
+  });
+
+  it.each(["1e2", "12px", "007", "abc", "-1", "50abc", " 50", "50 ", "0x10"])(
+    "rejects prefix-coerced slippageBps=%s before routing",
+    (token) => {
+      expect(() => parse(token)).toThrow();
+    },
+  );
+});

--- a/plugins/plugin-wallet/src/types/wallet-router.ts
+++ b/plugins/plugin-wallet/src/types/wallet-router.ts
@@ -221,6 +221,53 @@ const optionalPositiveAmount = optionalString.refine(
   { message: "amount must be a positive number" },
 );
 
+const MIN_WALLET_SLIPPAGE_BPS = 0;
+const MAX_WALLET_SLIPPAGE_BPS = 10_000;
+
+/**
+ * Wallet-router `slippageBps` is swap-tolerance identity, leftover tax
+ * after cloud list `limit` leftover-tax. Stock develop used
+ * z.coerce.number(), which treated string `1e2` / `007` / `0x10` as a
+ * slippage instead of a parse failure. support / dryRun / amount stay
+ * untouched. Missing still means the chain default. Exact integers
+ * above 10000 stay invalid. 0 is a legal zero-slippage quote.
+ */
+function parseWalletSlippageBps(raw: unknown): number {
+  if (typeof raw === "number") {
+    if (
+      !Number.isSafeInteger(raw) ||
+      raw < MIN_WALLET_SLIPPAGE_BPS ||
+      raw > MAX_WALLET_SLIPPAGE_BPS
+    ) {
+      throw new Error("Invalid slippageBps");
+    }
+    return raw;
+  }
+  if (typeof raw !== "string" || !/^(0|[1-9]\d*)$/.test(raw)) {
+    throw new Error("Invalid slippageBps");
+  }
+  const parsed = Number(raw);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < MIN_WALLET_SLIPPAGE_BPS ||
+    parsed > MAX_WALLET_SLIPPAGE_BPS
+  ) {
+    throw new Error("Invalid slippageBps");
+  }
+  return parsed;
+}
+
+const slippageBpsSchema = z
+  .custom<number>((value) => {
+    try {
+      parseWalletSlippageBps(value);
+      return true;
+    } catch {
+      return false;
+    }
+  }, "Invalid slippageBps")
+  .transform((value) => parseWalletSlippageBps(value));
+
 const optionalStringArray = z.preprocess((value) => {
   if (value === null || value === undefined) return undefined;
   if (Array.isArray(value)) {
@@ -245,7 +292,7 @@ export const WalletRouterParamsSchema = z.object({
   toToken: optionalString,
   amount: optionalPositiveAmount,
   recipient: optionalString,
-  slippageBps: z.coerce.number().int().min(0).max(10_000).optional(),
+  slippageBps: slippageBpsSchema.optional(),
   mode: z.enum(WALLET_ROUTER_MODES).default("prepare"),
   dryRun: z
     .preprocess((value) => {


### PR DESCRIPTION

# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on plugin-wallet
router `slippageBps` identity. Swap-tolerance class, leftover tax after
cloud list `limit`. Not a twin of those parsers — this is
`parseWalletRouterParams` / `WalletRouterParamsSchema` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. `slippageBps` only on wallet-router params. Omitted still means the
chain default. Exact integers 0..10000 still bind. Prefix-coerced /
unknown tokens fail before routing. support / dryRun / amount stay
untouched.

# Background

## What does this PR do?

Wallet-router `slippageBps` used `z.coerce.number()`, which treated
`1e2` / `007` / `0x10` as a swap tolerance instead of a parse failure.

- omitted → chain default
- exact `50` / `"250"` / `0` → that tolerance
- exact `10001` → parse failure
- `1e2` / `12px` / `007` / `0x10` / `foo` → **parse failure** before routing

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Callers set swap tolerance with `slippageBps`. A common `slippageBps=1e2`
or `007` after a client sends a numeric token must not silently become a
coerced tolerance. Leftover tax after cloud list `limit`. Disjoint files
from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/types/wallet-router.slippage.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-wallet && bunx vitest run --config ./vitest.config.ts src/types/wallet-router.slippage.test.ts
```

14 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; wallet-router `slippageBps` parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; wallet-router `slippageBps` parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; wallet-router `slippageBps` parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused schema tests drive the real slippageBps tokens and assert parse failure before routing; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens fail before routing.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
`slippageBps` tokens reject; omitted/canonical still bind the matching
swap tolerance.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the wallet-router
`slippageBps` parse only.

## Known gaps / failures

`bun run verify` was not run. Focused 14-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:294e408cb7762dad12122a5544ed73bb9903199d -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
