### PR TITLE
fix(cloud): reject malformed apps managed-domain path encoding

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/domains/guards.encoding.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/guards.encoding.test.ts
@@ -1,0 +1,100 @@
+/**
+ * /api/v1/apps/:id/domains/:domain path encoding is leftover tax after
+ * oauth callback provider decode. Stock develop called decodeURIComponent
+ * on the domain segment in loadCloudflareManagedDomain, so `%` / `%2` /
+ * `%ZZ` threw URIError instead of a typed 400. List/attach/detach and
+ * buy-route guards stay untouched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+const getById = mock(async () => ({
+  id: "app-1",
+  organization_id: "org-1",
+}));
+const isAppKeyOutOfScope = mock(async () => false);
+const getOwnDomainRow = mock(async () => ({
+  appId: "app-1",
+  domain: "example.com",
+  registrar: "cloudflare",
+  cloudflareZoneId: "zone-1",
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/auth/app-key-scope", () => ({
+  isAppKeyOutOfScope,
+}));
+mock.module("@/lib/services/apps", () => ({
+  appsService: { getById },
+}));
+mock.module("@/lib/services/managed-domains", () => ({
+  managedDomainsService: { getOwnDomainRow },
+}));
+
+const { loadCloudflareManagedDomain } = await import("./guards");
+
+function ctx(domain: string | undefined) {
+  return {
+    req: {
+      param: (key: string) => {
+        if (key === "id") return "app-1";
+        if (key === "domain") return domain;
+        return undefined;
+      },
+    },
+    get: () => undefined,
+  } as never;
+}
+
+describe("loadCloudflareManagedDomain encoding", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    getById.mockClear();
+    isAppKeyOutOfScope.mockClear();
+    getOwnDomainRow.mockClear();
+  });
+
+  test("canonical domain still reaches the managed-domain lookup", async () => {
+    const result = await loadCloudflareManagedDomain(ctx("example.com"));
+    expect(result).toMatchObject({
+      appId: "app-1",
+      domain: { domain: "example.com", cloudflareZoneId: "zone-1" },
+    });
+    expect(getOwnDomainRow).toHaveBeenCalledWith("org-1", "example.com");
+  });
+
+  test("canonical percent-encoded dot still decodes before lookup", async () => {
+    const result = await loadCloudflareManagedDomain(ctx("example%2Ecom"));
+    expect(result).toMatchObject({
+      appId: "app-1",
+      domain: { domain: "example.com", cloudflareZoneId: "zone-1" },
+    });
+    expect(getOwnDomainRow).toHaveBeenCalledWith("org-1", "example.com");
+  });
+
+  test("missing domain param is still 400 and does not look up", async () => {
+    const result = await loadCloudflareManagedDomain(ctx(undefined));
+    expect(result).toEqual({
+      error: "missing path params",
+      status: 400,
+    });
+    expect(getOwnDomainRow).not.toHaveBeenCalled();
+  });
+
+  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed domain %s with 400 before lookup",
+    async (token) => {
+      const result = await loadCloudflareManagedDomain(ctx(token));
+      expect(result).toEqual({
+        error: "invalid domain: malformed URL encoding",
+        status: 400,
+      });
+      expect(getOwnDomainRow).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/apps/[id]/domains/guards.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/guards.ts
@@ -29,6 +29,14 @@ type OwnedAppContext = {
   appId: string;
 };
 
+function decodeManagedDomainParam(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return null;
+  }
+}
+
 export async function loadOwnedApp(
   c: AppContext,
 ): Promise<GuardFailure | OwnedAppContext> {
@@ -59,11 +67,18 @@ export async function loadCloudflareManagedDomain(
   const domainParam = c.req.param("domain");
   if (!domainParam)
     return { error: "missing path params", status: 400 as const };
+  const domain = decodeManagedDomainParam(domainParam);
+  if (domain === null) {
+    return {
+      error: "invalid domain: malformed URL encoding",
+      status: 400 as const,
+    };
+  }
 
   // getOwnDomainRow is already scoped to the caller's organization.
   const md = await managedDomainsService.getOwnDomainRow(
     base.user.organization_id,
-    decodeURIComponent(domainParam),
+    domain,
   );
   if (!md || md.appId !== base.appId) {
     return { error: "Domain not attached to this app", status: 404 as const };


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
cloud apps managed-domain percent-encoding. Encoding class,
leftover tax after oauth callback provider decode (#21384).
Not a twin of that parser — this is
`loadCloudflareManagedDomain` on `/api/v1/apps/:id/domains/:domain`
only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on the managed-domain guard.
Canonical `example%2Ecom` still decodes to `example.com` and
reaches `getOwnDomainRow`. Malformed `%` / `%2` / `%ZZ` become
400 instead of an uncaught `URIError`. Missing-domain 400 and
list/attach/detach / buy-route guards stay untouched.

# Background

## What does this PR do?

`loadCloudflareManagedDomain` called `decodeURIComponent` on the
`:domain` path segment. Illegal percent-encoding threw `URIError`
instead of a typed 400 before the managed-domain lookup.

- `:domain=%` / `%2` / `%ZZ` → **400**
- `:domain=%E0%A4` → **400**
- `:domain=example%2Ecom` → still decodes to `example.com`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded domain
should get a request error, not a 500 that looks like a
Cloudflare DNS outage. Leftover tax after oauth callback
provider decode (#21384). Disjoint files from that parser.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/apps/[id]/domains/guards.encoding.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/apps/[id]/domains/guards.encoding.test.ts
```

7 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; apps managed-domain decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; apps managed-domain decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; apps managed-domain decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused guard tests drive the real percent-encoding tokens and assert 400 before managed-domain lookup; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before DNS record reads.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real guard.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded domains still
decode. Malformed tokens that previously threw now 400.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2fa0b4aea4057709c879b1c9cddae7d0b4bfaf1b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
