### PR TITLE
fix(vault): reject malformed saved-login listing encoding

### DIFF
--- a/packages/vault/src/credentials.ts
+++ b/packages/vault/src/credentials.ts
@@ -50,8 +50,19 @@ function encodeAccount(username: string): string {
   return encodeURIComponent(username).replace(/\./g, "%2E");
 }
 
-function decodeAccount(segment: string): string {
-  return decodeURIComponent(segment);
+/**
+ * Decode the stored account segment. Leftover tax after other path-decode
+ * work: stock develop called `decodeURIComponent` while listing saved
+ * logins, so a vault key with `%` / `%2` / `%ZZ` in the account segment
+ * threw URIError and aborted the whole listing. Canonical encodeAccount
+ * usernames still decode. Malformed segments are skipped, not invented.
+ */
+function decodeAccount(segment: string): string | null {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return null;
+  }
 }
 
 /** Lower-case domains so `Github.com` and `github.com` collide. */
@@ -128,13 +139,15 @@ export async function listSavedLogins(
     const parsed = parseLoginKey(key, normalizedDomain);
     if (!parsed) continue;
     if (parsed.account === AUTOALLOW_SEGMENT) continue;
+    const username = decodeAccount(parsed.account);
+    if (username === null) continue;
     const descriptor = await vault.describe(key);
     if (!descriptor) continue;
     // describe() returns lastModified directly; we don't need to
     // decrypt the value to render the listing UI.
     summaries.push({
       domain: parsed.domain,
-      username: decodeAccount(parsed.account),
+      username,
       lastModified: descriptor.lastModified,
     });
   }

--- a/packages/vault/test/credentials.encoding.test.ts
+++ b/packages/vault/test/credentials.encoding.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Saved-login listing account-segment encoding is leftover tax after
+ * other path-decode work. Stock develop called decodeURIComponent on
+ * every listed account segment, so a vault key with `%` / `%2` / `%ZZ`
+ * threw URIError and aborted the whole listing. Canonical encodeAccount
+ * usernames still decode. Malformed segments are skipped, not invented.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { listSavedLogins, setSavedLogin } from "../src/credentials.js";
+import { createTestVault, type TestVault } from "../src/testing.js";
+
+describe("credentials — listing account encoding", () => {
+  let test: TestVault;
+
+  beforeEach(async () => {
+    test = await createTestVault();
+  });
+  afterEach(async () => {
+    await test.dispose();
+  });
+
+  it("canonical percent-encoded usernames still list", async () => {
+    await setSavedLogin(test.vault, {
+      domain: "github.com",
+      username: "user.name+tag@site.co.uk",
+      password: "p",
+    });
+    await expect(listSavedLogins(test.vault, "github.com")).resolves.toEqual([
+      expect.objectContaining({
+        domain: "github.com",
+        username: "user.name+tag@site.co.uk",
+      }),
+    ]);
+  });
+
+  it.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "skips malformed account segment %s without aborting the listing",
+    async (token) => {
+      await setSavedLogin(test.vault, {
+        domain: "github.com",
+        username: "alice",
+        password: "p1",
+      });
+      await test.vault.set(`creds.github.com.${token}`, "{}", {
+        sensitive: true,
+      });
+
+      const list = await listSavedLogins(test.vault, "github.com");
+      expect(list.map((entry) => entry.username)).toEqual(["alice"]);
+      expect(JSON.stringify(list)).not.toContain(token);
+    },
+  );
+});


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
vault saved-login listing account-segment percent-encoding. Encoding
class, leftover tax after other path-decode work. Not a twin of
those parsers — this is `listSavedLogins` account decode only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Account-segment decode only while listing saved logins.
Canonical encodeAccount usernames still decode. A vault key with
`%` / `%2` / `%ZZ` in the account segment is skipped instead of
throwing `URIError` and aborting the whole listing.

# Background

## What does this PR do?

`listSavedLogins` called `decodeURIComponent` on every stored
account segment. Illegal percent-encoding threw `URIError` and
hid every other login for that domain.

- planted `creds.github.com.%` / `%2` / `%ZZ` → skipped
- planted `creds.github.com.%E0%A4` → skipped
- `user.name+tag@site.co.uk` → still lists

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A corrupted or hand-written vault key must not crash the autofill
listing UI. Leftover tax after other path-decode work. Disjoint
files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/vault/test/credentials.encoding.test.ts`

## Detailed testing steps

```bash
cd packages/vault && bunx vitest run --config vitest.config.ts test/credentials.encoding.test.ts
```

5 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; saved-login listing decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; saved-login listing decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; saved-login listing decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused vault tests plant the real percent-encoding tokens and assert listing continues; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens are skipped before a username is invented.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real listing helper.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical encoded usernames still decode.
Malformed stored segments that previously threw `URIError` are skipped.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b3c4306d69a1a7b11f496b18f93935bb66a368c0 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
