### PR TITLE
fix(plugin-imessage): reject malformed contact id encoding

### DIFF
--- a/plugins/plugin-imessage/src/data-routes.encoding.test.ts
+++ b/plugins/plugin-imessage/src/data-routes.encoding.test.ts
@@ -1,0 +1,181 @@
+/**
+ * PATCH/DELETE /api/imessage/contacts/:id path encoding is leftover tax
+ * after the messages-list limit parser. Stock develop called
+ * decodeURIComponent on the contact id, so `%` / `%2` / `%ZZ` threw
+ * URIError (500) instead of a typed 400. Messages list stays untouched.
+ */
+import type { IAgentRuntime, RouteRequest, RouteResponse } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+  buildSetupError: (code: string, message: string) => ({
+    error: { code, message },
+  }),
+}));
+
+import { imessageDataRoutes } from "./data-routes.ts";
+
+const patchRoute = imessageDataRoutes.find(
+  (route) => route.type === "PATCH" && route.path === "/api/imessage/contacts/:id"
+);
+const deleteRoute = imessageDataRoutes.find(
+  (route) => route.type === "DELETE" && route.path === "/api/imessage/contacts/:id"
+);
+const listRoute = imessageDataRoutes.find(
+  (route) => route.type === "GET" && route.path === "/api/imessage/contacts"
+);
+
+if (!patchRoute?.handler || !deleteRoute?.handler || !listRoute?.handler) {
+  throw new Error("iMessage contact handlers missing");
+}
+
+interface Captured {
+  status?: number;
+  body?: unknown;
+}
+
+interface ServiceCalls {
+  updates: string[];
+  deletes: string[];
+  lists: number;
+}
+
+function mockRes(captured: Captured): RouteResponse {
+  const res = {
+    status(code: number) {
+      captured.status = code;
+      return res;
+    },
+    json(data: unknown) {
+      captured.body = data;
+      return res;
+    },
+    send(data: unknown) {
+      captured.body = data;
+      return res;
+    },
+    end() {
+      return res;
+    },
+  };
+  return res;
+}
+
+function mockRuntime(calls: ServiceCalls): IAgentRuntime {
+  return {
+    getService: (key: string) => {
+      if (key !== "imessage") return null;
+      return {
+        isConnected: () => true,
+        getMessages: async () => [],
+        getRecentMessages: async () => [],
+        sendMessage: async () => ({ success: true }),
+        getChats: async () => [],
+        listAllContacts: async () => {
+          calls.lists += 1;
+          return [];
+        },
+        addContact: async () => "person-1",
+        updateContact: async (id: string) => {
+          calls.updates.push(id);
+          return true;
+        },
+        deleteContact: async (id: string) => {
+          calls.deletes.push(id);
+          return true;
+        },
+      };
+    },
+  } as unknown as IAgentRuntime;
+}
+
+async function patchContact(url: string, calls: ServiceCalls): Promise<Captured> {
+  const captured: Captured = {};
+  await patchRoute.handler?.(
+    { url, method: "PATCH", body: { firstName: "Ada" } } as RouteRequest,
+    mockRes(captured),
+    mockRuntime(calls)
+  );
+  return captured;
+}
+
+async function deleteContact(url: string, calls: ServiceCalls): Promise<Captured> {
+  const captured: Captured = {};
+  await deleteRoute.handler?.(
+    { url, method: "DELETE" } as RouteRequest,
+    mockRes(captured),
+    mockRuntime(calls)
+  );
+  return captured;
+}
+
+describe("PATCH /api/imessage/contacts/:id encoding", () => {
+  it("canonical id still reaches updateContact", async () => {
+    const calls: ServiceCalls = { updates: [], deletes: [], lists: 0 };
+    const captured = await patchContact("/api/imessage/contacts/ABCD-EFGH", calls);
+    expect(captured.status).toBe(200);
+    expect(calls.updates).toEqual(["ABCD-EFGH"]);
+  });
+
+  it("canonical percent-encoded hyphen still decodes before updateContact", async () => {
+    const calls: ServiceCalls = { updates: [], deletes: [], lists: 0 };
+    const captured = await patchContact("/api/imessage/contacts/ABCD%2DEFGH", calls);
+    expect(captured.status).toBe(200);
+    expect(calls.updates).toEqual(["ABCD-EFGH"]);
+  });
+
+  it("GET contacts list is untouched", async () => {
+    const calls: ServiceCalls = { updates: [], deletes: [], lists: 0 };
+    const captured: Captured = {};
+    await listRoute.handler?.(
+      { url: "/api/imessage/contacts", method: "GET" } as RouteRequest,
+      mockRes(captured),
+      mockRuntime(calls)
+    );
+    expect(captured.status).toBe(200);
+    expect(calls.lists).toBe(1);
+    expect(calls.updates).toEqual([]);
+    expect(calls.deletes).toEqual([]);
+  });
+
+  it.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed patch id %s with 400",
+    async (token) => {
+      const calls: ServiceCalls = { updates: [], deletes: [], lists: 0 };
+      const captured = await patchContact(`/api/imessage/contacts/${token}`, calls);
+      expect(captured.status).toBe(400);
+      expect(captured.body).toEqual({
+        error: {
+          code: "bad_request",
+          message: "Invalid contact id: malformed URL encoding",
+        },
+      });
+      expect(calls.updates).toEqual([]);
+    }
+  );
+});
+
+describe("DELETE /api/imessage/contacts/:id encoding", () => {
+  it("canonical id still reaches deleteContact", async () => {
+    const calls: ServiceCalls = { updates: [], deletes: [], lists: 0 };
+    const captured = await deleteContact("/api/imessage/contacts/ABCD-EFGH", calls);
+    expect(captured.status).toBe(200);
+    expect(calls.deletes).toEqual(["ABCD-EFGH"]);
+  });
+
+  it.each(["%", "%2", "%ZZ"])(
+    "rejects malformed delete id %s with 400",
+    async (token) => {
+      const calls: ServiceCalls = { updates: [], deletes: [], lists: 0 };
+      const captured = await deleteContact(`/api/imessage/contacts/${token}`, calls);
+      expect(captured.status).toBe(400);
+      expect(captured.body).toEqual({
+        error: {
+          code: "bad_request",
+          message: "Invalid contact id: malformed URL encoding",
+        },
+      });
+      expect(calls.deletes).toEqual([]);
+    }
+  );
+});

--- a/plugins/plugin-imessage/src/data-routes.ts
+++ b/plugins/plugin-imessage/src/data-routes.ts
@@ -128,17 +128,46 @@ function resolveService(runtime: IAgentRuntime): IMessageServiceLike | null {
   return isIMessageServiceLike(service) ? service : null;
 }
 
+type ParsedContactId =
+  | { ok: true; id: string }
+  | { ok: false; reason: "missing" | "malformed" };
+
 /**
  * Extract the `:id` segment from a contact path like
- * `/api/imessage/contacts/ABCD-EFGH-...`. Returns null if the path
- * doesn't match.
+ * `/api/imessage/contacts/ABCD-EFGH-...`. Missing segments stay
+ * `missing`. Illegal percent-encoding is `malformed` — leftover tax
+ * after the messages-list `limit` parser. `decodeURIComponent` used
+ * to throw `URIError` and the host mapped that to 500.
  */
-function parseContactId(pathname: string): string | null {
+function parseContactId(pathname: string): ParsedContactId {
   const prefix = "/api/imessage/contacts/";
-  if (!pathname.startsWith(prefix)) return null;
+  if (!pathname.startsWith(prefix)) return { ok: false, reason: "missing" };
   const rest = pathname.slice(prefix.length);
-  if (!rest) return null;
-  return decodeURIComponent(rest);
+  if (!rest) return { ok: false, reason: "missing" };
+  try {
+    const id = decodeURIComponent(rest);
+    if (!id) return { ok: false, reason: "missing" };
+    return { ok: true, id };
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — leftover tax after
+    // plugin-imessage messages `limit`. Malformed percent-encoding is
+    // invalid client input, not an iMessage contact-store outage.
+    return { ok: false, reason: "malformed" };
+  }
+}
+
+function rejectContactId(res: RouteResponse, parsed: ParsedContactId): parsed is { ok: true; id: string } {
+  if (parsed.ok) return true;
+  if (parsed.reason === "malformed") {
+    res
+      .status(400)
+      .json(
+        buildSetupError("bad_request", "Invalid contact id: malformed URL encoding")
+      );
+    return false;
+  }
+  res.status(400).json(buildSetupError("bad_request", "contact id is required in the path"));
+  return false;
 }
 
 const DEFAULT_MESSAGES_LIMIT = 50;
@@ -375,11 +404,11 @@ async function handleUpdateContact(
   runtime: IAgentRuntime
 ): Promise<void> {
   const pathname = req.url ?? "";
-  const id = parseContactId(pathname.split("?")[0]);
-  if (!id) {
-    res.status(400).json(buildSetupError("bad_request", "contact id is required in the path"));
+  const parsed = parseContactId(pathname.split("?")[0]);
+  if (!rejectContactId(res, parsed)) {
     return;
   }
+  const id = parsed.id;
   const service = resolveService(runtime);
   if (!service) {
     res.status(503).json(buildSetupError("service_unavailable", "imessage service not registered"));
@@ -435,11 +464,11 @@ async function handleDeleteContact(
   runtime: IAgentRuntime
 ): Promise<void> {
   const pathname = req.url ?? "";
-  const id = parseContactId(pathname.split("?")[0]);
-  if (!id) {
-    res.status(400).json(buildSetupError("bad_request", "contact id is required in the path"));
+  const parsed = parseContactId(pathname.split("?")[0]);
+  if (!rejectContactId(res, parsed)) {
     return;
   }
+  const id = parsed.id;
   const service = resolveService(runtime);
   if (!service) {
     res.status(503).json(buildSetupError("service_unavailable", "imessage service not registered"));


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
plugin-imessage contact id percent-encoding. Encoding class, leftover
tax after the messages-list `limit` parser. Not a twin of that
parser — this is `PATCH/DELETE /api/imessage/contacts/:id` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on contact PATCH/DELETE. Canonical
`ABCD%2DEFGH` still decodes to `ABCD-EFGH` and reaches the store.
Malformed `%` / `%2` / `%ZZ` become 400 instead of an uncaught
`URIError` 500. Messages list and contact list stay untouched.

# Background

## What does this PR do?

`parseContactId` called `decodeURIComponent` on the contact-id path
segment. Illegal percent-encoding throws `URIError`, which the host
mapped to 500.

- `/api/imessage/contacts/%` / `%2` / `%ZZ` → **400**
- `/api/imessage/contacts/ABCD%2DEFGH` → still decodes to `ABCD-EFGH`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded contact id
should get a request error, not a 500 that looks like an iMessage
contact-store outage. Leftover tax after the messages-list `limit`
parser. Disjoint files from that parser.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-imessage/src/data-routes.encoding.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-imessage && bunx vitest run --config vitest.config.ts src/data-routes.encoding.test.ts
```

11 identity tests passed at this head. Sibling messages-limit suite
still 13 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; iMessage contact id path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; iMessage contact id path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; iMessage contact id path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before updateContact / deleteContact; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before updateContact / deleteContact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
percent-encoding rejects; omitted/canonical still decode and reach
the store.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the iMessage
contact id path decode only.

## Known gaps / failures

`bun run verify` was not run. Focused 11-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1cb2dcd28478b0ce0e4caf73dcb8241615744a51 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
