### PR TITLE
fix(cloud): reject unknown twitter-connect connectionRole

### DIFF
--- a/packages/cloud/api/v1/twitter/connect/route.connection-role.test.ts
+++ b/packages/cloud/api/v1/twitter/connect/route.connection-role.test.ts
@@ -1,0 +1,100 @@
+/**
+ * POST /api/v1/twitter/connect `connectionRole` is owner-vs-agent
+ * identity, leftover tax after twitter-status (#21151) /
+ * twitter-disconnect (#21144) / x-dms-digest (#21143). Stock develop
+ * collapsed a failed ConnectBody.safeParse to {} and the ternary then
+ * mapped every non-"agent" token onto the personal owner OAuth
+ * connect. The documented default remains owner; garbage must 400
+ * before generateAuthLink. redirectUrl stays untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const generateAuthLink = mock(async () => ({
+  flow: "oauth2" as const,
+  url: "https://twitter.com/i/oauth2/authorize",
+  state: "state-1",
+  codeVerifier: "verifier",
+  redirectUri: "https://cloud.eliza.app/api/v1/twitter/callback",
+}));
+const isConfigured = mock(() => true);
+const cacheSet = mock(async () => undefined);
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: {
+      id: "user-1",
+      organization_id: "org-1",
+    },
+  }),
+}));
+mock.module("@/lib/services/twitter-automation", () => ({
+  twitterAutomationService: { generateAuthLink, isConfigured },
+}));
+mock.module("@/lib/cache/client", () => ({
+  cache: { set: cacheSet },
+}));
+mock.module("@/lib/security/redirect-validation", () => ({
+  getDefaultPlatformRedirectOrigins: () => [],
+  LOOPBACK_REDIRECT_ORIGINS: [],
+  resolveOAuthSuccessRedirectUrl: () => ({
+    target: new URL("https://cloud.eliza.app/cloud/settings?tab=connections"),
+    rejected: false,
+  }),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    warn: () => undefined,
+    info: () => undefined,
+    error: () => undefined,
+  },
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>
+    c.json({ error: "internal_error" }, 500),
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/v1/twitter/connect", route);
+
+function post(body: Record<string, unknown> | undefined) {
+  return app.request("/api/v1/twitter/connect", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/v1/twitter/connect connectionRole identity", () => {
+  beforeEach(() => {
+    generateAuthLink.mockClear();
+    isConfigured.mockClear();
+    cacheSet.mockClear();
+    isConfigured.mockReturnValue(true);
+  });
+
+  test.each([
+    [{}, "owner"],
+    [{ connectionRole: "" }, "owner"],
+    [{ connectionRole: "owner" }, "owner"],
+    [{ connectionRole: "agent" }, "agent"],
+  ])("accepts %j as %s", async (body, role) => {
+    const response = await post(body);
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as { connectionRole: string };
+    expect(json.connectionRole).toBe(role);
+    expect(generateAuthLink).toHaveBeenCalledTimes(1);
+    expect(generateAuthLink.mock.calls[0]?.[1]).toBe(role);
+  });
+
+  test.each(["AGENT", "Owner", "foo", "1e2", "agent ", "owner\n", 1])(
+    "rejects connectionRole=%j before generateAuthLink",
+    async (token) => {
+      const response = await post({ connectionRole: token });
+      expect(response.status).toBe(400);
+      const json = (await response.json()) as { error: string };
+      expect(json.error).toMatch(/connection_role|connectionRole/i);
+      expect(generateAuthLink).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/twitter/connect/route.ts
+++ b/packages/cloud/api/v1/twitter/connect/route.ts
@@ -32,9 +32,34 @@ app.post("/", async (c) => {
     }
 
     const rawBody = await c.req.json().catch(() => ({}));
+    // Role identity leftover after twitter-status (#21151) /
+    // twitter-disconnect (#21144) / x-dms-digest (#21143). safeParse
+    // failure used to collapse to {} and the ternary then mapped every
+    // non-"agent" token — AGENT, owner-typos, 1e2 — onto the personal
+    // owner OAuth connect. Missing/empty still defaults to owner.
+    // Garbage 400s before generateAuthLink.
+    const requestedRole =
+      rawBody && typeof rawBody === "object" && !Array.isArray(rawBody)
+        ? (rawBody as { connectionRole?: unknown }).connectionRole
+        : undefined;
+    if (
+      requestedRole !== undefined &&
+      requestedRole !== "" &&
+      requestedRole !== "agent" &&
+      requestedRole !== "owner"
+    ) {
+      return c.json(
+        {
+          error: "invalid_connection_role",
+          message:
+            'connectionRole must be specified at most once as "agent" or "owner".',
+        },
+        400,
+      );
+    }
     const parsedBody = ConnectBody.safeParse(rawBody);
     const body = parsedBody.success ? parsedBody.data : {};
-    const connectionRole = body.connectionRole === "agent" ? "agent" : "owner";
+    const connectionRole = requestedRole === "agent" ? "agent" : "owner";
     const baseUrl =
       c.env?.NEXT_PUBLIC_APP_URL ||
       process.env.NEXT_PUBLIC_APP_URL ||


### PR DESCRIPTION

# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
twitter-connect `connectionRole` identity. Role class, leftover tax
after twitter-status (#21151) / twitter-disconnect (#21144) /
x-dms-digest (#21143). Not a twin of those parsers — this is
`POST /api/v1/twitter/connect` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. `connectionRole` only on Twitter connect. Omitted / empty still
defaults to owner. Exact `agent` / `owner` still bind. Unknown tokens
400 before `generateAuthLink`. redirectUrl stays untouched.

# Background

## What does this PR do?

`POST /api/v1/twitter/connect` collapsed a failed `ConnectBody.safeParse`
to `{}` and then mapped every non-`"agent"` token onto the personal
owner OAuth connect.

- omitted / `""` / `"owner"` → owner
- `"agent"` → agent
- `AGENT` / `1e2` / `foo` → **400** before `generateAuthLink`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client that sends `connectionRole=AGENT` or `1e2` must not silently
start the personal owner Twitter OAuth flow. Leftover tax after
twitter-status / twitter-disconnect / x-dms-digest. Disjoint files from
those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/twitter/connect/route.connection-role.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/twitter/connect/route.connection-role.test.ts
```

11 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; twitter-connect connectionRole identity only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; twitter-connect connectionRole identity only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; twitter-connect connectionRole identity only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real connectionRole tokens and assert 400 before generateAuthLink; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before generateAuthLink.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
connectionRole tokens reject; omitted/canonical still start the matching
OAuth role.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the twitter-connect
connectionRole identity only.

## Known gaps / failures

`bun run verify` was not run. Focused 11-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:cfa18e5f0ebe96bdcc58db1b97fc2078692a7c1f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
