### PR TITLE
fix(plugin-personal-assistant): reject malformed relationship id encoding

### DIFF
--- a/plugins/plugin-personal-assistant/src/routes/relationships.encoding.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/relationships.encoding.test.ts
@@ -1,0 +1,185 @@
+/**
+ * /api/lifeops/relationships/:id path encoding is leftover tax after LifeOps
+ * routes already grew decodePathComponent. Stock develop called
+ * decodeURIComponent on GET/PATCH /:id and POST /:id/retire, so `%` / `%2` /
+ * `%ZZ` threw URIError instead of a typed 400. List, upsert, and observe stay
+ * untouched.
+ */
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import type { AgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { LifeOpsRouteContext } from "./lifeops-routes.js";
+
+const get = mock(async (id: string) => ({
+  relationshipId: id,
+  fromEntityId: "from-1",
+  toEntityId: "to-1",
+  type: "friend",
+}));
+const retire = mock(async () => undefined);
+const upsert = mock(async (row: unknown) => row);
+const list = mock(async () => []);
+const observe = mock(async (row: unknown) => row);
+
+mock.module("@elizaos/agent", () => ({
+  resolveKnowledgeGraphService: () => ({
+    getRelationshipStore: () => ({ get, retire, upsert, list, observe }),
+  }),
+}));
+
+const { handleRelationshipRoutes } = await import("./relationships.js");
+
+interface CapturedResponse {
+  statusCode?: number;
+  body?: string;
+  ended: boolean;
+}
+
+function buildCtx(
+  method: string,
+  pathname: string,
+): {
+  ctx: LifeOpsRouteContext;
+  res: CapturedResponse;
+} {
+  const res: CapturedResponse = { ended: false };
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  const httpReq = new IncomingMessage(socket);
+  httpReq.method = method;
+  const httpRes = new ServerResponse(httpReq);
+  httpRes.statusCode = 0;
+  httpRes.end = function end(
+    this: ServerResponse,
+    chunk?: unknown,
+    encodingOrCallback?: BufferEncoding | (() => void),
+    callback?: () => void,
+  ): ServerResponse {
+    res.ended = true;
+    res.body = typeof chunk === "string" ? chunk : "";
+    res.statusCode = this.statusCode;
+    const done =
+      typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+    done?.();
+    return this;
+  };
+
+  const ctx: LifeOpsRouteContext = {
+    req: httpReq,
+    res: httpRes,
+    method,
+    pathname,
+    url: new URL("http://localhost/api/lifeops/relationships"),
+    state: {
+      runtime: { agentId: "agent-1" } as unknown as AgentRuntime,
+      adminEntityId: null,
+    },
+    json(r, data, status = 200) {
+      r.statusCode = status;
+      r.setHeader?.("content-type", "application/json");
+      r.end?.(JSON.stringify(data));
+    },
+    error(r, message, status = 400) {
+      r.statusCode = status;
+      r.setHeader?.("content-type", "application/json");
+      r.end?.(JSON.stringify({ error: message }));
+    },
+    async readJsonBody<T extends object>(): Promise<T | null> {
+      return { reason: "manual_retire" } as T;
+    },
+    decodePathComponent(raw, r, fieldName) {
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        ctx.error(r, `Invalid ${fieldName}: malformed URL encoding`, 400);
+        return null;
+      }
+    },
+  };
+  return { ctx, res };
+}
+
+describe("lifeops relationship id encoding", () => {
+  beforeEach(() => {
+    get.mockClear();
+    retire.mockClear();
+    upsert.mockClear();
+    list.mockClear();
+    observe.mockClear();
+  });
+
+  test("canonical GET still reaches the relationship store", async () => {
+    const { ctx, res } = buildCtx("GET", "/api/lifeops/relationships/rel-1");
+    await handleRelationshipRoutes(ctx);
+    expect(res.statusCode).toBe(200);
+    expect(get).toHaveBeenCalledWith("rel-1");
+    expect(JSON.parse(res.body ?? "")).toEqual({
+      relationship: {
+        relationshipId: "rel-1",
+        fromEntityId: "from-1",
+        toEntityId: "to-1",
+        type: "friend",
+      },
+    });
+  });
+
+  test("canonical percent-encoded hyphen still decodes before GET", async () => {
+    const { ctx, res } = buildCtx("GET", "/api/lifeops/relationships/rel%2D1");
+    await handleRelationshipRoutes(ctx);
+    expect(res.statusCode).toBe(200);
+    expect(get).toHaveBeenCalledWith("rel-1");
+  });
+
+  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed GET id %s with 400 before store lookup",
+    async (token) => {
+      const { ctx, res } = buildCtx(
+        "GET",
+        `/api/lifeops/relationships/${token}`,
+      );
+      await handleRelationshipRoutes(ctx);
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body ?? "")).toEqual({
+        error: "Invalid relationship id: malformed URL encoding",
+      });
+      expect(get).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(["%", "%2", "%ZZ"])(
+    "rejects malformed PATCH id %s with 400 before store lookup",
+    async (token) => {
+      const { ctx, res } = buildCtx(
+        "PATCH",
+        `/api/lifeops/relationships/${token}`,
+      );
+      await handleRelationshipRoutes(ctx);
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body ?? "")).toEqual({
+        error: "Invalid relationship id: malformed URL encoding",
+      });
+      expect(get).not.toHaveBeenCalled();
+      expect(upsert).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(["%", "%2", "%ZZ"])(
+    "rejects malformed retire id %s with 400 before store lookup",
+    async (token) => {
+      const { ctx, res } = buildCtx(
+        "POST",
+        `/api/lifeops/relationships/${token}/retire`,
+      );
+      await handleRelationshipRoutes(ctx);
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body ?? "")).toEqual({
+        error: "Invalid relationship id: malformed URL encoding",
+      });
+      expect(retire).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/plugins/plugin-personal-assistant/src/routes/relationships.ts
+++ b/plugins/plugin-personal-assistant/src/routes/relationships.ts
@@ -146,13 +146,18 @@ export async function handleRelationshipRoutes(
     /^\/api\/lifeops\/relationships\/([^/]+)\/retire$/,
   );
   if (method === "POST" && retireMatch) {
-    const store = makeStore(ctx);
-    if (!store) return true;
-    const relationshipId = decodeURIComponent(retireMatch[1] ?? "");
+    const relationshipId = ctx.decodePathComponent(
+      retireMatch[1] ?? "",
+      res,
+      "relationship id",
+    );
+    if (relationshipId === null) return true;
     if (!relationshipId) {
       ctx.error(res, "relationship id required", 400);
       return true;
     }
+    const store = makeStore(ctx);
+    if (!store) return true;
     const body = await readJsonBody<{ reason?: unknown }>(req, res);
     if (!body) return true;
     await store.retire(relationshipId, asString(body.reason, "manual_retire"));
@@ -163,13 +168,18 @@ export async function handleRelationshipRoutes(
   // PATCH /api/lifeops/relationships/:id
   const patchMatch = pathname.match(/^\/api\/lifeops\/relationships\/([^/]+)$/);
   if (method === "PATCH" && patchMatch) {
-    const store = makeStore(ctx);
-    if (!store) return true;
-    const relationshipId = decodeURIComponent(patchMatch[1] ?? "");
+    const relationshipId = ctx.decodePathComponent(
+      patchMatch[1] ?? "",
+      res,
+      "relationship id",
+    );
+    if (relationshipId === null) return true;
     if (!relationshipId) {
       ctx.error(res, "relationship id required", 400);
       return true;
     }
+    const store = makeStore(ctx);
+    if (!store) return true;
     const existing = await store.get(relationshipId);
     if (!existing) {
       ctx.error(res, "relationship not found", 404);
@@ -202,13 +212,18 @@ export async function handleRelationshipRoutes(
     /^\/api\/lifeops\/relationships\/([^/]+)$/,
   );
   if (method === "GET" && getOneMatch) {
-    const store = makeStore(ctx);
-    if (!store) return true;
-    const relationshipId = decodeURIComponent(getOneMatch[1] ?? "");
+    const relationshipId = ctx.decodePathComponent(
+      getOneMatch[1] ?? "",
+      res,
+      "relationship id",
+    );
+    if (relationshipId === null) return true;
     if (!relationshipId) {
       ctx.error(res, "relationship id required", 400);
       return true;
     }
+    const store = makeStore(ctx);
+    if (!store) return true;
     const relationship = await store.get(relationshipId);
     if (!relationship) {
       ctx.error(res, "relationship not found", 404);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
LifeOps relationship-id percent-encoding. Encoding class,
leftover tax after LifeOps routes already grew
`decodePathComponent`. Not a twin of those parsers — this is
GET/PATCH `/api/lifeops/relationships/:id` and POST
`/api/lifeops/relationships/:id/retire` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on the relationship id.
Canonical `rel%2D1` still decodes to `rel-1` and reaches the
relationship store. Malformed `%` / `%2` / `%ZZ` become 400
instead of an uncaught `URIError`. List, upsert, and observe
stay untouched.

# Background

## What does this PR do?

GET/PATCH `/:id` and POST `/:id/retire` called
`decodeURIComponent` on the relationship-id path segment.
Illegal percent-encoding threw `URIError` instead of a typed
400 before `makeStore`.

- `/api/lifeops/relationships/%` / `%2` / `%ZZ` → **400**
- `/api/lifeops/relationships/%E0%A4` → **400**
- `/api/lifeops/relationships/rel%2D1` → still decodes to `rel-1`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded
relationship id should get a request error, not a 500 that
looks like a knowledge-graph outage. Leftover tax after LifeOps
routes already grew `decodePathComponent`. Disjoint files from
those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-personal-assistant/src/routes/relationships.encoding.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-personal-assistant && bun test src/routes/relationships.encoding.test.ts
```

12 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; lifeops relationship-id decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; lifeops relationship-id decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; lifeops relationship-id decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before store lookup; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before relationship store reads.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real handler.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded relationship
ids still decode. Malformed tokens that previously threw now 400.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4a7383c9160728239f1bf68b5f0745722c73baae -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
