### PR TITLE
fix: stop desktop chat overlay intercepting background scroll

### DIFF
--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -77,12 +77,16 @@ describe("App standalone chat-overlay wiring", () => {
 
     expect(overlayShell).toContain("<GlassStyles />");
     expect(overlayShell).toContain("<ShellFoundationMount useWebChatPanel />");
+    expect(overlayShell).not.toContain("useChatOverlayWindowBounds");
     expect(overlayShell).not.toContain("<AppBackground");
     expect(foundation).toContain("if (useWebChatPanel && shellIsOpen)");
     expect(foundation).toContain("<ChatOverlayMount");
     expect(foundation).toContain("onPilledChange={closeWebChatWhenPilled}");
     expect(foundation).toContain(
-      "hovered: useWebChatPanel && shellPreviewHovered",
+      'expanded: shellIsOpen && shellHostDetent !== "input"',
+    );
+    expect(foundation).toContain(
+      '(shellIsOpen && shellHostDetent === "input")',
     );
     expect(foundation).toContain(
       "useWebChatPanel ? setShellPreviewHovered : undefined",

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -88,6 +88,10 @@ describe("App standalone chat-overlay wiring", () => {
     expect(foundation).toContain(
       '(shellIsOpen && shellHostDetent === "input")',
     );
+    expect(foundation).toContain('shellPhase === "listening"');
+    expect(foundation).toContain(
+      'shellPreviewHovered || shellPhase === "listening"',
+    );
     expect(foundation).toContain(
       "useWebChatPanel ? setShellPreviewHovered : undefined",
     );

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1794,6 +1794,7 @@ function ShellFoundationMount({
   const controller = useShellControllerContext();
   const hasController = controller !== null;
   const shellIsOpen = controller?.isOpen ?? false;
+  const shellPhase = controller?.phase;
   const [shellPreviewHovered, setShellPreviewHovered] = useState(false);
   const [shellPreviewHostReady, setShellPreviewHostReady] = useState(false);
   const [shellHostDetent, setShellHostDetent] = useState<
@@ -1900,6 +1901,7 @@ function ShellFoundationMount({
           hovered:
             useWebChatPanel &&
             (shellPreviewHovered ||
+              shellPhase === "listening" ||
               (shellIsOpen && shellHostDetent === "input")),
         },
         timeoutMs: 1_000,
@@ -1907,12 +1909,12 @@ function ShellFoundationMount({
       if (
         !cancelled &&
         useWebChatPanel &&
-        shellPreviewHovered &&
+        (shellPreviewHovered || shellPhase === "listening") &&
         !shellIsOpen
       ) {
-        // Paint only after the native host is 600px wide. Before this
-        // acknowledgement, a wide DOM preview is clipped through the resting
-        // 96px WKWebView and appears as a narrow center slice.
+        // Paint hover and Fn-listening lanes only after the native host is
+        // 600px wide. Before this acknowledgement, wide DOM is clipped through
+        // the resting 96px WKWebView and appears as a narrow center slice.
         setShellPreviewHostReady(true);
       }
     })();
@@ -1924,6 +1926,7 @@ function ShellFoundationMount({
     hasController,
     shellHostDetent,
     shellIsOpen,
+    shellPhase,
     shellPreviewHovered,
     useWebChatPanel,
   ]);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -103,7 +103,6 @@ import { BuildBadge } from "./components/shell/BuildBadge";
 import { ChatOverlay } from "./components/shell/ChatOverlay";
 import { ChatSurface } from "./components/shell/ChatSurface";
 import { ConnectionLostOverlay } from "./components/shell/ConnectionLostOverlay";
-import { useChatOverlayWindowBounds } from "./components/shell/chat-overlay-window-bounds";
 import { DynamicPluginFallback } from "./components/shell/DynamicPluginFallback";
 import { HomeLauncherSurface } from "./components/shell/HomeLauncherSurface";
 import { HomePill } from "./components/shell/HomePill";
@@ -320,18 +319,6 @@ function ChatOverlayShell() {
   useBarSurfaceWindows();
   const controller = useShellControllerContext();
   const overlayOpen = controller?.isOpen ?? false;
-  const setActionNotice = useAppSelector((state) => state.setActionNotice);
-  const handleWindowBoundsFailure = useCallback((): void => {
-    if (overlayOpen) {
-      controller?.close();
-    }
-    setActionNotice(
-      "Desktop chat window resize failed. Close and reopen Eliza to retry.",
-      "error",
-      6_000,
-    );
-  }, [controller, overlayOpen, setActionNotice]);
-  useChatOverlayWindowBounds(overlayOpen, handleWindowBoundsFailure);
   // Escape collapses the overlay first — while it is open, AssistantOverlay's
   // own Escape handler closes it. Once already collapsed, Escape hides the
   // desktop window entirely (#12184) so the pill dismisses to the background
@@ -1809,6 +1796,9 @@ function ShellFoundationMount({
   const shellIsOpen = controller?.isOpen ?? false;
   const [shellPreviewHovered, setShellPreviewHovered] = useState(false);
   const [shellPreviewHostReady, setShellPreviewHostReady] = useState(false);
+  const [shellHostDetent, setShellHostDetent] = useState<
+    "pill" | "input" | "half" | "full"
+  >(shellIsOpen ? "input" : "pill");
   const focusComposerOnOpenRef = useRef(false);
   const { setChatInput } = useChatComposer();
   const chatInputRef = useChatInputRef();
@@ -1906,8 +1896,11 @@ function ShellFoundationMount({
         rpcMethod: "desktopSetBottomBarExpanded",
         ipcChannel: "desktop:setBottomBarExpanded",
         params: {
-          expanded: shellIsOpen,
-          hovered: useWebChatPanel && shellPreviewHovered,
+          expanded: shellIsOpen && shellHostDetent !== "input",
+          hovered:
+            useWebChatPanel &&
+            (shellPreviewHovered ||
+              (shellIsOpen && shellHostDetent === "input")),
         },
         timeoutMs: 1_000,
       });
@@ -1927,7 +1920,13 @@ function ShellFoundationMount({
     return () => {
       cancelled = true;
     };
-  }, [hasController, shellIsOpen, shellPreviewHovered, useWebChatPanel]);
+  }, [
+    hasController,
+    shellHostDetent,
+    shellIsOpen,
+    shellPreviewHovered,
+    useWebChatPanel,
+  ]);
   useEffect(() => {
     if (!useWebChatPanel || !shellIsOpen || !focusComposerOnOpenRef.current) {
       return;
@@ -1956,6 +1955,7 @@ function ShellFoundationMount({
         releaseFirstRunToHalf={false}
         onFirstRunReleaseHandled={() => {}}
         onPilledChange={closeWebChatWhenPilled}
+        onDetentChange={setShellHostDetent}
       />
     );
   }
@@ -1968,6 +1968,7 @@ function ShellFoundationMount({
         signingIn={controller.signingIn}
         onOpen={() => {
           focusComposerOnOpenRef.current = useWebChatPanel;
+          if (useWebChatPanel) setShellHostDetent("input");
           controller.open();
         }}
         onClose={controller.close}
@@ -2038,10 +2039,12 @@ function ChatOverlayMount({
   releaseFirstRunToHalf,
   onFirstRunReleaseHandled,
   onPilledChange,
+  onDetentChange,
 }: {
   releaseFirstRunToHalf: boolean;
   onFirstRunReleaseHandled: () => void;
   onPilledChange?: (pilled: boolean) => void;
+  onDetentChange?: (detent: "pill" | "input" | "half" | "full") => void;
 }): ReactNode {
   const controller = useShellControllerContext();
   const { characterData, agentStatus, firstRunComplete } =
@@ -2074,6 +2077,7 @@ function ChatOverlayMount({
       releaseFirstRunToHalf={releaseFirstRunToHalf}
       onFirstRunReleaseHandled={onFirstRunReleaseHandled}
       onPilledChange={onPilledChange}
+      onDetentChange={onDetentChange}
     />
   );
 }

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -247,6 +247,17 @@ function AppComposerHarness({
 }
 
 describe("ChatOverlay", () => {
+  it("reports the shallow input detent before chat history opens", () => {
+    const onDetentChange = vi.fn();
+    render(
+      <ChatOverlay
+        controller={makeController()}
+        onDetentChange={onDetentChange}
+      />,
+    );
+    expect(onDetentChange).toHaveBeenLastCalledWith("input");
+  });
+
   it("shows the mic and no send button when the draft is empty", () => {
     render(<ChatOverlay controller={makeController()} />);
     expect(screen.getByLabelText("talk")).toBeTruthy();

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -1174,6 +1174,7 @@ export function ChatOverlay({
   releaseFirstRunToHalf = false,
   onFirstRunReleaseHandled,
   onPilledChange,
+  onDetentChange,
 }: {
   controller: ShellController;
   /** Name shown in the composer placeholder ("Message {agentName}"). Defaults to Eliza. */
@@ -1205,6 +1206,8 @@ export function ChatOverlay({
    * entire transition local to the shared chat surface.
    */
   onPilledChange?: (pilled: boolean) => void;
+  /** Reports the settled visible footprint to transparent desktop hosts. */
+  onDetentChange?: (detent: "pill" | "input" | "half" | "full") => void;
 }): React.JSX.Element {
   const {
     messages,
@@ -5387,6 +5390,10 @@ export function ChatOverlay({
           : expanded
             ? "full"
             : "half";
+
+  React.useEffect(() => {
+    onDetentChange?.(detentLabel === "collapsed" ? "input" : detentLabel);
+  }, [detentLabel, onDetentChange]);
 
   // Onboarding-state probe: the newest first-run CHOICE turn's step id + option
   // values, surfaced as sr-only static AX text (mirrors chat-detent-probe /

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -283,6 +283,11 @@ export function HomePill({
       onPointerCancel={handlePointerCancel}
       onMouseEnter={() => setPreviewHover(true)}
       onMouseLeave={() => setPreviewHover(false)}
+      // A foreground NSWindow owns wheel routing before CSS hit-testing. Drop
+      // the wide hover host on the first scroll gesture so subsequent trackpad
+      // momentum reaches the application underneath instead of being trapped
+      // by a decorative preview.
+      onWheel={() => setPreviewHover(false)}
       style={{ zIndex: Z_SHELL_OVERLAY }}
       className={cn(
         "group pointer-events-auto relative mb-2 flex items-center justify-center rounded-full bg-transparent p-0",

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -45,9 +45,9 @@ export interface HomePillProps {
   /** Reports the idle pill's shallow composer-preview hover state. Desktop
    *  uses this to widen the transparent native hit area before painting it. */
   onPreviewHoverChange?: (hovered: boolean) => void;
-  /** True once the native host has acknowledged its wider hover frame. The
-   *  preview stays compact until then so WKWebView cannot clip the wide
-   *  composer into the resting 96px window. Web callers leave this unset. */
+  /** True once the native host has acknowledged its wider shallow frame. Hover
+   *  and listening lanes stay compact until then so WKWebView cannot clip them
+   *  into the resting 96px window. Web callers leave this unset. */
   previewHostReady?: boolean;
 }
 
@@ -251,8 +251,9 @@ export function HomePill({
 
   const signInLabel = `Sign in with ${appName} Cloud`;
   const previewVisible = previewHovered && previewHostReady;
-  const listeningExpanded = phase === "listening";
-  const chipExpanded = listeningExpanded || phase === "processing";
+  const listening = phase === "listening";
+  const listeningExpanded = listening && previewHostReady;
+  const chipExpanded = listening || phase === "processing";
   const composerSized = previewVisible || listeningExpanded;
   const label = needsAuth
     ? signingIn

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -105,6 +105,26 @@ describe("HomePill", () => {
     expect(screen.getByTestId("shell-home-pill-preview-label")).toBeTruthy();
   });
 
+  it("dismisses the wide preview on wheel so scrolling continues behind it", () => {
+    const onPreviewHoverChange = vi.fn();
+    render(
+      <HomePill
+        phase="idle"
+        onOpen={() => {}}
+        onClose={() => {}}
+        onPreviewHoverChange={onPreviewHoverChange}
+      />,
+    );
+    const button = screen.getByRole("button");
+    fireEvent.mouseEnter(button);
+    expect(screen.getByTestId("shell-home-pill-preview-label")).toBeTruthy();
+
+    fireEvent.wheel(button, { deltaY: 120 });
+
+    expect(screen.queryByTestId("shell-home-pill-preview-label")).toBeNull();
+    expect(onPreviewHoverChange).toHaveBeenLastCalledWith(false);
+  });
+
   it("uses the same hover composer while Cloud auth is required", () => {
     render(
       <HomePill phase="needs-auth" onOpen={() => {}} onClose={() => {}} />,

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -207,6 +207,24 @@ describe("HomePill", () => {
     }
   });
 
+  it("keeps listening compact until the native shallow host is ready", () => {
+    render(
+      <HomePill
+        phase="listening"
+        onOpen={() => {}}
+        onClose={() => {}}
+        previewHostReady={false}
+      />,
+    );
+
+    const button = screen.getByRole("button");
+    const mark = screen.getByTestId("shell-home-pill-mark");
+    expect(button.className).toContain("w-16");
+    expect(button.className).not.toContain("w-[36rem]");
+    expect(mark.className).toContain("w-20");
+    expect(mark.className).not.toContain("w-full");
+  });
+
   it("keeps the capsule white with no waveform bars outside listening", () => {
     for (const phase of [
       "booting",


### PR DESCRIPTION
## Summary

- make the bottom-bar RPC the sole owner of transparent desktop window geometry
- keep composer-only chat in the existing shallow 600×96 host instead of forcing every open state to 600×820
- report chat detent transitions so half/full history can expand the host deliberately
- dismiss the wide hover preview on the first wheel gesture so continued trackpad momentum reaches the application behind Eliza

Closes #21389

## Root cause

Two independent renderer paths resized the same native window. The detent-aware bottom-bar path requested a shallow composer host, but the legacy `useChatOverlayWindowBounds(overlayOpen)` path subsequently forced every open state to 600×820. Because native macOS hit-testing happens before DOM `pointer-events`, transparent pixels intercepted wheel and pointer input intended for windows behind Eliza.

## Verification

- focused UI tests: 263 passed after rebase
- UI typecheck: passed after rebase
- Biome and `git diff --check`: passed after rebase
- production cloud-only Electrobun build: passed
- installed `/Applications/Eliza.app` signature verification: passed
- CoreGraphics native window measurement: composer-only reduced from 600×820 to 600×96
- installed composer opened and autofocus landed on the Message Eliza textarea
- `audit:app`: 218/219 captures passed; failed only on existing unrelated minimalism-ratchet regressions in trajectory/background views, plus unrelated hover-probe timeouts

## Evidence matrix

- Before screenshot: user-provided screenshot in #21389 showing the Eliza preview over Codex while Codex could not scroll
- After desktop proof: CoreGraphics measurement above; no rendered pixels changed
- Mobile screenshot: N/A — native desktop host geometry only
- MP4: N/A — the fixed boundary is invisible native hit geometry; deterministic bounds measurement is the direct evidence
- Frontend/network/backend logs: N/A — no network or backend path is involved

## Contribution provenance

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex Desktop  
Contribution skill revision: `elizaOS/eliza@27401ef038ff272ecf3d99ea944d3b0d529d7a68:packages/skills/skills/contribute-to-eliza`  
Attribution status: self-reported

— [codex]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@27401ef038ff272ecf3d99ea944d3b0d529d7a68:packages/skills/skills/contribute-to-eliza"} -->
