### PR TITLE
fix(cloud): close auth/session CSRF, login-CSRF, and replay findings (W1-001/004/008/030/033/034/035/036)

### DIFF
--- a/packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts
+++ b/packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts
@@ -17,6 +17,23 @@ function deletedCookieNames(res: Response): string[] {
 }
 
 describe("DELETE /api/auth/steward-session cookie clearing", () => {
+  it("rejects a simple request without the non-simple marker", async () => {
+    const res = await app.request(
+      "/",
+      {
+        method: "DELETE",
+        headers: {
+          host: "api-staging.elizacloud.ai",
+          origin: "https://staging.elizacloud.ai",
+        },
+      },
+      { ENVIRONMENT: "staging", NODE_ENV: "test" },
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ code: "csrf_marker_required" });
+    expect(res.headers.getSetCookie()).toHaveLength(0);
+  });
+
   it("staging clears only the staging-suffixed pair", async () => {
     const res = await app.request(
       "/",
@@ -25,6 +42,7 @@ describe("DELETE /api/auth/steward-session cookie clearing", () => {
         headers: {
           host: "api-staging.elizacloud.ai",
           origin: "https://staging.elizacloud.ai",
+          "x-eliza-csrf": "1",
         },
       },
       { ENVIRONMENT: "staging", NODE_ENV: "test" },
@@ -47,6 +65,7 @@ describe("DELETE /api/auth/steward-session cookie clearing", () => {
         headers: {
           host: "api.elizacloud.ai",
           origin: "https://elizacloud.ai",
+          "x-eliza-csrf": "1",
         },
       },
       { ENVIRONMENT: "production", NODE_ENV: "test" },

--- a/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.integration.test.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.integration.test.ts
@@ -25,6 +25,21 @@ const OTHER_USER_ID = "22222222-2222-4222-8222-222222222222";
 const ORG_ID = "33333333-3333-4333-8333-333333333333";
 const API_KEY_ID = "44444444-4444-4444-8444-444444444444";
 
+// The route rejects non-UUID session ids before any state transition, so the
+// suites below drive it with server-shaped ids.
+const SESSION_IDS = {
+  sameUser: "55555555-5555-4555-8555-555555555555",
+  concurrent: "66666666-6666-4666-8666-666666666666",
+  crossUserRace: "77777777-7777-4777-8777-777777777777",
+  differentUser: "88888888-8888-4888-8888-888888888888",
+  ownerless: "99999999-9999-4999-8999-999999999999",
+  insertFailure: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  missingKeyReference: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+  missingKeyRow: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  mismatchedKeyOwner: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+  missing: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+} as const;
+
 interface CompleteResponseBody {
   alreadyAuthenticated: boolean;
   keyPrefix: string;
@@ -111,14 +126,26 @@ async function seedPendingSession(sessionId: string): Promise<void> {
     VALUES ('${sessionId}', 'pending', now() + interval '10 minutes')`);
 }
 
+const TEST_ENV = { NODE_ENV: "test" } as never;
+
 async function complete(
   sessionId: string,
   userId = currentUserId,
 ): Promise<Response> {
-  return app.request(`/api/auth/cli-session/${sessionId}/complete`, {
-    method: "POST",
-    headers: { "x-test-user-id": userId },
-  });
+  return app.request(
+    `/api/auth/cli-session/${sessionId}/complete`,
+    {
+      method: "POST",
+      // The cookie path requires the exact-host origin policy plus a
+      // non-simple marker; a JSON content type satisfies the marker.
+      headers: {
+        "x-test-user-id": userId,
+        origin: "http://localhost:8787",
+        "content-type": "application/json",
+      },
+    },
+    TEST_ENV,
+  );
 }
 
 async function afterConcurrentPendingReads<T>(
@@ -161,9 +188,69 @@ async function afterConcurrentPendingReads<T>(
 }
 
 describe("CLI session completion with real persistence", () => {
-  test("same-user retry succeeds without creating another API key", async () => {
-    await seedSession("same-user", USER_ID);
+  test("rejects a non-UUID session id before any state transition", async () => {
     const response = await complete("same-user");
+    expect(response.status).toBe(400);
+    expect(JSON.stringify(await response.json())).toContain(
+      "Invalid session ID format",
+    );
+  });
+
+  test("rejects a cookie-style request with no Origin or Referer", async () => {
+    const response = await app.request(
+      `/api/auth/cli-session/${SESSION_IDS.sameUser}/complete`,
+      {
+        method: "POST",
+        headers: {
+          "x-test-user-id": USER_ID,
+          "content-type": "application/json",
+        },
+      },
+      TEST_ENV,
+    );
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      code: "forbidden_origin",
+    });
+  });
+
+  test("rejects a cookie-style request without a non-simple marker", async () => {
+    const response = await app.request(
+      `/api/auth/cli-session/${SESSION_IDS.sameUser}/complete`,
+      {
+        method: "POST",
+        headers: {
+          "x-test-user-id": USER_ID,
+          origin: "http://localhost:8787",
+        },
+      },
+      TEST_ENV,
+    );
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      code: "csrf_marker_required",
+    });
+  });
+
+  test("programmatic credentials bypass the browser origin gate", async () => {
+    await seedSession(SESSION_IDS.sameUser, USER_ID);
+    const response = await app.request(
+      `/api/auth/cli-session/${SESSION_IDS.sameUser}/complete`,
+      {
+        method: "POST",
+        headers: {
+          "x-test-user-id": USER_ID,
+          authorization: "Bearer eliza_headless",
+        },
+      },
+      TEST_ENV,
+    );
+    expect(response.status).toBe(200);
+  });
+
+  test("same-user retry succeeds without creating another API key", async () => {
+    await seedSession(SESSION_IDS.sameUser, USER_ID);
+    const response = await complete(SESSION_IDS.sameUser);
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
       success: true,
@@ -177,7 +264,7 @@ describe("CLI session completion with real persistence", () => {
   });
 
   test("concurrent completions atomically mint exactly one API key", async () => {
-    await seedPendingSession("concurrent");
+    await seedPendingSession(SESSION_IDS.concurrent);
 
     // Wrap the real primary read with a barrier so both requests have observed
     // the same pending row before either can attempt the conditional claim.
@@ -187,7 +274,10 @@ describe("CLI session completion with real persistence", () => {
       result: [first, second],
       reads,
     } = await afterConcurrentPendingReads(() =>
-      Promise.all([complete("concurrent"), complete("concurrent")]),
+      Promise.all([
+        complete(SESSION_IDS.concurrent),
+        complete(SESSION_IDS.concurrent),
+      ]),
     );
     expect(reads).toBe(2);
     expect(first.status).toBe(200);
@@ -214,7 +304,7 @@ describe("CLI session completion with real persistence", () => {
     expect(keys.rows.every((row) => row.is_active === true)).toBe(true);
 
     const session = await dbWrite.execute(
-      "SELECT status, user_id, api_key_id FROM cli_auth_sessions WHERE session_id = 'concurrent'",
+      `SELECT status, user_id, api_key_id FROM cli_auth_sessions WHERE session_id = '${SESSION_IDS.concurrent}'`,
     );
     expect(session.rows[0]).toMatchObject({
       status: "authenticated",
@@ -225,13 +315,30 @@ describe("CLI session completion with real persistence", () => {
     ).toBe(true);
   });
 
+  test("minted CLI keys carry a finite expiry", async () => {
+    await seedPendingSession(SESSION_IDS.concurrent);
+    const response = await complete(SESSION_IDS.concurrent);
+    expect(response.status).toBe(200);
+
+    const keys = await dbWrite.execute(
+      `SELECT expires_at FROM api_keys WHERE id <> '${API_KEY_ID}'`,
+    );
+    expect(keys.rows).toHaveLength(1);
+    const expiresAt = new Date(keys.rows[0]?.expires_at as string);
+    expect(Number.isFinite(expiresAt.getTime())).toBe(true);
+    const ttlMs = expiresAt.getTime() - Date.now();
+    // 90-day TTL, asserted with a wide band for test-runtime drift.
+    expect(ttlMs).toBeGreaterThan(80 * 24 * 60 * 60 * 1000);
+    expect(ttlMs).toBeLessThanOrEqual(90 * 24 * 60 * 60 * 1000);
+  });
+
   test("concurrent different-user completions persist only the winner's key", async () => {
-    await seedPendingSession("cross-user-race");
+    await seedPendingSession(SESSION_IDS.crossUserRace);
 
     const { result: responses, reads } = await afterConcurrentPendingReads(() =>
       Promise.all([
-        complete("cross-user-race", USER_ID),
-        complete("cross-user-race", OTHER_USER_ID),
+        complete(SESSION_IDS.crossUserRace, USER_ID),
+        complete(SESSION_IDS.crossUserRace, OTHER_USER_ID),
       ]),
     );
 
@@ -252,7 +359,7 @@ describe("CLI session completion with real persistence", () => {
     );
     expect(keys.rows).toEqual([expect.objectContaining({ user_id: winnerId })]);
     const session = await dbWrite.execute(
-      "SELECT user_id, api_key_id FROM cli_auth_sessions WHERE session_id = 'cross-user-race'",
+      `SELECT user_id, api_key_id FROM cli_auth_sessions WHERE session_id = '${SESSION_IDS.crossUserRace}'`,
     );
     expect(session.rows[0]).toMatchObject({
       user_id: winnerId,
@@ -261,8 +368,8 @@ describe("CLI session completion with real persistence", () => {
   });
 
   test.each([
-    ["different-user", OTHER_USER_ID],
-    ["ownerless", null],
+    [SESSION_IDS.differentUser, OTHER_USER_ID],
+    [SESSION_IDS.ownerless, null],
   ])(
     "rejects %s sessions without exposing key metadata",
     async (sessionId, owner) => {
@@ -276,7 +383,7 @@ describe("CLI session completion with real persistence", () => {
   );
 
   test("rolls back the session claim when API-key insertion fails", async () => {
-    await seedPendingSession("insert-failure");
+    await seedPendingSession(SESSION_IDS.insertFailure);
     const generate = spyOn(apiKeysService, "generateApiKey").mockReturnValue({
       key: "eliza_duplicate_plaintext",
       hash: "hash",
@@ -284,14 +391,14 @@ describe("CLI session completion with real persistence", () => {
     });
 
     try {
-      const response = await complete("insert-failure");
+      const response = await complete(SESSION_IDS.insertFailure);
       expect(response.status).toBe(500);
     } finally {
       generate.mockRestore();
     }
 
     const session = await dbWrite.execute(
-      "SELECT status, user_id, api_key_id, authenticated_at FROM cli_auth_sessions WHERE session_id = 'insert-failure'",
+      `SELECT status, user_id, api_key_id, authenticated_at FROM cli_auth_sessions WHERE session_id = '${SESSION_IDS.insertFailure}'`,
     );
     expect(session.rows[0]).toMatchObject({
       status: "pending",
@@ -307,12 +414,15 @@ describe("CLI session completion with real persistence", () => {
 
   test.each([
     [
-      "missing-key-reference",
-      "UPDATE cli_auth_sessions SET api_key_id = NULL WHERE session_id = 'missing-key-reference'",
+      SESSION_IDS.missingKeyReference,
+      `UPDATE cli_auth_sessions SET api_key_id = NULL WHERE session_id = '${SESSION_IDS.missingKeyReference}'`,
     ],
-    ["missing-key-row", `DELETE FROM api_keys WHERE id = '${API_KEY_ID}'`],
     [
-      "mismatched-key-owner",
+      SESSION_IDS.missingKeyRow,
+      `DELETE FROM api_keys WHERE id = '${API_KEY_ID}'`,
+    ],
+    [
+      SESSION_IDS.mismatchedKeyOwner,
       `UPDATE api_keys SET user_id = '${OTHER_USER_ID}' WHERE id = '${API_KEY_ID}'`,
     ],
   ])(
@@ -330,7 +440,7 @@ describe("CLI session completion with real persistence", () => {
   );
 
   test("rejects a missing session", async () => {
-    const response = await complete("missing");
+    const response = await complete(SESSION_IDS.missing);
     expect(response.status).toBe(400);
     expect(JSON.stringify(await response.json())).toContain(
       "Invalid or expired session",

--- a/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.ts
@@ -3,6 +3,16 @@
  * Completes a pending CLI login after an authenticated user approves it in
  * the web UI. Session and API-key authentication share the same ownership
  * checks so headless clients can exercise the production boundary too.
+ *
+ * CSRF posture: this route mints an org API key, so the cookie-authenticated
+ * path must not be reachable by a cross-origin simple request. Requests
+ * carrying programmatic credentials (Authorization / X-API-Key) are already
+ * non-ambient — a browser cannot attach them cross-origin without a
+ * preflight — and skip the origin gate so headless clients keep working.
+ * Every other request must pass the exact-host Origin/Referer policy AND
+ * carry a non-simple marker (the X-Eliza-CSRF custom header or a JSON
+ * content type), which forces a preflight the first-party-only CORS layer
+ * fails for user-content origins.
  */
 
 import { Hono } from "hono";
@@ -10,8 +20,15 @@ import {
   failureResponse,
   ValidationError,
 } from "@/lib/api/cloud-worker-errors";
+import {
+  checkElizaMutatingRequestOrigin,
+  hasElizaNonSimpleRequestMarker,
+} from "@/lib/auth/browser-origin-policy";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { cliAuthSessionsService } from "@/lib/services/cli-auth-sessions";
+import {
+  cliAuthSessionsService,
+  looksLikeCliAuthSessionId,
+} from "@/lib/services/cli-auth-sessions";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -20,8 +37,30 @@ const app = new Hono<AppEnv>();
 app.post("/", async (c) => {
   try {
     const sessionId = c.req.param("sessionId");
-    if (!sessionId) {
-      return c.json({ error: "Session ID is required" }, 400);
+    if (!sessionId || !looksLikeCliAuthSessionId(sessionId)) {
+      return c.json({ error: "Invalid session ID format" }, 400);
+    }
+
+    const hasProgrammaticAuth = Boolean(
+      c.req.header("authorization") || c.req.header("x-api-key"),
+    );
+    if (!hasProgrammaticAuth) {
+      const originCheck = checkElizaMutatingRequestOrigin(
+        c.req,
+        c.env.NODE_ENV === "production",
+      );
+      if (!originCheck.ok) {
+        logger.warn("[CLI Auth] rejected cross-origin complete", {
+          detail: originCheck.reason,
+        });
+        return c.json({ error: "Forbidden", code: "forbidden_origin" }, 403);
+      }
+      if (!hasElizaNonSimpleRequestMarker(c.req)) {
+        return c.json(
+          { error: "Forbidden", code: "csrf_marker_required" },
+          403,
+        );
+      }
     }
 
     const user = await requireUserOrApiKeyWithOrg(c);

--- a/packages/cloud/api/auth/cli-session/[sessionId]/route.single-use.integration.test.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/route.single-use.integration.test.ts
@@ -178,6 +178,14 @@ async function within<T>(promise: Promise<T>, label: string): Promise<T> {
 }
 
 describe("CLI session single-use plaintext retrieval with real persistence", () => {
+  test("the poll route rejects a non-UUID session id before any lookup", async () => {
+    const response = await pollApp.request("/api/auth/cli-session/not-a-uuid");
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: "Invalid session ID format",
+    });
+  });
+
   test("the session lifecycle still uses the real repository guards", async () => {
     const sessionId = "lifecycle";
     const created = await cliAuthSessionsService.createSession(sessionId);
@@ -214,7 +222,7 @@ describe("CLI session single-use plaintext retrieval with real persistence", () 
   });
 
   test("two concurrent poll routes decrypt the candidate but exactly one returns plaintext", async () => {
-    const sessionId = "concurrent-poll";
+    const sessionId = "10101010-1010-4010-8010-101010101010";
     await seedAuthenticatedSession(sessionId);
 
     concurrentDecryptGate = new Promise<void>((resolve) => {
@@ -246,7 +254,7 @@ describe("CLI session single-use plaintext retrieval with real persistence", () 
   });
 
   test("a decrypt failure does not consume the session and a retry can win", async () => {
-    const sessionId = "decrypt-retry";
+    const sessionId = "20202020-2020-4020-8020-202020202020";
     await seedAuthenticatedSession(sessionId);
     decryptMode = "failure";
 
@@ -268,7 +276,7 @@ describe("CLI session single-use plaintext retrieval with real persistence", () 
   });
 
   test("a stale candidate cannot consume a session whose owner changes during decrypt", async () => {
-    const sessionId = "stale-candidate";
+    const sessionId = "30303030-3030-4030-8030-303030303030";
     await seedAuthenticatedSession(sessionId);
 
     let signalDecryptStarted: (() => void) | undefined;
@@ -303,7 +311,7 @@ describe("CLI session single-use plaintext retrieval with real persistence", () 
   });
 
   test("a session/API-key owner mismatch is rejected before decrypt", async () => {
-    const sessionId = "mismatched-owner";
+    const sessionId = "40404040-4040-4040-8040-404040404040";
     await seedAuthenticatedSession(sessionId, {
       sessionUserId: OTHER_USER_ID,
     });
@@ -342,7 +350,7 @@ describe("CLI session single-use plaintext retrieval with real persistence", () 
   });
 
   test("a real API-key regeneration update invalidates a decrypted candidate before claim", async () => {
-    const sessionId = "regenerated-during-decrypt";
+    const sessionId = "50505050-5050-4050-8050-505050505050";
     await seedAuthenticatedSession(sessionId);
 
     let signalDecryptStarted: (() => void) | undefined;

--- a/packages/cloud/api/auth/cli-session/[sessionId]/route.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/route.ts
@@ -5,7 +5,10 @@
  */
 
 import { Hono } from "hono";
-import { cliAuthSessionsService } from "@/lib/services/cli-auth-sessions";
+import {
+  cliAuthSessionsService,
+  looksLikeCliAuthSessionId,
+} from "@/lib/services/cli-auth-sessions";
 import { getCorsHeaders } from "@/lib/utils/cors";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -23,8 +26,8 @@ app.get("/", async (c) => {
   const corsHeaders = getCorsHeaders(c.req.header("origin") ?? null);
   try {
     const sessionId = c.req.param("sessionId");
-    if (!sessionId) {
-      return c.json({ error: "Session ID is required" }, 400, corsHeaders);
+    if (!sessionId || !looksLikeCliAuthSessionId(sessionId)) {
+      return c.json({ error: "Invalid session ID format" }, 400, corsHeaders);
     }
 
     const session = await cliAuthSessionsService.getActiveSession(sessionId);

--- a/packages/cloud/api/auth/cli-session/route.test.ts
+++ b/packages/cloud/api/auth/cli-session/route.test.ts
@@ -1,0 +1,87 @@
+/**
+ * POST /api/auth/cli-session contract: the server mints the session id and a
+ * client-supplied id is ignored (id squatting / row-spam hardening), with the
+ * minted id returned in the documented response shape.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const createSessionCalls: string[] = [];
+const nextSession: {
+  session_id: string;
+  status: string;
+  expires_at: Date;
+} = {
+  session_id: "bbbbbbbb-2222-4333-8444-cccccccccccc",
+  status: "pending",
+  expires_at: new Date("2026-05-14T08:00:00.000Z"),
+};
+
+mock.module("@/lib/services/cli-auth-sessions", () => ({
+  cliAuthSessionsService: {
+    createSession: async (sessionId: string) => {
+      createSessionCalls.push(sessionId);
+      return { ...nextSession, session_id: sessionId };
+    },
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { debug() {}, info() {}, warn() {}, error() {} },
+}));
+
+const { default: route } = await import("./route");
+
+const ENV = { NODE_ENV: "test" } as never;
+
+function buildApp() {
+  const app = new Hono();
+  app.route("/api/auth/cli-session", route);
+  return app;
+}
+
+beforeEach(() => {
+  createSessionCalls.length = 0;
+});
+
+describe("POST /api/auth/cli-session", () => {
+  test("mints a server-generated UUID session id", async () => {
+    const app = buildApp();
+    const res = await app.request(
+      "/api/auth/cli-session",
+      { method: "POST", headers: { "content-type": "application/json" } },
+      ENV,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      sessionId: string;
+      status: string;
+      expiresAt: string;
+    };
+    expect(body.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    expect(body.status).toBe("pending");
+    expect(typeof body.expiresAt).toBe("string");
+    expect(createSessionCalls).toEqual([body.sessionId]);
+  });
+
+  test("ignores a client-supplied sessionId", async () => {
+    const app = buildApp();
+    const res = await app.request(
+      "/api/auth/cli-session",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionId: "attacker-chosen-id" }),
+      },
+      ENV,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { sessionId: string };
+    expect(body.sessionId).not.toBe("attacker-chosen-id");
+    expect(body.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+});

--- a/packages/cloud/api/auth/cli-session/route.ts
+++ b/packages/cloud/api/auth/cli-session/route.ts
@@ -1,15 +1,36 @@
 /**
  * POST /api/auth/cli-session
  * Creates a new CLI authentication session for command-line tool authentication.
+ * Session ids are server-generated UUIDs: accepting client-chosen ids let any
+ * unauthenticated caller squat ids and insert unbounded rows (row-spam).
  */
 
 import { Hono } from "hono";
+import {
+  getIpKey,
+  RateLimitPresets,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { cliAuthSessionsService } from "@/lib/services/cli-auth-sessions";
 import { getCorsHeaders } from "@/lib/utils/cors";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
+
+// Pre-auth session-create endpoint: bound DB-row creation per source IP. Same
+// fail-closed-with-fallback posture as steward-session (login availability is
+// preserved through a Redis outage by the per-isolate bucket).
+app.use(
+  rateLimit({
+    ...RateLimitPresets.STRICT,
+    keyGenerator: getIpKey,
+    failClosed: true,
+    redisUnavailableFallback: {
+      namespace: "cli-session",
+    },
+  }),
+);
 
 app.options("/", (c) => {
   return new Response(null, {
@@ -21,14 +42,11 @@ app.options("/", (c) => {
 app.post("/", async (c) => {
   const corsHeaders = getCorsHeaders(c.req.header("origin") ?? null);
   try {
-    const body = await c.req.json().catch(() => ({}) as { sessionId?: string });
-    const { sessionId } = body;
-
-    if (!sessionId || typeof sessionId !== "string") {
-      return c.json({ error: "Session ID is required" }, 400, corsHeaders);
-    }
-
-    const session = await cliAuthSessionsService.createSession(sessionId);
+    // A client-supplied sessionId is deliberately ignored; the poll/complete
+    // routes only accept the server-issued UUID format.
+    const session = await cliAuthSessionsService.createSession(
+      crypto.randomUUID(),
+    );
 
     return c.json(
       {

--- a/packages/cloud/api/auth/create-anonymous-session/route.ts
+++ b/packages/cloud/api/auth/create-anonymous-session/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/api/auth/anonymous-session-config";
 import {
   getIpKey,
+  getRequestIp,
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
@@ -69,10 +70,10 @@ app.get("/", async (c) => {
 
     const newSessionToken = nanoid(32);
     const expiresAt = new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000);
-    const ipAddress =
-      c.req.header("x-real-ip")?.trim() ||
-      c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
-      undefined;
+    // Persist the edge-verified request IP (cf-connecting-ip first), never a
+    // client-spoofed x-real-ip / x-forwarded-for value — this row is the
+    // abuse-investigation audit trail.
+    const ipAddress = getRequestIp(c);
     const userAgent = c.req.header("user-agent") || undefined;
 
     const { newUser, newSession } = await createAnonymousUserAndSession({

--- a/packages/cloud/api/auth/migrate-anonymous/route.test.ts
+++ b/packages/cloud/api/auth/migrate-anonymous/route.test.ts
@@ -1,0 +1,110 @@
+/**
+ * POST /api/auth/migrate-anonymous contract: the anonymous session is honored
+ * only from the HttpOnly cookie (never the request body), and the
+ * cookie-authenticated mutation requires the exact-host origin policy plus a
+ * non-simple-request marker. Route handler is real; auth, session services,
+ * and the migration boundary are mocked.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+let migrationCalls: Array<{ anonUserId: string; stewardId: string }> = [];
+let anonSessionForToken: {
+  user_id: string;
+  converted_at: string | null;
+} | null = null;
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUser: async () => ({ id: "user-1", steward_id: "steward-1" }),
+}));
+
+mock.module("@/lib/services/anonymous-sessions", () => ({
+  anonymousSessionsService: {
+    getByToken: async (token: string) =>
+      token === "cookie-token" ? anonSessionForToken : null,
+  },
+}));
+
+mock.module("@/lib/session", () => ({
+  migrateAnonymousSession: async (anonUserId: string, stewardId: string) => {
+    migrationCalls.push({ anonUserId, stewardId });
+    return { mergedData: { conversations: 1 } };
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { debug() {}, info() {}, warn() {}, error() {} },
+}));
+
+const { default: route } = await import("./route");
+
+const ENV = { NODE_ENV: "test" } as never;
+
+function buildApp() {
+  const app = new Hono();
+  app.route("/api/auth/migrate-anonymous", route);
+  return app;
+}
+
+function postMigrate(headers: Record<string, string>, body?: string) {
+  return buildApp().request(
+    "/api/auth/migrate-anonymous",
+    { method: "POST", headers, ...(body ? { body } : {}) },
+    ENV,
+  );
+}
+
+beforeEach(() => {
+  migrationCalls = [];
+  anonSessionForToken = { user_id: "anon-1", converted_at: null };
+});
+
+describe("POST /api/auth/migrate-anonymous", () => {
+  test("rejects requests with no Origin or Referer", async () => {
+    const res = await postMigrate({
+      "content-type": "application/json",
+      cookie: "eliza-anon-session=cookie-token",
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ code: "forbidden_origin" });
+    expect(migrationCalls).toHaveLength(0);
+  });
+
+  test("rejects a simple request without the non-simple marker", async () => {
+    const res = await postMigrate({
+      origin: "http://localhost:3000",
+      "content-type": "text/plain",
+      cookie: "eliza-anon-session=cookie-token",
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ code: "csrf_marker_required" });
+    expect(migrationCalls).toHaveLength(0);
+  });
+
+  test("migrates the session identified by the HttpOnly cookie", async () => {
+    const res = await postMigrate({
+      origin: "http://localhost:3000",
+      "content-type": "application/json",
+      cookie: "eliza-anon-session=cookie-token",
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, migrated: true });
+    expect(migrationCalls).toEqual([
+      { anonUserId: "anon-1", stewardId: "steward-1" },
+    ]);
+  });
+
+  test("ignores a session token supplied in the request body", async () => {
+    // No cookie: a body-only token must NOT drive a migration.
+    const res = await postMigrate(
+      {
+        origin: "http://localhost:3000",
+        "content-type": "application/json",
+      },
+      JSON.stringify({ sessionToken: "cookie-token" }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ migrated: false });
+    expect(migrationCalls).toHaveLength(0);
+  });
+});

--- a/packages/cloud/api/auth/migrate-anonymous/route.ts
+++ b/packages/cloud/api/auth/migrate-anonymous/route.ts
@@ -2,11 +2,22 @@
  * POST /api/auth/migrate-anonymous
  * Migrates anonymous user data to the authenticated user. Called by the SPA
  * after a successful Steward authentication.
+ *
+ * The anonymous session is honored ONLY from the HttpOnly cookie — never from
+ * the request body, where a leaked token could be merged into an attacker's
+ * account or a poisoned session CSRF-merged into the victim's. The cookie
+ * path is guarded like the other session mutations: exact-host Origin policy
+ * plus a non-simple-request marker (X-Eliza-CSRF header or JSON content
+ * type) so a cross-origin simple request cannot drive it.
  */
 
 import { Hono } from "hono";
 import { deleteCookie, getCookie } from "hono/cookie";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import {
+  checkElizaMutatingRequestOrigin,
+  hasElizaNonSimpleRequestMarker,
+} from "@/lib/auth/browser-origin-policy";
 import { requireUser } from "@/lib/auth/workers-hono-auth";
 import { anonymousSessionsService } from "@/lib/services/anonymous-sessions";
 import { migrateAnonymousSession } from "@/lib/session";
@@ -30,19 +41,27 @@ const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   try {
+    const originCheck = checkElizaMutatingRequestOrigin(
+      c.req,
+      c.env.NODE_ENV === "production",
+    );
+    if (!originCheck.ok) {
+      logger.warn("[Migrate Anonymous] rejected cross-origin POST", {
+        detail: originCheck.reason,
+      });
+      return c.json({ error: "Forbidden", code: "forbidden_origin" }, 403);
+    }
+    if (!hasElizaNonSimpleRequestMarker(c.req)) {
+      return c.json({ error: "Forbidden", code: "csrf_marker_required" }, 403);
+    }
+
     const user = await requireUser(c);
 
     if (!user.steward_id) {
       return c.json({ error: "User does not have a Steward ID" }, 400);
     }
 
-    let sessionToken: string | undefined = getCookie(c, ANON_SESSION_COOKIE);
-    if (!sessionToken) {
-      const body = (await c.req.json().catch(() => ({}))) as {
-        sessionToken?: string;
-      };
-      sessionToken = body.sessionToken;
-    }
+    const sessionToken: string | undefined = getCookie(c, ANON_SESSION_COOKIE);
 
     if (!sessionToken) {
       return c.json({

--- a/packages/cloud/api/auth/steward-nonce-exchange/route.test.ts
+++ b/packages/cloud/api/auth/steward-nonce-exchange/route.test.ts
@@ -1,0 +1,158 @@
+/**
+ * POST /api/auth/steward-nonce-exchange contract: PKCE verifier is required,
+ * the non-simple-request marker is required alongside the exact-host origin
+ * policy, the verifier is forwarded to the Steward exchange, and the
+ * long-lived refresh token is never mirrored into the JSON body.
+ * Route handler is real; Steward upstream, token verification, and user sync
+ * are mocked.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const verifyCalls: string[] = [];
+let upstreamBodies: string[] = [];
+
+mock.module("@/lib/auth/steward-client", () => ({
+  STEWARD_AUTH_UPSTREAM_TIMEOUT_MS: 5_000,
+  verifyStewardTokenCached: async (_env: unknown, token: string) => {
+    verifyCalls.push(token);
+    if (token !== "steward-jwt") return null;
+    return {
+      userId: "steward-user-1",
+      email: "user@example.test",
+      tenantId: "elizacloud",
+      expiration: Math.floor(Date.now() / 1000) + 3600,
+    };
+  },
+}));
+
+mock.module("@/lib/steward-sync", () => ({
+  describeSyncError: (error: unknown) => String(error),
+  StewardTelegramAccountClaimError: class extends Error {},
+  syncUserFromSteward: async () => ({
+    id: "cloud-user-1",
+    organization_id: "org-1",
+    initialCreditsGranted: false,
+    initialFreeCreditsUsd: 0,
+    welcomeBonusWithheld: false,
+  }),
+}));
+
+mock.module("@/lib/steward/sign", () => ({
+  signStewardMutatingRequest: async () => undefined,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { debug() {}, info() {}, warn() {}, error() {} },
+}));
+
+const { default: route } = await import("./route");
+
+const ENV = {
+  NODE_ENV: "test",
+  STEWARD_API_URL: "https://steward.example.test",
+  STEWARD_SESSION_SECRET: "test-secret",
+} as never;
+
+const originalFetch = globalThis.fetch;
+
+function buildApp() {
+  const app = new Hono();
+  app.route("/api/auth/steward-nonce-exchange", route);
+  return app;
+}
+
+function postExchange(headers: Record<string, string>, body?: unknown) {
+  return buildApp().request(
+    "/api/auth/steward-nonce-exchange",
+    {
+      method: "POST",
+      headers,
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    },
+    ENV,
+  );
+}
+
+const FIRST_PARTY = {
+  origin: "http://localhost:3000",
+  "content-type": "application/json",
+};
+
+beforeEach(() => {
+  verifyCalls.length = 0;
+  upstreamBodies = [];
+  globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+    upstreamBodies.push(String(init?.body ?? ""));
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        token: "steward-jwt",
+        refreshToken: "steward-refresh",
+        expiresIn: 3600,
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("POST /api/auth/steward-nonce-exchange", () => {
+  test("rejects requests with no Origin or Referer", async () => {
+    const res = await postExchange(
+      { "content-type": "application/json" },
+      { code: "c", redirectUri: "https://eliza.app/login" },
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ code: "forbidden_origin" });
+  });
+
+  test("rejects a simple request without the non-simple marker", async () => {
+    const res = await postExchange(
+      { origin: "http://localhost:3000", "content-type": "text/plain" },
+      { code: "c", redirectUri: "https://eliza.app/login" },
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ code: "csrf_marker_required" });
+  });
+
+  test("rejects a verifier-less exchange", async () => {
+    const res = await postExchange(FIRST_PARTY, {
+      code: "one-time-code",
+      redirectUri: "https://eliza.app/login",
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "missing_code_verifier" });
+    expect(upstreamBodies).toHaveLength(0);
+  });
+
+  test("forwards the verifier upstream and never mirrors the refresh token", async () => {
+    const res = await postExchange(FIRST_PARTY, {
+      code: "one-time-code",
+      redirectUri: "https://eliza.app/login",
+      codeVerifier: "pkce-verifier",
+    });
+    expect(res.status).toBe(200);
+
+    expect(upstreamBodies).toHaveLength(1);
+    const upstream = JSON.parse(upstreamBodies[0] ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    expect(upstream.code_verifier).toBe("pkce-verifier");
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    // The SPA needs the short-lived access-token mirror; the long-lived
+    // refresh token must stay inside the HttpOnly cookie.
+    expect(body.token).toBe("steward-jwt");
+    expect(body).not.toHaveProperty("refreshToken");
+
+    const cookies = res.headers.getSetCookie().join("\n");
+    expect(cookies).toContain("steward-refresh-token");
+    expect(verifyCalls).toEqual(["steward-jwt"]);
+  });
+});

--- a/packages/cloud/api/auth/steward-nonce-exchange/route.ts
+++ b/packages/cloud/api/auth/steward-nonce-exchange/route.ts
@@ -31,6 +31,7 @@ import { setCookie } from "hono/cookie";
 import {
   browserOriginHost,
   checkElizaMutatingRequestOrigin,
+  hasElizaNonSimpleRequestMarker,
   isPermittedElizaBrowserOrigin,
 } from "@/lib/auth/browser-origin-policy";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
@@ -248,6 +249,12 @@ app.post("/", async (c) => {
     });
     return c.json(errorBody("Forbidden", "forbidden_origin"), 403);
   }
+  // Same non-simple-marker CSRF layer as /api/auth/steward-session: forces a
+  // preflight that user-content origins cannot pass.
+  if (!hasElizaNonSimpleRequestMarker(c.req)) {
+    logExchange("csrf-marker-missing");
+    return c.json(errorBody("Forbidden", "csrf_marker_required"), 403);
+  }
 
   const body = (await c.req.json().catch(() => ({}))) as {
     code?: unknown;
@@ -282,8 +289,10 @@ app.post("/", async (c) => {
     rawTenant.length > 0 ? rawTenant : envTenant.length > 0 ? envTenant : null;
   // PKCE verifier for `response_type=code`. The SPA stashes it before the
   // /authorize redirect and replays it here; we forward it to Steward, which
-  // checks it against the challenge bound at /authorize. Absent for compatibility
-  // (pre-PKCE) and wallet flows — forward only when present.
+  // checks it against the challenge bound at /authorize. It is REQUIRED: the
+  // hosted login always starts the flow with a S256 challenge, so a
+  // verifier-less exchange can only be a pre-PKCE client or a planted
+  // callback — both must fail closed.
   const codeVerifier =
     typeof body.codeVerifier === "string"
       ? body.codeVerifier.trim()
@@ -301,6 +310,13 @@ app.post("/", async (c) => {
   if (!redirectUri) {
     logExchange("missing-redirect-uri");
     return c.json(errorBody("redirectUri required", "missing_code"), 400);
+  }
+  if (!codeVerifier) {
+    logExchange("missing-code-verifier");
+    return c.json(
+      errorBody("codeVerifier required", "missing_code_verifier"),
+      400,
+    );
   }
   if (body.telegramContinuation !== undefined && !telegramContinuation) {
     logExchange("telegram-claim-invalid");
@@ -338,7 +354,7 @@ app.post("/", async (c) => {
       code,
       redirect_uri: redirectUri,
       tenant_id: tenantId,
-      ...(codeVerifier ? { code_verifier: codeVerifier } : {}),
+      code_verifier: codeVerifier,
     },
     c.env.STEWARD_TENANT_ID,
     c.env.STEWARD_REQUEST_SIGNING_SECRET,
@@ -457,16 +473,18 @@ app.post("/", async (c) => {
   });
 
   logExchange("ok");
-  // Returning `token` (and `refreshToken`) here so the SPA can mirror it into
-  // localStorage. The HttpOnly cookies above are the canonical session; the
-  // localStorage copy is what @stwd/react's `useAuth()` and the SPA's
+  // Returning `token` here so the SPA can mirror it into localStorage. The
+  // HttpOnly cookies above are the canonical session; the localStorage copy is
+  // what @stwd/react's `useAuth()` and the SPA's
   // `readStewardSessionFromStorage()` actually read on `/cloud` route
   // mount to decide `isAuthenticated`. Without this, OAuth users land back
   // on `/login` after a successful exchange (wallet/SIWE keeps working only
   // because the Steward SDK writes its own localStorage copy). The original
   // "tokens never enter JS" design intent is aspirational — until the SPA
   // auth check trusts the steward-authed marker cookie alone, the JWT has
-  // to be reachable from JS.
+  // to be reachable from JS. The long-lived refresh token is NOT mirrored:
+  // it stays in the HttpOnly cookie so a JS-readable token theft is bounded
+  // to the short-lived access token.
   return c.json({
     ok: true,
     userId: cloudUser.id,
@@ -478,9 +496,7 @@ app.post("/", async (c) => {
     welcomeBonusWithheld: cloudUser.welcomeBonusWithheld === true,
     welcomeBonusWithheldReason: cloudUser.welcomeBonusWithheldReason,
     welcomeBonusWithheldMessage: cloudUser.welcomeBonusWithheldMessage,
-    ...(shouldReturnClientToken(c, isProduction)
-      ? { token, refreshToken }
-      : {}),
+    ...(shouldReturnClientToken(c, isProduction) ? { token } : {}),
   });
 });
 

--- a/packages/cloud/api/auth/steward-nonce-exchange/steward-nonce-exchange-telegram-claim.test.ts
+++ b/packages/cloud/api/auth/steward-nonce-exchange/steward-nonce-exchange-telegram-claim.test.ts
@@ -100,6 +100,7 @@ describe("POST /api/auth/steward-nonce-exchange Telegram convergence", () => {
     const response = await post({
       code: "one-time-code",
       redirectUri: "https://cloud.eliza.app/login",
+      codeVerifier: "pkce-verifier",
       telegramContinuation: "opaque-telegram-claim-token",
     });
 
@@ -124,6 +125,7 @@ describe("POST /api/auth/steward-nonce-exchange Telegram convergence", () => {
     const response = await post({
       code: "one-time-code",
       redirectUri: "https://cloud.eliza.app/login",
+      codeVerifier: "pkce-verifier",
       telegramContinuation: "opaque-telegram-claim-token",
     });
 
@@ -138,6 +140,7 @@ describe("POST /api/auth/steward-nonce-exchange Telegram convergence", () => {
     const response = await post({
       code: "one-time-code",
       redirectUri: "https://cloud.eliza.app/login",
+      codeVerifier: "pkce-verifier",
       telegramContinuation: "platform:telegram:123456789",
     });
 

--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -12,7 +12,10 @@ import {
 import { Hono } from "hono";
 import { deleteCookie, setCookie } from "hono/cookie";
 import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleton";
-import { checkElizaMutatingRequestOrigin } from "@/lib/auth/browser-origin-policy";
+import {
+  checkElizaMutatingRequestOrigin,
+  hasElizaNonSimpleRequestMarker,
+} from "@/lib/auth/browser-origin-policy";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import { loadVerifiedStagingSessionUser } from "@/lib/auth/staging-session-binding";
 import {
@@ -61,6 +64,20 @@ function checkOrigin(
   return checkElizaMutatingRequestOrigin(c.req, isProduction);
 }
 
+/**
+ * Second CSRF layer after the Origin policy: a cross-origin "simple request"
+ * (the only kind that carries cookies without a preflight) cannot produce a
+ * custom header or a JSON content type. Hono parses `text/plain` bodies as
+ * JSON, so without this check an attacker page on a user-content subdomain
+ * could plant a session with a preflight-less POST. Requiring the marker
+ * forces the preflight that the first-party-only CORS layer fails for them.
+ */
+function checkNonSimpleMarker(c: {
+  req: { header: (name: string) => string | undefined };
+}): boolean {
+  return hasElizaNonSimpleRequestMarker(c.req);
+}
+
 let stewardAuthMetricCounter = 0;
 function logStewardAuth(outcome: string, ttl: number | null) {
   stewardAuthMetricCounter += 1;
@@ -106,6 +123,13 @@ app.post("/", async (c) => {
       });
       return c.json(
         { error: "Forbidden", code: "forbidden_origin" as const },
+        403,
+      );
+    }
+    if (!checkNonSimpleMarker(c)) {
+      logStewardAuth("csrf-marker-missing", null);
+      return c.json(
+        { error: "Forbidden", code: "csrf_marker_required" as const },
         403,
       );
     }
@@ -431,6 +455,10 @@ app.delete("/", (c) => {
   if (!originCheck.ok) {
     logStewardAuth("forbidden-origin-delete", null);
     return c.json({ error: "Forbidden" }, 403);
+  }
+  if (!checkNonSimpleMarker(c)) {
+    logStewardAuth("csrf-marker-missing-delete", null);
+    return c.json({ error: "Forbidden", code: "csrf_marker_required" }, 403);
   }
   const domain = cookieDomainForHost(c.req.header("host"));
   const opts = domain ? { path: "/", domain } : { path: "/" };

--- a/packages/cloud/api/test/e2e/group-a-auth.test.ts
+++ b/packages/cloud/api/test/e2e/group-a-auth.test.ts
@@ -178,8 +178,13 @@ describeE2E("Group A: auth + sessions", () => {
     // 403s (forbidden_origin) BEFORE body/token validation against staging.
     // Send a host that is UNCONDITIONALLY in PERMITTED_ORIGIN_HOSTS (works in
     // local dev AND deployed staging/prod) so the CSRF gate passes and the
-    // handler's real validation is what the test observes.
-    const stewardSessionHeaders = { Origin: "https://staging.elizacloud.ai" };
+    // handler's real validation is what the test observes. The X-Eliza-CSRF
+    // custom header is the route's non-simple-request marker; JSON bodies
+    // satisfy it implicitly, but a bodyless DELETE must send it explicitly.
+    const stewardSessionHeaders = {
+      Origin: "https://staging.elizacloud.ai",
+      "X-Eliza-CSRF": "1",
+    };
 
     test("POST validation: missing token returns 400", async () => {
       const res = await api.post(
@@ -241,7 +246,10 @@ describeE2E("Group A: auth + sessions", () => {
   describe("POST /api/auth/steward-nonce-exchange", () => {
     // Same CSRF-origin reasoning as stewardSessionHeaders above: a permitted
     // host unconditionally (localhost is dev-only, staging runs production).
-    const nonceHeaders = { Origin: "https://staging.elizacloud.ai" };
+    const nonceHeaders = {
+      Origin: "https://staging.elizacloud.ai",
+      "X-Eliza-CSRF": "1",
+    };
 
     test("validation: missing code returns 400 missing_code", async () => {
       const res = await api.post(
@@ -265,6 +273,17 @@ describeE2E("Group A: auth + sessions", () => {
       expect(body.code).toBe("missing_code");
     });
 
+    test("validation: missing codeVerifier returns 400 missing_code_verifier", async () => {
+      const res = await api.post(
+        "/api/auth/steward-nonce-exchange",
+        { code: "abc", redirectUri: "https://elizaos.ai/checkout" },
+        { headers: nonceHeaders },
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code?: string };
+      expect(body.code).toBe("missing_code_verifier");
+    });
+
     test("CSRF: POST without Origin returns 403 forbidden_origin", async () => {
       const res = await api.post("/api/auth/steward-nonce-exchange", {
         code: "abc",
@@ -282,6 +301,7 @@ describeE2E("Group A: auth + sessions", () => {
           code: "not-a-real-steward-code",
           redirectUri: "https://elizaos.ai/checkout",
           tenantId: "elizacloud",
+          codeVerifier: "e2e-pkce-verifier",
         },
         { headers: nonceHeaders },
       );

--- a/packages/cloud/api/test/e2e/group-b-account-billing.test.ts
+++ b/packages/cloud/api/test/e2e/group-b-account-billing.test.ts
@@ -39,6 +39,7 @@
  */
 
 import { afterAll, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { buildWalletProvisionChallenge } from "@elizaos/cloud-sdk";
 import { privateKeyToAccount } from "viem/accounts";
 import {
@@ -97,9 +98,15 @@ const TEST_WALLET_ACCOUNT = privateKeyToAccount(
 
 async function signedWalletHeaders(
   path: string,
+  body?: unknown,
 ): Promise<Record<string, string>> {
   const timestamp = Date.now();
-  const message = `Eliza Cloud Authentication\nTimestamp: ${timestamp}\nMethod: POST\nPath: ${path}`;
+  const rawBody = body === undefined ? "" : JSON.stringify(body);
+  const canonicalQuery = ""; // the e2e wallet calls carry no query string
+  const payloadHash = createHash("sha256")
+    .update(`${canonicalQuery}\n${rawBody}`)
+    .digest("hex");
+  const message = `Eliza Cloud Authentication\nTimestamp: ${timestamp}\nMethod: POST\nPath: ${path}\nPayload-SHA256: ${payloadHash}`;
   const signature = await TEST_WALLET_ACCOUNT.signMessage({ message });
 
   return {
@@ -491,17 +498,17 @@ describeE2E("POST /api/v1/user/wallets/rpc", () => {
   });
 
   test("happy path: signed wallet auth reaches ownership or RPC checks", async () => {
-    const res = await api.post(
-      "/api/v1/user/wallets/rpc",
-      {
-        clientAddress: "0x0000000000000000000000000000000000000000",
-        payload: { method: "personal_sign", params: ["hello"] },
-        signature: "0xdead",
-        timestamp: Date.now(),
-        nonce: `n-${Date.now()}`,
-      },
-      { headers: await signedWalletHeaders("/api/v1/user/wallets/rpc") },
-    );
+    const rpcBody = {
+      clientAddress: "0x0000000000000000000000000000000000000000",
+      payload: { method: "personal_sign", params: ["hello"] },
+      signature: "0xdead",
+      timestamp: Date.now(),
+      nonce: `n-${Date.now()}`,
+    };
+    const res = await api.post("/api/v1/user/wallets/rpc", rpcBody, {
+      // The signed payload hash must commit to the exact bytes sent.
+      headers: await signedWalletHeaders("/api/v1/user/wallets/rpc", rpcBody),
+    });
     // The signature verifies, but TEST_WALLET is not a provisioned wallet for
     // any org → ownership check rejects with 401.
     expect(res.status).toBe(401);

--- a/packages/cloud/api/v1/user/wallets/rpc/route.ts
+++ b/packages/cloud/api/v1/user/wallets/rpc/route.ts
@@ -42,11 +42,13 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 app.post("/", async (c) => {
   try {
     let body: unknown;
+    let rawBody = "";
     try {
-      body = await c.req.json();
+      rawBody = await c.req.text();
+      body = JSON.parse(rawBody);
     } catch {
-      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
-      // bare JSON.parse. SyntaxError must be a caller 400, not the
+      // error-policy:J3 untrusted request JSON — a bare JSON.parse.
+      // SyntaxError must be a caller 400, not the
       // failureResponse 500 that treats it as an unexpected server fault.
       // Wallet-signature verify and server-wallet RPC must not run on garbage.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
@@ -57,8 +59,12 @@ app.post("/", async (c) => {
     const validated = rpcPayloadSchema.parse(body);
 
     const url = new URL(c.req.url);
+    // The wallet-signature message commits to a hash of the raw body; the
+    // exact bytes must be forwarded or every payload-bound signature would
+    // verify against an empty body and fail.
     const authenticatedUser = await verifyWalletSignature(
       honoToWalletAuthRequest(c, url),
+      { bodyText: rawBody },
     );
     if (!authenticatedUser) {
       return c.json(

--- a/packages/cloud/e2e/tests/steward-session.spec.ts
+++ b/packages/cloud/e2e/tests/steward-session.spec.ts
@@ -117,7 +117,9 @@ test.describe("steward session", () => {
   }) => {
     const res = await fetch(`${stack.urls.api}${STEWARD_SESSION}`, {
       method: "DELETE",
-      headers: { Origin: stack.urls.api },
+      // The route's non-simple-request CSRF marker: a bodyless DELETE carries
+      // no JSON content type, so the custom header must be sent explicitly.
+      headers: { Origin: stack.urls.api, "X-Eliza-CSRF": "1" },
     });
     expect(res.status).toBe(200);
     expect((await res.json()) as { ok?: boolean }).toMatchObject({ ok: true });

--- a/packages/cloud/sdk/src/client.test.ts
+++ b/packages/cloud/sdk/src/client.test.ts
@@ -372,6 +372,34 @@ describe("ElizaCloudClient CLI login", () => {
       "https://eliza.app/auth/cli-login?session=cli-test-session",
     );
   });
+
+  it("honors the server-minted session id over the locally generated one", async () => {
+    const fetchImpl = (async (_input: unknown) => {
+      return new Response(
+        JSON.stringify({
+          sessionId: "11111111-2222-4333-8444-555555555555",
+          status: "pending",
+          expiresAt: "2026-05-14T08:00:00.000Z",
+        }),
+        {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = new ElizaCloudClient({
+      baseUrl: "https://api.eliza.app",
+      fetchImpl,
+    });
+
+    const result = await client.startCliLogin();
+
+    expect(result.sessionId).toBe("11111111-2222-4333-8444-555555555555");
+    expect(result.browserUrl).toBe(
+      "https://eliza.app/auth/cli-login?session=11111111-2222-4333-8444-555555555555",
+    );
+  });
 });
 
 describe("ElizaCloudClient web sign-in + app-credits affordances", () => {

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -352,28 +352,35 @@ export class ElizaCloudClient {
   startCliLogin(
     options: CliLoginStartOptions = {},
   ): Promise<CliLoginStartResponse> {
-    const sessionId = options.sessionId ?? getCryptoRandomUuid();
+    // The server mints the session id (client-chosen ids are ignored — they
+    // allowed id squatting and unauthenticated row-spam). A locally generated
+    // id is still sent for backward compatibility with pre-hardening servers,
+    // but the RESPONSE id is authoritative on both old and new servers.
+    const requestedSessionId = options.sessionId ?? getCryptoRandomUuid();
     const query = options.returnTo
       ? `?returnTo=${encodeURIComponent(options.returnTo)}`
       : "";
-    const browserBaseUrl = browserBaseUrlForCliLogin(this.baseUrl);
-    const browserUrl = `${browserBaseUrl}/auth/cli-login?session=${encodeURIComponent(
-      sessionId,
-    )}${query}`;
 
-    return this.request<{ status?: string; expiresAt?: string }>(
-      "POST",
-      "/api/auth/cli-session",
-      {
-        json: { sessionId },
-        skipAuth: true,
-      },
-    ).then((response) => ({
-      sessionId,
-      browserUrl,
-      status: response.status,
-      expiresAt: response.expiresAt,
-    }));
+    return this.request<{
+      sessionId: string;
+      status?: string;
+      expiresAt?: string;
+    }>("POST", "/api/auth/cli-session", {
+      json: { sessionId: requestedSessionId },
+      skipAuth: true,
+    }).then((response) => {
+      const sessionId = response.sessionId ?? requestedSessionId;
+      const browserBaseUrl = browserBaseUrlForCliLogin(this.baseUrl);
+      const browserUrl = `${browserBaseUrl}/auth/cli-login?session=${encodeURIComponent(
+        sessionId,
+      )}${query}`;
+      return {
+        sessionId,
+        browserUrl,
+        status: response.status,
+        expiresAt: response.expiresAt,
+      };
+    });
   }
 
   pollCliLogin(sessionId: string): Promise<CliLoginPollResponse> {

--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -98,6 +98,12 @@ export interface EndpointCallOptions extends CloudRequestOptions {
 }
 
 export interface CliLoginStartOptions {
+  /**
+   * @deprecated The server mints the session id and returns it in the
+   * response (client-chosen ids are ignored there). This value is still sent
+   * for compatibility with pre-hardening servers, but the response id is
+   * always authoritative.
+   */
   sessionId?: string;
   returnTo?: string;
 }

--- a/packages/cloud/shared/src/lib/auth/browser-origin-policy.test.ts
+++ b/packages/cloud/shared/src/lib/auth/browser-origin-policy.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "bun:test";
 import {
   browserOriginHost,
   checkElizaMutatingRequestOrigin,
+  hasElizaNonSimpleRequestMarker,
   isPermittedElizaBrowserOrigin,
 } from "./browser-origin-policy";
 
@@ -74,5 +75,36 @@ describe("Steward browser origin policy", () => {
         true,
       ),
     ).toEqual({ ok: true });
+  });
+
+  it("accepts the custom CSRF header or a JSON content type as the non-simple marker", () => {
+    expect(hasElizaNonSimpleRequestMarker(headers({ "x-eliza-csrf": "1" }))).toBe(true);
+    expect(
+      hasElizaNonSimpleRequestMarker(
+        headers({ "content-type": "application/json; charset=utf-8" }),
+      ),
+    ).toBe(true);
+    expect(hasElizaNonSimpleRequestMarker(headers({ "content-type": "Application/JSON" }))).toBe(
+      true,
+    );
+  });
+
+  it("rejects simple-request shapes that a cross-origin form/fetch can produce", () => {
+    // No headers at all (curl-style or header-less simple request).
+    expect(hasElizaNonSimpleRequestMarker(headers({}))).toBe(false);
+    // CORS-safelisted content types never force a preflight.
+    expect(hasElizaNonSimpleRequestMarker(headers({ "content-type": "text/plain" }))).toBe(false);
+    expect(
+      hasElizaNonSimpleRequestMarker(
+        headers({ "content-type": "application/x-www-form-urlencoded" }),
+      ),
+    ).toBe(false);
+    expect(
+      hasElizaNonSimpleRequestMarker(
+        headers({ "content-type": "multipart/form-data; boundary=x" }),
+      ),
+    ).toBe(false);
+    // An empty marker value is not a marker.
+    expect(hasElizaNonSimpleRequestMarker(headers({ "x-eliza-csrf": "  " }))).toBe(false);
   });
 });

--- a/packages/cloud/shared/src/lib/auth/browser-origin-policy.ts
+++ b/packages/cloud/shared/src/lib/auth/browser-origin-policy.ts
@@ -28,6 +28,23 @@ export interface RequestHeaderReader {
 
 export type BrowserOriginCheck = { ok: true } | { ok: false; reason: string };
 
+/**
+ * Custom header whose presence marks a non-simple request. A cross-origin
+ * "simple request" — the only browser request kind that carries cookies
+ * without a CORS preflight — cannot set custom headers or a JSON content
+ * type, so requiring one of those markers on a cookie-authenticated mutation
+ * forces a preflight that the first-party-only CORS layer fails for
+ * user-content origins. Same convention as the app-core session CSRF header.
+ */
+export const ELIZA_CSRF_HEADER = "x-eliza-csrf";
+
+export function hasElizaNonSimpleRequestMarker(req: RequestHeaderReader): boolean {
+  const csrf = req.header(ELIZA_CSRF_HEADER);
+  if (typeof csrf === "string" && csrf.trim().length > 0) return true;
+  const contentType = req.header("content-type") ?? "";
+  return contentType.toLowerCase().startsWith("application/json");
+}
+
 export function browserOriginHost(rawOrigin: string | undefined): string | null {
   if (!rawOrigin) return null;
   try {

--- a/packages/cloud/shared/src/lib/auth/wallet-auth.test.ts
+++ b/packages/cloud/shared/src/lib/auth/wallet-auth.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Wallet header auth payload-binding contract: the signed message commits to
+ * method+path plus a SHA-256 of the canonical query and raw body, so a
+ * captured header triple cannot be replayed with a rewritten body or query.
+ * The legacy (pre-binding) message is accepted only when the request carries
+ * no query and no body. Signature verification is real (viem); the cache and
+ * user provisioning boundaries are mocked.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { privateKeyToAccount } from "viem/accounts";
+
+const nonceStore = new Map<string, string>();
+
+mock.module("../cache/client", () => ({
+  cache: {
+    isAvailable: () => true,
+    setIfNotExists: async (key: string, value: string) => {
+      if (nonceStore.has(key)) return false;
+      nonceStore.set(key, value);
+      return true;
+    },
+    get: async () => null,
+    set: async () => {},
+    del: async () => {},
+  },
+}));
+
+mock.module("../services/wallet-signup", () => ({
+  findOrCreateUserByWalletAddress: async (walletAddress: string) => ({
+    user: {
+      id: "user-1",
+      wallet_address: walletAddress.toLowerCase(),
+      is_active: true,
+      organization_id: "org-1",
+      organization: { id: "org-1", is_active: true },
+    },
+  }),
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { debug() {}, info() {}, warn() {}, error() {} },
+}));
+
+const { canonicalWalletAuthQuery, verifyWalletSignature } = await import("./wallet-auth");
+
+const account = privateKeyToAccount(
+  "0x1111111111111111111111111111111111111111111111111111111111111111",
+);
+
+async function sha256Hex(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+interface SignedRequestInit {
+  method?: string;
+  query?: string;
+  body?: string;
+  /** Sign the pre-payload-binding legacy message instead. */
+  legacy?: boolean;
+  /** Override the exact canonical payload the signature commits to. */
+  signedPayload?: { canonicalQuery: string; body: string };
+  /** Fresh timestamp per request so distinct cases never share a nonce. */
+  timestamp?: number;
+}
+
+async function signedRequest(path: string, init: SignedRequestInit = {}): Promise<Request> {
+  const method = init.method ?? "POST";
+  const query = init.query ?? "";
+  const body = init.body ?? "";
+  const timestamp = init.timestamp ?? Date.now();
+  const url = `https://api.eliza.app${path}${query}`;
+
+  const canonical = init.signedPayload ?? {
+    canonicalQuery: canonicalWalletAuthQuery(new URL(url)),
+    body,
+  };
+  const base = `Eliza Cloud Authentication\nTimestamp: ${timestamp}\nMethod: ${method}\nPath: ${path}`;
+  const message = init.legacy
+    ? base
+    : `${base}\nPayload-SHA256: ${await sha256Hex(`${canonical.canonicalQuery}\n${canonical.body}`)}`;
+  const signature = await account.signMessage({ message });
+
+  return new Request(url, {
+    method,
+    headers: {
+      "X-Wallet-Address": account.address,
+      "X-Timestamp": String(timestamp),
+      "X-Wallet-Signature": signature,
+      ...(body ? { "content-type": "application/json" } : {}),
+    },
+    ...(body ? { body } : {}),
+  });
+}
+
+beforeEach(() => {
+  nonceStore.clear();
+});
+
+describe("canonicalWalletAuthQuery", () => {
+  test("sorts decoded pairs by key then value", () => {
+    const url = new URL("https://api.eliza.app/x?b=2&a=1&b=1&a=%20");
+    expect(canonicalWalletAuthQuery(url)).toBe("a= &a=1&b=1&b=2");
+  });
+
+  test("is empty when there is no query string", () => {
+    expect(canonicalWalletAuthQuery(new URL("https://api.eliza.app/x"))).toBe("");
+  });
+});
+
+describe("verifyWalletSignature payload binding", () => {
+  test("accepts a payload-bound signature and returns the user", async () => {
+    const request = await signedRequest("/api/v1/credits/topup", {
+      body: JSON.stringify({ walletAddress: account.address }),
+    });
+    const user = await verifyWalletSignature(request);
+    expect(user?.id).toBe("user-1");
+  });
+
+  test("rejects the same signature replayed with a rewritten body", async () => {
+    const timestamp = Date.now();
+    const honest = await signedRequest("/api/v1/credits/topup", {
+      body: JSON.stringify({ ref: "honest" }),
+      timestamp,
+    });
+    await verifyWalletSignature(honest);
+
+    // Attacker captures the header triple and replays it against a different
+    // body on the same path inside the freshness window.
+    const headers = new Headers(honest.headers);
+    const replayed = new Request("https://api.eliza.app/api/v1/credits/topup", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ ref: "attacker-rewrite" }),
+    });
+    await expect(verifyWalletSignature(replayed)).rejects.toThrow("Invalid wallet signature");
+  });
+
+  test("rejects the same signature replayed with a rewritten query", async () => {
+    const timestamp = Date.now();
+    const honest = await signedRequest("/api/v1/wallets", {
+      method: "GET",
+      query: "?limit=10",
+      timestamp,
+    });
+    await verifyWalletSignature(honest);
+
+    const replayed = new Request("https://api.eliza.app/api/v1/wallets?limit=500", {
+      method: "GET",
+      headers: new Headers(honest.headers),
+    });
+    await expect(verifyWalletSignature(replayed)).rejects.toThrow("Invalid wallet signature");
+  });
+
+  test("canonical query makes parameter order irrelevant", async () => {
+    const request = await signedRequest("/api/v1/wallets", {
+      method: "GET",
+      query: "?b=2&a=1",
+    });
+    // Same parameters, different order — the canonical hash is identical.
+    const reordered = new Request("https://api.eliza.app/api/v1/wallets?a=1&b=2", {
+      method: "GET",
+      headers: new Headers(request.headers),
+    });
+    const user = await verifyWalletSignature(reordered);
+    expect(user?.id).toBe("user-1");
+  });
+
+  test("accepts a legacy signature only when there is no query and no body", async () => {
+    const request = await signedRequest("/api/v1/user/wallets", {
+      method: "GET",
+      legacy: true,
+    });
+    const user = await verifyWalletSignature(request);
+    expect(user?.id).toBe("user-1");
+  });
+
+  test("rejects a legacy signature when the request carries a body", async () => {
+    const request = await signedRequest("/api/v1/credits/topup", {
+      body: JSON.stringify({ walletAddress: account.address }),
+      legacy: true,
+    });
+    await expect(verifyWalletSignature(request)).rejects.toThrow("Invalid wallet signature");
+  });
+
+  test("honors the caller-supplied exact body bytes (pre-consumed streams)", async () => {
+    const rawBody = JSON.stringify({ walletAddress: account.address });
+    const timestamp = Date.now();
+    const canonical = canonicalWalletAuthQuery(new URL("https://api.eliza.app/api/v1/topup/10"));
+    const payloadHash = await sha256Hex(`${canonical}\n${rawBody}`);
+    const message = `Eliza Cloud Authentication\nTimestamp: ${timestamp}\nMethod: POST\nPath: /api/v1/topup/10\nPayload-SHA256: ${payloadHash}`;
+    const signature = await account.signMessage({ message });
+
+    // Simulate the topup handler: the body was already read for JSON parsing,
+    // so the Request handed to the verifier carries only headers.
+    const headersOnly = new Request("https://api.eliza.app/api/v1/topup/10", {
+      method: "POST",
+      headers: {
+        "X-Wallet-Address": account.address,
+        "X-Timestamp": String(timestamp),
+        "X-Wallet-Signature": signature,
+        "content-type": "application/json",
+      },
+    });
+    const user = await verifyWalletSignature(headersOnly, {
+      bodyText: rawBody,
+    });
+    expect(user?.id).toBe("user-1");
+  });
+});

--- a/packages/cloud/shared/src/lib/auth/wallet-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/wallet-auth.ts
@@ -2,6 +2,14 @@
  * Per-request wallet auth via X-Wallet-Address, X-Timestamp, X-Wallet-Signature.
  * WHY: Clients can authenticate without storing an API key; method+path in message prevents replay on other endpoints.
  * Unknown wallets are created on first valid signature (findOrCreateUserByWalletAddress).
+ *
+ * Signed payload binding: the message also commits to a SHA-256 of the
+ * canonical query string and raw body (`Payload-SHA256`), so a captured
+ * header triple cannot be replayed within its freshness window with a
+ * rewritten body or query on the same path. The legacy method+path message
+ * (no payload hash) is still accepted ONLY for requests with no query string
+ * and no body, where there is nothing to rewrite — every other request must
+ * present the payload-bound signature.
  */
 import { getAddress, verifyMessage } from "viem";
 import { cache } from "../cache/client";
@@ -11,8 +19,30 @@ import type { UserWithOrganization } from "../types";
 
 const MAX_TIMESTAMP_AGE_MS = 5 * 60 * 1000; // WHY: limits replay window while allowing clock skew
 
+/**
+ * Canonical query string for the payload hash: decoded `key=value` pairs
+ * sorted by key then value and joined with `&`, so parameter reordering does
+ * not change the digest. Documented in packages/docs/cloud/authentication.mdx.
+ */
+export function canonicalWalletAuthQuery(url: URL): string {
+  return [...url.searchParams.entries()]
+    .sort(([keyA, valueA], [keyB, valueB]) =>
+      keyA === keyB ? (valueA < valueB ? -1 : valueA > valueB ? 1 : 0) : keyA < keyB ? -1 : 1,
+    )
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+}
+
+async function sha256Hex(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
 export async function verifyWalletSignature(
   request: Request,
+  options?: { bodyText?: string },
 ): Promise<UserWithOrganization | null> {
   const rawWalletAddress = request.headers.get("X-Wallet-Address") || "";
   const timestampStr = request.headers.get("X-Timestamp") || "";
@@ -41,8 +71,18 @@ export async function verifyWalletSignature(
 
   /* WHY method+path in message: binds signature to this request so it cannot be replayed on another endpoint. */
   const method = request.method;
-  const path = new URL(request.url).pathname;
-  const nonce = `${walletAddress}-${timestamp}-${method}-${path}`;
+  const url = new URL(request.url);
+  const path = url.pathname;
+
+  // The exact body bytes enter the payload hash. Callers that already
+  // consumed the body (topup handler, wallet RPC route) pass them via
+  // options; otherwise read through a clone so the original stream stays
+  // consumable by the downstream handler. Bodyless requests hash as "".
+  const bodyText = options?.bodyText ?? (await request.clone().text());
+  const canonicalQuery = canonicalWalletAuthQuery(url);
+  const payloadHash = await sha256Hex(`${canonicalQuery}\n${bodyText}`);
+
+  const nonce = `${walletAddress}-${timestamp}-${method}-${path}-${payloadHash}`;
   const nonceKey = `wallet-nonce:${nonce}`;
 
   // Fail closed if cache unavailable to prevent replay attacks during Redis outages.
@@ -51,14 +91,29 @@ export async function verifyWalletSignature(
     throw new Error("Service temporarily unavailable");
   }
 
-  const message = `Eliza Cloud Authentication\nTimestamp: ${timestamp}\nMethod: ${method}\nPath: ${path}`;
+  const message = `Eliza Cloud Authentication\nTimestamp: ${timestamp}\nMethod: ${method}\nPath: ${path}\nPayload-SHA256: ${payloadHash}`;
 
   // Note: Verify signature BEFORE consuming nonce to prevent attackers from burning valid nonces with invalid signatures
-  const isValid = await verifyMessage({
+  let isValid = await verifyMessage({
     address: walletAddress as `0x${string}`,
     message,
     signature: signature as `0x${string}`,
   });
+
+  if (!isValid) {
+    // Legacy transition window: the pre-payload-binding message is equivalent
+    // to the bound one only when the request carries no query and no body, so
+    // that is the only case where it remains acceptable.
+    if (canonicalQuery.length > 0 || bodyText.length > 0) {
+      throw new Error("Invalid wallet signature");
+    }
+    const legacyMessage = `Eliza Cloud Authentication\nTimestamp: ${timestamp}\nMethod: ${method}\nPath: ${path}`;
+    isValid = await verifyMessage({
+      address: walletAddress as `0x${string}`,
+      message: legacyMessage,
+      signature: signature as `0x${string}`,
+    });
+  }
 
   if (!isValid) {
     throw new Error("Invalid wallet signature");

--- a/packages/cloud/shared/src/lib/cors-constants.ts
+++ b/packages/cloud/shared/src/lib/cors-constants.ts
@@ -31,6 +31,11 @@ export const CORS_ALLOW_HEADER_NAMES = [
   "X-PAYMENT-RESPONSE",
   "X-PAYMENT-STATUS",
   "X-Steward-Tenant",
+  // Custom CSRF marker required on cookie-authenticated mutating auth routes
+  // (steward-session, steward-nonce-exchange, cli-session/complete,
+  // migrate-anonymous). Must be allow-listed or the first-party SPA's
+  // credentialed preflight fails. See lib/auth/browser-origin-policy.ts.
+  "X-Eliza-CSRF",
   // Read by /api/v1/chat/completions for safe retries (idempotency-key) and
   // affiliate attribution (X-Affiliate-Code); must be in the allow-list or the
   // browser CORS preflight rejects requests that send them.

--- a/packages/cloud/shared/src/lib/services/cli-auth-session-completion.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-session-completion.ts
@@ -13,6 +13,14 @@ interface CompletionState {
   apiKey: ApiKey | undefined;
 }
 
+/**
+ * CLI-minted API keys expire. A CLI key is minted through a browser-driven
+ * flow, so a permanent key turns any completion-endpoint mistake into a
+ * lifetime org credential; 90 days bounds the blast radius while keeping
+ * re-login infrequent.
+ */
+const CLI_API_KEY_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
 type ClaimResult =
   | {
       claimed: true;
@@ -123,7 +131,7 @@ export class CliAuthSessionCompletionService {
         user_id: userId,
         rate_limit: 1000,
         is_active: true,
-        expires_at: null,
+        expires_at: new Date(Date.now() + CLI_API_KEY_TTL_MS),
         key_hash: hash,
         key_prefix: prefix,
         key_ciphertext: encrypted.ciphertext,

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
@@ -14,6 +14,18 @@ import { cliAuthSessionCompletionService } from "./cli-auth-session-completion";
  */
 const SESSION_EXPIRY_MINUTES = 10; // Sessions expire after 10 minutes
 
+/**
+ * Session ids are server-generated UUIDs (POST /api/auth/cli-session mints
+ * them; client-chosen ids allowed squatting and unbounded row inserts).
+ * Routes validate the format before touching the store.
+ */
+const CLI_AUTH_SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function looksLikeCliAuthSessionId(sessionId: string): boolean {
+  return CLI_AUTH_SESSION_ID_PATTERN.test(sessionId);
+}
+
 export type CliAuthApiKeyRevealResult =
   | {
       status: "revealed";

--- a/packages/cloud/shared/src/lib/services/topup-handler.ts
+++ b/packages/cloud/shared/src/lib/services/topup-handler.ts
@@ -121,6 +121,7 @@ async function getTopupRecipient(
     referral_code?: string;
     appOwnerId?: string;
   },
+  rawBody?: string,
 ): Promise<TopupRecipient> {
   const hasWalletSig =
     !!request.headers.get("X-Wallet-Address") &&
@@ -128,7 +129,9 @@ async function getTopupRecipient(
     !!request.headers.get("X-Wallet-Signature");
 
   if (hasWalletSig) {
-    const walletUser = await verifyWalletSignature(request);
+    const walletUser = await verifyWalletSignature(request, {
+      bodyText: rawBody,
+    });
     if (!walletUser) throw new Error("Wallet signature verification failed");
     return {
       user: walletUser,
@@ -336,7 +339,19 @@ export function createTopupHandler(options: CreateTopupHandlerOptions) {
   const { amount, getSourceId } = options;
 
   return async function handler(req: Request, env?: TopupEnv): Promise<Response> {
-    const body = (await req.json().catch(() => ({}))) as TopupBody;
+    // Read the raw bytes once: JSON.parse for the DTO, and the exact text for
+    // the wallet-signature payload hash inside getTopupRecipient (the body
+    // stream cannot be read twice).
+    const rawBody = await req.text().catch(() => "");
+    let body: TopupBody = {};
+    try {
+      body = (rawBody ? JSON.parse(rawBody) : {}) as TopupBody;
+    } catch {
+      // error-policy:J3 malformed JSON reads as "no body fields"; the
+      // wallet-signature or walletAddress checks below reject the request on
+      // their own terms instead of fabricating a parsed body.
+      body = {};
+    }
     if (!body?.walletAddress?.trim() && !req.headers.get("X-Wallet-Signature")) {
       return Response.json(
         {
@@ -400,7 +415,7 @@ export function createTopupHandler(options: CreateTopupHandlerOptions) {
 
     let recipient;
     try {
-      recipient = await getTopupRecipient(req, body);
+      recipient = await getTopupRecipient(req, body, rawBody);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       if (msg.includes("walletAddress is required")) {

--- a/packages/docs/cloud/authentication.mdx
+++ b/packages/docs/cloud/authentication.mdx
@@ -157,8 +157,8 @@ Send on every request instead of storing an API key:
 - **X-Wallet-Address**: Ethereum address (any case).
 - **X-Timestamp**: Unix ms (must be within ±5 min of server time). **Why?** Binds the signature to a time window and limits replay.
 - **X-Wallet-Signature**: Signature of the message  
-  `Eliza Cloud Authentication\nTimestamp: ${timestamp}\nMethod: ${method}\nPath: ${path}`  
-  so the signature is bound to this request. **Why method + path?** Prevents reusing the same signature on another endpoint.
+  `Eliza Cloud Authentication\nTimestamp: ${timestamp}\nMethod: ${method}\nPath: ${path}\nPayload-SHA256: ${payloadHash}`  
+  where `payloadHash` is the lowercase hex SHA-256 of `${canonicalQuery}\n${rawBody}` — `canonicalQuery` is the decoded `key=value` pairs of the query string sorted by key then value and joined with `&` (empty when there is no query), and `rawBody` is the exact request body (empty when there is none). **Why the payload hash?** A captured header triple cannot be replayed within its time window with a rewritten body or query. **Why method + path?** Prevents reusing the same signature on another endpoint. The legacy message without `Payload-SHA256` is accepted only for requests with no query string and no body.
 
 If the wallet is unknown, the first valid signed request **creates** the account (same as SIWE signup). After that, any endpoint that uses `requireAuthOrApiKey` accepts wallet-header auth.
 

--- a/packages/docs/cloud/wallet-api.mdx
+++ b/packages/docs/cloud/wallet-api.mdx
@@ -42,8 +42,8 @@ Body: `{ message, signature }` (full SIWE message string and hex signature). Ser
 - **X-Wallet-Address**: Ethereum address.
 - **X-Timestamp**: Unix time in milliseconds; must be within ±5 min of server time.
 - **X-Wallet-Signature**: Signature of  
-  `Eliza Cloud Authentication\nTimestamp: ${timestamp}\nMethod: ${method}\nPath: ${path}`  
-  (so the signature is bound to this request).
+  `Eliza Cloud Authentication\nTimestamp: ${timestamp}\nMethod: ${method}\nPath: ${path}\nPayload-SHA256: ${payloadHash}`  
+  (so the signature is bound to this request, including its query and body). `payloadHash` is the lowercase hex SHA-256 of `${canonicalQuery}\n${rawBody}`: `canonicalQuery` is the query string's decoded `key=value` pairs sorted by key then value, joined with `&`; `rawBody` is the exact request body. Both are empty strings when absent. The legacy message without `Payload-SHA256` is accepted only when the request has no query and no body.
 
 Any route that uses `requireAuthOrApiKey` accepts wallet-header auth. If the wallet is unknown, the account is created on first valid signature.
 

--- a/packages/shared/src/steward-session-client/index.test.ts
+++ b/packages/shared/src/steward-session-client/index.test.ts
@@ -4,16 +4,59 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearStoredStewardToken,
+  exchangeStewardCode,
   hasStewardAuthedCookie,
   readStoredStewardToken,
+  STEWARD_CSRF_HEADER,
+  STEWARD_CSRF_HEADER_VALUE,
   STEWARD_REFRESH_TOKEN_KEY,
   STEWARD_SESSION_CHANGE_EVENT,
   STEWARD_TOKEN_KEY,
   type StewardSessionChangeDetail,
   sanitizeTelegramAccountClaimContinuation,
   stewardAuthedCookieName,
+  syncStewardSession,
   writeStoredStewardToken,
 } from "./index";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("Steward session client CSRF marker header", () => {
+  it("syncStewardSession sends the marker header with its JSON POST", async () => {
+    let seen: RequestInit | undefined;
+    const fetchImpl = (async (_input: unknown, init?: RequestInit) => {
+      seen = init;
+      return jsonResponse({ ok: true, userId: "u", stewardUserId: "s" });
+    }) as typeof fetch;
+
+    await syncStewardSession("token", null, { fetchImpl });
+
+    const headers = new Headers(seen?.headers);
+    expect(headers.get(STEWARD_CSRF_HEADER)).toBe(STEWARD_CSRF_HEADER_VALUE);
+    expect(headers.get("content-type")).toBe("application/json");
+  });
+
+  it("exchangeStewardCode sends the marker header with its JSON POST", async () => {
+    let seen: RequestInit | undefined;
+    const fetchImpl = (async (_input: unknown, init?: RequestInit) => {
+      seen = init;
+      return jsonResponse({ ok: true, userId: "u", stewardUserId: "s" });
+    }) as typeof fetch;
+
+    await exchangeStewardCode("one-time-code", {
+      fetchImpl,
+      codeVerifier: "verifier",
+    });
+
+    const headers = new Headers(seen?.headers);
+    expect(headers.get(STEWARD_CSRF_HEADER)).toBe(STEWARD_CSRF_HEADER_VALUE);
+  });
+});
 
 describe("Telegram account-claim credential", () => {
   it("accepts opaque tokens and rejects guessable platform ids", () => {

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -80,6 +80,15 @@ export const STEWARD_NONCE_EXCHANGE_ENDPOINT =
  */
 export const STEWARD_REFRESH_ENDPOINT = "/api/auth/steward-refresh";
 
+/**
+ * Custom CSRF marker header required by the cloud-api cookie-authenticated
+ * auth mutations. Presence alone is the contract: a cross-origin "simple
+ * request" cannot set custom headers, so any request carrying it either
+ * survived a preflight or never needed one (same-origin / non-browser).
+ */
+export const STEWARD_CSRF_HEADER = "x-eliza-csrf";
+export const STEWARD_CSRF_HEADER_VALUE = "1";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -158,7 +167,15 @@ export type StewardSessionErrorCode =
   | "code_expired"
   | "code_redirect_mismatch"
   | "code_tenant_mismatch"
+  /** The exchange was attempted without the PKCE verifier. The hosted login
+   * always starts the flow with a S256 challenge, so this is a planted or
+   * pre-PKCE callback — the client must restart sign-in. */
+  | "missing_code_verifier"
   | "steward_upstream_unavailable"
+  /** The request carried no non-simple-request marker (custom X-Eliza-CSRF
+   * header or JSON content type), so it could have been a cross-origin
+   * simple request. Rejected before any cookie was read. */
+  | "csrf_marker_required"
   | "forbidden_origin";
 
 export class StewardSessionError extends Error {
@@ -311,7 +328,10 @@ export async function syncStewardSession(
   const response = await f(endpoint, {
     method: "POST",
     credentials: "include",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      [STEWARD_CSRF_HEADER]: STEWARD_CSRF_HEADER_VALUE,
+    },
     body: JSON.stringify(body),
   });
   if (!response.ok) {
@@ -355,10 +375,10 @@ export interface StewardNonceExchangeResponse extends StewardSessionResponse {
    * write it to localStorage (required by `@stwd/react`'s `useAuth()` to
    * report `isAuthenticated=true`). HttpOnly cookies are still the canonical
    * session — this is the JS-readable copy that keeps the wallet and OAuth
-   * paths symmetric.
+   * paths symmetric. The long-lived refresh token is deliberately NOT
+   * mirrored; it stays in the HttpOnly cookie.
    */
   token?: string;
-  refreshToken?: string;
 }
 
 export interface ExchangeStewardCodeOpts extends SyncOpts {
@@ -392,7 +412,10 @@ export async function exchangeStewardCode(
   const response = await f(endpoint, {
     method: "POST",
     credentials: "include",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      [STEWARD_CSRF_HEADER]: STEWARD_CSRF_HEADER_VALUE,
+    },
     body: JSON.stringify(body),
   });
   if (!response.ok) {
@@ -416,7 +439,9 @@ export {
   consumeStewardPkceVerifier,
   createStewardPkceChallenge,
   createStewardPkcePair,
+  generateStewardOAuthState,
   generateStewardPkceVerifier,
+  peekStewardOAuthState,
   type StewardOAuthProvider,
   type StewardPkcePair,
   storeStewardPkceVerifier,
@@ -427,7 +452,11 @@ export function clearStewardSession(opts: ClearOpts = {}): void {
   const f = opts.fetchImpl ?? (typeof fetch !== "undefined" ? fetch : null);
   if (!f) return;
   for (const url of endpoints) {
-    f(url, { method: "DELETE", credentials: "include" }).catch(() => {
+    f(url, {
+      method: "DELETE",
+      credentials: "include",
+      headers: { [STEWARD_CSRF_HEADER]: STEWARD_CSRF_HEADER_VALUE },
+    }).catch(() => {
       // ignore — see jsdoc
     });
   }

--- a/packages/shared/src/steward-session-client/steward-oauth-pkce.test.ts
+++ b/packages/shared/src/steward-session-client/steward-oauth-pkce.test.ts
@@ -1,15 +1,28 @@
 /**
  * Unit coverage for the Steward OAuth PKCE helpers (`steward-oauth-pkce.ts`):
- * verifies the S256 code challenge derives from its verifier and that
+ * verifies the S256 code challenge derives from its verifier, that
  * `buildStewardOAuthAuthorizeUrl` includes the PKCE query params (code_challenge +
- * S256 method) when a challenge is supplied and omits them when it is not.
+ * S256 method) when a challenge is supplied and omits them when it is not, and
+ * that the OAuth `state` is carried in the authorize URL, stored beside the
+ * verifier, and peekable without consuming it.
  */
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
 import {
   buildStewardOAuthAuthorizeUrl,
   createStewardPkceChallenge,
   createStewardPkcePair,
+  generateStewardOAuthState,
+  peekStewardOAuthState,
+  storeStewardPkceVerifier,
 } from "./steward-oauth-pkce.js";
+
+const STORAGE_KEY = "steward.oauth.pkce.verifier";
+
+afterEach(() => {
+  window.sessionStorage.removeItem(STORAGE_KEY);
+  window.localStorage.removeItem(STORAGE_KEY);
+});
 
 describe("steward-oauth-pkce", () => {
   it("createStewardPkcePair challenge is the S256 hash of its verifier", async () => {
@@ -45,5 +58,48 @@ describe("steward-oauth-pkce", () => {
     const parsed = new URL(url);
     expect(parsed.searchParams.has("code_challenge")).toBe(false);
     expect(parsed.searchParams.has("code_challenge_method")).toBe(false);
+  });
+
+  it("buildStewardOAuthAuthorizeUrl carries state only when provided", () => {
+    const withState = new URL(
+      buildStewardOAuthAuthorizeUrl("google", "https://eliza.app/login", {
+        stewardApiUrl: "https://api.elizacloud.ai/steward",
+        codeChallenge: "challenge-abc",
+        state: "state-123",
+      }),
+    );
+    expect(withState.searchParams.get("state")).toBe("state-123");
+
+    const withoutState = new URL(
+      buildStewardOAuthAuthorizeUrl("google", "https://eliza.app/login", {
+        stewardApiUrl: "https://api.elizacloud.ai/steward",
+        codeChallenge: "challenge-abc",
+      }),
+    );
+    expect(withoutState.searchParams.has("state")).toBe(false);
+  });
+
+  it("generateStewardOAuthState is URL-safe, high-entropy, and unique", () => {
+    const first = generateStewardOAuthState();
+    const second = generateStewardOAuthState();
+    expect(first).toMatch(/^[A-Za-z0-9_-]+$/);
+    // 32 random bytes → 43 base64url chars (no padding).
+    expect(first).toHaveLength(43);
+    expect(first).not.toBe(second);
+  });
+
+  it("stores state beside the verifier and peeks it without consuming", () => {
+    expect(storeStewardPkceVerifier("verifier-1", "state-1")).toBe(true);
+    expect(peekStewardOAuthState()).toBe("state-1");
+    // Peek is non-consuming: a second read still sees the value.
+    expect(peekStewardOAuthState()).toBe("state-1");
+  });
+
+  it("peekStewardOAuthState is null for a legacy state-less blob", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ verifier: "v", expiresAt: Date.now() + 60_000 }),
+    );
+    expect(peekStewardOAuthState()).toBeNull();
   });
 });

--- a/packages/shared/src/steward-session-client/steward-oauth-pkce.ts
+++ b/packages/shared/src/steward-session-client/steward-oauth-pkce.ts
@@ -5,6 +5,11 @@
  * when `response_type=code`. Mint a verifier/challenge pair, send the challenge
  * at /authorize, stash the verifier in browser storage, and replay it at
  * /exchange via {@link exchangeStewardCode}.
+ *
+ * A random OAuth `state` is minted and stashed alongside the verifier, sent
+ * at /authorize, and required to match verbatim on the callback before the
+ * exchange runs — without it, a harvested `?code=` link could log a victim
+ * into the attacker's account (login CSRF).
  */
 
 export type StewardOAuthProvider = "google" | "discord" | "github" | "twitter";
@@ -12,9 +17,12 @@ export type StewardOAuthProvider = "google" | "discord" | "github" | "twitter";
 const STEWARD_PKCE_VERIFIER_STORAGE_KEY = "steward.oauth.pkce.verifier";
 const STEWARD_PKCE_VERIFIER_TTL_MS = 10 * 60 * 1000;
 const PKCE_VERIFIER_BYTES = 48;
+const OAUTH_STATE_BYTES = 32;
 
 type StoredPkceVerifier = {
   verifier: string;
+  /** OAuth anti-CSRF state sent at /authorize; absent only in legacy blobs. */
+  state?: string;
   expiresAt: number;
 };
 
@@ -29,6 +37,12 @@ function base64UrlEncode(bytes: Uint8Array): string {
 
 export function generateStewardPkceVerifier(): string {
   const bytes = new Uint8Array(PKCE_VERIFIER_BYTES);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+export function generateStewardOAuthState(): string {
+  const bytes = new Uint8Array(OAUTH_STATE_BYTES);
   crypto.getRandomValues(bytes);
   return base64UrlEncode(bytes);
 }
@@ -54,10 +68,14 @@ export async function createStewardPkcePair(): Promise<StewardPkcePair> {
   return { verifier, challenge };
 }
 
-export function storeStewardPkceVerifier(verifier: string): boolean {
+export function storeStewardPkceVerifier(
+  verifier: string,
+  state?: string,
+): boolean {
   if (typeof window === "undefined") return false;
   const stored = JSON.stringify({
     verifier,
+    ...(state ? { state } : {}),
     expiresAt: Date.now() + STEWARD_PKCE_VERIFIER_TTL_MS,
   } satisfies StoredPkceVerifier);
   let storedAnywhere = false;
@@ -83,6 +101,19 @@ export function consumeStewardPkceVerifier(): string | null {
   return sessionVerifier ?? localVerifier;
 }
 
+/**
+ * Non-consuming read of the OAuth state stashed beside the PKCE verifier.
+ * The callback compares it against the `?state=` echo BEFORE the verifier is
+ * consumed; a legacy blob without state (pre-state rollout) reads as null,
+ * which fails the callback's required exact match.
+ */
+export function peekStewardOAuthState(): string | null {
+  if (typeof window === "undefined") return null;
+  const sessionRecord = readStoredPkceRecord(window.sessionStorage);
+  const localRecord = readStoredPkceRecord(window.localStorage);
+  return sessionRecord?.state ?? localRecord?.state ?? null;
+}
+
 function consumeStoredPkceVerifier(storage: Storage): string | null {
   try {
     const verifier = storage.getItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY);
@@ -90,6 +121,35 @@ function consumeStoredPkceVerifier(storage: Storage): string | null {
     return parseStoredPkceVerifier(verifier);
   } catch {
     // error-policy:J4 web storage unavailable -> no verifier
+    return null;
+  }
+}
+
+function readStoredPkceRecord(storage: Storage): StoredPkceVerifier | null {
+  try {
+    const value = storage.getItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY);
+    if (!value) return null;
+    try {
+      const parsed = JSON.parse(value) as Partial<StoredPkceVerifier>;
+      if (
+        typeof parsed.verifier === "string" &&
+        typeof parsed.expiresAt === "number" &&
+        parsed.expiresAt >= Date.now()
+      ) {
+        return {
+          verifier: parsed.verifier,
+          ...(typeof parsed.state === "string" ? { state: parsed.state } : {}),
+          expiresAt: parsed.expiresAt,
+        };
+      }
+      return null;
+    } catch {
+      // Pre-JSON blobs stored the bare verifier string; they carry no state,
+      // so the callback's required state match fails for them by design.
+      return null;
+    }
+  } catch {
+    // error-policy:J4 web storage unavailable -> no stored record
     return null;
   }
 }
@@ -118,6 +178,12 @@ export function buildStewardOAuthAuthorizeUrl(
     stewardApiUrl: string;
     stewardTenantId?: string;
     codeChallenge?: string;
+    /**
+     * Anti-CSRF state echoed by Steward on the callback. Always send it: the
+     * login surface refuses callbacks whose `?state=` does not exactly match
+     * the value stashed beside the PKCE verifier.
+     */
+    state?: string;
   },
 ): string {
   const params = new URLSearchParams({
@@ -128,6 +194,9 @@ export function buildStewardOAuthAuthorizeUrl(
   if (options.codeChallenge) {
     params.set("code_challenge", options.codeChallenge);
     params.set("code_challenge_method", "S256");
+  }
+  if (options.state) {
+    params.set("state", options.state);
   }
   const stewardApiUrl = options.stewardApiUrl.replace(/\/+$/, "");
   return `${stewardApiUrl}/auth/oauth/${provider}/authorize?${params.toString()}`;

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.callback-state.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.callback-state.test.tsx
@@ -20,6 +20,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const callbackState = vi.hoisted(() => ({
   hasCallback: true,
+  expectedState: "state-1" as string | null,
+  pkceVerifier: "verifier-1" as string | undefined,
+  exchangeCalls: 0,
   exchange: (): Promise<{ token?: string }> => new Promise(() => {}),
 }));
 
@@ -27,11 +30,24 @@ vi.mock("../../lib/steward-session", () => ({
   hasStewardOAuthCallbackInUrl: () => callbackState.hasCallback,
   consumeStewardCodeFromQuery: () => "callback-code",
   consumeStewardTokensFromHash: () => null,
-  exchangeStewardCodeViaApi: () => callbackState.exchange(),
+  exchangeStewardCodeViaApi: () => {
+    callbackState.exchangeCalls += 1;
+    return callbackState.exchange();
+  },
   recoverStewardSessionViaCookie: () => Promise.resolve(null),
   refreshStewardSessionViaCookie: () => Promise.resolve({ ok: true as const }),
   syncStewardSessionCookie: () => Promise.resolve(),
 }));
+
+vi.mock("@elizaos/shared/steward-session-client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@elizaos/shared/steward-session-client")
+  >("@elizaos/shared/steward-session-client");
+  return {
+    ...actual,
+    peekStewardOAuthState: () => callbackState.expectedState,
+  };
+});
 
 vi.mock("@stwd/sdk", () => ({
   StewardAuth: class {
@@ -77,7 +93,7 @@ vi.mock("../../lib/steward-oauth-url", async () => {
   >("../../lib/steward-oauth-url");
   return {
     ...actual,
-    consumeStewardPkceVerifier: () => undefined,
+    consumeStewardPkceVerifier: () => callbackState.pkceVerifier,
     buildStewardOAuthRedirectUri: () => "https://app.example.test/login",
   };
 });
@@ -90,9 +106,9 @@ vi.mock("../../lib/login-return-to", () => ({
 
 import StewardLoginSection from "./steward-login-section";
 
-function renderSection() {
+function renderSection(initialUrl = "/login?code=callback-code&state=state-1") {
   return render(
-    <MemoryRouter initialEntries={["/login?code=callback-code"]}>
+    <MemoryRouter initialEntries={[initialUrl]}>
       <StewardLoginSection />
     </MemoryRouter>,
   );
@@ -101,6 +117,9 @@ function renderSection() {
 describe("StewardLoginSection — OAuth callback completion state (#13519)", () => {
   beforeEach(() => {
     callbackState.hasCallback = true;
+    callbackState.expectedState = "state-1";
+    callbackState.pkceVerifier = "verifier-1";
+    callbackState.exchangeCalls = 0;
     callbackState.exchange = () => new Promise(() => {});
   });
 
@@ -162,5 +181,49 @@ describe("StewardLoginSection — OAuth callback completion state (#13519)", () 
     expect(screen.queryByText(/Unauthorized/)).toBeNull();
     expect(screen.queryByText("Completing sign-in…")).toBeNull();
     expect(screen.getByPlaceholderText("you@example.com")).toBeTruthy();
+  });
+
+  it("refuses the exchange when the callback state does not match the stashed state", async () => {
+    callbackState.expectedState = "different-state";
+
+    renderSection("/login?code=callback-code&state=state-1");
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "This sign-in link is invalid or has expired. Please start sign-in again.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(callbackState.exchangeCalls).toBe(0);
+    expect(screen.queryByText("Completing sign-in…")).toBeNull();
+  });
+
+  it("refuses the exchange when the callback carries no state echo", async () => {
+    renderSection("/login?code=callback-code");
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "This sign-in link is invalid or has expired. Please start sign-in again.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(callbackState.exchangeCalls).toBe(0);
+  });
+
+  it("refuses the exchange when the stored PKCE verifier is gone", async () => {
+    callbackState.pkceVerifier = undefined;
+
+    renderSection("/login?code=callback-code&state=state-1");
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "This sign-in was started in another tab or has expired. Please start sign-in again.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(callbackState.exchangeCalls).toBe(0);
   });
 });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.loading-geometry.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.loading-geometry.test.tsx
@@ -63,13 +63,23 @@ vi.mock("../../../shell/CloudI18nProvider", () => ({
     opts?.defaultValue ?? _key,
 }));
 
+vi.mock("@elizaos/shared/steward-session-client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@elizaos/shared/steward-session-client")
+  >("@elizaos/shared/steward-session-client");
+  return {
+    ...actual,
+    peekStewardOAuthState: () => "state-1",
+  };
+});
+
 vi.mock("../../lib/steward-oauth-url", async () => {
   const actual = await vi.importActual<
     typeof import("../../lib/steward-oauth-url")
   >("../../lib/steward-oauth-url");
   return {
     ...actual,
-    consumeStewardPkceVerifier: () => undefined,
+    consumeStewardPkceVerifier: () => "verifier-1",
     buildStewardOAuthRedirectUri: () => "https://app.example.test/login",
   };
 });
@@ -127,7 +137,7 @@ describe("StewardLoginSection — reserved loading geometry (#18256)", () => {
   it("reserves the option-stack footprint under the completing-callback state", async () => {
     harness.hasCallback = true;
     harness.code = "callback-code";
-    renderSection("/login?code=callback-code");
+    renderSection("/login?code=callback-code&state=state-1");
 
     await waitFor(() =>
       expect(screen.getByText("Completing sign-in…")).toBeTruthy(),

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
@@ -19,7 +19,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const oauthState = vi.hoisted(() => ({
   pkceError: null as Error | null,
   storeVerifier: true,
+  storedVerifierArgs: [] as Array<{ verifier: string; state?: string }>,
+  authorizeUrlOptions: [] as Array<Record<string, unknown>>,
 }));
+
+vi.mock("@elizaos/shared/steward-session-client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@elizaos/shared/steward-session-client")
+  >("@elizaos/shared/steward-session-client");
+  return {
+    ...actual,
+    generateStewardOAuthState: () => "state-1",
+    buildStewardOAuthAuthorizeUrl: (
+      provider: string,
+      _redirectUri: string,
+      options: Record<string, unknown>,
+    ) => {
+      oauthState.authorizeUrlOptions.push(options);
+      return `https://api.example.test/steward/auth/oauth/${provider}/authorize`;
+    },
+  };
+});
 
 vi.mock("@stwd/sdk", () => ({
   StewardAuth: class {
@@ -90,9 +110,10 @@ vi.mock("../../lib/steward-oauth-url", async () => {
       if (oauthState.pkceError) throw oauthState.pkceError;
       return { verifier: "verifier", challenge: "challenge" };
     },
-    storeStewardPkceVerifier: () => oauthState.storeVerifier,
-    buildStewardOAuthAuthorizeUrl: (provider: string) =>
-      `https://api.example.test/steward/auth/oauth/${provider}/authorize`,
+    storeStewardPkceVerifier: (verifier: string, state?: string) => {
+      oauthState.storedVerifierArgs.push({ verifier, state });
+      return oauthState.storeVerifier;
+    },
   };
 });
 
@@ -131,6 +152,8 @@ describe("StewardLoginSection OAuth launch", () => {
     stubHostedLoginLocation();
     oauthState.pkceError = null;
     oauthState.storeVerifier = true;
+    oauthState.storedVerifierArgs = [];
+    oauthState.authorizeUrlOptions = [];
   });
 
   afterEach(() => {
@@ -159,6 +182,24 @@ describe("StewardLoginSection OAuth launch", () => {
       expect(openSpy).not.toHaveBeenCalled();
     },
   );
+
+  it("sends the PKCE challenge and a stashed OAuth state at authorize time", async () => {
+    renderSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Google" }));
+
+    await waitFor(() =>
+      expect(window.location.href).toContain("/steward/auth/oauth/"),
+    );
+    expect(oauthState.storedVerifierArgs).toEqual([
+      { verifier: "verifier", state: "state-1" },
+    ]);
+    expect(oauthState.authorizeUrlOptions).toHaveLength(1);
+    expect(oauthState.authorizeUrlOptions[0]).toMatchObject({
+      codeChallenge: "challenge",
+      state: "state-1",
+    });
+  });
 
   it("releases the OAuth provider lock after a back-forward cache restoration", async () => {
     renderSection();

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
@@ -77,13 +77,23 @@ vi.mock("../../../shell/CloudI18nProvider", () => ({
     opts?.defaultValue ?? _key,
 }));
 
+vi.mock("@elizaos/shared/steward-session-client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@elizaos/shared/steward-session-client")
+  >("@elizaos/shared/steward-session-client");
+  return {
+    ...actual,
+    peekStewardOAuthState: () => "state-1",
+  };
+});
+
 vi.mock("../../lib/steward-oauth-url", async () => {
   const actual = await vi.importActual<
     typeof import("../../lib/steward-oauth-url")
   >("../../lib/steward-oauth-url");
   return {
     ...actual,
-    consumeStewardPkceVerifier: () => undefined,
+    consumeStewardPkceVerifier: () => "verifier-1",
     buildStewardOAuthRedirectUri: () => "https://app.example.test/login",
   };
 });
@@ -180,7 +190,7 @@ describe("StewardLoginSection — session-cached provider fast path (#18256)", (
     harness.code = "callback-code";
     const callsBefore = harness.getProvidersCalls;
 
-    renderSection("/login?code=callback-code");
+    renderSection("/login?code=callback-code&state=state-1");
 
     await waitFor(() =>
       expect(screen.getByText("Completing sign-in…")).toBeTruthy(),

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -16,7 +16,10 @@
  */
 
 import {
+  buildStewardOAuthAuthorizeUrl as buildStewardOAuthAuthorizeUrlCore,
+  generateStewardOAuthState,
   hasStewardAuthedCookie,
+  peekStewardOAuthState,
   readStoredStewardToken,
   StewardSessionError,
   writeStoredStewardToken,
@@ -70,7 +73,6 @@ import {
 } from "../../lib/steward-email-login";
 import { subscribeStewardEmailLoginComplete } from "../../lib/steward-email-login-complete";
 import {
-  buildStewardOAuthAuthorizeUrl,
   buildStewardOAuthRedirectUri,
   consumeStewardPkceVerifier,
   createStewardPkcePair,
@@ -136,6 +138,34 @@ function persistStewardToken(token: string): void {
       "Eliza Cloud sign-in needs browser storage. Enable storage for this site and try again.",
     );
   }
+}
+
+/**
+ * `?token=` / `?refreshToken=` query links are not honored (a plain GET link
+ * must never plant a session — only the `#hash` legacy path remains). Strip
+ * them, plus the consumed OAuth `state` echo, from the address bar
+ * immediately so no credential lingers in history, copy/paste, or the reach
+ * of third-party scripts booting with the page. Returns true when anything
+ * was stripped.
+ */
+function stripLegacyTokenParamsFromAddressBar(): boolean {
+  if (typeof window === "undefined") return false;
+  const params = new URLSearchParams(window.location.search);
+  let stripped = false;
+  for (const key of ["token", "refreshToken", "state"] as const) {
+    if (params.has(key)) {
+      params.delete(key);
+      stripped = true;
+    }
+  }
+  if (!stripped) return false;
+  const query = params.toString();
+  window.history.replaceState(
+    null,
+    "",
+    `${window.location.pathname}${query ? `?${query}` : ""}${window.location.hash}`,
+  );
+  return true;
 }
 
 type Provider =
@@ -667,7 +697,37 @@ export default function StewardLoginSection() {
   useEffect(() => {
     const code = consumeStewardCodeFromQuery();
     if (code) {
-      const codeVerifier = consumeStewardPkceVerifier() ?? undefined;
+      // The OAuth `state` echo must exactly match the value stashed at
+      // /authorize time, and the PKCE verifier must still be in storage. A
+      // callback missing either is a planted or stale link: refusing the
+      // exchange is what stops a harvested `?code=` from logging this browser
+      // into the attacker's account. The verifier is consumed ONLY when the
+      // state matches, so the user's own in-flight flow survives clicking a
+      // foreign link.
+      const returnedState = searchParams.get("state");
+      const expectedState = peekStewardOAuthState();
+      if (!returnedState || !expectedState || returnedState !== expectedState) {
+        stripLegacyTokenParamsFromAddressBar();
+        setCompletingCallback(false);
+        setCallbackError(
+          t("cloud.login.callbackStateMismatch", {
+            defaultValue:
+              "This sign-in link is invalid or has expired. Please start sign-in again.",
+          }),
+        );
+        return;
+      }
+      const codeVerifier = consumeStewardPkceVerifier();
+      if (!codeVerifier) {
+        setCompletingCallback(false);
+        setCallbackError(
+          t("cloud.login.callbackVerifierMissing", {
+            defaultValue:
+              "This sign-in was started in another tab or has expired. Please start sign-in again.",
+          }),
+        );
+        return;
+      }
       exchangeStewardCodeViaApi(code, {
         redirectUri: buildStewardOAuthRedirectUri(window.location.origin),
         tenantId: STEWARD_TENANT_ID,
@@ -699,12 +759,18 @@ export default function StewardLoginSection() {
       return;
     }
 
+    // No OAuth code: drop any legacy query-token link from the address bar
+    // (never consumed), then honor only the `#hash` legacy path.
+    stripLegacyTokenParamsFromAddressBar();
     const fromHash = consumeStewardTokensFromHash();
-    const queryToken = searchParams.get("token");
-    const queryRefreshToken = searchParams.get("refreshToken");
-    const token = fromHash?.token ?? queryToken;
-    const refreshToken = fromHash?.refreshToken ?? queryRefreshToken ?? null;
-    if (!token) return;
+    const token = fromHash?.token;
+    const refreshToken = fromHash?.refreshToken ?? null;
+    if (!token) {
+      // A stripped `?token=` link (or no callback at all) must not hold the
+      // terminal "completing sign-in" state — render the sign-in options.
+      setCompletingCallback(false);
+      return;
+    }
 
     syncStewardSessionCookie(token, refreshToken)
       .then(() => {
@@ -724,7 +790,6 @@ export default function StewardLoginSection() {
   useEffect(() => {
     if (PLAYWRIGHT_TEST_AUTH_ENABLED) return;
     if (searchParams.get("code")) return;
-    if (searchParams.get("token")) return;
     if (searchParams.get("error")) return;
 
     let cancelled = false;
@@ -1234,9 +1299,14 @@ export default function StewardLoginSection() {
       ? "https://staging.eliza.app"
       : window.location.origin;
     let codeChallenge: string;
+    let state: string;
     try {
       const pkce = await createStewardPkcePair();
-      if (!storeStewardPkceVerifier(pkce.verifier)) {
+      state = generateStewardOAuthState();
+      // Verifier and state are stashed together: the callback requires the
+      // `?state=` echo to match AND the verifier to survive, so a harvested
+      // callback URL cannot be replayed in another browser.
+      if (!storeStewardPkceVerifier(pkce.verifier, state)) {
         setError(
           "Could not start sign-in. Browser storage is unavailable. Enable cookies / site data and try again.",
         );
@@ -1250,11 +1320,16 @@ export default function StewardLoginSection() {
       return;
     }
     storePendingOAuthReturnTo(searchParams);
-    const authorizeUrl = buildStewardOAuthAuthorizeUrl(provider, oauthOrigin, {
-      stewardApiUrl,
-      stewardTenantId: STEWARD_TENANT_ID,
-      codeChallenge,
-    });
+    const authorizeUrl = buildStewardOAuthAuthorizeUrlCore(
+      provider,
+      buildStewardOAuthRedirectUri(oauthOrigin),
+      {
+        stewardApiUrl,
+        stewardTenantId: STEWARD_TENANT_ID,
+        codeChallenge,
+        state,
+      },
+    );
     window.location.href = authorizeUrl;
   }
 


### PR DESCRIPTION
## Summary

Wave-1 security-audit fixes for the cloud auth/session group (worktree `sec-cloud-auth`). Each fix is mapped to its finding ID from the consolidated audit report. All eight findings in the group were verified still present on `origin/develop` before fixing, except where noted.

**CRITICAL / HIGH**

- **W1-001 (CRITICAL)** — `POST /api/auth/cli-session/:id/complete` minted a permanent org API key for any cookie-authenticated cross-origin request. The route now enforces the exact-host Origin/Referer policy plus a non-simple-request marker (custom `X-Eliza-CSRF` header or JSON content type) on the cookie path — a cross-origin simple request can no longer complete a CLI login. Programmatic callers (`Authorization` / `X-API-Key`) are unaffected so headless clients keep working. CLI-minted API keys now expire after 90 days instead of never.
- **W1-004 (HIGH)** — the `steward-session` origin suffix-match was already removed upstream (exact-host `browser-origin-policy.ts`); what remained was exploitable via CORS-safelisted simple requests and `?token=` links. `steward-session` (POST/DELETE), `steward-nonce-exchange`, and `migrate-anonymous` now require the non-simple-request marker, forcing a preflight that fails for non-first-party origins. `X-Eliza-CSRF` added to CORS allow-headers. Query-token consumption on `/login` removed (hash legacy path kept).

**MEDIUM / LOW**

- **W1-008** — the Steward OAuth flow had no anti-CSRF `state` and treated PKCE as optional. The login page now mints a random state, stashes it beside the PKCE verifier, sends it at `/authorize`, and requires an exact match on the callback before exchanging; the nonce-exchange route refuses verifier-less exchanges.
- **W1-030** — `create-anonymous-session` persisted a client-spoofable IP (`x-real-ip`/XFF). It now persists `getRequestIp(c)` (edge-verified `cf-connecting-ip` first).
- **W1-033** — `migrate-anonymous` accepted the session token in the request body. It now honors only the HttpOnly cookie and requires the Origin policy + marker.
- **W1-034** — `/login` no longer honors `?token=`/`?refreshToken=` links and strips them from the address bar immediately; the nonce exchange no longer mirrors the long-lived refresh token into the JSON body (access-token mirror kept for SPA auth state).
- **W1-035** — `POST /api/auth/cli-session` accepted arbitrary client-chosen ids with no rate limit. Ids are now server-generated UUIDs, poll/complete validate the format, and creation is IP rate-limited (STRICT preset, same posture as steward-session). `@elizaos/cloud-sdk` `startCliLogin` treats the response id as authoritative (works against old and new servers).
- **W1-036** — wallet header auth signed only method+path. The signed message now includes a `Payload-SHA256` line committing to a SHA-256 of the canonical (sorted) query and the raw body; the legacy message is accepted only when the request has no query and no body. The wallet RPC route and topup handler forward the exact body bytes they already consumed. Docs updated (`packages/docs/cloud/authentication.mdx`, `wallet-api.mdx`).

## Test evidence

All run on the rebased branch (`origin/develop` @ 2029ff84240f):

- `packages/cloud/api`: `bun test --isolate` over the auth route suites — **65 pass / 0 fail** across 12 files, including new contract tests for every behavior change (`cli-session/route.test.ts`, `steward-nonce-exchange/route.test.ts`, `migrate-anonymous/route.test.ts`, updated PGlite integration suites for cli-session completion/poll, steward-session DELETE gate, telegram-claim exchange with verifier).
- Full `packages/cloud/api` unit gate (355 files): same 12 pre-existing failures as unmodified `origin/develop` (miniflare/pglite environment issues — verified by running the gate on the base commit); **zero new failures**.
- `packages/cloud/shared`: `bun test --isolate` auth + cli-auth-sessions + topup suites — **89 pass, 0 fail, 1 pre-existing skip**, including the new `wallet-auth.test.ts` (payload-bound signatures: replay-with-rewritten-body/query rejected, canonical query ordering, legacy no-body acceptance).
- `packages/shared`: `vitest run src/steward-session-client/` — **18 pass** (new OAuth state + CSRF header contract tests).
- `packages/ui`: `vitest run src/cloud/public-pages/pages/login/` — **78 pass / 14 files** (updated callback-state/oauth-launch/loading-geometry/provider-cache tests; new state-mismatch, missing-state, missing-verifier, and authorize-time state assertions).
- `packages/cloud/sdk`: `vitest run src/client.test.ts` — **22 pass** (new server-minted-id test).
- Typecheck: `tsc --noEmit` passes for `packages/cloud/api`, `packages/cloud/shared`, `packages/shared`, `packages/ui`, `packages/cloud/sdk`.
- Lint: `biome check` clean on all changed files.
- e2e contract updates (not run here; live-stack lanes): `group-a-auth.test.ts` (marker headers + `missing_code_verifier` case + verifier in happy path), `group-b-account-billing.test.ts` (payload-bound wallet signing), `cloud/e2e/tests/steward-session.spec.ts` (DELETE sends the marker header).

## Risk / rollout notes

- **W1-008 state match depends on Steward echoing `state`** on the OAuth callback (standard RFC 6749 behavior, and the code path is already exercised by Steward's upstream provider callbacks, but it is an external-service invariant — flagged in the audit as partially needs-verification). If a deployment's Steward does not echo `state`, OAuth logins fail closed with a visible error rather than silently degrading. Worth a staging smoke of one Google/Discord login before production rollout.
- Pre-hardening CLI clients that pin their own session id will poll an id the server no longer creates and fail; current `@elizaos/cloud-sdk` is compatible both directions. CLI sessions have a 10-minute TTL, so cross-deploy skew is bounded.
- Existing API keys minted before this change keep their previous (possibly null) expiry; only new CLI keys get the 90-day TTL.
- The legacy wallet-signature message remains valid only for query-less, bodyless requests; any external client POSTing with the old format must adopt the documented `Payload-SHA256` message.
- `isPermittedElizaBrowserOrigin`'s same-host acceptance (`origin === requestHost`) is deliberately retained: it admits only content served by the API origin itself and is required for same-origin custom deployments (see the justification comment in `steward-nonce-exchange`).
