### PR TITLE
fix(app): hide the iOS keyboard accessory bar

### DIFF
--- a/packages/app/src/main.android-entrypoint.test.ts
+++ b/packages/app/src/main.android-entrypoint.test.ts
@@ -23,6 +23,7 @@ const androidBoot = vi.hoisted(() => ({
   installAec: vi.fn(),
   initializeDeepLinks: vi.fn(),
   initializeAppLifecycle: vi.fn(),
+  initializeKeyboard: vi.fn(async () => undefined),
   initializeNetworkListener: vi.fn(async () => undefined),
   startCameraBridgeResponder: vi.fn(() => vi.fn()),
   registerWebsiteBlocker: vi.fn(),
@@ -100,6 +101,7 @@ vi.mock("./mobile-lifecycle", () => ({
   createMobileLifecycle: vi.fn(() => ({
     initializeDeepLinks: androidBoot.initializeDeepLinks,
     initializeAppLifecycle: androidBoot.initializeAppLifecycle,
+    initializeKeyboard: androidBoot.initializeKeyboard,
     initializeNetworkListener: androidBoot.initializeNetworkListener,
   })),
 }));
@@ -153,6 +155,7 @@ describe("renderer Android local composition", () => {
     await vi.waitFor(() =>
       expect(androidBoot.startDeviceBridge).toHaveBeenCalledOnce(),
     );
+    expect(androidBoot.initializeKeyboard).toHaveBeenCalledOnce();
     await vi.waitFor(() =>
       expect(androidBoot.startCameraBridgeResponder).toHaveBeenCalledOnce(),
     );

--- a/packages/app/src/main.ios-interactive-entrypoint.test.ts
+++ b/packages/app/src/main.ios-interactive-entrypoint.test.ts
@@ -1,7 +1,8 @@
 /**
  * Boots the renderer through the ordinary interactive iOS path, then drives
- * the native lifecycle callbacks that the composition root owns: keyboard,
- * runtime-mode changes, and representative OS deep links.
+ * the native lifecycle callbacks that the composition root owns: runtime-mode
+ * changes and representative OS deep links. Keyboard behavior is delegated to
+ * and covered by the mobile-lifecycle contract suite.
  */
 import { Capacitor } from "@capacitor/core";
 import { runIosFullBunSmokeIfRequested } from "@elizaos/app-core/desktop-shell";
@@ -17,12 +18,12 @@ const iosBoot = vi.hoisted(() => ({
   createRoot: vi.fn(),
   runEmbedHandshake: vi.fn(async () => undefined),
   registerServiceWorker: vi.fn(),
-  keyboardListeners: new Map<string, (value?: unknown) => void>(),
   lifecycleDependencies: undefined as
     | { handleDeepLink: (url: string) => void }
     | undefined,
   initializeDeepLinks: vi.fn(),
   initializeAppLifecycle: vi.fn(),
+  initializeKeyboard: vi.fn(async () => undefined),
   initializeNetworkListener: vi.fn(async () => undefined),
   preferenceSet: vi.fn(async () => undefined),
 }));
@@ -61,10 +62,7 @@ vi.mock("@capacitor/keyboard", () => ({
     setResizeMode: vi.fn(async () => undefined),
     setScroll: vi.fn(async () => undefined),
     setAccessoryBarVisible: vi.fn(async () => undefined),
-    addListener: vi.fn((name: string, listener: (value?: unknown) => void) => {
-      iosBoot.keyboardListeners.set(name, listener);
-      return Promise.resolve({ remove: vi.fn(async () => undefined) });
-    }),
+    addListener: vi.fn(async () => ({ remove: vi.fn(async () => undefined) })),
   },
 }));
 vi.mock("@capacitor/status-bar", () => ({
@@ -85,6 +83,7 @@ vi.mock("./mobile-lifecycle", () => ({
       return {
         initializeDeepLinks: iosBoot.initializeDeepLinks,
         initializeAppLifecycle: iosBoot.initializeAppLifecycle,
+        initializeKeyboard: iosBoot.initializeKeyboard,
         initializeNetworkListener: iosBoot.initializeNetworkListener,
       };
     },
@@ -144,20 +143,12 @@ describe("renderer interactive iOS composition", () => {
     await vi.waitFor(() =>
       expect(iosBoot.initializeAppLifecycle).toHaveBeenCalledOnce(),
     );
+    expect(iosBoot.initializeKeyboard).toHaveBeenCalledOnce();
 
     expect(main.isIOS).toBe(true);
     expect(main.isNative).toBe(true);
     expect(iosBoot.installNativeRequest).toHaveBeenCalledTimes(2);
     expect(iosBoot.installFetch).toHaveBeenCalledTimes(2);
-
-    iosBoot.keyboardListeners.get("keyboardWillShow")?.({
-      keyboardHeight: 321,
-    });
-    expect(document.body.style.getPropertyValue("--keyboard-height")).toBe(
-      "321px",
-    );
-    iosBoot.keyboardListeners.get("keyboardWillHide")?.();
-    expect(document.body.classList).not.toContain("keyboard-open");
 
     document.dispatchEvent(new Event("eliza:mobile-runtime-mode-changed"));
 

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -41,7 +41,6 @@ import "./renderer-build-stamp";
 
 import { BackgroundRunner } from "@capacitor/background-runner";
 import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
-import { Keyboard, KeyboardResize } from "@capacitor/keyboard";
 import { Preferences } from "@capacitor/preferences";
 // #18056: desktop shell is loaded only via dynamic import / React.lazy so the
 // cold anonymous /login entry does not static-import app-core/ui browser graphs.
@@ -460,7 +459,6 @@ let mobileDeviceBridgeStartPromise: Promise<void> | null = null;
 let mobileAgentTunnelListener: PluginListenerHandle | null = null;
 let mobileAgentTunnelStartPromise: Promise<void> | null = null;
 let mobileRuntimeModeListenerInstalled = false;
-let keyboardListenersRegistered = false;
 let iosOnboardingSmokeStarted = false;
 let iosCloudOnboardingSmokeStarted = false;
 let iosOnboardingRelaunchSmokeStarted = false;
@@ -1847,7 +1845,7 @@ async function initializePlatform(): Promise<void> {
 
   if (isIOS || isAndroid) {
     await initializeStatusBar();
-    await initializeKeyboard();
+    await getMobileLifecycle().initializeKeyboard();
     initializeMobileRuntimeModeListener();
     void initializeMobileDeviceBridge();
     void initializeMobileAgentTunnel();
@@ -1927,41 +1925,9 @@ async function initializeStatusBar(): Promise<void> {
   }
 }
 
-async function initializeKeyboard(): Promise<void> {
-  if (keyboardListenersRegistered) return;
-
-  // A Keyboard-bridge throw (pod/plugin skew) must not reject and strand the
-  // rest of bootstrap (deep links, hardware back, pause/resume, network) —
-  // guard it exactly like the sibling initializeStatusBar.
-  try {
-    if (isIOS) {
-      await Keyboard.setResizeMode({ mode: KeyboardResize.None });
-      await Keyboard.setScroll({ isDisabled: true });
-      await Keyboard.setAccessoryBarVisible({ isVisible: true });
-    }
-
-    keyboardListenersRegistered = true;
-    Keyboard.addListener("keyboardWillShow", (info) => {
-      document.body.style.setProperty(
-        "--keyboard-height",
-        `${info.keyboardHeight}px`,
-      );
-      document.body.classList.add("keyboard-open");
-    });
-
-    Keyboard.addListener("keyboardWillHide", () => {
-      document.body.style.setProperty("--keyboard-height", "0px");
-      document.body.classList.remove("keyboard-open");
-    });
-  } catch (error) {
-    // error-policy:J4 optional native plugin — absence is a designed degrade
-    logNativePluginUnavailable("Keyboard", error);
-  }
-}
-
 /**
- * Live cross-platform lifecycle helper. `main.tsx` keeps its own
- * status-bar / keyboard wiring, but the app-lifecycle path (foreground/
+ * Live cross-platform lifecycle helper. `main.tsx` keeps its own status-bar
+ * wiring, but keyboard setup and the app-lifecycle path (foreground/
  * background events + the `visibilitychange` fallback, the hardware-back
  * contract — `dispatchBackIntent()` first, then `history.back()` /
  * `minimizeApp()` when unhandled (#9148) — and the deep-link bootstrap) and

--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -11,6 +11,7 @@
 
 import { App as CapacitorApp } from "@capacitor/app";
 import { Keyboard, KeyboardResize } from "@capacitor/keyboard";
+import { initializeIosKeyboardAccessoryBar } from "@elizaos/ui/components/shell/ios-chat-accessory-bar";
 import {
   APP_PAUSE_EVENT,
   APP_RESUME_EVENT,
@@ -172,9 +173,9 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
       if (ctx.isIOS) {
         await Keyboard.setResizeMode({ mode: KeyboardResize.None });
         await Keyboard.setScroll({ isDisabled: true });
-        // The app already provides its own chat controls; Capacitor's optional
-        // previous/next/done strip is redundant on the iPhone keyboard.
-        await Keyboard.setAccessoryBarVisible({ isVisible: false });
+        // Preserve the navigation/dismissal accessory for ordinary forms. The
+        // chat composer suppresses it only while that field owns focus.
+        await initializeIosKeyboardAccessoryBar();
       }
 
       keyboardListenersRegistered = true;

--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -172,7 +172,9 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
       if (ctx.isIOS) {
         await Keyboard.setResizeMode({ mode: KeyboardResize.None });
         await Keyboard.setScroll({ isDisabled: true });
-        await Keyboard.setAccessoryBarVisible({ isVisible: true });
+        // The app already provides its own chat controls; Capacitor's optional
+        // previous/next/done strip is redundant on the iPhone keyboard.
+        await Keyboard.setAccessoryBarVisible({ isVisible: false });
       }
 
       keyboardListenersRegistered = true;

--- a/packages/app/test/mobile-lifecycle.test.ts
+++ b/packages/app/test/mobile-lifecycle.test.ts
@@ -3,9 +3,12 @@
 
 /**
  * Coverage for `src/mobile-lifecycle.ts` — the idempotent Capacitor lifecycle
- * wiring (`createMobileLifecycle`). Exercises the two device-free seams a
+ * wiring (`createMobileLifecycle`). Exercises the three device-free seams a
  * jsdom test can drive deterministically:
  *
+ *   - `initializeKeyboard()` — iOS delegates WebView-global accessory
+ *     ownership to the focus-aware chat controller while retaining height
+ *     lifecycle events.
  *   - `initializeDeepLinks()` + `initializeAppLifecycle()` — early
  *     `appUrlOpen`/cold-launch capture plus `appStateChange` / `backButton`
  *     wiring. Asserts the events the module dispatches
@@ -99,7 +102,6 @@ const { keyboardListeners, keyboardMock } = vi.hoisted(() => {
     keyboardMock: {
       setResizeMode: vi.fn(async () => undefined),
       setScroll: vi.fn(async () => undefined),
-      setAccessoryBarVisible: vi.fn(async () => undefined),
       addListener: vi.fn(
         (eventName: string, handler: CapacitorEventHandler) => {
           const handlers = keyboardListeners.get(eventName) ?? [];
@@ -112,8 +114,13 @@ const { keyboardListeners, keyboardMock } = vi.hoisted(() => {
   };
 });
 
+const initializeAccessoryBar = vi.hoisted(() => vi.fn(async () => undefined));
+
 vi.mock("@capacitor/app", () => ({ App: capacitorAppMock }));
 vi.mock("@capacitor/network", () => ({ Network: networkMock }));
+vi.mock("@elizaos/ui/components/shell/ios-chat-accessory-bar", () => ({
+  initializeIosKeyboardAccessoryBar: initializeAccessoryBar,
+}));
 // `mobile-lifecycle.ts` imports these statically; only the app lifecycle and
 // network paths are exercised here, so the keyboard module just needs to load.
 vi.mock("@capacitor/keyboard", () => ({
@@ -233,7 +240,7 @@ describe("createMobileLifecycle — app lifecycle", () => {
     expect(mainSrc).not.toContain("async function initializeKeyboard()");
   });
 
-  it("keeps the iPhone software keyboard but disables its redundant accessory strip", async () => {
+  it("keeps keyboard height events and delegates iOS accessory ownership", async () => {
     const lifecycle = createMobileLifecycle(
       makeContext({ isIOS: true, isAndroid: false }),
     );
@@ -242,9 +249,7 @@ describe("createMobileLifecycle — app lifecycle", () => {
 
     expect(keyboardMock.setResizeMode).toHaveBeenCalledWith({ mode: "none" });
     expect(keyboardMock.setScroll).toHaveBeenCalledWith({ isDisabled: true });
-    expect(keyboardMock.setAccessoryBarVisible).toHaveBeenCalledWith({
-      isVisible: false,
-    });
+    expect(initializeAccessoryBar).toHaveBeenCalledOnce();
 
     for (const handler of keyboardListeners.get("keyboardWillShow") ?? []) {
       handler({ keyboardHeight: 321 });
@@ -270,7 +275,7 @@ describe("createMobileLifecycle — app lifecycle", () => {
 
     expect(keyboardMock.setResizeMode).not.toHaveBeenCalled();
     expect(keyboardMock.setScroll).not.toHaveBeenCalled();
-    expect(keyboardMock.setAccessoryBarVisible).not.toHaveBeenCalled();
+    expect(initializeAccessoryBar).not.toHaveBeenCalled();
   });
 
   it("dispatches APP_RESUME_EVENT when the app becomes active", async () => {

--- a/packages/app/test/mobile-lifecycle.test.ts
+++ b/packages/app/test/mobile-lifecycle.test.ts
@@ -92,17 +92,32 @@ const { appListeners, networkListeners, capacitorAppMock, networkMock } =
     };
   });
 
+const { keyboardListeners, keyboardMock } = vi.hoisted(() => {
+  const keyboardListeners = new Map<string, CapacitorEventHandler[]>();
+  return {
+    keyboardListeners,
+    keyboardMock: {
+      setResizeMode: vi.fn(async () => undefined),
+      setScroll: vi.fn(async () => undefined),
+      setAccessoryBarVisible: vi.fn(async () => undefined),
+      addListener: vi.fn(
+        (eventName: string, handler: CapacitorEventHandler) => {
+          const handlers = keyboardListeners.get(eventName) ?? [];
+          handlers.push(handler);
+          keyboardListeners.set(eventName, handlers);
+          return Promise.resolve({ remove: async () => undefined });
+        },
+      ),
+    },
+  };
+});
+
 vi.mock("@capacitor/app", () => ({ App: capacitorAppMock }));
 vi.mock("@capacitor/network", () => ({ Network: networkMock }));
 // `mobile-lifecycle.ts` imports these statically; only the app lifecycle and
 // network paths are exercised here, so the keyboard module just needs to load.
 vi.mock("@capacitor/keyboard", () => ({
-  Keyboard: {
-    setResizeMode: vi.fn(async () => undefined),
-    setScroll: vi.fn(async () => undefined),
-    setAccessoryBarVisible: vi.fn(async () => undefined),
-    addListener: vi.fn(async () => ({ remove: async () => undefined })),
-  },
+  Keyboard: keyboardMock,
   KeyboardResize: { None: "none" },
 }));
 
@@ -181,6 +196,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   appListeners.clear();
   networkListeners.clear();
+  keyboardListeners.clear();
   capacitorAppMock.__setLaunchUrl(null);
   historyBackSpy = vi
     .spyOn(window.history, "back")
@@ -203,6 +219,7 @@ describe("createMobileLifecycle — app lifecycle", () => {
     // The live entrypoint must route through the extracted helper — this suite
     // certifies the shipped behavior only while main.tsx actually calls it.
     expect(mainSrc).toContain("getMobileLifecycle().initializeAppLifecycle()");
+    expect(mainSrc).toContain("getMobileLifecycle().initializeKeyboard()");
     expect(mainSrc).toContain("getMobileLifecycle().initializeDeepLinks()");
     expect(mainSrc).toContain(
       "getMobileLifecycle().initializeNetworkListener()",
@@ -213,6 +230,47 @@ describe("createMobileLifecycle — app lifecycle", () => {
     expect(mainSrc).not.toContain('addEventListener("visibilitychange"');
     expect(mainSrc).not.toContain('addListener("backButton"');
     expect(mainSrc).not.toContain('addListener("appStateChange"');
+    expect(mainSrc).not.toContain("async function initializeKeyboard()");
+  });
+
+  it("keeps the iPhone software keyboard but disables its redundant accessory strip", async () => {
+    const lifecycle = createMobileLifecycle(
+      makeContext({ isIOS: true, isAndroid: false }),
+    );
+
+    await lifecycle.initializeKeyboard();
+
+    expect(keyboardMock.setResizeMode).toHaveBeenCalledWith({ mode: "none" });
+    expect(keyboardMock.setScroll).toHaveBeenCalledWith({ isDisabled: true });
+    expect(keyboardMock.setAccessoryBarVisible).toHaveBeenCalledWith({
+      isVisible: false,
+    });
+
+    for (const handler of keyboardListeners.get("keyboardWillShow") ?? []) {
+      handler({ keyboardHeight: 321 });
+    }
+    expect(document.body.style.getPropertyValue("--keyboard-height")).toBe(
+      "321px",
+    );
+    expect(document.body.classList).toContain("keyboard-open");
+
+    for (const handler of keyboardListeners.get("keyboardWillHide") ?? []) {
+      handler({});
+    }
+    expect(document.body.style.getPropertyValue("--keyboard-height")).toBe(
+      "0px",
+    );
+    expect(document.body.classList).not.toContain("keyboard-open");
+  });
+
+  it("does not change Android keyboard accessory policy", async () => {
+    const lifecycle = createMobileLifecycle(makeContext());
+
+    await lifecycle.initializeKeyboard();
+
+    expect(keyboardMock.setResizeMode).not.toHaveBeenCalled();
+    expect(keyboardMock.setScroll).not.toHaveBeenCalled();
+    expect(keyboardMock.setAccessoryBarVisible).not.toHaveBeenCalled();
   });
 
   it("dispatches APP_RESUME_EVENT when the app becomes active", async () => {

--- a/packages/ui/src/components/shell/ChatOverlay.ios-accessory.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.ios-accessory.test.tsx
@@ -14,10 +14,6 @@ vi.mock("./ios-chat-accessory-bar", () => ({
   setChatComposerAccessoryBarHidden: accessoryMock.setHidden,
 }));
 
-vi.mock("../composites/chat/ServingProviderChip", () => ({
-  ServingProviderChip: () => <span data-testid="serving-provider-chip" />,
-}));
-
 vi.mock("../../api/client", () => ({
   client: {
     fetch: vi.fn().mockRejectedValue(new Error("no api in test")),
@@ -84,7 +80,6 @@ describe("ChatOverlay iOS accessory bar", () => {
 
     const composer = screen.getByLabelText("message");
     const settingsField = screen.getByLabelText("Settings field");
-    expect(screen.getByTestId("serving-provider-chip")).toBeTruthy();
 
     act(() => composer.focus());
     await waitFor(() =>

--- a/packages/ui/src/components/shell/ChatOverlay.ios-accessory.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.ios-accessory.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Verifies the real chat composer scopes Capacitor's WebView-global iOS
+ * accessory suppression to its own focus lifecycle, including the handoff to
+ * a non-chat field. The native bridge is mocked; focus behavior is real jsdom.
+ */
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+const accessoryMock = vi.hoisted(() => ({ setHidden: vi.fn() }));
+
+vi.mock("./ios-chat-accessory-bar", () => ({
+  setChatComposerAccessoryBarHidden: accessoryMock.setHidden,
+}));
+
+vi.mock("../composites/chat/ServingProviderChip", () => ({
+  ServingProviderChip: () => <span data-testid="serving-provider-chip" />,
+}));
+
+vi.mock("../../api/client", () => ({
+  client: {
+    fetch: vi.fn().mockRejectedValue(new Error("no api in test")),
+    createTranscript: vi
+      .fn()
+      .mockResolvedValue({ transcript: { id: "t1", title: "Transcript" } }),
+    searchConversationMessages: vi.fn(),
+  },
+}));
+
+import { ChatOverlay } from "./ChatOverlay";
+import type { ShellController } from "./useShellController";
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function makeController(): ShellController {
+  return {
+    phase: "summoned",
+    messages: [
+      { id: "a", role: "assistant", content: "hi", createdAt: 1 },
+      { id: "b", role: "user", content: "hello", createdAt: 2 },
+    ],
+    canSend: true,
+    responding: false,
+    turnStatus: null,
+    recording: false,
+    transcript: "",
+    transcriptionMode: false,
+    modelStatus: { kind: "ready" },
+    send: vi.fn(),
+    stop: vi.fn(),
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+    toggleRecording: vi.fn(),
+    handsFree: false,
+    toggleHandsFree: vi.fn(),
+    toggleTranscriptionMode: vi.fn(),
+    stopTranscriptionAndMic: vi.fn(),
+    setDictationSink: vi.fn(),
+    setTranscriptSessionSink: vi.fn(),
+    setComposerHasDraft: vi.fn(),
+    clearConversation: vi.fn(),
+  } as unknown as ShellController;
+}
+
+describe("ChatOverlay iOS accessory bar", () => {
+  it("restores the global accessory before a non-chat field takes focus", async () => {
+    render(
+      <>
+        <ChatOverlay controller={makeController()} />
+        <input aria-label="Settings field" />
+      </>,
+    );
+
+    const composer = screen.getByLabelText("message");
+    const settingsField = screen.getByLabelText("Settings field");
+    expect(screen.getByTestId("serving-provider-chip")).toBeTruthy();
+
+    act(() => composer.focus());
+    await waitFor(() =>
+      expect(accessoryMock.setHidden).toHaveBeenCalledWith(true),
+    );
+
+    act(() => settingsField.focus());
+    await waitFor(() =>
+      expect(accessoryMock.setHidden).toHaveBeenLastCalledWith(false),
+    );
+    expect(document.activeElement).toBe(settingsField);
+  });
+});

--- a/packages/ui/src/components/shell/ChatOverlay.ios-accessory.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.ios-accessory.test.tsx
@@ -40,7 +40,9 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-function makeController(): ShellController {
+function makeController(
+  overrides: Partial<ShellController> = {},
+): ShellController {
   return {
     phase: "summoned",
     messages: [
@@ -67,6 +69,7 @@ function makeController(): ShellController {
     setTranscriptSessionSink: vi.fn(),
     setComposerHasDraft: vi.fn(),
     clearConversation: vi.fn(),
+    ...overrides,
   } as unknown as ShellController;
 }
 
@@ -107,5 +110,29 @@ describe("ChatOverlay iOS accessory bar", () => {
     unmount();
 
     expect(accessoryMock.setHidden).toHaveBeenLastCalledWith(false);
+  });
+
+  it("restores the global accessory when transcription replaces a focused textarea", async () => {
+    const { rerender } = render(<ChatOverlay controller={makeController()} />);
+    const composer = screen.getByLabelText("message");
+
+    act(() => composer.focus());
+    await waitFor(() =>
+      expect(accessoryMock.setHidden).toHaveBeenLastCalledWith(true),
+    );
+
+    rerender(
+      <ChatOverlay
+        controller={makeController({
+          transcriptionMode: true,
+          recording: true,
+        })}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(accessoryMock.setHidden).toHaveBeenLastCalledWith(false),
+    );
+    expect(screen.queryByLabelText("message")).toBeNull();
   });
 });

--- a/packages/ui/src/components/shell/ChatOverlay.ios-accessory.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.ios-accessory.test.tsx
@@ -94,4 +94,18 @@ describe("ChatOverlay iOS accessory bar", () => {
     );
     expect(document.activeElement).toBe(settingsField);
   });
+
+  it("restores the global accessory when a focused chat unmounts", async () => {
+    const { unmount } = render(<ChatOverlay controller={makeController()} />);
+    const composer = screen.getByLabelText("message");
+
+    act(() => composer.focus());
+    await waitFor(() =>
+      expect(accessoryMock.setHidden).toHaveBeenLastCalledWith(true),
+    );
+
+    unmount();
+
+    expect(accessoryMock.setHidden).toHaveBeenLastCalledWith(false);
+  });
 });

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -158,6 +158,7 @@ import {
   resolveChatPanelHalfDetentHeight,
   resolveChatPanelLayout,
 } from "./chat-panel-layout";
+import { setChatComposerAccessoryBarHidden } from "./ios-chat-accessory-bar";
 import { LIQUID_GLASS_SHEEN, liquidGlassEdgeShadow } from "./liquid-glass";
 import { withPressLatch } from "./press-latch";
 import { SlashCommandMenu, useSlashMenu } from "./SlashCommandMenu";
@@ -1629,6 +1630,14 @@ export function ChatOverlay({
   const [inputIdleEpoch, noteInputActivity] = React.useReducer(
     (epoch: number) => epoch + 1,
     0,
+  );
+  React.useEffect(
+    () => () => {
+      // The setting is WebView-global. Always restore it when chat leaves the
+      // tree so a later settings or onboarding field retains its accessory.
+      setChatComposerAccessoryBarHidden(false);
+    },
+    [],
   );
   // Whether the sheet was collapsed when the composer last gained focus — so
   // dismissing the keyboard (tap the handle, tap the scrim, tap outside) returns
@@ -6671,6 +6680,7 @@ export function ChatOverlay({
                     if (nextDraft.trim().length > 0) expandFromTyping();
                   }}
                   onFocus={() => {
+                    setChatComposerAccessoryBarHidden(true);
                     // Widen out of the short-landscape compact affordance (#14173)
                     // on focus, before the first keystroke.
                     setComposerFocused(true);
@@ -6691,6 +6701,7 @@ export function ChatOverlay({
                     if (cloudLoginWaiting) expand();
                   }}
                   onBlur={() => {
+                    setChatComposerAccessoryBarHidden(false);
                     setComposerFocused(false);
                     // A suppress-expand flag armed for a focus that never landed
                     // (openFromPill arms it BEFORE focusing) must not survive to

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -1639,6 +1639,15 @@ export function ChatOverlay({
     },
     [],
   );
+  React.useLayoutEffect(() => {
+    if (!transcriptionComposerActive && !realtimeVoiceComposerVisible) return;
+    // Removing a focused textarea does not reliably emit blur in WebKit. Give
+    // the WebView-global accessory back in the same commit that installs the
+    // voice/transcription surface, otherwise every later form can inherit
+    // chat's hidden state until the overlay itself unmounts.
+    setChatComposerAccessoryBarHidden(false);
+    setComposerFocused(false);
+  }, [realtimeVoiceComposerVisible, transcriptionComposerActive]);
   // Whether the sheet was collapsed when the composer last gained focus — so
   // dismissing the keyboard (tap the handle, tap the scrim, tap outside) returns
   // to the prior resting state (collapsed → input) instead of leaving the sheet

--- a/packages/ui/src/components/shell/ios-chat-accessory-bar.test.ts
+++ b/packages/ui/src/components/shell/ios-chat-accessory-bar.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Verifies the iOS chat accessory controller's visibility mapping and ordered
+ * WebView-global writes with a deterministic fake native bridge.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createChatAccessoryBarController } from "./ios-chat-accessory-bar";
+
+describe("iOS chat accessory controller", () => {
+  it("serializes chat hide then non-chat restore in request order", async () => {
+    let releaseHide: (() => void) | undefined;
+    const setAccessoryBarVisible = vi.fn(
+      ({ isVisible }: { isVisible: boolean }) => {
+        if (isVisible) return Promise.resolve();
+        return new Promise<void>((resolve) => {
+          releaseHide = resolve;
+        });
+      },
+    );
+    const reportError = vi.fn();
+    const controller = createChatAccessoryBarController({
+      enabled: true,
+      loadKeyboard: async () => ({ setAccessoryBarVisible }),
+      reportError,
+    });
+
+    void controller.setChatComposerHidden(true);
+    void controller.setChatComposerHidden(false);
+    await vi.waitFor(() =>
+      expect(setAccessoryBarVisible).toHaveBeenCalledOnce(),
+    );
+    expect(setAccessoryBarVisible).toHaveBeenLastCalledWith({
+      isVisible: false,
+    });
+
+    releaseHide?.();
+    await vi.waitFor(() =>
+      expect(setAccessoryBarVisible).toHaveBeenLastCalledWith({
+        isVisible: true,
+      }),
+    );
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("keeps a focused composer hidden when delayed boot settles, then restores on blur", async () => {
+    let releaseFocus: (() => void) | undefined;
+    const setAccessoryBarVisible = vi.fn(
+      ({ isVisible }: { isVisible: boolean }) => {
+        if (!isVisible && setAccessoryBarVisible.mock.calls.length === 1) {
+          return new Promise<void>((resolve) => {
+            releaseFocus = resolve;
+          });
+        }
+        return Promise.resolve();
+      },
+    );
+    const reportError = vi.fn();
+    const controller = createChatAccessoryBarController({
+      enabled: true,
+      loadKeyboard: async () => ({ setAccessoryBarVisible }),
+      reportError,
+    });
+
+    const focus = controller.setChatComposerHidden(true);
+    await vi.waitFor(() =>
+      expect(setAccessoryBarVisible).toHaveBeenCalledWith({ isVisible: false }),
+    );
+    const boot = controller.initializeBaseline();
+
+    releaseFocus?.();
+    await Promise.all([boot, focus]);
+    expect(setAccessoryBarVisible).toHaveBeenLastCalledWith({
+      isVisible: false,
+    });
+
+    await controller.setChatComposerHidden(false);
+    expect(setAccessoryBarVisible).toHaveBeenLastCalledWith({
+      isVisible: true,
+    });
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/shell/ios-chat-accessory-bar.test.ts
+++ b/packages/ui/src/components/shell/ios-chat-accessory-bar.test.ts
@@ -8,38 +8,29 @@ import { describe, expect, it, vi } from "vitest";
 import { createChatAccessoryBarController } from "./ios-chat-accessory-bar";
 
 describe("iOS chat accessory controller", () => {
-  it("serializes chat hide then non-chat restore in request order", async () => {
-    let releaseHide: (() => void) | undefined;
-    const setAccessoryBarVisible = vi.fn(
-      ({ isVisible }: { isVisible: boolean }) => {
-        if (isVisible) return Promise.resolve();
-        return new Promise<void>((resolve) => {
-          releaseHide = resolve;
-        });
-      },
-    );
+  it("drops a stale hide when focus leaves before the bridge loads", async () => {
+    let releaseBridge: (() => void) | undefined;
+    const bridgeReady = new Promise<void>((resolve) => {
+      releaseBridge = resolve;
+    });
+    const setAccessoryBarVisible = vi.fn(async () => undefined);
     const reportError = vi.fn();
     const controller = createChatAccessoryBarController({
       enabled: true,
-      loadKeyboard: async () => ({ setAccessoryBarVisible }),
+      loadKeyboard: async () => {
+        await bridgeReady;
+        return { setAccessoryBarVisible };
+      },
       reportError,
     });
 
     void controller.setChatComposerHidden(true);
     void controller.setChatComposerHidden(false);
+    releaseBridge?.();
     await vi.waitFor(() =>
       expect(setAccessoryBarVisible).toHaveBeenCalledOnce(),
     );
-    expect(setAccessoryBarVisible).toHaveBeenLastCalledWith({
-      isVisible: false,
-    });
-
-    releaseHide?.();
-    await vi.waitFor(() =>
-      expect(setAccessoryBarVisible).toHaveBeenLastCalledWith({
-        isVisible: true,
-      }),
-    );
+    expect(setAccessoryBarVisible).toHaveBeenCalledWith({ isVisible: true });
     expect(reportError).not.toHaveBeenCalled();
   });
 
@@ -79,5 +70,61 @@ describe("iOS chat accessory controller", () => {
       isVisible: true,
     });
     expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates repeated focus state without losing the boot baseline", async () => {
+    const setAccessoryBarVisible = vi.fn(async () => undefined);
+    const controller = createChatAccessoryBarController({
+      enabled: true,
+      loadKeyboard: async () => ({ setAccessoryBarVisible }),
+      reportError: vi.fn(),
+    });
+
+    await controller.initializeBaseline();
+    await controller.initializeBaseline();
+    await controller.setChatComposerHidden(true);
+    await controller.setChatComposerHidden(true);
+
+    expect(setAccessoryBarVisible.mock.calls).toEqual([
+      [{ isVisible: true }],
+      [{ isVisible: false }],
+    ]);
+  });
+
+  it("retries the latest state after a bridge failure", async () => {
+    const setAccessoryBarVisible = vi
+      .fn<({ isVisible }: { isVisible: boolean }) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("bridge unavailable"))
+      .mockResolvedValue(undefined);
+    const reportError = vi.fn();
+    const controller = createChatAccessoryBarController({
+      enabled: true,
+      loadKeyboard: async () => ({ setAccessoryBarVisible }),
+      reportError,
+    });
+
+    await controller.setChatComposerHidden(true);
+    await controller.setChatComposerHidden(true);
+
+    expect(reportError).toHaveBeenCalledOnce();
+    expect(setAccessoryBarVisible).toHaveBeenCalledTimes(2);
+    expect(setAccessoryBarVisible).toHaveBeenLastCalledWith({
+      isVisible: false,
+    });
+  });
+
+  it("does not load or mutate the native bridge off supported iPhone builds", async () => {
+    const loadKeyboard = vi.fn();
+    const controller = createChatAccessoryBarController({
+      enabled: false,
+      loadKeyboard,
+      reportError: vi.fn(),
+    });
+
+    await controller.initializeBaseline();
+    await controller.setChatComposerHidden(true);
+    await controller.setChatComposerHidden(false);
+
+    expect(loadKeyboard).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/shell/ios-chat-accessory-bar.test.ts
+++ b/packages/ui/src/components/shell/ios-chat-accessory-bar.test.ts
@@ -3,7 +3,7 @@
  * WebView-global writes with a deterministic fake native bridge.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createChatAccessoryBarController } from "./ios-chat-accessory-bar";
 
@@ -126,5 +126,47 @@ describe("iOS chat accessory controller", () => {
     await controller.setChatComposerHidden(false);
 
     expect(loadKeyboard).not.toHaveBeenCalled();
+  });
+});
+
+// The exported functions run against a module-level singleton whose `enabled`
+// flag and dynamic `@capacitor/keyboard` import are the actual production
+// wiring. The controller tests above inject fakes for both, so without these
+// the shipped path — the one that decides whether anything is hidden at all —
+// would be covered by nothing.
+describe("production singleton wiring", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("mutates the native bridge on a native iOS build", async () => {
+    const setAccessoryBarVisible = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("../../platform/init", () => ({ isNative: true, isIOS: true }));
+    vi.doMock("@capacitor/keyboard", () => ({
+      Keyboard: { setAccessoryBarVisible },
+    }));
+
+    const { setChatComposerAccessoryBarHidden } = await import(
+      "./ios-chat-accessory-bar"
+    );
+    setChatComposerAccessoryBarHidden(true);
+    await vi.waitFor(() =>
+      expect(setAccessoryBarVisible).toHaveBeenCalledWith({ isVisible: false }),
+    );
+  });
+
+  it("never imports the native bridge on a non-iOS build", async () => {
+    const keyboardModule = vi.fn();
+    vi.doMock("../../platform/init", () => ({ isNative: true, isIOS: false }));
+    vi.doMock("@capacitor/keyboard", keyboardModule);
+
+    const {
+      initializeIosKeyboardAccessoryBar,
+      setChatComposerAccessoryBarHidden,
+    } = await import("./ios-chat-accessory-bar");
+    await initializeIosKeyboardAccessoryBar();
+    setChatComposerAccessoryBarHidden(true);
+
+    expect(keyboardModule).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/shell/ios-chat-accessory-bar.ts
+++ b/packages/ui/src/components/shell/ios-chat-accessory-bar.ts
@@ -30,13 +30,20 @@ export function createChatAccessoryBarController({
 }): ChatAccessoryBarController {
   let update = Promise.resolve();
   let chatComposerHidden = false;
+  let appliedHidden: boolean | undefined;
 
-  const enqueueVisibility = (hidden: boolean): Promise<void> => {
+  const enqueueReconciliation = (): Promise<void> => {
     if (!enabled) return Promise.resolve();
     update = update
       .then(async () => {
         const Keyboard = await loadKeyboard();
-        await Keyboard.setAccessoryBarVisible({ isVisible: !hidden });
+        // Loading the bridge can outlive the focus that requested this turn.
+        // Read the desired state only after that await so an already-blurred
+        // composer cannot transiently hide the accessory for the next field.
+        const targetHidden = chatComposerHidden;
+        if (appliedHidden === targetHidden) return;
+        await Keyboard.setAccessoryBarVisible({ isVisible: !targetHidden });
+        appliedHidden = targetHidden;
       })
       .catch((error) => {
         // error-policy:J4 the optional native keyboard bridge can be absent or
@@ -50,11 +57,11 @@ export function createChatAccessoryBarController({
     initializeBaseline(): Promise<void> {
       // Boot can finish after React mounts and the composer takes focus. Apply
       // the current owner state instead of blindly restoring the global bar.
-      return enqueueVisibility(chatComposerHidden);
+      return enqueueReconciliation();
     },
     setChatComposerHidden(hidden: boolean): Promise<void> {
       chatComposerHidden = hidden;
-      return enqueueVisibility(hidden);
+      return enqueueReconciliation();
     },
   };
 }

--- a/packages/ui/src/components/shell/ios-chat-accessory-bar.ts
+++ b/packages/ui/src/components/shell/ios-chat-accessory-bar.ts
@@ -46,8 +46,10 @@ export function createChatAccessoryBarController({
         appliedHidden = targetHidden;
       })
       .catch((error) => {
-        // error-policy:J4 the optional native keyboard bridge can be absent or
-        // unavailable; ordinary WebView keyboard behavior remains usable.
+        // error-policy:J7 native keyboard-bridge diagnostics must not kill the
+        // focus loop. This narrows no error shape and renders no distinguishable
+        // state, so it is a diagnostics catch rather than a J4 degrade: the
+        // accessory bar simply keeps whatever visibility the WebView gave it.
         reportError(error);
       });
     return update;
@@ -75,7 +77,7 @@ const chatAccessoryBarController = createChatAccessoryBarController({
   reportError: (error) => {
     logger.warn(
       { error },
-      "[ChatOverlay] iOS keyboard accessory visibility unavailable",
+      "[ios-chat-accessory-bar] iOS keyboard accessory visibility unavailable",
     );
   },
 });

--- a/packages/ui/src/components/shell/ios-chat-accessory-bar.ts
+++ b/packages/ui/src/components/shell/ios-chat-accessory-bar.ts
@@ -1,0 +1,83 @@
+/**
+ * Scopes WebView-global iOS keyboard accessory suppression to the chat
+ * composer's focus lifecycle and serializes native bridge writes so a later
+ * restore cannot be overtaken by an earlier hide.
+ */
+
+import { logger } from "@elizaos/logger";
+
+import { isIOS, isNative } from "../../platform/init";
+
+interface KeyboardAccessoryBridge {
+  setAccessoryBarVisible(options: { isVisible: boolean }): Promise<void>;
+}
+
+type KeyboardAccessoryLoader = () => Promise<KeyboardAccessoryBridge>;
+
+export interface ChatAccessoryBarController {
+  initializeBaseline(): Promise<void>;
+  setChatComposerHidden(hidden: boolean): Promise<void>;
+}
+
+export function createChatAccessoryBarController({
+  enabled,
+  loadKeyboard,
+  reportError,
+}: {
+  enabled: boolean;
+  loadKeyboard: KeyboardAccessoryLoader;
+  reportError: (error: unknown) => void;
+}): ChatAccessoryBarController {
+  let update = Promise.resolve();
+  let chatComposerHidden = false;
+
+  const enqueueVisibility = (hidden: boolean): Promise<void> => {
+    if (!enabled) return Promise.resolve();
+    update = update
+      .then(async () => {
+        const Keyboard = await loadKeyboard();
+        await Keyboard.setAccessoryBarVisible({ isVisible: !hidden });
+      })
+      .catch((error) => {
+        // error-policy:J4 the optional native keyboard bridge can be absent or
+        // unavailable; ordinary WebView keyboard behavior remains usable.
+        reportError(error);
+      });
+    return update;
+  };
+
+  return {
+    initializeBaseline(): Promise<void> {
+      // Boot can finish after React mounts and the composer takes focus. Apply
+      // the current owner state instead of blindly restoring the global bar.
+      return enqueueVisibility(chatComposerHidden);
+    },
+    setChatComposerHidden(hidden: boolean): Promise<void> {
+      chatComposerHidden = hidden;
+      return enqueueVisibility(hidden);
+    },
+  };
+}
+
+const chatAccessoryBarController = createChatAccessoryBarController({
+  enabled: isNative && isIOS,
+  loadKeyboard: async () => {
+    const { Keyboard } = await import("@capacitor/keyboard");
+    return Keyboard;
+  },
+  reportError: (error) => {
+    logger.warn(
+      { error },
+      "[ChatOverlay] iOS keyboard accessory visibility unavailable",
+    );
+  },
+});
+
+/** Reconciles boot's ordinary-form baseline with any already-focused chat. */
+export function initializeIosKeyboardAccessoryBar(): Promise<void> {
+  return chatAccessoryBarController.initializeBaseline();
+}
+
+export function setChatComposerAccessoryBarHidden(hidden: boolean): void {
+  void chatAccessoryBarController.setChatComposerHidden(hidden);
+}


### PR DESCRIPTION
# Relates to

Closes #21383 only after the supported-device acceptance rows below pass.

# What this PR does

Removes duplicate keyboard initialization and keeps one mobile-lifecycle authority for keyboard resize, scroll, height events, and the ordinary-form accessory baseline.

Accessory suppression is scoped to chat-composer focus. Blur, composer-mode replacement, non-chat focus, navigation, and overlay unmount restore the strip. A serialized singleton prevents delayed boot/focus and rapid focus/blur writes from committing stale native visibility. Android and non-native builds remain no-ops.

# Exact source state

<!-- evidence-head:86acc8f9ad5efdeb70d5ff6efb6212ea08d660c7 -->

- Head: `86acc8f9ad5efdeb70d5ff6efb6212ea08d660c7`
- Base: `03ecee158a017e913513b45015623a5ebacc91a8`. At the independent source audit, `develop@f3431d79...` was 90 commits ahead and had changed all nine PR paths; a prospective three-way merge was nevertheless conflict-free and preserved the controller/lifecycle anchors. Live `develop` has since advanced to `2f901103...`, so an exact final merge-tree check remains required before merge. No evidence-invalidating rebase was performed.
- The preceding five-commit series remains patch-equivalent to the last reviewed source series; the final commit only corrects the diagnostics catch category and adds production-singleton wiring tests.
- Exact-head UI/controller lifecycle tests: 2 files, 10/10 PASS.
- Exact-head app lifecycle/entrypoint/keyboard tests: 4 files, 37/37 PASS. The package script prelude also passed 898 tests with 2 documented skips.
- Biome across all nine touched files and `git diff --check`: PASS.
- Independent API/source audit found no concrete P0-P3 source defect in the final commit.
- App typecheck was attempted but is not claimed: the reused dependency tree is incomplete/stale and reports broad missing `drizzle-orm`, `pg`, `ws`, and other workspace dependencies plus untouched current-source errors.
- Full clean install, root `bun run verify`, exact-head iOS build/install, `audit:app`, and physical-device interaction: NOT RUN/NOT COMPLETE on this head.

Historical simulator builds and captures do not prove `86acc8f`.

# Named physical-device merge hold

UIKit reads `inputAccessoryView` when a responder becomes first responder, while this PR changes it through an asynchronous Capacitor call. Mocked JavaScript tests cannot establish the two timing-sensitive outcomes required for merit:

1. From a cold launch, the redundant strip is absent on the **first** chat-composer keyboard presentation.
2. A direct blur/handoff into an ordinary field restores the native accessory strip for that field.

The exact rebuilt app must also demonstrate a real send/reply after those transitions. Both available physical iPhones were reported offline during the latest review.

<!-- evidence-row:before-screenshots -->
- [ ] Exact installed-device cold first-focus capture.
<!-- evidence-row:after-screenshots -->
- [ ] Exact installed-device ordinary-field restoration capture.
<!-- evidence-row:walkthrough-video -->
- [ ] Physical-device focus/handoff, navigation, unmount, and real send/reply walkthrough.
<!-- evidence-row:backend-logs -->
- [x] N/A - native/UI keyboard accessory behavior only.
<!-- evidence-row:frontend-logs -->
- [ ] Exact-head sanitized native/frontend logs.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] Exact rebuilt/cap-synced/installed identity and physical keyboard lifecycle receipt.
<!-- evidence-row:ocr-review -->
- [ ] Exact-device pixels/video, accessibility/OCR review, and `audit:app` review.

**MERGE HOLD:** keep this PR READY for review, but do not merge until the named physical-iPhone timing proof, exact installed identity, remaining source gates, app audit, and independent final-head approval exist. Pending hosted CI or device/operator evidence is not a reason to convert it back to draft.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [root/native-final-refresh]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza"} -->
