### PR TITLE
fix(agent): reject malformed route path encoding

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-message-delete.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-message-delete.test.ts
@@ -157,6 +157,17 @@ describe("DELETE /api/conversations/:id/messages/:messageId", () => {
     );
   });
 
+  it("decodes encoded conversation and message ids before deletion", async () => {
+    const seeded = [mem(1), mem(2)];
+    const { state, store } = makeState(seeded, [conv("c-a", roomA)]);
+    const encodedMessageId = memId(2).replace(/^0/, "%30");
+
+    const result = await deleteMessage("%63-a", encodedMessageId, state);
+
+    expect(result).toMatchObject({ status: 200, body: { deletedCount: 1 } });
+    expect(store.map((memory) => memory.id)).toEqual([memId(1)]);
+  });
+
   it("keeps the runtime delete fallback inside the acquired room owner", async () => {
     const store = [mem(1), mem(2)];
     const roomHandlerQueue = new RoomHandlerQueue();

--- a/packages/agent/src/api/__tests__/conversation-path-component.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-path-component.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Exercises every conversation-route path decoder through the production
+ * handler. Malformed encodings must commit a static 400 before conversation,
+ * body, or runtime work; valid encodings are decoded exactly once.
+ */
+import type http from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ConversationRouteContext,
+  type ConversationRouteState,
+  handleConversationRoutes,
+} from "../conversation-routes.ts";
+
+const MALFORMED_COMPONENTS = [
+  "%",
+  "%2",
+  "%ZZ",
+  "%E0%A4",
+  "%ED%A0%80",
+  "%C0%80",
+] as const;
+
+const ROUTES = [
+  {
+    label: "message list conversation id",
+    method: "GET",
+    path: (value: string) => `/api/conversations/${value}/messages`,
+    field: "conversation id",
+  },
+  {
+    label: "import conversation id",
+    method: "POST",
+    path: (value: string) => `/api/conversations/${value}/import`,
+    field: "conversation id",
+  },
+  {
+    label: "truncate conversation id",
+    method: "POST",
+    path: (value: string) => `/api/conversations/${value}/messages/truncate`,
+    field: "conversation id",
+  },
+  {
+    label: "single-message delete conversation id",
+    method: "DELETE",
+    path: (value: string) => `/api/conversations/${value}/messages/message-id`,
+    field: "conversation id",
+  },
+  {
+    label: "single-message delete message id",
+    method: "DELETE",
+    path: (value: string) => `/api/conversations/%61/messages/${value}`,
+    field: "conversation message id",
+  },
+  {
+    label: "stream conversation id",
+    method: "POST",
+    path: (value: string) => `/api/conversations/${value}/messages/stream`,
+    field: "conversation id",
+  },
+  {
+    label: "message-create conversation id",
+    method: "POST",
+    path: (value: string) => `/api/conversations/${value}/messages`,
+    field: "conversation id",
+  },
+  {
+    label: "greeting conversation id",
+    method: "POST",
+    path: (value: string) => `/api/conversations/${value}/greeting`,
+    field: "conversation id",
+  },
+  {
+    label: "patch conversation id",
+    method: "PATCH",
+    path: (value: string) => `/api/conversations/${value}`,
+    field: "conversation id",
+  },
+  {
+    label: "delete conversation id",
+    method: "DELETE",
+    path: (value: string) => `/api/conversations/${value}`,
+    field: "conversation id",
+  },
+] as const;
+
+type RecordedResponse = http.ServerResponse & {
+  body: string;
+  headers: Record<string, string | number | readonly string[]>;
+};
+
+function responseRecorder(): RecordedResponse {
+  return {
+    statusCode: 200,
+    body: "",
+    headers: {},
+    setHeader(
+      this: RecordedResponse,
+      name: string,
+      value: string | number | readonly string[],
+    ) {
+      this.headers[name.toLowerCase()] = value;
+      return this;
+    },
+    end(this: RecordedResponse, chunk?: unknown) {
+      if (chunk !== undefined) this.body += String(chunk);
+      return this;
+    },
+  } as unknown as RecordedResponse;
+}
+
+function makeContext(
+  method: string,
+  pathname: string,
+): {
+  context: ConversationRouteContext;
+  conversationsGet: ReturnType<typeof vi.fn>;
+  readJsonBody: ReturnType<typeof vi.fn>;
+  res: RecordedResponse;
+} {
+  const conversations = new Map();
+  const conversationsGet = vi.spyOn(conversations, "get");
+  const readJsonBody = vi.fn(async () => {
+    throw new Error("request body must not be read before path validation");
+  });
+  const res = responseRecorder();
+  const state = {
+    runtime: null,
+    config: {},
+    agentName: "Path Decoder",
+    adminEntityId: null,
+    chatUserId: null,
+    logBuffer: [],
+    conversations,
+    activeChatTurnCount: 0,
+    conversationRestorePromise: null,
+    deletedConversationIds: new Set<string>(),
+    broadcastWs: null,
+  } as unknown as ConversationRouteState;
+  const context = {
+    req: {
+      url: pathname,
+      headers: { host: "localhost" },
+      socket: { remoteAddress: "127.0.0.1" },
+    },
+    res,
+    method,
+    pathname,
+    readJsonBody,
+    json: vi.fn(),
+    error: vi.fn(),
+    state,
+  } as unknown as ConversationRouteContext;
+  return { context, conversationsGet, readJsonBody, res };
+}
+
+describe("conversation route path-component decoding", () => {
+  for (const route of ROUTES) {
+    for (const malformed of MALFORMED_COMPONENTS) {
+      it(`rejects ${route.label} ${malformed} before route work`, async () => {
+        const pathname = route.path(malformed);
+        const { context, conversationsGet, readJsonBody, res } = makeContext(
+          route.method,
+          pathname,
+        );
+
+        await expect(handleConversationRoutes(context)).resolves.toBe(true);
+
+        expect(res.statusCode).toBe(400);
+        expect(JSON.parse(res.body)).toEqual({
+          error: `Invalid ${route.field}: malformed URL encoding`,
+        });
+        expect(conversationsGet).not.toHaveBeenCalled();
+        expect(readJsonBody).not.toHaveBeenCalled();
+      });
+    }
+  }
+
+  it("decodes a valid conversation id once before lookup", async () => {
+    const { context, conversationsGet, res } = makeContext(
+      "GET",
+      "/api/conversations/%61/messages",
+    );
+
+    await expect(handleConversationRoutes(context)).resolves.toBe(true);
+
+    expect(conversationsGet).toHaveBeenCalledWith("a");
+    expect(conversationsGet.mock.calls.every(([id]) => id === "a")).toBe(true);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("does not decode an already encoded percent sequence twice", async () => {
+    const { context, conversationsGet, res } = makeContext(
+      "GET",
+      "/api/conversations/%2561/messages",
+    );
+
+    await expect(handleConversationRoutes(context)).resolves.toBe(true);
+
+    expect(conversationsGet).toHaveBeenCalledWith("%61");
+    expect(conversationsGet.mock.calls.every(([id]) => id === "%61")).toBe(
+      true,
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("decodes an encoded slash only after route matching", async () => {
+    const { context, conversationsGet, res } = makeContext(
+      "GET",
+      "/api/conversations/%2F/messages",
+    );
+
+    await expect(handleConversationRoutes(context)).resolves.toBe(true);
+
+    expect(conversationsGet).toHaveBeenCalledWith("/");
+    expect(conversationsGet.mock.calls.every(([id]) => id === "/")).toBe(true);
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -136,6 +136,7 @@ import { evictOldestConversation } from "./memory-bounds.ts";
 import { generateMessageCorpus, seedMessageCorpus } from "./message-corpus.ts";
 import {
   buildUserMessages,
+  decodePathComponent,
   getErrorMessage,
   resolveAppUserName,
   resolveConversationGreetingText,
@@ -2871,7 +2872,12 @@ export async function handleConversationRoutes(
     method === "GET" &&
     /^\/api\/conversations\/[^/]+\/messages$/.test(pathname)
   ) {
-    const convId = decodeURIComponent(pathname.split("/")[3]);
+    const convId = decodePathComponent(
+      pathname.split("/")[3],
+      res,
+      "conversation id",
+    );
+    if (convId === null) return true;
     const conv = await getConversationWithRestore(state, convId);
     if (!conv) {
       error(res, "Conversation not found", 404);
@@ -3202,7 +3208,12 @@ export async function handleConversationRoutes(
     method === "POST" &&
     /^\/api\/conversations\/[^/]+\/import$/.test(pathname)
   ) {
-    const convId = decodeURIComponent(pathname.split("/")[3]);
+    const convId = decodePathComponent(
+      pathname.split("/")[3],
+      res,
+      "conversation id",
+    );
+    if (convId === null) return true;
     const rawImport = await readJsonBody<Record<string, unknown>>(req, res);
     if (rawImport === null) return true;
     const rawMessages = rawImport.messages;
@@ -3599,7 +3610,12 @@ export async function handleConversationRoutes(
     method === "POST" &&
     /^\/api\/conversations\/[^/]+\/messages\/truncate$/.test(pathname)
   ) {
-    const convId = decodeURIComponent(pathname.split("/")[3]);
+    const convId = decodePathComponent(
+      pathname.split("/")[3],
+      res,
+      "conversation id",
+    );
+    if (convId === null) return true;
     const conv = await getConversationWithRestore(state, convId);
     if (!conv) {
       error(res, "Conversation not found", 404);
@@ -3695,8 +3711,14 @@ export async function handleConversationRoutes(
     /^\/api\/conversations\/[^/]+\/messages\/[^/]+$/.test(pathname)
   ) {
     const segments = pathname.split("/");
-    const convId = decodeURIComponent(segments[3]);
-    const messageId = decodeURIComponent(segments[5]);
+    const convId = decodePathComponent(segments[3], res, "conversation id");
+    if (convId === null) return true;
+    const messageId = decodePathComponent(
+      segments[5],
+      res,
+      "conversation message id",
+    );
+    if (messageId === null) return true;
     const conv = await getConversationWithRestore(state, convId);
     if (!conv) {
       error(res, "Conversation not found", 404);
@@ -3776,7 +3798,12 @@ export async function handleConversationRoutes(
     method === "POST" &&
     /^\/api\/conversations\/[^/]+\/messages\/stream$/.test(pathname)
   ) {
-    const convId = decodeURIComponent(pathname.split("/")[3]);
+    const convId = decodePathComponent(
+      pathname.split("/")[3],
+      res,
+      "conversation id",
+    );
+    if (convId === null) return true;
     const conv = await getConversationWithRestore(state, convId);
     if (!conv) {
       error(res, "Conversation not found", 404);
@@ -4671,7 +4698,12 @@ export async function handleConversationRoutes(
     method === "POST" &&
     /^\/api\/conversations\/[^/]+\/messages$/.test(pathname)
   ) {
-    const convId = decodeURIComponent(pathname.split("/")[3]);
+    const convId = decodePathComponent(
+      pathname.split("/")[3],
+      res,
+      "conversation id",
+    );
+    if (convId === null) return true;
     const conv = await getConversationWithRestore(state, convId);
     if (!conv) {
       error(res, "Conversation not found", 404);
@@ -5163,7 +5195,12 @@ export async function handleConversationRoutes(
     method === "POST" &&
     /^\/api\/conversations\/[^/]+\/greeting$/.test(pathname)
   ) {
-    const convId = decodeURIComponent(pathname.split("/")[3]);
+    const convId = decodePathComponent(
+      pathname.split("/")[3],
+      res,
+      "conversation id",
+    );
+    if (convId === null) return true;
     const conv = await getConversationWithRestore(state, convId);
     if (!conv) {
       error(res, "Conversation not found", 404);
@@ -5255,7 +5292,12 @@ export async function handleConversationRoutes(
     /^\/api\/conversations\/[^/]+$/.test(pathname) &&
     !pathname.endsWith("/messages")
   ) {
-    const convId = decodeURIComponent(pathname.split("/")[3]);
+    const convId = decodePathComponent(
+      pathname.split("/")[3],
+      res,
+      "conversation id",
+    );
+    if (convId === null) return true;
     const conv = await getConversationWithRestore(state, convId);
     if (!conv) {
       error(res, "Conversation not found", 404);
@@ -5445,7 +5487,12 @@ export async function handleConversationRoutes(
     !pathname.endsWith("/messages")
   ) {
     if (rejectWaifuNonAdminMutationIfNeeded(req, error, res)) return true;
-    const convId = decodeURIComponent(pathname.split("/")[3]);
+    const convId = decodePathComponent(
+      pathname.split("/")[3],
+      res,
+      "conversation id",
+    );
+    if (convId === null) return true;
     const conv = await getConversationWithRestore(state, convId);
     const runtime = state.runtime;
     if (conv?.roomId && runtime) {

--- a/packages/agent/src/api/database.path-component.test.ts
+++ b/packages/agent/src/api/database.path-component.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Exercises database-table path decoding through the production route handler.
+ * Invalid encodings must return a static 400 before Drizzle execution; valid
+ * encodings must reach table lookup exactly once.
+ */
+import type http from "node:http";
+import type { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleDatabaseRoute } from "./database.ts";
+
+const MALFORMED_COMPONENTS = [
+  "%",
+  "%2",
+  "%ZZ",
+  "%E0%A4",
+  "%ED%A0%80",
+  "%C0%80",
+] as const;
+
+type RecordedResponse = http.ServerResponse & {
+  body: string;
+  headers: Record<string, string | number | readonly string[]>;
+};
+
+function responseRecorder(): RecordedResponse {
+  return {
+    statusCode: 200,
+    body: "",
+    headers: {},
+    setHeader(
+      this: RecordedResponse,
+      name: string,
+      value: string | number | readonly string[],
+    ) {
+      this.headers[name.toLowerCase()] = value;
+      return this;
+    },
+    end(this: RecordedResponse, chunk?: unknown) {
+      if (chunk !== undefined) this.body += String(chunk);
+      return this;
+    },
+  } as unknown as RecordedResponse;
+}
+
+async function requestRows(tableComponent: string): Promise<{
+  execute: ReturnType<typeof vi.fn>;
+  handled: boolean;
+  res: RecordedResponse;
+}> {
+  const pathname = `/api/database/tables/${tableComponent}/rows`;
+  const execute = vi.fn().mockResolvedValue({ rows: [], fields: [] });
+  const runtime = {
+    adapter: { db: { execute } },
+  } as unknown as AgentRuntime;
+  const req = {
+    method: "GET",
+    url: pathname,
+    headers: { host: "localhost" },
+  } as unknown as http.IncomingMessage;
+  const res = responseRecorder();
+
+  const handled = await handleDatabaseRoute(req, res, runtime, pathname);
+  return { execute, handled, res };
+}
+
+describe("database table path-component decoding", () => {
+  for (const malformed of MALFORMED_COMPONENTS) {
+    it(`rejects ${malformed} before database execution`, async () => {
+      const { execute, handled, res } = await requestRows(malformed);
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body)).toEqual({
+        error: "Invalid database table name: malformed URL encoding",
+      });
+      expect(execute).not.toHaveBeenCalled();
+    });
+  }
+
+  it("decodes a valid table component before lookup", async () => {
+    const { execute, handled, res } = await requestRows("%61");
+
+    expect(handled).toBe(true);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Table "a" not found' });
+  });
+
+  it("does not decode an encoded percent sequence twice", async () => {
+    const { execute, res } = await requestRows("%2561");
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Table "%61" not found' });
+  });
+
+  it("decodes an encoded slash only after route matching", async () => {
+    const { execute, res } = await requestRows("%2F");
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Table "/" not found' });
+  });
+});

--- a/packages/agent/src/api/database.ts
+++ b/packages/agent/src/api/database.ts
@@ -42,6 +42,7 @@ import type {
   DatabaseProviderType,
   PostgresCredentials,
 } from "../config/types.eliza.ts";
+import { decodePathComponent } from "./server-helpers.ts";
 
 export {
   stripSqlBlockComments,
@@ -1376,7 +1377,12 @@ export async function handleDatabaseRoute(
   // ── Table row operations: /api/database/tables/:table/rows ────────────
   const rowsMatch = pathname.match(/^\/api\/database\/tables\/([^/]+)\/rows$/);
   if (rowsMatch) {
-    const tableNameDecoded = decodeURIComponent(rowsMatch[1]);
+    const tableNameDecoded = decodePathComponent(
+      rowsMatch[1],
+      res,
+      "database table name",
+    );
+    if (tableNameDecoded === null) return true;
 
     if (method === "GET") {
       await handleGetRows(req, res, runtime, tableNameDecoded);

--- a/packages/agent/src/api/remote-capability-routes.test.ts
+++ b/packages/agent/src/api/remote-capability-routes.test.ts
@@ -35,6 +35,14 @@ const originalEnabled = process.env.ELIZA_CAPABILITY_ROUTER_ENABLED;
 const originalUrls = process.env.ELIZA_CAPABILITY_ROUTER_URLS;
 const originalAllowedModules =
   process.env.ELIZA_CAPABILITY_ROUTER_ALLOWED_MODULES;
+const MALFORMED_COMPONENTS = [
+  "%",
+  "%2",
+  "%ZZ",
+  "%E0%A4",
+  "%ED%A0%80",
+  "%C0%80",
+] as const;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -203,6 +211,122 @@ describe("handleRemoteCapabilityRoutes", () => {
     expect(json).not.toHaveBeenCalled();
     expect(error).not.toHaveBeenCalled();
   });
+
+  it("decodes each valid remote-asset path component exactly once", async () => {
+    const getAsset = vi.fn().mockResolvedValue({
+      path: "/assets/remote-view.js",
+      contentType: "text/javascript",
+      bodyBase64: Buffer.from("export {};").toString("base64"),
+    });
+    const router = {
+      plugin: { getAsset },
+    } as unknown as ElizaCapabilityRouter;
+    const runtime = {
+      getService: () => router,
+    } as Partial<IAgentRuntime> as IAgentRuntime;
+    const { ctx, error } = makeCtx(
+      {},
+      {
+        method: "GET",
+        pathname:
+          "/api/capability-router/assets/%64evice/%72emote-demo/%61ssets/remote-view.js",
+        runtime,
+        res: {
+          writeHead: vi.fn(),
+          end: vi.fn(),
+        } as unknown as http.ServerResponse,
+      },
+    );
+
+    await expect(handleRemoteCapabilityRoutes(ctx)).resolves.toBe(true);
+
+    expect(getAsset).toHaveBeenCalledWith({
+      endpointId: "device",
+      moduleId: "remote-demo",
+      path: "/assets/remote-view.js",
+    });
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("decodes an encoded slash only after remote-asset route matching", async () => {
+    const getAsset = vi.fn().mockResolvedValue({
+      path: "/assets/remote-view.js",
+      contentType: "text/javascript",
+      bodyBase64: Buffer.from("export {};").toString("base64"),
+    });
+    const router = {
+      plugin: { getAsset },
+    } as unknown as ElizaCapabilityRouter;
+    const runtime = {
+      getService: () => router,
+    } as Partial<IAgentRuntime> as IAgentRuntime;
+    const { ctx, error } = makeCtx(
+      {},
+      {
+        method: "GET",
+        pathname:
+          "/api/capability-router/assets/%2F/%72emote-demo/%61ssets/remote-view.js",
+        runtime,
+        res: {
+          writeHead: vi.fn(),
+          end: vi.fn(),
+        } as unknown as http.ServerResponse,
+      },
+    );
+
+    await expect(handleRemoteCapabilityRoutes(ctx)).resolves.toBe(true);
+
+    expect(getAsset).toHaveBeenCalledWith({
+      endpointId: "/",
+      moduleId: "remote-demo",
+      path: "/assets/remote-view.js",
+    });
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  for (const malformed of MALFORMED_COMPONENTS) {
+    for (const route of [
+      {
+        field: "endpoint id",
+        pathname: `/api/capability-router/assets/${malformed}/module/assets/view.js`,
+      },
+      {
+        field: "module id",
+        pathname: `/api/capability-router/assets/device/${malformed}/assets/view.js`,
+      },
+      {
+        field: "asset path",
+        pathname: `/api/capability-router/assets/device/module/assets/${malformed}`,
+      },
+    ]) {
+      it(`rejects malformed ${route.field} ${malformed} before asset lookup`, async () => {
+        const getAsset = vi.fn();
+        const router = {
+          plugin: { getAsset },
+        } as unknown as ElizaCapabilityRouter;
+        const runtime = {
+          getService: () => router,
+        } as Partial<IAgentRuntime> as IAgentRuntime;
+        const { ctx, error } = makeCtx(
+          {},
+          {
+            method: "GET",
+            pathname: route.pathname,
+            runtime,
+          },
+        );
+
+        await expect(handleRemoteCapabilityRoutes(ctx)).resolves.toBe(true);
+
+        expect(error).toHaveBeenCalledWith(
+          ctx.res,
+          `Invalid ${route.field}: malformed URL encoding`,
+          400,
+        );
+        expect(getAsset).not.toHaveBeenCalled();
+      });
+    }
+  }
 
   it("serves remote asset HEAD requests with the decoded content length", async () => {
     const getAsset = vi.fn().mockResolvedValue({

--- a/packages/agent/src/api/remote-capability-routes.ts
+++ b/packages/agent/src/api/remote-capability-routes.ts
@@ -24,6 +24,7 @@ import {
   type RouteHelpers,
   type RouteRequestMeta,
 } from "@elizaos/core";
+import { decodeUrlPathComponent } from "@elizaos/shared";
 import {
   type ConnectCloudCapabilitySandboxOptions,
   type ConnectCloudCapabilitySandboxResult,
@@ -386,9 +387,19 @@ function parseAssetProxyPath(pathname: string): {
       "Capability asset URL must include endpoint id, module id, and path.",
     );
   }
-  const endpointId = decodeURIComponent(encodedEndpointId);
-  const moduleId = decodeURIComponent(encodedModuleId);
-  const assetSegments = assetParts.map((part) => decodeURIComponent(part));
+  const decodeAssetComponent = (raw: string, fieldName: string): string => {
+    const decoded = decodeUrlPathComponent(raw);
+    if (!decoded.ok) {
+      // error-policy:J3 malformed path encoding is explicit invalid input.
+      throw new Error(`Invalid ${fieldName}: malformed URL encoding`);
+    }
+    return decoded.value;
+  };
+  const endpointId = decodeAssetComponent(encodedEndpointId, "endpoint id");
+  const moduleId = decodeAssetComponent(encodedModuleId, "module id");
+  const assetSegments = assetParts.map((part) =>
+    decodeAssetComponent(part, "asset path"),
+  );
   const hasUnsafeSegment = assetSegments.some(
     (part) => !part || part === "." || part === ".." || part.includes("\\"),
   );

--- a/packages/agent/src/api/server.path-component-routes.test.ts
+++ b/packages/agent/src/api/server.path-component-routes.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Boots the real TCP API host with a deterministic browser-plugin boundary to
+ * prove host-owned browser package/workspace path segments reject malformed
+ * encoding before browser operations and decode valid values exactly once.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const browserMocks = vi.hoisted(() => ({
+  buildPackage: vi.fn(async (browser: string) => ({ browser, built: true })),
+  closeTab: vi.fn(async () => true),
+  getPackageStatus: vi.fn(() => ({ ready: true })),
+  getWorkspaceSnapshot: vi.fn(async () => ({ mode: "web", tabs: [] })),
+  openManager: vi.fn(async (browser: string) => ({ browser, opened: true })),
+}));
+
+vi.mock("@elizaos/plugin-browser", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@elizaos/plugin-browser")>()),
+  __mobileStub: false,
+  BROWSER_BRIDGE_KINDS: ["chrome", "safari"],
+  BROWSER_BRIDGE_PACKAGE_PATH_TARGETS: ["chrome-build"],
+  buildBrowserBridgeCompanionPackage: browserMocks.buildPackage,
+  closeBrowserWorkspaceTab: browserMocks.closeTab,
+  getBrowserBridgeCompanionPackageStatus: browserMocks.getPackageStatus,
+  getBrowserWorkspaceSnapshot: browserMocks.getWorkspaceSnapshot,
+  openBrowserBridgeCompanionManager: browserMocks.openManager,
+}));
+
+import { startApiServer } from "./server.ts";
+
+const MALFORMED_COMPONENTS = [
+  "%",
+  "%2",
+  "%ZZ",
+  "%E0%A4",
+  "%ED%A0%80",
+  "%C0%80",
+] as const;
+
+const TOKEN = "path-component-route-test";
+const touchedEnv = [
+  "ELIZA_API_AUTH_TOKEN",
+  "ELIZA_API_BIND_HOST",
+  "ELIZA_API_TOKEN",
+  "ELIZA_CONFIG_PATH",
+  "ELIZA_DEVICE_BRIDGE_ENABLED",
+  "ELIZA_PERSIST_CONFIG_PATH",
+  "ELIZA_PLATFORM",
+  "ELIZA_STATE_DIR",
+] as const;
+const originalEnv = new Map<string, string | undefined>();
+
+type ApiServer = Awaited<ReturnType<typeof startApiServer>>;
+let api: ApiServer;
+let root: string;
+
+async function request(pathname: string, method: string): Promise<Response> {
+  return fetch(`http://127.0.0.1:${api.port}${pathname}`, {
+    method,
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  });
+}
+
+beforeAll(async () => {
+  for (const key of touchedEnv) originalEnv.set(key, process.env[key]);
+  root = await mkdtemp(path.join(tmpdir(), "eliza-path-component-routes-"));
+  const configPath = path.join(root, "eliza.json");
+  await writeFile(configPath, JSON.stringify({ logging: { level: "fatal" } }));
+  process.env.ELIZA_STATE_DIR = root;
+  process.env.ELIZA_CONFIG_PATH = configPath;
+  process.env.ELIZA_PERSIST_CONFIG_PATH = configPath;
+  process.env.ELIZA_API_BIND_HOST = "127.0.0.1";
+  process.env.ELIZA_API_TOKEN = TOKEN;
+  delete process.env.ELIZA_API_AUTH_TOKEN;
+  delete process.env.ELIZA_DEVICE_BRIDGE_ENABLED;
+  delete process.env.ELIZA_PLATFORM;
+  api = await startApiServer({
+    port: 0,
+    skipDeferredStartupWork: true,
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterAll(async () => {
+  await api?.close();
+  await rm(root, { recursive: true, force: true });
+  for (const key of touchedEnv) {
+    const original = originalEnv.get(key);
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+});
+
+describe("host browser route path-component decoding", () => {
+  for (const malformed of MALFORMED_COMPONENTS) {
+    for (const route of [
+      {
+        label: "package build browser",
+        method: "POST",
+        path: `/api/browser-bridge/packages/${malformed}/build`,
+        error: "Invalid browser bridge package browser: malformed URL encoding",
+      },
+      {
+        label: "package manager browser",
+        method: "POST",
+        path: `/api/browser-bridge/packages/${malformed}/open-manager`,
+        error: "Invalid browser bridge package browser: malformed URL encoding",
+      },
+      {
+        label: "workspace tab id",
+        method: "DELETE",
+        path: `/api/browser-workspace/tabs/${malformed}`,
+        error: "Invalid browser workspace tab id: malformed URL encoding",
+      },
+    ]) {
+      it(`rejects malformed ${route.label} ${malformed} before browser work`, async () => {
+        const response = await request(route.path, route.method);
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toEqual({ error: route.error });
+        expect(browserMocks.buildPackage).not.toHaveBeenCalled();
+        expect(browserMocks.openManager).not.toHaveBeenCalled();
+        expect(browserMocks.closeTab).not.toHaveBeenCalled();
+      });
+    }
+  }
+
+  it("decodes a valid package-build browser before dispatch", async () => {
+    const response = await request(
+      "/api/browser-bridge/packages/%63hrome/build",
+      "POST",
+    );
+
+    expect(response.status).toBe(200);
+    expect(browserMocks.buildPackage).toHaveBeenCalledWith("chrome");
+  });
+
+  it("decodes a valid package-manager browser before dispatch", async () => {
+    const response = await request(
+      "/api/browser-bridge/packages/%73afari/open-manager",
+      "POST",
+    );
+
+    expect(response.status).toBe(200);
+    expect(browserMocks.openManager).toHaveBeenCalledWith("safari");
+  });
+
+  it("decodes a valid workspace tab id before dispatch", async () => {
+    const response = await request("/api/browser-workspace/tabs/%61", "DELETE");
+
+    expect(response.status).toBe(200);
+    expect(browserMocks.closeTab).toHaveBeenCalledWith("a");
+  });
+
+  it("decodes an encoded slash in a workspace tab only after routing", async () => {
+    const response = await request("/api/browser-workspace/tabs/%2F", "DELETE");
+
+    expect(response.status).toBe(200);
+    expect(browserMocks.closeTab).toHaveBeenCalledWith("/");
+  });
+
+  it("does not decode a workspace tab id twice", async () => {
+    const response = await request(
+      "/api/browser-workspace/tabs/%2561",
+      "DELETE",
+    );
+
+    expect(response.status).toBe(200);
+    expect(browserMocks.closeTab).toHaveBeenCalledWith("%61");
+  });
+});

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -776,11 +776,10 @@ function parseBrowserBridgeKind(
   value: string | undefined,
 ): BrowserBridgeKind | null {
   if (!value) return null;
-  const decoded = decodeURIComponent(value);
   return (browserPlugin.BROWSER_BRIDGE_KINDS as readonly string[]).includes(
-    decoded,
+    value,
   )
-    ? (decoded as BrowserBridgeKind)
+    ? (value as BrowserBridgeKind)
     : null;
 }
 
@@ -879,12 +878,18 @@ async function handleBuiltinOptionalRoutes(
     /^\/api\/browser-bridge\/packages\/([^/]+)\/build$/,
   );
   if (method === "POST" && packageBuildMatch) {
+    const decodedBrowser = decodePathComponent(
+      packageBuildMatch[1],
+      res,
+      "browser bridge package browser",
+    );
+    if (decodedBrowser === null) return true;
     const browserPlugin = await getBrowserBridgePlugin();
     if (!browserPlugin) {
       error(res, "Browser bridge is not available on this platform", 503);
       return true;
     }
-    const browser = parseBrowserBridgeKind(browserPlugin, packageBuildMatch[1]);
+    const browser = parseBrowserBridgeKind(browserPlugin, decodedBrowser);
     if (!browser) {
       error(res, "Invalid browser bridge package browser", 400);
       return true;
@@ -899,15 +904,18 @@ async function handleBuiltinOptionalRoutes(
     /^\/api\/browser-bridge\/packages\/([^/]+)\/open-manager$/,
   );
   if (method === "POST" && packageManagerMatch) {
+    const decodedBrowser = decodePathComponent(
+      packageManagerMatch[1],
+      res,
+      "browser bridge package browser",
+    );
+    if (decodedBrowser === null) return true;
     const browserPlugin = await getBrowserBridgePlugin();
     if (!browserPlugin) {
       error(res, "Browser bridge is not available on this platform", 503);
       return true;
     }
-    const browser = parseBrowserBridgeKind(
-      browserPlugin,
-      packageManagerMatch[1],
-    );
+    const browser = parseBrowserBridgeKind(browserPlugin, decodedBrowser);
     if (!browser) {
       error(res, "Invalid browser bridge package browser", 400);
       return true;
@@ -977,7 +985,17 @@ async function handleBuiltinOptionalRoutes(
     return false;
   }
 
-  const tabId = decodeURIComponent(tabMatch[1]).trim();
+  const decodedTabId = decodePathComponent(
+    tabMatch[1],
+    res,
+    "browser workspace tab id",
+  );
+  if (decodedTabId === null) return true;
+  const tabId = decodedTabId.trim();
+  if (!tabId) {
+    error(res, "Browser workspace tab id is required", 400);
+    return true;
+  }
   const action = tabMatch[2] ?? null;
 
   const browserPlugin = await getBrowserWorkspacePlugin();


### PR DESCRIPTION
# Relates to

Fixes #21296

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`2029ff84240ffcb3cf412b72879156bc0b2003be`).
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` were
      run after sync; the exact unrelated Windows blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the
      red/green handler matrix and command transcripts below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2029ff84240ffcb3cf412b72879156bc0b2003be:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] `bun run verify` was run post-sync; its unrelated App Core CRLF failure is
      documented in **Known gaps / failures**.

# Risks

Low. The change replaces 16 throwing path decodes with the repository's shared
decoder and static 400 responses. Valid values are still decoded exactly once.
The affected surface is limited to conversation IDs, remote-capability asset
parts, browser bridge/workspace IDs, and database table names.

# Background

## What does this PR do?

- Routes all ten conversation path decode sites through `decodePathComponent`.
- Rejects malformed endpoint, module, and asset components before capability
  registry access.
- Validates browser package kinds and workspace tab IDs before plugin loading.
- Rejects malformed database table names before Drizzle execution.
- Adds real handler/TCP regressions for all six adversarial encodings, service
  non-invocation, `%61`, `%2561`, and `%2F` behavior.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed. This restores the documented J3
invalid-input behavior at existing API boundaries.

# Testing

## Where should a reviewer start?

Start with `packages/agent/src/api/__tests__/conversation-path-component.test.ts`
and `packages/agent/src/api/server.path-component-routes.test.ts`, then inspect
the four production route files.

## Detailed testing steps

```bash
node packages/shared/scripts/generate-keywords.mjs
bunx vitest run \
  packages/agent/src/api/__tests__/conversation-path-component.test.ts \
  packages/agent/src/api/__tests__/conversation-message-delete.test.ts \
  packages/agent/src/api/remote-capability-routes.test.ts \
  packages/agent/src/api/database.path-component.test.ts \
  packages/agent/src/api/server.path-component-routes.test.ts \
  --config packages/agent/vitest.config.ts
bun run --cwd packages/agent lint:check
bun run --cwd packages/agent typecheck
bun run --cwd packages/agent build
```

# Evidence Gate

<!-- evidence-head:4d70aa8b2b949a550c2671b1fe34b279b94cb5ce -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend path-decoding behavior only; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend path-decoding behavior only; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - deterministic HTTP/handler boundary with no visual flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no deployed backend or credentials are needed; inline production-handler and real-TCP red/green transcripts are provided below.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code, console state, or browser network client changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no action, provider, prompt, model, or inference behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - this validation fix creates no persistent domain object; the inline adversarial HTTP matrix is the deterministic proof.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this is deterministic HTTP input validation and does not invoke a model.

## Backend + frontend logs

The test-only commit was applied to exact base
`08bb08c0f7170be08b66927903d2d2da0322c289` without the production fix:

```text
RED_EXIT=1
Test Files  4 failed | 1 passed (5)
Tests       102 failed | 50 passed (152)
conversation: promise rejected "URIError: URI malformed" instead of resolving
browser TCP routes: expected 400, received 500
```

The temporary red branch was deleted. On exact PR head
`b54e778799a034035311437043f8cb61799b2191`:

```text
Test Files  5 passed (5)
Tests       152 passed (152)
Agent lint: Checked 934 files. No fixes applied.
Agent typecheck: PASS
Agent build: PASS (196 relative imports rewritten)
```

Adversarial coverage:

| Surface | Malformed matrix | Valid / no-side-effect proof |
|---|---:|---|
| Conversation routes | 10 segment sites x 6 values | decoded Map key; body/runtime untouched on 400 |
| Remote capability assets | endpoint/module/asset x 6 values | decoded `getAsset` arguments; no lookup on 400 |
| Browser host routes | build/manager/tab x 6 values | real TCP 400 before plugin work |
| Database tables | 6 values | decoded table lookup; no Drizzle execution on 400 |

Every surface also pins `%61`, exactly-once `%2561`, and encoded-slash `%2F`
behavior where applicable. The malformed matrix is `%`, `%2`, `%ZZ`, `%E0%A4`,
`%ED%A0%80`, and `%C0%80`.

Frontend: N/A - no frontend files changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- Root `bun run verify` reaches the monorepo Turbo gates and fails on Biome
  formatting of untouched `packages/app-core/src/styles/electrobun-frameless.css`
  because the Windows checkout contains CRLF. Agent lint/typecheck/build pass.
- The canonical Agent batch runner currently fails to spawn all 446 batches on
  Windows with `spawn bunx ENOENT` (open portability PR #21288). For integration
  context only, #21288, #21299, and #21318 were temporarily composed on top of
  this head. All 446 files then ran; every changed route batch passed. Seven
  unrelated Windows-only batches remained red (POSIX permission/mode checks,
  absolute/newline filename assumptions, `sh` availability, and symlink privilege).
  None touch this PR's files. The composition branch was deleted and none of
  those commits are included here.
- Open PR #21180 changes only the distant conversation search-snippet truncation
  line around 2516; it does not overlap any decoder hunk or test in this PR.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2029ff84240ffcb3cf412b72879156bc0b2003be:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-agent-route-decoding]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2029ff84240ffcb3cf412b72879156bc0b2003be:packages/skills/skills/contribute-to-eliza"} -->


