### PR TITLE
fix(cloud): reject malformed oauth callback provider encoding

### DIFF
--- a/packages/cloud/api/v1/oauth/callback/[provider]/route.encoding.test.ts
+++ b/packages/cloud/api/v1/oauth/callback/[provider]/route.encoding.test.ts
@@ -1,0 +1,108 @@
+/**
+ * GET/POST /api/v1/oauth/callback/:provider path encoding is leftover tax
+ * after other cloud path-decode work. Stock develop called
+ * decodeURIComponent in providerFromCallbackUrl, so `%` / `%2` / `%ZZ`
+ * threw URIError and failureResponse mapped it to 500. Canonical providers
+ * and the unsupported-provider 400 stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getByStateTokenHash = mock(async () => null);
+const getOAuthIntentsService = mock(() => ({
+  getByStateTokenHash,
+  markDenied: mock(),
+  markBound: mock(),
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  getIpKey: () => "test-ip",
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/oauth-intents-default", () => ({
+  getOAuthIntentsService,
+}));
+
+mock.module("@/lib/services/oauth-callback-bus", () => ({
+  createOAuthCallbackBus: () => ({
+    publish: mock(async () => undefined),
+  }),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    error: mock(() => undefined),
+    warn: mock(() => undefined),
+    info: mock(() => undefined),
+  },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/api/v1/oauth/callback/:provider", route);
+
+function callbackUrl(provider: string, query = "state=oauth-state"): string {
+  return `https://api.example.test/api/v1/oauth/callback/${provider}?${query}`;
+}
+
+describe("GET /api/v1/oauth/callback/:provider encoding", () => {
+  beforeEach(() => {
+    getByStateTokenHash.mockClear();
+    getOAuthIntentsService.mockClear();
+  });
+
+  test("unsupported provider is untouched", async () => {
+    const response = await app.fetch(new Request(callbackUrl("not-a-provider")));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Unsupported provider",
+    });
+    expect(getByStateTokenHash).not.toHaveBeenCalled();
+  });
+
+  test("canonical provider still reaches intent lookup", async () => {
+    const response = await app.fetch(new Request(callbackUrl("google")));
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Unknown state token",
+    });
+    expect(getByStateTokenHash).toHaveBeenCalledTimes(1);
+  });
+
+  test("canonical percent-encoded letter still decodes before lookup", async () => {
+    const response = await app.fetch(new Request(callbackUrl("g%6Fogle")));
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Unknown state token",
+    });
+    expect(getByStateTokenHash).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed provider %s with 400",
+    async (token) => {
+      const response = await app.fetch(new Request(callbackUrl(token)));
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        success: false,
+        error: "invalid provider: malformed URL encoding",
+      });
+      expect(getByStateTokenHash).not.toHaveBeenCalled();
+    },
+  );
+
+  test("POST rejects malformed provider before intent lookup", async () => {
+    const response = await app.fetch(
+      new Request(callbackUrl("%"), { method: "POST" }),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "invalid provider: malformed URL encoding",
+    });
+    expect(getByStateTokenHash).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/oauth/callback/[provider]/route.ts
+++ b/packages/cloud/api/v1/oauth/callback/[provider]/route.ts
@@ -56,12 +56,21 @@ async function hashState(state: string): Promise<string> {
     .join("");
 }
 
-function providerFromCallbackUrl(url: string): string | undefined {
+function decodeCallbackProvider(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return null;
+  }
+}
+
+function providerFromCallbackUrl(url: string): string | undefined | null {
   const pathname = new URL(url).pathname.replace(/\/+$/, "");
   const provider = pathname.split("/").pop();
-  return provider && provider !== "callback"
-    ? decodeURIComponent(provider)
-    : undefined;
+  if (!provider || provider === "callback") {
+    return undefined;
+  }
+  return decodeCallbackProvider(provider);
 }
 
 const app = new Hono<AppEnv>();
@@ -75,7 +84,16 @@ app.use(
   }),
 );
 
-async function handleCallback(c: AppContext, rawProvider: string | undefined) {
+async function handleCallback(
+  c: AppContext,
+  rawProvider: string | undefined | null,
+) {
+  if (rawProvider === null) {
+    return c.json(
+      { success: false, error: "invalid provider: malformed URL encoding" },
+      400,
+    );
+  }
   const provider = rawProvider?.toLowerCase();
   if (!provider || !SUPPORTED_PROVIDERS.has(provider)) {
     return c.json({ success: false, error: "Unsupported provider" }, 400);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
cloud OAuth callback provider percent-encoding. Encoding
class, leftover tax after other path-decode work. Not a twin of
those parsers — this is GET/POST `/api/v1/oauth/callback/:provider`
only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on the OAuth callback provider.
Canonical `g%6Fogle` still decodes to `google` and reaches intent
lookup. Malformed `%` / `%2` / `%ZZ` become 400 instead of an
uncaught `URIError` mapped to 500. Unsupported-provider 400 stays
untouched.

# Background

## What does this PR do?

`providerFromCallbackUrl` called `decodeURIComponent` on the
provider path segment. Illegal percent-encoding threw `URIError`,
which `failureResponse` mapped to 500.

- `/api/v1/oauth/callback/%` / `%2` / `%ZZ` → **400**
- `/api/v1/oauth/callback/%E0%A4` → **400**
- `/api/v1/oauth/callback/g%6Fogle` → still decodes to `google`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded provider
should get a request error, not a 500 that looks like an OAuth
intent outage. Leftover tax after other path-decode work. Disjoint
files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/oauth/callback/[provider]/route.encoding.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/oauth/callback/[provider]/route.encoding.test.ts
```

8 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; oauth callback provider decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; oauth callback provider decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; oauth callback provider decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before intent lookup; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before OAuth intent reads.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real handler.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded providers still decode.
Malformed tokens that previously 500 now 400.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6925dc24ef364714f33c122131dea91606175938 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
