### PR TITLE
fix(agent): close unauthenticated agent-api disclosure and auth-bypass vectors (W1-010/011/024/037/038/039)

### DIFF
--- a/packages/agent/src/api/auth-routes-pair.test.ts
+++ b/packages/agent/src/api/auth-routes-pair.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit test for `POST /api/auth/pair` raw-token acceptance (W1-038): the
+ * static API token doubles as a pairing code only for trusted loopback
+ * operators — remote callers must present the rotating pairing code, so a
+ * weak human-chosen `ELIZA_API_TOKEN` is no longer an online-guessing oracle
+ * for anyone who can reach the port. The trusted-local classifier is mocked
+ * so the test drives both trust decisions deterministically.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isAuthorized: vi.fn(),
+  isTrustedLocalRequest: vi.fn(),
+}));
+
+vi.mock("./server-helpers-auth.ts", () => ({
+  isAuthorized: mocks.isAuthorized,
+  isTrustedLocalRequest: mocks.isTrustedLocalRequest,
+  resolveBoundaryRole: (req: unknown) =>
+    mocks.isAuthorized(req) ? "OWNER" : "GUEST",
+}));
+
+import { type AuthRouteContext, handleAuthRoutes } from "./auth-routes.ts";
+
+const API_TOKEN = "pair-test-static-api-token";
+const PAIRING_CODE = "ABCD-EFGH";
+const ENV_KEYS = [
+  "ELIZA_API_TOKEN",
+  "ELIZA_API_AUTH_TOKEN",
+  "ELIZA_CLOUD_PROVISIONED",
+] as const;
+const savedEnv = new Map<string, string | undefined>();
+
+function saveEnv(): void {
+  savedEnv.clear();
+  for (const key of ENV_KEYS) savedEnv.set(key, process.env[key]);
+}
+
+function restoreEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function mkCtx(code: string): {
+  ctx: AuthRouteContext;
+  captured: { body?: unknown; status?: number };
+  clearPairing: ReturnType<typeof vi.fn>;
+} {
+  const captured: { body?: unknown; status?: number } = {};
+  const clearPairing = vi.fn();
+  const ctx = {
+    req: {
+      method: "POST",
+      url: "/api/auth/pair",
+      headers: {},
+      socket: { remoteAddress: "127.0.0.1" },
+    },
+    res: {},
+    method: "POST",
+    pathname: "/api/auth/pair",
+    readJsonBody: async () => ({ code }),
+    json: (_res: unknown, body: unknown, status?: number) => {
+      captured.body = body;
+      captured.status = status ?? 200;
+    },
+    error: (_res: unknown, message: string, status?: number) => {
+      captured.body = { error: message };
+      captured.status = status ?? 500;
+    },
+    pairingEnabled: () => true,
+    ensurePairingCode: () => PAIRING_CODE,
+    normalizePairingCode: (c: string) =>
+      c.replace(/[^a-zA-Z0-9]/g, "").toUpperCase(),
+    rateLimitPairing: () => true,
+    getPairingExpiresAt: () => Date.now() + 60_000,
+    clearPairing,
+  } as unknown as AuthRouteContext;
+  return { ctx, captured, clearPairing };
+}
+
+describe("POST /api/auth/pair raw-token acceptance (W1-038)", () => {
+  afterEach(() => {
+    restoreEnv();
+    vi.clearAllMocks();
+  });
+
+  it("accepts the raw API token from a trusted loopback operator", async () => {
+    saveEnv();
+    process.env.ELIZA_API_TOKEN = API_TOKEN;
+    delete process.env.ELIZA_API_AUTH_TOKEN;
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+    mocks.isTrustedLocalRequest.mockReturnValue(true);
+
+    const { ctx, captured } = mkCtx(API_TOKEN);
+    expect(await handleAuthRoutes(ctx)).toBe(true);
+    expect(captured.status).toBe(200);
+    expect(captured.body).toEqual({ token: API_TOKEN });
+  });
+
+  it("rejects the raw API token from a remote caller", async () => {
+    saveEnv();
+    process.env.ELIZA_API_TOKEN = API_TOKEN;
+    delete process.env.ELIZA_API_AUTH_TOKEN;
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+    mocks.isTrustedLocalRequest.mockReturnValue(false);
+
+    const { ctx, captured, clearPairing } = mkCtx(API_TOKEN);
+    expect(await handleAuthRoutes(ctx)).toBe(true);
+    expect(captured.status).toBe(403);
+    expect(captured.body).toEqual({ error: "Invalid pairing code" });
+    expect(clearPairing).not.toHaveBeenCalled();
+  });
+
+  it("still accepts the rotating pairing code from a remote caller", async () => {
+    saveEnv();
+    process.env.ELIZA_API_TOKEN = API_TOKEN;
+    delete process.env.ELIZA_API_AUTH_TOKEN;
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+    mocks.isTrustedLocalRequest.mockReturnValue(false);
+
+    const { ctx, captured, clearPairing } = mkCtx(PAIRING_CODE);
+    expect(await handleAuthRoutes(ctx)).toBe(true);
+    expect(captured.status).toBe(200);
+    expect(captured.body).toEqual({ token: API_TOKEN });
+    expect(clearPairing).toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/api/auth-routes.ts
+++ b/packages/agent/src/api/auth-routes.ts
@@ -203,9 +203,12 @@ export async function handleAuthRoutes(
 
     const provided = parsed.data.code.trim();
 
-    // Accept the raw API token itself as a valid "pairing code" — lets operators
-    // share the token as a static secret without needing loopback access to read
-    // a generated code.
+    // Accept the raw API token itself as a valid "pairing code" — but only
+    // from a trusted loopback operator. Remote callers must use the rotating
+    // pairing code (real entropy, 10-minute expiry): accepting the static
+    // token from any reachable address made pairing an online guessing oracle
+    // for weak human-chosen `ELIZA_API_TOKEN` values, bounded only by the
+    // per-IP rate limit (W1-038).
     //
     // This path deliberately bypasses the pairing code's expiry window: the
     // token does not rotate, so a holder can pair at any time. It is still
@@ -217,7 +220,9 @@ export async function handleAuthRoutes(
     const tokenA = Buffer.from(token, "utf8");
     const tokenB = Buffer.from(provided, "utf8");
     const tokenMatch =
-      tokenA.length === tokenB.length && crypto.timingSafeEqual(tokenA, tokenB);
+      isTrustedLocalRequest(req) &&
+      tokenA.length === tokenB.length &&
+      crypto.timingSafeEqual(tokenA, tokenB);
 
     if (tokenMatch) {
       const response: PostAuthPairResponse = { token };

--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -15,13 +15,17 @@ import {
   handleStandaloneCloudPairRoute,
 } from "./cloud-pair-route.ts";
 
-vi.mock("@elizaos/core", () => ({
-  logger: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
-}));
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return {
+    ...actual,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
 
 interface FakeRes {
   res: http.ServerResponse;
@@ -126,7 +130,7 @@ function fakeReq(opts: {
     ...(opts.proto ? { "x-forwarded-proto": opts.proto } : {}),
   };
   Object.defineProperty(req.socket, "remoteAddress", {
-    value: opts.ip ?? "203.0.113.10",
+    value: opts.ip ?? "127.0.0.1",
     configurable: true,
   });
   return req;
@@ -240,6 +244,7 @@ describe("handleStandaloneCloudPairRoute", () => {
       search: "?token=pair-token",
       host: "eliza-staging-1.elizacloud.ai",
       proto: "https",
+      ip: "203.0.113.10",
     });
     req.headers["x-forwarded-host"] = "attacker.example";
     const harness = fakeRes();
@@ -250,15 +255,40 @@ describe("handleStandaloneCloudPairRoute", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("allows the explicit local-provider relay only for a loopback origin", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          apiKey: "agent_secret_value",
-          agentId: AGENT_ID,
-          agentName: "Local",
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
+  it("never exchanges for a remote peer spoofing a loopback forwarded host (W1-037)", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Before the fix, X-Forwarded-Host/Host were trusted for the loopback
+    // gate, so this exact request passed it: a remote peer presenting a
+    // loopback-looking origin could redeem a held pairing token through the
+    // relay and receive the minted agent apiKey in the handoff HTML.
+    const req = fakeReq({
+      pathname: "/pair",
+      search: "?token=pair-token",
+      host: "localhost:43123",
+      ip: "203.0.113.10",
+    });
+    req.headers["x-forwarded-host"] = "localhost";
+    req.headers["x-forwarded-proto"] = "http";
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(req, harness.res);
+
+    expect(harness.status()).toBe(421);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("allows the explicit local-provider relay for loopback and local-Docker peers", async () => {
+    const fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            apiKey: "agent_secret_value",
+            agentId: AGENT_ID,
+            agentName: "Local",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
       ),
     );
     vi.stubGlobal("fetch", fetchMock);
@@ -282,6 +312,44 @@ describe("handleStandaloneCloudPairRoute", () => {
       }),
     );
 
+    // The exchange origin is reconstructed from direct request metadata only:
+    // forwarded headers must not rewrite it (W1-037).
+    fetchMock.mockClear();
+    const forwardedHarness = fakeRes();
+    const forwardedReq = fakeReq({
+      pathname: "/pair",
+      search: "?token=pair-token",
+      host: "127.0.0.1:43123",
+      proto: "http",
+    });
+    forwardedReq.headers["x-forwarded-host"] = "attacker.example";
+    await handleStandaloneCloudPairRoute(forwardedReq, forwardedHarness.res);
+    expect(forwardedHarness.status()).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.eliza.app/api/auth/pair",
+      expect.objectContaining({
+        headers: expect.objectContaining({ origin: "http://127.0.0.1:43123" }),
+      }),
+    );
+
+    // Local-Docker deployments publish the port on the host's loopback, so
+    // inside the container the TCP peer is the bridge gateway — a private
+    // address, not 127.0.0.1. That supported flow must keep working.
+    fetchMock.mockClear();
+    const dockerHarness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({
+        pathname: "/pair",
+        search: "?token=pair-token",
+        host: "127.0.0.1:43123",
+        proto: "http",
+        ip: "172.17.0.1",
+      }),
+      dockerHarness.res,
+    );
+    expect(dockerHarness.status()).toBe(200);
+    expect(fetchMock).toHaveBeenCalled();
+
     fetchMock.mockClear();
     const publicHarness = fakeRes();
     await handleStandaloneCloudPairRoute(
@@ -290,6 +358,7 @@ describe("handleStandaloneCloudPairRoute", () => {
         search: "?token=pair-token",
         host: "agent.example",
         proto: "https",
+        ip: "203.0.113.10",
       }),
       publicHarness.res,
     );

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -5,15 +5,15 @@
  */
 
 import type http from "node:http";
-import { logger } from "@elizaos/core";
+import { isPrivateIpAddress, logger } from "@elizaos/core";
+import { isLoopbackRemoteAddress } from "@elizaos/shared";
 import {
   type CloudPairRelaySession,
   parseCloudPairRelaySession,
   renderCloudPairHandoffHtml,
   resolveCloudPairAgentIdFromEnv,
 } from "@elizaos/shared/contracts";
-import { isLoopbackBindHost } from "@elizaos/shared/runtime-env";
-import { resolveRequestOrigin } from "./request-origin.js";
+import { resolveDirectRequestOrigin } from "./request-origin.js";
 
 const RELAY_TIMEOUT_MS = 15_000;
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -58,20 +58,17 @@ function resolveCloudAuthRoot(): string {
   return resolveCloudApiBaseUrl().replace(/\/api\/v1\/?$/, "");
 }
 
-function isLoopbackOrigin(origin: string): boolean {
-  try {
-    return isLoopbackBindHost(new URL(origin).hostname);
-  } catch {
-    // error-policy:J3 malformed request origins are never trusted as loopback.
-    return false;
-  }
-}
-
 function canUseManagedDirectRelay(req: http.IncomingMessage): boolean {
-  return (
-    process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY === "1" &&
-    isLoopbackOrigin(resolveRequestOrigin(req))
-  );
+  if (process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY !== "1") return false;
+  // The local-only gate must key on the TCP peer, never on request headers:
+  // Host and X-Forwarded-Host are client-controlled, so a remote caller
+  // could previously spoof a loopback origin and redeem a held pairing token
+  // through this relay (W1-037). Private-range peers are accepted because
+  // the supported local-Docker deployment publishes the port on the host's
+  // loopback, so inside the container the peer is the bridge gateway rather
+  // than 127.0.0.1.
+  const peer = req.socket?.remoteAddress;
+  return isLoopbackRemoteAddress(peer) || isPrivateIpAddress(peer ?? "");
 }
 
 function escapeHtml(value: string): string {
@@ -224,7 +221,10 @@ export async function handleStandaloneCloudPairRoute(
     return true;
   }
 
-  const origin = resolveRequestOrigin(req);
+  // The origin forwarded to the Cloud exchange is reconstructed from direct
+  // request metadata only — forwarded headers are client-controlled and must
+  // not be able to rewrite the origin the exchange is bound to (W1-037).
+  const origin = resolveDirectRequestOrigin(req);
   if (!origin) {
     sendHtml(
       res,

--- a/packages/agent/src/api/health-routes.database-liveness.test.ts
+++ b/packages/agent/src/api/health-routes.database-liveness.test.ts
@@ -34,7 +34,12 @@ function makeContext(runtime: AgentRuntime | null): {
   return {
     responses,
     ctx: {
-      req: {} as HealthRouteContext["req"],
+      // Trusted-local shape: the /api/health detail payload is only served to
+      // callers that pass the trusted-local check (W1-039).
+      req: {
+        headers: { host: "127.0.0.1" },
+        socket: { remoteAddress: "127.0.0.1" },
+      } as unknown as HealthRouteContext["req"],
       res: {} as HealthRouteContext["res"],
       method: "GET",
       pathname: "/api/health",

--- a/packages/agent/src/api/health-routes.service-failures.test.ts
+++ b/packages/agent/src/api/health-routes.service-failures.test.ts
@@ -35,7 +35,12 @@ function makeContext(runtime: AgentRuntime): {
   return {
     responses,
     ctx: {
-      req: {} as HealthRouteContext["req"],
+      // Trusted-local shape: the /api/health detail payload is only served to
+      // callers that pass the trusted-local check (W1-039).
+      req: {
+        headers: { host: "127.0.0.1" },
+        socket: { remoteAddress: "127.0.0.1" },
+      } as unknown as HealthRouteContext["req"],
       res: {} as HealthRouteContext["res"],
       method: "GET",
       pathname: "/api/health",

--- a/packages/agent/src/api/health-routes.ts
+++ b/packages/agent/src/api/health-routes.ts
@@ -29,6 +29,7 @@ import { detectRuntimeModel } from "./agent-model.ts";
 import type { ConnectorHealthMonitor } from "./connector-health.ts";
 import { probeRuntimeDatabaseLiveness } from "./database-liveness.ts";
 import { loadLocalInferenceRouteApi } from "./local-inference-server-api.ts";
+import { isTrustedLocalRequest } from "./server-helpers-auth.ts";
 
 type CloudApiKeyResolver = {
   resolveCloudApiKey: (
@@ -482,7 +483,7 @@ export function computeCanRespond(
 export async function handleHealthRoutes(
   ctx: HealthRouteContext,
 ): Promise<boolean> {
-  const { res, method, pathname, url, state, json, error } = ctx;
+  const { req, res, method, pathname, url, state, json, error } = ctx;
 
   // ── GET /api/status ─────────────────────────────────────────────────────
   if (method === "GET" && pathname === "/api/status") {
@@ -594,6 +595,17 @@ export async function handleHealthRoutes(
       state.agentState !== "starting" &&
       state.agentState !== "restarting" &&
       !databaseLiveness.terminal;
+
+    // The endpoint stays unauthenticated for readiness probes, so callers
+    // that fail the trusted-local check receive only the liveness bit: the
+    // detailed shape discloses deployment topology (connector names, plugin
+    // and service counts, database internals, boot phase) to anyone who can
+    // reach the port (W1-039). The status code keeps its terminal/ready
+    // semantics for orchestrators.
+    if (!isTrustedLocalRequest(req)) {
+      json(res, { ready }, databaseLiveness.terminal ? 503 : 200);
+      return true;
+    }
 
     // Service registration truth (#16309): a service whose start() threw is
     // recorded as "failed" by the runtime but previously never reached this

--- a/packages/agent/src/api/model-provider-helpers.test.ts
+++ b/packages/agent/src/api/model-provider-helpers.test.ts
@@ -4,8 +4,10 @@
  * `models[]` / `metadata` shape — skips not-ready models, and derives chat vs
  * image categories, with global fetch stubbed.
  */
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchNearAIModels } from "./model-provider-helpers";
+import { resolveModelsCacheDir } from "../config/paths.ts";
+import { fetchNearAIModels, providerCachePath } from "./model-provider-helpers";
 
 describe("fetchNearAIModels", () => {
   afterEach(() => {
@@ -94,5 +96,33 @@ describe("fetchNearAIModels", () => {
       "https://cloud-api.near.ai/v1/models",
       { headers: {} },
     );
+  });
+});
+
+describe("providerCachePath (W1-024)", () => {
+  it("keeps canonical provider ids directly inside the models cache dir", () => {
+    for (const providerId of ["openai", "google-genai", "zai", "xai-2"]) {
+      expect(providerCachePath(providerId)).toBe(
+        path.join(resolveModelsCacheDir(), `${providerId}.json`),
+      );
+    }
+  });
+
+  it("rejects ids that would traverse out of the cache dir", () => {
+    for (const providerId of [
+      "../eliza",
+      "../../etc/passwd",
+      "..",
+      "a/b",
+      "a\\b",
+      ".hidden",
+      "openai.json",
+      "OPENAI",
+      "",
+    ]) {
+      expect(() => providerCachePath(providerId), providerId).toThrowError(
+        expect.objectContaining({ code: "INVALID_MODEL_PROVIDER_ID" }),
+      );
+    }
   });
 });

--- a/packages/agent/src/api/model-provider-helpers.ts
+++ b/packages/agent/src/api/model-provider-helpers.ts
@@ -7,7 +7,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import {
   DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
@@ -288,8 +288,33 @@ const PROVIDER_ENV_KEYS: Record<
 
 // ── Per-provider cache read/write ────────────────────────────────────────
 
+/**
+ * Canonical provider-id grammar. Cache paths are built by joining
+ * `${providerId}.json` under the models cache dir, so anything outside this
+ * shape (path separators, `.` segments) is rejected before a filesystem path
+ * exists — a `../` id would otherwise traverse out of the cache directory
+ * into an arbitrary unlink/read (W1-024).
+ */
+export const MODEL_PROVIDER_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
 export function providerCachePath(providerId: string): string {
-  return path.join(resolveModelsCacheDir(), `${providerId}.json`);
+  if (!MODEL_PROVIDER_ID_PATTERN.test(providerId)) {
+    throw new ElizaError(`Invalid model provider id: ${providerId}`, {
+      code: "INVALID_MODEL_PROVIDER_ID",
+      context: { providerId },
+    });
+  }
+  const cacheDir = resolveModelsCacheDir();
+  const result = path.join(cacheDir, `${providerId}.json`);
+  // Defense in depth: the joined path must stay directly inside the cache
+  // dir even if the id grammar above is ever loosened.
+  if (path.dirname(result) !== cacheDir) {
+    throw new ElizaError(
+      `Model provider cache path escapes the cache directory: ${providerId}`,
+      { code: "INVALID_MODEL_PROVIDER_ID", context: { providerId } },
+    );
+  }
+  return result;
 }
 
 export function readProviderCache(providerId: string): ProviderCache | null {

--- a/packages/agent/src/api/models-routes.test.ts
+++ b/packages/agent/src/api/models-routes.test.ts
@@ -123,6 +123,33 @@ describe("handleModelsRoutes catalog field", () => {
     }
   });
 
+  it("rejects traversal-shaped provider ids before any cache path is built (W1-024)", async () => {
+    for (const provider of [
+      "../eliza",
+      "../../etc/passwd",
+      "..\\eliza",
+      "a/b",
+      "openai.json",
+      "OPENAI",
+      "open ai",
+    ]) {
+      const unlinkFile = vi.fn();
+      const { ctx, json } = makeCtx(
+        `/api/models?provider=${encodeURIComponent(provider)}&refresh=true`,
+      );
+      ctx.unlinkFile = unlinkFile;
+      await expect(handleModelsRoutes(ctx as never)).resolves.toBe(true);
+      expect(json, provider).toHaveBeenCalledWith(
+        ctx.res,
+        { error: "Invalid provider id" },
+        400,
+      );
+      expect(unlinkFile, provider).not.toHaveBeenCalled();
+      expect(ctx.getOrFetchProvider, provider).not.toHaveBeenCalled();
+      expect(ctx.getOrFetchAllProviders, provider).not.toHaveBeenCalled();
+    }
+  });
+
   it("declines non-matching routes", async () => {
     const { ctx } = makeCtx("/api/models");
     ctx.pathname = "/api/models/config";

--- a/packages/agent/src/api/models-routes.ts
+++ b/packages/agent/src/api/models-routes.ts
@@ -15,6 +15,7 @@ import {
   type RouteRequestMeta,
 } from "@elizaos/core";
 import { buildModelCatalog, type ModelCatalog } from "./model-catalog.ts";
+import { MODEL_PROVIDER_ID_PATTERN } from "./model-provider-helpers.ts";
 
 function parseOptionalBooleanQuery(
   raw: string | null,
@@ -96,6 +97,14 @@ export async function handleModelsRoutes(
   }
 
   if (specificProvider) {
+    // The provider id becomes a filesystem path segment in providerCachePath,
+    // so reject anything outside the canonical id grammar before the cache
+    // bust or fetch runs — `../` ids would otherwise traverse the unlink/read
+    // out of the models cache dir (W1-024).
+    if (!MODEL_PROVIDER_ID_PATTERN.test(specificProvider)) {
+      json(res, { error: "Invalid provider id" }, 400);
+      return true;
+    }
     if (force) {
       try {
         unlinkFile(providerCachePath(specificProvider));

--- a/packages/agent/src/api/server-auth-boundary.test.ts
+++ b/packages/agent/src/api/server-auth-boundary.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Real-server contract for three agent API auth-boundary fixes:
+ *  - W1-010: GET /api/cloud/status and /api/cloud/credits no longer bypass the
+ *    token gate — an unauthenticated caller who merely reaches the port gets
+ *    401 instead of the owner's cloud userId/organizationId/credit balance.
+ *  - W1-039: GET /api/health keeps its unauthenticated liveness bit but trims
+ *    the topology detail (connectors, plugin/service counts, DB internals,
+ *    boot phase) for callers that fail the trusted-local check.
+ *  - W1-011: the device-bridge WS path fails closed (HTTP 404) when the
+ *    bridge cannot be attached, instead of skipping WS auth unconditionally.
+ * Boots the real `startApiServer` on an ephemeral loopback port with an
+ * explicit API token; a remote caller is simulated with a non-loopback
+ * X-Forwarded-For, which the trusted-local classifier treats as untrusted.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { startApiServer } from "./server.ts";
+
+// The gate contract under test lives in server.ts. The cloud plugin's own
+// handler is NOT exercised here: under the source-alias test environment the
+// real `@elizaos/plugin-elizacloud` module graph fails to evaluate (ENOTDIR
+// on its internal route scan) and the request 500s after passing the gate —
+// pre-existing behavior unrelated to the auth boundary. The authorized-caller
+// cases therefore assert the gate decision (no 401), while the 401 case
+// proves the unauthorized response.
+
+type ApiServer = Awaited<ReturnType<typeof startApiServer>>;
+
+const API_TOKEN = "auth-boundary-test-api-token";
+
+const touchedEnv = [
+  "ELIZA_API_AUTH_TOKEN",
+  "ELIZA_API_BIND_HOST",
+  "ELIZA_API_PORT",
+  "ELIZA_API_TOKEN",
+  "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_CONFIG_PATH",
+  "ELIZA_DEVICE_BRIDGE_ENABLED",
+  "ELIZA_DEVICE_BRIDGE_TOKEN",
+  "ELIZA_DEVICE_PAIRING_TOKEN",
+  "ELIZA_PERSIST_CONFIG_PATH",
+  "ELIZA_PORT",
+  "ELIZA_REQUIRE_LOCAL_AUTH",
+  "ELIZA_STATE_DIR",
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function snapshotEnvironment(): void {
+  originalEnv.clear();
+  for (const key of touchedEnv) originalEnv.set(key, process.env[key]);
+}
+
+function restoreEnvironment(): void {
+  for (const key of touchedEnv) {
+    const original = originalEnv.get(key);
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+  originalEnv.clear();
+}
+
+let stateDir: string | null = null;
+let api: ApiServer | null = null;
+
+beforeEach(async () => {
+  snapshotEnvironment();
+  stateDir = await mkdtemp(path.join(tmpdir(), "eliza-auth-boundary-"));
+  process.env.ELIZA_STATE_DIR = stateDir;
+  process.env.ELIZA_CONFIG_PATH = path.join(stateDir, "eliza.json");
+  process.env.ELIZA_PERSIST_CONFIG_PATH = path.join(stateDir, "eliza.json");
+  process.env.ELIZA_API_BIND_HOST = "127.0.0.1";
+  process.env.ELIZA_API_TOKEN = API_TOKEN;
+  delete process.env.ELIZA_API_AUTH_TOKEN;
+  delete process.env.ELIZA_CLOUD_PROVISIONED;
+  delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+  delete process.env.ELIZA_DEVICE_BRIDGE_ENABLED;
+  delete process.env.ELIZA_DEVICE_PAIRING_TOKEN;
+  delete process.env.ELIZA_DEVICE_BRIDGE_TOKEN;
+});
+
+afterEach(async () => {
+  if (api) {
+    await api.close();
+    api = null;
+  }
+  if (stateDir) {
+    await rm(stateDir, { recursive: true, force: true });
+    stateDir = null;
+  }
+  restoreEnvironment();
+});
+
+async function bootServer(): Promise<string> {
+  api = await startApiServer({ port: 0, skipDeferredStartupWork: true });
+  process.env.ELIZA_PORT = String(api.port);
+  process.env.ELIZA_API_PORT = String(api.port);
+  return `http://127.0.0.1:${api.port}`;
+}
+
+/** Headers that make a loopback test client look like a proxied remote peer. */
+const REMOTE_HEADERS = { "x-forwarded-for": "203.0.113.10" } as const;
+
+function wsUpgradeResponse(port: number, pathname: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(port, "127.0.0.1");
+    let raw = "";
+    socket.setTimeout(5_000, () => {
+      socket.destroy();
+      reject(new Error("timed out waiting for the upgrade rejection"));
+    });
+    socket.once("error", reject);
+    socket.once("connect", () => {
+      socket.write(
+        `GET ${pathname} HTTP/1.1\r\n` +
+          `Host: 127.0.0.1:${port}\r\n` +
+          "Connection: Upgrade\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+          "Sec-WebSocket-Version: 13\r\n" +
+          "\r\n",
+      );
+    });
+    socket.on("data", (chunk) => {
+      raw += chunk.toString("utf8");
+      if (raw.includes("\r\n\r\n")) {
+        socket.destroy();
+        resolve(raw);
+      }
+    });
+  });
+}
+
+describe("cloud session reads require authorization (W1-010)", () => {
+  it("rejects unauthenticated remote callers on /api/cloud/status and /api/cloud/credits", async () => {
+    const baseUrl = await bootServer();
+    for (const pathname of ["/api/cloud/status", "/api/cloud/credits"]) {
+      const res = await fetch(`${baseUrl}${pathname}`, {
+        headers: REMOTE_HEADERS,
+      });
+      expect(res.status, pathname).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.userId, pathname).toBeUndefined();
+      expect(body.organizationId, pathname).toBeUndefined();
+      expect(body.balance, pathname).toBeUndefined();
+    }
+  }, 120_000);
+
+  it("still lets a bearer-token caller through the gate", async () => {
+    const baseUrl = await bootServer();
+    for (const pathname of ["/api/cloud/status", "/api/cloud/credits"]) {
+      const res = await fetch(`${baseUrl}${pathname}`, {
+        headers: {
+          ...REMOTE_HEADERS,
+          Authorization: `Bearer ${API_TOKEN}`,
+        },
+      });
+      // Not 401: the request passes the gate and reaches dispatch (see the
+      // comment above for why no stronger status is asserted here).
+      expect(res.status, pathname).not.toBe(401);
+    }
+  }, 120_000);
+
+  it("still lets the trusted loopback dashboard through the gate", async () => {
+    const baseUrl = await bootServer();
+    for (const pathname of ["/api/cloud/status", "/api/cloud/credits"]) {
+      const res = await fetch(`${baseUrl}${pathname}`);
+      expect(res.status, pathname).not.toBe(401);
+    }
+  }, 120_000);
+});
+
+describe("/api/health topology trim (W1-039)", () => {
+  it("returns only the liveness bit to untrusted callers", async () => {
+    const baseUrl = await bootServer();
+    const res = await fetch(`${baseUrl}/api/health`, {
+      headers: REMOTE_HEADERS,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(typeof body.ready).toBe("boolean");
+    expect(body.connectors).toBeUndefined();
+    expect(body.plugins).toBeUndefined();
+    expect(body.services).toBeUndefined();
+    expect(body.databaseLiveness).toBeUndefined();
+    expect(body.agentState).toBeUndefined();
+    expect(body.startup).toBeUndefined();
+    expect(body.deferredBoot).toBeUndefined();
+  }, 120_000);
+
+  it("returns the full subsystem detail to trusted loopback callers", async () => {
+    const baseUrl = await bootServer();
+    const res = await fetch(`${baseUrl}/api/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(typeof body.ready).toBe("boolean");
+    expect(body.plugins).toBeDefined();
+    expect(body.services).toBeDefined();
+    expect(body.connectors).toBeDefined();
+  }, 120_000);
+});
+
+describe("device-bridge WS upgrade gate (W1-011)", () => {
+  it("rejects the device-bridge upgrade with 404 when the bridge cannot attach", async () => {
+    const baseUrl = await bootServer();
+    const port = Number(new URL(baseUrl).port);
+    const raw = await wsUpgradeResponse(
+      port,
+      "/api/local-inference/device-bridge",
+    );
+    expect(raw.startsWith("HTTP/1.1 404 Not Found")).toBe(true);
+  }, 120_000);
+});

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -1531,13 +1531,13 @@ async function handleRequest(
     method === "GET" &&
     pathname === "/api/first-run/status" &&
     isCloudProvisioned;
-  // app-core authenticates these session-tier dashboard reads before
-  // forwarding into the agent server. Do not require a second token here:
-  // browser sessions are stored by app-core and are intentionally opaque to
-  // the lower agent HTTP boundary.
-  const isAppCoreSessionCloudRead =
-    method === "GET" &&
-    (pathname === "/api/cloud/status" || pathname === "/api/cloud/credits");
+  // app-core authenticates the session-tier dashboard reads
+  // (/api/cloud/status, /api/cloud/credits) before forwarding into the agent
+  // server. They need no dedicated exemption here: app-core's forwarded
+  // requests arrive over trusted loopback and already pass `isAuthorized`,
+  // while exempting the paths let ANY unauthenticated caller who could reach
+  // the port (LAN/wildcard bind) read the owner's cloud userId, organizationId,
+  // and live credit balance (W1-010).
   const isAuthProtectedPath = isAuthProtectedRoute(pathname);
   let hostSessionAuthorization: AgentHttpRequestAuthorization = {
     ok: false,
@@ -1758,7 +1758,6 @@ async function handleRequest(
     !isAuthEndpoint &&
     !isHealthEndpoint &&
     !isCloudFirstRunStatusEndpoint &&
-    !isAppCoreSessionCloudRead &&
     !isPublicRuntimePluginRoute({
       runtime: state.runtime,
       method,
@@ -4060,6 +4059,28 @@ export async function startApiServer(opts?: {
     });
   }
 
+  // The device-bridge WebSocket endpoint delegates authentication to the
+  // capacitor bridge's own upgrade handler (a pairing-token check that closes
+  // unauthorized sockets with 4001). That delegation is only valid when the
+  // bridge can actually be attached: the plugin refuses to attach without a
+  // pairing token, so with none configured nothing is listening on the path —
+  // fall through to the standard upgrade rejection instead of skipping auth
+  // and leaving the socket unanswered (W1-011).
+  const isDeviceBridgeDelegationExpected = (): boolean => {
+    if (
+      !isMobilePlatform() &&
+      process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() !== "1"
+    ) {
+      return false;
+    }
+    // Mirrors the pairing-token env contract enforced by
+    // @elizaos/plugin-capacitor-bridge's attachMobileDeviceBridgeToServer.
+    return Boolean(
+      process.env.ELIZA_DEVICE_PAIRING_TOKEN?.trim() ||
+        process.env.ELIZA_DEVICE_BRIDGE_TOKEN?.trim(),
+    );
+  };
+
   // Handle upgrade requests for WebSocket
   server.on("upgrade", (request, socket, head) => {
     // The raw upgrade socket can emit 'error' (client RST mid-handshake) before
@@ -4081,7 +4102,10 @@ export async function startApiServer(opts?: {
         request.url ?? "/",
         `http://${request.headers.host ?? "localhost"}`,
       );
-      if (wsUrl.pathname === "/api/local-inference/device-bridge") {
+      if (
+        wsUrl.pathname === "/api/local-inference/device-bridge" &&
+        isDeviceBridgeDelegationExpected()
+      ) {
         return;
       }
       const rejection = resolveWebSocketUpgradeRejection(request, wsUrl);

--- a/packages/ui/src/services/local-inference/device-bridge.ts
+++ b/packages/ui/src/services/local-inference/device-bridge.ts
@@ -29,7 +29,7 @@
  * non-blocking — failures fall back to in-memory only.
  */
 
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import fs from "node:fs/promises";
 import type { Server as HttpServer, IncomingMessage } from "node:http";
 import path from "node:path";
@@ -50,6 +50,21 @@ const DEFAULT_CALL_TIMEOUT_MS = 60_000;
 const DEFAULT_LOAD_TIMEOUT_MS = 120_000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const PENDING_LOG_FILENAME = "pending-requests.json";
+
+/**
+ * Constant-time pairing-token comparison. The bridge fails closed when no
+ * token is configured (the caller checks `expectedPairingToken` first), so an
+ * unset `ELIZA_DEVICE_PAIRING_TOKEN` can never silently authenticate (W1-011).
+ */
+function pairingTokenMatches(
+  expected: string,
+  provided: string | null | undefined,
+): boolean {
+  if (!provided) return false;
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(provided, "utf8");
+  return a.length === b.length && timingSafeEqual(a, b);
+}
 
 interface DeviceCapabilities {
   platform: "ios" | "android" | "web" | "electrobun" | "desktop";
@@ -500,7 +515,10 @@ export class DeviceBridge {
     url: URL,
   ): void {
     const queryToken = url.searchParams.get("token")?.trim();
-    if (this.expectedPairingToken && queryToken !== this.expectedPairingToken) {
+    if (
+      !this.expectedPairingToken ||
+      !pairingTokenMatches(this.expectedPairingToken, queryToken)
+    ) {
       logger.warn("[device-bridge] Rejecting connection: bad query token");
       socket.close(4001, "unauthorized");
       return;
@@ -526,8 +544,11 @@ export class DeviceBridge {
           return;
         }
         if (
-          this.expectedPairingToken &&
-          msg.payload.pairingToken !== this.expectedPairingToken
+          !this.expectedPairingToken ||
+          !pairingTokenMatches(
+            this.expectedPairingToken,
+            msg.payload.pairingToken,
+          )
         ) {
           logger.warn("[device-bridge] Rejecting register: bad pairing token");
           socket.close(4001, "unauthorized");

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.auth.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.auth.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Device-bridge pairing-token enforcement on the canonical wired bridge
+ * (W1-011): a wrong `?token=` query value and a wrong register-frame pairing
+ * token are both closed with 4001. Real HTTP server + real `ws` client; the
+ * singleton reads its env at import time, so the token is staged before the
+ * dynamic import below.
+ */
+import http from "node:http";
+import { afterAll, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+
+const savedEnv = {
+	ELIZA_DEVICE_BRIDGE_ENABLED: process.env.ELIZA_DEVICE_BRIDGE_ENABLED,
+	ELIZA_DEVICE_PAIRING_TOKEN: process.env.ELIZA_DEVICE_PAIRING_TOKEN,
+};
+
+const pairingToken = "auth-test-pairing-token";
+
+process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+process.env.ELIZA_DEVICE_PAIRING_TOKEN = pairingToken;
+
+afterAll(() => {
+	for (const [key, value] of Object.entries(savedEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+});
+
+function listen(server: http.Server): Promise<number> {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				reject(new Error("test server did not expose a TCP port"));
+				return;
+			}
+			resolve(address.port);
+		});
+	});
+}
+
+function connectAndWaitForClose(url: string): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const socket = new WebSocket(url);
+		const timer = setTimeout(() => {
+			socket.terminate();
+			reject(new Error("timed out waiting for the bridge to close the socket"));
+		}, 5_000);
+		socket.once("close", (code) => {
+			clearTimeout(timer);
+			resolve(code);
+		});
+		socket.once("error", (err) => {
+			clearTimeout(timer);
+			reject(err);
+		});
+	});
+}
+
+function registerFrame(token: string): string {
+	return JSON.stringify({
+		type: "register",
+		payload: {
+			deviceId: "auth-test-device",
+			pairingToken: token,
+			capabilities: {
+				platform: "android",
+				deviceModel: "auth-test",
+				totalRamGb: 8,
+				cpuCores: 8,
+				gpu: { backend: "vulkan", available: true },
+			},
+			loadedPath: null,
+		},
+	});
+}
+
+describe("mobile device bridge pairing-token enforcement (W1-011)", () => {
+	it("closes a wrong query token with 4001", async () => {
+		const bridge = await import("./mobile-device-bridge-bootstrap");
+		const server = http.createServer((_req, res) => res.end("ok"));
+		try {
+			await bridge.attachMobileDeviceBridgeToServer(server);
+			const port = await listen(server);
+			await expect(
+				connectAndWaitForClose(
+					`ws://127.0.0.1:${port}/api/local-inference/device-bridge?token=wrong-token`,
+				),
+			).resolves.toBe(4001);
+			expect(bridge.mobileDeviceBridge.status().connected).toBe(false);
+		} finally {
+			await bridge.mobileDeviceBridge.close();
+			if (server.listening) await new Promise((r) => server.close(r));
+		}
+	});
+
+	it("closes a register frame with a wrong pairing token with 4001", async () => {
+		const bridge = await import("./mobile-device-bridge-bootstrap");
+		const server = http.createServer((_req, res) => res.end("ok"));
+		let socket: WebSocket | null = null;
+		try {
+			await bridge.attachMobileDeviceBridgeToServer(server);
+			const port = await listen(server);
+			socket = new WebSocket(
+				`ws://127.0.0.1:${port}/api/local-inference/device-bridge?token=${pairingToken}`,
+			);
+			await new Promise<void>((resolve, reject) => {
+				socket?.once("open", resolve);
+				socket?.once("error", reject);
+			});
+			const closed = new Promise<number>((resolve) =>
+				socket?.once("close", resolve),
+			);
+			socket.send(registerFrame("wrong-token"));
+			await expect(closed).resolves.toBe(4001);
+			expect(bridge.mobileDeviceBridge.status().connected).toBe(false);
+		} finally {
+			if (socket?.readyState === WebSocket.OPEN) socket.close();
+			await bridge.mobileDeviceBridge.close();
+			if (server.listening) await new Promise((r) => server.close(r));
+		}
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.no-token.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.no-token.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Device-bridge fail-closed contract (W1-011): with ELIZA_DEVICE_BRIDGE_ENABLED=1
+ * but NO pairing token configured, attachMobileDeviceBridgeToServer must refuse
+ * to attach — an unauthenticated WS client must never be able to register as an
+ * inference device and receive routed generation prompts. The singleton reads
+ * its env at import time, so the token vars are deleted before the dynamic
+ * import below.
+ */
+import http from "node:http";
+import { afterAll, describe, expect, it } from "vitest";
+
+const savedEnv = {
+	ELIZA_DEVICE_BRIDGE_ENABLED: process.env.ELIZA_DEVICE_BRIDGE_ENABLED,
+	ELIZA_DEVICE_PAIRING_TOKEN: process.env.ELIZA_DEVICE_PAIRING_TOKEN,
+	ELIZA_DEVICE_BRIDGE_TOKEN: process.env.ELIZA_DEVICE_BRIDGE_TOKEN,
+};
+
+process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+delete process.env.ELIZA_DEVICE_PAIRING_TOKEN;
+delete process.env.ELIZA_DEVICE_BRIDGE_TOKEN;
+
+afterAll(() => {
+	for (const [key, value] of Object.entries(savedEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+});
+
+describe("mobile device bridge with no pairing token (W1-011)", () => {
+	it("refuses to attach, so the bridge stays disabled", async () => {
+		const bridge = await import("./mobile-device-bridge-bootstrap");
+		const server = http.createServer((_req, res) => res.end("ok"));
+		try {
+			await bridge.attachMobileDeviceBridgeToServer(server);
+			expect(bridge.mobileDeviceBridge.status().enabled).toBe(false);
+			expect(bridge.mobileDeviceBridge.status().connected).toBe(false);
+		} finally {
+			if (server.listening) await new Promise((r) => server.close(r));
+		}
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -9,7 +9,7 @@
  * normal conversation routes keep using runtime model handlers.
  */
 
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import {
 	createWriteStream,
 	existsSync,
@@ -56,6 +56,21 @@ const DEFAULT_NATIVE_REQUEST_TIMEOUT_MS = 600_000;
 const DEFAULT_CALL_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const DEFAULT_LOAD_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const SERVICE_ENABLED = process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1";
+
+/**
+ * Constant-time pairing-token comparison (W1-011). Callers fail closed when
+ * no token is configured, so an unset `ELIZA_DEVICE_PAIRING_TOKEN` can never
+ * silently authenticate.
+ */
+function pairingTokenMatches(
+	expected: string,
+	provided: string | null | undefined,
+): boolean {
+	if (!provided) return false;
+	const a = Buffer.from(expected, "utf8");
+	const b = Buffer.from(provided, "utf8");
+	return a.length === b.length && timingSafeEqual(a, b);
+}
 const registeredRuntimes = new WeakSet<AgentRuntime>();
 let registeredRuntimeCount = 0;
 const deviceAttachUnsubscribers = new WeakMap<AgentRuntime, () => void>();
@@ -504,7 +519,7 @@ class MobileDeviceBridge {
 		const queryToken = url.searchParams.get("token")?.trim();
 		if (
 			!this.expectedPairingToken ||
-			queryToken !== this.expectedPairingToken
+			!pairingTokenMatches(this.expectedPairingToken, queryToken)
 		) {
 			logger.warn(
 				"[mobile-device-bridge] Rejecting connection: bad query token",
@@ -539,7 +554,10 @@ class MobileDeviceBridge {
 				}
 				if (
 					!this.expectedPairingToken ||
-					msg.payload.pairingToken !== this.expectedPairingToken
+					!pairingTokenMatches(
+						this.expectedPairingToken,
+						msg.payload.pairingToken,
+					)
 				) {
 					logger.warn(
 						"[mobile-device-bridge] Rejecting register: bad pairing token",

--- a/plugins/plugin-local-inference/src/services/device-bridge-auth.test.ts
+++ b/plugins/plugin-local-inference/src/services/device-bridge-auth.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Device-bridge WebSocket authentication contract (W1-011): with no
+ * ELIZA_DEVICE_PAIRING_TOKEN configured the bridge must FAIL CLOSED — an
+ * unauthenticated client must never register as an inference device (a rogue
+ * registration would supersede the real device and receive full generation
+ * prompts). Real HTTP server + real `ws` client; only the env is staged.
+ */
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { DeviceBridge } from "./device-bridge";
+
+const ENV_KEYS = [
+	"ELIZA_DEVICE_PAIRING_TOKEN",
+	"ELIZA_DEVICE_BRIDGE_TOKEN",
+] as const;
+const savedEnv = new Map<string, string | undefined>();
+
+function saveEnv(): void {
+	savedEnv.clear();
+	for (const key of ENV_KEYS) savedEnv.set(key, process.env[key]);
+}
+
+function restoreEnv(): void {
+	for (const key of ENV_KEYS) {
+		const value = savedEnv.get(key);
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+}
+
+afterEach(() => {
+	restoreEnv();
+});
+
+function listen(server: http.Server): Promise<number> {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				reject(new Error("test server did not expose a TCP port"));
+				return;
+			}
+			resolve(address.port);
+		});
+	});
+}
+
+/** Resolves with the close code once the socket closes (or opens then closes). */
+function connectAndWaitForClose(url: string): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const socket = new WebSocket(url);
+		const timer = setTimeout(() => {
+			socket.terminate();
+			reject(new Error("timed out waiting for the bridge to close the socket"));
+		}, 5_000);
+		socket.once("close", (code) => {
+			clearTimeout(timer);
+			resolve(code);
+		});
+		socket.once("error", (err) => {
+			clearTimeout(timer);
+			reject(err);
+		});
+	});
+}
+
+async function withBridgeServer(
+	bridge: DeviceBridge,
+	run: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+	const server = http.createServer((_req, res) => res.end("ok"));
+	try {
+		await bridge.attachToHttpServer(server);
+		const port = await listen(server);
+		await run(`ws://127.0.0.1:${port}/api/local-inference/device-bridge`);
+	} finally {
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	}
+}
+
+describe("DeviceBridge WebSocket authentication (W1-011)", () => {
+	it("fails closed when no pairing token is configured", async () => {
+		saveEnv();
+		delete process.env.ELIZA_DEVICE_PAIRING_TOKEN;
+		delete process.env.ELIZA_DEVICE_BRIDGE_TOKEN;
+		const bridge = new DeviceBridge();
+
+		await withBridgeServer(bridge, async (baseUrl) => {
+			await expect(connectAndWaitForClose(baseUrl)).resolves.toBe(4001);
+		});
+	});
+
+	it("rejects a wrong query token when a pairing token is configured", async () => {
+		saveEnv();
+		process.env.ELIZA_DEVICE_PAIRING_TOKEN = "expected-pairing-token";
+		const bridge = new DeviceBridge();
+
+		await withBridgeServer(bridge, async (baseUrl) => {
+			await expect(
+				connectAndWaitForClose(`${baseUrl}?token=wrong-token`),
+			).resolves.toBe(4001);
+		});
+	});
+
+	it("rejects a register frame with a wrong pairing token", async () => {
+		saveEnv();
+		process.env.ELIZA_DEVICE_PAIRING_TOKEN = "expected-pairing-token";
+		const bridge = new DeviceBridge();
+
+		await withBridgeServer(bridge, async (baseUrl) => {
+			const socket = new WebSocket(`${baseUrl}?token=expected-pairing-token`);
+			try {
+				await new Promise<void>((resolve, reject) => {
+					socket.once("open", resolve);
+					socket.once("error", reject);
+				});
+				const closed = new Promise<number>((resolve) =>
+					socket.once("close", resolve),
+				);
+				socket.send(
+					JSON.stringify({
+						type: "register",
+						payload: {
+							deviceId: "rogue-device",
+							pairingToken: "wrong-token",
+							capabilities: {
+								platform: "android",
+								deviceModel: "auth-test",
+								totalRamGb: 8,
+								cpuCores: 8,
+								gpu: null,
+							},
+							loadedPath: null,
+						},
+					}),
+				);
+				await expect(closed).resolves.toBe(4001);
+				expect(bridge.status().connected).toBe(false);
+			} finally {
+				socket.terminate();
+			}
+		});
+	});
+
+	it("registers a device that presents the configured token", async () => {
+		saveEnv();
+		process.env.ELIZA_DEVICE_PAIRING_TOKEN = "expected-pairing-token";
+		const bridge = new DeviceBridge();
+
+		await withBridgeServer(bridge, async (baseUrl) => {
+			const socket = new WebSocket(`${baseUrl}?token=expected-pairing-token`);
+			try {
+				await new Promise<void>((resolve, reject) => {
+					socket.once("open", resolve);
+					socket.once("error", reject);
+				});
+				socket.send(
+					JSON.stringify({
+						type: "register",
+						payload: {
+							deviceId: "legit-device",
+							pairingToken: "expected-pairing-token",
+							capabilities: {
+								platform: "android",
+								deviceModel: "auth-test",
+								totalRamGb: 8,
+								cpuCores: 8,
+								gpu: null,
+							},
+							loadedPath: null,
+						},
+					}),
+				);
+				const deadline = Date.now() + 3_000;
+				while (!bridge.status().connected) {
+					if (Date.now() >= deadline) {
+						throw new Error("device did not register in time");
+					}
+					await new Promise((resolve) => setTimeout(resolve, 10));
+				}
+				expect(bridge.status().devices[0]?.deviceId).toBe("legit-device");
+			} finally {
+				socket.terminate();
+			}
+		});
+	});
+});

--- a/plugins/plugin-local-inference/src/services/device-bridge.ts
+++ b/plugins/plugin-local-inference/src/services/device-bridge.ts
@@ -29,7 +29,7 @@
  * non-blocking — failures fall back to in-memory only.
  */
 
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import fs from "node:fs/promises";
 import type { Server as HttpServer, IncomingMessage } from "node:http";
 import path from "node:path";
@@ -47,6 +47,21 @@ const DEFAULT_LOAD_TIMEOUT_MS = 120_000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const PENDING_LOG_FILENAME = "pending-requests.json";
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Constant-time pairing-token comparison. The bridge fails closed when no
+ * token is configured (the caller checks `expectedPairingToken` first), so an
+ * unset `ELIZA_DEVICE_PAIRING_TOKEN` can never silently authenticate (W1-011).
+ */
+function pairingTokenMatches(
+	expected: string,
+	provided: string | null | undefined,
+): boolean {
+	if (!provided) return false;
+	const a = Buffer.from(expected, "utf8");
+	const b = Buffer.from(provided, "utf8");
+	return a.length === b.length && timingSafeEqual(a, b);
+}
 
 /**
  * `ELIZA_DEVICE_GENERATE_TIMEOUT_MS` is also read by the independent
@@ -556,7 +571,10 @@ export class DeviceBridge {
 		url: URL,
 	): void {
 		const queryToken = url.searchParams.get("token")?.trim();
-		if (this.expectedPairingToken && queryToken !== this.expectedPairingToken) {
+		if (
+			!this.expectedPairingToken ||
+			!pairingTokenMatches(this.expectedPairingToken, queryToken)
+		) {
 			logger.warn("[device-bridge] Rejecting connection: bad query token");
 			socket.close(4001, "unauthorized");
 			return;
@@ -582,8 +600,11 @@ export class DeviceBridge {
 					return;
 				}
 				if (
-					this.expectedPairingToken &&
-					msg.payload.pairingToken !== this.expectedPairingToken
+					!this.expectedPairingToken ||
+					!pairingTokenMatches(
+						this.expectedPairingToken,
+						msg.payload.pairingToken,
+					)
 				) {
 					logger.warn("[device-bridge] Rejecting register: bad pairing token");
 					socket.close(4001, "unauthorized");


### PR DESCRIPTION
## Summary

Six confirmed wave-1 security findings in the agent API surface and its device-bridge companions, each fixed minimally with contract tests.

- **W1-010 (MEDIUM)** — `GET /api/cloud/status` and `GET /api/cloud/credits` bypassed the API token gate for any caller who could reach the port, disclosing the owner's cloud identity and live credit balance. The dedicated gate exemption is removed: trusted-loopback app-core forwarding already passes the standard gate via `isAuthorized`, so the exemption only ever served unauthenticated remote callers.
- **W1-011 (MEDIUM)** — resolved the reported contradiction: the *wired* device-bridge (`plugin-capacitor-bridge`) already failed closed, but the two synced copies (`packages/ui`, `plugin-local-inference`) accepted WS registrations with no pairing check when `ELIZA_DEVICE_PAIRING_TOKEN` was unset. All three implementations now fail closed (close 4001 when no token is configured) and compare tokens with `crypto.timingSafeEqual`. Additionally, the agent server only skips standard WS auth for the device-bridge path when the bridge can actually be attached (enabled + token configured); otherwise the upgrade fails closed with a 404 instead of bypassing auth and dangling the socket.
- **W1-024 (MEDIUM)** — the `?provider=` parameter of `GET /api/models` flowed unchecked into the provider cache file path used by the cache-bust unlink and cache read, allowing path traversal outside the models cache directory. Provider ids are now validated against the canonical grammar at the route (400), and `providerCachePath` additionally asserts the joined path stays directly inside the cache dir.
- **W1-037 (LOW)** — the cloud-pair direct relay's local-only gate trusted client-controlled `Host`/`X-Forwarded-Host` headers. It now keys on the TCP peer address (loopback or private range; private range keeps the supported local-Docker publish shape working, where the in-container peer is the bridge gateway), and the origin forwarded to the Cloud token exchange is reconstructed from direct request metadata only.
- **W1-038 (LOW)** — `POST /api/auth/pair` accepted the raw static API token as a pairing code from any reachable address, making it an online guessing oracle for weak human-chosen tokens (bounded only by per-IP rate limit). Raw-token acceptance is now restricted to trusted loopback operators; remote callers use the rotating, expiring pairing code as before.
- **W1-039 (LOW)** — `GET /api/health` disclosed deployment topology (connector names, plugin/service counts, DB internals, boot phase) unauthenticated. Callers that fail the trusted-local check now receive only the liveness bit with unchanged status-code semantics for orchestrators; loopback dashboard callers keep the full detail.

## Test evidence

All run in the branch worktree after rebasing on `origin/develop` (08bb08c0):

- `packages/agent`: 67 tests passed across `server-auth-boundary.test.ts` (new real-server contract: remote-unauthenticated cloud reads → 401, bearer/loopback pass the gate, untrusted `/api/health` → trimmed, device-bridge upgrade → 404 when the bridge cannot attach), `cloud-pair-route.test.ts` (22, incl. new forwarded-host spoof regression and local-Docker peer case), `models-routes.test.ts` + `model-provider-helpers.test.ts` (traversal ids → 400 / throw), `auth-routes-pair.test.ts` (new: raw token loopback-only, rotating code still works remotely), health-routes suites.
- `plugins/plugin-local-inference`: 25 tests passed incl. new `device-bridge-auth.test.ts` (fail-closed when token unset, wrong-token 4001 on connect and register, happy-path registration).
- `plugins/plugin-capacitor-bridge`: 7 tests passed incl. new no-token (refuses to attach) and wrong-token (4001) suites.
- Typecheck: `packages/agent`, `packages/ui`, `plugins/plugin-local-inference`, `plugins/plugin-capacitor-bridge` all clean. `biome check` clean on all 19 changed files.

## Risk notes

- Behavior changes are confined to unauthenticated/edge callers: authenticated token, host-session, boundary-role, and trusted-loopback flows are unchanged (covered by the new boundary tests and existing auth-trust suites).
- `/api/health` trimming also applies inside cloud-provisioned containers (trusted-local is never granted there); readiness probes keying on the HTTP status code or the `ready` field are unaffected, but any remote consumer of the detailed health shape would need loopback or a follow-up authenticated-detail route.
- The cloud-pair gate now admits private-range TCP peers (not only loopback) so the documented local-Docker relay keeps working; internet-facing public peers remain blocked.
- Out of scope, flagged for follow-up: `packages/app-core/src/api/cloud-pair-route.ts` carries the same forwarded-host trust pattern as fixed here in the agent copy (owned by a different area); the dead `packages/ui` device-bridge copy was hardened rather than deleted to keep the diff minimal.