### PR TITLE
fix(cloud): observe SDK result rejections on barge-in cancellation

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.sync.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.sync.test.ts
@@ -21,15 +21,25 @@ const ORG_A = "11111111-1111-4111-8111-111111111111";
 const AGENT_ID = "agent-provision-1";
 const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
 
-const getAgentForWrite = mock(async () => ({
-  id: AGENT_ID,
-  organization_id: ORG_A,
-  agent_name: "already-up",
-  execution_tier: "dedicated-always",
-  status: "running",
-  bridge_url: "https://bridge.example.test",
-  health_url: "https://health.example.test",
-}));
+const getAgentForWrite = mock(
+  async (): Promise<{
+    id: string;
+    organization_id: string;
+    agent_name: string;
+    execution_tier: string;
+    status: string;
+    bridge_url: string | null;
+    health_url: string | null;
+  }> => ({
+    id: AGENT_ID,
+    organization_id: ORG_A,
+    agent_name: "already-up",
+    execution_tier: "dedicated-always",
+    status: "running",
+    bridge_url: "https://bridge.example.test",
+    health_url: "https://health.example.test",
+  }),
+);
 const provision = mock(async () => ({
   success: true,
   bridgeUrl: "https://bridge.example.test",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -621,6 +621,13 @@ export async function runSharedAgentTurnStream(
     });
 
     const providerReader = result.fullStream.getReader();
+    // error-policy:J5 cancel(reason) rejects the SDK's pending result
+    // promises; the parts iterator below is the observed failure channel, so
+    // mark these handled here to keep a barge-in from surfacing its
+    // cancellation reason as an unhandled rejection on the event loop.
+    void Promise.resolve(result.text).catch(() => {});
+    void Promise.resolve(result.totalUsage).catch(() => {});
+    void Promise.resolve(result.finishReason).catch(() => {});
     let providerStreamDone = false;
     let providerStreamCancelled = false;
     let providerCancelPromise: Promise<void> | null = null;


### PR DESCRIPTION
Cancelling the provider reader with a reason rejects the AI SDK's pending result promises (text/totalUsage/finishReason); nothing observed them on the barge-in path, so CI runners fail the shared-runtime suite with the cancellation reason as an unhandled error (release candidate runs 32048255533 and 32054799431 — the only red left in the full test lane; passes locally where timing hides it). The parts iterator remains the observed failure channel; these are marked handled at stream setup (error-policy:J5). Suites 9/9 + 22/22; cloud-shared typecheck 0 errors; Biome clean.