### PR TITLE
fix(security): secrets-logging hardening — logger redaction, file/dir permissions, key derivation (W1-018..021, W1-058..062)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -959,10 +959,8 @@
       "version": "2.0.12-beta.0",
       "dependencies": {
         "adze": "^2.2.5",
-        "fast-redact": "^3.5.0",
       },
       "devDependencies": {
-        "@types/fast-redact": "^3.0.4",
         "@types/node": "^24.0.0",
         "@typescript/native": "npm:typescript@^7.0.2",
       },

--- a/packages/agent/src/api/config-env.ts
+++ b/packages/agent/src/api/config-env.ts
@@ -279,7 +279,15 @@ export async function persistConfigEnv(
   await serialise(async () => {
     const filePath = resolveConfigEnvPath(opts.stateDir);
     const dir = path.dirname(filePath);
-    await fs.mkdir(dir, { recursive: true });
+    // Owner-only dir (the file itself is written 0600 below); the chmod heals
+    // state dirs created world-readable by older installs.
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+    try {
+      await fs.chmod(dir, 0o700);
+    } catch {
+      // error-policy:J6 best-effort heal for directories created by older
+      // installs; platforms without POSIX chmod semantics skip.
+    }
 
     const existing = (await readIfExists(filePath)) ?? "";
     const parsed = parseConfigEnv(existing);

--- a/packages/agent/src/config/paths.test.ts
+++ b/packages/agent/src/config/paths.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Verifies the agent host's `ensurePrivateDir` (W1-020): state directories
+ * holding the PGlite DB, `config.env`, and `secret-salt` must be created
+ * owner-only (0700), with the mode healed on directories left world-readable
+ * by older installs. Real temp directories; POSIX-only.
+ */
+import { chmodSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensurePrivateDir } from "./paths.ts";
+
+describe.skipIf(process.platform === "win32")("ensurePrivateDir", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), "eliza-privdir-"));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  const modeOf = (dir: string) => statSync(dir).mode & 0o777;
+
+  it("creates a new state dir with mode 0700", () => {
+    const dir = path.join(workDir, "state");
+    ensurePrivateDir(dir);
+    expect(modeOf(dir)).toBe(0o700);
+  });
+
+  it("heals a world-readable directory from an older install", () => {
+    const dir = path.join(workDir, "legacy-state");
+    ensurePrivateDir(dir);
+    chmodSync(dir, 0o755);
+
+    ensurePrivateDir(dir);
+    expect(modeOf(dir)).toBe(0o700);
+  });
+});

--- a/packages/agent/src/config/paths.ts
+++ b/packages/agent/src/config/paths.ts
@@ -23,6 +23,23 @@ function readEnvOverride(env: NodeJS.ProcessEnv): string | undefined {
 export { getElizaNamespace, resolveOAuthDir, resolveStateDir, resolveUserPath };
 
 /**
+ * Create a state directory (and parents) owner-only, then heal the mode on
+ * directories left behind by older installs. The state tree holds the PGlite
+ * memory DB, `config.env`, and `secret-salt` — all credential-bearing — so it
+ * must never be group/other-readable. `mkdir` only applies `mode` to newly
+ * created directories, hence the explicit chmod for the pre-existing case.
+ */
+export function ensurePrivateDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    fs.chmodSync(dir, 0o700);
+  } catch {
+    // error-policy:J6 best-effort heal for directories created by older
+    // installs; platforms without POSIX chmod semantics skip.
+  }
+}
+
+/**
  * Ordered list of on-disk config filenames to look for under the state dir,
  * given the active namespace. The first existing file wins; if none exist,
  * callers fall back to the first entry (the file to create/write).

--- a/packages/agent/src/config/sensitive-keys.test.ts
+++ b/packages/agent/src/config/sensitive-keys.test.ts
@@ -98,3 +98,66 @@ describe("PAT credential names (#16564)", () => {
     }
   });
 });
+
+/**
+ * W1-021: the GET /api/config masking contract must cover URL-shaped and misc
+ * credential carriers, not just *KEY/*SECRET names — a `postgres://user:pw@…`
+ * DSN or a Discord webhook URL is itself the credential.
+ */
+describe("URL-shaped and misc secret keys (W1-021)", () => {
+  it("classifies DSN/URL/URI/webhook names as sensitive", () => {
+    for (const key of [
+      "DATABASE_URL",
+      "POSTGRES_URL",
+      "REDIS_URL",
+      "MONGODB_URI",
+      "DISCORD_WEBHOOK_URL",
+      "webhookUrl",
+      "app.database.dsn",
+    ]) {
+      expect(isSensitiveConfigKey(key), key).toBe(true);
+    }
+  });
+
+  it("classifies misc credential names as sensitive", () => {
+    for (const key of [
+      "sessionKey",
+      "mnemonic",
+      "jwt",
+      "bearer",
+      "cookie",
+      "encryptionKey",
+      "masterKey",
+      "sshKey",
+      "signingKey",
+      "accessKey",
+      "SESSION_KEY",
+      "ENCRYPTION_KEY",
+    ]) {
+      expect(isSensitiveConfigKey(key), key).toBe(true);
+    }
+  });
+
+  it("keeps key-suffix lookalikes non-sensitive", () => {
+    for (const key of [
+      "monkey",
+      "turnkey",
+      "hotkey",
+      "KEYBOARD",
+      "maxTokens",
+    ]) {
+      expect(isSensitiveConfigKey(key), key).toBe(false);
+    }
+  });
+
+  it("round-trips DATABASE_URL through GET /api/config redaction", () => {
+    const redacted = redactConfigSecrets({
+      env: {
+        DATABASE_URL: "postgres://user:pw@host/db",
+        LOG_LEVEL: "info",
+      },
+    }) as { env: Record<string, unknown> };
+    expect(redacted.env.DATABASE_URL).toBe("[REDACTED]");
+    expect(redacted.env.LOG_LEVEL).toBe("info");
+  });
+});

--- a/packages/agent/src/config/sensitive-keys.ts
+++ b/packages/agent/src/config/sensitive-keys.ts
@@ -6,11 +6,24 @@
  * sensitivity hints for arbitrary config paths.
  */
 const SENSITIVE_CONFIG_KEY_RE =
-  /password|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|tokens?$|(?:^|[._-])pat$/i;
+  /password|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|tokens?$|(?:^|[._-])pat$|(?:^|[._-])webhook[a-z]*$|(?:^|[._-])(?:dsn|url|uri|jwt|bearer|cookie|mnemonic)$|(?:^|[._-])key$/i;
+
+/**
+ * camelCase companions for the separator-anchored names above, so
+ * `sessionKey`, `encryptionKey`, `webhookUrl`, `discordWebhook`, and
+ * `accessJwt` classify the same as their SCREAMING_SNAKE forms.
+ * Case-sensitive on purpose: all-lower and all-upper lookalikes (`monkey`,
+ * `turnkey`, `hotkey`, `KEYBOARD`) must stay non-sensitive.
+ */
+const SENSITIVE_CAMEL_KEY_RE =
+  /[a-z](?:Key|Url|Uri|Jwt|Bearer|Cookie|Mnemonic|Webhook)$/;
 
 export function isSensitiveConfigKey(key: string): boolean {
   const lastSegment = key.split(".").at(-1) ?? key;
   const normalized = lastSegment.replace(/[-_\s]/g, "").toLowerCase();
   if (/^maxtokens?$/.test(normalized)) return false;
-  return SENSITIVE_CONFIG_KEY_RE.test(key);
+  return (
+    SENSITIVE_CONFIG_KEY_RE.test(key) ||
+    SENSITIVE_CAMEL_KEY_RE.test(lastSegment)
+  );
 }

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -8,13 +8,7 @@
  * @module eliza
  */
 import crypto from "node:crypto";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -307,7 +301,11 @@ import {
   CONNECTOR_ENV_MAP,
   collectConnectorEnvVars,
 } from "../config/env-vars.ts";
-import { resolveStateDir, resolveUserPath } from "../config/paths.ts";
+import {
+  ensurePrivateDir,
+  resolveStateDir,
+  resolveUserPath,
+} from "../config/paths.ts";
 import {
   createHookEvent,
   type LoadHooksOptions,
@@ -2662,11 +2660,12 @@ export function applyDatabaseConfigToEnv(config: ElizaConfig): void {
     }
 
     // Ensure the PGlite data directory exists before init so PGlite does
-    // not silently fall back to in-memory mode on first run.
+    // not silently fall back to in-memory mode on first run. Owner-only:
+    // the tree holds full agent history (heals older 0755 installs too).
     const dataDir = process.env.PGLITE_DATA_DIR;
     if (dataDir) {
       const alreadyExisted = existsSync(dataDir);
-      mkdirSync(dataDir, { recursive: true });
+      ensurePrivateDir(dataDir);
       logger.debug(
         `[eliza] PGlite data dir: ${dataDir} (${alreadyExisted ? "existed" : "created"})`,
       );
@@ -4261,10 +4260,11 @@ export async function startEliza(
     }
     if (!salt) {
       salt = crypto.randomBytes(32).toString("hex");
-      mkdirSync(path.dirname(secretSaltPath), { recursive: true });
-      // 0o600: only the user account that wrote it can read it. The salt
-      // is a key-derivation input — anyone who reads it plus the
-      // ciphertext can decrypt persisted secrets.
+      // Owner-only state dir (also heals older 0755 installs): the salt is a
+      // key-derivation input — anyone who reads it plus the ciphertext can
+      // decrypt persisted secrets.
+      ensurePrivateDir(path.dirname(secretSaltPath));
+      // 0o600: only the user account that wrote it can read it.
       writeFileSync(secretSaltPath, salt, { encoding: "utf8", mode: 0o600 });
       logger.info(
         `[eliza] Generated SECRET_SALT and persisted to ${secretSaltPath}`,

--- a/packages/core/src/features/secrets/services/secrets-key-derivation.test.ts
+++ b/packages/core/src/features/secrets/services/secrets-key-derivation.test.ts
@@ -1,0 +1,83 @@
+/**
+ * SecretsService key derivation (W1-061): the active encryption key must be
+ * derived from the high-entropy ENCRYPTION_SALT — not from the public agentId
+ * (logs, API responses, DB rows), which contributed zero entropy as the KDF
+ * password. The legacy agentId-keyed key stays registered under keyId
+ * "default" so ciphertext written by older builds still decrypts. Pure unit
+ * test against createMockRuntime — no storage I/O.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createMockRuntime } from "../../../testing/mock-runtime.ts";
+import type { IAgentRuntime } from "../../../types/index.ts";
+import { deriveKeyPbkdf2, KeyManager } from "../crypto/encryption.ts";
+import { SecretsService } from "./secrets.ts";
+
+const ENCRYPTION_SALT = "unit-test-salt";
+const AGENT_ID =
+	"11111111-2222-3333-4444-555555555555" as IAgentRuntime["agentId"];
+
+function runtime(): IAgentRuntime {
+	return createMockRuntime({
+		agentId: AGENT_ID,
+		getSetting: ((key: string) =>
+			key === "ENCRYPTION_SALT"
+				? ENCRYPTION_SALT
+				: undefined) as IAgentRuntime["getSetting"],
+		character: {
+			name: "T",
+			bio: [],
+			settings: { secrets: {} },
+		} as IAgentRuntime["character"],
+	});
+}
+
+describe("SecretsService key derivation (W1-061)", () => {
+	it("derives the active key from the salt, not the public agentId", async () => {
+		const service = await SecretsService.start(runtime());
+		const keyManager = service.getKeyManager();
+
+		// New writes go out under the strong "v2" key…
+		expect(keyManager.getCurrentKeyId()).toBe("v2");
+
+		// …which differs from the legacy agentId-password derivation.
+		const legacyKey = deriveKeyPbkdf2(AGENT_ID, ENCRYPTION_SALT);
+		expect(keyManager.getKey("v2")).not.toEqual(legacyKey);
+
+		// The strong key is PBKDF2 over the salt, domain-bound to the agent.
+		const expected = deriveKeyPbkdf2(
+			ENCRYPTION_SALT,
+			Buffer.from(`elizaos:secrets:v2:${AGENT_ID}`, "utf8"),
+		);
+		expect(keyManager.getKey("v2")).toEqual(expected);
+
+		await service.stop();
+	});
+
+	it("round-trips new ciphertext under the v2 key", async () => {
+		const service = await SecretsService.start(runtime());
+		const keyManager = service.getKeyManager();
+
+		const encrypted = keyManager.encrypt("sk-live-secret-value");
+		expect(encrypted.keyId).toBe("v2");
+		expect(keyManager.decrypt(encrypted)).toBe("sk-live-secret-value");
+
+		await service.stop();
+	});
+
+	it("still decrypts legacy ciphertext keyed by the agentId derivation", async () => {
+		// Ciphertext produced by a pre-fix build: keyId "default", PBKDF2 with
+		// the agentId as the KDF password.
+		const legacyManager = new KeyManager();
+		legacyManager.initializeFromPassword(AGENT_ID, ENCRYPTION_SALT);
+		const legacyCiphertext = legacyManager.encrypt("legacy-secret");
+		expect(legacyCiphertext.keyId).toBe("default");
+
+		const service = await SecretsService.start(runtime());
+		expect(service.getKeyManager().decrypt(legacyCiphertext)).toBe(
+			"legacy-secret",
+		);
+
+		await service.stop();
+	});
+});

--- a/packages/core/src/features/secrets/services/secrets.ts
+++ b/packages/core/src/features/secrets/services/secrets.ts
@@ -12,7 +12,7 @@ import {
 	Service,
 	type ServiceTypeName,
 } from "../../../types/index.ts";
-import { KeyManager } from "../crypto/encryption.ts";
+import { deriveKeyPbkdf2, KeyManager } from "../crypto/encryption.ts";
 import {
 	BrokerSecretStorage,
 	CharacterSettingsStorage,
@@ -98,7 +98,22 @@ export class SecretsService extends Service {
 					"ENCRYPTION_SALT_REQUIRED",
 				);
 			}
+			// Legacy derivation retained as a DECRYPT-ONLY key: ciphertext
+			// written before the strong derivation existed carries keyId
+			// "default" (PBKDF2 with the agentId as password). The agentId is a
+			// public identifier — it appears in logs, API responses, URLs, and
+			// DB rows — so that password contributes zero entropy.
 			this.keyManager.initializeFromPassword(runtime.agentId, encryptionSalt);
+			// Active derivation: the high-entropy ENCRYPTION_SALT is the KDF
+			// password, bound to this agent via a domain-separated KDF salt, so
+			// the key's secrecy no longer rests on a public value. New writes
+			// carry keyId "v2"; KeyManager.decrypt selects by stored keyId.
+			const strongKey = deriveKeyPbkdf2(
+				encryptionSalt,
+				Buffer.from(`elizaos:secrets:v2:${runtime.agentId}`, "utf8"),
+			);
+			this.keyManager.addKey("v2", strongKey);
+			this.keyManager.setCurrentKey("v2");
 
 			// Initialize storage backends
 			this.globalStorage = new CharacterSettingsStorage(

--- a/packages/core/src/providers/recent-errors.test.ts
+++ b/packages/core/src/providers/recent-errors.test.ts
@@ -6,11 +6,17 @@
 
 import { describe, expect, it } from "vitest";
 import type { ReportedError } from "../errors";
+import { redactWithSecrets } from "../security/redact";
 import type { IAgentRuntime, Memory, State } from "../types";
 import { QUIET_ERROR_CODES, recentErrorsProvider } from "./recent-errors";
 
 function runtimeWith(entries: ReportedError[]): IAgentRuntime {
-	return { getRecentReportedErrors: () => entries } as unknown as IAgentRuntime;
+	return {
+		getRecentReportedErrors: () => entries,
+		// The real AgentRuntime scrubs via redactWithSecrets; identity is the
+		// right default for tests that don't exercise the scrubbing path.
+		redactSecrets: (text: string) => text,
+	} as unknown as IAgentRuntime;
 }
 
 const message = {} as Memory;
@@ -197,5 +203,40 @@ describe("RECENT_ERRORS provider", () => {
 		expect(QUIET_ERROR_CODES.has("TASK_TICK_FAILED")).toBe(true);
 		expect(QUIET_ERROR_CODES.has("TASK_WORKER_MISSING")).toBe(true);
 		expect(QUIET_ERROR_CODES.has("WALLET_RPC_DOWN")).toBe(false);
+	});
+
+	it("scrubs credentials from reported errors before they reach the prompt (W1-062)", async () => {
+		// A third-party plugin reports an error echoing a credential — in the
+		// message (value-shape pattern) and in the serialized context (literal
+		// configured secret). Neither may ship to the model provider.
+		const entries: ReportedError[] = [
+			{
+				scope: "ThirdPartyPlugin",
+				code: "UPLOAD_FAILED",
+				message: "POST https://api.example.com/upload failed",
+				context: {
+					authorization: "Bearer sk-livekey-notconfigured99",
+					password: "hunter2plainpass123",
+				},
+				at: Date.now(),
+			},
+		];
+		const runtime = {
+			getRecentReportedErrors: () => entries,
+			// Mirror AgentRuntime.redactSecrets: literal secrets + patterns.
+			redactSecrets: (text: string) =>
+				redactWithSecrets(text, {
+					secrets: { SERVICE_PASSWORD: "hunter2plainpass123" },
+				}),
+		} as unknown as IAgentRuntime;
+
+		const result = await recentErrorsProvider.get(runtime, message, state);
+
+		expect(result.text).not.toContain("sk-livekey-notconfigured99");
+		expect(result.text).not.toContain("hunter2plainpass123");
+		// Masked in both slots (the combined redactor re-masks its own marker,
+		// so assert the mask shape, not the exact marker format).
+		expect(result.text).toContain("[REDAC…ORD]");
+		expect(result.text).toContain("UPLOAD_FAILED");
 	});
 });

--- a/packages/core/src/providers/recent-errors.ts
+++ b/packages/core/src/providers/recent-errors.ts
@@ -8,6 +8,12 @@
  * the list, and appends a short instruction so the agent can attempt a fix or
  * tell the owner. It renders nothing (and costs no prompt tokens) when there are
  * no recent errors — no prompt bloat on the healthy path.
+ *
+ * Error text is third-party-controlled: a plugin can report an error whose
+ * message or context embeds a credential (a `?key=` URL, an Authorization
+ * header). Everything rendered into the prompt therefore goes through
+ * `runtime.redactSecrets` first, so reported errors can't ship secrets to
+ * external model providers.
  */
 
 import type { ReportedError } from "../errors";
@@ -92,11 +98,14 @@ function selectRecentErrors(
 		.slice(0, MAX_RECENT_ERRORS);
 }
 
-function renderText(selected: ReportedError[]): string {
+function renderText(
+	selected: ReportedError[],
+	redact: (text: string) => string,
+): string {
 	const lines = selected.map((entry) => {
 		const ctx = serializeContext(entry.context);
-		const suffix = ctx ? ` — ${ctx}` : "";
-		return `- [${entry.scope}] ${entry.code}: ${entry.message}${suffix}`;
+		const suffix = ctx ? ` — ${redact(ctx)}` : "";
+		return `- [${entry.scope}] ${entry.code}: ${redact(entry.message)}${suffix}`;
 	});
 	// The framing must make the block self-quarantining: rendered into a group
 	// turn, an unframed error list reads like conversation topic material — a
@@ -138,7 +147,7 @@ export const recentErrorsProvider: Provider = {
 		const selected = selectRecentErrors(entries, Date.now());
 		if (selected.length === 0) return EMPTY_RESULT;
 
-		const text = renderText(selected);
+		const text = renderText(selected, (value) => runtime.redactSecrets(value));
 		logger.debug(
 			{ src: "agent", count: selected.length },
 			"[RecentErrorsProvider] Surfacing recent reported errors",

--- a/packages/core/src/settings.salt.test.ts
+++ b/packages/core/src/settings.salt.test.ts
@@ -1,0 +1,75 @@
+/**
+ * SECRET_SALT lifecycle (W1-060): an unset salt must never silently fall back
+ * to the publicly known `"secretsalt"` constant — production throws (unless
+ * explicitly overridden), everything else gets an ephemeral per-process salt
+ * with a loud warning, so ciphertext can never be keyed by a published value.
+ * Uses real env manipulation plus the documented clearSaltCache() test seam.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearSaltCache, getSalt } from "./settings.ts";
+
+const ENV_KEYS = [
+	"SECRET_SALT",
+	"NODE_ENV",
+	"ELIZA_ALLOW_DEFAULT_SECRET_SALT",
+] as const;
+
+describe("getSalt (W1-060)", () => {
+	const saved: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		for (const key of ENV_KEYS) {
+			saved[key] = process.env[key];
+			delete process.env[key];
+		}
+		clearSaltCache();
+	});
+
+	afterEach(() => {
+		for (const key of ENV_KEYS) {
+			if (saved[key] === undefined) delete process.env[key];
+			else process.env[key] = saved[key];
+		}
+		clearSaltCache();
+	});
+
+	it("generates an ephemeral salt instead of the public constant when unset", () => {
+		const salt = getSalt();
+		expect(salt).not.toBe("secretsalt");
+		expect(salt).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("keeps the ephemeral salt stable across calls and cache clears", () => {
+		const first = getSalt();
+		clearSaltCache();
+		expect(getSalt()).toBe(first);
+	});
+
+	it("returns an explicitly configured salt as-is", () => {
+		process.env.SECRET_SALT = "operator-provided-salt";
+		expect(getSalt()).toBe("operator-provided-salt");
+	});
+
+	it("honors the legacy constant only under explicit opt-in", () => {
+		process.env.ELIZA_ALLOW_DEFAULT_SECRET_SALT = "true";
+		expect(getSalt()).toBe("secretsalt");
+	});
+
+	it("throws in production when the salt is unset", () => {
+		process.env.NODE_ENV = "production";
+		expect(() => getSalt()).toThrow(/SECRET_SALT must be set/);
+	});
+
+	it("throws in production when the salt is the legacy constant", () => {
+		process.env.NODE_ENV = "production";
+		process.env.SECRET_SALT = "secretsalt";
+		expect(() => getSalt()).toThrow(/SECRET_SALT must be set/);
+	});
+
+	it("allows the production override only with the opt-in flag", () => {
+		process.env.NODE_ENV = "production";
+		process.env.ELIZA_ALLOW_DEFAULT_SECRET_SALT = "true";
+		expect(getSalt()).toBe("secretsalt");
+	});
+});

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -6,7 +6,10 @@
  * short TTL because it runs on every getSetting string-decrypt — the hot path
  * avoids re-clearing the env cache, and clearSaltCache() is the test seam. In
  * production a non-default SECRET_SALT is required unless
- * ELIZA_ALLOW_DEFAULT_SECRET_SALT overrides the check.
+ * ELIZA_ALLOW_DEFAULT_SECRET_SALT overrides the check. Outside production an
+ * unset salt no longer falls back to the publicly known constant — a random
+ * per-process salt is generated with a loud warning instead, so ciphertext
+ * can never be keyed by a published value (and does not survive restart).
  *
  * Consumed by the runtime's getSetting/setSetting path and by world/character
  * setup: saltWorldSettings/unsaltWorldSettings (gated on each setting's `secret`
@@ -64,6 +67,22 @@ let saltCache: SaltCache | null = null;
 let saltErrorLogged = false;
 const SALT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes TTL
 
+/** The historical hardcoded fallback — a publicly known key input. */
+const LEGACY_DEFAULT_SECRET_SALT = "secretsalt";
+
+/**
+ * Random per-process salt for the unset-outside-production case. Deliberately
+ * NOT reset by clearSaltCache(): regenerating mid-process would orphan
+ * ciphertext produced earlier in the same process.
+ */
+let ephemeralSalt: string | null = null;
+function getEphemeralSalt(): string {
+	if (!ephemeralSalt) {
+		ephemeralSalt = BufferUtils.toHex(BufferUtils.randomBytes(32));
+	}
+	return ephemeralSalt;
+}
+
 function isEncryptedV1(value: string): boolean {
 	const parts = value.split(":");
 	if (parts.length !== 2) return false;
@@ -112,34 +131,58 @@ export function getSalt(): string {
 
 	// Cache miss / expired: re-read the environment from scratch.
 	getEnvironment().clearCache();
-	const currentEnvSalt = getEnv("SECRET_SALT", "secretsalt") || "secretsalt";
+	const envSalt = getEnv("SECRET_SALT", "") || "";
 	const nodeEnv = (getEnv("NODE_ENV", "") || "").toLowerCase();
 	const isProduction = nodeEnv === "production";
 	const allowDefaultSaltRaw =
 		getEnv("ELIZA_ALLOW_DEFAULT_SECRET_SALT", "") || "";
 	const allowDefaultSalt = allowDefaultSaltRaw.toLowerCase() === "true";
 
-	if (isProduction && currentEnvSalt === "secretsalt" && !allowDefaultSalt) {
+	const isDefaultOrUnset =
+		envSalt === "" || envSalt === LEGACY_DEFAULT_SECRET_SALT;
+
+	if (isProduction && isDefaultOrUnset && !allowDefaultSalt) {
 		throw new Error(
 			"SECRET_SALT must be set to a non-default value in production. " +
 				"Set ELIZA_ALLOW_DEFAULT_SECRET_SALT=true to override (not recommended).",
 		);
 	}
 
-	if (currentEnvSalt === "secretsalt" && !saltErrorLogged) {
-		logger.warn(
-			{ src: "core:settings", event: "core.settings.default_secret_salt" },
-			"SECRET_SALT is not set or using default value",
-		);
-		saltErrorLogged = true;
+	let value: string;
+	if (isDefaultOrUnset && !allowDefaultSalt) {
+		// Never key ciphertext by the publicly known constant: derive an
+		// ephemeral random salt instead. The loud trade-off is that settings
+		// encrypted under it are not decryptable after a process restart —
+		// set SECRET_SALT (the agent host persists one at boot) for durable
+		// at-rest encryption.
+		value = getEphemeralSalt();
+		if (!saltErrorLogged) {
+			logger.warn(
+				{ src: "core:settings", event: "core.settings.ephemeral_secret_salt" },
+				"SECRET_SALT is not set — generated an EPHEMERAL random salt for this process. " +
+					"Settings encrypted now will NOT be decryptable after restart. " +
+					"Set SECRET_SALT to a stable random value to persist encrypted settings.",
+			);
+			saltErrorLogged = true;
+		}
+	} else {
+		// Explicit salt, or the legacy constant under an explicit opt-in.
+		value = isDefaultOrUnset ? LEGACY_DEFAULT_SECRET_SALT : envSalt;
+		if (isDefaultOrUnset && !saltErrorLogged) {
+			logger.warn(
+				{ src: "core:settings", event: "core.settings.default_secret_salt" },
+				"SECRET_SALT is not set or using default value",
+			);
+			saltErrorLogged = true;
+		}
 	}
 
 	saltCache = {
-		value: currentEnvSalt,
+		value,
 		timestamp: now,
 	};
 
-	return currentEnvSalt;
+	return value;
 }
 
 /**

--- a/packages/core/src/truncation-suffix-reserve-2.test.ts
+++ b/packages/core/src/truncation-suffix-reserve-2.test.ts
@@ -70,6 +70,7 @@ describe("truncation suffix reserve batch 2 — 7 real provider sites", () => {
 		};
 		const runtime = {
 			getRecentReportedErrors: () => [entry],
+			redactSecrets: (text: string) => text,
 		} as unknown as import("./types/index.ts").IAgentRuntime;
 		const res = await recentErrorsProvider.get(
 			runtime,

--- a/packages/logger/AGENTS.md
+++ b/packages/logger/AGENTS.md
@@ -31,8 +31,10 @@ bun run --cwd packages/logger format
 
 ## Gotchas
 
-- Leaf package: depends only on `adze` + `fast-redact`. Do NOT add an `@elizaos/*`
+- Leaf package: depends only on `adze`. Do NOT add an `@elizaos/*`
   dependency — that would re-introduce the bundle-coupling this split removed.
+  Secret redaction is the built-in deep-walk redactor in `src/logger.ts`; its
+  key-name policy mirrors `@elizaos/core`'s `security/redact.ts` by hand.
 - Consumers that only need logging should import `@elizaos/logger`, not
   `@elizaos/core`, to stay off the core runtime's module graph.
 - The renderer resolves `@elizaos/logger` to source via a vite alias in

--- a/packages/logger/CLAUDE.md
+++ b/packages/logger/CLAUDE.md
@@ -31,8 +31,10 @@ bun run --cwd packages/logger format
 
 ## Gotchas
 
-- Leaf package: depends only on `adze` + `fast-redact`. Do NOT add an `@elizaos/*`
+- Leaf package: depends only on `adze`. Do NOT add an `@elizaos/*`
   dependency — that would re-introduce the bundle-coupling this split removed.
+  Secret redaction is the built-in deep-walk redactor in `src/logger.ts`; its
+  key-name policy mirrors `@elizaos/core`'s `security/redact.ts` by hand.
 - Consumers that only need logging should import `@elizaos/logger`, not
   `@elizaos/core`, to stay off the core runtime's module graph.
 - The renderer resolves `@elizaos/logger` to source via a vite alias in

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -32,9 +32,9 @@ const child = createLogger({ name: "worker" });
 
 ## Dependencies
 
-Only `adze` (logging backend) and `fast-redact` (secret redaction). Environment
-access is a tiny inlined reader (`src/env.ts`) so the package stays a leaf with
-no `@elizaos/*` dependency.
+Only `adze` (logging backend). Secret redaction is the built-in deep-walk
+redactor in `src/logger.ts`. Environment access is a tiny inlined reader
+(`src/env.ts`) so the package stays a leaf with no `@elizaos/*` dependency.
 
 ## Commands
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -51,12 +51,10 @@
     }
   },
   "dependencies": {
-    "adze": "^2.2.5",
-    "fast-redact": "^3.5.0"
+    "adze": "^2.2.5"
   },
   "devDependencies": {
     "@typescript/native": "npm:typescript@^7.0.2",
-    "@types/fast-redact": "^3.0.4",
     "@types/node": "^24.0.0"
   },
   "elizaos": {

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -399,3 +399,191 @@ describe("stripAnsi", () => {
     expect(stripAnsi("no ansi here")).toBe("no ansi here");
   });
 });
+
+/**
+ * Secret-redaction contract (W1-018/W1-019): the deep-walk redactor must mask
+ * credential-named keys at any depth, case-insensitively — including top-level
+ * keys, UPPERCASE env-style names, `Authorization` headers, and properties on
+ * Error wrappers — without mutating the caller's live objects. Observable
+ * surface is the in-memory ring buffer (`recentLogs`), the same text the
+ * `/api/logs` endpoints and WS stream serve.
+ */
+describe("secret redaction", () => {
+  const redactLogger = () => createLogger({ level: "trace" });
+
+  afterEach(() => {
+    redactLogger().clear();
+  });
+
+  it("masks top-level credential keys", () => {
+    const logger = redactLogger();
+    logger.info({ apiKey: "sk-top-level-secret" }, "ctx");
+    expect(recentLogs()).toContain("apiKey=[REDACTED]");
+    expect(recentLogs()).not.toContain("sk-top-level-secret");
+  });
+
+  it("masks UPPERCASE env-style keys case-insensitively", () => {
+    const logger = redactLogger();
+    logger.info({ OPENAI_API_KEY: "sk-uppercase-secret" }, "ctx");
+    expect(recentLogs()).toContain("OPENAI_API_KEY=[REDACTED]");
+    expect(recentLogs()).not.toContain("sk-uppercase-secret");
+  });
+
+  it("masks keys nested deeper than one level", () => {
+    const logger = redactLogger();
+    logger.info(
+      {
+        provider: { config: { credentials: { clientSecret: "deep-secret" } } },
+      },
+      "ctx",
+    );
+    expect(recentLogs()).not.toContain("deep-secret");
+    expect(recentLogs()).toContain("[REDACTED]");
+  });
+
+  it("masks Authorization headers inside a headers object", () => {
+    const logger = redactLogger();
+    logger.info(
+      { headers: { Authorization: "Bearer header-secret-token" } },
+      "ctx",
+    );
+    expect(recentLogs()).not.toContain("header-secret-token");
+  });
+
+  it("masks the extended credential key variants", () => {
+    const logger = redactLogger();
+    logger.info(
+      {
+        clientSecret: "v-client",
+        secretKey: "v-secret-key",
+        signingSecret: "v-signing",
+        botToken: "v-bot",
+        sessionKey: "v-session",
+        authToken: "v-auth",
+        encryptionKey: "v-encryption",
+        masterKey: "v-master",
+      },
+      "ctx",
+    );
+    const logs = recentLogs();
+    for (const secret of [
+      "v-client",
+      "v-secret-key",
+      "v-signing",
+      "v-bot",
+      "v-session",
+      "v-auth",
+      "v-encryption",
+      "v-master",
+    ]) {
+      expect(logs).not.toContain(secret);
+    }
+  });
+
+  it("redacts credentials carried on an Error wrapper without mutating it", () => {
+    const logger = redactLogger();
+    const err = new Error("request failed");
+    (err as unknown as Record<string, unknown>).config = {
+      headers: { Authorization: "Bearer axios-style-secret" },
+    };
+
+    logger.error(err);
+
+    expect(recentLogs()).not.toContain("axios-style-secret");
+    // The caller's live error object keeps its original values (W1-019).
+    const config = (err as unknown as Record<string, unknown>).config as {
+      headers: { Authorization: string };
+    };
+    expect(config.headers.Authorization).toBe("Bearer axios-style-secret");
+  });
+
+  it("never mutates nested objects the caller keeps using", () => {
+    const logger = redactLogger();
+    const original = { provider: { apiKey: "live-provider-key" } };
+
+    logger.info(original, "ctx");
+
+    expect(original.provider.apiKey).toBe("live-provider-key");
+    expect(recentLogs()).not.toContain("live-provider-key");
+  });
+
+  it("redacts objects passed as trailing args", () => {
+    const logger = redactLogger();
+    logger.info("plain message", { token: "trailing-arg-secret" });
+    expect(recentLogs()).not.toContain("trailing-arg-secret");
+  });
+
+  it("keeps non-secret token-count and key-suffix lookalikes visible", () => {
+    const logger = redactLogger();
+    logger.info(
+      { maxTokens: 2048, monkey: "see", turnkey: "sol", keyboard: "esc" },
+      "ctx",
+    );
+    const logs = recentLogs();
+    expect(logs).toContain("maxTokens=2048");
+    expect(logs).toContain("monkey=see");
+    expect(logs).toContain("turnkey=sol");
+    expect(logs).toContain("keyboard=esc");
+  });
+
+  it("collapses cycles instead of recursing forever", () => {
+    const logger = redactLogger();
+    const cyclic: Record<string, unknown> = { name: "loop" };
+    cyclic.self = cyclic;
+    expect(() => logger.info(cyclic, "ctx")).not.toThrow();
+    expect(recentLogs()).toContain("[Circular]");
+  });
+});
+
+/**
+ * File-sink permission contract (W1-059): output.log/prompts.log/chat.log
+ * must be created 0600, and files left world-readable by older builds must be
+ * healed on first open. Needs a fresh module instance per case because the
+ * sink opens lazily once per process; LOG_FILE is restored afterwards.
+ */
+describe("file sink permissions", () => {
+  it.skipIf(process.platform === "win32")(
+    "creates sinks 0600 and heals a legacy 0644 output.log",
+    async () => {
+      const fs = await import("node:fs/promises");
+      const os = await import("node:os");
+      const path = await import("node:path");
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), "eliza-log-perm-"));
+      const logPath = path.join(dir, "output.log");
+
+      // Legacy sink from an older build: world-readable.
+      await fs.writeFile(logPath, "old line\n");
+      await fs.chmod(logPath, 0o644);
+
+      const previous = process.env.LOG_FILE;
+      process.env.LOG_FILE = logPath;
+      try {
+        vi.resetModules();
+        const fresh = await import("./logger");
+        fresh.logger.info("perm-test-entry");
+        fresh.logPrompt("text", "prompt-body");
+        fresh.logChatIn({
+          agentName: "Eliza",
+          agentId: "agent-1",
+          roomId: "room-123456789",
+          messageId: "message-123456789",
+          text: "hi",
+        });
+
+        const modeOf = async (name: string) =>
+          (await fs.stat(path.join(dir, name))).mode & 0o777;
+        expect(await modeOf("output.log")).toBe(0o600);
+        expect(await modeOf("prompts.log")).toBe(0o600);
+        expect(await modeOf("chat.log")).toBe(0o600);
+        // The legacy content survives the heal (append-only sink).
+        expect(await fs.readFile(logPath, "utf8")).toContain("old line");
+        expect(await fs.readFile(logPath, "utf8")).toContain("perm-test-entry");
+      } finally {
+        if (previous === undefined) delete process.env.LOG_FILE;
+        else process.env.LOG_FILE = previous;
+        vi.resetModules();
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -2,11 +2,16 @@
  * elizaOS's standard structured logger, built on Adze. Exposes the `Logger`
  * interface and the `createLogger` factory (plus the default `logger` /
  * `elizaLogger` singletons) as a Pino-shaped API extended with custom
- * `success`/`progress` levels. Redacts sensitive fields via fast-redact, keeps
+ * `success`/`progress` levels. Redacts sensitive fields with a deep-walk
+ * redactor that deep-clones log context objects (callers keep their live
+ * objects unmutated) and masks every value under a credential-named key at any
+ * nesting depth, matched case-insensitively. String messages are passed through
+ * unredacted — value-shape scanning of free text is `@elizaos/core`'s
+ * security/redact.ts job, which the model-bound sinks apply downstream. Keeps
  * an in-memory ring buffer with real-time listeners for WebSocket streaming,
  * and lazily opens optional file sinks (`output.log`, `prompts.log`,
- * `chat.log`) with prompt/response/chat instrumentation helpers. Adapts between
- * node and a console-based browser path.
+ * `chat.log`, all 0600) with prompt/response/chat instrumentation helpers.
+ * Adapts between node and a console-based browser path.
  */
 // Test hook to clear env cache in logger tests (kept internal)
 export const __loggerTestHooks = {
@@ -38,8 +43,6 @@ interface AdzeLogMethods {
   debug(...args: unknown[]): void;
   verbose(...args: unknown[]): void;
 }
-
-import fastRedact from "fast-redact";
 
 // ============================================================================
 // Type Definitions
@@ -301,46 +304,175 @@ const serverId =
     ? `process-${process.pid}`
     : "edge-runtime");
 
-// Configure sensitive data redaction
-// fast-redact requires bracket notation for top-level keys or wildcard paths for nested
-// Using wildcard paths that match both top-level and nested objects
-let redact: ReturnType<typeof fastRedact>;
-try {
-  redact = fastRedact({
-    paths: [
-      // Wildcard paths for nested objects (also catches some top-level in object context)
-      "*.password",
-      "*.passwd",
-      "*.secret",
-      "*.token",
-      "*.apiKey",
-      "*.api_key",
-      "*.apiSecret",
-      "*.api_secret",
-      "*.authorization",
-      "*.auth",
-      "*.credential",
-      "*.credentials",
-      "*.privateKey",
-      "*.private_key",
-      "*.accessToken",
-      "*.access_token",
-      "*.refreshToken",
-      "*.refresh_token",
-      "*.cookie",
-      "*.session",
-      "*.jwt",
-      "*.bearer",
-    ],
-    serialize: false, // Don't stringify, just redact in place
-    censor: "[REDACTED]",
-  });
-} catch {
-  // Fallback for environments where fast-redact fails (e.g., browser extensions)
-  redact = ((obj: unknown) => obj) as ReturnType<typeof fastRedact>;
-  (redact as { restore?: (obj: unknown) => unknown }).restore = (
-    obj: unknown,
-  ) => obj;
+// ============================================================================
+// Sensitive-data redaction
+// ============================================================================
+
+const REDACTED_VALUE = "[REDACTED]";
+/** Bound on recursion so a pathological payload cannot hang the process. */
+const MAX_REDACT_DEPTH = 8;
+
+/**
+ * Separator-free substrings that mark an object key as holding a credential.
+ * Compared against the lowercased key with `_-. ` stripped, so `apiKey`,
+ * `OPENAI_API_KEY`, and `api.key` all match `apikey`. Mirrors the name policy
+ * of `@elizaos/core`'s security/redact.ts — this leaf package cannot import
+ * it, so the two lists must be kept in sync by hand.
+ */
+const SENSITIVE_KEY_SUBSTRINGS: readonly string[] = [
+  "password",
+  "passwd",
+  "passphrase",
+  "secret",
+  "mnemonic",
+  "seedphrase",
+  "privatekey",
+  "apikey",
+  "accesstoken",
+  "refreshtoken",
+  "authkey",
+  "credential",
+  "authorization",
+  "sessionkey",
+];
+
+/** Whole-key names (normalized) too generic for substring matching. */
+const SENSITIVE_KEY_EXACT: ReadonlySet<string> = new Set([
+  "auth",
+  "session",
+  "jwt",
+  "bearer",
+  "cookie",
+  "dsn",
+]);
+
+/**
+ * Telemetry/schema keys whose names contain "token" but whose values are
+ * counts, budgets, or correlation ids rather than credentials. Closed list,
+ * mirroring core's NON_SECRET_TOKEN_METADATA_KEYS.
+ */
+const NON_SECRET_TOKEN_METADATA_KEYS: ReadonlySet<string> = new Set([
+  "cachecreationinputtokens",
+  "cachereadinputtokens",
+  "completiontokens",
+  "compactionthresholdtokens",
+  "contextwindowtokens",
+  "estimatedinputtokens",
+  "inputtokens",
+  "maxtokens",
+  "maxtokensomitted",
+  "outputtokens",
+  "prompttokens",
+  "reasoningtokens",
+  "reservetokens",
+  "tokencount",
+  "tokencountestimated",
+  "tokenid",
+  "totaltokens",
+]);
+
+/**
+ * Whether an object key names a credential whose value must be masked.
+ * Case-insensitive and depth-independent — the walker applies it to every key
+ * at every level, so top-level and deeply nested secrets are treated alike.
+ */
+function isSensitiveLogKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[_\-. ]/g, "");
+  if (NON_SECRET_TOKEN_METADATA_KEYS.has(normalized)) return false;
+  if (SENSITIVE_KEY_EXACT.has(normalized)) return true;
+  if (SENSITIVE_KEY_SUBSTRINGS.some((needle) => normalized.includes(needle))) {
+    return true;
+  }
+  if (normalized.includes("token")) return true;
+  // Generic `*key` forms (encryptionKey, masterKey, sshKey, OPENAI_KEY) need a
+  // word boundary before "key" so monkey/turnkey/hotkey stay visible.
+  if (/(?:^|[_\-. ])key$/i.test(key) || /[a-z]Key$/.test(key)) return true;
+  // Same boundary treatment for the exact names in suffixed form
+  // (sessionCookie, SESSION_JWT, x-bearer).
+  if (
+    /(?:^|[_\-. ])(jwt|bearer|cookie)$/i.test(key) ||
+    /[a-z](Jwt|Bearer|Cookie)$/.test(key)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Deep-clone a log argument, masking every value under a credential-named key
+ * at any depth. The clone is what gets logged, so redaction never mutates the
+ * caller's live objects (previously a shallow copy let the redactor overwrite
+ * nested credentials in place, corrupting e.g. a provider config mid-use).
+ * Cycles and over-depth payloads collapse to a marker instead of recursing
+ * forever. Error instances keep their name/message/stack shape (Adze renders
+ * it) but their own enumerable properties — axios-style `err.config.headers`
+ * and the like — are walked and masked.
+ */
+function redactLogValue(
+  value: unknown,
+  seen: WeakSet<object>,
+  depth: number,
+): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[Circular]";
+  if (depth >= MAX_REDACT_DEPTH) return REDACTED_VALUE;
+  seen.add(value);
+
+  if (value instanceof Error) {
+    const clone = new Error(value.message);
+    clone.name = value.name;
+    if (value.stack) clone.stack = value.stack;
+    if (value.cause !== undefined) {
+      clone.cause = redactLogValue(value.cause, seen, depth + 1);
+    }
+    const target = clone as unknown as Record<string, unknown>;
+    for (const [key, entry] of Object.entries(value)) {
+      target[key] = isSensitiveLogKey(key)
+        ? REDACTED_VALUE
+        : redactLogValue(entry, seen, depth + 1);
+    }
+    return clone;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactLogValue(item, seen, depth + 1));
+  }
+
+  // Opaque built-ins have no enumerable credential keys to mask and are never
+  // mutated by the walker, so returning them by reference is safe.
+  if (
+    value instanceof Date ||
+    value instanceof RegExp ||
+    value instanceof Map ||
+    value instanceof Set ||
+    value instanceof WeakMap ||
+    value instanceof WeakSet ||
+    value instanceof Promise ||
+    ArrayBuffer.isView(value) ||
+    value instanceof ArrayBuffer
+  ) {
+    return value;
+  }
+
+  // Class instances are cloned into plain objects: JSON serialization only
+  // ever emits own enumerable properties anyway, and walking them here masks
+  // credentials stashed on config/response wrappers (axios-style).
+  const result: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    result[key] = isSensitiveLogKey(key)
+      ? REDACTED_VALUE
+      : redactLogValue(entry, seen, depth + 1);
+  }
+  return result;
+}
+
+/** Redact every object in a trailing-args list; strings pass through. */
+function redactTrailingArgs(args: readonly unknown[]): unknown[] {
+  return args.map((arg) =>
+    arg !== null && typeof arg === "object"
+      ? redactLogValue(arg, new WeakSet<object>(), 0)
+      : arg,
+  );
 }
 
 // ============================================================================
@@ -392,6 +524,26 @@ function stripAnsi(str: string): string {
 }
 
 /**
+ * Open a log sink for appending with owner-only permissions. The `0o600` mode
+ * only applies when the file is first created, so fchmod heals files left
+ * world-readable by older builds. Prompt and chat logs routinely contain
+ * user-pasted secrets, so the sinks must never be group/other-readable.
+ */
+function openLogFilePrivate(
+  fs: typeof import("node:fs"),
+  path: string,
+): number {
+  const fd = fs.openSync(path, "a", 0o600);
+  try {
+    fs.fchmodSync(fd, 0o600);
+  } catch {
+    // error-policy:J6 best-effort permission heal on an already-open sink;
+    // platforms without POSIX chmod semantics keep the creation-time mode.
+  }
+  return fd;
+}
+
+/**
  * Lazily open the log files on the first write.
  * Returns true if the files are ready for writing.
  */
@@ -434,9 +586,9 @@ function ensureFileLog(): boolean {
     const promptLogPath = pathMod.join(logDir, "prompts.log");
     const chatLogPath = pathMod.join(logDir, "chat.log");
 
-    _fileLogFd = fs.openSync(logFilePath, "a");
-    _promptLogFd = fs.openSync(promptLogPath, "a");
-    _chatLogFd = fs.openSync(chatLogPath, "a");
+    _fileLogFd = openLogFilePrivate(fs, logFilePath);
+    _promptLogFd = openLogFilePrivate(fs, promptLogPath);
+    _chatLogFd = openLogFilePrivate(fs, chatLogPath);
     _fileLogState = "active";
 
     process.on("exit", () => {
@@ -1062,10 +1214,14 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
       obj: Record<string, unknown>,
     ): Record<string, unknown> => {
       try {
-        const copy = { ...obj };
-        redact(copy);
-        return copy;
+        return redactLogValue(obj, new WeakSet<object>(), 0) as Record<
+          string,
+          unknown
+        >;
       } catch {
+        // error-policy:J7 logging must never break the runtime; a redactor
+        // failure degrades to the unredacted object, matching the historical
+        // fast-redact fallback behavior.
         return obj;
       }
     };
@@ -1075,24 +1231,28 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
       msg?: string,
       ...args: unknown[]
     ): unknown[] => {
+      // `msg` is typed string but runtime callers pass objects in that slot;
+      // fold it into the trailing args so objects always hit the redactor.
       if (typeof obj === "string") {
-        return msg !== undefined ? [obj, msg, ...args] : [obj, ...args];
+        const rest = msg !== undefined ? [msg, ...args] : args;
+        return [obj, ...redactTrailingArgs(rest)];
       }
       if (obj instanceof Error) {
-        return msg !== undefined
-          ? [obj.message, msg, ...args]
-          : [obj.message, ...args];
+        const rest = msg !== undefined ? [msg, ...args] : args;
+        return [obj.message, ...redactTrailingArgs(rest)];
       }
       // Redact sensitive data from objects
       const redactedObj = safeRedact(obj);
       if (msg !== undefined) {
         // Browser is always pretty mode - format as compact single line
         const formatted = formatPrettyLog(redactedObj, msg, false);
-        return [formatted, ...args];
+        return [formatted, ...redactTrailingArgs(args)];
       }
       // No message - format context only
       const formatted = formatPrettyLog(redactedObj, "", false);
-      return formatted ? [formatted, ...args] : [...args];
+      return formatted
+        ? [formatted, ...redactTrailingArgs(args)]
+        : [...redactTrailingArgs(args)];
     };
 
     return {
@@ -1205,21 +1365,21 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
   };
 
   /**
-   * Safely redact sensitive data from an object
-   * Creates a shallow copy to avoid mutating the original
+   * Safely redact sensitive data from an object.
+   * Deep-clones first so redaction never mutates the caller's live objects.
    */
   const safeRedact = (
     obj: Record<string, unknown>,
   ): Record<string, unknown> => {
     try {
-      // Create a shallow copy to avoid mutating original
-      const copy = { ...obj };
-      // fast-redact returns the redacted string when serialize:false
-      // but mutates the object in place, so we use the copy
-      redact(copy);
-      return copy;
+      return redactLogValue(obj, new WeakSet<object>(), 0) as Record<
+        string,
+        unknown
+      >;
     } catch {
-      // If redaction fails, return original (don't break logging)
+      // error-policy:J7 logging must never break the runtime; a redactor
+      // failure degrades to the unredacted object, matching the historical
+      // fast-redact fallback behavior.
       return obj;
     }
   };
@@ -1236,15 +1396,19 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
     msg?: string,
     ...args: unknown[]
   ): unknown[] => {
-    // String first argument - no context object
+    // String first argument - no context object. `msg` is typed string but
+    // runtime callers do pass objects in that slot; fold it into the trailing
+    // args so anything object-shaped still goes through the redactor.
     if (typeof obj === "string") {
-      return msg !== undefined ? [obj, msg, ...args] : [obj, ...args];
+      const rest = msg !== undefined ? [msg, ...args] : args;
+      return [obj, ...redactTrailingArgs(rest)];
     }
-    // Error object
+    // Error object - the wrapper must be redacted too: error instances can
+    // carry credentials on enumerable properties (request config, headers).
     if (obj instanceof Error) {
-      return msg !== undefined
-        ? [obj.message, { error: obj }, msg, ...args]
-        : [obj.message, { error: obj }, ...args];
+      const errorWrapper = safeRedact({ error: obj });
+      const rest = msg !== undefined ? [msg, ...args] : args;
+      return [obj.message, errorWrapper, ...redactTrailingArgs(rest)];
     }
 
     // Object (context) - redact sensitive data
@@ -1254,19 +1418,21 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
       // Pretty mode: format as compact single line
       if (!raw) {
         const formatted = formatPrettyLog(redactedObj, msg, raw);
-        return [formatted, ...args];
+        return [formatted, ...redactTrailingArgs(args)];
       }
       // JSON mode: keep structured object for machine parsing
-      return [msg, redactedObj, ...args];
+      return [msg, redactedObj, ...redactTrailingArgs(args)];
     }
 
     // No message provided - just context object
     if (!raw) {
       // Pretty mode: format the object as a simple string
       const formatted = formatPrettyLog(redactedObj, "", raw);
-      return formatted ? [formatted, ...args] : [...args];
+      return formatted
+        ? [formatted, ...redactTrailingArgs(args)]
+        : [...redactTrailingArgs(args)];
     }
-    return [redactedObj, ...args];
+    return [redactedObj, ...redactTrailingArgs(args)];
   };
 
   // Create log methods

--- a/packages/scripts/ensure-workspace-symlinks.mjs
+++ b/packages/scripts/ensure-workspace-symlinks.mjs
@@ -145,7 +145,6 @@ function main() {
   // (b) is imported across workspace boundaries.
   const HOIST_TRANSITIVE = [
     { name: "adze", consumer: "@elizaos/logger" },
-    { name: "fast-redact", consumer: "@elizaos/logger" },
   ];
   let hoisted = 0;
   for (const root of NODE_MODULES_DIRS) {

--- a/packages/scripts/ensure-workspace-symlinks.mjs
+++ b/packages/scripts/ensure-workspace-symlinks.mjs
@@ -143,9 +143,7 @@ function main() {
   // Add an entry whenever a workspace package depends on a package that
   // (a) appears in NO root manifest (and so isn't auto-hoisted) and
   // (b) is imported across workspace boundaries.
-  const HOIST_TRANSITIVE = [
-    { name: "adze", consumer: "@elizaos/logger" },
-  ];
+  const HOIST_TRANSITIVE = [{ name: "adze", consumer: "@elizaos/logger" }];
   let hoisted = 0;
   for (const root of NODE_MODULES_DIRS) {
     const nodeModulesRoot = join(REPO_ROOT, root);

--- a/packages/vault/src/external-credentials.ts
+++ b/packages/vault/src/external-credentials.ts
@@ -46,8 +46,10 @@ export class BackendNotSignedInError extends Error {
  * Subprocess executor injected by the manager (tests pass a test executor).
  *
  * Mirrors `node:child_process.execFile` with promises: returns combined
- * stdout/stderr, throws on non-zero exit. The `env` option matters for
- * Bitwarden (BW_SESSION) — 1Password uses an explicit `--session` flag.
+ * stdout/stderr, throws on non-zero exit. The `env` option is how session
+ * tokens reach the CLI (Bitwarden `BW_SESSION`, 1Password `OP_SESSION_*`) so
+ * they never appear in argv, where `ps`/`/proc/<pid>/cmdline` would expose
+ * them to other local users.
  */
 export type ExecFn = (
   cmd: string,
@@ -93,7 +95,8 @@ export async function listOnePasswordLogins(
   vault: Vault,
   exec: ExecFn,
 ): Promise<readonly ExternalLoginListEntry[]> {
-  const sessionArgs = await readOnePasswordSessionArgs(vault, exec);
+  const { args: sessionArgs, env: sessionEnv } =
+    await readOnePasswordSessionArgs(vault, exec);
 
   // Step 1: list Login items as JSON. `--format=json` is the documented
   // machine-readable form; the example in `op item list --help` chains it
@@ -103,7 +106,7 @@ export async function listOnePasswordLogins(
   const listOut = await exec(
     "op",
     [...sessionArgs, "item", "list", "--categories", "Login", "--format=json"],
-    { timeoutMs: 10_000 },
+    { ...(sessionEnv ? { env: sessionEnv } : {}), timeoutMs: 10_000 },
   );
   const items = parseJsonArray<OnePasswordListItem>(listOut.stdout);
 
@@ -142,14 +145,15 @@ export async function revealOnePasswordLogin(
 ): Promise<ExternalLoginReveal> {
   if (!externalId)
     throw new TypeError("revealOnePasswordLogin: externalId required");
-  const sessionArgs = await readOnePasswordSessionArgs(vault, exec);
+  const { args: sessionArgs, env: sessionEnv } =
+    await readOnePasswordSessionArgs(vault, exec);
 
   // `op item get <id> --format=json` includes the full `fields` array with
   // values for username/password/totp.
   const out = await exec(
     "op",
     [...sessionArgs, "item", "get", externalId, "--format=json"],
-    { timeoutMs: 10_000 },
+    { ...(sessionEnv ? { env: sessionEnv } : {}), timeoutMs: 10_000 },
   );
   const item = parseJsonObject<OnePasswordEnrichedItem>(out.stdout);
 
@@ -339,7 +343,7 @@ async function readSessionToken(
 }
 
 /**
- * Resolve op-invocation args (account + session) for one CLI call.
+ * Resolve op-invocation args + env (account + session) for one CLI call.
  *
  * 1Password 8's `op` CLI refuses to pick a default account when more than
  * one is registered — `op whoami` exits 1 with "account is not signed in"
@@ -349,20 +353,39 @@ async function readSessionToken(
  * integration triggers the normal Touch ID flow and the session-token
  * fallback is only used when no account is registered at all.
  *
- * Returns `["--account=<sh>"]` for desktop-app and
- * `["--account=<sh>", "--session=<token>"]` for session-token.
+ * The session token is passed via the `OP_SESSION_<account-shorthand>` env
+ * var, never argv — `--session=<token>` is visible to every local user via
+ * `ps` / `/proc/<pid>/cmdline`. The lone exception is the degenerate
+ * no-registered-account case, where the env var cannot be named and the
+ * (already non-functional) `--session` flag is the only form `op` accepts.
+ *
+ * Returns `{ args: ["--account=<sh>"] }` for desktop-app and
+ * `{ args: ["--account=<sh>"], env: { OP_SESSION_<sh>: token } }` for
+ * session-token.
  */
 async function readOnePasswordSessionArgs(
   vault: Vault,
   exec: ExecFn,
-): Promise<readonly string[]> {
+): Promise<{
+  readonly args: readonly string[];
+  readonly env?: NodeJS.ProcessEnv;
+}> {
   const account = await readDefaultOpAccount(exec);
   const accountArg = account ? [`--account=${account}`] : [];
   if (await isOnePasswordDesktopActiveWithExec(exec, accountArg)) {
-    return accountArg;
+    return { args: accountArg };
   }
   const session = await readSessionToken(vault, "1password");
-  return [...accountArg, `--session=${session}`];
+  if (!account) {
+    // No shorthand → the OP_SESSION_* var cannot be named. A session token
+    // without an account is rejected by `op` anyway, so this path only
+    // preserves the historical behavior for the error to surface.
+    return { args: [...accountArg, `--session=${session}`] };
+  }
+  return {
+    args: accountArg,
+    env: { ...process.env, [`OP_SESSION_${account}`]: session },
+  };
 }
 
 async function readDefaultOpAccount(exec: ExecFn): Promise<string | null> {

--- a/packages/vault/test/external-credentials.test.ts
+++ b/packages/vault/test/external-credentials.test.ts
@@ -215,7 +215,10 @@ describe("external-credentials — 1Password", () => {
       username: "bob@example.com",
       domain: "example.slack.com",
     });
-    // Session token must be passed via --session=, not BW_SESSION env.
+    // No registered account → the OP_SESSION_* env var cannot be named, so
+    // the degenerate fallback keeps the historical `--session=` argv form
+    // (a token without an account is rejected by `op` anyway). The env-var
+    // path for a registered account is covered by the next test.
     const listCall = calls.find(
       (c) => c.args.includes("item") && c.args.includes("list"),
     );
@@ -257,6 +260,39 @@ describe("external-credentials — 1Password", () => {
     expect(out).toHaveLength(1);
     expect(out[0]?.domain).toBeNull();
     expect(out[0]?.url).toBeNull();
+  });
+
+  it("passes the session token via OP_SESSION_* env, never argv (W1-058)", async () => {
+    // Registered account + stored session, desktop integration inactive →
+    // the token must travel as OP_SESSION_<shorthand> in the child env.
+    await vault.set("pm.1password.session", "TOKEN-OP", { sensitive: true });
+    const calls: ExecCall[] = [];
+    const exec = fakeExec(
+      [
+        accountListMy,
+        whoamiFails,
+        {
+          match: (_cmd, args) => args.includes("item") && args.includes("list"),
+          stdout: "[]",
+        },
+      ],
+      calls,
+    );
+
+    const out = await listOnePasswordLogins(vault, exec);
+    expect(out).toEqual([]);
+
+    const listCall = calls.find(
+      (c) => c.args.includes("item") && c.args.includes("list"),
+    );
+    expect(
+      listCall?.args.some((a) => a.startsWith("--session=")),
+      "session token must never appear in argv",
+    ).toBe(false);
+    expect(listCall?.args).toContain("--account=my");
+    expect(listCall?.env?.OP_SESSION_my).toBe("TOKEN-OP");
+    // The token string must not leak anywhere else in the argv list either.
+    expect(listCall?.args.join(" ")).not.toContain("TOKEN-OP");
   });
 
   it("returns [] for empty list (skips enrichment)", async () => {

--- a/plugins/plugin-sql/src/__tests__/unit/pglite-data-dir-permissions.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/pglite-data-dir-permissions.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Verifies `ensurePrivateDir` (W1-020): the PGlite memory DB directory must be
+ * created owner-only (0700) and directories left world-readable by older
+ * installs must be healed on boot, since the tree holds full agent history
+ * and connector ciphertext while PGlite's own files stay 0644. Real temp
+ * directories on the local filesystem; POSIX-only (mode bits are not
+ * enforceable on Windows).
+ */
+import { chmodSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensurePrivateDir } from "../../pglite/manager";
+
+describe.skipIf(process.platform === "win32")("ensurePrivateDir", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), "pglite-privdir-"));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  const modeOf = (dir: string) => statSync(dir).mode & 0o777;
+
+  it("creates a new data dir with mode 0700", () => {
+    const dataDir = path.join(workDir, "fresh-db");
+    ensurePrivateDir(dataDir);
+    expect(modeOf(dataDir)).toBe(0o700);
+  });
+
+  it("creates missing parents and leaves the data dir owner-only", () => {
+    const dataDir = path.join(workDir, "nested", "db");
+    ensurePrivateDir(dataDir);
+    expect(modeOf(dataDir)).toBe(0o700);
+  });
+
+  it("heals a world-readable directory from an older install", () => {
+    const dataDir = path.join(workDir, "legacy-db");
+    ensurePrivateDir(dataDir);
+    chmodSync(dataDir, 0o755);
+    expect(modeOf(dataDir)).toBe(0o755);
+
+    ensurePrivateDir(dataDir);
+    expect(modeOf(dataDir)).toBe(0o700);
+  });
+});

--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -7,7 +7,6 @@
  * Drizzle query-helper subpath, RLS management functions, and the PGlite
  * live-query / Electric Sync status/reset/close accessors used by hosts.
  */
-import { mkdirSync } from "node:fs";
 import type { IDatabaseAdapter, UUID } from "@elizaos/core";
 import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
 import {
@@ -38,6 +37,7 @@ import { PgDatabaseAdapter } from "./pg/adapter";
 import { PostgresConnectionManager } from "./pg/manager";
 import { PgliteDatabaseAdapter } from "./pglite/adapter";
 import {
+  ensurePrivateDir,
   type LiveNamespace,
   PGliteClientManager,
   type PgliteSyncStatus,
@@ -165,7 +165,7 @@ export function createDatabaseAdapter(
   // reserved `:` makes mkdirSync throw (on POSIX it silently creates a junk
   // `:memory:` directory), so skip directory creation for it and for URLs.
   if (dataDir && !dataDir.includes("://") && dataDir !== ":memory:") {
-    mkdirSync(dataDir, { recursive: true });
+    ensurePrivateDir(dataDir);
   }
 
   const manager = getOrCreatePgliteManagerForAgent(globalSingletons, dataDir, agentId, () => {

--- a/plugins/plugin-sql/src/index.ts
+++ b/plugins/plugin-sql/src/index.ts
@@ -7,7 +7,6 @@
  * `PgliteDatabaseAdapter`, and re-exports the RLS management functions plus
  * PGlite live-query / Electric Sync status/reset/close accessors.
  */
-import { mkdirSync } from "node:fs";
 import type { IDatabaseAdapter, UUID } from "@elizaos/core";
 import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
 
@@ -38,6 +37,7 @@ import { PgDatabaseAdapter } from "./pg/adapter";
 import { PostgresConnectionManager } from "./pg/manager";
 import { PgliteDatabaseAdapter } from "./pglite/adapter";
 import {
+  ensurePrivateDir,
   type LiveNamespace,
   PGliteClientManager,
   type PgliteSyncStatus,
@@ -159,7 +159,7 @@ export function createDatabaseAdapter(
   // reserved `:` makes mkdirSync throw (on POSIX it silently creates a junk
   // `:memory:` directory), so skip directory creation for it and for URLs.
   if (dataDir && !dataDir.includes("://") && dataDir !== ":memory:") {
-    mkdirSync(dataDir, { recursive: true });
+    ensurePrivateDir(dataDir);
   }
 
   const manager = getOrCreatePgliteManagerForAgent(globalSingletons, dataDir, agentId, () => {

--- a/plugins/plugin-sql/src/pglite/manager.ts
+++ b/plugins/plugin-sql/src/pglite/manager.ts
@@ -10,6 +10,7 @@
  * always stale.
  */
 import {
+  chmodSync,
   closeSync,
   existsSync,
   mkdirSync,
@@ -52,6 +53,22 @@ type PglitePidFileStatus =
   | "cleared-stale"
   | "cleared-malformed"
   | "check-failed";
+
+/**
+ * Create the PGlite data directory (and parents) owner-only, then heal the
+ * mode on directories left behind by older installs. The memory DB tree holds
+ * full agent history and connector ciphertext, and PGlite creates its files
+ * 0644 — a 0700 root keeps the whole tree unreachable for other local users.
+ */
+export function ensurePrivateDir(dataDir: string): void {
+  mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(dataDir, 0o700);
+  } catch {
+    // error-policy:J6 best-effort heal for directories created by older
+    // installs; platforms without POSIX chmod semantics skip.
+  }
+}
 
 interface PgliteDataDirLockInfo {
   pid: number | null;
@@ -691,7 +708,7 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
       return;
     }
 
-    mkdirSync(dataDir, { recursive: true });
+    ensurePrivateDir(dataDir);
     const lockPath = this.getDataDirLockPath(dataDir);
     for (let attempt = 0; attempt < 2; attempt++) {
       try {


### PR DESCRIPTION
## Summary

Wave-1 security-audit fixes for the **secrets-logging** group. Nine confirmed findings, one commit per area; all were verified still present on `origin/develop` before patching.

| Finding | Severity | Fix |
| --- | --- | --- |
| W1-018 | MEDIUM | Logger redaction missed top-level keys, UPPERCASE env-style names, nesting deeper than one level, `Authorization`, several credential key variants, and the `{ error }` wrapper. Replaced the path-list redactor with a self-contained deep-walk redactor that matches key names case-insensitively at any depth, walks Error wrappers and trailing args, and keeps non-secret lookalikes (`maxTokens`, `monkey`, `turnkey`, `keyboard`) visible. |
| W1-019 | MEDIUM | Logger redaction mutated callers' live objects through a shallow copy (a logged provider config had its credential overwritten in place). The deep-walk redactor now deep-clones first. |
| W1-020 | MEDIUM | PGlite memory DB and state dirs were created world-readable. Data/state dirs are now created `0700` and chmod-healed on every boot so older installs are fixed in place (plugin-sql `ensurePrivateDir`, agent `ensurePrivateDir` in `config/paths.ts`, plus the `PGLITE_DATA_DIR`, `secret-salt`, and `config.env` parent-dir sites). |
| W1-021 | MEDIUM | `GET /api/config` masking missed URL-shaped/misc secret keys (`DATABASE_URL`, `*_URI`, webhook URLs, `sessionKey`, `mnemonic`, `jwt`, `bearer`, `cookie`, `encryptionKey`, `masterKey`, `sshKey`, `signingKey`, `accessKey`). Extended the classifier regex + case-sensitive camelCase companion; contract test round-trips `DATABASE_URL` through the redactor. |
| W1-058 | LOW | 1Password session token traveled on the `op` command line. Now passed via the `OP_SESSION_<account-shorthand>` env var (the Bitwarden `BW_SESSION` pattern). Residual: the degenerate no-registered-account case keeps the flag form because the env var cannot be named there (a token without an account is rejected by `op` anyway). |
| W1-059 | LOW | Logger file sinks (`output.log`/`prompts.log`/`chat.log`) were created world-readable while `prompts.log` routinely contains user-pasted secrets. Sinks are opened `0600` and legacy files are `fchmod`-healed on first open. |
| W1-060 | LOW | `SECRET_SALT` silently defaulted to a hardcoded constant outside production, so dev/staging ciphertext was keyed by a published value. Now generates an ephemeral per-process random salt with a loud warning (ciphertext never keyed by the constant; documented cost: not durable across restart). Production still fails closed; `ELIZA_ALLOW_DEFAULT_SECRET_SALT` remains an explicit opt-in. |
| W1-061 | LOW | `SecretsService` derived its encryption key with the public `agentId` as the KDF password (zero contributed entropy). The active key is now PBKDF2 over the high-entropy salt, domain-bound to the agent (keyId `v2`); the legacy agentId-keyed key stays registered under `default` so pre-existing ciphertext still decrypts. |
| W1-062 | LOW | `RECENT_ERRORS` injected reported-error text (plugin-controlled) into model prompts unscrubbed. `renderText` now runs `runtime.redactSecrets` over the message and serialized context. |

Also: removed the now-unused `fast-redact` dependency from `@elizaos/logger` (leaf package is adze-only; its key-name policy mirrors `core/security/redact.ts` by hand — noted in the package guide) and the stale hoisting entry.

## Test evidence

- `packages/logger`: `test` **29/29** (new suites: top-level/uppercase/deep-nested/Authorization/key-variant masking, Error-wrapper redaction without caller mutation, trailing-arg redaction, false-positive guards, cycle collapse; file-sink 0600 creation + legacy heal), `typecheck` ✓, `lint:check` ✓
- `plugins/plugin-sql`: full `test` **135/135** (new `pglite-data-dir-permissions` suite: 0700 creation + 0755 heal), `typecheck` ✓, biome on changed files ✓, full build (node+browser+cjs) ✓
- `packages/agent`: focused `test` **52/52** (`sensitive-keys`, `paths`, `config-env`, `blocked-env-keys`, `eliza-runtime-settings`), `typecheck` ✓ (upstream `server.ts` error resolved by rebase; `plugin-todos/edge` needed a local build), biome on changed files ✓
- `packages/vault`: full `test` **202/202** (new test: session token only in `OP_SESSION_*` env, never argv), `typecheck` ✓, `lint:check` ✓
- `packages/core`: full `test` **6605 passed / 1 failed** — the failure is `features/documents actions-echo`, verified failing identically on the pristine base (pre-existing, unrelated); `typecheck` ✓, biome on changed files ✓, full multi-target build ✓
- Root **`bun run verify` exit 0** (parity, deps, types, lint, repo audits incl. anti-larp)

## Risk notes

- **Logger redactor is now hand-rolled** (fast-redact dropped): behavior is covered by 11 new redaction tests; string *messages* remain unscanned by design (value-shape scrubbing of model-bound text lives in `core/security/redact.ts`, unchanged).
- **Over-redaction direction** in `/api/config`: `*_URL`/`*_URI`/`*Key`-shaped names now mask in the dashboard even when a specific value is not secret (e.g. a public URL); PUT round-trips still preserve the real value via the existing `[REDACTED]` placeholder stripping. This is the audit-intended trade.
- **Ephemeral salt (W1-060)**: core-embedded consumers that previously relied on the silent default now get per-process ciphertext — persisted secret settings must be re-entered after restart unless `SECRET_SALT` is set. The agent host already persists a stable salt at boot, so standard installs are unaffected.
- **Secrets KDF rotation (W1-061)** is backwards-compatible: old `default`-keyId ciphertext decrypts via the retained legacy key; new writes use `v2`.
- Dir/file healing is best-effort and skips platforms without POSIX chmod semantics.
