### PR TITLE
fix(app-core): reject malformed sensitive-request id encoding

### DIFF
--- a/packages/app-core/src/api/sensitive-request-routes.encoding.test.ts
+++ b/packages/app-core/src/api/sensitive-request-routes.encoding.test.ts
@@ -1,0 +1,195 @@
+/**
+ * GET/POST /api/sensitive-requests/:id path encoding is leftover tax after
+ * avatar / push-token / project-id decode. Stock develop called
+ * decodeURIComponent in firstPathMatch, so `%` / `%2` / `%ZZ` threw URIError
+ * (500) instead of a typed 400. POST collection create stays untouched.
+ *
+ * `@elizaos/core` is mocked so this file does not load logger → pino →
+ * fast-redact. Encoding is a path-decode contract; it does not need the
+ * real policy/delivery implementations.
+ */
+import * as http from "node:http";
+import { Socket } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  defaultSensitiveRequestPolicy: () => ({
+    actor: "owner_or_linked_identity",
+    requirePrivateDelivery: true,
+    requireAuthenticatedLink: true,
+    allowInlineOwnerAppEntry: true,
+    allowPublicLink: false,
+    allowDmFallback: true,
+    allowTunnelLink: true,
+    allowCloudLink: true,
+  }),
+  getTunnelService: () => null,
+  resolveSensitiveRequestDelivery: () => ({
+    mode: "dm_or_owner_app_instruction",
+    source: "api",
+    authenticated: false,
+    publicLinkAllowed: false,
+    instruction: "Ask the owner to use a DM or the owner app.",
+  }),
+  redactSensitiveRequestMetadata: (value: unknown) => value,
+}));
+
+vi.mock("../services/vault-mirror", () => ({
+  sharedVault: () => ({ set: vi.fn() }),
+}));
+
+vi.mock("./auth.ts", () => ({
+  ensureRouteAuthorized: vi.fn(async () => true),
+  getCompatApiToken: () => undefined,
+  getProvidedApiToken: () => undefined,
+  tokenMatches: () => false,
+}));
+
+vi.mock("./compat-route-shared", () => ({
+  isTrustedLocalRequest: () => true,
+  readCompatJsonBody: async (req: { body?: unknown }) => req.body ?? {},
+}));
+
+import type { CompatRuntimeState } from "./compat-route-shared";
+import { handleSensitiveRequestRoutes } from "./sensitive-request-routes";
+import { LocalSensitiveRequestStore } from "./sensitive-request-store";
+
+const STATE: CompatRuntimeState = {
+  current: null,
+  pendingAgentName: null,
+  pendingRestartReasons: [],
+};
+
+function fakeRes(): {
+  res: http.ServerResponse;
+  body: () => unknown;
+  status: () => number;
+} {
+  let bodyText = "";
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.statusCode = 200;
+  res.setHeader = () => res;
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") bodyText += chunk;
+    else if (chunk) bodyText += chunk.toString("utf8");
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    body: () => (bodyText.length > 0 ? JSON.parse(bodyText) : null),
+    status: () => res.statusCode,
+  };
+}
+
+function fakeReq(method: string, pathname: string): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = method;
+  req.url = pathname;
+  req.headers = { host: "localhost:2138" };
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  return req;
+}
+
+async function call(
+  method: string,
+  pathname: string,
+  store = new LocalSensitiveRequestStore(),
+) {
+  const captured = fakeRes();
+  const handled = await handleSensitiveRequestRoutes(
+    fakeReq(method, pathname),
+    captured.res,
+    STATE,
+    { store, now: () => Date.parse("2026-05-10T12:00:00.000Z") },
+  );
+  return { handled, status: captured.status(), body: captured.body() };
+}
+
+describe("GET /api/sensitive-requests/:id encoding", () => {
+  it("POST collection create is untouched", async () => {
+    const captured = fakeRes();
+    const req = fakeReq("POST", "/api/sensitive-requests");
+    (req as { body?: unknown }).body = {
+      kind: "secret",
+      agentId: "agent-local",
+      source: "public",
+      target: { kind: "secret", key: "OPENAI_API_KEY" },
+    };
+    const handled = await handleSensitiveRequestRoutes(req, captured.res, STATE, {
+      store: new LocalSensitiveRequestStore(),
+      now: () => Date.parse("2026-05-10T12:00:00.000Z"),
+    });
+    expect(handled).toBe(true);
+    expect(captured.status()).toBe(201);
+    expect(captured.body()).toEqual(
+      expect.objectContaining({ ok: true, submitToken: expect.any(String) }),
+    );
+  });
+
+  it("canonical id still 404s as not found", async () => {
+    const result = await call("GET", "/api/sensitive-requests/ghost-id");
+    expect(result.handled).toBe(true);
+    expect(result.status).toBe(404);
+    expect(result.body).toEqual({ error: "not found" });
+  });
+
+  it("canonical percent-encoded hyphen still decodes before the 404", async () => {
+    const result = await call("GET", "/api/sensitive-requests/ghost%2Did");
+    expect(result.status).toBe(404);
+    expect(result.body).toEqual({ error: "not found" });
+  });
+
+  it.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed get id %s with 400",
+    async (token) => {
+      const result = await call("GET", `/api/sensitive-requests/${token}`);
+      expect(result.handled).toBe(true);
+      expect(result.status).toBe(400);
+      expect(result.body).toEqual({
+        error: "Invalid request id: malformed URL encoding",
+      });
+    },
+  );
+});
+
+describe("POST /api/sensitive-requests/:id submit/cancel encoding", () => {
+  it.each(["%", "%2", "%ZZ"])(
+    "rejects malformed submit id %s with 400",
+    async (token) => {
+      const result = await call(
+        "POST",
+        `/api/sensitive-requests/${token}/submit`,
+      );
+      expect(result.handled).toBe(true);
+      expect(result.status).toBe(400);
+      expect(result.body).toEqual({
+        error: "Invalid request id: malformed URL encoding",
+      });
+    },
+  );
+
+  it.each(["%", "%2"])(
+    "rejects malformed cancel id %s with 400",
+    async (token) => {
+      const result = await call(
+        "POST",
+        `/api/sensitive-requests/${token}/cancel`,
+      );
+      expect(result.handled).toBe(true);
+      expect(result.status).toBe(400);
+      expect(result.body).toEqual({
+        error: "Invalid request id: malformed URL encoding",
+      });
+    },
+  );
+});

--- a/packages/app-core/src/api/sensitive-request-routes.ts
+++ b/packages/app-core/src/api/sensitive-request-routes.ts
@@ -103,17 +103,39 @@ interface CreateBody {
   policy: unknown;
 }
 
+function decodeRequestId(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // error-policy:J3 leftover tax after avatar / push-token / project-id
+    // path decode. Malformed percent-encoding is invalid client input, not a
+    // vault or submit-token outage. POST /api/sensitive-requests stays
+    // untouched.
+    return null;
+  }
+}
+
 function firstPathMatch(
   pathname: string,
-): { id: string; action: "get" | "submit" | "cancel" } | null {
+):
+  | { id: string; action: "get" | "submit" | "cancel" }
+  | { malformed: true }
+  | null {
   const submit = /^\/api\/sensitive-requests\/([^/]+)\/submit$/.exec(pathname);
-  if (submit?.[1])
-    return { id: decodeURIComponent(submit[1]), action: "submit" };
+  if (submit?.[1]) {
+    const id = decodeRequestId(submit[1]);
+    return id === null ? { malformed: true } : { id, action: "submit" };
+  }
   const cancel = /^\/api\/sensitive-requests\/([^/]+)\/cancel$/.exec(pathname);
-  if (cancel?.[1])
-    return { id: decodeURIComponent(cancel[1]), action: "cancel" };
+  if (cancel?.[1]) {
+    const id = decodeRequestId(cancel[1]);
+    return id === null ? { malformed: true } : { id, action: "cancel" };
+  }
   const get = /^\/api\/sensitive-requests\/([^/]+)$/.exec(pathname);
-  if (get?.[1]) return { id: decodeURIComponent(get[1]), action: "get" };
+  if (get?.[1]) {
+    const id = decodeRequestId(get[1]);
+    return id === null ? { malformed: true } : { id, action: "get" };
+  }
   return null;
 }
 
@@ -552,6 +574,10 @@ export async function handleSensitiveRequestRoutes(
   }
 
   const match = firstPathMatch(pathname);
+  if (match && "malformed" in match) {
+    sendJsonError(res, 400, "Invalid request id: malformed URL encoding");
+    return true;
+  }
   if (!match || !SAFE_ID_RE.test(match.id)) {
     sendJsonError(res, 404, "not found");
     return true;


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
app-core sensitive-request id percent-encoding. Encoding class,
leftover tax after avatar / push-token / project-id decode. Not a
twin of those parsers — this is `GET /api/sensitive-requests/:id`
and `POST /api/sensitive-requests/:id/{submit,cancel}` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on sensitive-request get/submit/cancel.
Canonical `ghost%2Did` still decodes to `ghost-id` and 404s as not
found. Malformed `%` / `%2` / `%ZZ` become 400 instead of an
uncaught `URIError` 500. POST collection `/api/sensitive-requests`
stays untouched.

# Background

## What does this PR do?

`firstPathMatch` called `decodeURIComponent` on the request-id path
segment. Illegal percent-encoding throws `URIError`, which the host
mapped to 500.

- `/api/sensitive-requests/%` / `%2` / `%ZZ` → **400**
- `/api/sensitive-requests/%/submit` / `%/cancel` → **400**
- `/api/sensitive-requests/ghost%2Did` → still decodes to `ghost-id`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded request id
should get a request error, not a 500 that looks like a vault or
submit-token outage. Leftover tax after avatar / push-token /
project-id path decode. Disjoint files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/sensitive-request-routes.encoding.test.ts`

## Detailed testing steps

```bash
cd packages/app-core && bunx vitest run --config vitest.config.ts src/api/sensitive-request-routes.encoding.test.ts
```

12 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; sensitive-request id path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; sensitive-request id path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; sensitive-request id path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before vault or submit-token work; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before vault or submit-token work.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
percent-encoding rejects; omitted/canonical still decode and 404 as
not found. POST collection create stays 201.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the
sensitive-request id path decode only.

## Known gaps / failures

`bun run verify` was not run. Focused 12-test identity suite passed
at this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4be0965a9cdbc11948a9d152bd59f5fb198eaae9 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
