### PR TITLE
fix(cloud): reject malformed local-runtime conversation id encoding

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.encoding.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.encoding.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Local-runtime conversation-id path encoding is leftover tax after
+ * coding-container sync id decode. Stock develop called decodeURIComponent
+ * on the cloud voice stream conversation id, so `%` / `%2` / `%ZZ` threw
+ * URIError instead of a typed LocalRuntimeConversationFetchError.
+ * Unsupported paths and POST-method checks stay untouched.
+ *
+ * `@elizaos/shared` and the voice-session alias are mocked so this file
+ * does not load core → uuid. Encoding is a path-decode contract.
+ */
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+const TRANSPORT = "realtime-voice-client";
+
+mock.module("@elizaos/shared", () => ({
+  REALTIME_VOICE_CLIENT_TRANSPORT: TRANSPORT,
+}));
+mock.module("@/lib/voice-session/eliza-sse-bridge", () => ({
+  VOICE_STREAM_PROTOCOL: "delta-v2",
+}));
+
+const VALID_BODY = JSON.stringify({
+  text: "hello locally",
+  metadata: {
+    clientTransport: TRANSPORT,
+  },
+  streamProtocol: "delta-v2",
+});
+
+function unusedDownstream(): typeof fetch {
+  return (async () => {
+    throw new Error("downstream fetch must not run on malformed encoding");
+  }) as typeof fetch;
+}
+
+describe("local runtime conversation fetch encoding", () => {
+  let createLocalRuntimeConversationFetch: typeof import("../lib/local-runtime-conversation-fetch").createLocalRuntimeConversationFetch;
+  let LocalRuntimeConversationFetchError: typeof import("../lib/local-runtime-conversation-fetch").LocalRuntimeConversationFetchError;
+
+  beforeAll(async () => {
+    const mod = await import("../lib/local-runtime-conversation-fetch");
+    createLocalRuntimeConversationFetch = mod.createLocalRuntimeConversationFetch;
+    LocalRuntimeConversationFetchError = mod.LocalRuntimeConversationFetchError;
+  });
+
+  test("unsupported path is untouched", async () => {
+    const bridge = createLocalRuntimeConversationFetch(
+      "http://127.0.0.1:31337",
+      unusedDownstream(),
+    );
+    await expect(
+      bridge("https://cloud.example/api/v1/other", {
+        method: "POST",
+        body: VALID_BODY,
+      }),
+    ).rejects.toMatchObject({
+      name: "LocalRuntimeConversationFetchError",
+      message: expect.stringContaining("unsupported local voice upstream path"),
+    });
+  });
+
+  test("canonical percent-encoded conversation id still reaches the loopback rewrite", async () => {
+    const calls: Array<{ url: string }> = [];
+    const downstream = (async (input: RequestInfo | URL) => {
+      calls.push({ url: String(input) });
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+    const bridge = createLocalRuntimeConversationFetch(
+      "http://127.0.0.1:31337",
+      downstream,
+    );
+    const response = await bridge(
+      "https://cloud.example/api/v1/eliza/agents/agent-a/api/conversations/conv%2Did/messages/stream",
+      {
+        method: "POST",
+        body: VALID_BODY,
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(
+      "http://127.0.0.1:31337/api/conversations/conv-id/messages/stream",
+    );
+  });
+
+  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed conversation id %s before downstream fetch",
+    async (token) => {
+      const bridge = createLocalRuntimeConversationFetch(
+        "http://127.0.0.1:31337",
+        unusedDownstream(),
+      );
+      try {
+        await bridge(
+          `https://cloud.example/api/v1/eliza/agents/agent-a/api/conversations/${token}/messages/stream`,
+          {
+            method: "POST",
+            body: VALID_BODY,
+          },
+        );
+        throw new Error("expected LocalRuntimeConversationFetchError");
+      } catch (error) {
+        expect(error).toBeInstanceOf(LocalRuntimeConversationFetchError);
+        expect((error as Error).message).toBe(
+          "conversation id is not valid percent-encoding",
+        );
+        expect((error as Error).name).toBe("LocalRuntimeConversationFetchError");
+      }
+    },
+  );
+});

--- a/packages/cloud/api/v1/voice/session/lib/local-runtime-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/local-runtime-conversation-fetch.ts
@@ -18,6 +18,26 @@ export class LocalRuntimeConversationFetchError extends Error {
   }
 }
 
+/**
+ * Decode the untrusted conversation-id path segment. Leftover tax after
+ * coding-container sync id decode: stock develop called `decodeURIComponent`
+ * on the cloud voice stream conversation id, so `%` / `%2` / `%ZZ` threw
+ * URIError instead of a typed LocalRuntimeConversationFetchError. Unsupported
+ * paths and POST-method checks stay untouched.
+ */
+function decodeConversationId(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch (error) {
+    // error-policy:J3 untrusted conversation path segments are client input;
+    // malformed percent-encoding is a typed fetch error, not an uncaught URIError.
+    throw new LocalRuntimeConversationFetchError(
+      "conversation id is not valid percent-encoding",
+      { cause: error },
+    );
+  }
+}
+
 export function createLocalRuntimeConversationFetch(
   localRuntimeOrigin: string,
   fetchImpl: typeof fetch = fetch,
@@ -41,7 +61,7 @@ export function createLocalRuntimeConversationFetch(
       );
     }
 
-    const conversationId = decodeURIComponent(match[1]);
+    const conversationId = decodeConversationId(match[1]);
     const target = new URL(
       `/api/conversations/${encodeURIComponent(conversationId)}/messages/stream`,
       origin,


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
cloud local-runtime conversation-id percent-encoding. Encoding
class, leftover tax after coding-container sync id decode. Not a
twin of that parser — this is the voice loopback conversation-id
rewrite only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on the conversation-id rewrite.
Canonical `conv%2Did` still decodes to `conv-id` and reaches the
loopback SSE path. Malformed `%` / `%2` / `%ZZ` become a typed
`LocalRuntimeConversationFetchError` instead of an uncaught
`URIError`. Unsupported paths and POST-method checks stay untouched.

# Background

## What does this PR do?

`createLocalRuntimeConversationFetch` called `decodeURIComponent` on
the cloud voice stream conversation-id segment. Illegal
percent-encoding threw `URIError` instead of the adapter's typed
error.

- conversation id `%` / `%2` / `%ZZ` → typed fetch error
- conversation id `%E0%A4` → typed fetch error
- conversation id `conv%2Did` → still decodes to `conv-id`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded conversation
id should get a typed adapter error, not an uncaught `URIError` that
looks like a voice-session fault. Leftover tax after coding-container
sync id decode. Disjoint files from that parser.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.encoding.test.ts`

## Detailed testing steps

```bash
bun test packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.encoding.test.ts
```

6 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; conversation-id path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; conversation-id path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; conversation-id path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused adapter tests drive the real percent-encoding tokens and assert a typed error before downstream fetch; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens fail before loopback rewrite.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real adapter.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded ids still decode.
Malformed tokens that previously threw `URIError` now throw a typed
adapter error.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:da4d8384fd5d523a1f594f545e363f7a697f217b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
