### PR TITLE
fix(agent): 400 malformed memory-feed before cursors instead of emptying the feed

### DIFF
--- a/packages/agent/src/api/memory-feed-cursor.test.ts
+++ b/packages/agent/src/api/memory-feed-cursor.test.ts
@@ -53,6 +53,48 @@ describe("GET /api/memories/feed cursor", () => {
     });
   });
 
+  test("400s a malformed before cursor instead of silently emptying the feed", async () => {
+    // Number("abc") is NaN — a `number`, so it passes the undefined check in
+    // fetchMemoriesFromTables, and every `createdAt < NaN` comparison is
+    // false. Without the boundary guard this request returned 200 with an
+    // empty feed, indistinguishable from an agent that has no memories.
+    const getMemories = vi.fn(async () => []);
+    const runtime = {
+      agentId: "11111111-1111-4111-8111-111111111111" as UUID,
+      character: { name: "Eliza" },
+      ensureConnection: vi.fn(async () => undefined),
+      getMemories,
+    } as unknown as AgentRuntime;
+    const errors: Array<{ message: string; status?: number }> = [];
+    const context: MemoryRouteContext = {
+      req: {} as never,
+      res: {} as never,
+      method: "GET",
+      pathname: "/api/memories/feed",
+      url: new URL(
+        "https://agent.test/api/memories/feed?before=abc&type=messages",
+      ),
+      runtime,
+      agentName: "Eliza",
+      json: () => {
+        throw new Error("unexpected 200");
+      },
+      error: (_res, message, status) => {
+        errors.push({ message, status });
+      },
+      readJsonBody: async <T extends object>() => ({}) as T,
+    };
+
+    expect(await handleMemoryRoutes(context)).toBe(true);
+    expect(errors).toEqual([
+      {
+        message: "before must be a finite Unix timestamp in milliseconds",
+        status: 400,
+      },
+    ]);
+    expect(getMemories).not.toHaveBeenCalled();
+  });
+
   test("rejects an unknown type before scanning tables", async () => {
     const getMemories = vi.fn(async () => []);
     const runtime = {

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -576,6 +576,14 @@ export async function handleMemoryRoutes(
     const limit = Math.min(Math.max(requestedLimit, 1), MEMORY_FEED_MAX_LIMIT);
     const beforeParam = url.searchParams.get("before");
     const before = beforeParam ? Number(beforeParam) : undefined;
+    // Number("abc") is NaN, which is a `number` and so survives the
+    // `beforeTs !== undefined` cursor gate below — but every `< NaN`
+    // comparison is false, so a malformed cursor would silently empty the
+    // feed with a 200. Reject it here instead, mirroring the `type` guard.
+    if (before !== undefined && !Number.isFinite(before)) {
+      error(res, "before must be a finite Unix timestamp in milliseconds", 400);
+      return true;
+    }
     const tableFilter = parseMemoryTableFilter(url.searchParams.get("type"));
     if (!tableFilter.ok) {
       error(res, tableFilter.message, 400);


### PR DESCRIPTION
# Relates to

Follow-up to #20521 / #20520. My review on #20521 (posted before merge) verified this regression at its head; the PR merged without addressing it, so the fix lands here. Full credit to @Svector-anu for the original zero-cursor fix — this completes it for the malformed-cursor case.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (branched from `origin/develop` at `08bb08c0f7`).
- [x] `bun install` and `bun run verify` were run after sync — exit 0 at this exact head, see Testing.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5` (diagnosis, fix, tests), `anthropic/claude-fable-5` (final verify run, PR assembly)
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched directly off the latest `origin/develop` (`08bb08c0f7`); zero conflicts.
- [x] `bun run verify` passes post-sync at this head.

# Risks

Low. One added guard on one GET route, mirroring the `type` validation already in the same handler. The only behaviour change: `GET /api/memories/feed` with a `before` that does not parse to a finite number (`?before=abc`, `?before=NaN`, `?before=Infinity`) now returns **400** instead of 200. Valid cursors — including `?before=0`, the case #20521 fixed — are untouched, as is an absent/empty `before`.

# Background

## What does this PR do?

#20521 correctly fixed `?before=0` being swallowed by a truthiness check, replacing `if (beforeTs)` with `if (beforeTs !== undefined)`. But `before` is built as:

```ts
const before = beforeParam ? Number(beforeParam) : undefined;
```

`Number("abc")` is `NaN` — a `number`, so it satisfies the `number | undefined` annotation and passes `!== undefined`. Control reaches `filtered.filter((m) => memoryCreatedAt(m) < beforeTs)`, every comparison against `NaN` is `false`, and the request returns an **empty feed with a 200** — indistinguishable from an agent that genuinely has no memories.

Before #20521, a malformed cursor was falsy and therefore ignored (unfiltered feed). After it, the same request silently empties the feed. Both are wrong answers; this makes it an explicit `400 before must be a finite Unix timestamp in milliseconds`, which is the same posture the handler already takes for an unknown `type` (`400` before scanning tables). A paginating client that mangles its cursor learns immediately, instead of looping on page 1 (pre-#20521) or concluding the agent is empty (post-#20521).

`?before=Infinity` also lands in the 400: it parsed to a filter that kept everything (`< Infinity`), i.e. behaved as if no cursor was sent — reporting that as a client error rather than honoring it is deliberate, since no real paginator emits it.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/memory-feed-cursor.test.ts` — the new test `400s a malformed before cursor instead of silently emptying the feed`, in the file #20521 introduced, driving the real `handleMemoryRoutes` boundary. It asserts the 400 and that `getMemories` is never called.

## Detailed testing steps

None: Automated tests are acceptable.

Red→green: with the guard removed (exact #20521 / current-develop behaviour), the new test fails with `unexpected 200` — the handler returns an empty feed. With the guard, 6/6 in the file pass, including #20521's own epoch-cursor test unchanged:

```
× 400s a malformed before cursor instead of silently emptying the feed
  → unexpected 200            # develop behaviour, guard removed
✓ honors a before cursor at the Unix epoch
...
Tests  6 passed (6)           # at this head
```

# Evidence Gate

<!-- evidence-head:de5440f1cec943b0c75ef85acebfa9336e59ba71 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - HTTP API route guard; no rendered UI surface in the diff.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - HTTP API route guard; no rendered UI surface in the diff.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-UI change; behaviour is fully captured by the failing-before/passing-after route-handler test.`
<!-- evidence-row:backend-logs -->
- [x] Vitest run at this head attached below (route handler exercised end to end via `handleMemoryRoutes` with an in-memory runtime).
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend consumer changed; the memory viewer sends numeric cursors and is unaffected.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; pure HTTP parameter validation.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows/memories/tasks are created; the guard rejects before any table scan (asserted: getMemories not called).`
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

```
$ bunx vitest run src/api/memory-feed-cursor.test.ts
✓ GET /api/memories/feed cursor > honors a before cursor at the Unix epoch
✓ GET /api/memories/feed cursor > 400s a malformed before cursor instead of silently emptying the feed
✓ GET /api/memories/feed cursor > rejects an unknown type before scanning tables
✓ parseMemoryTableFilter > omitted and empty keep the unfiltered all-tables scan
✓ parseMemoryTableFilter > accepts the viewer table identities
✓ parseMemoryTableFilter > rejects unknown tokens instead of returning every table
Tests  6 passed (6)
```

Root `bun run verify` at this exact head: exit 0 (full output available on request).

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`
