### PR TITLE
fix(plugin-capacitor-bridge): reject malformed iOS transcript id encoding

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.transcripts.encoding.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.transcripts.encoding.test.ts
@@ -1,0 +1,154 @@
+/**
+ * iOS transcript-id path encoding is leftover tax after Android
+ * notifications / other path-decode work. Stock develop called
+ * decodeURIComponent on GET/PUT/DELETE /api/transcripts/:id, so `%` /
+ * `%2` / `%ZZ` threw URIError instead of a typed 400. List and create
+ * stay untouched.
+ */
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import type { TranscriptSegment } from "@elizaos/shared/transcripts";
+import { describe, expect, it } from "vitest";
+import {
+	handleDirectCoreRoute,
+	type IosBridgeBackend,
+} from "./bridge.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+
+function createFakeRuntime(): IAgentRuntime {
+	const tables = new Map<string, Memory[]>();
+	return {
+		agentId: AGENT_ID,
+		character: { name: "TestAgent" },
+		async getMemories(params: {
+			tableName: string;
+			roomId?: UUID;
+			limit?: number;
+			count?: number;
+		}): Promise<Memory[]> {
+			let rows = [...(tables.get(params.tableName) ?? [])];
+			if (params.roomId) {
+				rows = rows.filter((m) => m.roomId === params.roomId);
+			}
+			const cap = params.count ?? params.limit;
+			return typeof cap === "number" ? rows.slice(0, cap) : rows;
+		},
+		async getMemoryById(id: UUID): Promise<Memory | null> {
+			for (const rows of tables.values()) {
+				const found = rows.find((m) => m.id === id);
+				if (found) return found;
+			}
+			return null;
+		},
+		async createMemory(memory: Memory, tableName: string): Promise<UUID> {
+			const rows = tables.get(tableName) ?? [];
+			rows.push(memory);
+			tables.set(tableName, rows);
+			return memory.id as UUID;
+		},
+		async updateMemory(): Promise<boolean> {
+			throw new Error("updateMemory must not run on malformed encoding");
+		},
+		async deleteMemory(): Promise<void> {
+			throw new Error("deleteMemory must not run on malformed encoding");
+		},
+	} as unknown as IAgentRuntime;
+}
+
+function makeBackend(runtime: IAgentRuntime): IosBridgeBackend {
+	return {
+		runtime,
+		dispatchRoute: async () => null,
+		conversations: new Map(),
+		close: async () => {},
+	};
+}
+
+async function call(
+	backend: IosBridgeBackend,
+	method: string,
+	rawPath: string,
+	body?: unknown,
+): Promise<{ status: number; json: Record<string, unknown> }> {
+	const res = await handleDirectCoreRoute(
+		backend,
+		method,
+		rawPath,
+		body === undefined ? {} : { body: JSON.stringify(body) },
+	);
+	if (!res) throw new Error(`route returned null: ${method} ${rawPath}`);
+	return { status: res.status, json: JSON.parse(res.body) };
+}
+
+const seg = (text: string, endMs = 1000): TranscriptSegment => ({
+	id: `seg-${Math.random().toString(36).slice(2)}`,
+	speakerLabel: "Speaker 1",
+	startMs: 0,
+	endMs,
+	text,
+	words: [],
+});
+
+describe("iOS /api/transcripts/:id encoding", () => {
+	it("GET /api/transcripts list is untouched", async () => {
+		const backend = makeBackend(createFakeRuntime());
+		const { status, json } = await call(backend, "GET", "/api/transcripts");
+		expect(status).toBe(200);
+		expect(json).toEqual({ transcripts: [] });
+	});
+
+	it("POST /api/transcripts create is untouched", async () => {
+		const backend = makeBackend(createFakeRuntime());
+		const { status, json } = await call(backend, "POST", "/api/transcripts", {
+			title: "Standup",
+			segments: [seg("hello", 1500)],
+		});
+		expect(status).toBe(201);
+		expect(json.transcript).toMatchObject({
+			title: "Standup",
+			status: "ready",
+			durationMs: 1500,
+		});
+	});
+
+	it("canonical percent-encoded id still reaches transcript lookup", async () => {
+		const runtime = createFakeRuntime();
+		const seen: string[] = [];
+		runtime.getMemoryById = async (id: UUID) => {
+			seen.push(id);
+			return null;
+		};
+		const backend = makeBackend(runtime);
+		const { status, json } = await call(
+			backend,
+			"GET",
+			"/api/transcripts/t%2D1",
+		);
+		expect(seen).toEqual(["t-1"]);
+		expect(status).toBe(404);
+		expect(json).toEqual({ error: "not found" });
+	});
+
+	it.each(["%", "%2", "%ZZ", "%E0%A4"])(
+		"rejects malformed %s with 400 before transcript lookup",
+		async (token) => {
+			const runtime = createFakeRuntime();
+			runtime.getMemoryById = async () => {
+				throw new Error("getMemoryById must not run on malformed encoding");
+			};
+			const backend = makeBackend(runtime);
+			for (const method of ["GET", "PUT", "DELETE"] as const) {
+				const { status, json } = await call(
+					backend,
+					method,
+					`/api/transcripts/${token}`,
+					method === "PUT" ? { title: "x" } : undefined,
+				);
+				expect(status).toBe(400);
+				expect(json).toEqual({
+					error: "invalid transcript id: malformed URL encoding",
+				});
+			}
+		},
+	);
+});

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1491,6 +1491,14 @@ async function persistTranscript(
 	return transcript;
 }
 
+function decodeTranscriptId(raw: string): UUID | null {
+	try {
+		return decodeURIComponent(raw) as UUID;
+	} catch {
+		return null;
+	}
+}
+
 async function handleTranscriptsRoute(
 	runtime: IAgentRuntime,
 	method: string,
@@ -1529,7 +1537,19 @@ async function handleTranscriptsRoute(
 
 	const idMatch = pathname.match(/^\/api\/transcripts\/([^/]+)$/);
 	if (!idMatch) return null;
-	const id = decodeURIComponent(idMatch[1] ?? "") as UUID;
+	/**
+	 * Decode the untrusted transcript-id path segment. Leftover tax after
+	 * Android notifications / other path-decode work: stock develop called
+	 * `decodeURIComponent` on GET/PUT/DELETE `/api/transcripts/:id`, so `%` /
+	 * `%2` / `%ZZ` threw URIError instead of a typed 400. List and create
+	 * stay untouched.
+	 */
+	const id = decodeTranscriptId(idMatch[1] ?? "");
+	if (id === null) {
+		return jsonResponse(400, {
+			error: "invalid transcript id: malformed URL encoding",
+		});
+	}
 
 	if (method === "GET") {
 		const transcript = await getTranscript(runtime, id);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
iOS capacitor-bridge transcript-id percent-encoding. Encoding
class, leftover tax after Android notifications / other path-decode
work. Not a twin of those parsers — this is GET/PUT/DELETE
`/api/transcripts/:id` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on the iOS transcript-id route.
Canonical `t%2D1` still decodes to `t-1` and reaches memory lookup.
Malformed `%` / `%2` / `%ZZ` become 400 instead of an uncaught
`URIError`. GET `/api/transcripts` list and POST create stay
untouched.

# Background

## What does this PR do?

`handleTranscriptsRoute` called `decodeURIComponent` on the
transcript-id path segment. Illegal percent-encoding threw
`URIError` instead of a typed 400.

- `/api/transcripts/%` / `%2` / `%ZZ` → **400**
- `/api/transcripts/%E0%A4` → **400**
- `/api/transcripts/t%2D1` → still decodes to `t-1`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded transcript id
should get a request error, not a 500 that looks like a memory-store
outage. Leftover tax after Android notifications / other path-decode
work. Disjoint files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-capacitor-bridge/src/ios/bridge.transcripts.encoding.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-capacitor-bridge && bunx vitest run --config vitest.config.ts src/ios/bridge.transcripts.encoding.test.ts
```

7 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; transcript-id path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; transcript-id path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; transcript-id path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before memory reads; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before transcript memory reads.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real handler.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded ids still decode.
Malformed tokens that previously 500 now 400.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:18236bebaeced3bfcc2f8e5f1ff724c4affb2446 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
