### PR TITLE
fix(cloud): align terraform workflow assertions with the extracted validator

### DIFF
--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -441,7 +441,9 @@ describe("Cloudflare Pages domain durability", () => {
     expect(workflow).toContain("workflow_dispatch:");
     expect(workflow).toContain("options: [plan, apply, state-rm]");
     expect(workflow).toContain("terraform apply -no-color -input=false");
-    expect(workflow).toContain('entry.status !== "active"');
+    expect(workflow).toContain(
+      'canonical.certificate_packs?.[key]?.status !== "active"',
+    );
     expect(workflow).toContain(
       "TF_VAR_railway_tunnel_dns_records: $" +
         "{{ vars.RAILWAY_TUNNEL_DNS_RECORDS_JSON || '{}' }}",
@@ -454,8 +456,18 @@ describe("Cloudflare Pages domain durability", () => {
     );
     expect(workflow).toContain("allowEmpty || Object.keys(value).length > 0");
     expect(workflow).toContain("terraform output -json railway_tunnel_dns");
-    expect(workflow).toContain("record.proxied !== false");
-    expect(workflow).toContain("record.roles?.includes(role)");
+    // The record-shape checks moved from inline workflow script into the
+    // dedicated validator the workflow invokes after apply.
+    expect(workflow).toContain("validate-terraform-pages-domain-state.mjs");
+    const validator = readFileSync(
+      join(
+        import.meta.dir,
+        "../../../../packages/scripts/validate-terraform-pages-domain-state.mjs",
+      ),
+      "utf-8",
+    );
+    expect(validator).toContain("record?.proxied !== false");
+    expect(validator).toContain("record?.roles?.includes(role)");
     expect(workflow).toContain("--require-beacon");
     expect(workflow).not.toContain("bun install");
     expect(workflow).not.toContain("push:");


### PR DESCRIPTION
Last red in the release candidate's `bun run test` (run 32035853521): the infra workflow's post-apply record checks moved into `packages/scripts/validate-terraform-pages-domain-state.mjs` and the additive canonical-edge guard was rewritten around canonical outputs, but `terraform-static.test.ts` still pinned the old inline literals. The suite now pins the validator invocation in the workflow plus the moved expressions in the validator source — the durable contracts (proxied shape, role membership, active certificate packs) stay pinned where they live.

Evidence: suite 21/21 locally (195 expects). Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)