### PR TITLE
fix: align desktop pill with web chat

### DIFF
--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
@@ -9,6 +9,8 @@ import {
   DEFAULT_BOTTOM_BAR_WIDTH,
   EXPANDED_BOTTOM_BAR_HEIGHT,
   EXPANDED_BOTTOM_BAR_WIDTH,
+  HOVER_BOTTOM_BAR_HEIGHT,
+  HOVER_BOTTOM_BAR_WIDTH,
   resolveBottomBarFrameSize,
   resolveDesktopShellWindowPresentation,
   shouldReanchorBottomBar,
@@ -107,10 +109,16 @@ describe("desktop bottom-bar config", () => {
       expect(frame.height).toBe(48);
     });
 
-    it("resolves rest, sign-in chip, and expanded sizes", () => {
+    it("resolves rest, hover preview, sign-in chip, and expanded sizes", () => {
       expect(resolveBottomBarFrameSize({ expanded: false })).toEqual({
         width: DEFAULT_BOTTOM_BAR_WIDTH,
         height: DEFAULT_BOTTOM_BAR_HEIGHT,
+      });
+      expect(
+        resolveBottomBarFrameSize({ expanded: false, hovered: true }),
+      ).toEqual({
+        width: HOVER_BOTTOM_BAR_WIDTH,
+        height: HOVER_BOTTOM_BAR_HEIGHT,
       });
       expect(
         resolveBottomBarFrameSize({ expanded: false, chip: true }),
@@ -124,6 +132,16 @@ describe("desktop bottom-bar config", () => {
           height: EXPANDED_BOTTOM_BAR_HEIGHT,
         },
       );
+      expect(
+        resolveBottomBarFrameSize({
+          expanded: false,
+          chip: true,
+          hovered: true,
+        }),
+      ).toEqual({
+        width: AUTH_GATE_BOTTOM_BAR_WIDTH,
+        height: AUTH_GATE_BOTTOM_BAR_HEIGHT,
+      });
     });
 
     it("constrains the expanded chat hit area instead of spanning the display", () => {
@@ -140,14 +158,20 @@ describe("desktop bottom-bar config", () => {
   });
 
   describe("resolveDesktopShellWindowPresentation", () => {
-    it("reports the bottom-bar presentation by default (#10350)", () => {
+    it("keeps the bottom-bar host transparent on every desktop platform", () => {
       expect(resolveDesktopShellWindowPresentation({}, [], "win32")).toEqual({
         mode: "bottom-bar",
         titleBarStyle: "hidden",
-        transparent: false,
+        transparent: true,
         nativeShadow: false,
       });
       expect(resolveDesktopShellWindowPresentation({}, [], "darwin")).toEqual({
+        mode: "bottom-bar",
+        titleBarStyle: "hidden",
+        transparent: true,
+        nativeShadow: false,
+      });
+      expect(resolveDesktopShellWindowPresentation({}, [], "linux")).toEqual({
         mode: "bottom-bar",
         titleBarStyle: "hidden",
         transparent: true,

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
@@ -82,14 +82,13 @@ export interface DesktopShellWindowPresentation {
 /**
  * Resolve the window presentation for the current shell mode.
  *
- * Transparency is scoped to the chromeless bottom-bar pill on macOS only. The
- * full dashboard ("default") window and kiosk stay opaque: a transparent window
- * over dark web content reads as a full-window frosted sheet (the pill is the
- * only surface that should show the desktop through it). Win/Linux transparency
- * support varies, so the pill also stays opaque there for now (fork gap G4).
- * The transparent macOS pill disables the native window shadow because its
- * visible handle already paints a neutral separator; stacking both creates a
- * heavy halo on light desktops.
+ * Transparency is scoped to the chromeless bottom-bar shell on every desktop
+ * platform. Its renderer paints only the resting pill or shared web chat panel,
+ * so the native host must not expose an opaque rectangle around those surfaces.
+ * The full dashboard ("default") window and kiosk stay opaque. The transparent
+ * pill disables the native window shadow because its visible handle already
+ * paints a neutral separator; stacking both creates a heavy halo on light
+ * desktops.
  */
 export function resolveDesktopShellWindowPresentation(
   env: Record<string, string | undefined> = process.env,
@@ -106,7 +105,7 @@ export function resolveDesktopShellWindowPresentation(
         : platform === "darwin"
           ? "hiddenInset"
           : "default",
-    transparent: bottomBar && platform === "darwin",
+    transparent: bottomBar,
     nativeShadow: !kiosk && !bottomBar,
   };
 }
@@ -119,6 +118,10 @@ export const DEFAULT_BOTTOM_BAR_HEIGHT = 56;
 export const AUTH_GATE_BOTTOM_BAR_WIDTH = 336;
 export const AUTH_GATE_BOTTOM_BAR_HEIGHT = 72;
 
+/** Shallow host for the resting pill's composer preview while hovered. */
+export const HOVER_BOTTOM_BAR_WIDTH = 600;
+export const HOVER_BOTTOM_BAR_HEIGHT = 96;
+
 /** Expanded native hit area around the 560×640 glass panel and bottom pill. */
 export const EXPANDED_BOTTOM_BAR_WIDTH = 600;
 export const EXPANDED_BOTTOM_BAR_HEIGHT = 820;
@@ -127,9 +130,11 @@ export interface BottomBarSizeOptions {
   expanded: boolean;
   /** Labeled needs-auth chip. Ignored while the overlay is expanded. */
   chip?: boolean;
+  /** Resting composer preview. Ignored by expanded and auth-gated states. */
+  hovered?: boolean;
 }
 
-/** Resolve the native bottom-bar size for rest, sign-in chip, or overlay. */
+/** Resolve the native bottom-bar size for rest, hover, sign-in, or overlay. */
 export function resolveBottomBarFrameSize(options: BottomBarSizeOptions): {
   width: number;
   height: number;
@@ -144,6 +149,12 @@ export function resolveBottomBarFrameSize(options: BottomBarSizeOptions): {
     return {
       width: AUTH_GATE_BOTTOM_BAR_WIDTH,
       height: AUTH_GATE_BOTTOM_BAR_HEIGHT,
+    };
+  }
+  if (options.hovered) {
+    return {
+      width: HOVER_BOTTOM_BAR_WIDTH,
+      height: HOVER_BOTTOM_BAR_HEIGHT,
     };
   }
   return {

--- a/packages/app-core/platforms/electrobun/src/desktop-experience-contract.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-experience-contract.test.ts
@@ -42,16 +42,18 @@ describe("desktop experience contract — chat-first launch", () => {
     expect(tagged).toContain("shellMode=chat-overlay");
   });
 
-  it("presents the default window as a transparent, frameless bottom bar (macOS)", () => {
-    const presentation = resolveDesktopShellWindowPresentation(
-      {},
-      [],
-      "darwin",
-    );
-    expect(presentation.mode).toBe("bottom-bar");
-    expect(presentation.titleBarStyle).toBe("hidden");
-    expect(presentation.transparent).toBe(true);
-    expect(presentation.nativeShadow).toBe(false);
+  it("presents the default window as a transparent, frameless bottom bar on every desktop", () => {
+    for (const platform of ["darwin", "win32", "linux"] as const) {
+      const presentation = resolveDesktopShellWindowPresentation(
+        {},
+        [],
+        platform,
+      );
+      expect(presentation.mode).toBe("bottom-bar");
+      expect(presentation.titleBarStyle).toBe("hidden");
+      expect(presentation.transparent).toBe(true);
+      expect(presentation.nativeShadow).toBe(false);
+    }
   });
 
   it("keeps the full dashboard window opaque on macOS — transparency is the pill only (#12184)", () => {

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -414,6 +414,9 @@ describe("DesktopManager main window controls", () => {
     await manager.setBottomBarExpanded({ expanded: false });
     expect(window.setFrame).toHaveBeenLastCalledWith(502, 694, 96, 56);
 
+    await manager.setBottomBarExpanded({ expanded: false, hovered: true });
+    expect(window.setFrame).toHaveBeenLastCalledWith(250, 654, 600, 96);
+
     await manager.setBottomBarExpanded({ expanded: false, chip: true });
     expect(window.setFrame).toHaveBeenLastCalledWith(382, 678, 336, 72);
     await manager.dispose();

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -1542,9 +1542,10 @@ X-GNOME-Autostart-enabled=true
   async setBottomBarExpanded(options: {
     expanded: boolean;
     chip?: boolean;
+    hovered?: boolean;
   }): Promise<void> {
     // Record desired presentation before consulting transient native state. A
-    // missing window/display must not lose a 96↔240↔600 transition.
+    // missing window/display must not lose a rest↔hover↔auth↔panel transition.
     this.bottomBarSize = resolveBottomBarFrameSize(options);
     this.bottomBarFrameDirty = true;
     if (!this.bottomBarReanchorEnabled) return;

--- a/packages/app-core/platforms/electrobun/src/rpc-schema.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-schema.ts
@@ -1454,7 +1454,7 @@ export type ElizaDesktopRPCSchema = {
       desktopGetWindowBounds: { params: undefined; response: WindowBounds };
       desktopSetWindowBounds: { params: WindowBounds; response: undefined };
       desktopSetBottomBarExpanded: {
-        params: { expanded: boolean; chip?: boolean };
+        params: { expanded: boolean; chip?: boolean; hovered?: boolean };
         response: undefined;
       };
       desktopMinimizeWindow: { params: undefined; response: undefined };

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -51,7 +51,7 @@ const CHATVIEW_TSX = readFileSync(
 describe("App standalone chat-overlay wiring", () => {
   it("mounts the chat overlay outside the full chat tab", () => {
     expect(APP_TSX).toContain('shellMode === "chat-overlay"');
-    expect(APP_TSX).toContain("<ShellFoundationMount />");
+    expect(APP_TSX).toContain("<ShellFoundationMount useWebChatPanel />");
     expect(APP_TSX).toContain("pointer-events-none fixed inset-0");
     // The floating glass chat remains available in the main shell, including
     // the ambient /chat route.
@@ -65,20 +65,30 @@ describe("App standalone chat-overlay wiring", () => {
     );
   });
 
-  it("installs the glass recipe and provider truth in the packaged overlay tree", () => {
+  it("opens the packaged desktop pill into the shared web chat panel", () => {
     const overlayShell = APP_TSX.slice(
       APP_TSX.indexOf("function ChatOverlayShell()"),
       APP_TSX.indexOf("function TrayPopoverShell()"),
     );
     const foundation = APP_TSX.slice(
-      APP_TSX.indexOf("function ShellFoundationMount()"),
+      APP_TSX.indexOf("function ShellFoundationMount({"),
       APP_TSX.indexOf("function ChatOverlayMount("),
     );
 
     expect(overlayShell).toContain("<GlassStyles />");
-    expect(foundation).toContain("<ServingProviderChip");
-    expect(foundation.indexOf("<ServingProviderChip")).toBeLessThan(
-      foundation.indexOf("<ChatSurface"),
+    expect(overlayShell).toContain("<ShellFoundationMount useWebChatPanel />");
+    expect(overlayShell).not.toContain("<AppBackground");
+    expect(foundation).toContain("if (useWebChatPanel && shellIsOpen)");
+    expect(foundation).toContain("<ChatOverlayMount");
+    expect(foundation).toContain("onPilledChange={closeWebChatWhenPilled}");
+    expect(foundation).toContain(
+      "hovered: useWebChatPanel && shellPreviewHovered",
+    );
+    expect(foundation).toContain(
+      "useWebChatPanel ? setShellPreviewHovered : undefined",
+    );
+    expect(foundation).toContain(
+      "{!useWebChatPanel ? (\n        <AssistantOverlay",
     );
   });
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -357,7 +357,7 @@ function ChatOverlayShell() {
         data-testid="chat-overlay-shell"
         className="pointer-events-none fixed inset-0 flex items-end justify-center bg-transparent"
       >
-        <ShellFoundationMount />
+        <ShellFoundationMount useWebChatPanel />
       </div>
     </>
   );
@@ -1798,11 +1798,16 @@ function SecretsManagerModalMount(): ReactNode {
   );
 }
 
-function ShellFoundationMount() {
+function ShellFoundationMount({
+  useWebChatPanel = false,
+}: {
+  /** Desktop opens the same draggable chat surface as web, not a separate drawer. */
+  useWebChatPanel?: boolean;
+} = {}) {
   const controller = useShellControllerContext();
   const hasController = controller !== null;
   const shellIsOpen = controller?.isOpen ?? false;
-  const shellNeedsAuth = controller?.phase === "needs-auth";
+  const [shellPreviewHovered, setShellPreviewHovered] = useState(false);
   const { setChatInput } = useChatComposer();
   const chatInputRef = useChatInputRef();
   // Push-to-talk dictation on the ChatSurface mic drops its transcript into
@@ -1811,13 +1816,13 @@ function ShellFoundationMount() {
   // are mutually exclusive App surfaces, so the controller's single sink slot
   // is never contended.
   useEffect(() => {
-    if (!controller) return undefined;
+    if (!controller || useWebChatPanel) return undefined;
     controller.setDictationSink((text) => {
       const current = chatInputRef?.current ?? "";
       setChatInput(current ? `${current} ${text}` : text);
     });
     return () => controller.setDictationSink(null);
-  }, [controller, setChatInput, chatInputRef]);
+  }, [controller, setChatInput, chatInputRef, useWebChatPanel]);
 
   // Global push-to-talk hotkey (#20483): the OS shortcut is trigger-only (no
   // key-up event reaches the renderer), so the hotkey drives the SAME ptt
@@ -1897,7 +1902,10 @@ function ShellFoundationMount() {
       await invokeDesktopBridgeRequestWithTimeout<undefined>({
         rpcMethod: "desktopSetBottomBarExpanded",
         ipcChannel: "desktop:setBottomBarExpanded",
-        params: { expanded: shellIsOpen, chip: shellNeedsAuth },
+        params: {
+          expanded: shellIsOpen,
+          hovered: useWebChatPanel && shellPreviewHovered,
+        },
         timeoutMs: 1_000,
       });
     })();
@@ -1905,8 +1913,24 @@ function ShellFoundationMount() {
     return () => {
       cancelled = true;
     };
-  }, [hasController, shellIsOpen, shellNeedsAuth]);
+  }, [hasController, shellIsOpen, shellPreviewHovered, useWebChatPanel]);
+  const closeWebChatWhenPilled = useCallback(
+    (pilled: boolean) => {
+      if (pilled) controller?.close();
+    },
+    [controller],
+  );
   if (!controller) return null;
+
+  if (useWebChatPanel && shellIsOpen) {
+    return (
+      <ChatOverlayMount
+        releaseFirstRunToHalf={false}
+        onFirstRunReleaseHandled={() => {}}
+        onPilledChange={closeWebChatWhenPilled}
+      />
+    );
+  }
 
   return (
     <>
@@ -1936,32 +1960,37 @@ function ShellFoundationMount() {
           controller.stopRecording();
         }}
         onHoldCancel={controller.cancelRecording}
+        onPreviewHoverChange={
+          useWebChatPanel ? setShellPreviewHovered : undefined
+        }
       />
-      <AssistantOverlay
-        phase={controller.phase}
-        onClose={controller.close}
-        open={controller.isOpen}
-      >
-        <div className="flex h-full min-h-0 flex-col">
-          <div className="flex min-h-6 shrink-0 items-center justify-end pr-8">
-            <ServingProviderChip className="pointer-events-none text-muted-strong" />
+      {!useWebChatPanel ? (
+        <AssistantOverlay
+          phase={controller.phase}
+          onClose={controller.close}
+          open={controller.isOpen}
+        >
+          <div className="flex h-full min-h-0 flex-col">
+            <div className="flex min-h-6 shrink-0 items-center justify-end pr-8">
+              <ServingProviderChip className="pointer-events-none text-muted-strong" />
+            </div>
+            <div className="min-h-0 flex-1">
+              <ChatSurface
+                messages={controller.messages}
+                onSend={controller.send}
+                canSend={controller.canSend}
+                greeting={greetingForTimeOfDay()}
+                recording={controller.recording}
+                onToggleRecording={controller.toggleRecording}
+                onDictateStart={() => controller.startRecording("dictate")}
+                onDictateEnd={controller.stopRecording}
+                onVision={controller.captureVision}
+                visionActive={controller.visionCapturing}
+              />
+            </div>
           </div>
-          <div className="min-h-0 flex-1">
-            <ChatSurface
-              messages={controller.messages}
-              onSend={controller.send}
-              canSend={controller.canSend}
-              greeting={greetingForTimeOfDay()}
-              recording={controller.recording}
-              onToggleRecording={controller.toggleRecording}
-              onDictateStart={() => controller.startRecording("dictate")}
-              onDictateEnd={controller.stopRecording}
-              onVision={controller.captureVision}
-              visionActive={controller.visionCapturing}
-            />
-          </div>
-        </div>
-      </AssistantOverlay>
+        </AssistantOverlay>
+      ) : null}
     </>
   );
 }
@@ -1976,9 +2005,11 @@ function ShellFoundationMount() {
 function ChatOverlayMount({
   releaseFirstRunToHalf,
   onFirstRunReleaseHandled,
+  onPilledChange,
 }: {
   releaseFirstRunToHalf: boolean;
   onFirstRunReleaseHandled: () => void;
+  onPilledChange?: (pilled: boolean) => void;
 }): ReactNode {
   const controller = useShellControllerContext();
   const { characterData, agentStatus, firstRunComplete } =
@@ -2010,6 +2041,7 @@ function ChatOverlayMount({
       firstRunOpen={firstRunComplete === false}
       releaseFirstRunToHalf={releaseFirstRunToHalf}
       onFirstRunReleaseHandled={onFirstRunReleaseHandled}
+      onPilledChange={onPilledChange}
     />
   );
 }

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -4325,14 +4325,19 @@ describe("ChatOverlay single-thread (no chat swipe, #13531)", () => {
 
   it("steps INPUT → pill (CLOSED) on a grabber pull-down, then back to INPUT on tap", () => {
     const { controller } = makeSwipeController();
-    render(<ChatOverlay controller={controller} />);
+    const onPilledChange = vi.fn();
+    render(
+      <ChatOverlay controller={controller} onPilledChange={onPilledChange} />,
+    );
     const sheet = screen.getByTestId("chat-sheet");
     expect(sheet.getAttribute("data-chat-state")).toBe("INPUT");
+    expect(onPilledChange).toHaveBeenLastCalledWith(false);
 
     // INPUT → pill: a downward pull folds the composer into the pill capsule.
     grabberDrag(600, 700, 800);
     expect(sheet.getAttribute("data-detent")).toBe("pill");
     expect(sheet.getAttribute("data-chat-state")).toBe("CLOSED");
+    expect(onPilledChange).toHaveBeenLastCalledWith(true);
 
     // pill → back: a tap on the pill leaves the CLOSED/pill state (it re-forms
     // the bare input bar; thread reveal and keyboard are later gestures).
@@ -4341,6 +4346,7 @@ describe("ChatOverlay single-thread (no chat swipe, #13531)", () => {
     fireEvent.pointerUp(grabber, { clientY: 780, pointerId: 35 });
     expect(sheet.getAttribute("data-detent")).not.toBe("pill");
     expect(sheet.getAttribute("data-chat-state")).not.toBe("CLOSED");
+    expect(onPilledChange).toHaveBeenLastCalledWith(false);
   });
 
   it("an upward hold in the restore zone keeps it MAXIMIZED (only a downward pull exits)", () => {

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -1173,6 +1173,7 @@ export function ChatOverlay({
   firstRunOpen = false,
   releaseFirstRunToHalf = false,
   onFirstRunReleaseHandled,
+  onPilledChange,
 }: {
   controller: ShellController;
   /** Name shown in the composer placeholder ("Message {agentName}"). Defaults to Eliza. */
@@ -1197,6 +1198,13 @@ export function ChatOverlay({
   releaseFirstRunToHalf?: boolean;
   /** Acknowledges that the retained completion intent reached this overlay. */
   onFirstRunReleaseHandled?: () => void;
+  /**
+   * Reports entry to and exit from the component's own resting pill state.
+   * Desktop uses the pilled edge to collapse its transparent native host back
+   * to the small always-visible pill; web leaves this unset and keeps the
+   * entire transition local to the shared chat surface.
+   */
+  onPilledChange?: (pilled: boolean) => void;
 }): React.JSX.Element {
   const {
     messages,
@@ -1492,6 +1500,9 @@ export function ChatOverlay({
   const pilled = effectiveMode === "pill";
   const sheetOpen = effectiveMode === "half" || effectiveMode === "full";
   const expanded = effectiveMode === "full";
+  React.useEffect(() => {
+    onPilledChange?.(pilled);
+  }, [onPilledChange, pilled]);
   const previousSheetOpenRef = React.useRef(sheetOpen);
   React.useLayoutEffect(() => {
     const wasOpen = previousSheetOpenRef.current;

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -11,11 +11,11 @@
  * mid-hold, or sliding the pointer more than {@link SLIDE_CANCEL_PX} off the
  * pill before releasing.
  *
- * On a cloud-only build the `needs-auth` phase replaces both gestures with a
- * labeled chip that launches Cloud sign-in. Hold is not armed there.
+ * On a cloud-only build the `needs-auth` phase keeps the same neutral resting
+ * affordance; activating it launches Cloud sign-in. Hold is not armed there.
  */
 
-import { LoaderCircle, LogIn } from "lucide-react";
+import { AudioWaveform, Plus } from "lucide-react";
 import * as React from "react";
 
 import { useBranding } from "../../config/branding";
@@ -42,6 +42,9 @@ export interface HomePillProps {
   /** True while Cloud sign-in is in flight from this pill. Pulses the
    *  `needs-auth` chip so the wait is visible. */
   signingIn?: boolean;
+  /** Reports the idle pill's shallow composer-preview hover state. Desktop
+   *  uses this to widen the transparent native hit area before painting it. */
+  onPreviewHoverChange?: (hovered: boolean) => void;
 }
 
 /** How long the pointer must stay down before a press becomes a hold. Above
@@ -88,7 +91,7 @@ const PROCESS_DOTS = [
  * Each shell phase reads distinctly at a glance (the capsule is the only
  * always-visible surface, so it carries all ambient status):
  *   booting     — dim pulsing handle ("waking up").
- *   needs-auth  — orange labeled action ("Sign in with {appName} Cloud").
+ *   needs-auth  — same neutral handle and hover preview as idle.
  *   idle        — solid white handle ("here, ready").
  *   listening   — dark chip, live waveform bars ("mic is hot").
  *   processing  — dark chip, pulsing dots — mic closed,
@@ -107,6 +110,7 @@ export function HomePill({
   onHoldCancel,
   speaking = false,
   signingIn = false,
+  onPreviewHoverChange,
 }: HomePillProps): React.JSX.Element {
   const { appName } = useBranding();
   const needsAuth = phase === "needs-auth";
@@ -115,6 +119,23 @@ export function HomePill({
   // the overlay closed, and treating it as open would flash the label/pressed
   // state during every hold (#20483).
   const isOpen = phase === "summoned" || phase === "responding";
+  const previewEligible = phase === "idle" || needsAuth;
+  const [previewHovered, setPreviewHovered] = React.useState(false);
+
+  const setPreviewHover = React.useCallback(
+    (hovered: boolean) => {
+      const next = previewEligible && hovered;
+      setPreviewHovered(next);
+      onPreviewHoverChange?.(next);
+    },
+    [onPreviewHoverChange, previewEligible],
+  );
+
+  React.useEffect(() => {
+    if (previewEligible || !previewHovered) return;
+    setPreviewHovered(false);
+    onPreviewHoverChange?.(false);
+  }, [onPreviewHoverChange, previewEligible, previewHovered]);
 
   const holdTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const holdActiveRef = React.useRef(false);
@@ -218,8 +239,7 @@ export function HomePill({
   }, [isOpen, onOpen, onClose]);
 
   const signInLabel = `Sign in with ${appName} Cloud`;
-  const chipExpanded =
-    phase === "listening" || phase === "processing" || needsAuth;
+  const chipExpanded = phase === "listening" || phase === "processing";
   const label = needsAuth
     ? signingIn
       ? `Signing in to ${appName} Cloud`
@@ -247,11 +267,13 @@ export function HomePill({
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerCancel}
+      onMouseEnter={() => setPreviewHover(true)}
+      onMouseLeave={() => setPreviewHover(false)}
       style={{ zIndex: Z_SHELL_OVERLAY }}
       className={cn(
         "group pointer-events-auto relative mb-2 flex items-center justify-center rounded-full bg-transparent p-0",
-        needsAuth ? "h-12 w-[18rem]" : "h-8 w-16",
-        "transition-transform duration-200 hover:bg-transparent",
+        previewHovered ? "h-20 w-[36rem]" : "h-8 w-16",
+        "transition-[width,height,transform] duration-200 hover:bg-transparent motion-reduce:transition-none",
         needsAuth ? "active:scale-[0.96]" : "active:scale-95",
         "focus-visible:bg-transparent focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
       )}
@@ -262,18 +284,18 @@ export function HomePill({
         className={cn(
           "flex items-center justify-center rounded-full",
           "transition-[width,height,opacity,transform,background-color,box-shadow] duration-200",
-          // Listening/processing/needs-auth grow the capsule into a dark chip.
-          // Listening carries live bars; processing swaps them for dots;
-          // needs-auth fills the chip with the sign-in label.
-          needsAuth
-            ? "h-11 w-full gap-2 bg-[#FF5800] px-5 group-hover:bg-[#D94B00]"
+          // Listening/processing grow the capsule into a dark status chip.
+          // Logged-out and idle states share the neutral handle/hover preview.
+          previewHovered
+            ? "h-16 w-full justify-start overflow-hidden border border-white/55 bg-[linear-gradient(180deg,rgba(38,39,40,0.98),rgba(18,19,21,0.98))] px-6"
             : chipExpanded
               ? "h-7 w-20 gap-[3px] bg-neutral-900/95"
               : "h-2.5 w-12 gap-[3px] bg-white/95 group-hover:w-14",
-          needsAuth
-            ? "shadow-[0_8px_24px_rgba(255,88,0,0.42),0_0_0_1px_rgba(255,255,255,0.18)]"
+          previewHovered
+            ? "shadow-[0_14px_36px_rgba(0,0,0,0.42),inset_0_1px_0_rgba(255,255,255,0.12)]"
             : chipExpanded && "shadow-[0_4px_16px_rgba(0,0,0,0.35)]",
           !chipExpanded &&
+            !previewHovered &&
             (phase === "responding"
               ? speaking
                 ? // Speaking: stronger, tighter warm glow than thinking — the
@@ -288,29 +310,29 @@ export function HomePill({
             "animate-pulse opacity-90 motion-reduce:animate-none",
         )}
       >
-        {needsAuth && (
+        {previewHovered && (
           <>
-            {signingIn ? (
-              <LoaderCircle
-                aria-hidden="true"
-                data-testid="shell-home-pill-sign-in-spinner"
-                className="size-4 shrink-0 animate-spin text-white motion-reduce:animate-none"
-                strokeWidth={2}
-              />
-            ) : (
-              <LogIn
-                aria-hidden="true"
-                data-testid="shell-home-pill-sign-in-icon"
-                className="size-4 shrink-0 text-white"
-                strokeWidth={2}
-              />
-            )}
+            <Plus
+              aria-hidden="true"
+              data-testid="shell-home-pill-preview-plus"
+              className="size-7 shrink-0 text-white"
+              strokeWidth={2}
+            />
             <span
-              data-testid="shell-home-pill-sign-in"
-              className="whitespace-nowrap text-sm font-semibold leading-none text-white"
+              data-testid="shell-home-pill-preview-label"
+              className="ml-6 whitespace-nowrap text-lg font-normal leading-none text-white/85"
             >
-              {signInLabel}
+              Message {appName}
             </span>
+            <span className="absolute inset-x-0 top-4 flex justify-center">
+              <span className="h-2 w-12 rounded-full bg-white/95" />
+            </span>
+            <AudioWaveform
+              aria-hidden="true"
+              data-testid="shell-home-pill-preview-waveform"
+              className="ml-auto size-7 shrink-0 text-white"
+              strokeWidth={2}
+            />
           </>
         )}
         {phase === "listening" &&

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -44,6 +44,47 @@ describe("HomePill", () => {
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
+  it("expands the resting handle into a compact composer preview on hover", () => {
+    const onPreviewHoverChange = vi.fn();
+    render(
+      <HomePill
+        phase="idle"
+        onOpen={() => {}}
+        onClose={() => {}}
+        onPreviewHoverChange={onPreviewHoverChange}
+      />,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.mouseEnter(btn);
+
+    expect(btn.className).toContain("w-[36rem]");
+    expect(screen.getByTestId("shell-home-pill-mark").className).toContain(
+      "h-16",
+    );
+    expect(
+      screen.getByTestId("shell-home-pill-preview-label").textContent,
+    ).toBe("Message Eliza");
+    expect(screen.getByTestId("shell-home-pill-preview-plus")).toBeTruthy();
+    expect(screen.getByTestId("shell-home-pill-preview-waveform")).toBeTruthy();
+    expect(onPreviewHoverChange).toHaveBeenLastCalledWith(true);
+
+    fireEvent.mouseLeave(btn);
+    expect(btn.className).toContain("w-16");
+    expect(screen.queryByTestId("shell-home-pill-preview-label")).toBeNull();
+    expect(onPreviewHoverChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("uses the same hover composer while Cloud auth is required", () => {
+    render(
+      <HomePill phase="needs-auth" onOpen={() => {}} onClose={() => {}} />,
+    );
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    expect(
+      screen.getByTestId("shell-home-pill-preview-label").textContent,
+    ).toBe("Message Eliza");
+    expect(screen.queryByTestId("shell-home-pill-sign-in")).toBeNull();
+  });
+
   it("calls onClose when clicked from summoned", () => {
     const onClose = vi.fn();
     render(<HomePill phase="summoned" onOpen={() => {}} onClose={onClose} />);
@@ -179,7 +220,7 @@ describe("HomePill", () => {
     expect(mark.className).not.toContain("animate-pulse");
   });
 
-  it("grows into a labeled sign-in chip while needs-auth and does not arm hold", () => {
+  it("keeps the neutral resting handle while needs-auth and does not arm hold", () => {
     const onOpen = vi.fn();
     const hold = holdHandlers();
     render(
@@ -195,22 +236,20 @@ describe("HomePill", () => {
     });
     expect(btn.getAttribute("data-phase")).toBe("needs-auth");
     expect(btn.hasAttribute("aria-pressed")).toBe(false);
-    expect(screen.getByTestId("shell-home-pill-sign-in").textContent).toBe(
-      "Sign in with Eliza Cloud",
-    );
     const mark = screen.getByTestId("shell-home-pill-mark");
-    expect(btn.className).toContain("h-12");
-    expect(btn.className).toContain("w-[18rem]");
-    expect(mark.className).toContain("h-11");
-    expect(mark.className).toContain("w-full");
-    expect(mark.className).toContain("bg-[#FF5800]");
-    expect(screen.getByTestId("shell-home-pill-sign-in-icon")).toBeTruthy();
+    expect(btn.className).toContain("h-8");
+    expect(btn.className).toContain("w-16");
+    expect(mark.className).toContain("h-2.5");
+    expect(mark.className).toContain("w-12");
+    expect(mark.className).toContain("bg-white/95");
+    expect(mark.className).not.toContain("bg-[#FF5800]");
+    expect(screen.queryByTestId("shell-home-pill-sign-in-icon")).toBeNull();
     expect(screen.queryAllByTestId("shell-home-pill-wave-bar")).toHaveLength(0);
     fireEvent.click(btn);
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the sign-in chip opaque and shows a spinner during Cloud login", () => {
+  it("keeps the neutral handle and accessible busy state during Cloud login", () => {
     render(
       <HomePill
         phase="needs-auth"
@@ -222,7 +261,9 @@ describe("HomePill", () => {
     const mark = screen.getByTestId("shell-home-pill-mark");
     expect(mark.className).not.toContain("opacity-65");
     expect(mark.className).not.toContain("animate-pulse");
-    expect(screen.getByTestId("shell-home-pill-sign-in-spinner")).toBeTruthy();
+    expect(mark.className).toContain("bg-white/95");
+    expect(mark.className).not.toContain("bg-[#FF5800]");
+    expect(screen.queryByTestId("shell-home-pill-sign-in-spinner")).toBeNull();
     expect(screen.queryByTestId("shell-home-pill-sign-in-icon")).toBeNull();
     const btn = screen.getByRole("button", {
       name: /signing in to eliza cloud/i,


### PR DESCRIPTION
# Relates to

Operator-requested desktop shell refinement; no linked issue was provided.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun run verify` completed; it is currently blocked by the unrelated orphaned-plugin-test inventory documented below.
- [x] The installed cloud-only macOS build was exercised directly.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - local contribution workflow skill used; no portable repository revision available`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync; unrelated blocker documented below.

# Risks

Medium. This changes desktop shell geometry, pointer hover transitions, authentication presentation, and which shared chat surface is mounted. Web behavior is intentionally retained through the existing shared `ChatOverlay` implementation.

# Background

## What does this PR do?

- Keeps the desktop app in a small neutral resting pill.
- Expands that pill into a compact `Message Eliza` composer preview on hover.
- Removes the orange logged-out sign-in chip while preserving click-to-auth behavior.
- Opens the same draggable/resizable chat panel used by the web interface.
- Keeps the native desktop window transparent so no wallpaper or background shell appears behind chat.
- Collapses the native host when the shared chat panel is dragged back to its pill state.

## What kind of change is this?

Bug fix and desktop interface improvement.

# Documentation changes needed?

No public documentation change is required; the behavior is covered by component and native contract tests.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/components/shell/HomePill.tsx`, then follow the desktop `chat-overlay` branch in `packages/ui/src/App.tsx` and native geometry resolution in `packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts`.

## Detailed testing steps

1. Build/install a cloud-only Electrobun macOS app.
2. Remove `localStorage.steward_session_token` and restart the app.
3. Confirm the logged-out resting surface is a neutral white handle with no orange sign-in chip.
4. Hover the handle and confirm it widens into the compact `Message Eliza` composer preview.
5. Click the pill, authenticate, and confirm the opened surface is only the shared web chat panel.
6. Drag the chat panel between supported sizes and back to pill state.

Automated checks:

- `bun install` — passed with Bun 1.3.14.
- UI focused suite — 236 tests passed.
- Electrobun focused suite — 57 tests passed.
- `bun run --cwd packages/ui typecheck` — passed.
- `bun run --cwd packages/app-core/platforms/electrobun typecheck` — passed.
- `bun run verify` — blocked before workspace typecheck/lint by the existing 394-item orphaned plugin/vendor test inventory.

# Evidence Gate

<!-- evidence-head:9dd230256f08d5bb72485bf772e164a2b0ab0602 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: pending attachment during draft review.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: native logged-out pill was visually verified; attachment pending.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: privacy-safe native capture pending.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - this is renderer/native-window presentation behavior with no backend request contract change.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: pending evidence capture.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no database, memory, scheduling, wallet, or generated-domain artifact changed.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: pending evidence capture.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

Backend logs are N/A because this change does not alter backend behavior. Frontend evidence remains pending while this PR is in draft.

## Screenshots (before / after) + video walkthrough

Pending attachment during draft review. The current installed cloud-only app was rebuilt, signed, installed, restarted after deleting only `steward_session_token`, and visually checked in its neutral logged-out pill state.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- `bun run verify` stops at `ensure-plugin-test-conventions:check` because the current repository reports 394 orphaned plugin/vendor tests, primarily under vendored OpenCode and llama.cpp paths. None of those paths are touched by this PR.
- The latest full `packages/app` audit/evidence capture is not complete; this PR remains a draft until required UI evidence is attached.
