### PR TITLE
fix(plugin-capacitor-bridge): reject malformed Android notification id encoding

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.encoding.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.encoding.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Android `/api/notifications/:id` path encoding is leftover tax after
+ * capacitor iOS transcript id decode (#21380). Stock develop called
+ * decodeURIComponent on POST /:id/read and DELETE /:id, so `%` / `%2` /
+ * `%ZZ` threw URIError instead of a typed 400. List / read-all / clear
+ * stay untouched.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const list = mock(() => []);
+const getUnreadCount = mock(() => 0);
+const markRead = mock(async (_id: string) => true);
+const markAllRead = mock(async () => 1);
+const remove = mock(async (_id: string) => true);
+const clear = mock(async () => undefined);
+
+mock.module("@elizaos/core", () => ({
+	NotificationService: {
+		getAvailability: () => "ready",
+		requestRecovery: () => ({ retryAfterSeconds: 1 }),
+	},
+	ServiceType: { NOTIFICATION: "notification" },
+}));
+mock.module("@elizaos/shared", () => ({
+	readAliasedEnv: () => undefined,
+}));
+
+const { dispatchBufferedRequest } = await import("./dispatch.ts");
+
+function runtimeWithNotifier(): IAgentRuntime {
+	return {
+		getService: () => ({
+			list,
+			getUnreadCount,
+			markRead,
+			markAllRead,
+			remove,
+			clear,
+		}),
+	} as unknown as IAgentRuntime;
+}
+
+const dispatchRoute = async () => {
+	throw new Error("dispatchRoute must not run on notification encoding");
+};
+
+async function request(method: string, path: string) {
+	return dispatchBufferedRequest(runtimeWithNotifier(), dispatchRoute, {
+		method,
+		path,
+	});
+}
+
+describe("android notification id encoding", () => {
+	beforeEach(() => {
+		list.mockClear();
+		getUnreadCount.mockClear();
+		markRead.mockClear();
+		markAllRead.mockClear();
+		remove.mockClear();
+		clear.mockClear();
+	});
+
+	test("canonical mark-read still reaches the notification store", async () => {
+		const response = await request(
+			"POST",
+			"/api/notifications/notif-1/read",
+		);
+		expect(response.status).toBe(200);
+		expect(JSON.parse(response.body)).toEqual({ ok: true });
+		expect(markRead).toHaveBeenCalledWith("notif-1");
+	});
+
+	test("canonical percent-encoded hyphen still decodes before mark-read", async () => {
+		const response = await request(
+			"POST",
+			"/api/notifications/notif%2D1/read",
+		);
+		expect(response.status).toBe(200);
+		expect(markRead).toHaveBeenCalledWith("notif-1");
+	});
+
+	test("canonical delete still reaches the notification store", async () => {
+		const response = await request("DELETE", "/api/notifications/notif-1");
+		expect(response.status).toBe(200);
+		expect(JSON.parse(response.body)).toEqual({ ok: true });
+		expect(remove).toHaveBeenCalledWith("notif-1");
+	});
+
+	test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+		"rejects malformed mark-read id %s with 400 before store lookup",
+		async (token) => {
+			const response = await request(
+				"POST",
+				`/api/notifications/${token}/read`,
+			);
+			expect(response.status).toBe(400);
+			expect(JSON.parse(response.body)).toEqual({
+				error: "Invalid notification id: malformed URL encoding",
+			});
+			expect(markRead).not.toHaveBeenCalled();
+		},
+	);
+
+	test.each(["%", "%2", "%ZZ"])(
+		"rejects malformed delete id %s with 400 before store lookup",
+		async (token) => {
+			const response = await request(
+				"DELETE",
+				`/api/notifications/${token}`,
+			);
+			expect(response.status).toBe(400);
+			expect(JSON.parse(response.body)).toEqual({
+				error: "Invalid notification id: malformed URL encoding",
+			});
+			expect(remove).not.toHaveBeenCalled();
+		},
+	);
+
+	test("list remains untouched", async () => {
+		const response = await request("GET", "/api/notifications");
+		expect(response.status).toBe(200);
+		expect(list).toHaveBeenCalled();
+		expect(markRead).not.toHaveBeenCalled();
+		expect(remove).not.toHaveBeenCalled();
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -333,6 +333,16 @@ function isAndroidNotifier(
 	);
 }
 
+function decodeAndroidNotificationId(raw: string): string | null {
+	try {
+		return decodeURIComponent(raw);
+	} catch {
+		// error-policy:J3 untrusted path segment — malformed percent-encoding
+		// is invalid client input, not a notification-store failure.
+		return null;
+	}
+}
+
 /**
  * Serve the `/api/notifications` inbox surface over the Android UDS. These are
  * server-level routes (not plugin `runtime.routes`), so `dispatchRoute` never
@@ -425,7 +435,13 @@ async function directAndroidNotificationRoute(
 
 	const readMatch = pathname.match(/^\/api\/notifications\/([^/]+)\/read$/);
 	if (method === "POST" && readMatch) {
-		const ok = await service.markRead(decodeURIComponent(readMatch[1]));
+		const id = decodeAndroidNotificationId(readMatch[1] ?? "");
+		if (id === null) {
+			return jsonResponse(400, {
+				error: "Invalid notification id: malformed URL encoding",
+			});
+		}
+		const ok = await service.markRead(id);
 		return jsonResponse(200, { ok });
 	}
 
@@ -436,7 +452,13 @@ async function directAndroidNotificationRoute(
 
 	const idMatch = pathname.match(/^\/api\/notifications\/([^/]+)$/);
 	if (method === "DELETE" && idMatch) {
-		const ok = await service.remove(decodeURIComponent(idMatch[1]));
+		const id = decodeAndroidNotificationId(idMatch[1] ?? "");
+		if (id === null) {
+			return jsonResponse(400, {
+				error: "Invalid notification id: malformed URL encoding",
+			});
+		}
+		const ok = await service.remove(id);
 		return jsonResponse(200, { ok });
 	}
 


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
Android notification-id percent-encoding. Encoding class,
leftover tax after capacitor iOS transcript id decode
(#21380). Not a twin of those parsers — this is POST
`/api/notifications/:id/read` and DELETE
`/api/notifications/:id` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only on the notification id.
Canonical `notif%2D1` still decodes to `notif-1` and reaches the
notification store. Malformed `%` / `%2` / `%ZZ` become 400
instead of an uncaught `URIError`. List, read-all, and clear
stay untouched.

# Background

## What does this PR do?

POST `/:id/read` and DELETE `/:id` called
`decodeURIComponent` on the notification-id path segment.
Illegal percent-encoding threw `URIError` instead of a typed
400 before `markRead` / `remove`.

- `/api/notifications/%/read` / `%2` / `%ZZ` → **400**
- `/api/notifications/%E0%A4/read` → **400**
- `/api/notifications/notif%2D1/read` → still decodes to `notif-1`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded
notification id should get a request error, not a 500 that
looks like a notification-store outage. Leftover tax after
capacitor iOS transcript id decode (#21380). Disjoint files
from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-capacitor-bridge/src/android/dispatch.encoding.test.ts`

## Detailed testing steps

```bash
bun test plugins/plugin-capacitor-bridge/src/android/dispatch.encoding.test.ts
```

11 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; android notification-id decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; android notification-id decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; android notification-id decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real percent-encoding tokens and assert 400 before store lookup; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens 400 before notification store reads.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real handler.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded notification
ids still decode. Malformed tokens that previously threw now 400.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6eacf6c7ad99ce6e9115ccbce19050758d71ac53 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
