### PR TITLE
fix(app-core): reject malformed database-rows table-name encoding

### DIFF
--- a/packages/app-core/src/api/database-rows-compat-routes.encoding.test.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.encoding.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Database-rows compat path encoding is leftover tax after agent
+ * `database.ts` path work. Stock develop called decodeURIComponent on
+ * GET /api/database/tables/:name/rows, so `%` / `%2` / `%ZZ` threw
+ * URIError (500) instead of a typed 400. Non-rows paths and the
+ * already-fail-closed limit/offset parsers stay untouched.
+ *
+ * `@elizaos/core` is fully mocked so this file does not load
+ * logger → fast-redact. Encoding is a path-decode contract.
+ */
+import http from "node:http";
+import { Socket } from "node:net";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  executeRawSql: vi.fn(),
+}));
+
+vi.mock("@elizaos/core", () => ({
+  ElizaError: class ElizaError extends Error {
+    readonly code: string;
+    readonly context?: Record<string, unknown>;
+    readonly severity?: string;
+
+    constructor(
+      message: string,
+      options: {
+        code: string;
+        context?: Record<string, unknown>;
+        severity?: string;
+      },
+    ) {
+      super(message);
+      this.name = "ElizaError";
+      this.code = options.code;
+      this.context = options.context;
+      this.severity = options.severity;
+    }
+  },
+  logger: { warn() {}, debug() {}, info() {}, error() {} },
+}));
+
+vi.mock("@elizaos/shared", () => ({
+  executeRawSql: mocks.executeRawSql,
+  quoteIdent: (value: string) => `"${String(value).replace(/"/g, '""')}"`,
+  sanitizeIdentifier: (value: string | null | undefined) => {
+    if (value == null) return null;
+    const trimmed = String(value).trim();
+    return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed) ? trimmed : null;
+  },
+  sqlLiteral: (value: unknown) => `'${String(value).replace(/'/g, "''")}'`,
+}));
+
+vi.mock("./auth.ts", () => ({
+  ensureRouteMinRole: vi.fn(async () => true),
+}));
+
+vi.mock("./compat-route-shared", () => ({
+  DATABASE_UNAVAILABLE_MESSAGE: "Database unavailable",
+  isTrustedLocalRequest: () => false,
+}));
+
+const { handleDatabaseRowsCompatRoute } = await import(
+  "./database-rows-compat-routes"
+);
+
+const STATE_WITH_DB = {
+  current: { adapter: { db: {} } },
+} as unknown as Parameters<typeof handleDatabaseRowsCompatRoute>[2];
+
+function makeReq(url: string): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = "GET";
+  req.url = url;
+  req.headers = { host: "example.test:2138" };
+  return req;
+}
+
+function fakeRes() {
+  let body = "";
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.statusCode = 200;
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") body += chunk;
+    else if (chunk) body += chunk.toString("utf8");
+    return res;
+  }) as typeof res.end;
+  return {
+    json: () => (body ? JSON.parse(body) : null),
+    res,
+    status: () => res.statusCode,
+  };
+}
+
+function stubReadableTable() {
+  mocks.executeRawSql.mockImplementation(async (_runtime, sql: string) => {
+    if (sql.includes("information_schema.columns")) {
+      return { rows: [{ column_name: "id" }, { column_name: "value" }] };
+    }
+    if (sql.includes("count(*)")) {
+      return { rows: [{ total: 2 }] };
+    }
+    return {
+      rows: [
+        { id: 1, value: "a" },
+        { id: 2, value: "b" },
+      ],
+    };
+  });
+}
+
+beforeEach(() => {
+  mocks.executeRawSql.mockReset();
+});
+
+describe("GET /api/database/tables/:name/rows encoding", () => {
+  it("non-rows table path is untouched", async () => {
+    const res = fakeRes();
+    const ensureOwner = vi.fn(async () => true);
+    const handled = await handleDatabaseRowsCompatRoute(
+      makeReq("/api/database/tables/secrets"),
+      res.res,
+      STATE_WITH_DB,
+      { ensureOwner },
+    );
+    expect(handled).toBe(false);
+    expect(ensureOwner).not.toHaveBeenCalled();
+    expect(mocks.executeRawSql).not.toHaveBeenCalled();
+  });
+
+  it("canonical percent-encoded table name still reaches SQL", async () => {
+    stubReadableTable();
+    const res = fakeRes();
+    const ensureOwner = vi.fn(async () => true);
+    const handled = await handleDatabaseRowsCompatRoute(
+      makeReq("/api/database/tables/secret%73/rows?schema=public"),
+      res.res,
+      STATE_WITH_DB,
+      { ensureOwner },
+    );
+    expect(handled).toBe(true);
+    expect(ensureOwner).toHaveBeenCalled();
+    expect(mocks.executeRawSql).toHaveBeenCalled();
+    const sql = mocks.executeRawSql.mock.calls
+      .map((call) => String(call[1]))
+      .join("\n");
+    expect(sql).toContain('"secrets"');
+    expect(res.status()).toBe(200);
+    expect(res.json()).toMatchObject({ table: "secrets", schema: "public" });
+  });
+
+  it.each([
+    "/api/database/tables/%/rows",
+    "/api/database/tables/%2/rows",
+    "/api/database/tables/%ZZ/rows",
+    "/api/database/tables/%E0%A4/rows",
+  ])("rejects malformed %s with 400 before owner or SQL", async (url) => {
+    const res = fakeRes();
+    const ensureOwner = vi.fn(async () => true);
+    const handled = await handleDatabaseRowsCompatRoute(
+      makeReq(url),
+      res.res,
+      STATE_WITH_DB,
+      { ensureOwner },
+    );
+    expect(handled).toBe(true);
+    expect(res.status()).toBe(400);
+    expect(res.json()).toEqual({
+      error: "invalid table name: malformed URL encoding",
+    });
+    expect(ensureOwner).not.toHaveBeenCalled();
+    expect(mocks.executeRawSql).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/src/api/database-rows-compat-routes.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.ts
@@ -70,6 +70,20 @@ function parseDatabaseRowsOffset(raw: string | null): number | null {
   return parsed;
 }
 
+/**
+ * Decode the untrusted `:name` path segment. Leftover tax after agent
+ * `database.ts` path work: stock develop called `decodeURIComponent` on
+ * `/api/database/tables/:name/rows`, so `%` / `%2` / `%ZZ` threw URIError
+ * (500) instead of a typed 400. Limit/offset parsers stay untouched.
+ */
+function decodeTableName(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return null;
+  }
+}
+
 function rememberTableIntrospection(
   key: string,
   resolvedSchema: string,
@@ -101,6 +115,16 @@ export async function handleDatabaseRowsCompatRoute(
     return false;
   }
 
+  const decoded = decodeTableName(match[1] ?? "");
+  if (decoded === null) {
+    sendJsonErrorResponse(
+      res,
+      400,
+      "invalid table name: malformed URL encoding",
+    );
+    return true;
+  }
+
   const ensureOwner = deps.ensureOwner ?? ensureRouteMinRole;
   // Raw table reads expose arbitrary tables (secrets, sessions, identities),
   // so this must require OWNER - matching the sibling `/api/secrets/*` routes -
@@ -115,7 +139,7 @@ export async function handleDatabaseRowsCompatRoute(
     return true;
   }
 
-  const tableName = sanitizeIdentifier(decodeURIComponent(match[1]));
+  const tableName = sanitizeIdentifier(decoded);
   const requestUrl = new URL(req.url ?? "/", "http://localhost");
   const schemaName = sanitizeIdentifier(requestUrl.searchParams.get("schema"));
 


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
app-core database-rows-compat table-name percent-encoding. Encoding
class, leftover tax after agent `database.ts` path work. Not a twin
of those parsers or of #20784 page/limit — this is
`GET /api/database/tables/:name/rows` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on the table-name segment.
Canonical `secret%73` still decodes to `secrets` and reaches SQL.
Malformed `%` / `%2` / `%ZZ` become 400 instead of an uncaught
`URIError` 500. Non-rows table paths and the already-fail-closed
limit/offset parsers stay untouched.

# Background

## What does this PR do?

`handleDatabaseRowsCompatRoute` called `decodeURIComponent` on the
table-name path segment. Illegal percent-encoding throws `URIError`,
which the host mapped to 500.

- `/api/database/tables/%/rows` / `%2` / `%ZZ` → **400**
- `/api/database/tables/%E0%A4/rows` → **400**
- `/api/database/tables/secret%73/rows` → still decodes to `secrets`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded table name
should get a request error, not a 500 that looks like a database
outage. Leftover tax after agent `database.ts` path work. Disjoint
files from those parsers and from #20784.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/database-rows-compat-routes.encoding.test.ts`

## Detailed testing steps

```bash
cd packages/app-core && bunx vitest run --config vitest.config.ts src/api/database-rows-compat-routes.encoding.test.ts
```

6 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; table-name path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; table-name path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; table-name path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before owner or SQL; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before owner or SQL.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal
percent-encoding rejects; non-rows paths stay untouched; canonical
names still decode and reach SQL.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT synthesis change; this is the table-name
path decode only.

## Known gaps / failures

`bun run verify` was not run. Focused 6-test identity suite passed at
this head. Full-repo verify is the same unrelated cost as sibling
leftover-tax Fixes. The suite fully mocks `@elizaos/core` so it does
not hit the known logger → missing `fast-redact` hole and was not
forced with `bun install`. Existing `database-rows-compat-routes.test.ts`
was not edited.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c819f116831ee40f662bc722a49902a2604fd101 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
