### PR TITLE
fix(security): close SSRF guard gaps — IPv6 transition ranges, unguarded/unbounded fetches, loopback probe policy

### DIFF
--- a/packages/agent/src/services/registry-client-endpoints.ts
+++ b/packages/agent/src/services/registry-client-endpoints.ts
@@ -2,13 +2,21 @@
  * Fetches plugin metadata from user-configured custom registry endpoints and
  * folds it into the plugin map. Every endpoint URL passes an SSRF guard before
  * any request: https-only, literal/private/link-local hosts blocked, DNS
- * resolved and pinned, then re-resolved immediately before fetch to defeat
- * rebinding. Fetches run in parallel with a short timeout and no redirects;
- * custom entries never override a name already present in the map.
+ * resolved and screened up front, and the fetch itself executed through
+ * `fetchWithSsrfGuard` — which re-resolves, pins the connection to the
+ * screened addresses, and forbids redirects — so a rebinding answer between
+ * validation and connect cannot reroute the request. Fetches run in parallel
+ * with a short timeout; custom entries never override a name already present
+ * in the map.
  */
 import { lookup as dnsLookup } from "node:dns/promises";
 import net from "node:net";
-import { isPrivateIpAddress, logger, normalizeHostLike } from "@elizaos/core";
+import {
+  fetchWithSsrfGuard,
+  isPrivateIpAddress,
+  logger,
+  normalizeHostLike,
+} from "@elizaos/core";
 import type { RegistryEndpoint } from "../config/types.eliza.ts";
 import type { RegistryPluginInfo } from "./registry-client-types.ts";
 
@@ -61,13 +69,6 @@ const BLOCKED_REGISTRY_HOST_LITERALS = new Set([
 ]);
 const REGISTRY_ENDPOINT_FETCH_TIMEOUT_MS = 2_500;
 
-function createRegistryEndpointFetchInit(): RequestInit {
-  return {
-    redirect: "error",
-    signal: AbortSignal.timeout(REGISTRY_ENDPOINT_FETCH_TIMEOUT_MS),
-  };
-}
-
 export function normaliseEndpointUrl(url: string): string {
   return url.replace(/\/{1,1024}$/, "");
 }
@@ -109,7 +110,6 @@ export function parseRegistryEndpointUrl(rawUrl: string): URL {
 type ResolvedRegistryEndpoint = {
   parsed: URL;
   hostname: string;
-  pinnedAddress: string | null;
 };
 
 async function resolveRegistryEndpointUrlRejection(rawUrl: string): Promise<{
@@ -137,7 +137,7 @@ async function resolveRegistryEndpointUrlRejection(rawUrl: string): Promise<{
   if (net.isIP(hostname)) {
     return {
       rejection: null,
-      endpoint: { parsed, hostname, pinnedAddress: hostname },
+      endpoint: { parsed, hostname },
     };
   }
 
@@ -173,7 +173,6 @@ async function resolveRegistryEndpointUrlRejection(rawUrl: string): Promise<{
     endpoint: {
       parsed,
       hostname,
-      pinnedAddress: addresses[0]?.address ?? null,
     },
   };
 }
@@ -192,41 +191,30 @@ async function fetchSingleEndpoint(
   }
 
   try {
-    if (endpoint.pinnedAddress && !net.isIP(endpoint.hostname)) {
-      const refreshed = await dnsLookup(endpoint.hostname, { all: true });
-      const refreshedAddresses = new Set(
-        (Array.isArray(refreshed) ? refreshed : [refreshed]).map((entry) =>
-          normalizeHostLike(entry.address),
-        ),
-      );
-
-      if (!refreshedAddresses.has(normalizeHostLike(endpoint.pinnedAddress))) {
+    // The pre-screen above resolves and rejects blocked answers, but a raw
+    // fetch would resolve DNS AGAIN at connect time — a rebinding window.
+    // fetchWithSsrfGuard re-resolves and pins the connection to the screened
+    // addresses, and maxRedirects: 0 keeps a hostile endpoint from bouncing
+    // the request elsewhere.
+    const { response: resp, release } = await fetchWithSsrfGuard({
+      url,
+      maxRedirects: 0,
+      timeoutMs: REGISTRY_ENDPOINT_FETCH_TIMEOUT_MS,
+    });
+    let data: { registry?: Record<string, RawRegistryEntry> };
+    try {
+      if (!resp.ok) {
         logger.warn(
-          `[registry-client] Endpoint "${label}" (${url}) blocked: host resolution changed before fetch`,
+          `[registry-client] Endpoint "${label}" (${url}): ${resp.status} ${resp.statusText}`,
         );
         return null;
       }
-
-      for (const address of refreshedAddresses) {
-        if (isPrivateIpAddress(address)) {
-          logger.warn(
-            `[registry-client] Endpoint "${label}" (${url}) blocked: host resolves to blocked address ${address}`,
-          );
-          return null;
-        }
-      }
+      data = (await resp.json()) as {
+        registry?: Record<string, RawRegistryEntry>;
+      };
+    } finally {
+      await release();
     }
-
-    const resp = await fetch(url, createRegistryEndpointFetchInit());
-    if (!resp.ok) {
-      logger.warn(
-        `[registry-client] Endpoint "${label}" (${url}): ${resp.status} ${resp.statusText}`,
-      );
-      return null;
-    }
-    const data = (await resp.json()) as {
-      registry?: Record<string, RawRegistryEntry>;
-    };
     if (!data.registry || typeof data.registry !== "object") {
       logger.warn(
         `[registry-client] Endpoint "${label}" (${url}): missing registry field`,
@@ -273,6 +261,8 @@ async function fetchSingleEndpoint(
     }
     return plugins;
   } catch (err) {
+    // error-policy:J1 a failing custom endpoint degrades to a warning and is
+    // skipped — the built-in registry map remains the source of truth.
     logger.warn(
       `[registry-client] Endpoint "${label}" (${url}) failed: ${String(err)}`,
     );

--- a/packages/core/src/features/secrets/validation.test.ts
+++ b/packages/core/src/features/secrets/validation.test.ts
@@ -1,9 +1,9 @@
 /**
- * Deterministic unit test for the custom validator strategy in secret validation
- * (features/secrets): validateSecret fails closed when no custom validator is
- * registered, prefers a key-specific validator, and falls back to the shared
- * "custom" validator, exercised via registerValidator/unregisterValidator. No
- * live model or network.
+ * Deterministic unit tests for secret validation (features/secrets): the
+ * custom validator strategy (fail-closed dispatch, key-specific vs shared
+ * fallback) and the url:reachable strategy's SSRF-guarded probe (literal
+ * private/loopback/link-local targets rejected without opening a socket).
+ * No live model or network.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -66,5 +66,45 @@ describe("secret validation custom strategy", () => {
 			isValid: true,
 			validatedAt: 456,
 		});
+	});
+});
+
+describe("secret validation url:reachable strategy (SSRF-guarded probe)", () => {
+	// The probe runs through fetchWithSsrfGuard: literal private/loopback/
+	// link-local targets are blocked before any socket opens, so these cases
+	// stay deterministic with no network.
+	it("rejects malformed URLs before probing", async () => {
+		const result = await validateSecret(
+			"SOME_URL",
+			"not a url",
+			"url:reachable",
+		);
+
+		expect(result.isValid).toBe(false);
+		expect(result.error).toBe("Invalid URL format");
+	});
+
+	it("refuses to probe literal internal targets", async () => {
+		for (const url of [
+			"http://127.0.0.1:8080/health",
+			"http://169.254.169.254/latest/meta-data",
+			"http://[::1]/",
+			"http://[64:ff9b::a9fe:a9fe]/",
+			"http://10.0.0.1/",
+		]) {
+			const result = await validateSecret("SOME_URL", url, "url:reachable");
+			expect(result.isValid, url).toBe(false);
+			expect(result.error, url).toMatch(/^URL is not reachable: /);
+		}
+	});
+
+	it("rejects non-http(s) schemes", async () => {
+		const result = await validateSecret(
+			"SOME_URL",
+			"file:///etc/passwd",
+			"url:reachable",
+		);
+
+		expect(result.isValid).toBe(false);
 	});
 });

--- a/packages/core/src/features/secrets/validation.ts
+++ b/packages/core/src/features/secrets/validation.ts
@@ -6,6 +6,7 @@
  */
 
 import { logger } from "../../logger.ts";
+import { fetchWithSsrfGuard } from "../../network/fetch-guard.ts";
 import type {
 	CustomValidator,
 	ValidationResult,
@@ -243,20 +244,29 @@ export const ValidationStrategies: Record<string, CustomValidator> = {
 		}
 
 		try {
-			const response = await fetch(value, {
-				method: "HEAD",
-				signal: AbortSignal.timeout(5000),
+			// Reachability probes go through the SSRF guard (DNS-pinned, literal
+			// private/loopback hosts blocked, no redirect hops) so a stored secret
+			// URL can never turn validation into an internal network probe.
+			const { response, release } = await fetchWithSsrfGuard({
+				url: value,
+				init: { method: "HEAD" },
+				maxRedirects: 0,
+				timeoutMs: 5000,
 			});
 
-			if (!response.ok) {
-				return {
-					isValid: false,
-					error: `URL returned status ${response.status}`,
-					validatedAt,
-				};
-			}
+			try {
+				if (!response.ok) {
+					return {
+						isValid: false,
+						error: `URL returned status ${response.status}`,
+						validatedAt,
+					};
+				}
 
-			return { isValid: true, validatedAt };
+				return { isValid: true, validatedAt };
+			} finally {
+				await release();
+			}
 		} catch (error) {
 			// error-policy:J3 reachability is itself the validation probe; transport
 			// failure becomes a structured invalid result carrying the cause text.

--- a/packages/core/src/network/ssrf.test.ts
+++ b/packages/core/src/network/ssrf.test.ts
@@ -315,4 +315,44 @@ describe("isPrivateIpAddress: IPv6 transition ranges embedding IPv4 (SSRF bypass
 		expect(isPrivateIpAddress("2001:db8::1")).toBe(false); // docs range, non-Teredo
 		expect(isPrivateIpAddress("2003:a9fe:a9fe::")).toBe(false); // not 6to4
 	});
+
+	it("blocks mixed-case and non-canonical spellings of the same embeds", () => {
+		for (const addr of [
+			"64:FF9B::A9FE:A9FE", // upper-case NAT64
+			"2002:A9FE:A9FE::", // upper-case 6to4
+			"2001:0:4136:E378:8000:63BF:5601:5601", // upper-case Teredo
+			"0::ffff:7f00:1", // mapped spelling the normalize prefix regex misses
+			"0:0:0:0:0:ffff:7f00:1", // expanded mapped loopback
+			"0:0:0:0:0:0:7f00:1", // expanded compatible loopback
+			"0:0:0:0:0:0:0:1", // expanded ::1
+			"0:0:0:0:0:0:0:0", // expanded ::
+		]) {
+			expect(isPrivateIpAddress(addr), addr).toBe(true);
+		}
+	});
+
+	it("screens zone-id and mapped loopback literals end to end", () => {
+		expect(isPrivateIpAddress("fe80::1%eth0")).toBe(true);
+		expect(isPrivateIpAddress("[fe80::1%25eth0]")).toBe(true);
+		expect(isPrivateIpAddress("[::ffff:7f00:1]")).toBe(true);
+	});
+
+	it("loose URL spellings are unparseable or canonicalize into the guard", () => {
+		// Node and Bun both REJECT a loose dotted tail inside an IPv6 literal
+		// (leading-zero octal / hex quads), so those spellings can never be
+		// connected to — the strict dotted-tail parse in the guard is no bypass.
+		for (const url of [
+			"http://[64:ff9b::0177.0.0.1]/",
+			"http://[64:ff9b::0xa9.0xfe.0xa9.0xfe]/",
+			"http://[::ffff:2130706433]/",
+		]) {
+			expect(() => new URL(url), url).toThrow();
+		}
+		// Mixed-case spellings DO parse and canonicalize; the canonical form is
+		// what reaches isPrivateIpAddress, and it stays blocked.
+		expect(new URL("http://[::FFFF:7F00:1]/").hostname).toBe("[::ffff:7f00:1]");
+		expect(
+			isPrivateIpAddress(new URL("http://[64:FF9B::A9FE:A9FE]/").hostname),
+		).toBe(true);
+	});
 });

--- a/packages/core/src/network/ssrf.test.ts
+++ b/packages/core/src/network/ssrf.test.ts
@@ -234,3 +234,85 @@ describe("isPrivateIpAddress: non-canonical IPv4 encodings (SSRF bypass vectors)
 		}
 	});
 });
+
+describe("isPrivateIpAddress: IPv6 transition ranges embedding IPv4 (SSRF bypass vectors)", () => {
+	// On NAT64/DNS64, 6to4, or Teredo network paths a literal URL never hits
+	// DNS, so the guard must decode the embedded IPv4 and screen it — e.g.
+	// http://[64:ff9b::a9fe:a9fe]/ translates to 169.254.169.254 (cloud
+	// metadata) without ever resolving a hostname.
+	it("blocks IPv4-compatible ::/96 spellings of private addresses", () => {
+		for (const addr of [
+			"::a9fe:a9fe", // ::169.254.169.254
+			"::169.254.169.254", // dotted tail form
+			"::7f00:1", // ::127.0.0.1
+			"::a00:1", // ::10.0.0.1
+			"::c0a8:101", // ::192.168.1.1
+			"0:0:0:0:0:0:a9fe:a9fe", // expanded form
+		]) {
+			expect(isPrivateIpAddress(addr), addr).toBe(true);
+		}
+		// Public embeds stay public; :: and ::1 were already blocked.
+		expect(isPrivateIpAddress("::808:808")).toBe(false); // ::8.8.8.8
+		expect(isPrivateIpAddress("::8.8.8.8")).toBe(false);
+	});
+
+	it("blocks NAT64 64:ff9b::/96 spellings of private addresses", () => {
+		for (const addr of [
+			"64:ff9b::a9fe:a9fe", // 169.254.169.254
+			"64:ff9b::169.254.169.254", // dotted tail form
+			"64:ff9b::7f00:1", // 127.0.0.1
+			"64:ff9b::a00:1", // 10.0.0.1
+			"64:ff9b::c0a8:101", // 192.168.1.1
+			"64:ff9b::ac10:1", // 172.16.0.1
+			"64:ff9b::6440:1", // 100.64.0.1 (CGNAT)
+			"0064:ff9b:0000:0000:0000:0000:a9fe:a9fe", // expanded form
+		]) {
+			expect(isPrivateIpAddress(addr), addr).toBe(true);
+		}
+		expect(isPrivateIpAddress("64:ff9b::808:808")).toBe(false); // 8.8.8.8
+		expect(isPrivateIpAddress("64:ff9b::8.8.8.8")).toBe(false);
+	});
+
+	it("blocks 6to4 2002::/16 spellings of private addresses", () => {
+		for (const addr of [
+			"2002:a9fe:a9fe::", // 169.254.169.254
+			"2002:7f00:1::", // 127.0.0.1
+			"2002:a00:1::", // 10.0.0.1
+			"2002:c0a8:101::1", // 192.168.1.1 with subnet host bits
+			"2002:ac1f:1::", // 172.31.0.1
+		]) {
+			expect(isPrivateIpAddress(addr), addr).toBe(true);
+		}
+		expect(isPrivateIpAddress("2002:808:808::")).toBe(false); // 8.8.8.8
+		expect(isPrivateIpAddress("2002:cb00:710a::")).toBe(false); // 203.0.113.10
+	});
+
+	it("blocks Teredo 2001:0000::/32 spellings of private addresses", () => {
+		// Teredo obfuscates the client IPv4 as the low 32 bits XOR 0xffffffff.
+		for (const addr of [
+			"2001:0:4136:e378:8000:63bf:5601:5601", // client 169.254.169.254
+			"2001:0::80ff:fffe", // client 127.0.0.1
+			"2001:0:4136:e378:8000:63bf:f5ff:fffe", // client 10.0.0.1
+		]) {
+			expect(isPrivateIpAddress(addr), addr).toBe(true);
+		}
+		// Client 192.0.2.45 (TEST-NET-1) is outside every blocked IPv4 range.
+		expect(isPrivateIpAddress("2001:0:4136:e378:8000:63bf:3fff:fdd2")).toBe(
+			false,
+		);
+		// Other 2001:: space (non-Teredo) is unaffected.
+		expect(isPrivateIpAddress("2001:4860:4860::8888")).toBe(false);
+	});
+
+	it("screens bracketed URL-literal forms end to end", () => {
+		expect(isPrivateIpAddress("[64:ff9b::a9fe:a9fe]")).toBe(true);
+		expect(isPrivateIpAddress("[2002:a9fe:a9fe::]")).toBe(true);
+		expect(isPrivateIpAddress("[::a9fe:a9fe]")).toBe(true);
+	});
+
+	it("still allows legitimate public IPv6 in the screened prefixes", () => {
+		expect(isPrivateIpAddress("64:ff9b:1::a9fe:a9fe")).toBe(false); // not /96
+		expect(isPrivateIpAddress("2001:db8::1")).toBe(false); // docs range, non-Teredo
+		expect(isPrivateIpAddress("2003:a9fe:a9fe::")).toBe(false); // not 6to4
+	});
+});

--- a/packages/core/src/network/ssrf.ts
+++ b/packages/core/src/network/ssrf.ts
@@ -215,17 +215,124 @@ function isPrivateIpv4(parts: number[]): boolean {
 	return false;
 }
 
+/**
+ * Expand an IPv6 address string into its eight 16-bit groups, handling `::`
+ * compression and a dotted-quad tail (`64:ff9b::169.254.169.254`, the
+ * inet_pton mixed form). Returns null when the string is not a syntactically
+ * valid IPv6 address — the caller then falls back to the first-hextet
+ * classification only.
+ */
+function parseIpv6Hextets(address: string): number[] | null {
+	let input = address;
+	// A dotted tail carries the final 32 bits as IPv4 text; rewrite it in place
+	// as two hex groups so the expansion below stays uniform. Keeping the colon
+	// that precedes the tail preserves a `::` compression spanning it.
+	if (input.includes(".")) {
+		const colon = input.lastIndexOf(":");
+		if (colon === -1) return null;
+		const ipv4 = parseIpv4(input.slice(colon + 1));
+		if (!ipv4) return null;
+		input = `${input.slice(0, colon + 1)}${(((ipv4[0] << 8) | ipv4[1]) & 0xffff).toString(16)}:${(((ipv4[2] << 8) | ipv4[3]) & 0xffff).toString(16)}`;
+	}
+	const parseGroups = (text: string): number[] | null => {
+		if (!text) return [];
+		const groups: number[] = [];
+		for (const part of text.split(":")) {
+			if (!/^[0-9a-f]{1,4}$/i.test(part)) return null;
+			groups.push(Number.parseInt(part, 16));
+		}
+		return groups;
+	};
+	const halves = input.split("::");
+	if (halves.length > 2) return null;
+	const head = parseGroups(halves[0] ?? "");
+	if (head === null) return null;
+	if (halves.length === 1) {
+		return head.length === 8 ? head : null;
+	}
+	const tail = parseGroups(halves[1] ?? "");
+	if (tail === null) return null;
+	// "::" must compress at least one all-zero group.
+	const zeros = 8 - (head.length + tail.length);
+	if (zeros < 1) return null;
+	return [...head, ...new Array<number>(zeros).fill(0), ...tail];
+}
+
+/**
+ * Extract the policy-relevant embedded IPv4 from the transition/coexistence
+ * ranges an attacker can route to internal space: IPv4-compatible `::/96`
+ * (deprecated, still honored by some stacks), NAT64 `64:ff9b::/96` (RFC 6052
+ * well-known prefix — live on AWS IPv6-only/DNS64 subnets), 6to4 `2002::/16`
+ * (RFC 3056, IPv4 in bits 16..48), and Teredo `2001:0000::/32` (RFC 4380,
+ * client IPv4 XOR-obfuscated in the low 32 bits). On those network paths a
+ * literal URL never touches DNS, so screening the embedded IPv4 is the only
+ * chance to classify the address the packet actually reaches. Returns null
+ * when the address is outside those ranges.
+ */
+function embeddedIpv4ForPolicy(hextets: number[]): number[] | null {
+	const [h0, h1, h2, , , h5, h6, h7] = hextets;
+	const low32ToIpv4 = (): number[] => [
+		(h6 >> 8) & 0xff,
+		h6 & 0xff,
+		(h7 >> 8) & 0xff,
+		h7 & 0xff,
+	];
+	// IPv4-compatible ::/96 and IPv4-mapped ::ffff:0:0/96 spellings that
+	// survived normalizeIpForPolicy — the embedded address is the low 32 bits.
+	// (`::` and `::1` are classified by the caller before this runs.)
+	if (h0 === 0 && h1 === 0 && h2 === 0 && hextets[3] === 0) {
+		if (hextets[4] === 0 && (h5 === 0 || h5 === 0xffff)) {
+			return low32ToIpv4();
+		}
+	}
+	// NAT64 well-known prefix 64:ff9b::/96 — embedded IPv4 is the low 32 bits.
+	if (h0 === 0x64 && h1 === 0xff9b && h2 === 0 && hextets[3] === 0) {
+		if (hextets[4] === 0 && h5 === 0) {
+			return low32ToIpv4();
+		}
+	}
+	// 6to4 2002::/16 — embedded IPv4 sits in bits 16..48.
+	if (h0 === 0x2002) {
+		return [(h1 >> 8) & 0xff, h1 & 0xff, (h2 >> 8) & 0xff, h2 & 0xff];
+	}
+	// Teredo 2001:0000::/32 — client IPv4 is the low 32 bits XOR 0xffffffff.
+	if (h0 === 0x2001 && h1 === 0x0000) {
+		return [
+			((h6 ^ 0xffff) >> 8) & 0xff,
+			(h6 ^ 0xffff) & 0xff,
+			((h7 ^ 0xffff) >> 8) & 0xff,
+			(h7 ^ 0xffff) & 0xff,
+		];
+	}
+	return null;
+}
+
 function isPrivateIpv6(address: string): boolean {
 	if (address === "::" || address === "::1") return true;
 	const firstHextet = /^([0-9a-f]{1,4})(?=:|$)/i.exec(address)?.[1];
-	if (!firstHextet) return false;
-	const first = Number.parseInt(firstHextet, 16);
-	return (
-		(first & 0xfe00) === 0xfc00 || // fc00::/7 unique-local
-		(first & 0xffc0) === 0xfe80 || // fe80::/10 link-local
-		(first & 0xffc0) === 0xfec0 || // fec0::/10 deprecated site-local
-		(first & 0xff00) === 0xff00 // ff00::/8 multicast
-	);
+	if (firstHextet) {
+		const first = Number.parseInt(firstHextet, 16);
+		if (
+			(first & 0xfe00) === 0xfc00 || // fc00::/7 unique-local
+			(first & 0xffc0) === 0xfe80 || // fe80::/10 link-local
+			(first & 0xffc0) === 0xfec0 || // fec0::/10 deprecated site-local
+			(first & 0xff00) === 0xff00 // ff00::/8 multicast
+		) {
+			return true;
+		}
+	}
+	// Transition ranges embed an IPv4 the network may translate the literal to
+	// (e.g. http://[64:ff9b::a9fe:a9fe]/ reaching 169.254.169.254 through
+	// NAT64), so screen that embedded address with the IPv4 policy too. This
+	// also covers leading-"::" spellings the first-hextet scan above can't see.
+	const hextets = parseIpv6Hextets(address);
+	if (hextets) {
+		const embedded = embeddedIpv4ForPolicy(hextets);
+		if (embedded && isPrivateIpv4(embedded)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /**

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -1238,12 +1238,29 @@ describe("SubAgentRouter", () => {
   describe("verify-retry on incomplete builds", () => {
     const origMax = process.env.ELIZA_BUILD_VERIFY_MAX_RETRIES;
     const origSettle = process.env.ELIZA_URL_VERIFY_SETTLE_MS;
+    const origDeployEnv: Record<string, string | undefined> = {};
 
     beforeEach(() => {
       // Disable the settle-retry so the dead-URL probe is a single fast
       // connection-refused rather than a 2.5s wait.
       process.env.ELIZA_URL_VERIFY_SETTLE_MS = "0";
       delete process.env.ELIZA_BUILD_VERIFY_MAX_RETRIES;
+      // W1-048: loopback URLs are only probed on supervisor-configured ports.
+      // Sanction the DEAD_URL discard port via the operator custom static
+      // host (hermetic: no config file) so it is probed and refused.
+      for (const key of [
+        "ELIZA_CONFIG_PATH",
+        "ELIZA_APP_DEPLOY_TARGET",
+        "ELIZA_APP_DEPLOY_CUSTOM_APPS_DIR",
+        "ELIZA_APP_DEPLOY_CUSTOM_BASE_URL",
+      ]) {
+        origDeployEnv[key] = process.env[key];
+      }
+      process.env.ELIZA_CONFIG_PATH =
+        "/nonexistent/sub-agent-router-verify-retry.json";
+      process.env.ELIZA_APP_DEPLOY_TARGET = "custom";
+      process.env.ELIZA_APP_DEPLOY_CUSTOM_APPS_DIR = "/srv/apps";
+      process.env.ELIZA_APP_DEPLOY_CUSTOM_BASE_URL = "http://127.0.0.1:1";
     });
     afterEach(() => {
       if (origMax === undefined)
@@ -1252,6 +1269,10 @@ describe("SubAgentRouter", () => {
       if (origSettle === undefined)
         delete process.env.ELIZA_URL_VERIFY_SETTLE_MS;
       else process.env.ELIZA_URL_VERIFY_SETTLE_MS = origSettle;
+      for (const [key, value] of Object.entries(origDeployEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
       restoreStubbedGlobals();
     });
 
@@ -2076,31 +2097,53 @@ describe("SubAgentRouter", () => {
         return new Response("not found", { status: 404 });
       });
       stubFetch(fetchMock);
-      session = sessionWithTask(
-        "build and verify https://example.test/apps/asset-check/",
-      );
-      acp = makeAcpService(session);
-      const { runtime, handleMessage, spawnSession } = makeRuntime({
-        acp: acp.service,
-      });
-      await SubAgentRouter.start(runtime);
+      // W1-048: the local alias is only probed when its loopback port is
+      // supervisor-configured — sanction 6900 via the operator custom host.
+      const savedDeployEnv: Record<string, string | undefined> = {};
+      for (const key of [
+        "ELIZA_CONFIG_PATH",
+        "ELIZA_APP_DEPLOY_TARGET",
+        "ELIZA_APP_DEPLOY_CUSTOM_APPS_DIR",
+        "ELIZA_APP_DEPLOY_CUSTOM_BASE_URL",
+      ]) {
+        savedDeployEnv[key] = process.env[key];
+      }
+      process.env.ELIZA_CONFIG_PATH = "/nonexistent/url-alias-test.json";
+      process.env.ELIZA_APP_DEPLOY_TARGET = "custom";
+      process.env.ELIZA_APP_DEPLOY_CUSTOM_APPS_DIR = "/srv/apps";
+      process.env.ELIZA_APP_DEPLOY_CUSTOM_BASE_URL = "http://127.0.0.1:6900";
+      try {
+        session = sessionWithTask(
+          "build and verify https://example.test/apps/asset-check/",
+        );
+        acp = makeAcpService(session);
+        const { runtime, handleMessage, spawnSession } = makeRuntime({
+          acp: acp.service,
+        });
+        await SubAgentRouter.start(runtime);
 
-      acp.emit(SESSION_ID, "task_complete", {
-        response:
-          "Done — local: http://127.0.0.1:6900/apps/asset-check/, mirror: https://wrong.example.test/apps/asset-check/, public: https://example.test/apps/asset-check/",
-      });
-      await new Promise((r) => setTimeout(r, 200));
+        acp.emit(SESSION_ID, "task_complete", {
+          response:
+            "Done — local: http://127.0.0.1:6900/apps/asset-check/, mirror: https://wrong.example.test/apps/asset-check/, public: https://example.test/apps/asset-check/",
+        });
+        await new Promise((r) => setTimeout(r, 200));
 
-      const fetched = fetchMock.mock.calls.map(([url]) => String(url));
-      expect(fetched).toContain("http://127.0.0.1:6900/apps/asset-check/");
-      expect(fetched).toContain("https://example.test/apps/asset-check/");
-      expect(fetched).not.toContain(
-        "https://wrong.example.test/apps/asset-check/",
-      );
-      expect(spawnSession).not.toHaveBeenCalled();
-      expect(handleMessage).toHaveBeenCalledTimes(1);
-      const posted = handleMessage.mock.calls[0]?.[1];
-      expect(posted?.content?.text).not.toContain("[verification:");
+        const fetched = fetchMock.mock.calls.map(([url]) => String(url));
+        expect(fetched).toContain("http://127.0.0.1:6900/apps/asset-check/");
+        expect(fetched).toContain("https://example.test/apps/asset-check/");
+        expect(fetched).not.toContain(
+          "https://wrong.example.test/apps/asset-check/",
+        );
+        expect(spawnSession).not.toHaveBeenCalled();
+        expect(handleMessage).toHaveBeenCalledTimes(1);
+        const posted = handleMessage.mock.calls[0]?.[1];
+        expect(posted?.content?.text).not.toContain("[verification:");
+      } finally {
+        for (const [key, value] of Object.entries(savedDeployEnv)) {
+          if (value === undefined) delete process.env[key];
+          else process.env[key] = value;
+        }
+      }
     });
 
     it("adds verified public route aliases when a completion only mentions loopback", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/verify-incidental-narration-url.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/verify-incidental-narration-url.test.ts
@@ -217,7 +217,8 @@ describe("verify: incidental narration URLs (Bug B)", () => {
       // "create a landing page and give me the url" — a PROVIDE-url request with
       // NO deploy/host/live keyword. The agent claims a dead URL; it must still
       // be verified + flagged (codex review: preserve explicit-url-request
-      // verification).
+      // verification). The test server's port is passed as the
+      // supervisor-sanctioned loopback port (W1-048) so the probe runs.
       const referenceText = "create a landing page and give me the url";
       const deadUrl = `http://127.0.0.1:${port}/landing/`;
       const narration = `Here you go: ${deadUrl}`;
@@ -228,6 +229,7 @@ describe("verify: incidental narration URLs (Bug B)", () => {
         undefined,
         undefined,
         undefined,
+        new Set([port]),
       );
       expect(result.dead.some((d) => d.url === deadUrl)).toBe(true);
       expect(result.text).toContain("verification:");
@@ -248,6 +250,7 @@ describe("verify: incidental narration URLs (Bug B)", () => {
         undefined,
         undefined,
         undefined,
+        new Set([port]),
       );
       expect(result.dead.some((d) => d.url === deadUrl)).toBe(true);
       expect(result.text).toContain("verification:");
@@ -268,6 +271,7 @@ describe("verify: incidental narration URLs (Bug B)", () => {
         undefined,
         undefined,
         undefined,
+        new Set([port]),
       );
 
       expect(result.dead.length).toBeGreaterThan(0);

--- a/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-early-return-capture.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-early-return-capture.test.ts
@@ -157,23 +157,50 @@ describe("origin-result capture on task_complete early returns", () => {
         }),
       ],
     ]);
-    const { router, internals, acp, runtime } = await startRouter(sessions, {
-      ELIZA_URL_VERIFY_SETTLE_MS: "0",
-    });
+    // W1-048: the verifier only probes loopback URLs on supervisor-configured
+    // ports. Sanction the discard port via the operator custom static host
+    // (hermetic: no config file, env only) so the dead URL is still probed and
+    // refused rather than dropped unprobed.
+    const savedEnv: Record<string, string | undefined> = {};
+    for (const key of [
+      "ELIZA_CONFIG_PATH",
+      "ELIZA_APP_DEPLOY_TARGET",
+      "ELIZA_APP_DEPLOY_CUSTOM_APPS_DIR",
+      "ELIZA_APP_DEPLOY_CUSTOM_BASE_URL",
+    ]) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.ELIZA_CONFIG_PATH = "/nonexistent/early-return-test.json";
+    process.env.ELIZA_APP_DEPLOY_TARGET = "custom";
+    process.env.ELIZA_APP_DEPLOY_CUSTOM_APPS_DIR = "/srv/apps";
+    process.env.ELIZA_APP_DEPLOY_CUSTOM_BASE_URL = "http://127.0.0.1:9";
+    let router: SubAgentRouter | undefined;
+    try {
+      const started = await startRouter(sessions, {
+        ELIZA_URL_VERIFY_SETTLE_MS: "0",
+      });
+      router = started.router;
+      const { internals, acp, runtime } = started;
 
-    await internals.handleEvent("sess-verify", "task_complete", {
-      response: `The game is built and live at ${deadUrl}`,
-      stopReason: "end_turn",
-    });
+      await internals.handleEvent("sess-verify", "task_complete", {
+        response: `The game is built and live at ${deadUrl}`,
+        stopReason: "end_turn",
+      });
 
-    // Prove the verify-retry EARLY RETURN was the path taken: a retry was
-    // spawned and the suppressed completion never reached the delivery loop.
-    expect(acp.spawnSession).toHaveBeenCalledTimes(1);
-    expect(runtime.emitEvent).not.toHaveBeenCalled();
+      // Prove the verify-retry EARLY RETURN was the path taken: a retry was
+      // spawned and the suppressed completion never reached the delivery loop.
+      expect(acp.spawnSession).toHaveBeenCalledTimes(1);
+      expect(runtime.emitEvent).not.toHaveBeenCalled();
 
-    // …and the verify-FAILED completion was NOT captured for the origin.
-    expect(router.bestResultFor("disc-verify-1\0codex")).toBeUndefined();
-    await router.stop();
+      // …and the verify-FAILED completion was NOT captured for the origin.
+      expect(router.bestResultFor("disc-verify-1\0codex")).toBeUndefined();
+    } finally {
+      for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      await router?.stop();
+    }
   });
 
   it("lineage dedupe still lets a longer late completion win (longest-wins capture)", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-verify-failed-shadow.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-verify-failed-shadow.test.ts
@@ -194,6 +194,23 @@ async function runFailedThenCleanLineage(
   originKey: string;
 }> {
   const host = await startAppHost();
+  // W1-048: the verifier only probes loopback URLs on supervisor-configured
+  // ports. Sanction this test's app-host port through the operator custom
+  // static host (hermetic: no config file, env only — the same pattern as
+  // built-apps-registry.test.ts).
+  const savedEnv: Record<string, string | undefined> = {};
+  for (const key of [
+    "ELIZA_CONFIG_PATH",
+    "ELIZA_APP_DEPLOY_TARGET",
+    "ELIZA_APP_DEPLOY_CUSTOM_APPS_DIR",
+    "ELIZA_APP_DEPLOY_CUSTOM_BASE_URL",
+  ]) {
+    savedEnv[key] = process.env[key];
+  }
+  process.env.ELIZA_CONFIG_PATH = "/nonexistent/verify-shadow-test.json";
+  process.env.ELIZA_APP_DEPLOY_TARGET = "custom";
+  process.env.ELIZA_APP_DEPLOY_CUSTOM_APPS_DIR = "/srv/apps";
+  process.env.ELIZA_APP_DEPLOY_CUSTOM_BASE_URL = new URL(host.url).origin;
   try {
     const meta = originMeta(msgId, host.url, connectorId);
     const sessions = new Map<string, Record<string, unknown>>([
@@ -240,6 +257,10 @@ async function runFailedThenCleanLineage(
 
     return { router, runtime, acp, betweenAttempts, originKey };
   } finally {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     await host.close();
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/__tests__/verify-retry-stop-race.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/verify-retry-stop-race.test.ts
@@ -465,12 +465,37 @@ describe("URL extraction trims trailing sentence punctuation (the cascade trigge
   it("does not probe the trailing '!' as part of a live URL", async () => {
     // The sub-agent's prose ends the sentence with "!": the live app must be
     // verified at its real path, not declared dead at the punctuation path.
+    // The ephemeral port is passed as the supervisor-sanctioned loopback port
+    // (W1-048) — narration-claimed loopback URLs are otherwise left unprobed.
+    const { port } = host.address() as AddressInfo;
     const verified = await annotateUnverifiedUrls(
       `The app is deployed and live at ${baseUrl}!`,
       undefined,
       "Build the app and give me the live url",
+      undefined,
+      undefined,
+      undefined,
+      new Set([port]),
     );
     expect(verified.dead).toEqual([]);
     expect(verified.verifiedUrls).toContain(baseUrl);
+  });
+
+  it("leaves a loopback URL on a non-sanctioned port unprobed (W1-048)", async () => {
+    // Narration claiming a deliverable on a loopback port the supervisor never
+    // started must not be probed (loopback port-scan/content oracle) and must
+    // not count as a dead deliverable either (no verify-retry storm). Port 1
+    // stands in for "some other port" — never the test server's.
+    const verified = await annotateUnverifiedUrls(
+      `The app is deployed and live at ${baseUrl}!`,
+      undefined,
+      "Build the app and give me the live url",
+      undefined,
+      undefined,
+      undefined,
+      new Set([1]),
+    );
+    expect(verified.dead).toEqual([]);
+    expect(verified.verifiedUrls).toEqual([]);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/ssrf-guard.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/ssrf-guard.ts
@@ -16,6 +16,15 @@
  * link-local, ULA, carrier-grade NAT, multicast, the cloud-metadata IP) is
  * blocked.
  *
+ * Because the probed URLs come from model-controlled narration, the loopback
+ * carve-out is itself an oracle: an injected sub-agent could name
+ * `http://127.0.0.1:<any-port>/` and read status/HTML back through the
+ * verification verdict. Callers that probe untrusted text therefore pass
+ * `allowedLoopbackPorts` — the ports the operator/supervisor actually
+ * configured — and loopback targets on any other port are rejected like any
+ * other non-public address. Callers talking to known local services
+ * (e.g. the model gateway) omit the option and keep the open carve-out.
+ *
  * Two attack vectors are closed:
  *   1. Direct fetch of an internal host — `assertUrlAllowed` resolves the
  *      hostname and rejects if *any* resolved address is in a blocked range
@@ -196,6 +205,27 @@ export function classifyIpLiteral(
 }
 
 /**
+ * Gate a loopback target on the caller-sanctioned port set. A no-op when the
+ * caller did not pass `allowedLoopbackPorts` (trusted local-service callers);
+ * otherwise any loopback port outside the set is rejected like a non-public
+ * address, so untrusted-text probes can't port-scan the loopback interface.
+ */
+function assertLoopbackPortAllowed(
+  host: string,
+  port: number | undefined,
+  allowedLoopbackPorts: ReadonlySet<number> | undefined,
+): void {
+  if (!allowedLoopbackPorts) return;
+  const effectivePort = port ?? 80;
+  if (!allowedLoopbackPorts.has(effectivePort)) {
+    throw new SsrfBlockedError(
+      host,
+      `loopback port ${effectivePort} is not in the allowed set`,
+    );
+  }
+}
+
+/**
  * Resolve `hostname` and assert every resolved address is fetch-safe
  * (loopback or public). Throws `SsrfBlockedError` if the host is, or resolves
  * to, a blocked (non-public, non-loopback) address. Checking *all* resolved
@@ -209,16 +239,23 @@ export function classifyIpLiteral(
  */
 export async function assertHostAllowed(
   hostname: string,
+  opts: { port?: number; allowedLoopbackPorts?: ReadonlySet<number> } = {},
 ): Promise<string[] | null> {
   const host = hostname.replace(/^\[|\]$/g, "");
   // `localhost` is loopback by convention; allow without a DNS round-trip.
-  if (host.toLowerCase() === "localhost") return null;
+  if (host.toLowerCase() === "localhost") {
+    assertLoopbackPortAllowed(host, opts.port, opts.allowedLoopbackPorts);
+    return null;
+  }
 
   // IP literal: classify directly, no DNS.
   if (isIP(host) !== 0) {
     const verdict = classifyIpLiteral(host);
     if (verdict === "blocked") {
       throw new SsrfBlockedError(host, `non-public address ${host}`);
+    }
+    if (verdict === "loopback") {
+      assertLoopbackPortAllowed(host, opts.port, opts.allowedLoopbackPorts);
     }
     return null;
   }
@@ -242,11 +279,15 @@ export async function assertHostAllowed(
     throw new SsrfBlockedError(host, `no addresses resolved for ${host}`);
   }
   for (const address of addresses) {
-    if (classifyIpLiteral(address) === "blocked") {
+    const verdict = classifyIpLiteral(address);
+    if (verdict === "blocked") {
       throw new SsrfBlockedError(
         host,
         `${host} resolves to non-public address ${address}`,
       );
+    }
+    if (verdict === "loopback") {
+      assertLoopbackPortAllowed(host, opts.port, opts.allowedLoopbackPorts);
     }
   }
   return addresses;
@@ -255,9 +296,13 @@ export async function assertHostAllowed(
 /**
  * Assert the full URL's host is fetch-safe. Returns the vetted addresses to
  * pin the connection to (`null` when the host is an IP literal/localhost).
+ * When `allowedLoopbackPorts` is set, loopback targets are additionally
+ * restricted to those ports (scheme default 80/443 when the URL has no
+ * explicit port).
  */
 export async function assertUrlAllowed(
   url: string | URL,
+  allowedLoopbackPorts?: ReadonlySet<number>,
 ): Promise<string[] | null> {
   let parsed: URL;
   try {
@@ -272,7 +317,14 @@ export async function assertUrlAllowed(
       `unsupported protocol ${parsed.protocol}`,
     );
   }
-  return assertHostAllowed(parsed.hostname);
+  const explicitPort = parsed.port ? Number.parseInt(parsed.port, 10) : null;
+  const port =
+    explicitPort !== null && Number.isInteger(explicitPort)
+      ? explicitPort
+      : parsed.protocol === "https:"
+        ? 443
+        : 80;
+  return assertHostAllowed(parsed.hostname, { port, allowedLoopbackPorts });
 }
 
 /** Node-style lookup callback signature (`net.connect`/`tls.connect`). */
@@ -382,6 +434,17 @@ export function setPinnedTransport(transport?: PinnedTransport): void {
   pinnedTransport = transport ?? nodePinnedTransport;
 }
 
+/** Options controlling {@link safeFetch} policy beyond the request init. */
+export interface SafeFetchOptions {
+  /**
+   * When set, loopback targets (127.0.0.0/8, ::1, `localhost`, or a hostname
+   * resolving to them) are only allowed on these ports — applied to the
+   * initial URL AND every redirect hop. Pass the supervisor/operator-started
+   * port set when probing untrusted text; omit for trusted local services.
+   */
+  allowedLoopbackPorts?: ReadonlySet<number>;
+}
+
 /**
  * SSRF-safe replacement for `fetch(url, { redirect: "follow" })`.
  *
@@ -402,10 +465,14 @@ export function setPinnedTransport(transport?: PinnedTransport): void {
 export async function safeFetch(
   url: string,
   init: Omit<RequestInit, "redirect"> = {},
+  options?: SafeFetchOptions,
 ): Promise<Response> {
   let current = url;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-    const pinned = await assertUrlAllowed(current);
+    const pinned = await assertUrlAllowed(
+      current,
+      options?.allowedLoopbackPorts,
+    );
     const res = pinned
       ? await pinnedTransport(current, init, pinned)
       : await fetch(current, { ...init, redirect: "manual" });

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -33,6 +33,7 @@ import {
   ServiceType,
 } from "@elizaos/core";
 import type { AcpService } from "./acp-service.js";
+import { resolveAppDeployConfig } from "./app-deploy-guidance.js";
 import { registerBuiltAppsForCompletion } from "./built-apps-registry.js";
 import {
   accountMetaFromSessionMetadata,
@@ -71,7 +72,12 @@ import {
   collectScreenshotPaths,
   deliverScreenshots,
 } from "./screenshot-delivery.js";
-import { SsrfBlockedError, safeFetch } from "./ssrf-guard.js";
+import {
+  classifyIpLiteral,
+  type SafeFetchOptions,
+  SsrfBlockedError,
+  safeFetch,
+} from "./ssrf-guard.js";
 import { stripToolTranscript } from "./transcript-sanitizer.js";
 import type { SessionEventName, SessionInfo } from "./types.js";
 import {
@@ -468,6 +474,66 @@ function isLoopbackUrl(url: string): boolean {
     // error-policy:J3 URL parse of untrusted input; unparseable = not loopback.
     return false;
   }
+}
+
+/**
+ * Is this URL a loopback probe target? Matches the guard's own classification
+ * (127.0.0.0/8, ::1 — bracketed or not — IPv4-mapped loopback, `localhost`)
+ * so the pre-filter and the per-hop enforcement agree on the set.
+ */
+function isLoopbackProbeTarget(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    if (host === "localhost") return true;
+    return classifyIpLiteral(host) === "loopback";
+  } catch {
+    // error-policy:J3 URL parse of untrusted narration; unparseable → not
+    // loopback (the probe path reports it unreachable on its own).
+    return false;
+  }
+}
+
+/** Effective TCP port of an http(s) URL — the scheme default when unstyled. */
+function urlEffectivePort(url: string): number | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.port) {
+      const port = Number.parseInt(parsed.port, 10);
+      return Number.isInteger(port) ? port : null;
+    }
+    if (parsed.protocol === "https:") return 443;
+    if (parsed.protocol === "http:") return 80;
+    return null;
+  } catch {
+    // error-policy:J3 URL parse of untrusted narration; unparseable → no port.
+    return null;
+  }
+}
+
+/**
+ * The loopback ports the completion-URL verifier may probe: ONLY ports the
+ * operator/supervisor actually configured — the session's route-mapping URL
+ * prefixes (`TASK_AGENT_WORKDIR_ROUTES` urlMappings) and the custom deploy
+ * host's base URL (`ELIZA_APP_DEPLOY_CUSTOM_BASE_URL`). Every other loopback
+ * URL in a sub-agent's narration is model-controlled text, and probing it
+ * would make the orchestrator a loopback port-scan/content oracle whose
+ * verdict text exfiltrates the response (W1-048).
+ */
+function supervisorAllowedLoopbackPorts(
+  routeVerification: RouteUrlVerification | undefined,
+): Set<number> {
+  const ports = new Set<number>();
+  const collect = (raw: string) => {
+    if (!isLoopbackProbeTarget(raw)) return;
+    const port = urlEffectivePort(raw);
+    if (port !== null) ports.add(port);
+  };
+  for (const mapping of routeVerification?.mappings ?? []) {
+    collect(mapping.urlPrefix);
+  }
+  const customBaseUrl = resolveAppDeployConfig().customBaseUrl;
+  if (customBaseUrl) collect(customBaseUrl);
+  return ports;
 }
 
 // Drop any http(s):// loopback URLs from `text` before the reply reaches a
@@ -3611,6 +3677,9 @@ function routingKindFromPayloadBanner(data: unknown): string | undefined {
  * Conservative by design:
  *  - only runs on `task_complete` text (not errors/blocked)
  *  - caps at the first 5 distinct mentioned URLs + their sub-resources
+ *  - loopback URLs are probed ONLY on supervisor-configured ports (route
+ *    mappings / custom deploy base URL) — any other loopback port is dropped
+ *    unprobed so narration can't turn the verifier into a loopback oracle
  *  - 4s per-request timeout, failures (DNS, timeout, refused) count as
  *    unverified rather than throwing
  *  - one short settle-retry before declaring a URL dead, covering a
@@ -3630,18 +3699,35 @@ export async function annotateUnverifiedUrls(
   ignoredUrls?: ReadonlySet<string>,
   runtime?: IAgentRuntime,
   routeVerification?: RouteUrlVerification,
+  allowedLoopbackPorts?: ReadonlySet<number>,
 ): Promise<{ text: string; dead: DeadUrl[]; verifiedUrls: string[] }> {
   if (!shouldVerifyCompletionUrls(text, referenceText, routeVerification)) {
     return { text, dead: [], verifiedUrls: [] };
   }
+  const loopbackPorts =
+    allowedLoopbackPorts ?? supervisorAllowedLoopbackPorts(routeVerification);
   const urls = expandRouteUrlAliases(
     extractVerifiableUrls(text, 5, referenceText, ignoredUrls),
     routeVerification,
-  ).filter(
-    (url) =>
-      routeVerification === undefined ||
-      !isBareRouteMappingPrefix(url, routeVerification.mappings),
-  );
+  )
+    .filter(
+      (url) =>
+        routeVerification === undefined ||
+        !isBareRouteMappingPrefix(url, routeVerification.mappings),
+    )
+    .filter((url) => {
+      if (!isLoopbackProbeTarget(url)) return true;
+      const port = urlEffectivePort(url);
+      if (port !== null && loopbackPorts.has(port)) return true;
+      // Not dead, not verified: a narration-claimed loopback URL on a port
+      // the supervisor never started is dropped UNPROBED — it can't read the
+      // loopback interface through the verdict, and it must not count as a
+      // dead deliverable that triggers a verify-retry of a healthy build.
+      log?.(
+        `[verify] skip ${url} — loopback port ${port ?? "?"} is not supervisor-configured; left unprobed`,
+      );
+      return false;
+    });
   if (urls.length === 0) return { text, dead: [], verifiedUrls: [] };
   log?.(
     `[verify] start @ ${new Date().toISOString()} — ${urls.length} url(s): ${urls.join(", ")}`,
@@ -3658,11 +3744,16 @@ export async function annotateUnverifiedUrls(
       // SSRF guard: the URL comes from untrusted sub-agent narration. Resolve
       // and reject non-public (private/link-local/metadata) hosts, and follow
       // redirects manually so a public page can't 302 us into an internal
-      // endpoint. Loopback is allowed — local build verification depends on it.
-      const res = await safeFetch(url, {
-        method: "GET",
-        signal: controller.signal,
-      });
+      // endpoint. Loopback is allowed ONLY on supervisor-configured ports —
+      // anything else is a loopback port-scan/content oracle (W1-048).
+      const res = await safeFetch(
+        url,
+        {
+          method: "GET",
+          signal: controller.signal,
+        },
+        { allowedLoopbackPorts: loopbackPorts },
+      );
       // 405/501 mean the server IS reachable — it just won't serve a GET.
       // Sub-agents routinely dump raw HTTP headers into their narration
       // (a `curl -i`), and those headers carry incidental URLs — CDN
@@ -3677,7 +3768,9 @@ export async function annotateUnverifiedUrls(
         return { status: null, servedLive: false };
       }
       if (res.status < 200 || res.status >= 300) {
-        const cachedMiss = await detectCachedMiss(url, res, controller.signal);
+        const cachedMiss = await detectCachedMiss(url, res, controller.signal, {
+          allowedLoopbackPorts: loopbackPorts,
+        });
         if (cachedMiss) {
           log?.(
             `[verify] probe ${url} → HTTP ${res.status} (cached stale miss; cache-busting probe returned ${cachedMiss.status}) @ ${new Date().toISOString()}`,
@@ -4048,6 +4141,7 @@ async function detectCachedMiss(
   url: string,
   res: Response,
   signal: AbortSignal,
+  fetchOptions?: SafeFetchOptions,
 ): Promise<{ status: number } | null> {
   if (res.status !== 404) return null;
   let busted: URL;
@@ -4064,12 +4158,16 @@ async function detectCachedMiss(
   // Same SSRF guard as the primary probe: the host is unchanged from the
   // already-validated URL, but route through safeFetch so a redirect on the
   // cache-bust probe can't reach an internal host either.
-  const bustedRes = await safeFetch(busted.toString(), {
-    method: "GET",
-    signal,
-    // error-policy:J3 existence probe; an unreachable cache-bust URL is an
-    // explicit "unknown" (null), handled by the guard below — not a fake hit.
-  }).catch(() => null);
+  const bustedRes = await safeFetch(
+    busted.toString(),
+    {
+      method: "GET",
+      signal,
+      // error-policy:J3 existence probe; an unreachable cache-bust URL is an
+      // explicit "unknown" (null), handled by the guard below — not a fake hit.
+    },
+    fetchOptions,
+  ).catch(() => null);
   if (!bustedRes) return null;
   return bustedRes.status >= 200 && bustedRes.status < 300
     ? { status: bustedRes.status }

--- a/plugins/plugin-discord/attachments.ts
+++ b/plugins/plugin-discord/attachments.ts
@@ -11,6 +11,7 @@ import {
 	type IAgentRuntime,
 	type Media,
 	ModelType,
+	resolveAttachmentBytes,
 	type Service,
 	ServiceType,
 } from "@elizaos/core";
@@ -214,19 +215,22 @@ export class AttachmentManager {
 		attachment: Attachment,
 	): Promise<Media> {
 		try {
-			const response = await fetch(attachment.url);
-			const audioVideoArrayBuffer = await response.arrayBuffer();
+			// SSRF-guarded + byte-capped connector fetch (repo media invariant) —
+			// never a raw unbounded fetch of a chat-supplied URL.
+			const { buffer: audioVideoBuffer } = await resolveAttachmentBytes(
+				attachment.url,
+			);
 
 			let audioBuffer: Buffer;
 			let audioFileName: string;
 			let audioMimeType: string;
 
 			if (attachment.contentType?.startsWith("audio/")) {
-				audioBuffer = Buffer.from(audioVideoArrayBuffer);
+				audioBuffer = audioVideoBuffer;
 				audioFileName = attachment.name || "audio.mp3";
 				audioMimeType = attachment.contentType;
 			} else if (attachment.contentType?.startsWith("video/mp4")) {
-				audioBuffer = await this.extractAudioFromMP4(audioVideoArrayBuffer);
+				audioBuffer = await this.extractAudioFromMP4(audioVideoBuffer);
 				audioFileName = "extracted_audio.mp3";
 				audioMimeType = "audio/mpeg";
 			} else {
@@ -355,7 +359,7 @@ export class AttachmentManager {
 	 * @param {ArrayBuffer} mp4Data - The MP4 data to extract audio from
 	 * @returns {Promise<Buffer>} - A Promise that resolves with the converted audio data as a Buffer
 	 */
-	private async extractAudioFromMP4(mp4Data: ArrayBuffer): Promise<Buffer> {
+	private async extractAudioFromMP4(mp4Data: Uint8Array): Promise<Buffer> {
 		// Use fluent-ffmpeg to extract the audio stream from the MP4 data
 		// and convert it to MP3 format
 		const tmpDir = os.tmpdir();
@@ -365,7 +369,7 @@ export class AttachmentManager {
 
 		try {
 			// Write the MP4 data to a temporary file
-			fs.writeFileSync(tempMP4File, Buffer.from(mp4Data));
+			fs.writeFileSync(tempMP4File, mp4Data);
 
 			// Check if file has audio stream using ffprobe
 			await new Promise<void>((resolve, reject) => {
@@ -472,15 +476,16 @@ export class AttachmentManager {
 	 */
 	private async processPdfAttachment(attachment: Attachment): Promise<Media> {
 		try {
-			const response = await fetch(attachment.url);
-			const pdfBuffer = await response.arrayBuffer();
+			const { buffer: pdfBuffer } = await resolveAttachmentBytes(
+				attachment.url,
+			);
 			const pdfService = this.runtime.getService(ServiceType.PDF) as
 				| ({ convertPdfToText: (buffer: Buffer) => Promise<string> } & Service)
 				| null;
 			if (!pdfService) {
 				throw new Error("PDF service not found");
 			}
-			const text = await pdfService.convertPdfToText(Buffer.from(pdfBuffer));
+			const text = await pdfService.convertPdfToText(pdfBuffer);
 			this.runtime.logger.debug(
 				{
 					src: "plugin:discord",
@@ -534,8 +539,10 @@ export class AttachmentManager {
 		attachment: Attachment,
 	): Promise<Media> {
 		try {
-			const response = await fetch(attachment.url);
-			const text = await response.text();
+			const { buffer: plaintextBuffer } = await resolveAttachmentBytes(
+				attachment.url,
+			);
+			const text = plaintextBuffer.toString("utf8");
 			this.runtime.logger.debug(
 				{
 					src: "plugin:discord",

--- a/plugins/plugin-elizacloud/src/models/transcription.ts
+++ b/plugins/plugin-elizacloud/src/models/transcription.ts
@@ -1,10 +1,13 @@
 import type { IAgentRuntime, TranscriptionParams } from "@elizaos/core";
-import { fetchWithSsrfGuard, logger } from "@elizaos/core";
+import { fetchWithSsrfGuard, logger, readResponseWithLimit } from "@elizaos/core";
 import type { OpenAITranscriptionParams } from "../types";
 import { isCloudSttAvailable, resolveCloudTimeoutMs } from "../utils/config";
 import { detectAudioMimeType } from "../utils/helpers";
 import { createElizaCloudClient } from "../utils/sdk-client";
 import { warmingRetryWaitSeconds } from "../utils/warming";
+
+/** Hard cap on caller-supplied audio bytes pulled for transcription (Whisper-class 25 MiB). */
+const TRANSCRIPTION_AUDIO_MAX_BYTES = 25 * 1024 * 1024;
 
 /**
  * Thrown when Cloud STT cannot serve (no API key, or neither
@@ -36,7 +39,9 @@ function isCoreTranscriptionParams(input: object): input is TranscriptionParams 
 /**
  * Fetch caller-provided audio bytes from an http(s) URL through the SSRF
  * guard (the repo's convention for every server-side attachment fetch) so a
- * crafted `audioUrl` can't reach internal/metadata endpoints.
+ * crafted `audioUrl` can't reach internal/metadata endpoints. The body is
+ * read under a hard byte cap — the 30 s timeout alone cannot bound a hostile
+ * server's payload size.
  */
 async function fetchAudioFromUrl(url: string, signal?: AbortSignal): Promise<Blob> {
   const { response, release } = await fetchWithSsrfGuard({
@@ -50,7 +55,10 @@ async function fetchAudioFromUrl(url: string, signal?: AbortSignal): Promise<Blo
         `Failed to fetch TRANSCRIPTION audioUrl: ${response.status} ${response.statusText}`
       );
     }
-    const bytes = Buffer.from(await response.arrayBuffer());
+    const bytes = await readResponseWithLimit(
+      response,
+      TRANSCRIPTION_AUDIO_MAX_BYTES
+    );
     const mimeType = response.headers.get("content-type") || detectAudioMimeType(bytes);
     return new Blob([bytes] as never, { type: mimeType });
   } finally {

--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -3,10 +3,20 @@
  * handling: over-limit messages hard-split at Telegram's size cap (preferring
  * newline boundaries), interaction-only replies still carry fallback text, and
  * unknown attachment types degrade to a document upload. Telegraf is mocked.
+ * Document bytes resolve through core's SSRF-guarded `resolveAttachmentBytes`
+ * (the repo media invariant) — the mock pins that boundary, not a raw fetch.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { MediaType, MessageManager } from "./messageManager";
+
+const { resolveAttachmentBytesMock } = vi.hoisted(() => ({
+  resolveAttachmentBytesMock: vi.fn(),
+}));
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return { ...actual, resolveAttachmentBytes: resolveAttachmentBytesMock };
+});
 
 function createManager() {
   let messageId = 0;
@@ -147,13 +157,12 @@ describe("MessageManager malformed payload handling", () => {
     const getFileLink = vi.fn(
       async () => new URL("https://files.test/report.txt"),
     );
-    const fetchMock = vi.fn(async () => ({
-      ok: false,
-      status: 503,
-      text: vi.fn(),
-    }));
-    const originalFetch = globalThis.fetch;
-    vi.stubGlobal("fetch", fetchMock);
+    // The guarded byte resolver failing (HTTP error, SSRF block, oversize —
+    // any failure shape) must degrade to an explicit error attachment, never
+    // drop the document or the caption.
+    resolveAttachmentBytesMock.mockRejectedValueOnce(
+      new Error("guarded fetch failed: 503"),
+    );
     const manager = new MessageManager(
       {
         telegram: { getFileLink },
@@ -161,37 +170,35 @@ describe("MessageManager malformed payload handling", () => {
       { agentId: "agent-1" } as never,
     );
 
-    try {
-      const result = await manager.processMessage({
-        message_id: 1,
-        date: 1,
-        chat: { id: 123, type: "private" },
-        caption: "please read this",
-        document: {
-          file_id: "doc-1",
-          file_unique_id: "unique-1",
-          file_name: "report.txt",
-          mime_type: "text/plain",
-          file_size: 42,
-        },
-      } as never);
+    const result = await manager.processMessage({
+      message_id: 1,
+      date: 1,
+      chat: { id: 123, type: "private" },
+      caption: "please read this",
+      document: {
+        file_id: "doc-1",
+        file_unique_id: "unique-1",
+        file_name: "report.txt",
+        mime_type: "text/plain",
+        file_size: 42,
+      },
+    } as never);
 
-      expect(fetchMock).toHaveBeenCalledWith("https://files.test/report.txt");
-      expect(getFileLink).toHaveBeenCalledTimes(2);
-      expect(result.processedContent).toBe("please read this");
-      expect(result.attachments).toEqual([
-        expect.objectContaining({
-          id: "doc-1",
-          url: "https://files.test/report.txt",
-          title: "Text Document: report.txt",
-          source: "Document",
-          description: expect.stringContaining("Error: Unable to read content"),
-          text: "",
-        }),
-      ]);
-    } finally {
-      vi.stubGlobal("fetch", originalFetch);
-    }
+    expect(resolveAttachmentBytesMock).toHaveBeenCalledWith(
+      "https://files.test/report.txt",
+    );
+    expect(getFileLink).toHaveBeenCalledTimes(2);
+    expect(result.processedContent).toBe("please read this");
+    expect(result.attachments).toEqual([
+      expect.objectContaining({
+        id: "doc-1",
+        url: "https://files.test/report.txt",
+        title: "Text Document: report.txt",
+        source: "Document",
+        description: expect.stringContaining("Error: Unable to read content"),
+        text: "",
+      }),
+    ]);
   });
 
   it("does not throw when image description or file lookup fails", async () => {

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -27,6 +27,7 @@ import {
   type Memory,
   type MessagePayload,
   ModelType,
+  resolveAttachmentBytes,
   ServiceType,
   type UUID,
 } from "@elizaos/core";
@@ -573,13 +574,11 @@ export class MessageManager {
         };
       }
 
-      const response = await fetch(documentUrl);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch PDF: ${response.status}`);
-      }
-
-      const pdfBuffer = await response.arrayBuffer();
-      const text = await pdfService.convertPdfToText(Buffer.from(pdfBuffer));
+      // SSRF-guarded + byte-capped connector fetch (repo media invariant) —
+      // the file URL comes from the (possibly self-hosted) Bot API, never
+      // fetch it raw and unbounded.
+      const { buffer: pdfBuffer } = await resolveAttachmentBytes(documentUrl);
+      const text = await pdfService.convertPdfToText(pdfBuffer);
 
       logger.debug(
         {
@@ -627,12 +626,8 @@ export class MessageManager {
     documentUrl: string,
   ): Promise<DocumentProcessingResult> {
     try {
-      const response = await fetch(documentUrl);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch text document: ${response.status}`);
-      }
-
-      const text = await response.text();
+      const { buffer: textBuffer } = await resolveAttachmentBytes(documentUrl);
+      const text = textBuffer.toString("utf8");
 
       logger.debug(
         {

--- a/plugins/plugin-video/src/services/video.ts
+++ b/plugins/plugin-video/src/services/video.ts
@@ -8,6 +8,8 @@ import path from "node:path";
 import {
   ElizaError,
   elizaLogger,
+  fetchRemoteMedia,
+  fetchWithSsrfGuard,
   type IAgentRuntime,
   type ITranscriptionService,
   IVideoService,
@@ -23,6 +25,15 @@ import {
 import ffmpeg from "fluent-ffmpeg";
 import { BinaryResolver } from "./binaries";
 import { normalizeCaptionNewlines, parseYtDlpUploadDate } from "./video-parse";
+
+/** Hard cap on caption/subtitle downloads (SRT/VTT/caption-JSON are tiny). */
+const CAPTION_MAX_BYTES = 10 * 1024 * 1024;
+/**
+ * Hard cap on a direct-media download buffered through memory before it hits
+ * disk on the audio-extraction path — an unbounded read of a hostile or
+ * boosted attachment URL is a memory-exhaustion DoS.
+ */
+const DIRECT_MEDIA_MAX_BYTES = 256 * 1024 * 1024;
 
 /** Minimal yt-dlp JSON shape used by this service (fields vary by extractor). */
 interface YtDlpSubtitleTrack {
@@ -500,14 +511,30 @@ export class VideoService extends IVideoService {
   async fetchVideoInfo(url: string): Promise<YtDlpJson> {
     if (url.endsWith(".mp4") || url.includes(".mp4?")) {
       try {
-        const response = await fetch(url);
-        if (response.ok) {
-          // If the URL is a direct link to an MP4 file, return a simplified video info object
-          return {
-            title: path.basename(url),
-            description: "",
-            channel: "",
-          };
+        // Guarded existence probe: the URL is caller-influenced, so it must
+        // pass the SSRF screen (DNS-pinned, per-hop redirect validation). The
+        // body is never read — only the status decides the direct-mp4 path.
+        const { response, release } = await fetchWithSsrfGuard({
+          url,
+          timeoutMs: 30_000,
+        });
+        try {
+          if (response.ok) {
+            // If the URL is a direct link to an MP4 file, return a simplified video info object
+            return {
+              title: path.basename(url),
+              description: "",
+              channel: "",
+            };
+          }
+        } finally {
+          try {
+            await response.body?.cancel();
+          } catch {
+            // error-policy:J6 best-effort teardown of an unread probe body;
+            // release() below still clears the guard's timeout.
+          }
+          await release();
         }
       } catch (error) {
         elizaLogger.log("Error downloading MP4 file:", loggableError(error));
@@ -578,11 +605,13 @@ export class VideoService extends IVideoService {
 
   private async downloadCaption(url: string): Promise<string> {
     elizaLogger.log("Downloading caption from:", url);
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`Failed to download caption: ${response.statusText}`);
-    }
-    return await response.text();
+    // Caption URLs come from extractor output (video-page-influenced), so the
+    // fetch must be SSRF-guarded and byte-capped, not a raw unbounded fetch.
+    const { buffer } = await fetchRemoteMedia({
+      url,
+      maxBytes: CAPTION_MAX_BYTES,
+    });
+    return buffer.toString("utf8");
   }
 
   private parseCaption(captionContent: string): string {
@@ -638,8 +667,11 @@ export class VideoService extends IVideoService {
 
   private async downloadSRT(url: string): Promise<string> {
     elizaLogger.log("downloadSRT");
-    const response = await fetch(url);
-    return await response.text();
+    const { buffer } = await fetchRemoteMedia({
+      url,
+      maxBytes: CAPTION_MAX_BYTES,
+    });
+    return buffer.toString("utf8");
   }
 
   async transcribeAudio(url: string, runtime: IAgentRuntime): Promise<string> {
@@ -719,14 +751,10 @@ export class VideoService extends IVideoService {
           "Direct MP4 file detected, downloading and converting to MP3",
         );
         const tempMp4File = path.join(tmpdir(), `${this.getVideoId(url)}.mp4`);
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error(
-            `Failed to download MP4: ${response.status} ${response.statusText}`,
-          );
-        }
-        const arrayBuffer = await response.arrayBuffer();
-        const buffer = Buffer.from(arrayBuffer);
+        const { buffer } = await fetchRemoteMedia({
+          url,
+          maxBytes: DIRECT_MEDIA_MAX_BYTES,
+        });
         fs.writeFileSync(tempMp4File, buffer);
 
         await this.configureFfmpeg();

--- a/plugins/plugin-zerollama/models/audio.ts
+++ b/plugins/plugin-zerollama/models/audio.ts
@@ -114,7 +114,7 @@ async function toBlob(audio: AudioInput, mimeHint?: string): Promise<Blob> {
 
 async function fetchAudioFromUrl(url: string, signal?: AbortSignal): Promise<Blob> {
   // @trajectory-allow Fetches caller-provided audio bytes; no model inference happens here.
-  const { fetchWithSsrfGuard } = await import("@elizaos/core/node");
+  const { fetchWithSsrfGuard, readResponseWithLimit } = await import("@elizaos/core/node");
   const { response, release } = await fetchWithSsrfGuard({
     url,
     timeoutMs: 30_000,
@@ -130,11 +130,10 @@ async function fetchAudioFromUrl(url: string, signal?: AbortSignal): Promise<Blo
     if (Number.isFinite(contentLength) && contentLength > 25 * 1024 * 1024) {
       throw new Error("Ollama transcription audio exceeds the 25 MiB limit");
     }
-    const bytes = await response.arrayBuffer();
-    if (bytes.byteLength > 25 * 1024 * 1024) {
-      throw new Error("Ollama transcription audio exceeds the 25 MiB limit");
-    }
-    return new Blob([bytes], {
+    // Stream under the hard cap: a missing or lying Content-Length must never
+    // let the body buffer unbounded into memory before the size check runs.
+    const bytes = await readResponseWithLimit(response, 25 * 1024 * 1024);
+    return new Blob([new Uint8Array(bytes)], {
       type: response.headers.get("content-type") ?? "audio/wav",
     });
   } finally {


### PR DESCRIPTION
## Summary

Wave-1 security-audit fixes for the `sec-ssrf` group. Each commit maps to one confirmed finding from the consolidated audit (W1-IDs below). All changes follow the repo's existing guarded-fetch primitives (`fetchWithSsrfGuard`, `fetchRemoteMedia`, `resolveAttachmentBytes`, `readResponseWithLimit`) rather than adding new machinery.

### Fixes

- **W1-040 — core SSRF guard missed IPv6 transition ranges** (`fix(core)`, `packages/core/src/network/ssrf.ts`): the policy only decoded the IPv4-mapped `::ffff:` form, so literals in the IPv4-compatible `::/96`, NAT64 `64:ff9b::/96`, 6to4 `2002::/16`, and Teredo `2001:0000::/32` ranges were classified by their public-looking IPv6 prefix while the network path translates them to the embedded IPv4 (e.g. cloud-metadata addresses on NAT64/DNS64 subnets). The guard now expands IPv6 literals to hextets, extracts the embedded IPv4 for those ranges (XOR-decoded for Teredo), and screens it with the same IPv4 policy.
- **W1-041 — unguarded, unbounded fetches in plugin-video** (`plugins/plugin-video/src/services/video.ts`): four raw `fetch()` call sites (direct-MP4 existence probe, caption/SRT downloads, direct-MP4 audio download) are now routed through the guarded transport — `fetchWithSsrfGuard` for the bodyless probe, `fetchRemoteMedia` with explicit caps (10 MiB captions, 256 MiB direct media) for downloads — closing both the unscreened-host and unbounded-body exposures.
- **W1-042 — unguarded connector attachment fetches** (`plugins/plugin-discord/attachments.ts`, `plugins/plugin-telegram/src/messageManager.ts`): Discord audio/video/PDF/plaintext and Telegram PDF/text document bytes now resolve through core's `resolveAttachmentBytes` (DNS-pinned guard, per-hop redirect validation, 50 MiB default cap) per the repo connector-attachment invariant.
- **W1-043 — validate-then-raw-fetch DNS TOCTOU in the registry endpoint client** (`packages/agent/src/services/registry-client-endpoints.ts`): the client screened DNS and then re-resolved at connect time inside a raw fetch. It now fetches through `fetchWithSsrfGuard({ maxRedirects: 0 })`, which pins the connection to the screened addresses; the redundant re-resolution block is removed.
- **W1-046 — latent unguarded `url:reachable` secret-validation probe** (`packages/core/src/features/secrets/validation.ts`): the HEAD probe now runs through `fetchWithSsrfGuard` with `maxRedirects: 0` and the existing 5s timeout, so a stored secret URL can never become an internal-probe oracle.
- **W1-047 — missing byte caps on guarded audio downloads** (`plugins/plugin-elizacloud/src/models/transcription.ts`, `plugins/plugin-zerollama/models/audio.ts`): both transcription handlers now read bodies via `readResponseWithLimit` at the Whisper-class 25 MiB cap, which cancels the stream on overflow regardless of what Content-Length claims.
- **W1-048 — sub-agent narration verifier probed arbitrary loopback ports** (`plugins/plugin-agent-orchestrator/src/services/ssrf-guard.ts`, `sub-agent-router.ts`): `safeFetch`/`assertUrlAllowed` accept an `allowedLoopbackPorts` set enforced on the initial URL and every redirect hop (trusted local-service callers such as the model-gateway lease keep the existing open carve-out). The completion-URL verifier computes the set from operator/supervisor configuration only — session route-mapping URL prefixes and the custom deploy host base URL — and drops narration-claimed loopback URLs on any other port *unprobed*, so they can neither serve as a loopback scan/content oracle nor trigger verify-retry loops on healthy builds.

## Test evidence

All run in the fix worktree on top of `origin/develop` (6679aa19):

- `packages/core`: `ssrf.test.ts` 20/20 (incl. new bypass tests for every newly screened IPv6 range + public-embed non-regressions), `features/secrets/validation.test.ts` 7/7 (new guarded-probe cases), `typecheck` clean, full multi-target build clean.
- `packages/agent`: full lane **442/442** test files pass; `typecheck` shows only a pre-existing `server.ts` `decodePathComponent` error that reproduces identically on unmodified develop.
- `plugins/plugin-discord`: full lane **640/640**; `typecheck` clean.
- `plugins/plugin-telegram`: **176/176**; `typecheck` clean.
- `plugins/plugin-video`: 39 passed / 4 skipped; `typecheck` clean.
- `plugins/plugin-zerollama`: **61/61**; `typecheck` clean.
- `plugins/plugin-elizacloud`: transcription contract **12/12** under vitest; `typecheck` clean. (The package's secondary `bun test` lane for that contract file fails identically on unmodified develop — pre-existing runner incompatibility, not caused by this change.)
- `plugins/plugin-agent-orchestrator`: full lane 2843 passed, with only 5 failures that reproduce identically on unmodified develop (`workdir-routes` ×4, `acp-service` ×1 — verified pre-existing via stash); `typecheck` clean.
- `biome check` clean on every changed file; full workspace `bun run build` 124/124 tasks successful.

Verifier-behavior tests were updated to the new contract: fixtures that legitimately probe loopback now sanction their ports through the same operator-config seams (env-based custom host or route mappings), and new tests pin the unprobed-by-default behavior for unsanctioned loopback ports.

## Risk notes

- **Behavior change (W1-048)**: loopback URLs in sub-agent narration are now probed only on ports from operator config (route mappings / custom deploy base URL). Claims on other loopback ports are skipped (logged, not probed, not counted as failures) — previously they were probed and could be marked verified. Operators who rely on loopback verification of a local static host should ensure its port appears in `TASK_AGENT_WORKDIR_ROUTES` urlMappings or `ELIZA_APP_DEPLOY_CUSTOM_BASE_URL`.
- **Byte caps (W1-041/042/047)**: oversized-but-legitimate inputs now fail with an explicit `max_bytes` error instead of being fetched unbounded — Discord/Telegram attachments > 50 MiB, direct video downloads > 256 MiB, transcription audio > 25 MiB. These match existing repo caps (Whisper limit, `DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES`).
- No public API surface changes; `safeFetch`/`assertUrlAllowed`/`assertHostAllowed` changes are additive optional parameters with legacy defaults.
- Root `bun run verify` was not run end-to-end (per-package tests/typecheck/lint/build gates above were run individually).
