### PR TITLE
Prevent cloud-only desktop startup from falling back to localhost

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1808,6 +1808,7 @@ function ShellFoundationMount({
   const hasController = controller !== null;
   const shellIsOpen = controller?.isOpen ?? false;
   const [shellPreviewHovered, setShellPreviewHovered] = useState(false);
+  const [shellPreviewHostReady, setShellPreviewHostReady] = useState(false);
   const focusComposerOnOpenRef = useRef(false);
   const { setChatInput } = useChatComposer();
   const chatInputRef = useChatInputRef();
@@ -1897,6 +1898,7 @@ function ShellFoundationMount({
   useEffect(() => {
     if (!hasController) return undefined;
     let cancelled = false;
+    setShellPreviewHostReady(false);
 
     void (async () => {
       if (cancelled) return;
@@ -1909,6 +1911,17 @@ function ShellFoundationMount({
         },
         timeoutMs: 1_000,
       });
+      if (
+        !cancelled &&
+        useWebChatPanel &&
+        shellPreviewHovered &&
+        !shellIsOpen
+      ) {
+        // Paint only after the native host is 600px wide. Before this
+        // acknowledgement, a wide DOM preview is clipped through the resting
+        // 96px WKWebView and appears as a narrow center slice.
+        setShellPreviewHostReady(true);
+      }
     })();
 
     return () => {
@@ -1981,6 +1994,7 @@ function ShellFoundationMount({
         onPreviewHoverChange={
           useWebChatPanel ? setShellPreviewHovered : undefined
         }
+        previewHostReady={!useWebChatPanel || shellPreviewHostReady}
       />
       {!useWebChatPanel ? (
         <AssistantOverlay

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1808,6 +1808,7 @@ function ShellFoundationMount({
   const hasController = controller !== null;
   const shellIsOpen = controller?.isOpen ?? false;
   const [shellPreviewHovered, setShellPreviewHovered] = useState(false);
+  const focusComposerOnOpenRef = useRef(false);
   const { setChatInput } = useChatComposer();
   const chatInputRef = useChatInputRef();
   // Push-to-talk dictation on the ChatSurface mic drops its transcript into
@@ -1914,6 +1915,20 @@ function ShellFoundationMount({
       cancelled = true;
     };
   }, [hasController, shellIsOpen, shellPreviewHovered, useWebChatPanel]);
+  useEffect(() => {
+    if (!useWebChatPanel || !shellIsOpen || !focusComposerOnOpenRef.current) {
+      return;
+    }
+    focusComposerOnOpenRef.current = false;
+    const frame = window.requestAnimationFrame(() => {
+      document
+        .querySelector<HTMLTextAreaElement>(
+          '[data-testid="chat-composer-textarea"]',
+        )
+        ?.focus({ preventScroll: true });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [shellIsOpen, useWebChatPanel]);
   const closeWebChatWhenPilled = useCallback(
     (pilled: boolean) => {
       if (pilled) controller?.close();
@@ -1938,7 +1953,10 @@ function ShellFoundationMount({
         phase={controller.phase}
         speaking={controller.speaking}
         signingIn={controller.signingIn}
-        onOpen={controller.open}
+        onOpen={() => {
+          focusComposerOnOpenRef.current = useWebChatPanel;
+          controller.open();
+        }}
         onClose={controller.close}
         onHoldStart={() => {
           if (controller.authGate.gated) {

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -45,6 +45,10 @@ export interface HomePillProps {
   /** Reports the idle pill's shallow composer-preview hover state. Desktop
    *  uses this to widen the transparent native hit area before painting it. */
   onPreviewHoverChange?: (hovered: boolean) => void;
+  /** True once the native host has acknowledged its wider hover frame. The
+   *  preview stays compact until then so WKWebView cannot clip the wide
+   *  composer into the resting 96px window. Web callers leave this unset. */
+  previewHostReady?: boolean;
 }
 
 /** How long the pointer must stay down before a press becomes a hold. Above
@@ -117,6 +121,7 @@ export function HomePill({
   speaking = false,
   signingIn = false,
   onPreviewHoverChange,
+  previewHostReady = true,
 }: HomePillProps): React.JSX.Element {
   const { appName } = useBranding();
   const needsAuth = phase === "needs-auth";
@@ -245,9 +250,10 @@ export function HomePill({
   }, [isOpen, onOpen, onClose]);
 
   const signInLabel = `Sign in with ${appName} Cloud`;
+  const previewVisible = previewHovered && previewHostReady;
   const listeningExpanded = phase === "listening";
   const chipExpanded = listeningExpanded || phase === "processing";
-  const composerSized = previewHovered || listeningExpanded;
+  const composerSized = previewVisible || listeningExpanded;
   const label = needsAuth
     ? signingIn
       ? `Signing in to ${appName} Cloud`
@@ -294,18 +300,18 @@ export function HomePill({
           "transition-[width,height,opacity,transform,background-color,box-shadow] duration-200",
           // Listening/processing grow the capsule into a dark status chip.
           // Logged-out and idle states share the neutral handle/hover preview.
-          previewHovered
+          previewVisible
             ? "h-14 w-full justify-start overflow-hidden border border-white/55 bg-[linear-gradient(180deg,rgba(38,39,40,0.98),rgba(18,19,21,0.98))] px-5"
             : listeningExpanded
               ? "h-14 w-full justify-between overflow-hidden border border-white/55 bg-neutral-900/95 px-5"
               : chipExpanded
                 ? "h-7 w-20 gap-[3px] bg-neutral-900/95"
                 : "h-2.5 w-12 gap-[3px] bg-white/95 group-hover:w-14",
-          previewHovered
+          previewVisible
             ? "shadow-[0_14px_36px_rgba(0,0,0,0.42),inset_0_1px_0_rgba(255,255,255,0.12)]"
             : chipExpanded && "shadow-[0_4px_16px_rgba(0,0,0,0.35)]",
           !chipExpanded &&
-            !previewHovered &&
+            !previewVisible &&
             (phase === "responding"
               ? speaking
                 ? // Speaking: stronger, tighter warm glow than thinking — the
@@ -320,7 +326,7 @@ export function HomePill({
             "animate-pulse opacity-90 motion-reduce:animate-none",
         )}
       >
-        {previewHovered && (
+        {previewVisible && (
           <>
             <Plus
               aria-hidden="true"

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -15,7 +15,7 @@
  * affordance; activating it launches Cloud sign-in. Hold is not armed there.
  */
 
-import { AudioWaveform, Plus } from "lucide-react";
+import { AudioWaveform, Plus, Square } from "lucide-react";
 import * as React from "react";
 
 import { useBranding } from "../../config/branding";
@@ -61,15 +61,21 @@ export const SLIDE_CANCEL_PX = 44;
  *  middle out) rather than a marching sequence — mirroring the density of the
  *  studied Wispr Flow bar. Ids are stable keys; delays repeat symmetrically. */
 const WAVE_BARS = [
-  { id: "l4", delayMs: 420 },
-  { id: "l3", delayMs: 240 },
-  { id: "l2", delayMs: 120 },
-  { id: "l1", delayMs: 60 },
-  { id: "c0", delayMs: 0 },
-  { id: "r1", delayMs: 60 },
-  { id: "r2", delayMs: 120 },
-  { id: "r3", delayMs: 240 },
-  { id: "r4", delayMs: 420 },
+  { id: "l7", delayMs: 420, height: 10 },
+  { id: "l6", delayMs: 320, height: 13 },
+  { id: "l5", delayMs: 240, height: 17 },
+  { id: "l4", delayMs: 180, height: 16 },
+  { id: "l3", delayMs: 120, height: 21 },
+  { id: "l2", delayMs: 80, height: 22 },
+  { id: "l1", delayMs: 40, height: 26 },
+  { id: "c0", delayMs: 0, height: 28 },
+  { id: "r1", delayMs: 40, height: 26 },
+  { id: "r2", delayMs: 80, height: 22 },
+  { id: "r3", delayMs: 120, height: 21 },
+  { id: "r4", delayMs: 180, height: 16 },
+  { id: "r5", delayMs: 240, height: 17 },
+  { id: "r6", delayMs: 320, height: 13 },
+  { id: "r7", delayMs: 420, height: 10 },
 ] as const;
 
 /** Processing-state dots: the mic closed but transcription is in flight —
@@ -239,7 +245,9 @@ export function HomePill({
   }, [isOpen, onOpen, onClose]);
 
   const signInLabel = `Sign in with ${appName} Cloud`;
-  const chipExpanded = phase === "listening" || phase === "processing";
+  const listeningExpanded = phase === "listening";
+  const chipExpanded = listeningExpanded || phase === "processing";
+  const composerSized = previewHovered || listeningExpanded;
   const label = needsAuth
     ? signingIn
       ? `Signing in to ${appName} Cloud`
@@ -272,7 +280,7 @@ export function HomePill({
       style={{ zIndex: Z_SHELL_OVERLAY }}
       className={cn(
         "group pointer-events-auto relative mb-2 flex items-center justify-center rounded-full bg-transparent p-0",
-        previewHovered ? "h-20 w-[36rem]" : "h-8 w-16",
+        composerSized ? "h-16 w-[36rem]" : "h-8 w-16",
         "transition-[width,height,transform] duration-200 hover:bg-transparent motion-reduce:transition-none",
         needsAuth ? "active:scale-[0.96]" : "active:scale-95",
         "focus-visible:bg-transparent focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
@@ -287,10 +295,12 @@ export function HomePill({
           // Listening/processing grow the capsule into a dark status chip.
           // Logged-out and idle states share the neutral handle/hover preview.
           previewHovered
-            ? "h-16 w-full justify-start overflow-hidden border border-white/55 bg-[linear-gradient(180deg,rgba(38,39,40,0.98),rgba(18,19,21,0.98))] px-6"
-            : chipExpanded
-              ? "h-7 w-20 gap-[3px] bg-neutral-900/95"
-              : "h-2.5 w-12 gap-[3px] bg-white/95 group-hover:w-14",
+            ? "h-14 w-full justify-start overflow-hidden border border-white/55 bg-[linear-gradient(180deg,rgba(38,39,40,0.98),rgba(18,19,21,0.98))] px-5"
+            : listeningExpanded
+              ? "h-14 w-full justify-between overflow-hidden border border-white/55 bg-neutral-900/95 px-5"
+              : chipExpanded
+                ? "h-7 w-20 gap-[3px] bg-neutral-900/95"
+                : "h-2.5 w-12 gap-[3px] bg-white/95 group-hover:w-14",
           previewHovered
             ? "shadow-[0_14px_36px_rgba(0,0,0,0.42),inset_0_1px_0_rgba(255,255,255,0.12)]"
             : chipExpanded && "shadow-[0_4px_16px_rgba(0,0,0,0.35)]",
@@ -315,12 +325,12 @@ export function HomePill({
             <Plus
               aria-hidden="true"
               data-testid="shell-home-pill-preview-plus"
-              className="size-7 shrink-0 text-white"
+              className="size-5 shrink-0 text-white"
               strokeWidth={2}
             />
             <span
               data-testid="shell-home-pill-preview-label"
-              className="ml-6 whitespace-nowrap text-lg font-normal leading-none text-white/85"
+              className="ml-5 whitespace-nowrap text-sm font-normal leading-none text-white/85"
             >
               Message {appName}
             </span>
@@ -330,20 +340,35 @@ export function HomePill({
             <AudioWaveform
               aria-hidden="true"
               data-testid="shell-home-pill-preview-waveform"
-              className="ml-auto size-7 shrink-0 text-white"
+              className="ml-auto size-5 shrink-0 text-white"
               strokeWidth={2}
             />
           </>
         )}
-        {phase === "listening" &&
-          WAVE_BARS.map((bar) => (
-            <span
-              key={bar.id}
-              data-testid="shell-home-pill-wave-bar"
-              className="home-pill-wave-bar h-[6px] w-[3px] rounded-full bg-white/95 motion-reduce:animate-none"
-              style={{ animationDelay: `${bar.delayMs}ms` }}
+        {phase === "listening" ? (
+          <>
+            <span className="w-5 shrink-0" aria-hidden="true" />
+            <span className="flex flex-1 items-center justify-center gap-2 px-6">
+              {WAVE_BARS.map((bar) => (
+                <span
+                  key={bar.id}
+                  data-testid="shell-home-pill-wave-bar"
+                  className="home-pill-wave-bar w-1 origin-center rounded-full bg-white/95 shadow-[0_0_9px_rgba(255,255,255,0.4)] motion-reduce:animate-none"
+                  style={{
+                    animationDelay: `${bar.delayMs}ms`,
+                    height: `${bar.height}px`,
+                  }}
+                />
+              ))}
+            </span>
+            <Square
+              aria-hidden="true"
+              data-testid="shell-home-pill-listening-stop"
+              className="size-5 shrink-0 fill-white/90 text-white/90"
+              strokeWidth={1.5}
             />
-          ))}
+          </>
+        ) : null}
         {phase === "processing" &&
           PROCESS_DOTS.map((dot) => (
             <span

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -74,6 +74,37 @@ describe("HomePill", () => {
     expect(onPreviewHoverChange).toHaveBeenLastCalledWith(false);
   });
 
+  it("waits for the native hover frame before painting the wide preview", () => {
+    const onPreviewHoverChange = vi.fn();
+    const { rerender } = render(
+      <HomePill
+        phase="idle"
+        onOpen={() => {}}
+        onClose={() => {}}
+        onPreviewHoverChange={onPreviewHoverChange}
+        previewHostReady={false}
+      />,
+    );
+    const button = screen.getByRole("button");
+    fireEvent.mouseEnter(button);
+
+    expect(onPreviewHoverChange).toHaveBeenLastCalledWith(true);
+    expect(button.className).toContain("w-16");
+    expect(screen.queryByTestId("shell-home-pill-preview-label")).toBeNull();
+
+    rerender(
+      <HomePill
+        phase="idle"
+        onOpen={() => {}}
+        onClose={() => {}}
+        onPreviewHoverChange={onPreviewHoverChange}
+        previewHostReady
+      />,
+    );
+    expect(button.className).toContain("w-[36rem]");
+    expect(screen.getByTestId("shell-home-pill-preview-label")).toBeTruthy();
+  });
+
   it("uses the same hover composer while Cloud auth is required", () => {
     render(
       <HomePill phase="needs-auth" onOpen={() => {}} onClose={() => {}} />,

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -59,7 +59,7 @@ describe("HomePill", () => {
 
     expect(btn.className).toContain("w-[36rem]");
     expect(screen.getByTestId("shell-home-pill-mark").className).toContain(
-      "h-16",
+      "h-14",
     );
     expect(
       screen.getByTestId("shell-home-pill-preview-label").textContent,
@@ -133,22 +133,23 @@ describe("HomePill", () => {
     );
   });
 
-  it("grows into a dark chip with waveform bars while listening", () => {
+  it("uses the composer-sized microphone activity lane while listening", () => {
     render(<HomePill phase="listening" onOpen={() => {}} onClose={() => {}} />);
     const mark = screen.getByTestId("shell-home-pill-mark");
-    // Wispr-style listening chip: larger dark capsule, no colored ring — the
-    // live bars alone carry the "mic is hot" signal.
+    // Fn/hold-to-talk uses the same footprint and bar count as the open
+    // composer's microphone activity lane instead of a separate tiny chip.
     expect(mark.className).toContain("bg-neutral-900/95");
-    expect(mark.className).toContain("h-7");
-    expect(mark.className).toContain("w-20");
+    expect(mark.className).toContain("h-14");
+    expect(mark.className).toContain("w-full");
+    expect(screen.getByRole("button").className).toContain("w-[36rem]");
     expect(mark.className).not.toContain("239,68,68");
     expect(mark.className).not.toContain("bg-white/95");
     const bars = screen.getAllByTestId("shell-home-pill-wave-bar");
-    expect(bars).toHaveLength(9);
+    expect(bars).toHaveLength(15);
     // Center-weighted stagger: symmetric around the middle bar, not monotonic.
     const delays = bars.map((b) => Number.parseInt(b.style.animationDelay, 10));
     expect(delays).toEqual([...delays].reverse());
-    expect(Math.min(...delays)).toBe(delays[4]);
+    expect(Math.min(...delays)).toBe(delays[Math.floor(delays.length / 2)]);
     for (const bar of bars) {
       expect(bar.className).toContain("home-pill-wave-bar");
       expect(bar.className).toContain("motion-reduce:animate-none");

--- a/packages/ui/src/state/startup-coordinator.test.ts
+++ b/packages/ui/src/state/startup-coordinator.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  createDesktopPolicy,
   INITIAL_STARTUP_STATE,
   isShellPaintable,
   startupReducer,
@@ -11,6 +12,26 @@ import {
 import { deriveAgentReady } from "./types";
 
 describe("startup coordinator", () => {
+  it("uses a cloud-managed policy for cloud-only desktop builds", () => {
+    expect(createDesktopPolicy({ cloudOnly: true })).toEqual(
+      expect.objectContaining({
+        supportsLocalRuntime: false,
+        probeForExistingInstall: false,
+        defaultTarget: "cloud-managed",
+      }),
+    );
+  });
+
+  it("keeps the embedded-local policy for full desktop builds", () => {
+    expect(createDesktopPolicy()).toEqual(
+      expect.objectContaining({
+        supportsLocalRuntime: true,
+        probeForExistingInstall: true,
+        defaultTarget: "embedded-local",
+      }),
+    );
+  });
+
   it("starts by restoring session state", () => {
     expect(INITIAL_STARTUP_STATE).toEqual({ phase: "restoring-session" });
   });

--- a/packages/ui/src/state/startup-coordinator.ts
+++ b/packages/ui/src/state/startup-coordinator.ts
@@ -26,6 +26,12 @@ export type RuntimeTarget =
 export interface PlatformPolicy {
   /** Can this platform run a local embedded agent? */
   supportsLocalRuntime: boolean;
+  /**
+   * Whether a connection-level failure against a saved remote may abandon it
+   * for the page's local origin. Cloud-only desktop builds set this false:
+   * their loopback origin serves renderer assets only and has no agent.
+   */
+  allowLocalOriginRecovery?: boolean;
   /** Backend poll timeout (ms) — desktop gets longer */
   backendTimeoutMs: number;
   /** Agent ready timeout (ms) — initial, before sliding extensions */
@@ -364,7 +370,19 @@ export const INITIAL_STARTUP_STATE: StartupState = {
 
 // ── Policy factories ─────────────────────────────────────────────────
 
-export function createDesktopPolicy(): PlatformPolicy {
+export function createDesktopPolicy(options?: {
+  cloudOnly?: boolean;
+}): PlatformPolicy {
+  if (options?.cloudOnly === true) {
+    return {
+      supportsLocalRuntime: false,
+      allowLocalOriginRecovery: false,
+      backendTimeoutMs: 180_000,
+      agentReadyTimeoutMs: 180_000,
+      probeForExistingInstall: false,
+      defaultTarget: "cloud-managed",
+    };
+  }
   return {
     supportsLocalRuntime: true,
     backendTimeoutMs: 180_000,

--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -281,6 +281,63 @@ describe("runPollingBackend", () => {
     expect(dispatch).not.toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
   });
 
+  it("does not abandon a saved cloud target for localhost when the build has no local runtime", async () => {
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    (globalThis as { window?: unknown }).window = {
+      location: {
+        origin: "http://127.0.0.1:5174",
+        protocol: "http:",
+        port: "5174",
+      },
+    };
+    const cloudBase =
+      "https://api.eliza.app/api/v1/eliza/agents/personal%3Aowner";
+    clientMock.getBaseUrl.mockReturnValue(cloudBase);
+    clientMock.getAuthStatus.mockRejectedValue(
+      Object.assign(new Error("Request timed out after 10000ms"), {
+        kind: "timeout",
+        path: "/api/auth/status",
+      }),
+    );
+
+    const savedCloud = {
+      id: "cloud:personal",
+      kind: "cloud" as const,
+      label: "Personal Eliza",
+      apiBase: cloudBase,
+      accessToken: "cloud-session",
+    };
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        supportsLocalRuntime: false,
+        allowLocalOriginRecovery: false,
+        backendTimeoutMs: 1,
+        agentReadyTimeoutMs: 1,
+        probeForExistingInstall: false,
+        defaultTarget: "cloud-managed",
+      },
+      {
+        persistedActiveServer: savedCloud,
+        restoredActiveServer: savedCloud,
+        shouldPreserveCompletedFirstRun: true,
+        hadPriorFirstRun: true,
+      },
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(clearPersistedActiveServer).not.toHaveBeenCalled();
+    expect(clientMock.setBaseUrl).not.toHaveBeenCalledWith(null);
+    expect(clientMock.setToken).not.toHaveBeenCalledWith(null);
+    expect(dispatch).toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
+  });
+
   it("requests a native local-agent start on every poll iteration for the polled base", async () => {
     // #15189: on a fresh install the native auto-start gate ran before the
     // renderer pre-seeded the local target, so the agent the poll waits for

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -1227,6 +1227,7 @@ export async function runPollingBackend(
       }
       if (
         !fellBackToLocal &&
+        policy.allowLocalOriginRecovery !== false &&
         shouldFallBackToLocalOrigin({ error: err, ...recoveryEnv() })
       ) {
         recoverToLocalOrigin("saved server unreachable");

--- a/packages/ui/src/state/useStartupCoordinator.ts
+++ b/packages/ui/src/state/useStartupCoordinator.ts
@@ -18,6 +18,7 @@ import { logger } from "@elizaos/logger";
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { client } from "../api";
 import { isElectrobunRuntime } from "../bridge";
+import { getBootConfig } from "../config/boot-config-store";
 import { enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot } from "../first-run/device-ram-gate";
 import { reconcilePersistedMobileRuntimeModeAtBoot } from "../first-run/reconcile-mobile-runtime-mode";
 import { isAndroid, isElizaOS, isIOS, isNative } from "../platform";
@@ -144,7 +145,11 @@ export interface StartupCoordinatorHandle {
 }
 
 function detectPlatformPolicy(): PlatformPolicy {
-  if (isElectrobunRuntime()) return createDesktopPolicy();
+  if (isElectrobunRuntime()) {
+    return createDesktopPolicy({
+      cloudOnly: getBootConfig().branding.cloudOnly === true,
+    });
+  }
   // ElizaOS check must come before the generic mobile branch — both are
   // native, but ElizaOS bundles the on-device agent and needs the longer
   // backend timeout (vanilla mobile is cloud-only with a fast-fail budget).


### PR DESCRIPTION
## Summary

- Add a cloud-only desktop startup policy that preserves saved cloud targets when requests fail.
- Disable local-runtime probing and localhost recovery for cloud-only desktop builds.
- Gate the wide composer preview on native host readiness to avoid WKWebView clipping.
- Improve the listening-state pill with a composer-sized layout, expanded waveform, and stop control.
- Add focused tests for startup policy, cloud-target recovery, hover-preview readiness, and listening UI behavior.

## Testing

- Added and updated Vitest coverage for startup coordination, backend polling, and `HomePill` rendering behavior.
- Not run (not requested)