### PR TITLE
fix(ci): restore authenticated temporary checkout in Cloud CF release

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -239,9 +239,10 @@ jobs:
           # `early EOF` / `fetch-pack: invalid index-pack output` (observed run
           # 28544777730, both attempts). HTTP/1.1 avoids the h2 stream-reset
           # path entirely at negligible cost for a single-stream shallow fetch.
+          auth_header="AUTHORIZATION: basic $(printf 'x-access-token:%s' "${CHECKOUT_TOKEN}" | base64 | tr -d '\n')"
           fetched=
           for attempt in 1 2 3; do
-            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 -c http.version=HTTP/1.1 -c http.extraheader="AUTHORIZATION: bearer ${CHECKOUT_TOKEN}" fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
+            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 -c http.version=HTTP/1.1 -c http.extraheader="$auth_header" fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
               fetched=1
               break
             fi
@@ -1578,13 +1579,14 @@ jobs:
           # loaded box die under HTTP/2 (`curl 92 ... CANCEL` / `early EOF` /
           # `invalid index-pack output`, observed run 28544777730); HTTP/1.1
           # avoids the h2 stream-reset path at negligible single-stream cost.
+          auth_header="AUTHORIZATION: basic $(printf 'x-access-token:%s' "${CHECKOUT_TOKEN}" | base64 | tr -d '\n')"
           fetched=
           for attempt in 1 2 3; do
             # Pages builds materialize packages/app + linked UI/core workspaces.
             # Blobless fetch pushes that cost into checkout as lazy hydration and
             # has repeatedly timed out on the deploy fleet, so use a normal
             # shallow fetch here.
-            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 -c http.version=HTTP/1.1 -c http.extraheader="AUTHORIZATION: bearer ${CHECKOUT_TOKEN}" fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
+            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 -c http.version=HTTP/1.1 -c http.extraheader="$auth_header" fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
               fetched=1
               break
             fi

--- a/packages/scripts/__tests__/cloud-cf-release-checkout-auth.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-release-checkout-auth.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression test for Cloud CF release temporary checkout authentication.
+ *
+ * GitHub Smart HTTP authentication requires Basic auth with base64(x-access-token:<token>)
+ * rather than Bearer auth, while keeping the token out of persistent git config / remote URLs.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "yaml";
+
+const workflowPath = join(
+  import.meta.dir,
+  "../../../.github/workflows/cloud-cf-release.yml",
+);
+const workflow = parse(readFileSync(workflowPath, "utf8"));
+
+function steps(jobName: string): Array<{
+  name?: string;
+  id?: string;
+  if?: string;
+  run?: string;
+  env?: Record<string, string>;
+}> {
+  return workflow.jobs[jobName].steps;
+}
+
+function step(jobName: string, name: string) {
+  const found = steps(jobName).find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`Missing ${jobName} step: ${name}`);
+  return found;
+}
+
+describe("Cloud CF release temporary checkout authentication", () => {
+  it("authenticates git fetch in deploy-api with ephemeral Basic header", () => {
+    const checkoutStep = step("deploy-api", "Checkout repository");
+    expect(checkoutStep.run).toBeDefined();
+    expect(checkoutStep.run).toContain("auth_header=");
+    expect(checkoutStep.run).toContain("AUTHORIZATION: basic");
+    expect(checkoutStep.run).toContain("x-access-token:");
+    expect(checkoutStep.run).toContain("base64");
+    expect(checkoutStep.run).not.toContain("AUTHORIZATION: bearer");
+    expect(checkoutStep.env?.CHECKOUT_TOKEN).toContain("github.token");
+  });
+
+  it("authenticates git fetch in deploy-app with ephemeral Basic header", () => {
+    const checkoutStep = step("deploy-app", "Checkout repository");
+    expect(checkoutStep.run).toBeDefined();
+    expect(checkoutStep.run).toContain("auth_header=");
+    expect(checkoutStep.run).toContain("AUTHORIZATION: basic");
+    expect(checkoutStep.run).toContain("x-access-token:");
+    expect(checkoutStep.run).toContain("base64");
+    expect(checkoutStep.run).not.toContain("AUTHORIZATION: bearer");
+    expect(checkoutStep.env?.CHECKOUT_TOKEN).toContain("github.token");
+  });
+});


### PR DESCRIPTION
## Summary
- Resolves #21372.
- In `.github/workflows/cloud-cf-release.yml`, replaces `AUTHORIZATION: bearer ${CHECKOUT_TOKEN}` with the canonical ephemeral in-memory Basic auth header `AUTHORIZATION: basic $(printf 'x-access-token:%s' "${CHECKOUT_TOKEN}" | base64 | tr -d '\n')` across both deploy temporary checkout sites.
- Keeps credentials strictly ephemeral in memory without persisting tokens in git config or remote URLs.
- Adds a regression test in `packages/scripts/__tests__/cloud-cf-release-checkout-auth.test.ts`.

## Verification
- `bun test packages/scripts/__tests__/cloud-cf-release-checkout-auth.test.ts`: 2 passed
- `bun test packages/scripts/__tests__/cloud-cf-*.test.ts`: 36 passed
- `bunx biome check packages/scripts/__tests__/cloud-cf-release-checkout-auth.test.ts`: clean