### PR TITLE
feat: add desktop cloud target flag

### DIFF
--- a/packages/app-core/scripts/README.md
+++ b/packages/app-core/scripts/README.md
@@ -13,6 +13,20 @@ Most scripts here are invoked from **root `package.json`** (`bun run …`). **Ap
 
 **Full guide (WHYs for signals, `detached`, HMR vs Rollup watch, multiple `bun` PIDs):** [Desktop local development](../docs/apps/desktop-local-development.md)
 
+### Production and staging Cloud targets
+
+Desktop builds use production Eliza Cloud by default. To bake the staging
+control plane into the renderer, pass the explicit build target:
+
+```bash
+node packages/app-core/scripts/desktop-build.mjs build --cloud-only --cloud-target staging
+```
+
+CI can set `ELIZA_DESKTOP_CLOUD_TARGET=staging` instead. Accepted values are
+`production` and `staging`; any other value fails the build. The staging target
+starts from `https://staging.eliza.app`, and the shared domain contract derives
+the matching staging API and authenticated Cloud app hosts.
+
 ### Bun Version (Windows)
 
 - Recommended: **Bun 1.3.x stable** for `dev:win` flows.

--- a/packages/app-core/scripts/desktop-build.mjs
+++ b/packages/app-core/scripts/desktop-build.mjs
@@ -13,6 +13,10 @@ import { fileURLToPath } from "node:url";
 import { resolveElectrobunDir, resolveMainAppDir } from "./lib/app-dir.mjs";
 import { artifactStaleness, maxMtimeUnder } from "./lib/artifact-staleness.mjs";
 import {
+  applyDesktopCloudTarget,
+  resolveDesktopCloudTarget,
+} from "./lib/desktop-cloud-target.mjs";
+import {
   buildWindowsRepairSteps,
   classifyElectrobunViewFailure,
   findElectrobunManifestPath,
@@ -226,6 +230,12 @@ const buildVariant = resolveBuildVariant(
   getArgValue(args, "build-variant") ?? process.env.ELIZA_BUILD_VARIANT,
 );
 const buildEnv = getArgValue(args, "env") ?? process.env.BUILD_ENV ?? "";
+let desktopCloudTarget;
+try {
+  desktopCloudTarget = resolveDesktopCloudTarget(args, process.env);
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}
 // Cloud-only consumer lane: package without the embedded agent runtime and
 // bake the cloud-only brand flag into the bundle. The flag is exported into
 // this process's env so every downstream consumer — the renderer build, the
@@ -945,7 +955,7 @@ function ensureWorkspaceRuntimePackagesBuilt() {
 }
 
 function desktopRendererBuildEnv() {
-  const env = {
+  let env = {
     ...process.env,
     VITE_APP_VARIANT: variant,
     ELIZA_BUILD_VARIANT: buildVariant,
@@ -956,6 +966,7 @@ function desktopRendererBuildEnv() {
     // window global, but Vite-served index.html never runs that inject).
     env.VITE_ELIZA_DESKTOP_RUNTIME_MODE = "cloud";
   }
+  env = applyDesktopCloudTarget(env, desktopCloudTarget);
   if (env.ELIZA_SKIP_LOCAL_UPSTREAMS !== "1") {
     env.ELIZA_FORCE_LOCAL_UPSTREAMS = "1";
   }
@@ -1793,6 +1804,12 @@ Options:
                                    bake cloudOnly into brand-config.json so the
                                    packaged shell runs against Eliza Cloud.
                                    (env: ELIZA_DESKTOP_CLOUD_ONLY=1)
+  --cloud-target <production|staging>
+                                   Bake the selected Eliza Cloud environment
+                                   into the desktop renderer. Staging uses
+                                   https://staging.eliza.app and derives the
+                                   matching API and Cloud app hosts.
+                                   (env: ELIZA_DESKTOP_CLOUD_TARGET)
   --env <channel>                  Electrobun build env (e.g. canary, stable)
   --stage-macos-release-app        Stage a direct macOS .app + DMG from the Electrobun build output
   --exclude-optional-pack <name>   Exclude a manifest-classified optional capability pack during staging
@@ -1803,6 +1820,7 @@ Options:
 
 Environment:
   ELIZA_DESKTOP_COMMAND_PREFIX    Prefix every spawned command, e.g. "arch -x86_64"
+  ELIZA_DESKTOP_CLOUD_TARGET      Desktop Cloud target: production or staging.
   ELIZA_VERIFY_MAS=1              Enable mas-smoke entitlement verification on store builds.
 `);
 }

--- a/packages/app-core/scripts/lib/desktop-cloud-target.mjs
+++ b/packages/app-core/scripts/lib/desktop-cloud-target.mjs
@@ -1,0 +1,57 @@
+/**
+ * Resolves the explicit Cloud environment baked into desktop renderer builds.
+ */
+
+const CLOUD_TARGET_ORIGINS = Object.freeze({
+  production: "https://eliza.app",
+  staging: "https://staging.eliza.app",
+});
+
+/**
+ * Resolve a desktop Cloud target from CLI arguments or the CI-friendly env.
+ * An omitted target preserves the renderer's existing production default and
+ * any explicit `VITE_ELIZA_CLOUD_BASE` override supplied by the operator.
+ */
+export function resolveDesktopCloudTarget(args, env = process.env) {
+  const inline = args.find((arg) => arg.startsWith("--cloud-target="));
+  const exactIndex = args.indexOf("--cloud-target");
+  if (
+    exactIndex >= 0 &&
+    (!args[exactIndex + 1] || args[exactIndex + 1].startsWith("--"))
+  ) {
+    throw new Error(
+      'Desktop Cloud target is missing. Expected "production" or "staging".',
+    );
+  }
+  const cliValue = inline
+    ? inline.slice("--cloud-target=".length)
+    : exactIndex >= 0
+      ? args[exactIndex + 1]
+      : undefined;
+  const raw = cliValue ?? env.ELIZA_DESKTOP_CLOUD_TARGET;
+
+  if (raw === undefined || raw === null || raw.trim() === "") {
+    return null;
+  }
+
+  const target = raw.trim().toLowerCase();
+  if (!(target in CLOUD_TARGET_ORIGINS)) {
+    throw new Error(
+      `Unknown desktop Cloud target "${raw}". Expected "production" or "staging".`,
+    );
+  }
+
+  return {
+    target,
+    origin: CLOUD_TARGET_ORIGINS[target],
+  };
+}
+
+/** Return the renderer env with an explicit target baked in when requested. */
+export function applyDesktopCloudTarget(env, target) {
+  if (!target) return env;
+  return {
+    ...env,
+    VITE_ELIZA_CLOUD_BASE: target.origin,
+  };
+}

--- a/packages/app-core/scripts/lib/desktop-cloud-target.test.mjs
+++ b/packages/app-core/scripts/lib/desktop-cloud-target.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * Verifies deterministic desktop Cloud target selection without running a package build.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  applyDesktopCloudTarget,
+  resolveDesktopCloudTarget,
+} from "./desktop-cloud-target.mjs";
+
+describe("desktop Cloud build target", () => {
+  it("preserves the normal renderer default when no target is supplied", () => {
+    expect(resolveDesktopCloudTarget([], {})).toBeNull();
+  });
+
+  it("maps the staging build flag to the staging marketing origin", () => {
+    expect(
+      resolveDesktopCloudTarget(["--cloud-target", "staging"], {}),
+    ).toEqual({
+      target: "staging",
+      origin: "https://staging.eliza.app",
+    });
+  });
+
+  it("accepts the inline production form", () => {
+    expect(
+      resolveDesktopCloudTarget(["--cloud-target=production"], {}),
+    ).toEqual({
+      target: "production",
+      origin: "https://eliza.app",
+    });
+  });
+
+  it("uses the environment form for CI builds", () => {
+    expect(
+      resolveDesktopCloudTarget([], {
+        ELIZA_DESKTOP_CLOUD_TARGET: "staging",
+      }),
+    ).toEqual({
+      target: "staging",
+      origin: "https://staging.eliza.app",
+    });
+  });
+
+  it("lets an explicit CLI value override the environment", () => {
+    expect(
+      resolveDesktopCloudTarget(["--cloud-target=production"], {
+        ELIZA_DESKTOP_CLOUD_TARGET: "staging",
+      }),
+    ).toEqual({
+      target: "production",
+      origin: "https://eliza.app",
+    });
+  });
+
+  it("rejects unknown targets instead of silently falling back", () => {
+    expect(() =>
+      resolveDesktopCloudTarget(["--cloud-target", "preview"], {}),
+    ).toThrow('Unknown desktop Cloud target "preview"');
+  });
+
+  it("rejects a flag without a value", () => {
+    expect(() => resolveDesktopCloudTarget(["--cloud-target"], {})).toThrow(
+      "Desktop Cloud target is missing",
+    );
+  });
+
+  it("bakes staging into the renderer environment", () => {
+    const target = resolveDesktopCloudTarget(["--cloud-target=staging"], {});
+    expect(
+      applyDesktopCloudTarget(
+        { VITE_ELIZA_CLOUD_BASE: "https://custom.example" },
+        target,
+      ),
+    ).toEqual({ VITE_ELIZA_CLOUD_BASE: "https://staging.eliza.app" });
+  });
+
+  it("preserves an existing renderer override when no target was requested", () => {
+    const env = { VITE_ELIZA_CLOUD_BASE: "https://custom.example" };
+    expect(applyDesktopCloudTarget(env, null)).toBe(env);
+  });
+});


### PR DESCRIPTION
# Relates to

Explicit operator request; no issue or Project card was provided.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the unrelated verification blocker is recorded below.
- [x] A reviewer can confirm the build-target behavior from the focused tests and desktop preflight output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - local contribution workflow skill used; no portable repository revision available`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` was run post-sync; its unrelated `check:i18n` blocker is documented below.

# Risks

Low. The new target is opt-in, production remains the default, accepted values are allowlisted, and invalid values fail before the build proceeds. The main risk is selecting staging intentionally and then using production credentials, which staging correctly rejects because it is a separate environment.

# Background

## What does this PR do?

Adds `--cloud-target <production|staging>` to the desktop build. The staging value bakes `https://staging.eliza.app` into `VITE_ELIZA_CLOUD_BASE`; the existing shared domain contract then derives the corresponding staging API and authenticated Cloud app origins. CI can use `ELIZA_DESKTOP_CLOUD_TARGET=staging`.

When the flag and environment variable are absent, the existing renderer default and any explicit `VITE_ELIZA_CLOUD_BASE` override are preserved.

## What kind of change is this?

Feature: a non-breaking desktop packaging option.

# Documentation changes needed?

The desktop build-script README and command help now document the flag, environment form, accepted values, and staging origin.

# Testing

## Where should a reviewer start?

Start with `packages/app-core/scripts/lib/desktop-cloud-target.mjs`, then inspect its use in `desktopRendererBuildEnv()` in `packages/app-core/scripts/desktop-build.mjs`.

## Detailed testing steps

```bash
bunx vitest run packages/app-core/scripts/lib/desktop-cloud-target.test.mjs
node packages/app-core/scripts/desktop-build.mjs preflight --cloud-target staging
bun run --cwd packages/app-core typecheck
bun run audit:scripts
```

Results on the final rebased head:

- 9 target-resolution and renderer-environment tests passed.
- Desktop preflight passed with Bun 1.3.14 and `--cloud-target staging`.
- Missing and unsupported target values are covered by rejection tests.
- `@elizaos/app-core` typecheck passed.
- Script inventory audit passed.
- Biome and `git diff --check` passed.

# Evidence Gate

<!-- evidence-head:6b7c7c8f0a01bfc5d82b62e2c4928e918645cf13 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this changes build-script configuration and does not alter rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this changes build-script configuration and does not alter rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the acceptance surface is deterministic CLI/build configuration with no visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend request or runtime server path changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime behavior or request path changed; the generated renderer environment is asserted directly.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduling, wallet, or generated-domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - this is a build-time environment-selection seam. The focused tests assert that staging is injected into `VITE_ELIZA_CLOUD_BASE`, production is selected explicitly when requested, custom overrides remain untouched when no target is requested, and invalid input fails closed.

## Screenshots (before / after) + video walkthrough

N/A - no UI files or rendered presentation changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

`bun run verify` currently stops in the pre-existing `check:i18n` gate because `origin/develop` references six missing English translation keys in unrelated billing and login files:

- `cloud.billingTab.invalidPaymentLink`
- `cloud.billingTab.invalidCheckoutUrl`
- `cloud.login.callbackStateMismatch`
- `cloud.login.callbackVerifierMissing`
- `cloud.appCharge.invalidCheckoutLink`
- `cloud.paymentRequest.invalidCheckoutUrl`

This PR changes only desktop build scripts and their documentation/tests; it does not touch those UI call sites or locale catalogs.
