### PR TITLE
fix(core): reject malformed trajectory-detail id encoding

### DIFF
--- a/packages/core/src/features/trajectories/read-routes.encoding.test.ts
+++ b/packages/core/src/features/trajectories/read-routes.encoding.test.ts
@@ -128,4 +128,101 @@ describe("GET /api/trajectories/:id encoding", () => {
 			error: "invalid trajectory id: malformed URL encoding",
 		});
 	});
+
+	it.each([
+		"/api/trajectories/%2F",
+		"/api/trajectories/%5C",
+		"/api/trajectories/%00",
+		"/api/trajectories/%2E",
+		"/api/trajectories/%2E%2E",
+	])(
+		"rejects decoded non-segment id %s before detail lookup",
+		async (pathname) => {
+			let detailCalls = 0;
+			const service = {
+				getTrajectoryDetail: async () => {
+					detailCalls += 1;
+					return null;
+				},
+			};
+			const { res, get } = mockRes();
+			const handled = await tryHandleTrajectoryReadRoutes({
+				pathname,
+				method: "GET",
+				url: url(pathname),
+				runtime: runtimeWith(service),
+				res,
+			});
+			expect(handled).toBe(true);
+			expect(detailCalls).toBe(0);
+			expect(get()).toEqual({
+				status: 400,
+				body: { error: "invalid trajectory id: invalid path segment" },
+			});
+		},
+	);
+
+	it("classifies an encoded stats segment before detail lookup", async () => {
+		let detailCalls = 0;
+		const service = {
+			getStats: async () => ({ count: 3 }),
+			getTrajectoryDetail: async () => {
+				detailCalls += 1;
+				return null;
+			},
+		};
+		const { res, get } = mockRes();
+		const pathname = "/api/trajectories/%73tats";
+		const handled = await tryHandleTrajectoryReadRoutes({
+			pathname,
+			method: "GET",
+			url: url(pathname),
+			runtime: runtimeWith(service),
+			res,
+		});
+		expect(handled).toBe(true);
+		expect(detailCalls).toBe(0);
+		expect(get()).toEqual({ status: 200, body: { count: 3 } });
+	});
+
+	it("leaves an encoded config segment for the host route", async () => {
+		let detailCalls = 0;
+		const service = {
+			getTrajectoryDetail: async () => {
+				detailCalls += 1;
+				return null;
+			},
+		};
+		const { res, get } = mockRes();
+		const pathname = "/api/trajectories/%63onfig";
+		const handled = await tryHandleTrajectoryReadRoutes({
+			pathname,
+			method: "GET",
+			url: url(pathname),
+			runtime: runtimeWith(service),
+			res,
+		});
+		expect(handled).toBe(false);
+		expect(detailCalls).toBe(0);
+		expect(get()).toEqual({ status: 0, body: undefined });
+	});
+
+	it("decodes exactly once", async () => {
+		const seen: string[] = [];
+		const service = {
+			getTrajectoryDetail: async (id: string) => {
+				seen.push(id);
+				return null;
+			},
+		};
+		const { res } = mockRes();
+		await tryHandleTrajectoryReadRoutes({
+			pathname: "/api/trajectories/%252F",
+			method: "GET",
+			url: url("/api/trajectories/%252F"),
+			runtime: runtimeWith(service),
+			res,
+		});
+		expect(seen).toEqual(["%2F"]);
+	});
 });

--- a/packages/core/src/features/trajectories/read-routes.encoding.test.ts
+++ b/packages/core/src/features/trajectories/read-routes.encoding.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Trajectory-detail path encoding is leftover tax after media-store /
+ * views-routes path decode. Stock develop called decodeURIComponent on
+ * GET /api/trajectories/:id before the handler try/catch, so `%` / `%2` /
+ * `%ZZ` threw URIError (500) instead of a typed 400. GET /api/trajectories
+ * list and GET /api/trajectories/stats stay untouched.
+ */
+import type { ServerResponse } from "node:http";
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime } from "../../types";
+import { tryHandleTrajectoryReadRoutes } from "./read-routes";
+
+function mockRes(): {
+	res: ServerResponse;
+	get: () => { status: number; body: unknown };
+} {
+	const state = { status: 0, body: undefined as unknown };
+	const res = {
+		statusCode: 0,
+		setHeader() {},
+		end(payload?: string) {
+			state.status = (this as { statusCode: number }).statusCode;
+			state.body = payload ? JSON.parse(payload) : undefined;
+		},
+	} as unknown as ServerResponse;
+	return { res, get: () => ({ status: state.status, body: state.body }) };
+}
+
+function runtimeWith(service: unknown): IAgentRuntime {
+	return {
+		getService: (type: string) => (type === "trajectories" ? service : null),
+		getRoom: async () => null,
+	} as unknown as IAgentRuntime;
+}
+
+const url = (p: string) => new URL(`http://localhost${p}`);
+
+describe("GET /api/trajectories/:id encoding", () => {
+	it("GET /api/trajectories list is untouched", async () => {
+		const list = {
+			listTrajectories: async () => ({ trajectories: [], total: 0 }),
+			getTrajectoryDetail: async () => {
+				throw new Error("detail must not run on the list path");
+			},
+		};
+		const { res, get } = mockRes();
+		const handled = await tryHandleTrajectoryReadRoutes({
+			pathname: "/api/trajectories",
+			method: "GET",
+			url: url("/api/trajectories"),
+			runtime: runtimeWith(list),
+			res,
+		});
+		expect(handled).toBe(true);
+		expect(get().status).toBe(200);
+		expect(get().body).toEqual({
+			trajectories: [],
+			total: 0,
+			offset: 0,
+			limit: 50,
+		});
+	});
+
+	it("GET /api/trajectories/stats is untouched", async () => {
+		const stats = {
+			getStats: async () => ({ count: 2 }),
+			getTrajectoryDetail: async () => {
+				throw new Error("detail must not run on the stats path");
+			},
+		};
+		const { res, get } = mockRes();
+		const handled = await tryHandleTrajectoryReadRoutes({
+			pathname: "/api/trajectories/stats",
+			method: "GET",
+			url: url("/api/trajectories/stats"),
+			runtime: runtimeWith(stats),
+			res,
+		});
+		expect(handled).toBe(true);
+		expect(get().status).toBe(200);
+		expect(get().body).toEqual({ count: 2 });
+	});
+
+	it("canonical percent-encoded id still reaches detail lookup", async () => {
+		const seen: string[] = [];
+		const service = {
+			getTrajectoryDetail: async (id: string) => {
+				seen.push(id);
+				return null;
+			},
+		};
+		const { res, get } = mockRes();
+		const handled = await tryHandleTrajectoryReadRoutes({
+			pathname: "/api/trajectories/t%2D1",
+			method: "GET",
+			url: url("/api/trajectories/t%2D1"),
+			runtime: runtimeWith(service),
+			res,
+		});
+		expect(handled).toBe(true);
+		expect(seen).toEqual(["t-1"]);
+		expect(get().status).toBe(404);
+		expect(get().body).toEqual({ error: 'Trajectory "t-1" not found' });
+	});
+
+	it.each([
+		"/api/trajectories/%",
+		"/api/trajectories/%2",
+		"/api/trajectories/%ZZ",
+		"/api/trajectories/%E0%A4",
+	])("rejects malformed %s with 400 before detail lookup", async (pathname) => {
+		const service = {
+			getTrajectoryDetail: async () => {
+				throw new Error("detail must not run on malformed encoding");
+			},
+		};
+		const { res, get } = mockRes();
+		const handled = await tryHandleTrajectoryReadRoutes({
+			pathname,
+			method: "GET",
+			url: url(pathname),
+			runtime: runtimeWith(service),
+			res,
+		});
+		expect(handled).toBe(true);
+		expect(get().status).toBe(400);
+		expect(get().body).toEqual({
+			error: "invalid trajectory id: malformed URL encoding",
+		});
+	});
+});

--- a/packages/core/src/features/trajectories/read-routes.ts
+++ b/packages/core/src/features/trajectories/read-routes.ts
@@ -113,11 +113,32 @@ function sendJson(
  * `%ZZ` threw URIError (500) instead of a typed 400. List and stats stay
  * untouched.
  */
-function decodeTrajectoryId(raw: string): string | null {
+function decodeTrajectoryId(
+	raw: string,
+):
+	| { id: string }
+	| { error: "malformed URL encoding" | "invalid path segment" } {
 	try {
-		return decodeURIComponent(raw);
+		const id = decodeURIComponent(raw);
+		const hasControlCharacter = Array.from(id).some((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x1f || codePoint === 0x7f;
+		});
+		if (
+			!id ||
+			id === "." ||
+			id === ".." ||
+			id.includes("/") ||
+			id.includes("\\") ||
+			hasControlCharacter
+		) {
+			return { error: "invalid path segment" };
+		}
+		return { id };
 	} catch {
-		return null;
+		// error-policy:J3 malformed percent escapes are rejected at the route
+		// boundary and never reach the trajectory service.
+		return { error: "malformed URL encoding" };
 	}
 }
 
@@ -304,17 +325,21 @@ export async function tryHandleTrajectoryReadRoutes(options: {
 	// Only the read routes the viewer needs belong to this boundary. Unsupported
 	// mutation and export paths fall through for the API host to reject.
 	const isList = pathname === "/api/trajectories";
-	const isStats = pathname === "/api/trajectories/stats";
+	let isStats = pathname === "/api/trajectories/stats";
 	const idMatch = pathname.match(/^\/api\/trajectories\/([^/]+)$/);
 	let detailId: string | null = null;
-	if (idMatch && idMatch[1] !== "stats" && idMatch[1] !== "config") {
-		detailId = decodeTrajectoryId(idMatch[1] ?? "");
-		if (detailId === null) {
+	if (idMatch) {
+		const decoded = decodeTrajectoryId(idMatch[1] ?? "");
+		if ("error" in decoded) {
 			sendJson(res, 400, {
-				error: "invalid trajectory id: malformed URL encoding",
+				error: `invalid trajectory id: ${decoded.error}`,
 			});
 			return true;
 		}
+		// Classify reserved segments after decoding so percent encoding cannot
+		// turn a host-owned route into a trajectory lookup.
+		if (decoded.id === "stats") isStats = true;
+		else if (decoded.id !== "config") detailId = decoded.id;
 	}
 	if (!isList && !isStats && !detailId) {
 		return false;

--- a/packages/core/src/features/trajectories/read-routes.ts
+++ b/packages/core/src/features/trajectories/read-routes.ts
@@ -106,6 +106,21 @@ function sendJson(
 	res.end(JSON.stringify(body));
 }
 
+/**
+ * Decode the untrusted `:id` path segment. Leftover tax after media-store /
+ * views-routes path work: stock develop called `decodeURIComponent` on
+ * `GET /api/trajectories/:id` before the handler try/catch, so `%` / `%2` /
+ * `%ZZ` threw URIError (500) instead of a typed 400. List and stats stay
+ * untouched.
+ */
+function decodeTrajectoryId(raw: string): string | null {
+	try {
+		return decodeURIComponent(raw);
+	} catch {
+		return null;
+	}
+}
+
 // timeout collapses to the viewer's tri-state "error".
 function normalizeStatus(
 	status: string | undefined,
@@ -291,10 +306,16 @@ export async function tryHandleTrajectoryReadRoutes(options: {
 	const isList = pathname === "/api/trajectories";
 	const isStats = pathname === "/api/trajectories/stats";
 	const idMatch = pathname.match(/^\/api\/trajectories\/([^/]+)$/);
-	const detailId =
-		idMatch && idMatch[1] !== "stats" && idMatch[1] !== "config"
-			? decodeURIComponent(idMatch[1])
-			: null;
+	let detailId: string | null = null;
+	if (idMatch && idMatch[1] !== "stats" && idMatch[1] !== "config") {
+		detailId = decodeTrajectoryId(idMatch[1] ?? "");
+		if (detailId === null) {
+			sendJson(res, 400, {
+				error: "invalid trajectory id: malformed URL encoding",
+			});
+			return true;
+		}
+	}
 	if (!isList && !isStats && !detailId) {
 		return false;
 	}


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
core trajectory-detail id percent-encoding. Encoding class, leftover
tax after media-store / views-routes path work. Not a twin of those
parsers — this is `GET /api/trajectories/:id` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on the trajectory-detail id.
Canonical `t%2D1` still decodes to `t-1` and reaches the service.
Malformed `%` / `%2` / `%ZZ` become 400 instead of an uncaught
`URIError` 500. GET `/api/trajectories` list and `/stats` stay
untouched.

# Background

## What does this PR do?

`tryHandleTrajectoryReadRoutes` called `decodeURIComponent` on the
detail-id path segment before the handler try/catch. Illegal
percent-encoding threw `URIError`, which the host mapped to 500.

- `/api/trajectories/%` / `%2` / `%ZZ` → **400**
- `/api/trajectories/%E0%A4` → **400**
- `/api/trajectories/t%2D1` → still decodes to `t-1`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded trajectory id
should get a request error, not a 500 that looks like a trajectory
service outage. Leftover tax after media-store / views-routes path
work. Disjoint files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/core/src/features/trajectories/read-routes.encoding.test.ts`

## Detailed testing steps

```bash
cd packages/core && bunx vitest run --config vitest.config.ts src/features/trajectories/read-routes.encoding.test.ts
```

15 encoding tests plus 10 existing read-route tests passed at this exact head (25 total).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; trajectory-id path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; trajectory-id path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; trajectory-id path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before service.list/detail; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before trajectory service reads.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real handler.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded ids still decode.
Malformed tokens that previously 500 now 400.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0206b4d5d70e112d78fc96b0b8b120eec665379c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Maintainer validation

Rebased and repaired exact head `0206b4d5d70e112d78fc96b0b8b120eec665379c`. The route now validates the decoded opaque segment without imposing UUID-only compatibility: malformed UTF-8/percent escapes and decoded slash, backslash, control, dot, and dot-dot segments return 400 before service access; encoded `stats` remains the stats route; encoded `config` falls through to the host; double encoding is decoded exactly once. Focused + existing route suites: 2/2 files, 25/25 tests. Biome and diff checks pass. Core typecheck was attempted after generating keywords; this isolated sparse environment lacks existing package dependencies (`@noble/hashes`, `drizzle-orm`, `ai`, `mammoth`, `unpdf`, `dedent`, `dotenv`), and no touched-file diagnostic was reported.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@f3382c2999006a976ae37fe60d387776bc630626
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@f3382c2999006a976ae37fe60d387776bc630626"} -->