### PR TITLE
fix(inbox): resolve tied thread categories by frequency

### DIFF
--- a/plugins/plugin-inbox/src/inbox/aggregate.ts
+++ b/plugins/plugin-inbox/src/inbox/aggregate.ts
@@ -275,6 +275,12 @@ function applyLlmScores(
   }
 }
 
+const PRIORITY_CATEGORY_TIE_ORDER = [
+  "important",
+  "planning",
+  "casual",
+] as const satisfies readonly PriorityCategory[];
+
 function buildThreadGroups(
   messages: LifeOpsInboxMessage[],
   llmScores?: ReadonlyMap<string, PriorityScore>,
@@ -324,23 +330,31 @@ function buildThreadGroups(
     }
     if (llmScores && llmScores.size > 0) {
       const seen = new Map<PriorityCategory, number>();
-      let best: { category: PriorityCategory; score: number } | null = null;
+      let bestScore = Number.NEGATIVE_INFINITY;
+      const bestCategories = new Set<PriorityCategory>();
       for (const member of members) {
         const score = llmScores.get(member.id);
         if (!score) continue;
         seen.set(score.category, (seen.get(score.category) ?? 0) + 1);
-        if (!best || score.score > best.score) {
-          best = { category: score.category, score: score.score };
+        if (score.score > bestScore) {
+          bestScore = score.score;
+          bestCategories.clear();
+          bestCategories.add(score.category);
+        } else if (score.score === bestScore) {
+          bestCategories.add(score.category);
         }
       }
-      // Prefer the category attached to the highest-scoring message; ties
-      // fall back to the most common category.
-      if (best) {
-        priorityCategory = best.category;
-      } else if (seen.size > 0) {
-        let topCategory: PriorityCategory = "casual";
+      // Prefer the category attached to the highest-scoring message. When
+      // multiple categories share that score, frequency breaks the tie only
+      // among those candidates; a frequent low-scoring category cannot win.
+      if (bestCategories.size === 1) {
+        priorityCategory = bestCategories.values().next().value;
+      } else if (bestCategories.size > 1) {
+        let topCategory: PriorityCategory = "important";
         let topCount = -1;
-        for (const [cat, count] of seen) {
+        for (const cat of PRIORITY_CATEGORY_TIE_ORDER) {
+          if (!bestCategories.has(cat)) continue;
+          const count = seen.get(cat) ?? 0;
           if (count > topCount) {
             topCount = count;
             topCategory = cat;

--- a/plugins/plugin-inbox/test/inbox-aggregate.real-runtime.test.ts
+++ b/plugins/plugin-inbox/test/inbox-aggregate.real-runtime.test.ts
@@ -395,6 +395,105 @@ describe("aggregate builders", () => {
     expect(inbox.messages[0]?.priorityScore).toBeUndefined();
   });
 
+  it("uses the most common category when top LLM scores tie", () => {
+    const now = Date.now();
+    const messages = [
+      inboundChat({
+        id: "tie-important",
+        text: "latest message",
+        threadId: "tie-thread",
+        timestamp: now,
+      }),
+      inboundChat({
+        id: "tie-planning-1",
+        text: "planning message one",
+        threadId: "tie-thread",
+        timestamp: now - 1000,
+      }),
+      inboundChat({
+        id: "tie-planning-2",
+        text: "planning message two",
+        threadId: "tie-thread",
+        timestamp: now - 2000,
+      }),
+      ...[0, 1, 2].map((index) =>
+        inboundChat({
+          id: `lower-casual-${index}`,
+          text: "lower-scoring casual message",
+          threadId: "tie-thread",
+          timestamp: now - 3000 - index,
+        }),
+      ),
+    ];
+    const inbox = buildInbox(messages, {
+      limit: 10,
+      allowed: new Set<LifeOpsInboxChannel>(["discord"]),
+      sources: [{ source: "chat", state: "ok", degradations: [] }],
+      groupByThread: true,
+      llmScores: new Map([
+        [
+          "discord:tie-important",
+          { score: 90, category: "important", flags: [] },
+        ],
+        [
+          "discord:tie-planning-1",
+          { score: 90, category: "planning", flags: [] },
+        ],
+        [
+          "discord:tie-planning-2",
+          { score: 80, category: "planning", flags: [] },
+        ],
+        ...[0, 1, 2].map(
+          (index) =>
+            [
+              `discord:lower-casual-${index}`,
+              { score: 20, category: "casual", flags: [] },
+            ] as const,
+        ),
+      ]),
+    });
+
+    expect(inbox.threadGroups?.[0]?.priorityCategory).toBe("planning");
+  });
+
+  it("uses fixed priority order for an exact tied-category frequency", () => {
+    const now = Date.now();
+    const inbox = buildInbox(
+      [
+        inboundChat({
+          id: "exact-important",
+          text: "important",
+          threadId: "exact-thread",
+          timestamp: now,
+        }),
+        inboundChat({
+          id: "exact-planning",
+          text: "planning",
+          threadId: "exact-thread",
+          timestamp: now - 1000,
+        }),
+      ],
+      {
+        limit: 10,
+        allowed: new Set<LifeOpsInboxChannel>(["discord"]),
+        sources: [{ source: "chat", state: "ok", degradations: [] }],
+        groupByThread: true,
+        llmScores: new Map([
+          [
+            "discord:exact-important",
+            { score: 90, category: "important", flags: [] },
+          ],
+          [
+            "discord:exact-planning",
+            { score: 90, category: "planning", flags: [] },
+          ],
+        ]),
+      },
+    );
+
+    expect(inbox.threadGroups?.[0]?.priorityCategory).toBe("important");
+  });
+
   it("missedOnly requires a real priority score instead of keyword fallback", () => {
     const old = Date.now() - 25 * 60 * 60 * 1000;
     const inbox = buildInbox(


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
- AI assistance: Yes - initial author assistance plus maintainer review and remediation
<!-- attribution-row:models -->
- Models: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client/tooling: Codex CLI, Claude Code, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - the contribution skill was not used for this maintainer review and remediation
<!-- attribution-row:status -->
- Provenance status: self-reported

AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: traced the fix logic by hand to confirm it correctly handles a unique-max-category short-circuit, a genuine multi-category tie resolved by overall frequency, and secondary-tie determinism via the fixed priority order - confirmed `PriorityCategory` genuinely has only the three values used in that order (`"important" | "planning" | "casual"`, checked directly in `priority-scoring.ts`), so nothing is silently excluded from the tie-break. Ran the full mutation check myself, reran the full package test suite/biome/typecheck, and re-traced reachability against the real route handler.

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low. Changes only the category-selection logic inside `buildThreadGroups` for the case where multiple messages tie at the top LLM score; threads with a single top-scoring message (the common case) are unaffected.

# Background

## What does this PR do?

`buildThreadGroups` documented that when multiple LLM-scored messages share the highest score, the thread category falls back to the most common category. The implementation instead retained the first message with that score. Because thread members are sorted newest-first, the category became dependent on message recency/order and could disagree with the thread's dominant category.

Before fix: a thread's newest message (score 90, category `important`) ties with an older message (score 90, category `planning`), while `planning` is the thread's overall majority category (2 messages vs 1). The old code picked `important` (the first/newest tied message) instead of `planning` (the documented frequency-based tie-break).

After fix: correctly resolves to `planning`.

## What kind of change is this?

Bug fix — no new capability, no schema change.

# Documentation changes needed?

No.

# Testing

New test `uses the most common category when top LLM scores tie` in `plugins/plugin-inbox/test/inbox-aggregate.real-runtime.test.ts`, constructing a real thread with a genuine score tie across categories and asserting the documented frequency-based resolution.

# Evidence Gate

<!-- evidence-head:da250ca8e5bbe315481d4c039b1351b52ce55e02 -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend logic fix, no UI surface
- <!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual behavior changed

## Known gaps / failures

None found. Full package test/lint/typecheck all clean, `build:types` succeeds.

## Reachability

`plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts` calls `service.getInbox(request)`, which forwards to `InboxDomain.getInbox` -> `buildInboxWithLlm` -> `buildThreadGroups`. The personal-assistant check-in service also calls the same production path. LLM scores are produced by `scoreInboxMessages` and keyed to real fetched message ids before grouping - this is a live, non-test-only path.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic focused regression tests are documented in the Testing section and produce no persistent backend log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by this logic change

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered interface changed
