### PR TITLE
fix(agent-skills): bound skill IDs and preserve route compatibility

### DIFF
--- a/plugins/plugin-agent-skills/src/api/skills-routes.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.test.ts
@@ -7,6 +7,7 @@
 import type http from "node:http";
 import type { AgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
+import { SKILL_NAME_MAX_LENGTH } from "../types";
 import {
   handleSkillsRoutes,
   type SkillsRouteContext,
@@ -20,11 +21,15 @@ function createSkillsContext(
   ctx: SkillsRouteContext;
   json: ReturnType<typeof vi.fn>;
   error: ReturnType<typeof vi.fn>;
+  readJsonBody: ReturnType<typeof vi.fn>;
+  discoverSkills: ReturnType<typeof vi.fn>;
 } {
   const req = { method, url: pathname } as http.IncomingMessage;
   const res = {} as http.ServerResponse;
   const json = vi.fn();
   const error = vi.fn();
+  const readJsonBody = vi.fn().mockResolvedValue({});
+  const discoverSkills = vi.fn().mockResolvedValue([]);
   const ctx: SkillsRouteContext = {
     req,
     res,
@@ -42,13 +47,13 @@ function createSkillsContext(
     },
     json,
     error,
-    readJsonBody: vi.fn().mockResolvedValue({}),
+    readJsonBody,
     readBody: vi.fn().mockResolvedValue(""),
-    discoverSkills: vi.fn().mockResolvedValue([]),
+    discoverSkills,
     ...overrides,
   };
 
-  return { ctx, json, error };
+  return { ctx, json, error, readJsonBody, discoverSkills };
 }
 
 describe("handleSkillsRoutes path encoding validation", () => {
@@ -246,6 +251,60 @@ describe("handleSkillsRoutes path encoding validation", () => {
     expect(error).toHaveBeenCalledWith(
       ctx.res,
       expect.stringContaining("Invalid skill ID"),
+      400,
+    );
+  });
+
+  it.each([
+    [
+      "POST",
+      `/api/skills/${"a".repeat(SKILL_NAME_MAX_LENGTH + 1)}/acknowledge`,
+    ],
+    [
+      "PUT",
+      `/api/skills/${"a".repeat(SKILL_NAME_MAX_LENGTH + 1)}/source`,
+    ],
+  ])("rejects overlong skill IDs before collaborators for %s %s", async (method, pathname) => {
+    const { ctx, error, readJsonBody, discoverSkills } = createSkillsContext(method, pathname);
+
+    await expect(handleSkillsRoutes(ctx)).resolves.toBe(true);
+
+    expect(error).toHaveBeenCalledWith(ctx.res, expect.stringContaining("Invalid skill ID"), 400);
+    expect(readJsonBody).not.toHaveBeenCalled();
+    expect(discoverSkills).not.toHaveBeenCalled();
+    expect(ctx.state.runtime?.getCache).not.toHaveBeenCalled();
+    expect(ctx.state.runtime?.getService).not.toHaveBeenCalled();
+  });
+
+  it("accepts a skill ID at the canonical length limit", async () => {
+    const skillId = "a".repeat(SKILL_NAME_MAX_LENGTH);
+    const { ctx, error, readJsonBody } = createSkillsContext(
+      "POST",
+      `/api/skills/${skillId}/acknowledge`,
+    );
+
+    await expect(handleSkillsRoutes(ctx)).resolves.toBe(true);
+
+    expect(readJsonBody).toHaveBeenCalledOnce();
+    expect(error).not.toHaveBeenCalledWith(
+      ctx.res,
+      expect.stringContaining("Invalid skill ID"),
+      400,
+    );
+  });
+
+  it("ignores the deprecated decoder callback while preserving its input contract", async () => {
+    const legacyDecoder = vi.fn(() => "rewritten-by-host");
+    const { ctx, error } = createSkillsContext("GET", "/api/skills/%/scan", {
+      decodePathComponent: legacyDecoder,
+    });
+
+    await expect(handleSkillsRoutes(ctx)).resolves.toBe(true);
+
+    expect(legacyDecoder).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Invalid skill ID: malformed URL encoding",
       400,
     );
   });

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -153,6 +153,15 @@ export interface SkillsRouteContext {
     options?: ReadJsonBodyOptions,
   ) => Promise<T | null>;
   readBody: (req: http.IncomingMessage) => Promise<string>;
+  /**
+   * @deprecated Retained for source compatibility with older Agent hosts.
+   * Route identifiers are decoded internally and this callback is ignored.
+   */
+  decodePathComponent?: (
+    raw: string,
+    res: http.ServerResponse,
+    fieldName: string,
+  ) => string | null;
   // Functions from server.ts that skills routes need
   discoverSkills: (
     workspaceDir: string,
@@ -180,6 +189,7 @@ function validateSkillId(
 ): string | null {
   if (
     !skillId ||
+    skillId.length > SKILL_NAME_MAX_LENGTH ||
     !SAFE_SKILL_ID_RE.test(skillId) ||
     skillId === "." ||
     skillId.includes("..")


### PR DESCRIPTION
# Relates to

Corrective follow-up to merged #21115.

- [x] Targets `develop` and was rebased onto current `origin/develop` at exact-head creation.
- [x] Focused plugin contract gates pass.
- [ ] Exact-head full CI and independent review are pending.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Directly based on current `origin/develop` at head creation; zero conflicts.
- [ ] Full `bun run verify` pending exact-head CI.

# Risks

Low. Two-file compatibility/security correction to the route contract merged in #21115.

# Background

## What does this PR do?

#21115 removed `decodePathComponent` from exported `SkillsRouteContext` while leaving two follow-up gaps. #21186 independently removed the stale in-repository Agent injection and is already in this branch's base. This remaining correction:

- retains an optional deprecated/ignored field on the exported context for source compatibility with older external hosts;
- applies the existing canonical `SKILL_NAME_MAX_LENGTH` (64) to all decoded skill IDs, closing the general-route length/resource-abuse gap left by #21115;
- proves 65-character POST/PUT identifiers fail before body parsing, discovery, cache, or services; 64 characters remain accepted; and a legacy decoder callback is never invoked.

## What kind of change is this?

Source-compatibility and input-validation bug fix.

# Documentation changes needed?

No user documentation change. The exported deprecated field has inline API documentation.

# Testing

## Where should a reviewer start?

Start with `SkillsRouteContext`, `validateSkillId`, and the new collaborator non-invocation cases.

## Detailed testing steps

- Pinned Bun 1.3.14 focused route suite: 25/25 passing.
- Plugin build: passing.
- Plugin typecheck: passing.
- Biome and `git diff --check`: passing.

# Evidence Gate

<!-- evidence-head:0ebcee7bf01f8caa0352e9c7469d6e73f9f68967 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend route/type/test change; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend route/type/test change; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic route tests prove rejection before collaborators; no deployed backend was mutated.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, action, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain state changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual source changed.

# Known gaps / failures

Exact-head full CI is required. #21186 superseded the in-repository caller fix while this review was running; the branch was rebased so it now contains only the unsuperseded compatibility and length-bound work.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->