### PR TITLE
fix(plugin-local-inference): reject malformed voice-profiles-management id encoding

### DIFF
--- a/plugins/plugin-local-inference/src/routes/voice-profiles-management-routes.encoding.test.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-profiles-management-routes.encoding.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Voice-profile management path encoding is leftover tax after OmniVoice
+ * /v1/voice/profiles id decode. Stock develop called decodeURIComponent on
+ * /api/voice/profiles/:id[...], so `%` / `%2` / `%ZZ` threw URIError (500)
+ * instead of a typed 400. GET /api/voice/profiles list and POST /export
+ * stay untouched.
+ *
+ * `@elizaos/core` is mocked so this file does not load logger → fast-redact.
+ * Encoding is a path-decode contract.
+ */
+import * as http from "node:http";
+import { Socket } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+	logger: { warn() {}, debug() {}, info() {}, error() {} },
+	readJsonBody: async () => null,
+	resolveStateDir: () => "/tmp",
+	sendJson: (
+		res: http.ServerResponse,
+		body: unknown,
+		status = 200,
+	) => {
+		res.statusCode = status;
+		res.end(JSON.stringify(body));
+	},
+	sendJsonError: (
+		res: http.ServerResponse,
+		message: string,
+		status = 400,
+	) => {
+		res.statusCode = status;
+		res.end(JSON.stringify({ error: message }));
+	},
+}));
+
+import type { VoiceProfileStore } from "../services/voice/profile-store";
+
+const {
+	handleVoiceProfilesManagementRoutes,
+	setVoiceProfilesManagementStore,
+}: typeof import("./voice-profiles-management-routes") = await import(
+	"./voice-profiles-management-routes"
+);
+
+const store = {
+	list: vi.fn(async () => []),
+	get: vi.fn(async () => null),
+};
+
+beforeEach(() => {
+	store.list.mockClear();
+	store.get.mockClear();
+	setVoiceProfilesManagementStore(store as unknown as VoiceProfileStore);
+});
+
+afterEach(() => {
+	setVoiceProfilesManagementStore(null);
+});
+
+function request(method: string, pathname: string): http.IncomingMessage {
+	const req = new http.IncomingMessage(new Socket());
+	req.method = method;
+	req.url = pathname;
+	return req;
+}
+
+function response(): {
+	res: http.ServerResponse;
+	status: () => number;
+	body: () => unknown;
+} {
+	let raw = "";
+	const req = new http.IncomingMessage(new Socket());
+	const res = new http.ServerResponse(req);
+	res.statusCode = 200;
+	res.setHeader = () => res;
+	res.end = ((chunk?: string | Buffer) => {
+		if (typeof chunk === "string") raw += chunk;
+		else if (chunk) raw += chunk.toString("utf8");
+		return res;
+	}) as typeof res.end;
+	return {
+		res,
+		status: () => res.statusCode,
+		body: () => (raw ? JSON.parse(raw) : null),
+	};
+}
+
+describe("DELETE /api/voice/profiles/:id encoding", () => {
+	it("GET /api/voice/profiles list is untouched", async () => {
+		const out = response();
+		const handled = await handleVoiceProfilesManagementRoutes(
+			request("GET", "/api/voice/profiles"),
+			out.res,
+		);
+		expect(handled).toBe(true);
+		expect(out.status()).toBe(200);
+		expect(out.body()).toEqual({ profiles: [] });
+		expect(store.list).toHaveBeenCalled();
+		expect(store.get).not.toHaveBeenCalled();
+	});
+
+	it("canonical percent-encoded id still reaches store lookup", async () => {
+		const out = response();
+		await handleVoiceProfilesManagementRoutes(
+			request("DELETE", "/api/voice/profiles/guest%2Did"),
+			out.res,
+		);
+		expect(store.get).toHaveBeenCalledWith("guest-id");
+		expect(out.status()).toBe(404);
+	});
+
+	it.each([
+		"/api/voice/profiles/%",
+		"/api/voice/profiles/%2",
+		"/api/voice/profiles/%ZZ",
+		"/api/voice/profiles/%E0%A4/unbind",
+	])("rejects malformed %s with 400", async (pathname) => {
+		const out = response();
+		const handled = await handleVoiceProfilesManagementRoutes(
+			request("DELETE", pathname),
+			out.res,
+		);
+		expect(handled).toBe(true);
+		expect(out.status()).toBe(400);
+		expect(out.body()).toEqual({
+			error: "invalid profile id: malformed URL encoding",
+		});
+		expect(store.get).not.toHaveBeenCalled();
+		expect(store.list).not.toHaveBeenCalled();
+	});
+});

--- a/plugins/plugin-local-inference/src/routes/voice-profiles-management-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-profiles-management-routes.ts
@@ -192,6 +192,18 @@ function validId(id: string): boolean {
 	return PROFILE_ID_RE.test(id);
 }
 
+function decodeProfileId(raw: string): string | null {
+	try {
+		return decodeURIComponent(raw);
+	} catch {
+		// error-policy:J3 leftover tax after OmniVoice /v1/voice/profiles id
+		// decode. Malformed percent-encoding is invalid client input, not a
+		// VoiceProfileStore outage. GET /api/voice/profiles list and POST
+		// /export stay untouched.
+		return null;
+	}
+}
+
 export async function handleVoiceProfilesManagementRoutes(
 	req: http.IncomingMessage,
 	res: http.ServerResponse,
@@ -216,7 +228,11 @@ export async function handleVoiceProfilesManagementRoutes(
 
 	const m = ID_SUB.exec(pathname);
 	if (!m) return false;
-	const id = decodeURIComponent(m[1] ?? "");
+	const id = decodeProfileId(m[1] ?? "");
+	if (id === null) {
+		sendJsonError(res, "invalid profile id: malformed URL encoding", 400);
+		return true;
+	}
 	const sub = m[2];
 	if (!validId(id)) {
 		sendJsonError(res, `invalid profile id: ${id}`, 400);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
plugin-local-inference voice-profiles-management id percent-encoding.
Encoding class, leftover tax after OmniVoice `/v1/voice/profiles` id
decode. Not a twin of those parsers — this is
`/api/voice/profiles/:id[...]` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on management profile-id segments.
Canonical `guest%2Did` still decodes to `guest-id` and reaches store
lookup. Malformed `%` / `%2` / `%ZZ` become 400 instead of an
uncaught `URIError` 500. GET `/api/voice/profiles` list and POST
`/export` stay untouched.

# Background

## What does this PR do?

`handleVoiceProfilesManagementRoutes` called `decodeURIComponent` on
the profile-id path segment. Illegal percent-encoding throws
`URIError`, which the host mapped to 500.

- `/api/voice/profiles/%` / `%2` / `%ZZ` → **400**
- `/api/voice/profiles/%E0%A4/unbind` → **400**
- `/api/voice/profiles/guest%2Did` → still decodes to `guest-id`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded profile id
should get a request error, not a 500 that looks like a
VoiceProfileStore outage. Leftover tax after OmniVoice
`/v1/voice/profiles` id decode. Disjoint files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/src/routes/voice-profiles-management-routes.encoding.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-local-inference && bunx vitest run --config vitest.config.ts src/routes/voice-profiles-management-routes.encoding.test.ts
```

6 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; management profile-id path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; management profile-id path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; management profile-id path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before store reads; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before store reads.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
percent-encoding rejects; list/export stay untouched; canonical
ids still decode and reach store lookup.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the management
profile-id path decode only.

## Known gaps / failures

`bun run verify` was not run. Focused 6-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes. The suite fully mocks `@elizaos/core` so it does
not hit the known logger → missing `fast-redact` hole and was not
forced with `bun install`.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a75e48ce8255f95defa7a0e337625a4ad0a11dfa -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
