### PR TITLE
fix(app-core): reject malformed secrets-inventory key encoding

### DIFF
--- a/packages/app-core/src/api/secrets-inventory-routes.encoding.test.ts
+++ b/packages/app-core/src/api/secrets-inventory-routes.encoding.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Inventory key/profile path encoding is leftover tax after
+ * sensitive-request id decode. Stock develop called decodeURIComponent
+ * on /api/secrets/inventory/:key[...], so `%` / `%2` / `%ZZ` threw
+ * URIError (500) instead of a typed 400. GET /api/secrets/inventory
+ * list and GET /api/secrets/routing stay untouched.
+ *
+ * `@elizaos/vault` and auth are mocked so this file does not load the
+ * real vault or OWNER gate. Encoding is a path-decode contract.
+ */
+import * as http from "node:http";
+import { Socket } from "node:net";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const vaultMocks = vi.hoisted(() => ({
+  listVaultInventory: vi.fn(async () => []),
+  readRoutingConfig: vi.fn(async () => ({})),
+  readEntryMeta: vi.fn(async () => null),
+  has: vi.fn(async () => false),
+  reveal: vi.fn(),
+}));
+
+vi.mock("@elizaos/vault", () => ({
+  listVaultInventory: vaultMocks.listVaultInventory,
+  profileStorageKey: (key: string, profileId: string) =>
+    `${key}.profile.${profileId}`,
+  ROUTING_KEY: "_routing",
+  readEntryMeta: vaultMocks.readEntryMeta,
+  readRoutingConfig: vaultMocks.readRoutingConfig,
+  removeEntryMeta: vi.fn(),
+  setEntryMeta: vi.fn(),
+  writeRoutingConfig: vi.fn(),
+}));
+
+vi.mock("../services/vault-mirror", () => ({
+  sharedVault: () => ({
+    has: vaultMocks.has,
+    reveal: vaultMocks.reveal,
+  }),
+}));
+
+vi.mock("./auth.ts", () => ({
+  ensureRouteMinRole: vi.fn(async () => true),
+  ensureCompatSensitiveRouteAuthorized: vi.fn(() => true),
+}));
+
+import { handleSecretsInventoryRoute } from "./secrets-inventory-routes";
+
+function fakeRes(): {
+  res: http.ServerResponse;
+  body: () => unknown;
+  status: () => number;
+} {
+  let bodyText = "";
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.statusCode = 200;
+  res.setHeader = () => res;
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") bodyText += chunk;
+    else if (chunk) bodyText += chunk.toString("utf8");
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    body: () => (bodyText ? JSON.parse(bodyText) : null),
+    status: () => res.statusCode,
+  };
+}
+
+function req(method: string, pathname: string): http.IncomingMessage {
+  const incoming = new http.IncomingMessage(new Socket());
+  incoming.method = method;
+  incoming.url = pathname;
+  incoming.headers = { host: "127.0.0.1" };
+  return incoming;
+}
+
+const STATE = { current: null };
+
+describe("GET /api/secrets/inventory/:key encoding", () => {
+  beforeEach(() => {
+    vaultMocks.listVaultInventory.mockClear();
+    vaultMocks.readRoutingConfig.mockClear();
+    vaultMocks.readEntryMeta.mockClear();
+    vaultMocks.has.mockClear();
+  });
+
+  it("GET /api/secrets/inventory list is untouched", async () => {
+    const res = fakeRes();
+    const handled = await handleSecretsInventoryRoute(
+      req("GET", "/api/secrets/inventory"),
+      res.res,
+      "/api/secrets/inventory",
+      "GET",
+      STATE,
+    );
+    expect(handled).toBe(true);
+    expect(res.status()).toBe(200);
+    expect(res.body()).toEqual({ ok: true, entries: [] });
+    expect(vaultMocks.listVaultInventory).toHaveBeenCalled();
+    expect(vaultMocks.readEntryMeta).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/secrets/routing is untouched", async () => {
+    const res = fakeRes();
+    const handled = await handleSecretsInventoryRoute(
+      req("GET", "/api/secrets/routing"),
+      res.res,
+      "/api/secrets/routing",
+      "GET",
+      STATE,
+    );
+    expect(handled).toBe(true);
+    expect(res.status()).toBe(200);
+    expect(vaultMocks.readRoutingConfig).toHaveBeenCalled();
+    expect(vaultMocks.readEntryMeta).not.toHaveBeenCalled();
+  });
+
+  it("canonical percent-encoded key still reaches vault lookup", async () => {
+    vaultMocks.has.mockResolvedValueOnce(false);
+    const res = fakeRes();
+    await handleSecretsInventoryRoute(
+      req("GET", "/api/secrets/inventory/OPENAI%5FAPI%5FKEY"),
+      res.res,
+      "/api/secrets/inventory/OPENAI%5FAPI%5FKEY",
+      "GET",
+      STATE,
+    );
+    expect(vaultMocks.readEntryMeta).toHaveBeenCalledWith(
+      expect.anything(),
+      "OPENAI_API_KEY",
+    );
+    expect(vaultMocks.has).toHaveBeenCalledWith("OPENAI_API_KEY");
+  });
+
+  it.each([
+    "/api/secrets/inventory/%",
+    "/api/secrets/inventory/%2",
+    "/api/secrets/inventory/%ZZ",
+    "/api/secrets/inventory/%E0%A4/profiles",
+  ])("rejects malformed %s with 400", async (pathname) => {
+    const res = fakeRes();
+    const handled = await handleSecretsInventoryRoute(
+      req("GET", pathname),
+      res.res,
+      pathname,
+      "GET",
+      STATE,
+    );
+    expect(handled).toBe(true);
+    expect(res.status()).toBe(400);
+    expect(res.body()).toEqual({
+      error: expect.stringContaining("malformed URL encoding"),
+    });
+    expect(vaultMocks.readEntryMeta).not.toHaveBeenCalled();
+    expect(vaultMocks.has).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/src/api/secrets-inventory-routes.ts
+++ b/packages/app-core/src/api/secrets-inventory-routes.ts
@@ -81,6 +81,22 @@ function isReservedKey(key: string): boolean {
   );
 }
 
+function decodeInventoryPathSegment(
+  raw: string,
+  res: http.ServerResponse,
+  field: string,
+): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // error-policy:J3 leftover tax after sensitive-request id decode.
+    // Malformed percent-encoding is invalid client input, not a vault outage.
+    // GET /api/secrets/inventory list and GET /api/secrets/routing stay untouched.
+    sendJsonError(res, 400, `invalid ${field}: malformed URL encoding`);
+    return null;
+  }
+}
+
 export async function handleSecretsInventoryRoute(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -202,17 +218,26 @@ export async function handleSecretsInventoryRoute(
   const activeProfileMatch = activeProfileRe.exec(tail);
 
   if (profileIdMatch) {
-    key = decodeURIComponent(profileIdMatch[1] ?? "");
-    profileId = decodeURIComponent(profileIdMatch[2] ?? "");
+    key = decodeInventoryPathSegment(profileIdMatch[1] ?? "", res, "key");
+    if (key === null) return true;
+    profileId = decodeInventoryPathSegment(
+      profileIdMatch[2] ?? "",
+      res,
+      "profileId",
+    );
+    if (profileId === null) return true;
     segment = "profile";
   } else if (profilesMatch) {
-    key = decodeURIComponent(profilesMatch[1] ?? "");
+    key = decodeInventoryPathSegment(profilesMatch[1] ?? "", res, "key");
+    if (key === null) return true;
     segment = "profiles";
   } else if (activeProfileMatch) {
-    key = decodeURIComponent(activeProfileMatch[1] ?? "");
+    key = decodeInventoryPathSegment(activeProfileMatch[1] ?? "", res, "key");
+    if (key === null) return true;
     segment = "active-profile";
   } else if (!tail.includes("/")) {
-    key = decodeURIComponent(tail);
+    key = decodeInventoryPathSegment(tail, res, "key");
+    if (key === null) return true;
     segment = "key";
   } else {
     return false;


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
app-core secrets-inventory key percent-encoding. Encoding class,
leftover tax after sensitive-request id decode. Not a twin of
those parsers — this is `GET /api/secrets/inventory/:key` and
profile subpaths only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on inventory key/profile segments.
Canonical `OPENAI%5FAPI%5FKEY` still decodes to `OPENAI_API_KEY` and
reaches vault lookup. Malformed `%` / `%2` / `%ZZ` become 400
instead of an uncaught `URIError` 500. GET `/api/secrets/inventory`
list and GET `/api/secrets/routing` stay untouched.

# Background

## What does this PR do?

`handleSecretsInventoryRoute` called `decodeURIComponent` on the
inventory key and profile-id path segments. Illegal percent-encoding
throws `URIError`, which the host mapped to 500.

- `/api/secrets/inventory/%` / `%2` / `%ZZ` → **400**
- `/api/secrets/inventory/%E0%A4/profiles` → **400**
- `/api/secrets/inventory/OPENAI%5FAPI%5FKEY` → still decodes to `OPENAI_API_KEY`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded inventory key
should get a request error, not a 500 that looks like a vault
outage. Leftover tax after sensitive-request id decode. Disjoint
files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/secrets-inventory-routes.encoding.test.ts`

## Detailed testing steps

```bash
cd packages/app-core && bunx vitest run --config vitest.config.ts src/api/secrets-inventory-routes.encoding.test.ts
```

7 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; inventory key path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; inventory key path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; inventory key path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before vault reads; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before vault reads.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
percent-encoding rejects; omitted/canonical still decode and reach
vault lookup.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the inventory key
path decode only.

## Known gaps / failures

`bun run verify` was not run. Focused 7-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes. Sibling `secrets-routes-auth.test.ts` still hits
the known `@elizaos/core` → logger → missing `fast-redact` hole and
was not forced with `bun install`.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9b40d04b5532f19a98fcacd327b726023f5cab70 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
