### PR TITLE
fix(cloud): reject malformed coding-containers sync id encoding

### DIFF
--- a/packages/cloud/api/v1/coding-containers/[containerId]/sync/route.encoding.test.ts
+++ b/packages/cloud/api/v1/coding-containers/[containerId]/sync/route.encoding.test.ts
@@ -1,0 +1,100 @@
+/**
+ * POST /api/v1/coding-containers/:containerId/sync path encoding is leftover
+ * tax after plugin-elizacloud coding-container sync id decode (#21337).
+ * Stock develop called decodeURIComponent on the container-id, so `%` / `%2`
+ * / `%ZZ` threw URIError and failureResponse mapped it to 500. Canonical
+ * ids and the missing-body 400 stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    error: mock(() => undefined),
+    warn: mock(() => undefined),
+    info: mock(() => undefined),
+  },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route(
+  "/api/v1/coding-containers/:containerId/sync",
+  route,
+);
+
+const VALID_BODY = JSON.stringify({
+  target: { sourceKind: "project", projectId: "proj-1" },
+});
+
+function syncUrl(containerId: string): string {
+  return `https://api.example.test/api/v1/coding-containers/${containerId}/sync`;
+}
+
+async function postSync(containerId: string, body: string | null = VALID_BODY) {
+  return app.fetch(
+    new Request(syncUrl(containerId), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    }),
+  );
+}
+
+describe("POST /api/v1/coding-containers/:containerId/sync encoding", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+  });
+
+  test("canonical container id still reaches the control-plane forward", async () => {
+    const response = await postSync("ctr-1");
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      success: false,
+      code: "CONTAINER_CONTROL_PLANE_NOT_CONFIGURED",
+      error: "Container control plane URL is not configured",
+    });
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+  });
+
+  test("canonical percent-encoded hyphen still decodes before forward", async () => {
+    const response = await postSync("ctr%2D1");
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      success: false,
+      code: "CONTAINER_CONTROL_PLANE_NOT_CONFIGURED",
+      error: "Container control plane URL is not configured",
+    });
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+  });
+
+  test("invalid body after a canonical decode is still 400", async () => {
+    const response = await postSync("ctr-1", JSON.stringify({ nope: true }));
+    expect(response.status).toBe(400);
+    const json = (await response.json()) as { success: boolean; error: string };
+    expect(json.success).toBe(false);
+    expect(json.error).toBeTruthy();
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed container id %s with 400 before body parse",
+    async (token) => {
+      const response = await postSync(token, JSON.stringify({ nope: true }));
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        success: false,
+        error: "invalid container id: malformed URL encoding",
+      });
+      expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/packages/cloud/api/v1/coding-containers/[containerId]/sync/route.ts
+++ b/packages/cloud/api/v1/coding-containers/[containerId]/sync/route.ts
@@ -28,6 +28,14 @@ function readStringEnv(c: AppContext, keys: readonly string[]): string | null {
   return null;
 }
 
+function decodeCodingContainerId(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return null;
+  }
+}
+
 async function forwardContainerSync(
   c: AppContext,
   user: Pick<AuthedUser, "id"> & { organization_id: string },
@@ -152,6 +160,16 @@ app.post("/", async (c) => {
     if (!containerId) {
       return c.json({ success: false, error: "Container id required" }, 400);
     }
+    const decodedContainerId = decodeCodingContainerId(containerId);
+    if (decodedContainerId === null) {
+      return c.json(
+        {
+          success: false,
+          error: "invalid container id: malformed URL encoding",
+        },
+        400,
+      );
+    }
 
     const body = (await c.req.json().catch(() => null)) as unknown;
     const parsed = SyncCloudCodingContainerRequestSchema.safeParse(body);
@@ -168,7 +186,7 @@ app.post("/", async (c) => {
     return forwardContainerSync(
       c,
       user,
-      decodeURIComponent(containerId),
+      decodedContainerId,
       parsed.data,
     );
   } catch (error) {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
cloud coding-containers sync container-id percent-encoding.
Encoding class, leftover tax after plugin-elizacloud
coding-container sync id decode (#21337). Not a twin of that
parser — this is POST `/api/v1/coding-containers/:containerId/sync`
only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on the coding-containers sync
container-id. Canonical `ctr%2D1` still decodes to `ctr-1` and
reaches the control-plane forward. Malformed `%` / `%2` / `%ZZ`
become 400 instead of an uncaught `URIError` mapped to 500.
Invalid-body 400 after a canonical decode stays untouched.

# Background

## What does this PR do?

The sync route called `decodeURIComponent` on the container-id
after auth. Illegal percent-encoding threw `URIError`, which
`failureResponse` mapped to 500.

- `/api/v1/coding-containers/%/sync` / `%2` / `%ZZ` → **400**
- `/api/v1/coding-containers/%E0%A4/sync` → **400**
- `/api/v1/coding-containers/ctr%2D1/sync` → still decodes to `ctr-1`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded container
id should get a request error, not a 500 that looks like a
control-plane outage. Leftover tax after plugin-elizacloud
coding-container sync id decode (#21337). Disjoint files from
that parser.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/coding-containers/[containerId]/sync/route.encoding.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/coding-containers/[containerId]/sync/route.encoding.test.ts
```

7 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; coding-containers sync id decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; coding-containers sync id decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; coding-containers sync id decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before body parse / control-plane forward; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before container sync forward.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real handler.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded container ids
still decode. Malformed tokens that previously 500 now 400.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:dedf9627e5b7798625fa2f30595ae3bb1624a010 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
