### PR TITLE
fix(app-core): reject malformed secrets-login path encoding

### DIFF
--- a/packages/app-core/src/api/secrets-manager-routes.encoding.test.ts
+++ b/packages/app-core/src/api/secrets-manager-routes.encoding.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Saved-login path encoding is leftover tax after sensitive-request id
+ * decode. Stock develop called decodeURIComponent on
+ * GET/PUT /api/secrets/logins/:domain/autoallow and
+ * GET/DELETE /api/secrets/logins/:domain/:user, so `%` / `%2` / `%ZZ`
+ * threw URIError (500) instead of a typed 400. GET /api/secrets/logins
+ * list and POST collection create stay untouched.
+ *
+ * `@elizaos/vault` and auth are mocked so this file does not load the
+ * real vault or OWNER gate. Encoding is a path-decode contract.
+ */
+import * as http from "node:http";
+import { Socket } from "node:net";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const vaultMocks = vi.hoisted(() => ({
+  getAutofillAllowed: vi.fn(async () => false),
+  getSavedLogin: vi.fn(async () => null),
+  deleteSavedLogin: vi.fn(async () => undefined),
+  setSavedLogin: vi.fn(async () => undefined),
+  createManager: vi.fn(),
+}));
+
+vi.mock("@elizaos/vault", () => ({
+  createManager: vaultMocks.createManager,
+  deleteSavedLogin: vaultMocks.deleteSavedLogin,
+  getAutofillAllowed: vaultMocks.getAutofillAllowed,
+  getSavedLogin: vaultMocks.getSavedLogin,
+  resolveRunnableMethods: vi.fn(() => []),
+  setAutofillAllowed: vi.fn(),
+  setSavedLogin: vaultMocks.setSavedLogin,
+}));
+
+vi.mock("../services/vault-mirror", () => ({
+  sharedVault: () => ({}),
+}));
+
+vi.mock("../services/secrets-manager-installer", () => ({
+  _resetSecretsManagerInstallerForTesting: vi.fn(),
+  getSecretsManagerInstaller: vi.fn(),
+}));
+
+vi.mock("./auth.ts", () => ({
+  ensureRouteMinRole: vi.fn(async () => true),
+  ensureCompatSensitiveRouteAuthorized: vi.fn(() => true),
+}));
+
+import {
+  _setSecretsManagerForTesting,
+  handleSecretsManagerRoute,
+} from "./secrets-manager-routes";
+
+function fakeRes(): {
+  res: http.ServerResponse;
+  body: () => unknown;
+  status: () => number;
+} {
+  let bodyText = "";
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.statusCode = 200;
+  res.setHeader = () => res;
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") bodyText += chunk;
+    else if (chunk) bodyText += chunk.toString("utf8");
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    body: () => (bodyText ? JSON.parse(bodyText) : null),
+    status: () => res.statusCode,
+  };
+}
+
+function req(method: string, pathname: string): http.IncomingMessage {
+  const incoming = new http.IncomingMessage(new Socket());
+  incoming.method = method;
+  incoming.url = pathname;
+  incoming.headers = { host: "127.0.0.1" };
+  return incoming;
+}
+
+const STATE = { current: null };
+
+describe("GET/DELETE /api/secrets/logins/:domain encoding", () => {
+  beforeEach(() => {
+    vaultMocks.getAutofillAllowed.mockClear();
+    vaultMocks.getSavedLogin.mockClear();
+    vaultMocks.deleteSavedLogin.mockClear();
+    _setSecretsManagerForTesting({
+      listAllSavedLogins: async () => ({ logins: [], failures: [] }),
+    } as never);
+  });
+
+  it("GET /api/secrets/logins list is untouched", async () => {
+    const res = fakeRes();
+    const handled = await handleSecretsManagerRoute(
+      req("GET", "/api/secrets/logins"),
+      res.res,
+      "/api/secrets/logins",
+      "GET",
+      STATE,
+    );
+    expect(handled).toBe(true);
+    expect(res.status()).toBe(200);
+    expect(res.body()).toEqual({ ok: true, logins: [], failures: [] });
+    expect(vaultMocks.getAutofillAllowed).not.toHaveBeenCalled();
+    expect(vaultMocks.getSavedLogin).not.toHaveBeenCalled();
+  });
+
+  it("canonical percent-encoded domain still reaches autofill lookup", async () => {
+    vaultMocks.getAutofillAllowed.mockResolvedValueOnce(true);
+    const res = fakeRes();
+    await handleSecretsManagerRoute(
+      req("GET", "/api/secrets/logins/example%2Ecom/autoallow"),
+      res.res,
+      "/api/secrets/logins/example%2Ecom/autoallow",
+      "GET",
+      STATE,
+    );
+    expect(vaultMocks.getAutofillAllowed).toHaveBeenCalledWith(
+      {},
+      "example.com",
+    );
+    expect(res.status()).toBe(200);
+  });
+
+  it.each([
+    ["/api/secrets/logins/%/autoallow", "GET"],
+    ["/api/secrets/logins/%2/autoallow", "GET"],
+    ["/api/secrets/logins/%ZZ/autoallow", "GET"],
+    ["/api/secrets/logins/%E0%A4/user", "DELETE"],
+  ])("rejects malformed %s with 400", async (pathname, method) => {
+    const res = fakeRes();
+    const handled = await handleSecretsManagerRoute(
+      req(method, pathname),
+      res.res,
+      pathname,
+      method,
+      STATE,
+    );
+    expect(handled).toBe(true);
+    expect(res.status()).toBe(400);
+    expect(res.body()).toEqual({
+      error: expect.stringContaining("malformed URL encoding"),
+    });
+    expect(vaultMocks.getAutofillAllowed).not.toHaveBeenCalled();
+    expect(vaultMocks.getSavedLogin).not.toHaveBeenCalled();
+    expect(vaultMocks.deleteSavedLogin).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/src/api/secrets-manager-routes.ts
+++ b/packages/app-core/src/api/secrets-manager-routes.ts
@@ -391,6 +391,22 @@ export async function handleSecretsManagerRoute(
 const LOGIN_PATH_RE = /^\/api\/secrets\/logins\/([^/]+)\/([^/]+)$/;
 const LOGIN_AUTOALLOW_RE = /^\/api\/secrets\/logins\/([^/]+)\/autoallow$/;
 
+function decodeLoginPathSegment(
+  raw: string,
+  res: http.ServerResponse,
+  field: string,
+): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // error-policy:J3 leftover tax after sensitive-request id decode.
+    // Malformed percent-encoding is invalid client input, not a vault outage.
+    // GET /api/secrets/logins list and POST collection create stay untouched.
+    sendJsonError(res, 400, `invalid ${field}: malformed URL encoding`);
+    return null;
+  }
+}
+
 function isUnifiedSource(
   v: unknown,
 ): v is "in-house" | "1password" | "bitwarden" {
@@ -513,7 +529,8 @@ async function handleSavedLoginsRoute(
       sendJsonError(res, 400, "missing domain");
       return true;
     }
-    const domain = decodeURIComponent(rawDomain);
+    const domain = decodeLoginPathSegment(rawDomain, res, "domain");
+    if (domain === null) return true;
     if (method === "GET") {
       const allowed = await getAutofillAllowed(vault, domain);
       sendJson(res, 200, { ok: true, allowed });
@@ -550,8 +567,10 @@ async function handleSavedLoginsRoute(
       sendJsonError(res, 400, "missing path segment");
       return true;
     }
-    const domain = decodeURIComponent(rawDomain);
-    const username = decodeURIComponent(rawUser);
+    const domain = decodeLoginPathSegment(rawDomain, res, "domain");
+    if (domain === null) return true;
+    const username = decodeLoginPathSegment(rawUser, res, "username");
+    if (username === null) return true;
 
     if (method === "GET") {
       const login = await getSavedLogin(vault, domain, username);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
app-core secrets-login path percent-encoding. Encoding class,
leftover tax after sensitive-request id decode. Not a twin of
those parsers — this is `GET/PUT /api/secrets/logins/:domain/autoallow`
and `GET/DELETE /api/secrets/logins/:domain/:user` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on saved-login domain/username.
Canonical `example%2Ecom` still decodes to `example.com` and reaches
autofill lookup. Malformed `%` / `%2` / `%ZZ` become 400 instead of
an uncaught `URIError` 500. GET `/api/secrets/logins` list and POST
collection create stay untouched.

# Background

## What does this PR do?

`handleSavedLoginsRoute` called `decodeURIComponent` on the domain
and username path segments. Illegal percent-encoding throws
`URIError`, which the host mapped to 500.

- `/api/secrets/logins/%/autoallow` / `%2` / `%ZZ` → **400**
- `/api/secrets/logins/%E0%A4/user` → **400**
- `/api/secrets/logins/example%2Ecom/autoallow` → still decodes to `example.com`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded login domain
should get a request error, not a 500 that looks like a vault
outage. Leftover tax after sensitive-request id decode. Disjoint
files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/secrets-manager-routes.encoding.test.ts`

## Detailed testing steps

```bash
cd packages/app-core && bunx vitest run --config vitest.config.ts src/api/secrets-manager-routes.encoding.test.ts
```

6 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; saved-login path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; saved-login path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; saved-login path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before vault reads; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before vault reads.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
percent-encoding rejects; omitted/canonical still decode and reach
autofill lookup.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the saved-login
path decode only.

## Known gaps / failures

`bun run verify` was not run. Focused 6-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes. Sibling `secrets-routes-auth.test.ts` still hits
the known `@elizaos/core` → logger → missing `fast-redact` hole and
was not forced with `bun install`.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4e744053fc62420bfe9b2ab54dd86b9da9d85609 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
