### PR TITLE
fix(plugin-elizacloud): reject malformed coding-container sync id encoding

### DIFF
--- a/plugins/plugin-elizacloud/src/routes/cloud-coding-container-routes.encoding.test.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-coding-container-routes.encoding.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Cloud coding-container sync path encoding is leftover tax after
+ * apps-path / scheduling / workflow / computer-use encoding Fixes.
+ * Stock develop called decodeURIComponent on
+ * POST /api/cloud/coding-containers/:id/sync, so `%` / `%2` / `%ZZ`
+ * threw URIError (500) instead of a typed 400. Promotions / create
+ * stay untouched.
+ */
+import type http from "node:http";
+import { describe, expect, it, vi } from "vitest";
+
+const CLOUD_CONTAINER_SERVICE_TYPE = "cloud-container-service";
+
+vi.mock("@elizaos/shared", () => ({
+	CLOUD_CONTAINER_SERVICE_TYPE,
+	PromoteVfsToCloudContainerRequestSchema: {
+		safeParse: (body: unknown) => ({ success: true, data: body }),
+	},
+	RequestCodingAgentContainerRequestSchema: {
+		safeParse: (body: unknown) => ({ success: true, data: body }),
+	},
+	SyncCloudCodingContainerRequestSchema: {
+		safeParse: (body: unknown) => ({ success: true, data: body }),
+	},
+}));
+
+const { handleCloudCodingContainerRoute } = await import(
+	"./cloud-coding-container-routes"
+);
+
+function requestWithBody(body: unknown): http.IncomingMessage {
+	return {
+		body,
+		headers: {},
+		method: "POST",
+		url: "/",
+	} as http.IncomingMessage & { body: unknown };
+}
+
+function responseSink(): http.ServerResponse & { jsonBody: () => unknown } {
+	let body = "";
+	const sink = {
+		headersSent: false,
+		statusCode: 200,
+		setHeader: () => {},
+		end: (chunk?: unknown) => {
+			body = typeof chunk === "string" ? chunk : String(chunk ?? "");
+			sink.headersSent = true;
+			return {} as http.ServerResponse;
+		},
+		jsonBody: () => JSON.parse(body),
+	};
+	return sink as http.ServerResponse & { jsonBody: () => unknown };
+}
+
+function unusedService() {
+	return {
+		promoteVfsToCloudContainer: vi.fn(async () => {
+			throw new Error("unexpected promote");
+		}),
+		requestCodingAgentContainer: vi.fn(async () => {
+			throw new Error("unexpected request");
+		}),
+		syncCodingContainerChanges: vi.fn(async () => {
+			throw new Error("unexpected sync");
+		}),
+	};
+}
+
+describe("POST /api/cloud/coding-containers/:id/sync encoding", () => {
+	it("canonical container id still reaches sync", async () => {
+		let capturedContainerId: string | null = null;
+		const service = {
+			...unusedService(),
+			syncCodingContainerChanges: vi.fn(
+				async (containerId: string, request: Record<string, unknown>) => {
+					capturedContainerId = containerId;
+					return {
+						success: true,
+						data: { syncId: "sync-1", containerId, request },
+					};
+				},
+			),
+		};
+		const runtime = { getService: () => service };
+		const response = responseSink();
+
+		await handleCloudCodingContainerRoute(
+			requestWithBody({
+				direction: "pull",
+				target: {
+					sourceKind: "workspace",
+					workspaceId: "workspace-1",
+					baseRevision: "rev-1",
+				},
+			}),
+			response,
+			"/api/cloud/coding-containers/container-1/sync",
+			"POST",
+			{ runtime: runtime as never },
+		);
+
+		expect(capturedContainerId).toBe("container-1");
+		expect(service.syncCodingContainerChanges).toHaveBeenCalledTimes(1);
+		expect(response.statusCode).toBe(200);
+	});
+
+	it("canonical percent-encoded slash still decodes before sync", async () => {
+		let capturedContainerId: string | null = null;
+		const service = {
+			...unusedService(),
+			syncCodingContainerChanges: vi.fn(async (containerId: string) => {
+				capturedContainerId = containerId;
+				return { success: true, data: { containerId } };
+			}),
+		};
+		const runtime = { getService: () => service };
+		const response = responseSink();
+
+		await handleCloudCodingContainerRoute(
+			requestWithBody({
+				direction: "pull",
+				target: {
+					sourceKind: "workspace",
+					workspaceId: "workspace-1",
+					baseRevision: "rev-1",
+				},
+			}),
+			response,
+			"/api/cloud/coding-containers/container%2Fone/sync",
+			"POST",
+			{ runtime: runtime as never },
+		);
+
+		expect(capturedContainerId).toBe("container/one");
+		expect(service.syncCodingContainerChanges).toHaveBeenCalledTimes(1);
+	});
+
+	it("POST promotions is untouched", async () => {
+		const service = unusedService();
+		service.promoteVfsToCloudContainer = vi.fn(async () => ({
+			success: true,
+			data: { promotionId: "promo-1" },
+		}));
+		const runtime = {
+			getService: (serviceType: string) =>
+				serviceType === CLOUD_CONTAINER_SERVICE_TYPE ? service : null,
+		};
+		const response = responseSink();
+
+		const handled = await handleCloudCodingContainerRoute(
+			requestWithBody({
+				source: { sourceKind: "project", projectId: "vfs-project-1" },
+			}),
+			response,
+			"/api/cloud/coding-containers/promotions",
+			"POST",
+			{ runtime: runtime as never },
+		);
+
+		expect(handled).toBe(true);
+		expect(service.syncCodingContainerChanges).not.toHaveBeenCalled();
+		expect(service.promoteVfsToCloudContainer).toHaveBeenCalled();
+	});
+
+	it.each(["%", "%2", "%ZZ", "%E0%A4"])(
+		"rejects malformed container id %s with 400",
+		async (token) => {
+			const service = unusedService();
+			const runtime = { getService: () => service };
+			const response = responseSink();
+
+			const handled = await handleCloudCodingContainerRoute(
+				requestWithBody({
+					direction: "pull",
+					target: {
+						sourceKind: "workspace",
+						workspaceId: "workspace-1",
+						baseRevision: "rev-1",
+					},
+				}),
+				response,
+				`/api/cloud/coding-containers/${token}/sync`,
+				"POST",
+				{ runtime: runtime as never },
+			);
+
+			expect(handled).toBe(true);
+			expect(response.statusCode).toBe(400);
+			expect(response.jsonBody()).toEqual({
+				error: "Invalid container id: malformed URL encoding",
+			});
+			expect(service.syncCodingContainerChanges).not.toHaveBeenCalled();
+		},
+	);
+});

--- a/plugins/plugin-elizacloud/src/routes/cloud-coding-container-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-coding-container-routes.ts
@@ -22,6 +22,18 @@ export interface CloudCodingContainerRouteState {
   } | null;
 }
 
+function decodeContainerId(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — leftover tax after
+    // apps-path / scheduling / workflow / computer-use encoding Fixes.
+    // Malformed percent-encoding is invalid client input, not a cloud
+    // container outage.
+    return null;
+  }
+}
+
 export async function handleCloudCodingContainerRoute(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -86,12 +98,25 @@ export async function handleCloudCodingContainerRoute(
     pathname,
   );
   if (method === "POST" && syncMatch) {
+    const rawId = syncMatch[1];
+    if (rawId === undefined) {
+      sendJsonError(res, "Missing container id", 400);
+      return true;
+    }
+    const containerId = decodeContainerId(rawId);
+    if (containerId === null) {
+      sendJsonError(
+        res,
+        "Invalid container id: malformed URL encoding",
+        400,
+      );
+      return true;
+    }
     const service = getCloudContainerService(state);
     if (!service) {
       sendJsonError(res, "Cloud container service is not available", 503);
       return true;
     }
-    const containerId = decodeURIComponent(syncMatch[1]);
     const body = await readJsonBody(req, res);
     if (!body) return true;
     const parsed = SyncCloudCodingContainerRequestSchema.safeParse(body);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
plugin-elizacloud coding-container sync id percent-encoding. Encoding
class, leftover tax after apps-path / scheduling / workflow /
computer-use encoding Fixes. Not a twin of those parsers — this is
`POST /api/cloud/coding-containers/:id/sync` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on coding-container sync. Canonical
`container%2Fone` still decodes to `container/one` and syncs. Malformed
`%` / `%2` / `%ZZ` become 400 instead of an uncaught `URIError` 500.
Promotions / create stay untouched.

# Background

## What does this PR do?

`handleCloudCodingContainerRoute` called `decodeURIComponent` on the
container-id path segment. Illegal percent-encoding throws `URIError`,
which the host mapped to 500.

- `/api/cloud/coding-containers/%/sync` / `%2` / `%ZZ` → **400**
- `/api/cloud/coding-containers/container%2Fone/sync` → still decodes to `container/one`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded container id on
the sync path should get a request error, not a 500 that looks like a
cloud-container outage. Leftover tax after apps-path / scheduling /
workflow / computer-use encoding Fixes. Disjoint files from those
parsers. Not the cloud-login-persist surface.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-elizacloud/src/routes/cloud-coding-container-routes.encoding.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-elizacloud && bunx vitest run --config vitest.config.ts src/routes/cloud-coding-container-routes.encoding.test.ts
```

7 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; coding-container sync id path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; coding-container sync id path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; coding-container sync id path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before syncCodingContainerChanges; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before syncCodingContainerChanges.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
percent-encoding rejects; omitted/canonical still decode and sync.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the coding-container
sync id path decode only.

## Known gaps / failures

`bun run verify` was not run. Focused 7-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0f615955f7f853de234c662a8f25cb86743d1abc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
