### PR TITLE
fix(repo): use canonical pathToFileURL entrypoint guard in 19 scripts

### DIFF
--- a/packages/app-core/scripts/kernel-patches/vulkan-dispatch-log.mjs
+++ b/packages/app-core/scripts/kernel-patches/vulkan-dispatch-log.mjs
@@ -4,6 +4,7 @@
  * tuning the Vulkan kernel patches.
  */
 import fs from "node:fs";
+import { pathToFileURL } from "node:url";
 
 const DISPATCH_RE = /ggml_vk_dispatch_pipeline\(([^,\s)]+)/g;
 const MUL_MAT_RE =
@@ -143,7 +144,10 @@ function usage() {
   ].join("\n");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   const files = process.argv.slice(2);
   if (files.length < 1 || files.length > 2) {
     console.error(usage());

--- a/packages/cloud/scripts/canonical-deploy-source-guard.mjs
+++ b/packages/cloud/scripts/canonical-deploy-source-guard.mjs
@@ -14,6 +14,7 @@
  * Divergence, missing successor proof, and unverifiable state all fail hard.
  */
 import { appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import {
   execFileSync,
   spawnSync,
@@ -376,7 +377,10 @@ async function main() {
   process.exitCode = 1;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   main().catch((error) => {
     // error-policy:J1 the CLI boundary translates remote resolution failures
     // into a visible, fail-closed workflow result before provider mutation.

--- a/packages/cloud/scripts/deploy-freshness-guard-cli.mjs
+++ b/packages/cloud/scripts/deploy-freshness-guard-cli.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * CLI wrapper for the cloud deploy freshness guard (#14083).
  *
@@ -20,6 +21,7 @@
  * fetched, ancestry is reported as `null` and the guard deploys (fail-open).
  */
 import fs from "node:fs";
+import { pathToFileURL } from "node:url";
 import { execFileSync } from "../../scripts/lib/spawn-sync-captured.mjs";
 
 import {
@@ -228,7 +230,10 @@ async function main() {
 }
 
 // Only run when invoked directly (not when imported by tests).
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   main().catch((err) => {
     // Even an unexpected crash must fail-open: log and deploy.
     console.error(

--- a/packages/cloud/scripts/verify-environment-routing-cli.mjs
+++ b/packages/cloud/scripts/verify-environment-routing-cli.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * CLI for the cross-environment routing verifier.
  *
@@ -20,6 +21,7 @@
  * A GitHub step summary is appended when $GITHUB_STEP_SUMMARY is set.
  */
 import fs from "node:fs";
+import { pathToFileURL } from "node:url";
 
 import {
   classifyProbe,
@@ -151,7 +153,10 @@ async function main() {
   process.exit(verdict.ok ? 0 : 1);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   main().catch((err) => {
     // error-policy:J1 boundary translation - an unexpected verifier crash must
     // leave CI red instead of being mistaken for healthy routing.

--- a/packages/cloud/scripts/verify-pages-frontend-cli.mjs
+++ b/packages/cloud/scripts/verify-pages-frontend-cli.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * CLI for the Cloudflare Pages frontend freshness verifier.
  *
@@ -15,6 +16,7 @@
  *     --require-text "Signing in to your agent"
  */
 import fs from "node:fs";
+import { pathToFileURL } from "node:url";
 
 import { verifyPagesFrontendOnce } from "./verify-pages-frontend.mjs";
 
@@ -133,7 +135,10 @@ async function main() {
   process.exit(report.ok ? 0 : 1);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   main().catch((err) => {
     // error-policy:J1 boundary translation - verifier crashes must fail the
     // deployment gate instead of letting a stale frontend read as healthy.

--- a/packages/scripts/audit-mvp-evidence-matrix.mjs
+++ b/packages/scripts/audit-mvp-evidence-matrix.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
-import process from "node:process";
 /**
  * Evidence expectation matrix for active LifeOps MVP project issues. The board
  * can show that a row is human-gated, but closeout still needs a concrete proof contract
  * per issue so screenshots, videos, logs, trajectories, and domain artifacts do
  * not collapse into a vague "needs review" bucket.
  */
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { projectItemIsIssue } from "./check-mvp-board-readiness.mjs";
 

--- a/packages/scripts/audit-mvp-evidence-matrix.mjs
+++ b/packages/scripts/audit-mvp-evidence-matrix.mjs
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import process from "node:process";
 /**
  * Evidence expectation matrix for active LifeOps MVP project issues. The board
  * can show that a row is human-gated, but closeout still needs a concrete proof contract
  * per issue so screenshots, videos, logs, trajectories, and domain artifacts do
  * not collapse into a vague "needs review" bucket.
  */
-
-import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
-import process from "node:process";
+import { pathToFileURL } from "node:url";
 import { projectItemIsIssue } from "./check-mvp-board-readiness.mjs";
 
 const DEFAULT_REPO = "elizaOS/eliza";
@@ -610,7 +611,10 @@ async function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   main().catch((error) => {
     process.stderr.write(
       `[audit-mvp-evidence-matrix] ${error instanceof Error ? error.message : String(error)}\n`,

--- a/packages/scripts/audit-mvp-project-board.mjs
+++ b/packages/scripts/audit-mvp-project-board.mjs
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import process from "node:process";
 /**
  * Read-only audit for the LifeOps MVP project board. The GitHub Project is the
  * live kanban, but closeout work needs a compact stale-state report instead of
  * a raw project dump: closed issues that are not Done, open issues still
  * active, and the subset that is explicitly human-gated.
  */
-
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import process from "node:process";
+import { pathToFileURL } from "node:url";
 import { projectItemIsIssue } from "./check-mvp-board-readiness.mjs";
 
 const DEFAULT_OWNER = "elizaOS";
@@ -438,7 +439,10 @@ async function main() {
   writeSummary(summary, args);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   main().catch((error) => {
     process.stderr.write(
       `[audit-mvp-project-board] ${error instanceof Error ? error.message : String(error)}\n`,

--- a/packages/scripts/audit-mvp-project-board.mjs
+++ b/packages/scripts/audit-mvp-project-board.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import process from "node:process";
 /**
  * Read-only audit for the LifeOps MVP project board. The GitHub Project is the
  * live kanban, but closeout work needs a compact stale-state report instead of
  * a raw project dump: closed issues that are not Done, open issues still
  * active, and the subset that is explicitly human-gated.
  */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { projectItemIsIssue } from "./check-mvp-board-readiness.mjs";
 

--- a/packages/scripts/audit-scripts-inventory.mjs
+++ b/packages/scripts/audit-scripts-inventory.mjs
@@ -47,7 +47,7 @@
  */
 import { existsSync, lstatSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { parseDocument } from "yaml";
 import {
   atomicWriteJsonSync,
@@ -1007,7 +1007,10 @@ function main() {
 
 export { buildInventory };
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   try {
     main();
   } catch (error) {

--- a/packages/scripts/audit-scripts.mjs
+++ b/packages/scripts/audit-scripts.mjs
@@ -40,7 +40,7 @@
  */
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { isScriptTestPath } from "./lib/script-test-inventory.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -708,4 +708,5 @@ function main() {
 
 export { auditScripts };
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
+  main();

--- a/packages/scripts/audit-test-lane-membership.mjs
+++ b/packages/scripts/audit-test-lane-membership.mjs
@@ -27,7 +27,7 @@
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { normalizeGitRepositoryPath } from "./lib/repository-file-integrity.mjs";
 import { resolveTestLaneDeclarations } from "./lib/script-metadata.mjs";
 import { execFileSync } from "./lib/spawn-sync-captured.mjs";
@@ -439,7 +439,10 @@ function main() {
   printSuccess(report);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   try {
     main();
   } catch (error) {

--- a/packages/scripts/audit-tsconfig-workspace-resolution.mjs
+++ b/packages/scripts/audit-tsconfig-workspace-resolution.mjs
@@ -7,7 +7,7 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import ts from "typescript";
 
 import { resolveWorkspacePackageDirs } from "./lib/workspace-package-dirs.mjs";
@@ -614,7 +614,10 @@ export function auditTsconfigWorkspaceResolution(options = {}) {
   return { projects, violations: [...new Set(violations)].sort() };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   const result = auditTsconfigWorkspaceResolution();
   console.log(
     `[audit-tsconfig-workspace-resolution] inspected ${result.projects} project(s)`,

--- a/packages/scripts/ci-turbo-cache-contract.mjs
+++ b/packages/scripts/ci-turbo-cache-contract.mjs
@@ -14,7 +14,7 @@
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const DEFAULT_REPO_ROOT = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -116,7 +116,10 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
   return { workflowCount: workflowFiles.length };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   try {
     const { workflowCount } = runContract();
     console.log(

--- a/packages/scripts/launch-qa/run.mjs
+++ b/packages/scripts/launch-qa/run.mjs
@@ -4,7 +4,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..", "..", "..");
@@ -411,7 +411,10 @@ export async function runLaunchQa(argv = process.argv.slice(2)) {
   return summary;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   try {
     const summary = await runLaunchQa();
     process.exit(summary.ok ? 0 : 1);

--- a/packages/scripts/run-mvp-closeout-audit.mjs
+++ b/packages/scripts/run-mvp-closeout-audit.mjs
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import process from "node:process";
 /**
  * Produces one atomic LifeOps MVP closeout report from a single Project 15
  * snapshot. Board state, readiness policy, and evidence expectations consume
  * identical inputs so rate limits or mid-run board changes cannot create a
  * false parity result.
  */
-
-import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
-import process from "node:process";
+import { pathToFileURL } from "node:url";
 import { buildEvidenceMatrix } from "./audit-mvp-evidence-matrix.mjs";
 import {
   strictViolations,
@@ -324,7 +325,10 @@ async function main() {
   if (!report.integrityOk) process.exitCode = 1;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   main().catch((error) => {
     // error-policy:J1 Translate the outer CLI boundary to stderr and a failing exit code.
     process.stderr.write(

--- a/packages/scripts/run-mvp-closeout-audit.mjs
+++ b/packages/scripts/run-mvp-closeout-audit.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
-import process from "node:process";
 /**
  * Produces one atomic LifeOps MVP closeout report from a single Project 15
  * snapshot. Board state, readiness policy, and evidence expectations consume
  * identical inputs so rate limits or mid-run board changes cannot create a
  * false parity result.
  */
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { buildEvidenceMatrix } from "./audit-mvp-evidence-matrix.mjs";
 import {

--- a/packages/scripts/validate-terraform-canonical-edge-additive-plan.mjs
+++ b/packages/scripts/validate-terraform-canonical-edge-additive-plan.mjs
@@ -5,6 +5,7 @@
 
 import { readFileSync } from "node:fs";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
 export function validateCanonicalEdgeAdditivePlan(plan, environment) {
   if (environment !== "staging" && environment !== "production") {
@@ -89,4 +90,5 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
+  main();

--- a/packages/scripts/validate-terraform-pages-domain-state.mjs
+++ b/packages/scripts/validate-terraform-pages-domain-state.mjs
@@ -5,6 +5,7 @@
 
 import { readFileSync } from "node:fs";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
 const DNS_ONLY_TYPES = new Set(["CNAME", "TXT"]);
 const REQUIRED_TUNNEL_ROLES = [
@@ -197,4 +198,5 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
+  main();

--- a/packages/ui/scripts/scan-reserved-storage-writers.mjs
+++ b/packages/ui/scripts/scan-reserved-storage-writers.mjs
@@ -34,7 +34,7 @@
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "..", "..", "..");
@@ -402,7 +402,10 @@ export function findRawReservedStorageWriters() {
   return violations;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   const v = findRawReservedStorageWriters();
   if (v.length === 0) {
     console.log("[surface-realm-writers] OK — no raw reserved-key writers");

--- a/plugins/plugin-local-inference/native/verify/mtp_runtime_smoke.mjs
+++ b/plugins/plugin-local-inference/native/verify/mtp_runtime_smoke.mjs
@@ -9,7 +9,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   buildSpeculativeBenchmarkReport,
   latestSpeculativeReportPath,
@@ -421,6 +421,6 @@ function main() {
   if (!mtp.pass) process.exitCode = 3;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }


### PR DESCRIPTION
## Summary
- Resolves #21365.
- Replaces the Windows-broken `file://${process.argv[1]}` string interpolation with the canonical `process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href` entrypoint guard across 19 scripts.
- Ensures direct CLI invocations work reliably across Windows (backslashes) and POSIX systems (including symlinked paths).

## Verification
- `bunx biome check` across modified scripts: clean
- `bun test packages/scripts/`: passed (including script isolation tests)