### PR TITLE
fix(app-core): reject malformed electrobun browser-workspace tab id encoding

### DIFF
--- a/packages/app-core/platforms/electrobun/src/browser-workspace-bridge-server.encoding.test.ts
+++ b/packages/app-core/platforms/electrobun/src/browser-workspace-bridge-server.encoding.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Electrobun browser-workspace tab-id path encoding is leftover tax after
+ * capacitor iOS transcript id decode (#21380). Stock develop called
+ * decodeURIComponent on /tabs/:id, so `%` / `%2` / `%ZZ` threw URIError and
+ * the bridge mapped it to 500. List/create and /health stay untouched.
+ */
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const closeTab = mock(async (options: { id: string }) => options.id === "tab-1");
+
+mock.module("./native/browser-workspace", () => ({
+  getBrowserWorkspaceManager: () => ({
+    listTabs: async () => ({ tabs: [] }),
+    closeTab,
+    snapshotTab: async () => {
+      throw new Error("snapshotTab must not run on malformed encoding");
+    },
+    showTab: async () => {
+      throw new Error("showTab must not run on malformed encoding");
+    },
+    hideTab: async () => {
+      throw new Error("hideTab must not run on malformed encoding");
+    },
+    navigateTab: async () => {
+      throw new Error("navigateTab must not run on malformed encoding");
+    },
+    evaluateTab: async () => {
+      throw new Error("evaluateTab must not run on malformed encoding");
+    },
+  }),
+}));
+
+const { startBrowserWorkspaceBridgeServer } = await import(
+  "./browser-workspace-bridge-server"
+);
+
+const savedUrl = process.env.ELIZA_BROWSER_WORKSPACE_URL;
+const savedToken = process.env.ELIZA_BROWSER_WORKSPACE_TOKEN;
+const savedPort = process.env.ELIZA_BROWSER_WORKSPACE_PORT;
+
+let stop: (() => void) | undefined;
+
+async function request(
+  method: string,
+  path: string,
+  token: string,
+  port: number,
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  return await new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method,
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) =>
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)),
+        );
+        res.on("end", () => {
+          const body = Buffer.concat(chunks).toString("utf8");
+          resolve({
+            status: res.statusCode ?? 0,
+            json: JSON.parse(body) as Record<string, unknown>,
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("electrobun browser-workspace tab id encoding", () => {
+  beforeEach(() => {
+    closeTab.mockClear();
+    process.env.ELIZA_BROWSER_WORKSPACE_PORT = "31991";
+    process.env.ELIZA_BROWSER_WORKSPACE_TOKEN = "test-tab-encoding-token";
+  });
+
+  afterEach(() => {
+    stop?.();
+    stop = undefined;
+    if (savedUrl === undefined) delete process.env.ELIZA_BROWSER_WORKSPACE_URL;
+    else process.env.ELIZA_BROWSER_WORKSPACE_URL = savedUrl;
+    if (savedToken === undefined)
+      delete process.env.ELIZA_BROWSER_WORKSPACE_TOKEN;
+    else process.env.ELIZA_BROWSER_WORKSPACE_TOKEN = savedToken;
+    if (savedPort === undefined) delete process.env.ELIZA_BROWSER_WORKSPACE_PORT;
+    else process.env.ELIZA_BROWSER_WORKSPACE_PORT = savedPort;
+  });
+
+  async function startBridge() {
+    stop = await startBrowserWorkspaceBridgeServer();
+    const base = process.env.ELIZA_BROWSER_WORKSPACE_URL ?? "";
+    const token = process.env.ELIZA_BROWSER_WORKSPACE_TOKEN ?? "";
+    const port = Number(new URL(base).port);
+    return { token, port };
+  }
+
+  test("canonical tab id still reaches closeTab", async () => {
+    const { token, port } = await startBridge();
+    const response = await request("DELETE", "/tabs/tab-1", token, port);
+    expect(response.status).toBe(200);
+    expect(response.json).toEqual({ closed: true });
+    expect(closeTab).toHaveBeenCalledWith({ id: "tab-1" });
+  });
+
+  test("canonical percent-encoded hyphen still decodes before closeTab", async () => {
+    const { token, port } = await startBridge();
+    const response = await request("DELETE", "/tabs/tab%2D1", token, port);
+    expect(response.status).toBe(200);
+    expect(response.json).toEqual({ closed: true });
+    expect(closeTab).toHaveBeenCalledWith({ id: "tab-1" });
+  });
+
+  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed tab id %s with 400 before closeTab",
+    async (tokenId) => {
+      const { token, port } = await startBridge();
+      const response = await request("DELETE", `/tabs/${tokenId}`, token, port);
+      expect(response.status).toBe(400);
+      expect(response.json).toEqual({
+        error: "invalid tab id: malformed URL encoding",
+      });
+      expect(closeTab).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/app-core/platforms/electrobun/src/browser-workspace-bridge-server.ts
+++ b/packages/app-core/platforms/electrobun/src/browser-workspace-bridge-server.ts
@@ -112,8 +112,14 @@ function isAuthorized(req: http.IncomingMessage, token: string): boolean {
   return req.headers.authorization === `Bearer ${token}`;
 }
 
-function normalizeTabId(raw: string): string {
-  return decodeURIComponent(raw).trim();
+function normalizeTabId(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw).trim();
+  } catch {
+    // error-policy:J3 untrusted tab-id path segments; malformed
+    // percent-encoding is an invalid request, not a bridge failure.
+    return null;
+  }
 }
 
 function readIntegerSearchParam(url: URL, key: string): number | undefined {
@@ -239,6 +245,10 @@ export async function startBrowserWorkspaceBridgeServer(): Promise<() => void> {
       }
 
       const tabId = normalizeTabId(match[1]);
+      if (tabId === null) {
+        json(res, 400, { error: "invalid tab id: malformed URL encoding" });
+        return;
+      }
       const action = match[2] ?? null;
 
       if (!action && method === "DELETE") {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
electrobun browser-workspace tab-id percent-encoding. Encoding
class, leftover tax after capacitor iOS transcript decode
(#21380). Not a twin of that parser — this is
`normalizeTabId` on `/tabs/:id` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on the electrobun workspace tab id.
Canonical `tab%2D1` still decodes to `tab-1` and reaches
`closeTab`. Malformed `%` / `%2` / `%ZZ` become 400 instead of
an uncaught `URIError` mapped to 500. Health, list, create, and
navigate handlers stay untouched.

# Background

## What does this PR do?

`normalizeTabId` called `decodeURIComponent` on the tab-id path
segment. Illegal percent-encoding threw `URIError`, which the
bridge server catch mapped to 500.

- `/tabs/%` / `%2` / `%ZZ` → **400**
- `/tabs/%E0%A4` → **400**
- `/tabs/tab%2D1` → still decodes to `tab-1`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded tab id
should get a request error, not a 500 that looks like a
browser-workspace outage. Leftover tax after capacitor iOS
transcript decode (#21380). Disjoint files from that parser.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/src/browser-workspace-bridge-server.encoding.test.ts`

## Detailed testing steps

```bash
cd packages/app-core/platforms/electrobun && bun test src/browser-workspace-bridge-server.encoding.test.ts
```

6 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; electrobun workspace tab-id decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; electrobun workspace tab-id decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; electrobun workspace tab-id decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused bridge tests drive the real percent-encoding tokens and assert 400 before closeTab; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before tab close.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real handler.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded tab ids still
decode. Malformed tokens that previously 500 now 400.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9a36937b1aba02eafd516d583d4d4955353cdacc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
