### PR TITLE
fix(plugin-computeruse): reject malformed computer-use approval id encoding

### DIFF
--- a/plugins/plugin-computeruse/src/routes/computer-use-routes.encoding.test.ts
+++ b/plugins/plugin-computeruse/src/routes/computer-use-routes.encoding.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Computer-use approval-id path encoding is leftover tax after apps /
+ * scheduling percent-encoding Fixes. Stock develop called
+ * decodeURIComponent on POST /api/computer-use/approvals/:id, so `%` /
+ * `%2` / `%ZZ` threw URIError (500) instead of a typed 400. List /
+ * stream / approval-mode stay untouched.
+ */
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import { describe, expect, it } from "vitest";
+import { handleComputerUseRoutes } from "./computer-use-routes.ts";
+
+interface CapturedResponse {
+  statusCode?: number;
+  body?: string;
+  ended: boolean;
+}
+
+async function hit(
+  pathname: string,
+  method = "POST",
+): Promise<CapturedResponse> {
+  const captured: CapturedResponse = { ended: false };
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  const req = new IncomingMessage(socket);
+  req.method = method;
+  const res = new ServerResponse(req);
+  res.statusCode = 0;
+  res.end = function end(
+    this: ServerResponse,
+    chunk?: unknown,
+    encodingOrCallback?: BufferEncoding | (() => void),
+    callback?: () => void,
+  ): ServerResponse {
+    captured.ended = true;
+    captured.body = typeof chunk === "string" ? chunk : "";
+    captured.statusCode = this.statusCode;
+    const done =
+      typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+    done?.();
+    return this;
+  };
+  await handleComputerUseRoutes(req, res, pathname, method);
+  return captured;
+}
+
+describe("POST /api/computer-use/approvals/:id encoding", () => {
+  it("canonical approval id still 404s as not pending", async () => {
+    const res = await hit("/api/computer-use/approvals/approval-1");
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body ?? "")).toEqual({
+      error: "Computer-use approval is not pending.",
+      id: "approval-1",
+    });
+  });
+
+  it("canonical percent-encoded hyphen still decodes before the 404", async () => {
+    const res = await hit("/api/computer-use/approvals/demo%2Did");
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body ?? "")).toEqual({
+      error: "Computer-use approval is not pending.",
+      id: "demo-id",
+    });
+  });
+
+  it("GET approvals list is untouched", async () => {
+    const res = await hit("/api/computer-use/approvals", "GET");
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body ?? "")).toMatchObject({
+      mode: "full_control",
+      pendingCount: 0,
+    });
+  });
+
+  it.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed approval id %s with 400",
+    async (token) => {
+      const res = await hit(`/api/computer-use/approvals/${token}`);
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body ?? "")).toEqual({
+        error: "Invalid approval id: malformed URL encoding",
+      });
+    },
+  );
+});

--- a/plugins/plugin-computeruse/src/routes/computer-use-routes.ts
+++ b/plugins/plugin-computeruse/src/routes/computer-use-routes.ts
@@ -23,6 +23,16 @@ function sendJson(
   res.end(JSON.stringify(body));
 }
 
+function decodeApprovalId(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — malformed percent-encoding
+    // is invalid client input, not an approval-router outage.
+    return null;
+  }
+}
+
 function sendEmptyApprovalStream(res: http.ServerResponse): void {
   res.writeHead(200, {
     "Content-Type": "text/event-stream",
@@ -66,9 +76,16 @@ export async function handleComputerUseRoutes(
     pathname,
   );
   if (method === "POST" && approvalDecision) {
+    const id = decodeApprovalId(approvalDecision[1] ?? "");
+    if (id === null) {
+      sendJson(res, 400, {
+        error: "Invalid approval id: malformed URL encoding",
+      });
+      return true;
+    }
     sendJson(res, 404, {
       error: "Computer-use approval is not pending.",
-      id: decodeURIComponent(approvalDecision[1] ?? ""),
+      id,
     });
     return true;
   }


### PR DESCRIPTION

# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
plugin-computeruse approval-id percent-encoding. Encoding class, leftover
tax after apps / scheduling path-decode Fixes. Not a twin of those
parsers — this is `POST /api/computer-use/approvals/:id` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on computer-use approval decide. Canonical
`demo%2Did` still decodes to `demo-id` and 404s as not pending. Malformed
`%` / `%2` / `%ZZ` become 400 instead of an uncaught `URIError` 500.
List / stream / approval-mode stay untouched.

# Background

## What does this PR do?

`handleComputerUseRoutes` called `decodeURIComponent` on the approval-id
path segment. Illegal percent-encoding throws `URIError`, which the host
mapped to 500.

- `/api/computer-use/approvals/%` / `%2` / `%ZZ` → **400**
- `/api/computer-use/approvals/demo%2Did` → still decodes to `demo-id`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded approval id should
get a request error, not a 500 that looks like a computer-use outage.
Leftover tax after apps / scheduling path-decode. Disjoint files from
both.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-computeruse/src/routes/computer-use-routes.encoding.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-computeruse && bunx vitest run --config vitest.config.ts src/routes/computer-use-routes.encoding.test.ts
```

7 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; computer-use approval-id path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; computer-use approval-id path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; computer-use approval-id path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before the not-pending response; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before the not-pending response.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
percent-encoding rejects; omitted/canonical still decode and 404 as
not pending.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the computer-use
approval-id path decode only.

## Known gaps / failures

`bun run verify` was not run. Focused 7-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e5573790023fab819716494ab0b4db4bc47e6660 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
