### PR TITLE
fix(core): fail closed on edge document extraction instead of shipping unresolvable parser imports

### DIFF
--- a/packages/cloud/api/__tests__/document-parser-stub-exclusion.test.ts
+++ b/packages/cloud/api/__tests__/document-parser-stub-exclusion.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Guards the Worker bundle against re-inlining core's document parsers
+ * (#21327). Wrangler resolves `@elizaos/core/edge` to core SOURCE (this
+ * package's tsconfig paths), so core's `await import("unpdf" | "mammoth")`
+ * calls are inlined into the deployed artifact — ~70 pdfjs modules plus the
+ * jszip/pako/bluebird docx graph, ~2.2 MB minified — even though document
+ * extraction runs on the Node sidecar and `documents` is `false` in core's
+ * `nativeRuntimeFeatureDefaults`. Three invariants keep that exclusion honest:
+ *   1. wrangler.toml aliases both packages to Worker stubs,
+ *   2. the stubs export every symbol core's parser call sites dereference,
+ *   3. those stubs fail closed (throw) rather than returning empty text,
+ * and, when a dry-run artifact is present, that no parser code survived it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import * as mammothStub from "../src/stubs/mammoth";
+import * as unpdfStub from "../src/stubs/unpdf";
+
+const apiRoot = resolve(import.meta.dir, "..");
+const repoRoot = resolve(apiRoot, "../../..");
+const wranglerConfig = readFileSync(join(apiRoot, "wrangler.toml"), "utf8");
+
+describe("Worker bundle excludes core's document parsers", () => {
+  test("wrangler aliases both parser packages to Worker stubs", () => {
+    expect(wranglerConfig).toMatch(
+      /^"unpdf"\s*=\s*"\.\/src\/stubs\/unpdf\.ts"$/m,
+    );
+    expect(wranglerConfig).toMatch(
+      /^"mammoth"\s*=\s*"\.\/src\/stubs\/mammoth\.ts"$/m,
+    );
+  });
+
+  test("stubs export the symbols core's parser call sites destructure", () => {
+    // core/src/features/documents/parsers.ts binds these two names; a stub that
+    // omits one fails the bundle at link time with "Export named 'X' not found".
+    const parserSource = readFileSync(
+      join(repoRoot, "packages/core/src/features/documents/parsers.ts"),
+      "utf8",
+    );
+    expect(parserSource).toContain('await import("unpdf")');
+    expect(parserSource).toContain('await import("mammoth")');
+
+    expect(typeof unpdfStub.extractText).toBe("function");
+    expect(typeof mammothStub.extractRawText).toBe("function");
+  });
+
+  test("stubbed parsers fail closed instead of returning empty text", () => {
+    expect(() => unpdfStub.extractText()).toThrow(
+      /not available on Cloudflare Workers/i,
+    );
+    expect(() => mammothStub.extractRawText()).toThrow(
+      /not available on Cloudflare Workers/i,
+    );
+  });
+
+  test("a produced dry-run bundle carries no PDF/DOCX parser code", () => {
+    // Populated by `bun run --cwd packages/cloud/api check:worker-bundle`.
+    // Skipped when absent so the unit lane stays fast; CI's bundle check and
+    // the reviewer-facing dry run both exercise it.
+    const bundle = join(apiRoot, ".wrangler-dry-run/index.js");
+    if (!existsSync(bundle)) return;
+    const emitted = readFileSync(bundle, "utf8");
+
+    expect(emitted).not.toMatch(/pdfjs/);
+    expect(emitted).not.toMatch(/dingbat-to-unicode/);
+    expect(emitted).toContain("not available on Cloudflare Workers");
+  });
+});

--- a/packages/cloud/api/src/stubs/mammoth.ts
+++ b/packages/cloud/api/src/stubs/mammoth.ts
@@ -1,0 +1,50 @@
+/**
+ * mammoth — Cloudflare Workers bundle shim.
+ *
+ * mammoth is a CJS DOCX parser whose module graph does `require("fs")` at load
+ * (`lib/unzip.js`) and drags jszip/pako/bluebird/dingbat-to-unicode with it.
+ * `@elizaos/core` loads it through `await import()`, but Wrangler bundles core
+ * from source (see this package's `tsconfig.json` alias for
+ * `@elizaos/core/edge`), so the whole docx toolchain lands in the deployed
+ * Worker. DOCX extraction does not run here — the agent runtime lives on the
+ * sidecar and `documents` is `false` in core's `nativeRuntimeFeatureDefaults` —
+ * so it is stubbed at bundle time and any real call throws a clear error rather
+ * than returning empty text (#21327).
+ */
+
+const NOT_AVAILABLE =
+  "mammoth is not available on Cloudflare Workers — DOCX text extraction runs on the Node sidecar (cloud/INFRA.md).";
+
+export function extractRawText(): never {
+  throw new Error(NOT_AVAILABLE);
+}
+
+export function convertToHtml(): never {
+  throw new Error(NOT_AVAILABLE);
+}
+
+export function convertToMarkdown(): never {
+  throw new Error(NOT_AVAILABLE);
+}
+
+export function embedStyleMap(): never {
+  throw new Error(NOT_AVAILABLE);
+}
+
+export const images = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error(NOT_AVAILABLE);
+    },
+  },
+);
+
+const workerMammothSurface = {
+  convertToHtml,
+  convertToMarkdown,
+  embedStyleMap,
+  extractRawText,
+  images,
+};
+export default workerMammothSurface;

--- a/packages/cloud/api/src/stubs/unpdf.ts
+++ b/packages/cloud/api/src/stubs/unpdf.ts
@@ -1,0 +1,55 @@
+/**
+ * unpdf — Cloudflare Workers bundle shim.
+ *
+ * `@elizaos/core`'s document feature reaches unpdf through `await import()`,
+ * which keeps it off the Node startup path but does not keep it out of this
+ * Worker bundle: Wrangler bundles core from source (see this package's
+ * `tsconfig.json` alias for `@elizaos/core/edge`) and inlines the whole PDF
+ * toolchain — ~70 pdfjs modules — into the deployed artifact. Document
+ * extraction does not run on the Worker (the agent runtime lives on the
+ * sidecar, and `documents` is `false` in core's `nativeRuntimeFeatureDefaults`),
+ * so the parser is stubbed at bundle time. Any code path that actually calls it
+ * throws a clear error instead of silently returning empty text (#21327).
+ */
+
+const NOT_AVAILABLE =
+  "unpdf is not available on Cloudflare Workers — PDF text extraction runs on the Node sidecar (cloud/INFRA.md).";
+
+export function extractText(): never {
+  throw new Error(NOT_AVAILABLE);
+}
+
+export function getDocumentProxy(): never {
+  throw new Error(NOT_AVAILABLE);
+}
+
+export function definePDFJSModule(): never {
+  throw new Error(NOT_AVAILABLE);
+}
+
+export function getResolvedPDFJS(): never {
+  throw new Error(NOT_AVAILABLE);
+}
+
+export function extractImages(): never {
+  throw new Error(NOT_AVAILABLE);
+}
+
+export function renderPageAsImage(): never {
+  throw new Error(NOT_AVAILABLE);
+}
+
+export function getMeta(): never {
+  throw new Error(NOT_AVAILABLE);
+}
+
+const workerUnpdfSurface = {
+  definePDFJSModule,
+  extractImages,
+  extractText,
+  getDocumentProxy,
+  getMeta,
+  getResolvedPDFJS,
+  renderPageAsImage,
+};
+export default workerUnpdfSurface;

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -45,6 +45,15 @@ __filename = '"/worker.js"'
 # that don't exist on Workers. Re-export runtime globals + map the
 # Agent/Pool/Dispatcher classes.
 "undici" = "./src/stubs/undici.ts"
+# unpdf/mammoth are core's document parsers. Core loads them via `await
+# import()`, but this bundle resolves @elizaos/core/edge to core SOURCE
+# (tsconfig paths), so the dynamic import is inlined and the PDF/DOCX
+# toolchains (~70 pdfjs modules, jszip/pako/bluebird) ship in the deployed
+# Worker. Document extraction runs on the sidecar and `documents` is false in
+# core's nativeRuntimeFeatureDefaults, so both are stubbed here; an accidental
+# Worker-side call throws instead of returning empty text (#21327).
+"unpdf" = "./src/stubs/unpdf.ts"
+"mammoth" = "./src/stubs/mammoth.ts"
 
 [observability]
 enabled = true

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -766,6 +766,24 @@ const edgeRuntimeSourcesPlugin: BunPlugin = {
 						}
 					: undefined,
 		);
+		// mammoth/unpdf are `external` for this target, but a single-file worker
+		// bundle still inlines both graphs (~2.1 MB minified) because the bare
+		// specifiers survive into the artifact and every downstream bundler
+		// resolves them. Aliasing the one module that imports them removes the
+		// specifiers entirely, honoring the `documents: false` edge default
+		// (#21327).
+		build.onResolve(
+			{ filter: /^\.\/parsers(?:\.ts|\.js)?$/ },
+			({ importer }) =>
+				importer.endsWith("/src/features/documents/utils.ts")
+					? {
+							path: join(
+								process.cwd(),
+								"src/features/documents/parsers.edge.ts",
+							),
+						}
+					: undefined,
+		);
 	},
 };
 

--- a/packages/core/src/__tests__/runtime-barrel.test.ts
+++ b/packages/core/src/__tests__/runtime-barrel.test.ts
@@ -78,4 +78,34 @@ describe("@elizaos/core runtime barrel", () => {
 			/export\s+\*\s+from\s+["']\.\/features\/basic-capabilities\/index["']/,
 		);
 	});
+
+	it("keeps the document parser graph out of the edge artifact (#21327)", () => {
+		// `mammoth`/`unpdf` are already external for this target, but external only
+		// leaves a bare specifier in the artifact — it does not remove the parser
+		// entry points. The edge build aliases the one module that imports them to
+		// a throwing stub, so the shipped artifact carries neither specifier.
+		const buildScript = readFileSync(resolve(packageRoot, "build.ts"), "utf8");
+		expect(buildScript).toMatch(
+			/filter:\s*\/\^\\\.\\\/parsers\(\?:\\\.ts\|\\\.js\)\?\$\//,
+		);
+		expect(buildScript).toContain("src/features/documents/parsers.edge.ts");
+
+		// utils.ts must reach the parsers through ./parsers so the importer-scoped
+		// alias covers every consumer; the pure helpers beside them stay live on
+		// edge and must NOT move into the stubbed module.
+		const utils = readFileSync(
+			resolve(sourceRoot, "features/documents/utils.ts"),
+			"utf8",
+		);
+		expect(utils).toMatch(
+			/export\s*\{[^}]*convertPdfToTextFromBuffer[^}]*\}\s*from\s*["']\.\/parsers\.ts["']/s,
+		);
+		expect(utils).toContain("export function normalizeDocumentContentType");
+
+		const artifact = resolve(packageRoot, "dist/edge/index.edge.js");
+		if (!existsSync(artifact)) return;
+		const edgeBundle = readFileSync(artifact, "utf8");
+		expect(edgeBundle).not.toContain('import("unpdf")');
+		expect(edgeBundle).not.toContain('import("mammoth")');
+	});
 });

--- a/packages/core/src/features/documents/parsers.edge.test.ts
+++ b/packages/core/src/features/documents/parsers.edge.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Contract for the edge-target document parser stub: both entry points must
+ * fail closed with a named, actionable error rather than returning empty text,
+ * so a caller that reaches them on workerd gets a diagnosable failure instead of
+ * a silent capability hole (#21327). Runs the real stub module; no mocks.
+ */
+import { Buffer } from "node:buffer";
+
+import { describe, expect, it } from "vitest";
+
+import {
+	convertPdfToTextFromBuffer,
+	extractTextFromFileBuffer,
+} from "./parsers.edge.ts";
+
+describe("edge document parser stubs", () => {
+	it("fails closed on DOCX extraction instead of returning empty text", async () => {
+		await expect(
+			extractTextFromFileBuffer(
+				Buffer.from("PK"),
+				"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+				"quarterly-report.docx",
+			),
+		).rejects.toThrow(/unavailable on the edge runtime/i);
+	});
+
+	it("names the requested document in the DOCX failure", async () => {
+		await expect(
+			extractTextFromFileBuffer(
+				Buffer.from("PK"),
+				"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+				"quarterly-report.docx",
+			),
+		).rejects.toThrow(/quarterly-report\.docx/);
+	});
+
+	it("fails closed on PDF conversion instead of returning empty text", async () => {
+		await expect(
+			convertPdfToTextFromBuffer(Buffer.from("%PDF-1.7"), "invoice.pdf"),
+		).rejects.toThrow(/unavailable on the edge runtime/i);
+	});
+
+	it("still fails closed when no filename is supplied", async () => {
+		await expect(
+			convertPdfToTextFromBuffer(Buffer.from("%PDF-1.7")),
+		).rejects.toThrow(/unavailable on the edge runtime/i);
+	});
+});

--- a/packages/core/src/features/documents/parsers.edge.ts
+++ b/packages/core/src/features/documents/parsers.edge.ts
@@ -1,0 +1,34 @@
+/**
+ * Edge-target replacement for `parsers.ts`, aliased in by
+ * `edgeRuntimeSourcesPlugin` at build time (#21327). The Node parsers reach
+ * mammoth and unpdf through `await import(...)`, which keeps them off the Node
+ * startup path but cannot keep them out of a single-file worker bundle — the
+ * bundler inlines both graphs (~2.1 MB minified) into every cold start. Document
+ * extraction is already declared unavailable on this target (`documents` is
+ * `false` in `nativeRuntimeFeatureDefaults`), so these entry points fail closed
+ * with a named, greppable error instead of shipping parsers that are never
+ * meant to run here.
+ */
+import type { Buffer } from "node:buffer";
+
+const UNSUPPORTED_MESSAGE =
+	"Document text extraction is unavailable on the edge runtime: the mammoth/unpdf parser graph is excluded from this bundle and the documents feature is disabled on this target";
+
+export async function extractTextFromFileBuffer(
+	_fileBuffer: Buffer,
+	contentType: string,
+	originalFilename: string,
+): Promise<string> {
+	throw new Error(
+		`${UNSUPPORTED_MESSAGE} (requested ${contentType} for ${originalFilename})`,
+	);
+}
+
+export async function convertPdfToTextFromBuffer(
+	_pdfBuffer: Buffer,
+	filename?: string,
+): Promise<string> {
+	throw new Error(
+		`${UNSUPPORTED_MESSAGE} (requested PDF conversion${filename ? ` for ${filename}` : ""})`,
+	);
+}

--- a/packages/core/src/features/documents/parsers.ts
+++ b/packages/core/src/features/documents/parsers.ts
@@ -1,0 +1,139 @@
+/**
+ * Heavyweight document text extraction: DOCX via mammoth, PDF via unpdf, plain
+ * text with a UTF-8 fallback. Split from `utils.ts` so the parser graph is one
+ * module the edge build can alias away (`parsers.edge.ts`) without touching the
+ * pure helpers beside it, which edge code genuinely uses; `utils.ts` re-exports
+ * these, so existing import sites keep working (#21327). The `await import(...)`
+ * calls below keep the parsers off the Node startup path; they cannot keep them
+ * out of a single-file worker bundle, which is what the edge alias is for.
+ */
+import type { Buffer } from "node:buffer";
+
+const PLAIN_TEXT_CONTENT_TYPES = [
+	"application/typescript",
+	"text/typescript",
+	"text/x-python",
+	"application/x-python-code",
+	"application/yaml",
+	"text/yaml",
+	"application/x-yaml",
+	"application/json",
+	"text/markdown",
+	"text/csv",
+];
+
+const MAX_FALLBACK_SIZE_BYTES = 5 * 1024 * 1024;
+const BINARY_CHECK_BYTES = 1024;
+
+export async function extractTextFromFileBuffer(
+	fileBuffer: Buffer,
+	contentType: string,
+	originalFilename: string,
+): Promise<string> {
+	const lowerContentType = contentType.toLowerCase();
+
+	if (
+		lowerContentType ===
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	) {
+		try {
+			// Loaded on use: mammoth is a CJS parser whose static import drags the
+			// whole docx toolchain into every consumer bundle (edge included).
+			const mammoth = await import("mammoth");
+			const result = await mammoth.extractRawText({ buffer: fileBuffer });
+			return result.value;
+		} catch (docxError) {
+			// error-policy:J2 Add document identity while preserving the parser cause.
+			const errorMessage =
+				docxError instanceof Error ? docxError.message : String(docxError);
+			throw new Error(
+				`Failed to parse DOCX file ${originalFilename}: ${errorMessage}`,
+				{ cause: docxError },
+			);
+		}
+	} else if (
+		lowerContentType === "application/msword" ||
+		originalFilename.toLowerCase().endsWith(".doc")
+	) {
+		throw new Error(
+			`Legacy Microsoft Word documents are not supported: ${originalFilename}`,
+		);
+	} else if (
+		lowerContentType.startsWith("text/") ||
+		PLAIN_TEXT_CONTENT_TYPES.includes(lowerContentType)
+	) {
+		return fileBuffer.toString("utf-8");
+	} else {
+		if (fileBuffer.length > MAX_FALLBACK_SIZE_BYTES) {
+			throw new Error(
+				`File ${originalFilename} exceeds maximum size for fallback (${MAX_FALLBACK_SIZE_BYTES} bytes)`,
+			);
+		}
+
+		const initialBytes = fileBuffer.subarray(
+			0,
+			Math.min(fileBuffer.length, BINARY_CHECK_BYTES),
+		);
+		if (initialBytes.includes(0)) {
+			throw new Error(
+				`File ${originalFilename} appears to be binary based on initial byte check`,
+			);
+		}
+
+		try {
+			const textContent = fileBuffer.toString("utf-8");
+			if (textContent.includes("\ufffd")) {
+				throw new Error(
+					`File ${originalFilename} seems to be binary or has encoding issues (detected \ufffd)`,
+				);
+			}
+			return textContent;
+		} catch (fallbackError) {
+			// error-policy:J2 Preserve the failed UTF-8 validation as the cause.
+			throw new Error(
+				`Unsupported content type: ${contentType} for ${originalFilename}. Fallback to plain text failed`,
+				{ cause: fallbackError },
+			);
+		}
+	}
+}
+
+export async function convertPdfToTextFromBuffer(
+	pdfBuffer: Buffer,
+	_filename?: string,
+): Promise<string> {
+	try {
+		const uint8Array = new Uint8Array(
+			pdfBuffer.buffer.slice(
+				pdfBuffer.byteOffset,
+				pdfBuffer.byteOffset + pdfBuffer.byteLength,
+			),
+		);
+
+		// Loaded on use like mammoth above: unpdf's static import would pin the
+		// PDF toolchain into every consumer bundle (edge included).
+		const { extractText } = await import("unpdf");
+		const result = await extractText(uint8Array, {
+			mergePages: true,
+		});
+
+		if (result.text.trim().length === 0) {
+			throw new Error("PDF contained no extractable text");
+		}
+
+		const cleanedText = result.text
+			.split("\n")
+			.map((line: string) => line.trim())
+			.filter((line: string) => line.length > 0)
+			.join("\n")
+			.replace(/\n{3,}/g, "\n\n");
+
+		return cleanedText;
+	} catch (error) {
+		// error-policy:J2 Preserve the PDF parser failure as the conversion cause.
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		throw new Error(`Failed to convert PDF to text: ${errorMessage}`, {
+			cause: error,
+		});
+	}
+}

--- a/packages/core/src/features/documents/utils.ts
+++ b/packages/core/src/features/documents/utils.ts
@@ -10,141 +10,12 @@ import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { v5 as uuidv5 } from "uuid";
 
-const PLAIN_TEXT_CONTENT_TYPES = [
-	"application/typescript",
-	"text/typescript",
-	"text/x-python",
-	"application/x-python-code",
-	"application/yaml",
-	"text/yaml",
-	"application/x-yaml",
-	"application/json",
-	"text/markdown",
-	"text/csv",
-];
-
-const MAX_FALLBACK_SIZE_BYTES = 5 * 1024 * 1024;
-const BINARY_CHECK_BYTES = 1024;
-
 /**
  * Return the case-insensitive MIME essence used for routing document content.
  * Parameters belong to the media type but do not change its routing identity.
  */
 export function normalizeDocumentContentType(contentType: string): string {
 	return contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
-}
-
-export async function extractTextFromFileBuffer(
-	fileBuffer: Buffer,
-	contentType: string,
-	originalFilename: string,
-): Promise<string> {
-	const lowerContentType = contentType.toLowerCase();
-
-	if (
-		lowerContentType ===
-		"application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-	) {
-		try {
-			// Loaded on use: mammoth is a CJS parser whose static import drags the
-			// whole docx toolchain into every consumer bundle (edge included).
-			const mammoth = await import("mammoth");
-			const result = await mammoth.extractRawText({ buffer: fileBuffer });
-			return result.value;
-		} catch (docxError) {
-			// error-policy:J2 Add document identity while preserving the parser cause.
-			const errorMessage =
-				docxError instanceof Error ? docxError.message : String(docxError);
-			throw new Error(
-				`Failed to parse DOCX file ${originalFilename}: ${errorMessage}`,
-				{ cause: docxError },
-			);
-		}
-	} else if (
-		lowerContentType === "application/msword" ||
-		originalFilename.toLowerCase().endsWith(".doc")
-	) {
-		throw new Error(
-			`Legacy Microsoft Word documents are not supported: ${originalFilename}`,
-		);
-	} else if (
-		lowerContentType.startsWith("text/") ||
-		PLAIN_TEXT_CONTENT_TYPES.includes(lowerContentType)
-	) {
-		return fileBuffer.toString("utf-8");
-	} else {
-		if (fileBuffer.length > MAX_FALLBACK_SIZE_BYTES) {
-			throw new Error(
-				`File ${originalFilename} exceeds maximum size for fallback (${MAX_FALLBACK_SIZE_BYTES} bytes)`,
-			);
-		}
-
-		const initialBytes = fileBuffer.subarray(
-			0,
-			Math.min(fileBuffer.length, BINARY_CHECK_BYTES),
-		);
-		if (initialBytes.includes(0)) {
-			throw new Error(
-				`File ${originalFilename} appears to be binary based on initial byte check`,
-			);
-		}
-
-		try {
-			const textContent = fileBuffer.toString("utf-8");
-			if (textContent.includes("\ufffd")) {
-				throw new Error(
-					`File ${originalFilename} seems to be binary or has encoding issues (detected \ufffd)`,
-				);
-			}
-			return textContent;
-		} catch (fallbackError) {
-			// error-policy:J2 Preserve the failed UTF-8 validation as the cause.
-			throw new Error(
-				`Unsupported content type: ${contentType} for ${originalFilename}. Fallback to plain text failed`,
-				{ cause: fallbackError },
-			);
-		}
-	}
-}
-
-export async function convertPdfToTextFromBuffer(
-	pdfBuffer: Buffer,
-	_filename?: string,
-): Promise<string> {
-	try {
-		const uint8Array = new Uint8Array(
-			pdfBuffer.buffer.slice(
-				pdfBuffer.byteOffset,
-				pdfBuffer.byteOffset + pdfBuffer.byteLength,
-			),
-		);
-
-		// Loaded on use like mammoth above: unpdf's static import would pin the
-		// PDF toolchain into every consumer bundle (edge included).
-		const { extractText } = await import("unpdf");
-		const result = await extractText(uint8Array, {
-			mergePages: true,
-		});
-
-		if (result.text.trim().length === 0) {
-			throw new Error("PDF contained no extractable text");
-		}
-
-		const cleanedText = result.text
-			.split("\n")
-			.map((line: string) => line.trim())
-			.filter((line: string) => line.length > 0)
-			.join("\n")
-			.replace(/\n{3,}/g, "\n\n");
-
-		return cleanedText;
-	} catch (error) {
-		// error-policy:J2 Preserve the PDF parser failure as the conversion cause.
-		const errorMessage = error instanceof Error ? error.message : String(error);
-		throw new Error(`Failed to convert PDF to text: ${errorMessage}`, {
-			cause: error,
-		});
-	}
 }
 
 export function isBinaryContentType(
@@ -315,6 +186,13 @@ export {
 	deriveDocumentTitle,
 	stripDocumentFilenameExtension,
 } from "./naming.ts";
+// The heavyweight parsers live in ./parsers so the edge build can alias that
+// one module to a throwing stub without disturbing the pure helpers above
+// (#21327); re-exported here for compatibility.
+export {
+	convertPdfToTextFromBuffer,
+	extractTextFromFileBuffer,
+} from "./parsers.ts";
 
 export function isTextBackedDocumentContent(
 	contentType: string,


### PR DESCRIPTION
Closes #21327.

## What the deployed Worker actually ships

`mammoth`/`unpdf` are loaded through `await import()` in core, which keeps them off the Node startup path but not out of a Worker bundle. The production deploy bundles core from **source** — `wrangler.toml` sets `main = "src/index.ts"`, and `packages/cloud/api/tsconfig.json` maps `@elizaos/core/edge` to `packages/core/src/index.edge.ts` — so both parser graphs are inlined into the artifact Cloudflare receives.

My first pass argued production consumed core's built edge artifact instead. That was wrong; @startrack3r's review caught it, and re-measuring with the package's own dry run (not the pinned Miniflare harness) confirms it.

## The fix, in two halves

**Deploy path (`packages/cloud/api`)** — alias both packages to Worker stubs, the pattern this `wrangler.toml` already uses for `ssh2` and `undici`. Document extraction runs on the Node sidecar and `documents` is `false` in core's `nativeRuntimeFeatureDefaults`, so the parsers are excluded at bundle time and an accidental Worker-side call throws a named error rather than returning empty text.

**Artifact path (`packages/core`)** — extract the two parser entry points into `features/documents/parsers.ts`, re-exported from `utils.ts` so every import site keeps working (the split `features/documents/naming.ts` already made, for this reason), add a throwing `parsers.edge.ts`, and register a fourth importer-scoped alias in `edgeRuntimeSourcesPlugin`. This stops the built artifact shipping bare specifiers it can neither resolve nor refuse. Splitting rather than stubbing `utils.ts` wholesale is forced by the artifact: `normalizeDocumentContentType`, `isBinaryContentType`, `generateContentBasedId` and `deriveDocumentTitle` are all live on edge.

Together they cover both ways core reaches a worker. The browser target is deliberately untouched — `external` is correct there, since a host bundler resolves the parsers Node-side.

## Contract test

Per the review, a suite that pins the exclusion: both aliases present, the stubs exporting exactly the symbols core's call sites destructure (a missing name fails the bundle at link time — the failure class tracked in #21338), the stubs failing closed, and no `pdfjs`/`dingbat-to-unicode` surviving a produced dry-run artifact. Removing either alias fails the suite.

## Corrections owed to the issue

From my own measurements: per-package minified contributions are unpdf ~1.63 MB and mammoth ~0.49 MB (2,146,826 combined), not ~2.3 MB for unpdf alone. And the existing `build.ts` comment claiming unpdf "pulls in Node fs/util internals" does not hold for unpdf 1.8.0 — zero `node:` specifiers, and it advertises worker support. The mammoth half is accurate (`lib/unzip.js:1` does `require("fs")` at module load). I left that comment alone rather than widen the diff.

# Evidence

<!-- evidence-head:21ae0ae9a4bc465ffb8398cb20e0b8387cd1bf36 -->

<!-- evidence-row:before-screenshots -->
N/A - Worker bundle composition and build-target aliasing; no rendered UI surface in the diff.

<!-- evidence-row:after-screenshots -->
N/A - Worker bundle composition and build-target aliasing; no rendered UI surface in the diff.

<!-- evidence-row:walkthrough-video -->
N/A - non-UI change; behavior proven by the production dry-run measurements and suites below.

<!-- evidence-row:backend-logs -->
Suites at this head:

```
bun test packages/cloud/api/__tests__/document-parser-stub-exclusion.test.ts
 4 pass  0 fail  11 expect() calls
packages/core: bun run test src/features/documents/parsers.edge.test.ts src/__tests__/runtime-barrel.test.ts
 Test Files  2 passed (2)   Tests  10 passed (10)
bun test packages/cloud/api/__tests__/eliza-runtime-edge.miniflare.test.ts   (real workerd)
 1 pass  0 fail
Root bun run verify at this exact head: exit 0 (repo-wide lint pre-swept clean).
```

Baseline note: `packages/core/src/features/documents` carries one pre-existing failure on develop ("renders a blob-shaped filePath as the neutral noun with a bounded log view", 243 passed / 1 failed). It reproduces identically with this branch's source changes stashed.

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface; the browser target is deliberately untouched.

<!-- evidence-row:llm-trajectory -->
N/A - no model behavior in scope; bundle composition and fail-closed stubs, exercised deterministically.

<!-- evidence-row:domain-artifacts -->
Production Worker dry run (`bun run --cwd packages/cloud/api check:worker-bundle`) — the path Wrangler actually deploys:

```
BEFORE  Total Upload: 26025.65 KiB / gzip: 6326.40 KiB
        .wrangler-dry-run/index.js  26,650,261 bytes    pdfjs x70   mammoth x6   unpdf x4
AFTER   Total Upload: 23859.80 KiB / gzip: 5683.79 KiB
        .wrangler-dry-run/index.js  24,432,440 bytes    pdfjs x0    stub message x3
DELTA   -2,217,821 bytes minified   -642.61 KiB gzipped
```

Core edge artifact (second half of the fix): 4,814,558 to 4,812,053 bytes, with both bare specifiers gone. Node build retains both parsers, guarding the barrel-drop hazard in `bundle-safety.ts`: `extractTextFromFileBuffer` appears 3 times in `dist/node/index.node.js`.

<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface in this change.

---
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M083194YMZXD73F435MSCZKV","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-17T14:46:58.463Z","completed_at":"2026-08-17T15:06:16.582Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"UbnXGLxVQJDRPSNznNbLyY46Z0v9-ulDAstcFu3Bc4KnjEeo7CRI7Yr7ixSchfJUPzdYGKRFoPLZqgjZf5_hAQ"}} -->
