### PR TITLE
fix(plugin-local-inference): reject malformed voice-profile id encoding

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/voice-profile-routes.encoding.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-profile-routes.encoding.test.ts
@@ -1,0 +1,197 @@
+/**
+ * OmniVoice preset activate/delete path encoding is leftover tax after
+ * speaker-profile bind/unbind. Stock develop called decodeURIComponent on
+ * POST /v1/voice/profiles/:id/activate and DELETE /v1/voice/profiles/:id,
+ * so `%` / `%2` / `%ZZ` threw URIError (500) instead of a typed 400.
+ * GET list stays untouched.
+ */
+import * as fs from "node:fs";
+import * as http from "node:http";
+import { Socket } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+	resolveStateDir: () => "/tmp",
+}));
+
+const {
+	handleVoiceProfileRoutes,
+}: typeof import("./voice-profile-routes") = await import(
+	"./voice-profile-routes"
+);
+type VoiceProfileCatalog =
+	import("./voice-profile-routes").VoiceProfileCatalog;
+type VoiceProfileRouteOptions =
+	import("./voice-profile-routes").VoiceProfileRouteOptions;
+
+let tmpDir: string;
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "voice-profile-routes-encoding-"),
+	);
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeEmptyPreset(filePath: string): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	const buf = Buffer.alloc(64, 0);
+	buf.writeUInt32LE(0x315a4c45, 0);
+	buf.writeUInt32LE(2, 4);
+	fs.writeFileSync(filePath, buf);
+}
+
+function makeReq(method: string, url: string): http.IncomingMessage {
+	const req = new http.IncomingMessage(new Socket());
+	req.method = method;
+	req.url = url;
+	req.headers = { host: "127.0.0.1:31337" };
+	Object.defineProperty(req.socket, "remoteAddress", {
+		value: "127.0.0.1",
+		configurable: true,
+	});
+	return req;
+}
+
+function makeRes(): {
+	res: http.ServerResponse;
+	status: () => number;
+	body: () => string;
+} {
+	const fakeReq = new http.IncomingMessage(new Socket());
+	const res = new http.ServerResponse(fakeReq);
+	let statusCode = 200;
+	let chunks = Buffer.alloc(0);
+	res.writeHead = ((code: number) => {
+		statusCode = code;
+		res.statusCode = code;
+		return res;
+	}) as typeof res.writeHead;
+	res.end = ((chunk?: string | Buffer | Uint8Array) => {
+		if (chunk) {
+			chunks = Buffer.concat([
+				chunks,
+				Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
+			]);
+		}
+		return res;
+	}) as typeof res.end;
+	return {
+		res,
+		status: () => statusCode,
+		body: () => chunks.toString("utf8"),
+	};
+}
+
+function catalogOpts(): VoiceProfileRouteOptions {
+	const bundleRoot = path.join(tmpDir, "bundle");
+	writeEmptyPreset(path.join(bundleRoot, "cache", "voice-preset-alloy.bin"));
+	const voiceModelsDir = path.join(tmpDir, "models", "voice");
+	fs.mkdirSync(path.join(voiceModelsDir, "profiles"), { recursive: true });
+	const catalog: VoiceProfileCatalog = {
+		version: 1,
+		defaultProfileId: "same",
+		profiles: [],
+	};
+	fs.writeFileSync(
+		path.join(voiceModelsDir, "profiles", "catalog.json"),
+		JSON.stringify(catalog),
+	);
+	return { voiceModelsDir, bundleRoot };
+}
+
+describe("POST /v1/voice/profiles/:id/activate encoding", () => {
+	it("canonical activate still 404s as not found", async () => {
+		const opts = catalogOpts();
+		const { res, status, body } = makeRes();
+		const handled = await handleVoiceProfileRoutes(
+			makeReq("POST", "/v1/voice/profiles/ghost/activate"),
+			res,
+			opts,
+		);
+		expect(handled).toBe(true);
+		expect(status()).toBe(404);
+		expect(JSON.parse(body())).toEqual({ error: "Profile 'ghost' not found" });
+	});
+
+	it("canonical percent-encoded letter still decodes before the 404", async () => {
+		const opts = catalogOpts();
+		const { res, status } = makeRes();
+		await handleVoiceProfileRoutes(
+			makeReq("POST", "/v1/voice/profiles/gh%6Fst/activate"),
+			res,
+			opts,
+		);
+		expect(status()).toBe(404);
+	});
+
+	it("GET voice-profiles list is untouched", async () => {
+		const opts = catalogOpts();
+		const { res, status, body } = makeRes();
+		const handled = await handleVoiceProfileRoutes(
+			makeReq("GET", "/v1/voice/profiles"),
+			res,
+			opts,
+		);
+		expect(handled).toBe(true);
+		expect(status()).toBe(200);
+		const json = JSON.parse(body());
+		expect(json).toHaveProperty("profiles");
+		expect(Array.isArray(json.profiles)).toBe(true);
+	});
+
+	it.each(["%", "%2", "%ZZ", "%E0%A4"])(
+		"rejects malformed activate id %s with 400",
+		async (token) => {
+			const opts = catalogOpts();
+			const { res, status, body } = makeRes();
+			const handled = await handleVoiceProfileRoutes(
+				makeReq("POST", `/v1/voice/profiles/${token}/activate`),
+				res,
+				opts,
+			);
+			expect(handled).toBe(true);
+			expect(status()).toBe(400);
+			expect(JSON.parse(body())).toEqual({
+				error: "Invalid profile id: malformed URL encoding",
+			});
+		},
+	);
+});
+
+describe("DELETE /v1/voice/profiles/:id encoding", () => {
+	it("canonical delete still 404s as not found", async () => {
+		const opts = catalogOpts();
+		const { res, status } = makeRes();
+		const handled = await handleVoiceProfileRoutes(
+			makeReq("DELETE", "/v1/voice/profiles/ghost"),
+			res,
+			opts,
+		);
+		expect(handled).toBe(true);
+		expect(status()).toBe(404);
+	});
+
+	it.each(["%", "%2", "%ZZ"])(
+		"rejects malformed delete id %s with 400",
+		async (token) => {
+			const opts = catalogOpts();
+			const { res, status, body } = makeRes();
+			const handled = await handleVoiceProfileRoutes(
+				makeReq("DELETE", `/v1/voice/profiles/${token}`),
+				res,
+				opts,
+			);
+			expect(handled).toBe(true);
+			expect(status()).toBe(400);
+			expect(JSON.parse(body())).toEqual({
+				error: "Invalid profile id: malformed URL encoding",
+			});
+		},
+	);
+});

--- a/plugins/plugin-local-inference/src/services/voice/voice-profile-routes.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-profile-routes.ts
@@ -241,6 +241,17 @@ function sendError(
 	sendJson(res, status, { error: message });
 }
 
+function decodeProfileId(raw: string): string | null {
+	try {
+		return decodeURIComponent(raw);
+	} catch {
+		// error-policy:J3 untrusted-input sanitizing — leftover tax after
+		// speaker-profile / voice-models path work. Malformed percent-encoding
+		// is invalid client input, not a voice-preset catalog outage.
+		return null;
+	}
+}
+
 /**
  * Route handler for all `/v1/voice/profiles*` endpoints.
  *
@@ -285,7 +296,11 @@ export async function handleVoiceProfileRoutes(
 		pathname,
 	);
 	if (method === "POST" && activateMatch) {
-		const profileId = decodeURIComponent(activateMatch[1] ?? "");
+		const profileId = decodeProfileId(activateMatch[1] ?? "");
+		if (profileId === null) {
+			sendError(res, 400, "Invalid profile id: malformed URL encoding");
+			return true;
+		}
 		if (!profileId || !/^[A-Za-z0-9._-]+$/.test(profileId)) {
 			sendError(res, 400, `Invalid profile id: ${profileId}`);
 			return true;
@@ -335,7 +350,11 @@ export async function handleVoiceProfileRoutes(
 	// -------------------------------------------------------------------
 	const deleteMatch = /^\/v1\/voice\/profiles\/([^/]+)$/.exec(pathname);
 	if (method === "DELETE" && deleteMatch) {
-		const profileId = decodeURIComponent(deleteMatch[1] ?? "");
+		const profileId = decodeProfileId(deleteMatch[1] ?? "");
+		if (profileId === null) {
+			sendError(res, 400, "Invalid profile id: malformed URL encoding");
+			return true;
+		}
 		if (!profileId || !/^[A-Za-z0-9._-]+$/.test(profileId)) {
 			sendError(res, 400, `Invalid profile id: ${profileId}`);
 			return true;


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
plugin-local-inference OmniVoice profile id percent-encoding. Encoding
class, leftover tax after speaker-profile bind/unbind. Not a twin of
those parsers — this is `POST /v1/voice/profiles/:id/activate` and
`DELETE /v1/voice/profiles/:id` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on OmniVoice activate/delete. Canonical
`gh%6Fst` still decodes to `ghost` and 404s as not found. Malformed
`%` / `%2` / `%ZZ` become 400 instead of an uncaught `URIError` 500.
GET list stays untouched.

# Background

## What does this PR do?

`handleVoiceProfileRoutes` called `decodeURIComponent` on the
profile-id path segment. Illegal percent-encoding throws `URIError`,
which the host mapped to 500.

- `/v1/voice/profiles/%/activate` / `%2` / `%ZZ` → **400**
- `/v1/voice/profiles/gh%6Fst/activate` → still decodes to `ghost`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded OmniVoice
profile id should get a request error, not a 500 that looks like a
preset-catalog outage. Leftover tax after speaker-profile bind/unbind.
Disjoint files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/src/services/voice/voice-profile-routes.encoding.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-local-inference && bunx vitest run --config vitest.config.ts src/services/voice/voice-profile-routes.encoding.test.ts
```

11 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; OmniVoice profile id path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; OmniVoice profile id path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; OmniVoice profile id path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before catalog writes; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before catalog writes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
percent-encoding rejects; omitted/canonical still decode and 404 as
not found.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the OmniVoice
profile id path decode only.

## Known gaps / failures

`bun run verify` was not run. Focused 11-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:fe07b1959a9764264af151424200296bdc08eaa6 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
