### PR TITLE
fix(cloud): widen provision sync-route mock to its nullable bridge fields

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.sync.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.sync.test.ts
@@ -21,15 +21,25 @@ const ORG_A = "11111111-1111-4111-8111-111111111111";
 const AGENT_ID = "agent-provision-1";
 const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
 
-const getAgentForWrite = mock(async () => ({
-  id: AGENT_ID,
-  organization_id: ORG_A,
-  agent_name: "already-up",
-  execution_tier: "dedicated-always",
-  status: "running",
-  bridge_url: "https://bridge.example.test",
-  health_url: "https://health.example.test",
-}));
+const getAgentForWrite = mock(
+  async (): Promise<{
+    id: string;
+    organization_id: string;
+    agent_name: string;
+    execution_tier: string;
+    status: string;
+    bridge_url: string | null;
+    health_url: string | null;
+  }> => ({
+    id: AGENT_ID,
+    organization_id: ORG_A,
+    agent_name: "already-up",
+    execution_tier: "dedicated-always",
+    status: "running",
+    bridge_url: "https://bridge.example.test",
+    health_url: "https://health.example.test",
+  }),
+);
 const provision = mock(async () => ({
   success: true,
   bridgeUrl: "https://bridge.example.test",


### PR DESCRIPTION
Same mock-typing class as #21113/#21146, merged onto develop within the last hour: route.sync.test.ts's default getAgentForWrite mock infers non-null bridge_url/health_url, so the stopped-agent mockImplementationOnce with nulls is a TS2322, failing cloud-api typecheck repo-wide (release candidate run 32053807955). The mock now declares the nullable return. cloud-api typecheck exit 0; suite 16/16; Biome clean.