### PR TITLE
fix(ui): remove duplicate last-heartbeat date in agent detail

### DIFF
--- a/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
@@ -1,4 +1,4 @@
-/** Verifies agent detail rendering rejects malformed API timestamps. */
+/** Verifies agent detail rendering rejects malformed API timestamps and avoids duplicate dates. */
 // @vitest-environment jsdom
 
 import type { AgentDetailDto } from "@elizaos/cloud-shared/lib/types/cloud-api";
@@ -60,12 +60,14 @@ vi.mock("./components/eliza-connect-button", () => ({
 import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import AgentDetailPage, {
   formatDate,
+  formatHeartbeatSecondary,
   formatRelativeShort,
+  formatTime,
 } from "./AgentDetailPage";
 
 const t = vi.fn(
-  (_key: string, options?: { defaultValue?: string }) =>
-    options?.defaultValue ?? _key,
+  (_key: string, options?: { defaultValue?: string; n?: number }) =>
+    (options?.defaultValue ?? _key).replace("{{n}}", String(options?.n ?? "")),
 ) as never;
 
 const baseAgent: AgentDetailDto = {
@@ -114,13 +116,32 @@ describe("AgentDetailPage date formatting", () => {
 
   it("renders an unavailable fallback for malformed non-null dates", async () => {
     expect(formatDate("not-a-date")).toBe("—");
+    expect(formatTime("not-a-date")).toBe("—");
+    expect(formatHeartbeatSecondary("not-a-date")).toBe("—");
     expect(formatRelativeShort("not-a-date", t)).toBe("Never");
   });
 
   it("preserves valid and null date behavior", () => {
     expect(formatDate(null)).toBe("—");
+    expect(formatTime(null)).toBe("—");
+    expect(formatHeartbeatSecondary(null)).toBeNull();
     expect(formatRelativeShort(null, t)).toBe("Never");
     expect(formatRelativeShort(new Date().toISOString(), t)).toBe("Just now");
+  });
+
+  it("formats secondary heartbeat as date when recent and time when >= 24h old", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T12:00:00.000Z"));
+
+    // Recent heartbeat (<24h ago): primary is relative, secondary is date
+    const recent = "2026-08-17T10:00:00.000Z";
+    expect(formatRelativeShort(recent, t)).toBe("2h ago");
+    expect(formatHeartbeatSecondary(recent)).toBe(formatDate(recent));
+
+    // Old heartbeat (>=24h ago): primary is date, secondary is exact time (not duplicate date)
+    const old = "2026-08-13T09:30:00.000Z";
+    expect(formatRelativeShort(old, t)).toBe(formatDate(old));
+    expect(formatHeartbeatSecondary(old)).toBe(formatTime(old));
   });
 
   it("renders intentional fallbacks for malformed non-null timestamps", () => {
@@ -150,7 +171,7 @@ describe("AgentDetailPage date formatting", () => {
     expect(screen.getByText("Never")).toBeTruthy();
   });
 
-  it("preserves ordinary rendered date, time, and relative-time values", () => {
+  it("preserves ordinary rendered date, time, and relative-time values for recent heartbeats", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-12T12:00:00.000Z"));
     const createdAt = "2026-08-11T09:15:00.000Z";
@@ -171,5 +192,22 @@ describe("AgentDetailPage date formatting", () => {
     expect(screen.getByText(formatDate(lastHeartbeatAt))).toBeTruthy();
     expect(screen.queryByText("—")).toBeNull();
     expect(screen.queryByText("Never")).toBeNull();
+  });
+
+  it("renders absolute date once and exact time for heartbeats older than 24 hours", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T12:00:00.000Z"));
+    const createdAt = "2026-08-11T09:15:00.000Z";
+    const lastHeartbeatAt = "2026-08-13T10:45:00.000Z";
+
+    renderPage({ ...baseAgent, createdAt, lastHeartbeatAt });
+
+    const heartbeatDate = formatDate(lastHeartbeatAt);
+    const heartbeatTime = formatTime(lastHeartbeatAt);
+
+    // The heartbeat date should appear exactly once in the document
+    expect(screen.getAllByText(heartbeatDate)).toHaveLength(1);
+    // The exact heartbeat time is rendered as secondary text
+    expect(screen.getByText(heartbeatTime)).toBeTruthy();
   });
 });

--- a/packages/ui/src/cloud/instances/AgentDetailPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.tsx
@@ -45,7 +45,7 @@ export function formatDate(date: string | null): string {
   });
 }
 
-function formatTime(date: string | null): string {
+export function formatTime(date: string | null): string {
   if (!date) return "—";
   const timestamp = new Date(date).getTime();
   if (!Number.isFinite(timestamp)) return "—";
@@ -80,6 +80,19 @@ export function formatRelativeShort(
       n: diffH,
     });
   return formatDate(date);
+}
+
+export function formatHeartbeatSecondary(date: string | null): string | null {
+  if (!date) return null;
+  const timestamp = new Date(date).getTime();
+  if (!Number.isFinite(timestamp)) return "—";
+  const diffMs = Date.now() - timestamp;
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) {
+    return formatDate(date);
+  }
+  return formatTime(date);
 }
 
 export default function AgentDetailPage() {
@@ -275,7 +288,7 @@ export default function AgentDetailPage() {
           </p>
           {agent.lastHeartbeatAt && (
             <p className="text-2xs text-muted tabular-nums">
-              {formatDate(agent.lastHeartbeatAt)}
+              {formatHeartbeatSecondary(agent.lastHeartbeatAt)}
             </p>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Resolves #21382.
- In `packages/ui/src/cloud/instances/AgentDetailPage.tsx`, introduces `formatHeartbeatSecondary()` to render the exact timestamp (`formatTime()`) when the last heartbeat is >= 24 hours old, avoiding the duplicate date display produced when `formatRelativeShort()` falls back to `formatDate()`.
- Preserves relative primary string + absolute date secondary string for recent heartbeats (<24h).
- Preserves intentional fallback handling for `null` and malformed date strings.
- Adds focused unit tests in `packages/ui/src/cloud/instances/AgentDetailPage.test.tsx` verifying recent, old, null, and malformed heartbeat rendering.

## Verification
- `bunx vitest run src/cloud/instances/AgentDetailPage.test.tsx`: 7 passed
- `bunx biome check packages/ui/src/cloud/instances/AgentDetailPage.tsx packages/ui/src/cloud/instances/AgentDetailPage.test.tsx`: clean