### PR TITLE
fix(ci): authenticate protected release checkouts

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -229,6 +229,8 @@ jobs:
               || git -C "$CHECKOUT_DIR" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
           }
           init_checkout_dir
+          checkout_basic_auth="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
+          echo "::add-mask::$checkout_basic_auth"
           # Shared, heavily-loaded self-hosted box (wrangler dev + PGlite + the full
           # Worker suite): a single shallow fetch can stall for minutes or wedge
           # entirely. Retry with a per-attempt timeout so a stuck fetch aborts and
@@ -241,7 +243,7 @@ jobs:
           # path entirely at negligible cost for a single-stream shallow fetch.
           fetched=
           for attempt in 1 2 3; do
-            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 -c http.version=HTTP/1.1 -c http.extraheader="AUTHORIZATION: bearer ${CHECKOUT_TOKEN}" fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
+            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 -c http.version=HTTP/1.1 -c http.extraheader="AUTHORIZATION: basic ${checkout_basic_auth}" fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
               fetched=1
               break
             fi
@@ -1570,6 +1572,8 @@ jobs:
               || git -C "$CHECKOUT_DIR" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
           }
           init_checkout_dir
+          checkout_basic_auth="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
+          echo "::add-mask::$checkout_basic_auth"
           # Shared, heavily-loaded self-hosted box (wrangler dev + PGlite + the full
           # Worker suite): a single shallow fetch can stall for minutes or wedge
           # entirely. Retry with a per-attempt timeout so a stuck fetch aborts and
@@ -1584,7 +1588,7 @@ jobs:
             # Blobless fetch pushes that cost into checkout as lazy hydration and
             # has repeatedly timed out on the deploy fleet, so use a normal
             # shallow fetch here.
-            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 -c http.version=HTTP/1.1 -c http.extraheader="AUTHORIZATION: bearer ${CHECKOUT_TOKEN}" fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
+            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 -c http.version=HTTP/1.1 -c http.extraheader="AUTHORIZATION: basic ${checkout_basic_auth}" fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
               fetched=1
               break
             fi

--- a/packages/scripts/__tests__/cloud-cf-checkout-auth.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-checkout-auth.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Proves the protected Cloud release's temporary Git checkout against a real
+ * authenticated HTTP remote while keeping credentials out of repository state.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, normalize, sep } from "node:path";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const workflow = readFileSync(
+  new URL(".github/workflows/cloud-cf-release.yml", repoRoot),
+  "utf8",
+);
+
+function git(cwd: string, args: string[], extraEnv?: Record<string, string>) {
+  return Bun.spawnSync({
+    cmd: ["git", ...args],
+    cwd,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0", ...extraEnv },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+}
+
+async function gitAsync(
+  cwd: string,
+  args: string[],
+  extraEnv?: Record<string, string>,
+) {
+  const process = Bun.spawn({
+    cmd: ["git", ...args],
+    cwd,
+    env: { ...globalThis.process.env, GIT_TERMINAL_PROMPT: "0", ...extraEnv },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [exitCode, stderr, stdout] = await Promise.all([
+    process.exited,
+    new Response(process.stderr).text(),
+    new Response(process.stdout).text(),
+  ]);
+  return { exitCode, stderr, stdout };
+}
+
+describe("Cloud CF temporary checkout authentication", () => {
+  test("uses ephemeral Basic auth at both fetch sites", () => {
+    expect(
+      workflow.match(
+        /checkout_basic_auth="\$\(printf 'x-access-token:%s' "\$CHECKOUT_TOKEN" \| base64 \| tr -d '\\n'\)"/g,
+      ),
+    ).toHaveLength(2);
+    expect(
+      workflow.match(
+        /http\.extraheader="AUTHORIZATION: basic \$\{checkout_basic_auth\}"/g,
+      ),
+    ).toHaveLength(2);
+    expect(workflow.match(/::add-mask::\$checkout_basic_auth/g)).toHaveLength(
+      2,
+    );
+    expect(workflow).not.toContain("AUTHORIZATION: bearer");
+    expect(workflow).not.toMatch(
+      /https:\/\/x-access-token:\$\{CHECKOUT_TOKEN\}@/,
+    );
+  });
+
+  describe("real Git HTTP boundary", () => {
+    const token = "checkout-test-token";
+    const basic = Buffer.from(`x-access-token:${token}`, "utf8").toString(
+      "base64",
+    );
+    const expectedAuthorization = `basic ${basic}`;
+    const root = mkdtempSync(join(tmpdir(), "eliza-checkout-auth-"));
+    const source = join(root, "source");
+    const remote = join(root, "remote.git");
+    const checkout = join(root, "checkout");
+    let server: ReturnType<typeof Bun.serve>;
+    let remoteUrl: string;
+
+    beforeAll(() => {
+      mkdirSync(source);
+      expect(git(source, ["init", "--initial-branch=main"]).exitCode).toBe(0);
+      expect(
+        git(source, ["config", "user.name", "Checkout Test"]).exitCode,
+      ).toBe(0);
+      expect(
+        git(source, ["config", "user.email", "checkout-test@example.invalid"])
+          .exitCode,
+      ).toBe(0);
+      writeFileSync(join(source, "receipt.txt"), "authenticated fetch\n");
+      expect(git(source, ["add", "receipt.txt"]).exitCode).toBe(0);
+      expect(
+        git(source, ["commit", "-m", "seed authenticated remote"]).exitCode,
+      ).toBe(0);
+      expect(git(root, ["clone", "--bare", source, remote]).exitCode).toBe(0);
+      expect(
+        git(root, ["--git-dir", remote, "update-server-info"]).exitCode,
+      ).toBe(0);
+
+      server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch(request) {
+          if (request.headers.get("authorization") !== expectedAuthorization) {
+            return new Response("authentication required", {
+              status: 401,
+              headers: { "www-authenticate": 'Basic realm="git"' },
+            });
+          }
+
+          const pathname = decodeURIComponent(new URL(request.url).pathname);
+          const relative = pathname.replace(/^\/+/, "");
+          const resolved = normalize(join(root, relative));
+          if (resolved !== root && !resolved.startsWith(`${root}${sep}`)) {
+            return new Response("invalid path", { status: 400 });
+          }
+          const file = Bun.file(resolved);
+          return file
+            .exists()
+            .then((exists) =>
+              exists
+                ? new Response(file)
+                : new Response("not found", { status: 404 }),
+            );
+        },
+      });
+      remoteUrl = `http://127.0.0.1:${server.port}/remote.git`;
+    });
+
+    afterAll(() => {
+      server?.stop(true);
+      rmSync(root, { force: true, recursive: true });
+    });
+
+    test("rejects bearer auth but fetches with the GitHub Basic scheme", async () => {
+      const bearer = await gitAsync(root, [
+        "-c",
+        `http.extraheader=AUTHORIZATION: bearer ${token}`,
+        "ls-remote",
+        remoteUrl,
+        "HEAD",
+      ]);
+      expect(bearer.exitCode).not.toBe(0);
+
+      mkdirSync(checkout);
+      expect(git(checkout, ["init"]).exitCode).toBe(0);
+      expect(
+        git(checkout, ["remote", "add", "origin", remoteUrl]).exitCode,
+      ).toBe(0);
+      const fetched = await gitAsync(checkout, [
+        "-c",
+        `http.extraheader=AUTHORIZATION: basic ${basic}`,
+        "fetch",
+        "--force",
+        "--no-tags",
+        "origin",
+        "HEAD",
+      ]);
+      expect(fetched.exitCode).toBe(0);
+
+      const config = readFileSync(join(checkout, ".git", "config"), "utf8");
+      expect(config).toContain(remoteUrl);
+      expect(config).not.toContain(token);
+      expect(config).not.toContain(basic);
+      expect(config).not.toContain("extraheader");
+    });
+  });
+});


### PR DESCRIPTION
# Relates to

Part of #21372.

# What changed

Protected Cloud releases initialize credential-free temporary remotes, then fetch through an in-memory Git HTTP header. Security hardening in #21169 used the REST-style Bearer scheme for Git Smart HTTP, causing protected staging run `32053140540` to fail before Worker source materialization.

Both proven temp-checkout sites now:

- derive GitHub's Basic credential shape, base64(`x-access-token:<GITHUB_TOKEN>`), in memory;
- mask the derived credential before any fetch;
- pass it only through per-command `http.extraheader`;
- retain a credential-free remote URL and clean `.git/config`.

No APNs, provider, Worker runtime, gateway, staging, production, secret value, or channel behavior is changed.

# Exact source

- Base: `4733ec9170cbd7595a0b8471ff023eb5fea3ca3a`
- Head: `ca771609ced87dfddced530b2ea9c58121b1d65d`
- Tree: `5dab4a7825b7037cf0399caf6e5d3eb8c954d8b5`

# Ground truth

Protected run `32053140540@3517e4ff`, Worker job `95458115289`:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

Secret-safe real Git Smart HTTP A/B with the identical authenticated token:

- `Authorization: bearer`: `remote: invalid credentials`, exit 128.
- correct Basic header: exit 0.

The new regression spins up a real authenticated local HTTP Git remote, proves Bearer rejection and Basic fetch success, then inspects the checkout's actual `.git/config` to prove the token, encoded credential, and `extraheader` were not persisted.

# Validation

- 74 pass / 8 intentionally pre-existing provider-or-shell-gated skip / 0 fail / 20,438 assertions across the new auth test and nine Cloud release contract suites.
- New genuine Git HTTP suite: 2/2, 13 assertions.
- Pinned actionlint on `.github/workflows/cloud-cf-release.yml`: PASS.
- Biome exact new test: PASS.
- `git diff --check origin/develop...HEAD`: PASS.
- Worktree clean.

# Ownership / deconflict

APNs owner explicitly handed off only checkout hunks around deploy-api and deploy-app. Draft #21080's APNs binding/config/verification hunks remain untouched and byte-outside this diff. Watchtower retains release-gate servicing. No release run was approved or cancelled.

# Evidence

- Before/after screenshots: N/A — workflow and test only; no UI.
- Video walkthrough: N/A — no rendered client surface.
- Frontend logs: N/A — no frontend change.
- Live model trajectory: N/A — no agent/model/action/provider change.
- Domain artifact: real authenticated Git fetch plus inspected credential-free `.git/config`, asserted by the committed regression.
- Protected staging receipt: pending legitimate merge and exact-current gate-service handoff; production remains untouched.

# Known gaps

Source correctness is proven, but final closure of #21372 still requires a protected exact-current staging run to complete Worker checkout, verification/E2E/build/deploy, exact health, and canary. This PR must not authorize or dispatch that run itself.

AI provider/model: OpenAI / Codex based on GPT-5
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-root/shared-latency]