### PR TITLE
fix(cloud): wave-1 security hardening for cloud shared services (W1-025/044/045/067/068/070/072)

### DIFF
--- a/packages/cloud/api/__tests__/apps-crud.integration.test.ts
+++ b/packages/cloud/api/__tests__/apps-crud.integration.test.ts
@@ -493,6 +493,29 @@ describe("POST /api/v1/apps (create)", () => {
     expect(json.details).toBeDefined();
   });
 
+  test("400 app_url / allowed_origins targeting localhost or private addresses", async () => {
+    const unsafeBodies = [
+      { name: "Bad", app_url: "http://localhost:3000" },
+      { name: "Bad", app_url: "http://169.254.169.254/latest/meta-data" },
+      { name: "Bad", app_url: "http://10.0.0.8/app" },
+      { name: "Bad", app_url: "https://user:pass@example.com" },
+      {
+        name: "Bad",
+        app_url: "https://ok.example.com",
+        allowed_origins: ["https://ok.example.com", "http://192.168.1.1"],
+      },
+    ];
+    for (const body of unsafeBodies) {
+      const { status, json } = await req("POST", "/api/v1/apps", {
+        key: KEY_A,
+        body,
+      });
+      expect(status).toBe(400);
+      expect(json.error).toBe("Invalid request data");
+    }
+    expect(createApp).not.toHaveBeenCalled();
+  });
+
   test("400 missing required name", async () => {
     const { status, json } = await req("POST", "/api/v1/apps", {
       key: KEY_A,
@@ -862,6 +885,21 @@ describe("PATCH /api/v1/apps/:id (update)", () => {
       body: { app_url: "nope" },
     });
     expect(status).toBe(400);
+  });
+
+  test("400 app_url / allowed_origins retargeted at localhost or private addresses", async () => {
+    const a = seed({ organization_id: ORG_A });
+    for (const body of [
+      { app_url: "http://127.0.0.1:9000/hook" },
+      { allowed_origins: ["http://172.16.0.1"] },
+    ]) {
+      const { status, json } = await req("PATCH", `/api/v1/apps/${a.id}`, {
+        key: KEY_A,
+        body,
+      });
+      expect(status).toBe(400);
+      expect(json.error).toBe("Invalid request data");
+    }
   });
 
   test("200 partial description patch", async () => {

--- a/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
+++ b/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
@@ -55,6 +55,9 @@ describe("elizaos-core Worker stub", () => {
     const noFetch = () => {
       throw new Error("fetch must not be reached for a blocked URL");
     };
+    // Tests inject a deterministic resolver so no real DNS is needed; the
+    // address is a public one (example.com's 93.184.216.34).
+    const publicDns = async () => [{ address: "93.184.216.34" }];
 
     test("blocks non-http(s) schemes, localhost, internal names, and private/reserved IPs", async () => {
       const blocked = [
@@ -88,6 +91,7 @@ describe("elizaos-core Worker stub", () => {
       const { response, finalUrl, release } = await fetchWithSsrfGuard({
         url: "https://example.com/audio.mp3",
         fetchImpl: async () => new Response("bytes", { status: 200 }),
+        dnsResolver: publicDns,
       });
       expect(response.status).toBe(200);
       expect(finalUrl).toBe("https://example.com/audio.mp3");
@@ -118,6 +122,7 @@ describe("elizaos-core Worker stub", () => {
         url: "https://a.example.com/start",
         init: { headers: { authorization: "Bearer secret" } },
         fetchImpl,
+        dnsResolver: publicDns,
       });
       expect(response.status).toBe(200);
       expect(finalUrl).toBe("https://b.example.com/next");
@@ -129,6 +134,7 @@ describe("elizaos-core Worker stub", () => {
       await expect(
         fetchWithSsrfGuard({
           url: "https://a.example.com/start",
+          dnsResolver: publicDns,
           fetchImpl: async () =>
             new Response(null, {
               status: 302,
@@ -143,6 +149,7 @@ describe("elizaos-core Worker stub", () => {
         fetchWithSsrfGuard({
           url: "https://a.example.com/loop",
           maxRedirects: 2,
+          dnsResolver: publicDns,
           fetchImpl: async (input) =>
             new Response(null, {
               status: 302,
@@ -150,6 +157,75 @@ describe("elizaos-core Worker stub", () => {
             }),
         }),
       ).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    test("blocks a public hostname that resolves to a private/reserved address", async () => {
+      const privateAnswers = [
+        [{ address: "10.0.0.8" }],
+        [{ address: "169.254.169.254" }],
+        [{ address: "192.168.0.1" }],
+        [{ address: "fd00::1" }],
+        [{ address: "::ffff:127.0.0.1" }],
+        // mixed answer set: one private answer poisons the whole set
+        [{ address: "93.184.216.34" }, { address: "127.0.0.1" }],
+      ];
+      for (const answers of privateAnswers) {
+        await expect(
+          fetchWithSsrfGuard({
+            url: "https://rebind.attacker.example/audio.mp3",
+            fetchImpl: noFetch,
+            dnsResolver: async () => answers,
+          }),
+        ).rejects.toBeInstanceOf(SsrfBlockedError);
+      }
+    });
+
+    test("fails closed when DNS resolution errors or answers are empty", async () => {
+      await expect(
+        fetchWithSsrfGuard({
+          url: "https://nxdomain.example/audio.mp3",
+          fetchImpl: noFetch,
+          dnsResolver: async () => {
+            throw new Error("ENOTFOUND");
+          },
+        }),
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+
+      await expect(
+        fetchWithSsrfGuard({
+          url: "https://empty.example/audio.mp3",
+          fetchImpl: noFetch,
+          dnsResolver: async () => [],
+        }),
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    test("screens DNS again on every redirect hop", async () => {
+      const seenHosts: string[] = [];
+      const fetchImpl = async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "https://a.example.com/start") {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://evil.example.com/next" },
+          });
+        }
+        return new Response("done", { status: 200 });
+      };
+      await expect(
+        fetchWithSsrfGuard({
+          url: "https://a.example.com/start",
+          fetchImpl,
+          dnsResolver: async (hostname) => {
+            seenHosts.push(hostname);
+            // The redirect target rebinds to loopback — hop 2 must be blocked.
+            if (hostname === "evil.example.com")
+              return [{ address: "127.0.0.1" }];
+            return [{ address: "93.184.216.34" }];
+          },
+        }),
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+      expect(seenHosts).toEqual(["a.example.com", "evil.example.com"]);
     });
   });
 });

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -698,18 +698,19 @@ export function handleDedicatedAgentProxy(
       handleManagedPairAtEdge(request, env, url, agentId),
     );
   }
-  if (!isDedicatedProxyBrowserOriginAllowed(request, url)) {
-    return Promise.resolve(
-      new Response(null, {
+  // The whole browser-policy path runs inside the bindings context so
+  // isFirstPartyOrigin reads THIS request's ENVIRONMENT binding — outside it
+  // would fall back to process.env and silently evaluate as non-production.
+  return runWithCloudBindingsAsync(env, async () => {
+    if (!isDedicatedProxyBrowserOriginAllowed(request, url)) {
+      return new Response(null, {
         status: 403,
         headers: { "cache-control": "no-store" },
-      }),
-    );
-  }
-  if (request.method === "OPTIONS") {
-    return Promise.resolve(dedicatedProxyPreflight(request, url));
-  }
-  return runWithCloudBindingsAsync(env, async () => {
+      });
+    }
+    if (request.method === "OPTIONS") {
+      return dedicatedProxyPreflight(request, url);
+    }
     const response = await proxyDedicatedAgent(request, env, url, agentId);
     return withDedicatedProxyBrowserPolicy(request, url, response);
   });

--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -558,12 +558,22 @@ export function runWithTrajectoryPurpose<T>(
 // fetchWithSsrfGuard — Worker-safe port of @elizaos/core/network/fetch-guard.
 //
 // Pulled into the bundle via plugin-elizacloud transcription (`audioUrl`
-// fetch). workerd has no `node:dns`, so the core guard's DNS pinning is not
-// portable; everything else is reproduced: http(s)-only, blocked-hostname +
-// private/loopback/link-local literal-IP rejection, manual redirect following
-// with re-validation on every hop, credential-header stripping on
-// cross-origin hops, spec-correct 301/302/303 GET rewrites, and timeout
-// wiring. Fail-closed: a URL this port cannot positively clear is rejected.
+// fetch). Everything the core guard does is reproduced: http(s)-only,
+// blocked-hostname + private/loopback/link-local literal-IP rejection, DNS
+// resolution with every answer screened (fail closed on resolution error,
+// empty answers, or any private/reserved answer), manual redirect following
+// with re-validation on every hop, credential-header stripping on cross-origin
+// hops, spec-correct 301/302/303 GET rewrites, and timeout wiring.
+// Fail-closed: a URL this port cannot positively clear is rejected.
+//
+// EDGE-SSRF residual (#12229 M5): workerd cannot pin fetch() to the screened
+// IP, so the platform re-resolves between our screening and connect — a
+// millisecond DNS-rebinding window remains. This is only safe behind the
+// documented operator egress policy: the Cloudflare zone must deny outbound to
+// RFC1918/link-local (or route edge egress through a resolve-and-connect-by-IP
+// proxy). The DNS screening here closes the "public name resolving to a
+// private address" hole for static answers; the egress policy owns the
+// rebinding window.
 // ---------------------------------------------------------------------------
 
 /** Mirrors core's `SsrfBlockedError` for callers that match on `name`. */
@@ -573,6 +583,15 @@ export class SsrfBlockedError extends Error {
     this.name = "SsrfBlockedError";
   }
 }
+
+export type DnsAnswer = { address: string };
+
+/**
+ * DNS resolution hook for SSRF screening. Defaults to `node:dns` lookup
+ * (implemented in workerd under `nodejs_compat` via Cloudflare's resolver);
+ * tests inject a stub so no real DNS is needed.
+ */
+export type SsrfDnsResolver = (hostname: string) => Promise<DnsAnswer[]>;
 
 export type GuardedFetchOptions = {
   url: string;
@@ -584,6 +603,7 @@ export type GuardedFetchOptions = {
   maxRedirects?: number;
   timeoutMs?: number;
   signal?: AbortSignal;
+  dnsResolver?: SsrfDnsResolver;
 };
 
 export type GuardedFetchResult = {
@@ -675,6 +695,58 @@ function assertSsrfAllowedUrl(url: URL): void {
   }
 }
 
+/** IP literals are screened directly by assertSsrfAllowedUrl — no DNS needed. */
+function isIpLiteralHostname(host: string): boolean {
+  const h = host.replace(/^\[|\]$/g, "");
+  if (h.includes(":")) return true;
+  return /^\d{1,3}(\.\d{1,3}){3}$/.test(h);
+}
+
+async function defaultDnsResolver(hostname: string): Promise<DnsAnswer[]> {
+  // Dynamic import keeps the module loadable where the node:dns alias is
+  // absent; in the Worker bundle `nodejs_compat` provides it.
+  const { lookup } = await import("node:dns/promises");
+  return lookup(hostname, { all: true, verbatim: true });
+}
+
+/**
+ * Screen a hostname's DNS answers: every resolved address must be public.
+ * Fails closed — resolution errors, empty answer sets, and any
+ * private/reserved answer all reject before the fetch is attempted (a public
+ * name may never smuggle a private target past the literal-IP checks).
+ */
+async function assertHostnameResolvesPublicly(
+  url: URL,
+  resolve: SsrfDnsResolver,
+): Promise<void> {
+  const host = url.hostname.toLowerCase().replace(/\.$/, "");
+  if (isIpLiteralHostname(host)) return;
+
+  let records: DnsAnswer[];
+  try {
+    records = await resolve(host);
+  } catch (err) {
+    // error-policy:J2 DNS failure must fail closed — rethrown as a typed
+    // SsrfBlockedError (cause preserved in the message) so guarded callers see
+    // one rejection shape and the fetch is never attempted.
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new SsrfBlockedError(
+      `Unable to resolve hostname for SSRF screening: ${host} (${detail})`,
+    );
+  }
+
+  if (records.length === 0) {
+    throw new SsrfBlockedError(`Hostname resolved to no addresses: ${host}`);
+  }
+  for (const record of records) {
+    if (isBlockedIpLiteral(record.address)) {
+      throw new SsrfBlockedError(
+        `Blocked hostname resolving to a private/reserved address: ${host}`,
+      );
+    }
+  }
+}
+
 const SSRF_CROSS_ORIGIN_STRIPPED_HEADERS = [
   "authorization",
   "proxy-authorization",
@@ -731,9 +803,15 @@ export async function fetchWithSsrfGuard(
   let method = (options.init?.method ?? "GET").toUpperCase();
   let body = options.init?.body;
   let headers = new Headers(options.init?.headers);
+  const dnsResolver = options.dnsResolver ?? defaultDnsResolver;
 
   for (let hop = 0; hop <= maxRedirects; hop++) {
     assertSsrfAllowedUrl(current);
+    // Re-screen DNS on every hop (redirect targets included). workerd cannot
+    // pin the connection to the screened address, so the platform re-resolves
+    // at connect time — the residual rebinding window is owned by the
+    // documented Cloudflare egress policy (see the section header above).
+    await assertHostnameResolvesPublicly(current, dnsResolver);
     const response = await fetchImpl(current.toString(), {
       ...options.init,
       method,

--- a/packages/cloud/api/v1/apps/[id]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.ts
@@ -13,6 +13,7 @@ import type { NewApp } from "@/db/schemas/apps";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { isSafeRegistrationUrl } from "@/lib/security/outbound-url";
 import { appCleanupService } from "@/lib/services/app-cleanup";
 import { buildReviewCandidate } from "@/lib/services/app-review";
 import { appsService } from "@/lib/services/apps";
@@ -30,10 +31,21 @@ const optionalEmail = z
 const UpdateAppSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   description: z.string().optional(),
-  app_url: optionalUrl,
+  // Same registration-time screen as POST /apps: callback delivery is confined
+  // to app_url/allowed_origins, so they must never point at localhost/private
+  // targets (fetch-time safeFetch re-validates with DNS).
+  app_url: optionalUrl.refine(isSafeRegistrationUrl, {
+    message: "app_url must be a public http(s) URL",
+  }),
   website_url: optionalUrl,
   contact_email: optionalEmail,
-  allowed_origins: z.array(z.string()).optional(),
+  allowed_origins: z
+    .array(
+      z.string().refine(isSafeRegistrationUrl, {
+        message: "allowed_origins entries must be public http(s) origins",
+      }),
+    )
+    .optional(),
   logo_url: optionalUrl,
   is_active: z.boolean().optional(),
   linked_character_ids: z.array(z.string().uuid()).max(4).optional(),

--- a/packages/cloud/api/v1/apps/route.ts
+++ b/packages/cloud/api/v1/apps/route.ts
@@ -9,6 +9,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { isSafeRegistrationUrl } from "@/lib/security/outbound-url";
 import { appCreditsService } from "@/lib/services/app-credits";
 import { appFactoryService } from "@/lib/services/app-factory";
 import {
@@ -22,10 +23,21 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const CreateAppSchema = z.object({
   name: z.string().min(1).max(100),
   description: z.string().optional(),
-  app_url: z.string().url(),
+  // Screened at registration so charge-callback delivery (which is confined
+  // to these URLs) can never be aimed at localhost/private targets; fetch-time
+  // safeFetch re-validates with DNS.
+  app_url: z.string().url().refine(isSafeRegistrationUrl, {
+    message: "app_url must be a public http(s) URL",
+  }),
   website_url: z.string().url().optional(),
   contact_email: z.string().email().optional(),
-  allowed_origins: z.array(z.string()).optional(),
+  allowed_origins: z
+    .array(
+      z.string().refine(isSafeRegistrationUrl, {
+        message: "allowed_origins entries must be public http(s) origins",
+      }),
+    )
+    .optional(),
   logo_url: z.string().url().optional(),
   skipGitHubRepo: z.boolean().optional(),
   // Optional monetization config applied immediately after creation. A `true`

--- a/packages/cloud/shared/src/db/repositories/agents/entities.ts
+++ b/packages/cloud/shared/src/db/repositories/agents/entities.ts
@@ -9,6 +9,7 @@ import { eq, inArray, sql } from "drizzle-orm";
 import { sqlRows } from "../../execute-helpers";
 import { dbRead, dbWrite } from "../../helpers";
 import { entityTable } from "../../schemas/eliza";
+import { escapeLikePattern } from "../../utils/like-pattern";
 
 /**
  * Input for creating a new entity.
@@ -148,7 +149,7 @@ export class EntitiesRepository {
       WHERE agent_id = ${agentId}::uuid
         AND EXISTS (
           SELECT 1 FROM unnest(names) AS name
-          WHERE name ILIKE ${`%${namePattern}%`}
+          WHERE name ILIKE ${`%${escapeLikePattern(namePattern)}%`} ESCAPE '\\'
         )
       LIMIT ${limit}
     `,

--- a/packages/cloud/shared/src/db/repositories/characters.ts
+++ b/packages/cloud/shared/src/db/repositories/characters.ts
@@ -9,16 +9,9 @@ import {
   type UserCharacter,
   userCharacters,
 } from "../schemas/user-characters";
+import { escapeLikePattern } from "../utils/like-pattern";
 
 export type { NewUserCharacter, UserCharacter };
-
-/**
- * Escapes special LIKE pattern characters to prevent pattern injection.
- * Characters %, _, and \ have special meaning in SQL LIKE patterns.
- */
-function escapeLikePattern(str: string): string {
-  return str.replace(/[%_\\]/g, "\\$&");
-}
 
 function ilikeEscaped(column: unknown, query: string): SQL {
   return sql`${column as SQL} ILIKE ${`%${escapeLikePattern(query)}%`} ESCAPE '\\'`;

--- a/packages/cloud/shared/src/db/repositories/cloud-files.ts
+++ b/packages/cloud/shared/src/db/repositories/cloud-files.ts
@@ -2,6 +2,7 @@
 import { and, desc, eq, ilike, sql } from "drizzle-orm";
 import { dbRead, dbWrite } from "../helpers";
 import { type CloudFile, cloudFiles, type NewCloudFile } from "../schemas/cloud-files";
+import { escapeLikePattern } from "../utils/like-pattern";
 
 export type { CloudFile, NewCloudFile };
 
@@ -49,7 +50,7 @@ export class CloudFilesRepository {
     if (options.kind) conditions.push(eq(cloudFiles.kind, options.kind));
     if (options.mimeType) conditions.push(eq(cloudFiles.mime_type, options.mimeType));
     if (options.search) {
-      conditions.push(ilike(cloudFiles.filename, `%${options.search}%`));
+      conditions.push(ilike(cloudFiles.filename, `%${escapeLikePattern(options.search)}%`));
     }
 
     const rows = await dbRead.query.cloudFiles.findMany({

--- a/packages/cloud/shared/src/db/repositories/user-mcps.ts
+++ b/packages/cloud/shared/src/db/repositories/user-mcps.ts
@@ -10,6 +10,7 @@ import {
   type UserMcp,
   userMcps,
 } from "../schemas";
+import { escapeLikePattern } from "../utils/like-pattern";
 
 /**
  * User MCPs Repository
@@ -101,7 +102,10 @@ export const userMcpsRepository = {
 
     if (search) {
       conditions.push(
-        or(ilike(userMcps.name, `%${search}%`), ilike(userMcps.description, `%${search}%`))!,
+        or(
+          ilike(userMcps.name, `%${escapeLikePattern(search)}%`),
+          ilike(userMcps.description, `%${escapeLikePattern(search)}%`),
+        )!,
       );
     }
 
@@ -142,7 +146,10 @@ export const userMcpsRepository = {
     }
     if (search) {
       conditions.push(
-        or(ilike(userMcps.name, `%${search}%`), ilike(userMcps.description, `%${search}%`))!,
+        or(
+          ilike(userMcps.name, `%${escapeLikePattern(search)}%`),
+          ilike(userMcps.description, `%${escapeLikePattern(search)}%`),
+        )!,
       );
     }
     const [result] = await dbRead

--- a/packages/cloud/shared/src/db/utils/__tests__/like-pattern.test.ts
+++ b/packages/cloud/shared/src/db/utils/__tests__/like-pattern.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Unit contract for escapeLikePattern: LIKE metacharacters in user search
+ * text must be backslash-escaped so they match literally (Postgres' default
+ * LIKE escape is the backslash), while ordinary text passes through unchanged.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { escapeLikePattern } from "../like-pattern";
+
+describe("escapeLikePattern", () => {
+  test("escapes %, _, and backslash", () => {
+    expect(escapeLikePattern("100%")).toBe("100\\%");
+    expect(escapeLikePattern("a_b")).toBe("a\\_b");
+    expect(escapeLikePattern("C:\\path")).toBe("C:\\\\path");
+    expect(escapeLikePattern("%_%")).toBe("\\%\\_\\%");
+  });
+
+  test("passes ordinary text through unchanged", () => {
+    expect(escapeLikePattern("my search term")).toBe("my search term");
+    expect(escapeLikePattern("mcp-server 2")).toBe("mcp-server 2");
+    expect(escapeLikePattern("")).toBe("");
+    expect(escapeLikePattern("'*\"; DROP TABLE--")).toBe("'*\"; DROP TABLE--");
+  });
+});

--- a/packages/cloud/shared/src/db/utils/like-pattern.ts
+++ b/packages/cloud/shared/src/db/utils/like-pattern.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared LIKE/ILIKE pattern escaping for repository search filters.
+ *
+ * User-supplied search text is always bound as a parameter (no SQL injection),
+ * but unescaped `%`/`_` still act as wildcards — a search term would match far
+ * more rows than its literal text intends. Escape the LIKE metacharacters so
+ * the pattern matches the literal substring. Postgres' default LIKE escape
+ * character is the backslash, so escaped patterns work with drizzle's
+ * `ilike()`; raw-SQL sites should spell `ESCAPE '\'` out explicitly.
+ */
+
+/**
+ * Escapes special LIKE pattern characters to prevent pattern injection.
+ * Characters %, _, and \ have special meaning in SQL LIKE patterns.
+ */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[%_\\]/g, "\\$&");
+}

--- a/packages/cloud/shared/src/lib/auth/service-jwt.test.ts
+++ b/packages/cloud/shared/src/lib/auth/service-jwt.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Service-JWT claim contract: a token under the shared HS256 secret must carry
+ * an `exp` (jose only enforces it when present, so a no-exp token would never
+ * expire) whose horizon stays within the service maximum, and must match the
+ * operator-pinned issuer/audience when ELIZA_SERVICE_JWT_ISSUER/AUDIENCE are
+ * configured. Real jose verification; db helpers and logger mocked (the
+ * staging-session token-class guard names dbRead at module scope).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { SignJWT } from "jose";
+
+const SECRET = "service-jwt-test-secret-0123456789abcdef";
+const ENV_KEYS = [
+  "ELIZA_SERVICE_JWT_SECRET",
+  "ELIZA_SERVICE_JWT_ISSUER",
+  "ELIZA_SERVICE_JWT_AUDIENCE",
+] as const;
+
+mock.module("../../db/helpers", () => ({
+  dbRead: {},
+  dbWrite: {},
+  writeTransaction: async () => {
+    throw new Error("transaction is outside this service-JWT test path");
+  },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} },
+  redact: { id: (v: string) => v, orgId: (v: string) => v, userId: (v: string) => v },
+}));
+
+const { verifyServiceJwt } = await import("./service-jwt");
+
+function secretKey(): Uint8Array {
+  return new TextEncoder().encode(SECRET);
+}
+
+async function mint(claims: Record<string, unknown> = {}): Promise<string> {
+  return await new SignJWT({ userId: "waifu:svc", ...claims })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .sign(secretKey());
+}
+
+describe("verifyServiceJwt — token lifecycle claims", () => {
+  const savedEnv = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      savedEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    process.env.ELIZA_SERVICE_JWT_SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const saved = savedEnv.get(key);
+      if (saved === undefined) delete process.env[key];
+      else process.env[key] = saved;
+    }
+    savedEnv.clear();
+  });
+
+  async function verify(token: string) {
+    return await verifyServiceJwt(`Bearer ${token}`);
+  }
+
+  test("accepts a short-lived token and returns its claims", async () => {
+    const token = await new SignJWT({ userId: "waifu:svc", email: "svc@waifu.test" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(secretKey());
+
+    const payload = await verify(token);
+    expect(payload?.userId).toBe("waifu:svc");
+    expect(payload?.email).toBe("svc@waifu.test");
+  });
+
+  test("rejects a token with no exp claim (would never expire)", async () => {
+    const token = await mint();
+    expect(await verify(token)).toBeNull();
+  });
+
+  test("rejects a token whose TTL exceeds the service maximum", async () => {
+    const token = await new SignJWT({ userId: "waifu:svc" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("2h")
+      .sign(secretKey());
+    expect(await verify(token)).toBeNull();
+  });
+
+  test("rejects an already-expired token", async () => {
+    const token = await new SignJWT({ userId: "waifu:svc" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 120)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+      .sign(secretKey());
+    expect(await verify(token)).toBeNull();
+  });
+
+  test("enforces the pinned issuer only when configured", async () => {
+    const withoutIss = await new SignJWT({ userId: "waifu:svc" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(secretKey());
+    const withIss = await new SignJWT({ userId: "waifu:svc" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .setIssuer("waifu-core")
+      .sign(secretKey());
+
+    process.env.ELIZA_SERVICE_JWT_ISSUER = "waifu-core";
+    expect(await verify(withoutIss)).toBeNull();
+    expect(await verify(withIss)).not.toBeNull();
+  });
+
+  test("enforces the pinned audience only when configured", async () => {
+    const wrongAud = await new SignJWT({ userId: "waifu:svc" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .setAudience("some-other-service")
+      .sign(secretKey());
+    const rightAud = await new SignJWT({ userId: "waifu:svc" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .setAudience("eliza-cloud")
+      .sign(secretKey());
+
+    process.env.ELIZA_SERVICE_JWT_AUDIENCE = "eliza-cloud";
+    expect(await verify(wrongAud)).toBeNull();
+    expect(await verify(rightAud)).not.toBeNull();
+  });
+
+  test("rejects a token signed with a different secret", async () => {
+    const token = await new SignJWT({ userId: "waifu:svc" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(new TextEncoder().encode("attacker-controlled-secret"));
+    expect(await verify(token)).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/auth/service-jwt.ts
+++ b/packages/cloud/shared/src/lib/auth/service-jwt.ts
@@ -3,6 +3,9 @@
  *
  * Validates HS256-signed JWTs issued by waifu-core's AgentClient.
  * Env: ELIZA_SERVICE_JWT_SECRET -- shared secret with waifu-core.
+ *      ELIZA_SERVICE_JWT_ISSUER / ELIZA_SERVICE_JWT_AUDIENCE -- optional
+ *      iss/aud pins for the service token class (jose enforces them only when
+ *      configured, so deployments pin without a code change).
  */
 
 import * as jose from "jose";
@@ -17,9 +20,18 @@ export interface ServiceJwtPayload {
 }
 
 const SECRET_ENV_KEY = "ELIZA_SERVICE_JWT_SECRET";
+const ISSUER_ENV_KEY = "ELIZA_SERVICE_JWT_ISSUER";
+const AUDIENCE_ENV_KEY = "ELIZA_SERVICE_JWT_AUDIENCE";
+
+/**
+ * Service tokens are short-lived S2S credentials minted immediately before the
+ * call; an hour covers the mint→verify round trip with clock-skew headroom.
+ */
+const MAX_SERVICE_JWT_TTL_SECONDS = 3600;
 
 let _secret: Uint8Array | null = null;
 let _secretRaw: string | null = null;
+let _warnedClaimsNotPinned = false;
 
 function getSecret(): Uint8Array | null {
   const raw = getCloudAwareEnv()[SECRET_ENV_KEY];
@@ -44,9 +56,23 @@ export async function verifyServiceJwt(
   const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : authHeader;
   if (!token) return null;
 
+  const env = getCloudAwareEnv();
+  const issuer = env[ISSUER_ENV_KEY]?.trim() || undefined;
+  const audience = env[AUDIENCE_ENV_KEY]?.trim() || undefined;
+  if (!issuer && !audience && !_warnedClaimsNotPinned) {
+    // Once per process: without pins, any HS256 token under the shared secret
+    // is accepted regardless of issuer/audience. Operators should set
+    // ELIZA_SERVICE_JWT_ISSUER / ELIZA_SERVICE_JWT_AUDIENCE to the values the
+    // minting service emits.
+    _warnedClaimsNotPinned = true;
+    logger.warn("[service-jwt] iss/aud not pinned — set ELIZA_SERVICE_JWT_ISSUER/AUDIENCE");
+  }
+
   try {
     const { payload, protectedHeader } = await jose.jwtVerify(token, secret, {
       algorithms: ["HS256"],
+      ...(issuer ? { issuer } : {}),
+      ...(audience ? { audience } : {}),
     });
 
     // A QA browser session must never acquire service-account authority, even
@@ -56,6 +82,19 @@ export async function verifyServiceJwt(
     // an unconditional boundary in addition to the deployment-time key check.
     if (protectedHeader.typ === STAGING_SESSION_TOKEN_TYP) {
       logger.warn("[service-jwt] Rejected staging QA session token class");
+      return null;
+    }
+
+    // jose enforces `exp` only when the claim exists — a token minted without
+    // one would never expire. Service tokens are short-lived S2S credentials:
+    // require an expiry and cap its horizon so a leaked token's usefulness is
+    // bounded.
+    if (typeof payload.exp !== "number") {
+      logger.warn("[service-jwt] Rejected token without an exp claim");
+      return null;
+    }
+    if (payload.exp * 1000 - Date.now() > MAX_SERVICE_JWT_TTL_SECONDS * 1000) {
+      logger.warn("[service-jwt] Rejected token whose TTL exceeds the service maximum");
       return null;
     }
 

--- a/packages/cloud/shared/src/lib/cors-constants.ts
+++ b/packages/cloud/shared/src/lib/cors-constants.ts
@@ -98,3 +98,25 @@ export const APP_LOCAL_ORIGIN_RE =
   /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\]|\[0:0:0:0:0:0:0:1\])(:\d+)?$/i;
 export const APP_SCHEME_ORIGIN_RE =
   /^(capacitor|capacitor-electron|app|tauri|file|electrobun):\/\/.*$/i;
+
+/**
+ * Exact Capacitor WebView origin (`iosScheme`/`androidScheme` = "https", no
+ * port — see packages/app/capacitor.config.ts). A browser page cannot mint a
+ * portless loopback origin for a credentialed cross-origin request, so this
+ * one stays first-party in every environment.
+ */
+export const CAPACITOR_WEBVIEW_ORIGIN = "https://localhost";
+
+/**
+ * Loopback http(s) origins any local process can serve (any port, the https
+ * and `[::1]` variants, and portless `http://localhost`). Reflecting these
+ * WITH `Access-Control-Allow-Credentials: true` in production would let a
+ * hostile local page ride a user's cloud session cookies against the API, so
+ * every credentialed allowlist (Hono-CORS, utils/cors, proxy/cors) must honor
+ * them only outside production (`ENVIRONMENT !== "production"`). The portless
+ * {@link CAPACITOR_WEBVIEW_ORIGIN} is excluded — it stays first-party
+ * everywhere (see above).
+ */
+export function isLocalDevLoopbackOrigin(origin: string): boolean {
+  return APP_LOCAL_ORIGIN_RE.test(origin) && origin !== CAPACITOR_WEBVIEW_ORIGIN;
+}

--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
@@ -8,7 +8,7 @@
  * every request.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Hono } from "hono";
 import { secureHeaders } from "hono/secure-headers";
 import { setHttpTelemetryHeaders } from "../observability/http-telemetry";
@@ -100,6 +100,57 @@ describe("isFirstPartyOrigin — Eliza app WebView origins", () => {
     // controlled — allowed regardless of host (mirrors the dedicated-agent
     // APP_ORIGIN_RE in packages/agent/src/api/server-helpers-auth.ts).
     expect(isFirstPartyOrigin("capacitor://anything")).toBe(true);
+  });
+});
+
+describe("isFirstPartyOrigin — environment gating of loopback dev origins", () => {
+  let savedEnvironment: string | undefined;
+
+  beforeEach(() => {
+    savedEnvironment = process.env.ENVIRONMENT;
+  });
+
+  afterEach(() => {
+    if (savedEnvironment === undefined) delete process.env.ENVIRONMENT;
+    else process.env.ENVIRONMENT = savedEnvironment;
+  });
+
+  test("any-port loopback origins stay first-party outside production (local dev)", () => {
+    delete process.env.ENVIRONMENT;
+    expect(isFirstPartyOrigin("http://localhost:5173")).toBe(true);
+    expect(isFirstPartyOrigin("http://127.0.0.1:3000")).toBe(true);
+    expect(isFirstPartyOrigin("https://localhost:2138")).toBe(true);
+  });
+
+  test("any-port loopback origins are NOT first-party in production", () => {
+    process.env.ENVIRONMENT = "production";
+    expect(isFirstPartyOrigin("http://localhost:5173")).toBe(false);
+    expect(isFirstPartyOrigin("http://127.0.0.1:3000")).toBe(false);
+    expect(isFirstPartyOrigin("http://[::1]:5173")).toBe(false);
+    expect(isFirstPartyOrigin("https://localhost:2138")).toBe(false);
+    expect(isFirstPartyOrigin("https://127.0.0.1")).toBe(false);
+    // The native WebView origins stay first-party in production — a browser
+    // page cannot mint them, so no session-riding risk.
+    expect(isFirstPartyOrigin("https://localhost")).toBe(true);
+    expect(isFirstPartyOrigin("capacitor://localhost")).toBe(true);
+    expect(isFirstPartyOrigin("electrobun://localhost")).toBe(true);
+    // Static first-party origins are unaffected.
+    expect(isFirstPartyOrigin("https://www.eliza.app")).toBe(true);
+  });
+
+  test("the credentialed middleware does not reflect a loopback dev origin in production", async () => {
+    process.env.ENVIRONMENT = "production";
+    const res = await req("GET", "http://localhost:5173", false, "/ping");
+    // The protective invariant: the origin is not reflected, so the browser
+    // blocks the credentialed cross-origin read.
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  test("the credentialed middleware still reflects the WebView origin in production", async () => {
+    process.env.ENVIRONMENT = "production";
+    const res = await req("GET", "https://localhost", false, "/ping");
+    expect(res.headers.get("access-control-allow-origin")).toBe("https://localhost");
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true");
   });
 });
 

--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
@@ -29,11 +29,12 @@ import type { MiddlewareHandler } from "hono";
 import { cors } from "hono/cors";
 
 import {
-  APP_LOCAL_ORIGIN_RE,
   APP_SCHEME_ORIGIN_RE,
+  CAPACITOR_WEBVIEW_ORIGIN,
   CORS_ALLOW_HEADER_NAMES,
   CORS_ALLOW_METHOD_NAMES,
   CORS_EXPOSE_HEADER_NAMES,
+  isLocalDevLoopbackOrigin,
 } from "../cors-constants";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 
@@ -94,30 +95,6 @@ const PUBLIC_TOKEN_API_PATHS = new Set<string>([
 ]);
 
 /**
- * Exact Capacitor WebView origin (`iosScheme="https"`, no port — see
- * packages/app/capacitor.config.ts). A browser page cannot mint a portless
- * loopback origin for a credentialed cross-origin request, so this one stays
- * first-party in every environment.
- */
-const CAPACITOR_WEBVIEW_ORIGIN = "https://localhost";
-
-/**
- * Loopback http(s) origins with an explicit port (`http://localhost:5173`,
- * `http://127.0.0.1:3000`, the https and `[::1]` variants). Any local process
- * can serve one of these, so in production reflecting them WITH
- * `Access-Control-Allow-Credentials: true` would let a hostile local page ride
- * a user's cloud session cookies against the API. They are a local-dev
- * convenience and stay first-party only outside production.
- */
-function isLoopbackDevOrigin(origin: string): boolean {
-  return (
-    origin.startsWith("http://localhost:") ||
-    origin.startsWith("http://127.0.0.1:") ||
-    APP_LOCAL_ORIGIN_RE.test(origin)
-  );
-}
-
-/**
  * First-party origins that may use cookie/session credentials. These get
  * `Access-Control-Allow-Credentials: true` with the origin reflected.
  */
@@ -129,7 +106,9 @@ export function isFirstPartyOrigin(origin: string): boolean {
   if (origin === CAPACITOR_WEBVIEW_ORIGIN || APP_SCHEME_ORIGIN_RE.test(origin)) {
     return true;
   }
-  if (isLoopbackDevOrigin(origin)) {
+  // Any-port loopback origins are a local-dev convenience: any local process
+  // can serve one, so they stay first-party only outside production.
+  if (isLocalDevLoopbackOrigin(origin)) {
     return getCloudAwareEnv().ENVIRONMENT !== "production";
   }
   return false;

--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
@@ -35,6 +35,7 @@ import {
   CORS_ALLOW_METHOD_NAMES,
   CORS_EXPOSE_HEADER_NAMES,
 } from "../cors-constants";
+import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 
 const STATIC_ALLOWED_ORIGINS = new Set<string>([
   ...Object.values(ELIZA_DOMAIN_CONTRACTS).flatMap((contract) => [
@@ -93,18 +94,43 @@ const PUBLIC_TOKEN_API_PATHS = new Set<string>([
 ]);
 
 /**
+ * Exact Capacitor WebView origin (`iosScheme="https"`, no port — see
+ * packages/app/capacitor.config.ts). A browser page cannot mint a portless
+ * loopback origin for a credentialed cross-origin request, so this one stays
+ * first-party in every environment.
+ */
+const CAPACITOR_WEBVIEW_ORIGIN = "https://localhost";
+
+/**
+ * Loopback http(s) origins with an explicit port (`http://localhost:5173`,
+ * `http://127.0.0.1:3000`, the https and `[::1]` variants). Any local process
+ * can serve one of these, so in production reflecting them WITH
+ * `Access-Control-Allow-Credentials: true` would let a hostile local page ride
+ * a user's cloud session cookies against the API. They are a local-dev
+ * convenience and stay first-party only outside production.
+ */
+function isLoopbackDevOrigin(origin: string): boolean {
+  return (
+    origin.startsWith("http://localhost:") ||
+    origin.startsWith("http://127.0.0.1:") ||
+    APP_LOCAL_ORIGIN_RE.test(origin)
+  );
+}
+
+/**
  * First-party origins that may use cookie/session credentials. These get
  * `Access-Control-Allow-Credentials: true` with the origin reflected.
  */
 export function isFirstPartyOrigin(origin: string): boolean {
   if (STATIC_ALLOWED_ORIGINS.has(origin)) return true;
-  if (origin.startsWith("http://localhost:") || origin.startsWith("http://127.0.0.1:")) {
+  // The Eliza app WebView (Capacitor `https://localhost`/`capacitor://localhost`,
+  // Electrobun, other native app schemes) — credentialed SSE reads need
+  // origin-reflected CORS, and a browser page cannot mint these origins.
+  if (origin === CAPACITOR_WEBVIEW_ORIGIN || APP_SCHEME_ORIGIN_RE.test(origin)) {
     return true;
   }
-  // The Eliza app WebView (Capacitor `https://localhost`/`capacitor://localhost`,
-  // Electrobun, local dev) — credentialed SSE reads need origin-reflected CORS.
-  if (APP_LOCAL_ORIGIN_RE.test(origin) || APP_SCHEME_ORIGIN_RE.test(origin)) {
-    return true;
+  if (isLoopbackDevOrigin(origin)) {
+    return getCloudAwareEnv().ENVIRONMENT !== "production";
   }
   return false;
 }

--- a/packages/cloud/shared/src/lib/security/outbound-url.test.ts
+++ b/packages/cloud/shared/src/lib/security/outbound-url.test.ts
@@ -7,7 +7,9 @@ vi.mock("node:dns/promises", () => ({
   lookup: lookupMock,
 }));
 
-const { assertSafeOutboundUrl, isForbiddenIpAddress } = await import("./outbound-url");
+const { assertSafeOutboundUrl, isForbiddenIpAddress, isSafeRegistrationUrl } = await import(
+  "./outbound-url"
+);
 
 // `vi.mock("node:dns/promises")` is process-global in bun:test, so this stub
 // leaks into every suite loaded afterwards. Left in its reset (undefined-
@@ -117,5 +119,42 @@ describe("outbound URL SSRF validation", () => {
     await expect(assertSafeOutboundUrl("https://example.com/")).rejects.toThrow(
       "Unable to resolve endpoint hostname",
     );
+  });
+});
+
+describe("isSafeRegistrationUrl", () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+  });
+
+  test("passes null/empty values — presence is the schema's job", () => {
+    expect(isSafeRegistrationUrl(null)).toBe(true);
+    expect(isSafeRegistrationUrl(undefined)).toBe(true);
+    expect(isSafeRegistrationUrl("")).toBe(true);
+  });
+
+  test.each([
+    "https://my-app.example.com",
+    "https://my-app.example.com/path",
+    "http://placeholder.invalid",
+    "https://local-app.example.test",
+  ])("accepts public registration URL %s without resolving DNS", (url) => {
+    expect(isSafeRegistrationUrl(url)).toBe(true);
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    "not-a-url",
+    "ftp://example.com/file",
+    "https://user:pass@example.com/",
+    "http://localhost:3000",
+    "https://localhost",
+    "http://127.0.0.1:8080",
+    "http://[::1]/",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://10.0.0.8/callback",
+    "http://192.168.1.1/callback",
+  ])("rejects unsafe registration URL %s", (url) => {
+    expect(isSafeRegistrationUrl(url)).toBe(false);
   });
 });

--- a/packages/cloud/shared/src/lib/security/outbound-url.ts
+++ b/packages/cloud/shared/src/lib/security/outbound-url.ts
@@ -211,6 +211,27 @@ export function assertSafeOutboundUrlSync(rawUrl: string): URL {
 }
 
 /**
+ * zod-refine-friendly predicate form of {@link assertSafeOutboundUrlSync} for
+ * registration-time URL fields (e.g. an app's `app_url` / `allowed_origins`).
+ * Null/empty values pass — presence and shape are the schema's job; this only
+ * screens dangerous targets (non-http(s), embedded credentials, localhost,
+ * private/reserved IP literals). DNS-based screening still runs at fetch time
+ * via safeFetch, so a momentarily unresolvable public host is not rejected
+ * here.
+ */
+export function isSafeRegistrationUrl(value: string | null | undefined): boolean {
+  if (value == null || value === "") return true;
+  try {
+    assertSafeOutboundUrlSync(value);
+    return true;
+  } catch {
+    // error-policy:J3 untrusted registration input — a guard rejection is an
+    // explicit invalid result (false), never a swallowed error.
+    return false;
+  }
+}
+
+/**
  * Resolves `hostname` (or accepts an IP literal) and rejects the whole answer
  * set if any record points at a private/reserved range. Returns every resolved
  * address so callers can both validate and pin a single connection target.

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.test.ts
@@ -1,0 +1,132 @@
+/**
+ * SSRF-guard contract for app-charge callback delivery: the HTTP callback POST
+ * must go through the IP-screening `safeFetch` (never a raw fetch), and a guard
+ * rejection must surface as a recorded dispatch error — not a thrown exception
+ * (the charge leg is already settled; only the notification fails). DB reads
+ * and the safeFetch transport are mocked; the real dispatch logic runs.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const CALLBACK_URL = "https://developer.example.com/hooks/app-charge";
+const CHARGE_ID = "charge-123";
+const APP_ID = "app-456";
+
+let chargeRow: Record<string, unknown> | undefined;
+const safeFetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+let safeFetchImpl: (url: string, init?: RequestInit) => Promise<Response>;
+
+mock.module("../../db/helpers", () => ({
+  dbRead: {
+    query: {
+      cryptoPayments: {
+        findFirst: async () => chargeRow,
+      },
+    },
+  },
+  dbWrite: {},
+  writeTransaction: async () => {
+    throw new Error("transaction is outside this callback test path");
+  },
+}));
+
+mock.module("../../db/repositories/agents/memories", () => ({
+  memoriesRepository: { create: async () => ({}) },
+}));
+
+mock.module("./callback-channel-authz", () => ({
+  callbackRoomBelongsToOrganization: async () => false,
+}));
+
+mock.module("../security/safe-fetch", () => ({
+  safeFetch: (url: string, init?: RequestInit) => {
+    safeFetchCalls.push({ url, init });
+    return safeFetchImpl(url, init);
+  },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} },
+  redact: { id: (v: string) => v, orgId: (v: string) => v, userId: (v: string) => v },
+}));
+
+const { appChargeCallbacksService } = await import("./app-charge-callbacks");
+
+function seedCharge(metadata: Record<string, unknown>): void {
+  chargeRow = {
+    id: CHARGE_ID,
+    organization_id: "org-1",
+    expected_amount: "12.50",
+    metadata,
+  };
+}
+
+const DISPATCH_PARAMS = {
+  appId: APP_ID,
+  chargeRequestId: CHARGE_ID,
+  status: "paid" as const,
+  provider: "stripe" as const,
+  providerPaymentId: "pi_123",
+  amountUsd: "12.50",
+};
+
+describe("AppChargeCallbacksService — SSRF-guarded HTTP callback", () => {
+  beforeEach(() => {
+    chargeRow = undefined;
+    safeFetchCalls.length = 0;
+    safeFetchImpl = async () => new Response("ok", { status: 200 });
+  });
+
+  it("delivers the callback POST through safeFetch with the signed headers", async () => {
+    seedCharge({
+      kind: "app_charge_request",
+      app_id: APP_ID,
+      callback_url: CALLBACK_URL,
+      callback_secret: "whsec_test",
+    });
+
+    const result = await appChargeCallbacksService.dispatch(DISPATCH_PARAMS);
+
+    expect(result.httpPosted).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(safeFetchCalls).toHaveLength(1);
+    const call = safeFetchCalls[0];
+    expect(call.url).toBe(CALLBACK_URL);
+    expect(call.init?.method).toBe("POST");
+    const headers = call.init?.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["X-Eliza-Event"]).toBe("app_charge.paid");
+    expect(headers["X-Eliza-Signature"]).toMatch(/^sha256=[0-9a-f]{64}$/);
+  });
+
+  it("records a guard rejection as a dispatch error instead of throwing", async () => {
+    seedCharge({
+      kind: "app_charge_request",
+      app_id: APP_ID,
+      callback_url: CALLBACK_URL,
+    });
+    safeFetchImpl = async () => {
+      throw new Error("Private or reserved IP addresses are not allowed");
+    };
+
+    const result = await appChargeCallbacksService.dispatch(DISPATCH_PARAMS);
+
+    expect(result.httpPosted).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("Private or reserved IP");
+  });
+
+  it("returns a non-OK callback status as a recorded error", async () => {
+    seedCharge({
+      kind: "app_charge_request",
+      app_id: APP_ID,
+      callback_url: CALLBACK_URL,
+    });
+    safeFetchImpl = async () => new Response("nope", { status: 500 });
+
+    const result = await appChargeCallbacksService.dispatch(DISPATCH_PARAMS);
+
+    expect(result.httpPosted).toBe(false);
+    expect(result.errors[0]).toContain("500");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { dbRead } from "../../db/helpers";
 import { memoriesRepository } from "../../db/repositories/agents/memories";
 import { cryptoPayments } from "../../db/schemas/crypto-payments";
+import { safeFetch } from "../security/safe-fetch";
 import type { DialogueMetadata } from "../types/message-content";
 import { logger } from "../utils/logger";
 import { callbackRoomBelongsToOrganization } from "./callback-channel-authz";
@@ -296,7 +297,12 @@ export class AppChargeCallbacksService {
       );
     }
 
-    const response = await fetch(callbackUrl, {
+    // safeFetch re-resolves DNS and pins the connection (on Node) so a
+    // developer-supplied callback host cannot point at private/reserved
+    // addresses; every redirect hop is re-validated. A guard rejection throws
+    // and is recorded as a dispatch error by the caller — the charge leg
+    // itself is already settled, only the notification fails.
+    const response = await safeFetch(callbackUrl, {
       method: "POST",
       headers,
       body,

--- a/packages/cloud/shared/src/lib/services/eliza-app/whatsapp-auth.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/whatsapp-auth.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Verify-token handshake contract for the eliza-app WhatsApp webhook: the
+ * subscription GET must accept the exact configured token and reject
+ * mismatches (including prefix near-misses and nulls) through the
+ * constant-time comparison. Deterministic — config is env-driven; only the
+ * logger is mocked.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const VERIFY_TOKEN = "meta-verify-token-0123456789";
+const ENV_KEY = "ELIZA_APP_WHATSAPP_VERIFY_TOKEN";
+
+mock.module("../../utils/logger", () => ({
+  logger: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} },
+  redact: { id: (v: string) => v, orgId: (v: string) => v, userId: (v: string) => v },
+}));
+
+const { whatsAppAuthService } = await import("./whatsapp-auth");
+
+describe("WhatsAppAuthService.verifyWebhookSubscription", () => {
+  let savedToken: string | undefined;
+
+  beforeEach(() => {
+    savedToken = process.env[ENV_KEY];
+    process.env[ENV_KEY] = VERIFY_TOKEN;
+  });
+
+  afterEach(() => {
+    if (savedToken === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedToken;
+  });
+
+  test("returns the challenge for the exact configured token", () => {
+    expect(
+      whatsAppAuthService.verifyWebhookSubscription("subscribe", VERIFY_TOKEN, "challenge-1"),
+    ).toBe("challenge-1");
+  });
+
+  test("rejects a wrong token, a prefix near-miss, and null", () => {
+    expect(
+      whatsAppAuthService.verifyWebhookSubscription("subscribe", "wrong-token", "c"),
+    ).toBeNull();
+    // Length-mismatched near-miss: constant-time compare must still reject.
+    expect(
+      whatsAppAuthService.verifyWebhookSubscription("subscribe", VERIFY_TOKEN.slice(0, -1), "c"),
+    ).toBeNull();
+    expect(whatsAppAuthService.verifyWebhookSubscription("subscribe", null, "c")).toBeNull();
+  });
+
+  test("rejects a non-subscribe mode and a missing challenge", () => {
+    expect(
+      whatsAppAuthService.verifyWebhookSubscription("unsubscribe", VERIFY_TOKEN, "c"),
+    ).toBeNull();
+    expect(
+      whatsAppAuthService.verifyWebhookSubscription("subscribe", VERIFY_TOKEN, null),
+    ).toBeNull();
+  });
+
+  test("fails closed when no verify token is configured", () => {
+    delete process.env[ENV_KEY];
+    expect(
+      whatsAppAuthService.verifyWebhookSubscription("subscribe", VERIFY_TOKEN, "c"),
+    ).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/whatsapp-auth.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/whatsapp-auth.ts
@@ -5,6 +5,7 @@
  * Also handles the webhook verification GET handshake.
  */
 
+import { timingSafeEqualSecret } from "../../auth/cron";
 import { logger } from "../../utils/logger";
 import { verifyWhatsAppSignature } from "../../utils/whatsapp-api";
 import { elizaAppConfig } from "./config";
@@ -61,7 +62,9 @@ class WhatsAppAuthService {
       return null;
     }
 
-    if (verifyToken !== expectedToken) {
+    // Constant-time comparison (never `!==` on a secret): the handshake runs
+    // on the internet-facing Meta webhook subscription endpoint.
+    if (!verifyToken || !timingSafeEqualSecret(verifyToken, expectedToken)) {
       logger.warn("[WhatsAppAuth] Verify token mismatch");
       return null;
     }

--- a/packages/cloud/shared/src/lib/services/proxy/cors.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/cors.test.ts
@@ -8,7 +8,7 @@
  * headers the client sends.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { applyCorsHeaders, getCorsHeaders, handleCorsOptions, isAppOrigin } from "./cors";
 
 describe("isAppOrigin", () => {
@@ -24,6 +24,40 @@ describe("isAppOrigin", () => {
     // host is not attacker-controlled — allowed regardless of host, mirroring the
     // dedicated-agent APP_ORIGIN_RE.
     expect(isAppOrigin("capacitor://anything")).toBe(true);
+  });
+});
+
+describe("isAppOrigin — environment gating of loopback dev origins", () => {
+  const savedEnvironment = process.env.ENVIRONMENT;
+
+  afterEach(() => {
+    if (savedEnvironment === undefined) delete process.env.ENVIRONMENT;
+    else process.env.ENVIRONMENT = savedEnvironment;
+  });
+
+  test("any-port loopback origins are not app origins in production", () => {
+    process.env.ENVIRONMENT = "production";
+    expect(isAppOrigin("http://localhost:5173")).toBe(false);
+    expect(isAppOrigin("http://localhost")).toBe(false);
+    expect(isAppOrigin("https://localhost:2138")).toBe(false);
+    expect(isAppOrigin("http://127.0.0.1:3000")).toBe(false);
+    expect(isAppOrigin("http://[::1]:8080")).toBe(false);
+    // The native WebView + scheme origins stay first-party in production.
+    expect(isAppOrigin("https://localhost")).toBe(true);
+    expect(isAppOrigin("capacitor://localhost")).toBe(true);
+    expect(isAppOrigin("electrobun://localhost")).toBe(true);
+  });
+
+  test("a loopback origin in production falls back to wildcard WITHOUT credentials", () => {
+    process.env.ENVIRONMENT = "production";
+    const h = getCorsHeaders("POST, OPTIONS", "http://localhost:5173");
+    expect(h["Access-Control-Allow-Origin"]).toBe("*");
+    expect(h["Access-Control-Allow-Credentials"]).toBeUndefined();
+  });
+
+  test("loopback dev origins stay app origins outside production (local dev)", () => {
+    delete process.env.ENVIRONMENT;
+    expect(isAppOrigin("http://localhost:5173")).toBe(true);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/proxy/cors.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/cors.ts
@@ -1,11 +1,13 @@
 // Coordinates cloud service cors behavior behind route handlers.
 import {
-  APP_LOCAL_ORIGIN_RE,
   APP_SCHEME_ORIGIN_RE,
+  CAPACITOR_WEBVIEW_ORIGIN,
   CORS_ALLOW_HEADERS,
   CORS_EXPOSE_HEADER_NAMES,
   CORS_MAX_AGE,
+  isLocalDevLoopbackOrigin,
 } from "../../cors-constants";
+import { getCloudAwareEnv } from "../../runtime/cloud-bindings";
 
 /**
  * Shared CORS utilities for proxy services
@@ -40,7 +42,9 @@ import {
  *  - `https://localhost` — android/iosScheme = "https" (see packages/app/capacitor.config.ts)
  *  - `capacitor://localhost` / `capacitor-electron://localhost` — Capacitor defaults
  *  - `http://localhost[:port]` / `http://127.0.0.1[:port]` — local web dev/preview
+ *    (non-production only — see isLocalDevLoopbackOrigin)
  *  - `https://localhost[:port]` / `https://127.0.0.1[:port]` — https local dev
+ *    (non-production only)
  * Mirrors the dedicated-agent LOCAL_ORIGIN_RE + APP_ORIGIN_RE allow-list.
  * Regexes live in cors-constants.ts (single source of truth).
  */
@@ -49,9 +53,19 @@ import {
  * An origin that authenticates with credentials (cookies/native fetch) from the
  * Eliza app/local-dev WebView. These get the origin reflected + credentials, since
  * `*` is invalid for a credentialed cross-origin read (e.g. an SSE chat stream).
+ * Any-port loopback origins are honored only outside production — any local
+ * process can serve one, so in production reflecting them with credentials
+ * would let a hostile local page ride a user's cloud session cookies (matches
+ * isFirstPartyOrigin in lib/cors/cloud-api-hono-cors.ts).
  */
 export function isAppOrigin(origin: string): boolean {
-  return APP_LOCAL_ORIGIN_RE.test(origin) || APP_SCHEME_ORIGIN_RE.test(origin);
+  if (APP_SCHEME_ORIGIN_RE.test(origin) || origin === CAPACITOR_WEBVIEW_ORIGIN) {
+    return true;
+  }
+  if (isLocalDevLoopbackOrigin(origin)) {
+    return getCloudAwareEnv().ENVIRONMENT !== "production";
+  }
+  return false;
 }
 
 export function getCorsHeaders(methods?: string, origin?: string | null): Record<string, string> {

--- a/packages/cloud/shared/src/lib/services/tenant-db/direct-pg-executor.tls.test.ts
+++ b/packages/cloud/shared/src/lib/services/tenant-db/direct-pg-executor.tls.test.ts
@@ -1,0 +1,124 @@
+/**
+ * TLS pinning contract for DirectPgExecutor: the tenant cluster serves a
+ * self-signed cert on the private apps network, so provisioning connections
+ * must verify the server against a PINNED cluster CA (TENANT_DB_TLS_CA inline
+ * PEM / PGSSLROOTCERT file) with rejectUnauthorized:true — never the default
+ * public-CA chain (which self-signed fails) and, once pinned, never
+ * skip-verify. Without a pin the historical encrypted-but-unverified path is
+ * kept, and an unreadable pin file must fail fast. `pg` is faked (Client) so
+ * the real executor ssl-config logic runs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+interface CapturedConfig {
+  connectionString?: string;
+  ssl?: unknown;
+}
+
+const clientConfigs: CapturedConfig[] = [];
+
+class FakeClient {
+  constructor(public readonly config: CapturedConfig) {
+    clientConfigs.push(config);
+  }
+  async connect(): Promise<void> {}
+  async query() {
+    return { rowCount: 0, rows: [] };
+  }
+  async end(): Promise<void> {}
+}
+
+mock.module("pg", () => ({ Client: FakeClient }));
+
+const ADMIN_DSN = "postgres://admin:pw@10.30.1.10:5432/postgres";
+const PINNED_CA =
+  "-----BEGIN CERTIFICATE-----\nMIIBfakepinnedclusterCA\n-----END CERTIFICATE-----\n";
+
+const TLS_ENV_KEYS = ["TENANT_DB_TLS_CA", "PGSSLROOTCERT", "PGSSLMODE"] as const;
+
+describe("DirectPgExecutor — tenant-cluster TLS pinning", () => {
+  const savedEnv = new Map<string, string | undefined>();
+  let certDir: string | null = null;
+
+  beforeEach(() => {
+    clientConfigs.length = 0;
+    for (const key of TLS_ENV_KEYS) {
+      savedEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of TLS_ENV_KEYS) {
+      const saved = savedEnv.get(key);
+      if (saved === undefined) delete process.env[key];
+      else process.env[key] = saved;
+    }
+    savedEnv.clear();
+    if (certDir) {
+      rmSync(certDir, { recursive: true, force: true });
+      certDir = null;
+    }
+  });
+
+  async function connectOnce(dsn: string = ADMIN_DSN): Promise<CapturedConfig> {
+    const { DirectPgExecutor } = await import("./direct-pg-executor");
+    const exec = new DirectPgExecutor(dsn);
+    await exec.databaseExists("tenant_db");
+    expect(clientConfigs).toHaveLength(1);
+    return clientConfigs[0];
+  }
+
+  it("verifies against the pinned inline CA (TENANT_DB_TLS_CA) with rejectUnauthorized:true", async () => {
+    process.env.TENANT_DB_TLS_CA = PINNED_CA;
+
+    const config = await connectOnce();
+    const ssl = config.ssl as {
+      ca: string;
+      rejectUnauthorized: boolean;
+      checkServerIdentity: unknown;
+    };
+    expect(ssl.ca).toBe(PINNED_CA);
+    expect(ssl.rejectUnauthorized).toBe(true);
+    // verify-ca semantics: the pinned anchor is the identity, so the
+    // self-signed cert's missing IP SAN does not fail the handshake.
+    expect(typeof ssl.checkServerIdentity).toBe("function");
+  });
+
+  it("reads the pinned CA from the PGSSLROOTCERT file", async () => {
+    certDir = mkdtempSync(join(tmpdir(), "direct-pg-executor-tls-"));
+    writeFileSync(join(certDir, "cluster-ca.pem"), PINNED_CA);
+    process.env.PGSSLROOTCERT = join(certDir, "cluster-ca.pem");
+
+    const config = await connectOnce();
+    const ssl = config.ssl as { ca: string; rejectUnauthorized: boolean };
+    expect(ssl.ca).toBe(PINNED_CA);
+    expect(ssl.rejectUnauthorized).toBe(true);
+  });
+
+  it("fails fast when the configured PGSSLROOTCERT file is unreadable", async () => {
+    process.env.PGSSLROOTCERT = "/nonexistent/tenant-cluster-ca.pem";
+
+    const { DirectPgExecutor } = await import("./direct-pg-executor");
+    const exec = new DirectPgExecutor(ADMIN_DSN);
+    await expect(exec.databaseExists("tenant_db")).rejects.toThrow();
+    expect(clientConfigs).toHaveLength(0);
+  });
+
+  it("keeps the encrypted-but-unverified path when no CA is pinned", async () => {
+    const config = await connectOnce();
+    expect(config.ssl).toEqual({ rejectUnauthorized: false });
+  });
+
+  it("sslmode=disable connects in plaintext even with a pinned CA configured", async () => {
+    process.env.TENANT_DB_TLS_CA = PINNED_CA;
+
+    const config = await connectOnce(`${ADMIN_DSN}?sslmode=disable`);
+    expect(config.ssl).toBeUndefined();
+    expect(config.connectionString).not.toContain("sslmode");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/tenant-db/direct-pg-executor.ts
+++ b/packages/cloud/shared/src/lib/services/tenant-db/direct-pg-executor.ts
@@ -9,8 +9,58 @@
  * validated against a real Postgres (integration), not mocked.
  */
 
-import { Client } from "pg";
+import { readFileSync } from "node:fs";
+import { Client, type ClientConfig } from "pg";
+import { logger } from "../../utils/logger";
 import type { TenantDbSqlExecutor } from "./tenant-db-provisioner";
+
+let warnedUnverifiedTls = false;
+
+/**
+ * Read the operator-pinned CA anchor for the tenant cluster: `TENANT_DB_TLS_CA`
+ * (inline PEM) or `PGSSLROOTCERT` (path to the PEM, the standard libpq name).
+ * An unreadable configured file throws — provisioning must fail fast rather
+ * than silently fall back to an unverified connection.
+ */
+function readPinnedClusterCa(): string | null {
+  const inline = process.env.TENANT_DB_TLS_CA;
+  if (inline && inline.trim().length > 0) return inline;
+  const caPath = process.env.PGSSLROOTCERT?.trim();
+  if (!caPath) return null;
+  return readFileSync(caPath, "utf8");
+}
+
+/**
+ * TLS config for the tenant-cluster connection.
+ *
+ * The cluster is a self-managed node on the PRIVATE apps network (10.30.x)
+ * serving a self-signed cert, so a public-CA chain check can never pass.
+ * Verification is therefore PINNED: when the operator configures the cluster
+ * cert or internal CA, the server certificate is verified against exactly that
+ * anchor (`rejectUnauthorized: true`), so an interposer on the private segment
+ * presenting its own cert is detected instead of silently trusted. Hostname
+ * checking is relaxed (libpq `verify-ca` semantics): the pinned anchor IS the
+ * identity, and the self-signed cert carries no SAN for the private IP.
+ *
+ * Without a pinned CA there is nothing to verify against: the connection stays
+ * encrypted but unverified, and a one-time warning keeps that residual visible
+ * to operators instead of silent.
+ */
+function tenantClusterSsl(): ClientConfig["ssl"] {
+  const ca = readPinnedClusterCa();
+  if (ca) {
+    return { ca, rejectUnauthorized: true, checkServerIdentity: () => undefined };
+  }
+  if (!warnedUnverifiedTls) {
+    warnedUnverifiedTls = true;
+    logger.warn(
+      "[DirectPgExecutor] No pinned tenant-cluster CA (TENANT_DB_TLS_CA / PGSSLROOTCERT): " +
+        "provisioning connections are TLS-encrypted but NOT certificate-verified. " +
+        "Pin the cluster CA to make interposition on the private network detectable.",
+    );
+  }
+  return { rejectUnauthorized: false };
+}
 
 export class DirectPgExecutor implements TenantDbSqlExecutor {
   private readonly adminDsn: string;
@@ -27,15 +77,13 @@ export class DirectPgExecutor implements TenantDbSqlExecutor {
     // self-signed chain ("self-signed certificate") — which would fail EVERY
     // tenant-DB provision in prod. Strip `sslmode` from the DSN textually (NOT
     // via `new URL().toString()`, which re-encodes the userinfo and can corrupt
-    // the admin password) and set `ssl` explicitly: still TLS in-transit, but
-    // skip CA-chain verification (safe — already private-network isolated). A
-    // DSN-level `sslmode` would otherwise win over an explicit `ssl` object.
-    // Verified live against the prod tenant DB (10.30.1.10) via the apps-control
-    // node e2e (connection reaches auth; the self-signed reject is gone).
+    // the admin password) and set `ssl` explicitly. A DSN-level `sslmode` would
+    // otherwise win over an explicit `ssl` object. See tenantClusterSsl() for
+    // the pinned-CA verification policy.
     // A local/CI throwaway Postgres has no TLS at all. When the DSN explicitly
     // opts out (`sslmode=disable`) or PGSSLMODE=disable is set, connect in
-    // plaintext. Prod sets neither, so the TLS-with-skip-verify path is
-    // preserved for the self-signed private-network tenant cluster.
+    // plaintext. Prod sets neither, so the TLS path is preserved for the
+    // self-signed private-network tenant cluster.
     const noSsl =
       /[?&]sslmode=disable/i.test(connectionString) || process.env.PGSSLMODE === "disable";
     const cleaned = connectionString
@@ -43,7 +91,7 @@ export class DirectPgExecutor implements TenantDbSqlExecutor {
       .replace(/\?$/, "");
     const client = new Client({
       connectionString: cleaned,
-      ...(noSsl ? {} : { ssl: { rejectUnauthorized: false } }),
+      ...(noSsl ? {} : { ssl: tenantClusterSsl() }),
     });
     await client.connect();
     return client;

--- a/packages/cloud/shared/src/lib/services/whatsapp-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/whatsapp-automation/index.error-policy.test.ts
@@ -19,12 +19,14 @@ const ORG_ID = "00000000-0000-4000-8000-00000000d001";
 // legitimately-unconfigured org (the designed-empty case, not a failure).
 let storedAccessToken: string | null = "org-access-token";
 let storedPhoneNumberId: string | null = "1234567890";
+let storedVerifyToken: string | null = null;
 
 mock.module("../secrets", () => ({
   secretsService: {
     get: async (_org: string, name: string) => {
       if (name.includes("ACCESS_TOKEN")) return storedAccessToken;
       if (name.includes("PHONE_NUMBER_ID")) return storedPhoneNumberId;
+      if (name.includes("VERIFY_TOKEN")) return storedVerifyToken;
       return null;
     },
   },
@@ -157,5 +159,50 @@ describe("sendMessage error policy (#13415)", () => {
     expect(result.success).toBe(true);
     expect(result.messageId).toBe("wamid.TEST123");
     expect(result.error).toBeUndefined();
+  });
+});
+
+describe("verifyWebhookSubscription — constant-time verify-token check", () => {
+  const VERIFY_TOKEN = "org-verify-token-0123456789";
+
+  beforeEach(() => {
+    storedVerifyToken = VERIFY_TOKEN;
+  });
+
+  afterEach(() => {
+    storedVerifyToken = null;
+  });
+
+  test("returns the challenge for the exact stored token", async () => {
+    const result = await whatsappAutomationService.verifyWebhookSubscription(
+      ORG_ID,
+      "subscribe",
+      VERIFY_TOKEN,
+      "challenge-1",
+    );
+    expect(result).toBe("challenge-1");
+  });
+
+  test("rejects a wrong token and a prefix near-miss", async () => {
+    for (const attempted of ["wrong-token", VERIFY_TOKEN.slice(0, -1)]) {
+      const result = await whatsappAutomationService.verifyWebhookSubscription(
+        ORG_ID,
+        "subscribe",
+        attempted,
+        "challenge-1",
+      );
+      expect(result).toBeNull();
+    }
+  });
+
+  test("fails closed when the org has no stored verify token", async () => {
+    storedVerifyToken = null;
+    const result = await whatsappAutomationService.verifyWebhookSubscription(
+      ORG_ID,
+      "subscribe",
+      VERIFY_TOKEN,
+      "challenge-1",
+    );
+    expect(result).toBeNull();
   });
 });

--- a/packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts
@@ -10,6 +10,7 @@
  */
 
 import crypto from "crypto";
+import { timingSafeEqualSecret } from "../../auth/cron";
 import { cache } from "../../cache/client";
 import {
   WHATSAPP_ACCESS_TOKEN,
@@ -365,7 +366,9 @@ class WhatsAppAutomationService {
     }
 
     const storedToken = await this.getVerifyToken(organizationId);
-    if (!storedToken || verifyToken !== storedToken) {
+    // Constant-time comparison (never `!==` on a secret): the handshake runs
+    // on the internet-facing Meta webhook subscription endpoint.
+    if (!storedToken || !timingSafeEqualSecret(verifyToken, storedToken)) {
       return null;
     }
 

--- a/packages/cloud/shared/src/lib/utils/cors.test.ts
+++ b/packages/cloud/shared/src/lib/utils/cors.test.ts
@@ -1,5 +1,5 @@
 // Exercises cors behavior with deterministic cloud-shared lib fixtures.
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import { getCorsHeaders } from "./cors";
 
 describe("getCorsHeaders", () => {
@@ -38,5 +38,52 @@ describe("getCorsHeaders", () => {
 
     expect(headers).not.toHaveProperty("Access-Control-Allow-Origin");
     expect(headers).not.toHaveProperty("Access-Control-Allow-Credentials");
+  });
+});
+
+describe("getCorsHeaders — environment gating of loopback dev origins", () => {
+  const savedEnvironment = process.env.ENVIRONMENT;
+
+  afterEach(() => {
+    if (savedEnvironment === undefined) delete process.env.ENVIRONMENT;
+    else process.env.ENVIRONMENT = savedEnvironment;
+  });
+
+  test("any-port loopback origins are not reflected with credentials in production", () => {
+    process.env.ENVIRONMENT = "production";
+
+    for (const origin of [
+      "http://localhost:2138",
+      "http://localhost",
+      "http://127.0.0.1:3000",
+      "https://localhost:5173",
+      "http://[::1]:8080",
+    ]) {
+      const headers = getCorsHeaders(origin);
+      expect(headers).not.toHaveProperty("Access-Control-Allow-Origin");
+      expect(headers).not.toHaveProperty("Access-Control-Allow-Credentials");
+    }
+  });
+
+  test("native WebView + static origins stay reflected in production", () => {
+    process.env.ENVIRONMENT = "production";
+
+    expect(getCorsHeaders("https://localhost")["Access-Control-Allow-Origin"]).toBe(
+      "https://localhost",
+    );
+    expect(getCorsHeaders("capacitor://localhost")["Access-Control-Allow-Origin"]).toBe(
+      "capacitor://localhost",
+    );
+    expect(getCorsHeaders("https://cloud.eliza.app")["Access-Control-Allow-Origin"]).toBe(
+      "https://cloud.eliza.app",
+    );
+  });
+
+  test("loopback dev origins stay reflected outside production (local dev)", () => {
+    delete process.env.ENVIRONMENT;
+
+    expect(getCorsHeaders("http://localhost:2138")["Access-Control-Allow-Origin"]).toBe(
+      "http://localhost:2138",
+    );
   });
 });

--- a/packages/cloud/shared/src/lib/utils/cors.ts
+++ b/packages/cloud/shared/src/lib/utils/cors.ts
@@ -1,5 +1,11 @@
 // Provides cloud utility cors helpers shared by backend services.
-import { APP_LOCAL_ORIGIN_RE, APP_SCHEME_ORIGIN_RE, CORS_ALLOW_HEADERS } from "../cors-constants";
+import {
+  APP_SCHEME_ORIGIN_RE,
+  CAPACITOR_WEBVIEW_ORIGIN,
+  CORS_ALLOW_HEADERS,
+  isLocalDevLoopbackOrigin,
+} from "../cors-constants";
+import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 
 const ALLOWED_ORIGINS = [
   process.env.NEXT_PUBLIC_APP_URL,
@@ -23,15 +29,24 @@ const ALLOWED_ORIGINS = [
   // Eliza + Eliza mobile apps load from these custom schemes and
   // call public auth endpoints directly from the WebView.
   "capacitor://localhost",
-  "http://localhost",
 ].filter(Boolean) as string[];
 
 function isAllowedOrigin(origin: string): boolean {
-  return (
-    ALLOWED_ORIGINS.includes(origin) ||
-    APP_LOCAL_ORIGIN_RE.test(origin) ||
-    APP_SCHEME_ORIGIN_RE.test(origin)
-  );
+  if (ALLOWED_ORIGINS.includes(origin) || APP_SCHEME_ORIGIN_RE.test(origin)) {
+    return true;
+  }
+  // Portless https://localhost is the Capacitor WebView origin — first-party
+  // in every environment (a browser page cannot mint it).
+  if (origin === CAPACITOR_WEBVIEW_ORIGIN) {
+    return true;
+  }
+  // Any-port loopback origins (incl. portless http://localhost) are a
+  // local-dev convenience: credentialed reflection stays non-production only,
+  // matching isFirstPartyOrigin in lib/cors/cloud-api-hono-cors.ts.
+  if (isLocalDevLoopbackOrigin(origin)) {
+    return getCloudAwareEnv().ENVIRONMENT !== "production";
+  }
+  return false;
 }
 
 export function getCorsHeaders(origin: string | null): Record<string, string> {

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -310,6 +310,10 @@ export interface Bindings {
   STEWARD_JWT_SECRET?: string;
   /** HS256 service-account bridge secret; must never equal the staging QA signer. */
   ELIZA_SERVICE_JWT_SECRET?: string;
+  /** Optional issuer pin for service-account JWTs (jose enforces it only when set). */
+  ELIZA_SERVICE_JWT_ISSUER?: string;
+  /** Optional audience pin for service-account JWTs (jose enforces it only when set). */
+  ELIZA_SERVICE_JWT_AUDIENCE?: string;
   /** Steward vault encryption master password. Required for wallet/key operations. */
   STEWARD_MASTER_PASSWORD?: string;
   /** Tenant scoping. */

--- a/plugins/plugin-whatsapp/__tests__/webhook-verify-token.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/webhook-verify-token.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Verify-token handshake contract for the plugin's Meta webhook subscription:
+ * verifyWebhook must accept only an exact configured token — compared through
+ * the constant-time helper, so prefix near-misses and length mismatches
+ * reject. Deterministic: the service is constructed with an inert runtime and
+ * its configs injected directly (same harness as webhook-account-idempotency).
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { WhatsAppConnectorService } from "../src/runtime-service";
+import { timingSafeEqualSecretString } from "../src/webhook-auth";
+
+const VERIFY_TOKEN = "meta-verify-token-0123456789";
+
+function inertRuntime(): IAgentRuntime {
+	return {
+		getSetting: vi.fn(() => undefined),
+		logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+	} as never as IAgentRuntime;
+}
+
+function serviceWithVerifyToken(token: string | undefined): WhatsAppConnectorService {
+	const service = new WhatsAppConnectorService(inertRuntime());
+	Object.assign(service, {
+		defaultAccountId: "default",
+		configs: new Map([
+			[
+				"default",
+				{
+					accountId: "default",
+					transport: "cloudapi",
+					accessToken: "access-token",
+					phoneNumberId: "phone-1",
+					webhookVerifyToken: token,
+				},
+			],
+		]),
+	});
+	return service;
+}
+
+describe("WhatsAppConnectorService.verifyWebhook — constant-time token check", () => {
+	it("returns the challenge for the exact configured token", () => {
+		const service = serviceWithVerifyToken(VERIFY_TOKEN);
+		expect(service.verifyWebhook("subscribe", VERIFY_TOKEN, "challenge-1")).toBe("challenge-1");
+	});
+
+	it("rejects a wrong token and a prefix near-miss", () => {
+		const service = serviceWithVerifyToken(VERIFY_TOKEN);
+		expect(service.verifyWebhook("subscribe", "wrong-token", "challenge-1")).toBeNull();
+		expect(service.verifyWebhook("subscribe", VERIFY_TOKEN.slice(0, -1), "challenge-1")).toBeNull();
+	});
+
+	it("rejects a non-subscribe mode and fails closed with no configured token", () => {
+		const service = serviceWithVerifyToken(VERIFY_TOKEN);
+		expect(service.verifyWebhook("unsubscribe", VERIFY_TOKEN, "challenge-1")).toBeNull();
+		const unconfigured = serviceWithVerifyToken(undefined);
+		expect(unconfigured.verifyWebhook("subscribe", VERIFY_TOKEN, "challenge-1")).toBeNull();
+	});
+});
+
+describe("timingSafeEqualSecretString", () => {
+	it("accepts exact matches and rejects mismatches of any length", () => {
+		expect(timingSafeEqualSecretString("abc", "abc")).toBe(true);
+		expect(timingSafeEqualSecretString("abc", "abd")).toBe(false);
+		expect(timingSafeEqualSecretString("abc", "ab")).toBe(false);
+		expect(timingSafeEqualSecretString("abc", "abcd")).toBe(false);
+		expect(timingSafeEqualSecretString("", "")).toBe(true);
+	});
+});

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -66,6 +66,7 @@ import type {
   WhatsAppMessageResponse,
   WhatsAppWebhookEvent,
 } from "./types";
+import { timingSafeEqualSecretString } from "./webhook-auth";
 
 type RuntimeServiceConfig =
   | {
@@ -1019,7 +1020,9 @@ export class WhatsAppConnectorService extends Service {
     if (
       mode === "subscribe" &&
       challenge &&
-      expectedTokens.some((expectedToken) => expectedToken && token === expectedToken)
+      expectedTokens.some(
+        (expectedToken) => expectedToken && timingSafeEqualSecretString(token, expectedToken)
+      )
     ) {
       return challenge;
     }

--- a/plugins/plugin-whatsapp/src/webhook-auth.ts
+++ b/plugins/plugin-whatsapp/src/webhook-auth.ts
@@ -22,6 +22,21 @@ export function resolveWhatsAppAppSecret(runtime: IAgentRuntime): string | null 
 }
 
 /**
+ * Constant-time string equality for webhook shared secrets (the subscription
+ * verify token). Never use `===`/`!==` on a secret: the comparison runs on the
+ * public Meta handshake endpoint, where response timing could leak it
+ * byte-by-byte.
+ */
+export function timingSafeEqualSecretString(provided: string, expected: string): boolean {
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const providedBuffer = Buffer.from(provided, "utf8");
+  return (
+    expectedBuffer.length === providedBuffer.length &&
+    crypto.timingSafeEqual(expectedBuffer, providedBuffer)
+  );
+}
+
+/**
  * Verify Meta WhatsApp webhook signature (X-Hub-Signature-256).
  * @see https://developers.facebook.com/docs/graph-api/webhooks/getting-started#verification-requests
  */


### PR DESCRIPTION
## Summary

Wave-1 security-audit fixes for the `sec-cloud-shared` group: seven confirmed findings in cloud shared services, the cloud API worker, and plugin-whatsapp. Each fix is its own commit, mapped below to its audit ID.

- **W1-025 (MEDIUM)** — Tenant-DB provisioning TLS verification. `DirectPgExecutor` connected to the self-managed tenant Postgres cluster with certificate verification unconditionally disabled. It now supports operator-pinned verification via `TENANT_DB_TLS_CA` (inline PEM) or `PGSSLROOTCERT` (file path, standard libpq name) with `rejectUnauthorized: true` and verify-ca semantics, so the self-signed cluster cert keeps working while interposition becomes detectable. An unreadable pinned-CA file fails fast; without a pin, connections stay encrypted-but-unverified and a one-time warning surfaces the residual. Operator follow-up: distribute the cluster CA to the provisioning daemon and set one of these vars.
- **W1-045 (LOW)** — Unguarded payment-callback POST. App-charge callback delivery now goes through the platform `safeFetch` (DNS-resolved, IP-screened, per-hop redirect re-validation) instead of a raw `fetch`, and `app_url` / `allowed_origins` are screened at app registration and update time via a new `isSafeRegistrationUrl` predicate (rejects non-http(s), embedded credentials, localhost, and private/reserved IP literals; no DNS at write time by design). A guard rejection at dispatch is recorded as a callback error — the settled charge leg is unaffected.
- **W1-067 (LOW)** — WhatsApp webhook verify-token comparisons. All three Meta subscription-handshake comparisons (cloud eliza-app `whatsapp-auth`, `whatsapp-automation`, and plugin-whatsapp's runtime service) now use constant-time comparison (`timingSafeEqualSecret` / a new plugin-local `timingSafeEqualSecretString`) instead of `===`/`!==`.
- **W1-068 (LOW)** — Service-JWT lifecycle hardening. The verifier now requires an `exp` claim (jose only enforces it when present) with a maximum one-hour horizon, and operators can pin the token class via `ELIZA_SERVICE_JWT_ISSUER` / `ELIZA_SERVICE_JWT_AUDIENCE` (enforced only when configured; a one-time warning reports the unpinned state). The staging-QA token-class rejection is unchanged and still runs first. Deployments minting never-expiring service tokens must start minting short-lived ones.
- **W1-070 (LOW)** — Credentialed-CORS loopback tightening. Any-port `localhost`/`127.0.0.1` origins are first-party (reflected with `Access-Control-Allow-Credentials`) only outside production (`ENVIRONMENT` binding). The native WebView origins a browser cannot mint — the exact Capacitor `https://localhost` origin and the app-scheme origins — stay first-party everywhere. The dedicated-agent proxy's browser-policy path now runs inside the request's bindings context so the environment check cannot silently fall back to `process.env`.
- **W1-044 (LOW)** — Worker stub SSRF guard DNS screening. The workerd port of `fetchWithSsrfGuard` now resolves every non-literal hostname (`node:dns` under `nodejs_compat`, injectable for tests) and screens every answer, failing closed on resolution errors, empty answers, or any private/reserved answer; redirect hops are re-screened. The header documents the remaining residual: workerd cannot pin connect-by-IP, so the documented Cloudflare egress policy (deny RFC1918/link-local) owns the millisecond rebinding window (#12229 M5).
- **W1-072 (INFO)** — ILIKE wildcard escaping. `escapeLikePattern` is hoisted to `db/utils/like-pattern.ts` and applied to user search text in `user-mcps` (list + count), `cloud-files`, and `agents/entities` repositories (parameterized already, so hardening only; raw-SQL sites spell `ESCAPE '\'` explicitly).

## Test evidence

Environment: worktree at `origin/develop` (6679aa19e987), `bun run install:light`, `@elizaos/core` + `plugin-sql` built, keyword codegen run.

Focused suites (all passing):

- `bun test` (packages/cloud/shared) over 11 touched/new suites — **140 pass, 0 fail**: `direct-pg-executor.tls` (new, 5), `direct-pg-executor.error-policy` (5), `app-charge-callbacks` (new, 3), `outbound-url` (incl. new `isSafeRegistrationUrl` block), `service-jwt` (new, 7), `waifu-bridge-wallet-claim` (2), `cloud-api-hono-cors` (incl. new production-gating block), `whatsapp-auth` (new, 4), `whatsapp-automation/index.error-policy` (incl. new verify-token block), `like-pattern` (new, 2), `user-mcps` (24).
- `bun test` (packages/cloud/api), per file — `elizaos-core-stub` **11/11** (incl. new DNS-screening cases), `apps-crud.integration` **43/43** (incl. new registration-screening 400s), `dedicated-agent-proxy` **39/39**, `eliza-app-webhook-whatsapp-verification` **6/6**, `staging-session-exchange` **55/55** (incl. the QA-token-through-service-JWT laundering guard).
- `bun run --cwd plugins/plugin-whatsapp test` — **66 pass, 0 fail** (10 files, incl. new `webhook-verify-token` suite).
- Typecheck: `packages/cloud/shared`, `packages/cloud/api`, `plugins/plugin-whatsapp` — all exit 0, zero `error TS`.
- Lint: `biome check` on all 29 changed/new files — clean.

Full-package lanes (`packages/cloud/shared` and `packages/cloud/api` isolated runners) were also run. They fail in this environment on a small set of suites unrelated to this diff (pglite `agent-sandbox-pre-delete-recovery`, miniflare boot timeouts, eliza-agents DB-backed setup, bluebubbles gateway config, a pre-existing barrel-export mismatch in onboarding-chat). Each failing suite was re-run at the unmodified base commit and fails identically there — verified pre-existing, not caused by this PR.

## Risk notes

- **W1-025**: behavior is unchanged unless an operator sets `TENANT_DB_TLS_CA` / `PGSSLROOTCERT`; when set, an unreadable file or wrong anchor fails provisioning fast (intended). Rolling out the pinned CA is a coordinated operator follow-up.
- **W1-068**: never-expiring service tokens are now rejected, as are TTLs over 1h. waifu-core (external minter) must issue short-lived tokens; iss/aud pinning is opt-in via env so deployments can enforce it once the minter's claims are known.
- **W1-070**: local browser dev against a *production* API from a loopback dev server loses credentialed CORS (by design); non-production environments are unchanged. Native app WebViews are unaffected.
- **W1-044**: transcription-time `audioUrl` fetches in the Worker now depend on `node:dns` resolution succeeding in workerd (`nodejs_compat` is enabled in `wrangler.toml`); resolution failure fails closed.
- **W1-045**: existing apps whose registered URLs are already unsafe are untouched (write-time screen only); fetch-time `safeFetch` enforcement applies to all callback deliveries immediately.
