### PR TITLE
fix(commands): scope detection to dispatch runtime

### DIFF
--- a/plugins/plugin-commands/__tests__/command-actions.test.ts
+++ b/plugins/plugin-commands/__tests__/command-actions.test.ts
@@ -15,9 +15,11 @@ import {
 } from "../src/actions";
 import { commandRegistryProvider } from "../src/index";
 import {
+	getCommandsForRuntime,
 	getEnabledCommandsForRuntime,
 	initForRuntime,
 	registerCommand,
+	registerCommandForRuntime,
 	useRuntime,
 } from "../src/registry";
 
@@ -106,6 +108,38 @@ describe("runCommand / resolveCommand — deterministic handlers (#8790)", () =>
 
 		expect(r.handled).toBe(true);
 		expect(r.reply).toContain(`Commands enabled: ${agentACommandCount}`);
+	});
+
+	it("detects commands against the dispatch runtime instead of the last active registry", async () => {
+		initForRuntime("agent-a");
+		const modelCommand = getCommandsForRuntime("agent-a").find(
+			(command) => command.key === "model",
+		);
+		if (!modelCommand) throw new Error("Model command is required");
+
+		initForRuntime("agent-b");
+		registerCommandForRuntime("agent-b", {
+			...modelCommand,
+			enabled: false,
+		});
+
+		const runtimeA = makeRuntime("agent-a");
+		const message = msg("/model");
+		const result = await resolveCommand(runtimeA, message, {
+			isAuthorized: true,
+			isElevated: true,
+		});
+
+		expect(result).toMatchObject({
+			handled: true,
+			command: { key: "model" },
+			reply: "Model is default.",
+		});
+		const modelAction = commandActions.find(
+			(action) => action.name === "MODEL_COMMAND",
+		);
+		if (!modelAction) throw new Error("Model command action is required");
+		await expect(modelAction.validate(runtimeA, message)).resolves.toBe(true);
 	});
 
 	it("/whoami reflects the sender context", async () => {

--- a/plugins/plugin-commands/src/actions/command-actions.ts
+++ b/plugins/plugin-commands/src/actions/command-actions.ts
@@ -11,7 +11,7 @@
 
 import type { Action, IAgentRuntime, Memory } from "@elizaos/core";
 import { detectCommand, hasCommand } from "../parser";
-import { findCommandByKey } from "../registry";
+import { findCommandByKey, useRuntime } from "../registry";
 import { resolveCommand } from "./dispatch";
 import { isDeterministicCommand } from "./handlers";
 
@@ -51,7 +51,8 @@ function buildAction(
 		similes: aliases,
 		suppressEarlyReply: true,
 		suppressPostActionContinuation: true,
-		validate: async (_runtime: IAgentRuntime, message: Memory) => {
+		validate: async (runtime: IAgentRuntime, message: Memory) => {
+			useRuntime(runtime.agentId);
 			const text = message.content.text ?? "";
 			if (!hasCommand(text)) return false;
 			const detection = detectCommand(text);

--- a/plugins/plugin-commands/src/actions/dispatch.ts
+++ b/plugins/plugin-commands/src/actions/dispatch.ts
@@ -13,7 +13,7 @@
 
 import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
 import { detectCommand, hasCommand } from "../parser";
-import { findCommandByKeyForRuntime } from "../registry";
+import { findCommandByKeyForRuntime, useRuntime } from "../registry";
 import type { CommandContext, ParsedCommand } from "../types";
 import { isDeterministicCommand, runCommand } from "./handlers";
 
@@ -76,6 +76,7 @@ export async function resolveCommand(
 	message: Memory,
 	options: CommandDispatchOptions = {},
 ): Promise<CommandDispatchResult> {
+	useRuntime(runtime.agentId);
 	const text = message.content.text ?? "";
 	if (!hasCommand(text)) return { handled: false };
 


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->
AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: reproduced the cross-runtime detection bug myself, ran the full mutation check myself, reran the full package test suite/biome/typecheck, re-traced reachability against the real Telegram/Discord connector call sites, and specifically checked whether the `useRuntime`-then-read pattern could race under concurrent dispatch - confirmed `useRuntime` and `hasCommand`/`detectCommand` are all synchronous with no `await` between the pointer swap and the read, so this is safe under JS's single-threaded execution model and matches the function's own documented usage contract, not a new risk.

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low. Adds one synchronous `useRuntime(runtime.agentId)` call at each of two existing detection boundaries, using an already-existing, already-documented function ("Providers and actions should call this before accessing commands"). Single-agent processes (the common case, where there's only one registry) are unaffected since there's no other runtime's registry to be pointed at incorrectly.

# Background

## What does this PR do?

`resolveCommand` and each registered deterministic command action's `validate` function detected commands against the module-global active command registry, before selecting the runtime that actually owned the incoming message. In a multi-agent process, the last initialized or used agent controlled whether another agent's command was recognized.

Before fix: runtime A has the deterministic `/model` command enabled, runtime B has `/model` disabled via the public per-runtime registry API and is the active registry. Dispatching `/model` for runtime A incorrectly returns `{ handled: false }`.

After fix: dispatching `/model` for runtime A correctly returns `{ handled: true, command: { key: "model" }, ... }` regardless of which runtime's registry was last active.

## What kind of change is this?

Bug fix — no new capability, no schema change.

# Documentation changes needed?

No.

# Testing

New test `detects commands against the dispatch runtime instead of the last active registry` in `plugins/plugin-commands/__tests__/command-actions.test.ts`, configuring two runtimes with conflicting command registries and verifying both the `resolveCommand` path and `MODEL_COMMAND.validate` resolve against the dispatch runtime, not the last-active one.

# Evidence Gate

<!-- evidence-head:6411f9e2f107a6f542762e95ac5b601e32662903 -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend logic fix, no UI surface
- <!-- evidence-row:walkthrough-video --> N/A - not applicable to a backend logic fix
- <!-- evidence-row:backend-logs -->
  Mutation check, reverted just the source fix via `git apply -R`, kept the test:
  ```text
  AssertionError: expected { handled: false } to match object { handled: true, ... }
  Test Files  1 failed (1)
       Tests  1 failed | 17 skipped (18)
  ```
  Restored: `Test Files  1 passed (1)` / `Tests  1 passed | 17 skipped (18)`. Full package: `Test Files  10 passed (10)` / `Tests  144 passed (144)`. `biome check` and `tsc --noEmit` both clean.
- <!-- evidence-row:frontend-logs --> N/A - no frontend
- <!-- evidence-row:llm-trajectory --> N/A - deterministic registry-lookup logic, no LLM in the loop
- <!-- evidence-row:domain-artifacts --> N/A
- <!-- evidence-row:ocr-review --> N/A

## Known gaps / failures

None found. Full package test/lint/typecheck all clean.

## Reachability

- `plugins/plugin-telegram/src/command-registration.ts` constructs a `Memory` from the Telegram user's command text and calls `resolveCommand(runtime, message, ...)`.
- `plugins/plugin-discord/catalog-commands.ts` constructs a command memory from a Discord interaction and calls the same function.
- `plugins/plugin-commands/src/actions/command-actions.ts` calls `resolveCommand` from registered deterministic command action handlers; the same file's action `validate` functions call `hasCommand`/`detectCommand` directly, which is why that second boundary needed the same fix.
- `plugins/plugin-commands/src/index.ts` creates one isolated registry per runtime, while initialization and later `useRuntime` calls change the shared active-store pointer; `CommandRegistryService.register` also exposes `registerCommandForRuntime` to real plugins, so runtime catalogs can genuinely differ.
- A multi-agent host with differing command enablement or replacement reaches this bug through real connector messages and agent command actions.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported


## Maintainer validation

Rebased on current `develop` and validated exact head `6411f9e2f107a6f542762e95ac5b601e32662903`. Static call-path review confirms Telegram, Discord, pre-LLM dispatch, and deterministic action validation can reach the cross-runtime registry bug. The runtime selection and both registry reads are synchronous with no suspension point. Full package suite: 10/10 files, 144/144 tests. Package typecheck, Biome on all three changed files, and diff check pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@66e782ce9791aacef93a62c3e691e883697071ca
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@66e782ce9791aacef93a62c3e691e883697071ca"} -->