### PR TITLE
fix(cloud): reject malformed internal-eliza conversation path encoding

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-conversation-fetch.encoding.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-conversation-fetch.encoding.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Internal Eliza conversation stream path encoding is leftover tax after
+ * local-runtime conversation-id decode. Stock develop called
+ * decodeURIComponent on agentId and conversationId, so `%` / `%2` / `%ZZ`
+ * threw URIError instead of a typed 400. Unsupported paths still throw.
+ * Auth 404 after a canonical decode stays untouched.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import type { Bindings } from "@/types/cloud-worker-env";
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+mock.module("@/lib/cache/client", () => ({
+  cache: {
+    get: mock(async () => null),
+    set: mock(async () => undefined),
+    del: mock(async () => undefined),
+  },
+}));
+
+mock.module("@/lib/cache/keys", () => ({
+  CacheKeys: {
+    sharedAgentScope: {
+      voice: () => "voice-scope-key",
+    },
+  },
+}));
+
+mock.module("@/lib/runtime/cloud-bindings", () => ({
+  hasCloudBindingsContext: () => false,
+  runWithCloudBindingsAsync: async (
+    _env: unknown,
+    fn: () => Promise<unknown>,
+  ) => fn(),
+}));
+
+mock.module("@/lib/auth/cron", () => ({
+  timingSafeEqualSecret: () => false,
+}));
+
+mock.module("@/lib/services/shared-runtime/canonical-scoped-stream", () => ({
+  handleCanonicalScopedAgentStream: mock(),
+}));
+
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  coordinateSharedConversationPrewarm: mock(),
+  coordinateSharedLifecycleEvent: mock(),
+}));
+
+mock.module("@/lib/services/shared-runtime/personal-shared-agent", () => ({
+  isPersonalSharedAgentId: () => false,
+  personalSharedAgent: () => null,
+}));
+
+const { createInternalElizaConversationFetch } = await import(
+  "../lib/internal-eliza-conversation-fetch"
+);
+
+const AGENT_ID = "agent-1";
+const CONVERSATION_ID = "conv-1";
+
+function fetchImpl() {
+  return createInternalElizaConversationFetch(
+    {
+      VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer voice-service",
+    } as Bindings,
+    {
+      agentId: AGENT_ID,
+      conversationId: CONVERSATION_ID,
+      organizationId: "org-1",
+      userId: "user-1",
+    },
+  );
+}
+
+function streamUrl(agentId: string, conversationId: string): string {
+  return `https://voice.internal/api/v1/eliza/agents/${agentId}/api/conversations/${conversationId}/messages/stream`;
+}
+
+describe("internal Eliza conversation stream path encoding", () => {
+  test("unsupported path is untouched", async () => {
+    await expect(
+      fetchImpl()("https://voice.internal/api/v1/eliza/other", {
+        method: "POST",
+      }),
+    ).rejects.toThrow("unsupported internal Eliza stream path");
+  });
+
+  test("canonical ids still reach auth after decode", async () => {
+    const response = await fetchImpl()(streamUrl(AGENT_ID, CONVERSATION_ID), {
+      method: "POST",
+    });
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Agent not found",
+      code: "agent_not_found",
+    });
+  });
+
+  test("canonical percent-encoded hyphen still decodes before auth", async () => {
+    const response = await fetchImpl()(streamUrl("agent%2D1", "conv%2D1"), {
+      method: "POST",
+    });
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Agent not found",
+      code: "agent_not_found",
+    });
+  });
+
+  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed conversation id %s with 400",
+    async (token) => {
+      const response = await fetchImpl()(streamUrl(AGENT_ID, token), {
+        method: "POST",
+      });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        success: false,
+        error: "invalid conversation path: malformed URL encoding",
+      });
+    },
+  );
+
+  test.each(["%", "%2", "%ZZ"])(
+    "rejects malformed agent id %s with 400",
+    async (token) => {
+      const response = await fetchImpl()(streamUrl(token, CONVERSATION_ID), {
+        method: "POST",
+      });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        success: false,
+        error: "invalid conversation path: malformed URL encoding",
+      });
+    },
+  );
+});

--- a/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-conversation-fetch.history-cutoff.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-conversation-fetch.history-cutoff.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Server-attested historyCutoffAt is leftover pairing after #21385 path
+ * encoding. Only an authenticated voice-service turn may elevate a finite
+ * positive integer cutoff onto the canonical stream request. Malformed or
+ * untrusted values must not reach handleCanonicalScopedAgentStream.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Bindings } from "@/types/cloud-worker-env";
+
+const handleCanonicalScopedAgentStream = mock(async () => new Response("ok"));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+mock.module("@/lib/cache/client", () => ({
+  cache: {
+    get: mock(async () => ({
+      id: "agent-1",
+      organization_id: "org-1",
+      user_id: "user-1",
+      execution_tier: "shared",
+    })),
+    set: mock(async () => undefined),
+    del: mock(async () => undefined),
+  },
+}));
+
+mock.module("@/lib/cache/keys", () => ({
+  CacheKeys: {
+    sharedAgentScope: {
+      voice: () => "voice-scope-key",
+    },
+  },
+}));
+
+mock.module("@/lib/runtime/cloud-bindings", () => ({
+  hasCloudBindingsContext: () => false,
+  runWithCloudBindingsAsync: async (
+    _env: unknown,
+    fn: () => Promise<unknown>,
+  ) => fn(),
+}));
+
+mock.module("@/lib/auth/cron", () => ({
+  timingSafeEqualSecret: (presented: string, configured: string) =>
+    presented === configured,
+}));
+
+mock.module("@/lib/services/shared-runtime/canonical-scoped-stream", () => ({
+  handleCanonicalScopedAgentStream,
+}));
+
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  coordinateSharedConversationPrewarm: mock(),
+  coordinateSharedLifecycleEvent: mock(),
+}));
+
+mock.module("@/lib/services/shared-runtime/personal-shared-agent", () => ({
+  isPersonalSharedAgentId: () => false,
+  personalSharedAgent: () => null,
+}));
+
+const { createInternalElizaConversationFetch } = await import(
+  "../lib/internal-eliza-conversation-fetch"
+);
+
+const AGENT_ID = "agent-1";
+const CONVERSATION_ID = "conv-1";
+const ORGANIZATION_ID = "org-1";
+const USER_ID = "user-1";
+const CUTOFF_AT = 1_724_000_000_000;
+
+function fetchImpl() {
+  return createInternalElizaConversationFetch(
+    {
+      VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer voice-service",
+      SHARED_RUNTIME_CONVERSATIONS: {
+        getByName() {
+          throw new Error("coordinator must not be reached");
+        },
+      },
+    } as Bindings,
+    {
+      agentId: AGENT_ID,
+      conversationId: CONVERSATION_ID,
+      organizationId: ORGANIZATION_ID,
+      userId: USER_ID,
+    },
+    {
+      waitUntil() {
+        return undefined;
+      },
+    },
+  );
+}
+
+function streamUrl(): string {
+  return `https://voice.internal/api/v1/eliza/agents/${AGENT_ID}/api/conversations/${CONVERSATION_ID}/messages/stream`;
+}
+
+function streamInit(
+  body: Record<string, unknown>,
+  authorization = "Bearer voice-service",
+): RequestInit {
+  return {
+    method: "POST",
+    headers: {
+      Authorization: authorization,
+      "Content-Type": "application/json",
+      "X-Eliza-Agent-Id": AGENT_ID,
+      "X-Eliza-Conversation-Id": CONVERSATION_ID,
+      "X-Eliza-Organization-Id": ORGANIZATION_ID,
+      "X-Eliza-User-Id": USER_ID,
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+describe("internal Eliza conversation historyCutoffAt transport", () => {
+  beforeEach(() => {
+    handleCanonicalScopedAgentStream.mockClear();
+  });
+
+  test("authenticated elevation passes finite positive historyCutoffAt and strips it from body", async () => {
+    const response = await fetchImpl()(
+      streamUrl(),
+      streamInit({
+        text: "open the call",
+        messageRole: "system",
+        historyCutoffAt: CUTOFF_AT,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(handleCanonicalScopedAgentStream).toHaveBeenCalledTimes(1);
+    const request = handleCanonicalScopedAgentStream.mock.calls[0]?.[0] as {
+      historyCutoffAt?: unknown;
+      trustedMessageRole?: unknown;
+      body?: { historyCutoffAt?: unknown; text?: unknown };
+    };
+    expect(request.historyCutoffAt).toBe(CUTOFF_AT);
+    expect(request.trustedMessageRole).toBe("system");
+    expect(request.body).toEqual({
+      text: "open the call",
+      messageRole: "system",
+    });
+    expect(request.body).not.toHaveProperty("historyCutoffAt");
+  });
+
+  test.each([
+    { label: "prefix-coerced string", token: "123" },
+    { label: "prefix-coerced mixed string", token: "123abc" },
+    { label: "ISO timestamp string", token: "2026-08-17T00:00:00Z" },
+    { label: "zero", token: 0 },
+    { label: "negative", token: -1 },
+    { label: "float", token: 1.5 },
+    { label: "NaN", token: Number.NaN },
+    { label: "Infinity", token: Number.POSITIVE_INFINITY },
+    { label: "boolean", token: true },
+    { label: "null", token: null },
+    { label: "object", token: { at: CUTOFF_AT } },
+    { label: "array", token: [CUTOFF_AT] },
+  ])(
+    "malformed historyCutoffAt $label is denied with 400 after auth",
+    async ({ token }) => {
+      const response = await fetchImpl()(
+        streamUrl(),
+        streamInit({
+          text: "open the call",
+          historyCutoffAt: token,
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        success: false,
+        error:
+          "invalid historyCutoffAt: expected a finite positive integer timestamp",
+      });
+      expect(handleCanonicalScopedAgentStream).not.toHaveBeenCalled();
+    },
+  );
+
+  test("untrusted request cannot elevate historyCutoffAt", async () => {
+    const response = await fetchImpl()(
+      streamUrl(),
+      streamInit(
+        {
+          text: "open the call",
+          historyCutoffAt: CUTOFF_AT,
+        },
+        "Bearer attacker",
+      ),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Agent not found",
+      code: "agent_not_found",
+    });
+    expect(handleCanonicalScopedAgentStream).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -259,7 +259,23 @@ async function dispatchInternalElizaConversationFetch(
 ): Promise<Response> {
   const request = new Request(input, init);
   const url = new URL(request.url);
-  assertCanonicalVoiceStreamPath(url, claims);
+  try {
+    assertCanonicalVoiceStreamPath(url, claims);
+  } catch (error) {
+    if (
+      error instanceof TypeError &&
+      error.message === "invalid internal Eliza stream path: malformed URL encoding"
+    ) {
+      return Response.json(
+        {
+          success: false,
+          error: "invalid conversation path: malformed URL encoding",
+        },
+        { status: 400 },
+      );
+    }
+    throw error;
+  }
   if (request.method !== "POST") {
     return Response.json(
       { success: false, error: "Method not allowed" },
@@ -339,6 +355,14 @@ async function dispatchInternalElizaConversationFetch(
   });
 }
 
+function decodeStreamPathSegment(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return null;
+  }
+}
+
 function assertCanonicalVoiceStreamPath(
   url: URL,
   claims: InternalElizaConversationFetchClaims,
@@ -351,8 +375,13 @@ function assertCanonicalVoiceStreamPath(
       `unsupported internal Eliza stream path: ${url.pathname}`,
     );
   }
-  const agentId = decodeURIComponent(match[1]);
-  const conversationId = decodeURIComponent(match[2]);
+  const agentId = decodeStreamPathSegment(match[1]);
+  const conversationId = decodeStreamPathSegment(match[2]);
+  if (agentId === null || conversationId === null) {
+    throw new TypeError(
+      "invalid internal Eliza stream path: malformed URL encoding",
+    );
+  }
   if (agentId !== claims.agentId || conversationId !== claims.conversationId) {
     throw new TypeError(
       "internal Eliza stream path does not match session scope",

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -264,7 +264,8 @@ async function dispatchInternalElizaConversationFetch(
   } catch (error) {
     if (
       error instanceof TypeError &&
-      error.message === "invalid internal Eliza stream path: malformed URL encoding"
+      error.message ===
+        "invalid internal Eliza stream path: malformed URL encoding"
     ) {
       return Response.json(
         {
@@ -334,7 +335,19 @@ async function dispatchInternalElizaConversationFetch(
     body = {};
   }
 
-  return handleCanonicalScopedAgentStream({
+  const cutoff = readAttestedHistoryCutoffAt(body);
+  if (!cutoff.ok) {
+    return Response.json(
+      {
+        success: false,
+        error:
+          "invalid historyCutoffAt: expected a finite positive integer timestamp",
+      },
+      { status: 400 },
+    );
+  }
+
+  const streamRequest = {
     abortSignal: request.signal,
     agent,
     agentId: claims.agentId,
@@ -348,11 +361,51 @@ async function dispatchInternalElizaConversationFetch(
       (body as { messageRole?: unknown }).messageRole === "system"
         ? "system"
         : undefined,
-    body,
+    body: stripUntrustedHistoryCutoffAt(body),
     origin: headers.get("origin"),
     namespace: runtime.namespace,
     executionCtx: runtime.executionCtx,
-  });
+  };
+
+  return handleCanonicalScopedAgentStream(
+    cutoff.value === undefined
+      ? streamRequest
+      : Object.assign(streamRequest, { historyCutoffAt: cutoff.value }),
+  );
+}
+
+type HistoryCutoffRead = { ok: true; value?: number } | { ok: false };
+
+/**
+ * Server-attest a client-supplied history cutoff only after voice-service auth.
+ * Prefix-coerced strings, non-integers, and non-positive values are denied.
+ */
+function readAttestedHistoryCutoffAt(body: unknown): HistoryCutoffRead {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: true };
+  }
+  if (!Object.hasOwn(body, "historyCutoffAt")) {
+    return { ok: true };
+  }
+  const value = (body as { historyCutoffAt: unknown }).historyCutoffAt;
+  if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
+    return { ok: true, value };
+  }
+  return { ok: false };
+}
+
+function stripUntrustedHistoryCutoffAt(body: unknown): unknown {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return body;
+  }
+  if (!Object.hasOwn(body, "historyCutoffAt")) {
+    return body;
+  }
+  const { historyCutoffAt: _ignored, ...rest } = body as Record<
+    string,
+    unknown
+  >;
+  return rest;
 }
 
 function decodeStreamPathSegment(raw: string): string | null {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
internal-eliza conversation stream path percent-encoding, plus the
owner-authored server-attested `historyCutoffAt` transport on the
same adapter. Encoding class, leftover tax after local-runtime
conversation-id decode. Not a twin of that parser — this is
`/api/v1/eliza/agents/:agentId/api/conversations/:conversationId/messages/stream`
only. Paired / do-not-twin with #21384. Not an overlay of #21396.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode and post-auth cutoff attestation only on the
internal Eliza stream path. Canonical `agent%2D1` / `conv%2D1` still
decode and reach auth. Malformed `%` / `%2` / `%ZZ` become 400 instead
of an uncaught `URIError`. Unsupported paths still throw. Untrusted
`historyCutoffAt` never elevates; malformed cutoff is 400 after auth.

# Background

## What does this PR do?

`assertCanonicalVoiceStreamPath` called `decodeURIComponent` on
the agent-id and conversation-id segments. Illegal
percent-encoding threw `URIError` instead of a typed 400.

- malformed agent or conversation id `%` / `%2` / `%ZZ` → **400**
- `%E0%A4` conversation id → **400**
- `agent%2D1` / `conv%2D1` → still decodes to `agent-1` / `conv-1`

After voice-service auth, a finite positive integer `historyCutoffAt`
is elevated onto the canonical stream request and stripped from the
untrusted body. Prefix-coerced strings, non-integers, and unauthenticated
requests cannot elevate it.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded stream path
should get a request error, not a 500 that looks like a voice
runtime outage. Leftover tax after local-runtime conversation-id
decode. Disjoint files from that parser. The cutoff transport is the
owner-authored pairing artifact so Twilio recovery can rebase after
#21384 + #21385 without editing this file.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/voice/session/__tests__/internal-eliza-conversation-fetch.encoding.test.ts`
`packages/cloud/api/v1/voice/session/__tests__/internal-eliza-conversation-fetch.history-cutoff.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test \
  v1/voice/session/__tests__/internal-eliza-conversation-fetch.encoding.test.ts \
  v1/voice/session/__tests__/internal-eliza-conversation-fetch.history-cutoff.test.ts
```

24 identity tests passed at this head (10 encoding + 14 cutoff).

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; internal stream path decode and cutoff attestation only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; internal stream path decode and cutoff attestation only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; internal stream path decode and cutoff attestation only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused fetch tests drive the real percent-encoding tokens and the attested cutoff; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before conversation auth; untrusted cutoff never elevates.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding and cutoff contracts are asserted in-process against the real fetch adapter.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded ids still decode.
Malformed tokens that previously threw now 400. Authenticated finite
positive integer `historyCutoffAt` is attested; malformed/untrusted
values are denied. No live voice/provider traffic.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3fb20bd2845cefb15d11c00ccbf7e30b728473d9 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
