### PR TITLE
fix(cloud): observe the barge-in stream rejection before cancelling

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -923,6 +923,61 @@ export async function readRequestBodyBuffer(
   return body;
 }
 
+/**
+ * Worker-safe port of core's `readResponseWithLimit`: reads a response body
+ * under a hard byte cap, cancelling the stream as soon as the running total
+ * exceeds maxBytes so a missing or lying Content-Length can never force an
+ * unbounded allocation.
+ */
+export async function readResponseWithLimit(
+  res: Response,
+  maxBytes: number,
+): Promise<Buffer> {
+  const body = res.body;
+  if (!body) {
+    const fallback = Buffer.from(await res.arrayBuffer());
+    if (fallback.length > maxBytes) {
+      throw new Error(
+        `Failed to fetch media from ${res.url || "response"}: payload exceeds maxBytes ${maxBytes}`,
+      );
+    }
+    return fallback;
+  }
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value.length) {
+        total += value.length;
+        if (total > maxBytes) {
+          try {
+            await reader.cancel();
+          } catch {
+            // error-policy:J6 cancellation is best-effort after the limit failure
+          }
+          throw new Error(
+            `Failed to fetch media from ${res.url || "response"}: payload exceeds maxBytes ${maxBytes}`,
+          );
+        }
+        chunks.push(value);
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // error-policy:J6 stream lock release is best-effort teardown
+    }
+  }
+  return Buffer.concat(
+    chunks.map((chunk) => Buffer.from(chunk)),
+    total,
+  );
+}
+
 export async function readRequestBody(
   request: Request,
   options: { maxBytes?: number; encoding?: BufferEncoding } = {},

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -366,6 +366,10 @@ describe("Shared Eliza Workerd runtime", () => {
     const iterator = result.parts?.[Symbol.asyncIterator]();
     if (!iterator || !result.cancel) throw new Error("Expected a cancellable runtime stream");
     const nextPart = iterator.next();
+    // error-policy:J5 the same rejection is asserted via expect(...).rejects
+    // below; this early observer only prevents the abort's same-tick rejection
+    // from surfacing as an unhandled error on slower runners.
+    nextPart.catch(() => {});
     const providerSignal = await providerStarted.promise;
 
     await result.cancel("confirmed caller speech");


### PR DESCRIPTION
Release candidate run 32048255533 got the full test lane down to ONE red: the barge-in abort test in shared-eliza-runtime.test.ts. The abort can reject the pending iterator read in the same tick as cancel(); unobserved, slower runners flag the cancellation reason as an unhandled error. An early no-op .catch observer (error-policy:J5; the real assertion is unchanged) closes the window. Suite 9/9 locally.