### PR TITLE
fix(plugin-local-inference): reject malformed speaker-profile id encoding

### DIFF
--- a/plugins/plugin-local-inference/src/routes/voice-speaker-profile-routes.encoding.test.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-speaker-profile-routes.encoding.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Speaker-profile bind/unbind path encoding is leftover tax after
+ * voice-profiles / voice-models route work. Stock develop called
+ * decodeURIComponent on POST /v1/voice/speaker-profiles/:id/{bind,unbind},
+ * so `%` / `%2` / `%ZZ` threw URIError (500) instead of a typed 400.
+ * List stays untouched.
+ */
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+	logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+	resolveStateDir: () => "/tmp",
+	sendJson: (
+		res: { statusCode: number; end: (chunk?: string) => void },
+		body: unknown,
+		status = 200,
+	) => {
+		res.statusCode = status;
+		res.end(JSON.stringify(body));
+	},
+	sendJsonError: (
+		res: { statusCode: number; end: (chunk?: string) => void },
+		message: string,
+		status = 400,
+	) => {
+		res.statusCode = status;
+		res.end(JSON.stringify({ error: message }));
+	},
+	readJsonBody: async (req: AsyncIterable<Buffer> & { body?: unknown }) => {
+		if (req.body && typeof req.body === "object") {
+			return req.body as Record<string, unknown>;
+		}
+		const chunks: Buffer[] = [];
+		for await (const chunk of req) {
+			chunks.push(chunk);
+		}
+		const raw = Buffer.concat(chunks).toString("utf8").trim();
+		return raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+	},
+}));
+
+const {
+	handleVoiceSpeakerProfileRoutes,
+	setVoiceSpeakerProfileStore,
+} = await import("./voice-speaker-profile-routes");
+
+function makeReq(args: {
+	method: "GET" | "POST";
+	url: string;
+	body?: string | null;
+}): import("node:http").IncomingMessage {
+	const emitter = new EventEmitter();
+	const body =
+		args.body == null ? Buffer.alloc(0) : Buffer.from(args.body, "utf8");
+	(emitter as unknown as { method: string }).method = args.method;
+	(emitter as unknown as { url: string }).url = args.url;
+	(emitter as unknown as { headers: Record<string, string> }).headers = {
+		"content-type": "application/json",
+		"content-length": String(body.length),
+	};
+	(
+		emitter as unknown as {
+			[Symbol.asyncIterator]: () => AsyncIterator<Buffer>;
+		}
+	)[Symbol.asyncIterator] = async function* () {
+		yield body;
+	};
+	return emitter as unknown as import("node:http").IncomingMessage;
+}
+
+interface CapturedResponse {
+	statusCode: number;
+	body: string;
+}
+
+function makeRes(): {
+	res: import("node:http").ServerResponse;
+	captured: CapturedResponse;
+} {
+	const captured: CapturedResponse = { statusCode: 200, body: "" };
+	const chunks: Buffer[] = [];
+	const res = {
+		statusCode: 200,
+		headersSent: false,
+		setHeader() {},
+		writeHead(code: number) {
+			captured.statusCode = code;
+		},
+		write(chunk: Buffer | string) {
+			chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+			return true;
+		},
+		end(chunk?: Buffer | string) {
+			if (chunk != null) {
+				chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+			}
+			captured.body = Buffer.concat(chunks).toString("utf8");
+			if (captured.statusCode === 200) {
+				captured.statusCode = (res as unknown as { statusCode: number })
+					.statusCode;
+			}
+		},
+	};
+	return {
+		res: res as unknown as import("node:http").ServerResponse,
+		captured,
+	};
+}
+
+function mockStore() {
+	return {
+		bindEntity: vi.fn(async () => null),
+		unbindEntity: vi.fn(async () => null),
+		list: vi.fn(async () => []),
+		get: vi.fn(async () => null),
+		init: vi.fn(async () => undefined),
+	};
+}
+
+afterEach(() => {
+	setVoiceSpeakerProfileStore(null);
+});
+
+describe("POST /v1/voice/speaker-profiles/:id encoding", () => {
+	it("canonical bind id still 404s as not found", async () => {
+		const store = mockStore();
+		setVoiceSpeakerProfileStore(store as never);
+		const { res, captured } = makeRes();
+		const handled = await handleVoiceSpeakerProfileRoutes(
+			makeReq({
+				method: "POST",
+				url: "/v1/voice/speaker-profiles/vp_missing/bind",
+				body: JSON.stringify({ entityId: "ent_jill" }),
+			}),
+			res,
+		);
+		expect(handled).toBe(true);
+		expect(captured.statusCode).toBe(404);
+		expect(store.bindEntity).toHaveBeenCalledWith({
+			profileId: "vp_missing",
+			entityId: "ent_jill",
+			label: undefined,
+		});
+	});
+
+	it("canonical percent-encoded underscore still decodes before the 404", async () => {
+		const store = mockStore();
+		setVoiceSpeakerProfileStore(store as never);
+		const { res, captured } = makeRes();
+		await handleVoiceSpeakerProfileRoutes(
+			makeReq({
+				method: "POST",
+				url: "/v1/voice/speaker-profiles/vp%5Fmissing/bind",
+				body: JSON.stringify({ entityId: "ent_jill" }),
+			}),
+			res,
+		);
+		expect(captured.statusCode).toBe(404);
+		expect(store.bindEntity).toHaveBeenCalledWith({
+			profileId: "vp_missing",
+			entityId: "ent_jill",
+			label: undefined,
+		});
+	});
+
+	it("GET speaker-profiles list is untouched", async () => {
+		const store = mockStore();
+		setVoiceSpeakerProfileStore(store as never);
+		const { res, captured } = makeRes();
+		const handled = await handleVoiceSpeakerProfileRoutes(
+			makeReq({ method: "GET", url: "/v1/voice/speaker-profiles" }),
+			res,
+		);
+		expect(handled).toBe(true);
+		expect(captured.statusCode).toBe(200);
+		expect(JSON.parse(captured.body)).toEqual({ profiles: [] });
+		expect(store.bindEntity).not.toHaveBeenCalled();
+		expect(store.unbindEntity).not.toHaveBeenCalled();
+	});
+
+	it.each(["%", "%2", "%ZZ", "%E0%A4"])(
+		"rejects malformed bind id %s with 400",
+		async (token) => {
+			const store = mockStore();
+			setVoiceSpeakerProfileStore(store as never);
+			const { res, captured } = makeRes();
+			const handled = await handleVoiceSpeakerProfileRoutes(
+				makeReq({
+					method: "POST",
+					url: `/v1/voice/speaker-profiles/${token}/bind`,
+					body: JSON.stringify({ entityId: "ent_jill" }),
+				}),
+				res,
+			);
+			expect(handled).toBe(true);
+			expect(captured.statusCode).toBe(400);
+			expect(JSON.parse(captured.body)).toEqual({
+				error: "Invalid profile id: malformed URL encoding",
+			});
+			expect(store.bindEntity).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each(["%", "%2", "%ZZ"])(
+		"rejects malformed unbind id %s with 400",
+		async (token) => {
+			const store = mockStore();
+			setVoiceSpeakerProfileStore(store as never);
+			const { res, captured } = makeRes();
+			const handled = await handleVoiceSpeakerProfileRoutes(
+				makeReq({
+					method: "POST",
+					url: `/v1/voice/speaker-profiles/${token}/unbind`,
+				}),
+				res,
+			);
+			expect(handled).toBe(true);
+			expect(captured.statusCode).toBe(400);
+			expect(JSON.parse(captured.body)).toEqual({
+				error: "Invalid profile id: malformed URL encoding",
+			});
+			expect(store.unbindEntity).not.toHaveBeenCalled();
+		},
+	);
+});

--- a/plugins/plugin-local-inference/src/routes/voice-speaker-profile-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-speaker-profile-routes.ts
@@ -107,6 +107,17 @@ const PROFILE_ID_RE = /^[A-Za-z0-9._-]+$/;
 const BIND_RE = /^\/v1\/voice\/speaker-profiles\/([^/]+)\/bind$/;
 const UNBIND_RE = /^\/v1\/voice\/speaker-profiles\/([^/]+)\/unbind$/;
 
+function decodeProfileId(raw: string): string | null {
+	try {
+		return decodeURIComponent(raw);
+	} catch {
+		// error-policy:J3 untrusted-input sanitizing — leftover tax after
+		// voice-profiles / voice-models path work. Malformed percent-encoding
+		// is invalid client input, not a speaker-profile store outage.
+		return null;
+	}
+}
+
 /**
  * Handle `/v1/voice/speaker-profiles*` requests.
  *
@@ -135,7 +146,11 @@ export async function handleVoiceSpeakerProfileRoutes(
 	// POST /v1/voice/speaker-profiles/:id/bind { entityId, label? }
 	const bindMatch = BIND_RE.exec(pathname);
 	if (method === "POST" && bindMatch) {
-		const profileId = decodeURIComponent(bindMatch[1] ?? "");
+		const profileId = decodeProfileId(bindMatch[1] ?? "");
+		if (profileId === null) {
+			sendJsonError(res, "Invalid profile id: malformed URL encoding", 400);
+			return true;
+		}
 		if (!PROFILE_ID_RE.test(profileId)) {
 			sendJsonError(res, `invalid profile id: ${profileId}`, 400);
 			return true;
@@ -180,7 +195,11 @@ export async function handleVoiceSpeakerProfileRoutes(
 	// POST /v1/voice/speaker-profiles/:id/unbind
 	const unbindMatch = UNBIND_RE.exec(pathname);
 	if (method === "POST" && unbindMatch) {
-		const profileId = decodeURIComponent(unbindMatch[1] ?? "");
+		const profileId = decodeProfileId(unbindMatch[1] ?? "");
+		if (profileId === null) {
+			sendJsonError(res, "Invalid profile id: malformed URL encoding", 400);
+			return true;
+		}
 		if (!PROFILE_ID_RE.test(profileId)) {
 			sendJsonError(res, `invalid profile id: ${profileId}`, 400);
 			return true;


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
plugin-local-inference speaker-profile id percent-encoding. Encoding
class, leftover tax after voice-models / voice-profiles-management.
Not a twin of those parsers — this is
`POST /v1/voice/speaker-profiles/:id/{bind,unbind}` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on speaker-profile bind/unbind. Canonical
`vp%5Fmissing` still decodes to `vp_missing` and 404s as not found.
Malformed `%` / `%2` / `%ZZ` become 400 instead of an uncaught
`URIError` 500. GET list stays untouched.

# Background

## What does this PR do?

`handleVoiceSpeakerProfileRoutes` called `decodeURIComponent` on the
profile-id path segment. Illegal percent-encoding throws `URIError`,
which the host mapped to 500.

- `/v1/voice/speaker-profiles/%/{bind,unbind}` / `%2` / `%ZZ` → **400**
- `/v1/voice/speaker-profiles/vp%5Fmissing/{bind,unbind}` → still decodes to `vp_missing`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded speaker-profile
id should get a request error, not a 500 that looks like a voice-store
outage. Leftover tax after voice-models / voice-profiles-management.
Disjoint files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/src/routes/voice-speaker-profile-routes.encoding.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-local-inference && bunx vitest run --config vitest.config.ts src/routes/voice-speaker-profile-routes.encoding.test.ts
```

10 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; speaker-profile id path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; speaker-profile id path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; speaker-profile id path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before bindEntity / unbindEntity; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before bindEntity / unbindEntity.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
percent-encoding rejects; omitted/canonical still decode and 404 as
not found.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the speaker-profile
id path decode only.

## Known gaps / failures

`bun run verify` was not run. Focused 10-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b7e50f9e6fc0de91c55fd21b66ebb4ce40291e61 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
