### PR TITLE
fix(plugin-x): reject malformed X DM draft participant encoding

### DIFF
--- a/plugins/plugin-x/src/lifeops-message-adapter.encoding.test.ts
+++ b/plugins/plugin-x/src/lifeops-message-adapter.encoding.test.ts
@@ -1,0 +1,86 @@
+/**
+ * X DM draft participant encoding is leftover tax after LifeOps relationship
+ * id decode (#21395). Stock develop called decodeURIComponent on the
+ * recipient segment inside parseDraftId, so `twitter:%:…` / `%2` / `%ZZ`
+ * threw URIError instead of the existing malformed-draftId Error. List and
+ * createDraft stay untouched.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { XDmAdapter } from "./lifeops-message-adapter.ts";
+
+const sendDirectMessageForAccount = mock(async () => ({
+  ok: true,
+  status: 201,
+  messageId: "sent-1",
+}));
+const fetchDirectMessagesForAccount = mock(async () => []);
+
+function runtimeWithXService(): IAgentRuntime {
+  return {
+    agentId: "agent-1",
+    getService: (serviceType: string) =>
+      serviceType === "x"
+        ? { sendDirectMessageForAccount, fetchDirectMessagesForAccount }
+        : null,
+  } as unknown as IAgentRuntime;
+}
+
+function draftId(participant: string, body = "hello"): string {
+  return `twitter:${participant}:${Date.now()}:${Buffer.from(body, "utf8").toString("base64url")}`;
+}
+
+describe("x dm draft participant encoding", () => {
+  beforeEach(() => {
+    sendDirectMessageForAccount.mockClear();
+    fetchDirectMessagesForAccount.mockClear();
+  });
+
+  test("canonical createDraft still reaches sendDirectMessageForAccount", async () => {
+    const adapter = new XDmAdapter();
+    const runtime = runtimeWithXService();
+    const draft = await adapter.createDraft(runtime, {
+      to: [{ identifier: "recipient-1" }],
+      body: "see you tomorrow",
+    });
+    const sent = await adapter.sendDraft(runtime, draft.draftId);
+    expect(sendDirectMessageForAccount).toHaveBeenCalledWith("default", {
+      participantId: "recipient-1",
+      text: "see you tomorrow",
+    });
+    expect(sent).toEqual({ externalId: "sent-1" });
+  });
+
+  test("canonical percent-encoded hyphen still decodes before send", async () => {
+    const adapter = new XDmAdapter();
+    const runtime = runtimeWithXService();
+    await adapter.sendDraft(runtime, draftId("user%2D1"));
+    expect(sendDirectMessageForAccount).toHaveBeenCalledWith("default", {
+      participantId: "user-1",
+      text: "hello",
+    });
+  });
+
+  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed recipient encoding %s before the X service",
+    async (token) => {
+      const adapter = new XDmAdapter();
+      const runtime = runtimeWithXService();
+      await expect(
+        adapter.sendDraft(runtime, draftId(token)),
+      ).rejects.toThrow("[XDmAdapter] malformed draftId encoding");
+      expect(sendDirectMessageForAccount).not.toHaveBeenCalled();
+    },
+  );
+
+  test("list remains untouched", async () => {
+    const adapter = new XDmAdapter();
+    const runtime = runtimeWithXService();
+    await adapter.listMessages(runtime, { limit: 5 });
+    expect(fetchDirectMessagesForAccount).toHaveBeenCalledWith("default", {
+      participantId: undefined,
+      limit: 5,
+    });
+    expect(sendDirectMessageForAccount).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-x/src/lifeops-message-adapter.encoding.test.ts
+++ b/plugins/plugin-x/src/lifeops-message-adapter.encoding.test.ts
@@ -6,15 +6,15 @@
  * createDraft stay untouched.
  */
 import type { IAgentRuntime } from "@elizaos/core";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { XDmAdapter } from "./lifeops-message-adapter.ts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { XDmAdapter } from "./lifeops-message-adapter.js";
 
-const sendDirectMessageForAccount = mock(async () => ({
+const sendDirectMessageForAccount = vi.fn(async () => ({
   ok: true,
   status: 201,
   messageId: "sent-1",
 }));
-const fetchDirectMessagesForAccount = mock(async () => []);
+const fetchDirectMessagesForAccount = vi.fn(async () => []);
 
 function runtimeWithXService(): IAgentRuntime {
   return {
@@ -36,7 +36,7 @@ describe("x dm draft participant encoding", () => {
     fetchDirectMessagesForAccount.mockClear();
   });
 
-  test("canonical createDraft still reaches sendDirectMessageForAccount", async () => {
+  it("canonical createDraft still reaches sendDirectMessageForAccount", async () => {
     const adapter = new XDmAdapter();
     const runtime = runtimeWithXService();
     const draft = await adapter.createDraft(runtime, {
@@ -51,7 +51,7 @@ describe("x dm draft participant encoding", () => {
     expect(sent).toEqual({ externalId: "sent-1" });
   });
 
-  test("canonical percent-encoded hyphen still decodes before send", async () => {
+  it("canonical percent-encoded hyphen still decodes before send", async () => {
     const adapter = new XDmAdapter();
     const runtime = runtimeWithXService();
     await adapter.sendDraft(runtime, draftId("user%2D1"));
@@ -61,7 +61,7 @@ describe("x dm draft participant encoding", () => {
     });
   });
 
-  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+  it.each(["%", "%2", "%ZZ", "%E0%A4"])(
     "rejects malformed recipient encoding %s before the X service",
     async (token) => {
       const adapter = new XDmAdapter();
@@ -73,7 +73,7 @@ describe("x dm draft participant encoding", () => {
     },
   );
 
-  test("list remains untouched", async () => {
+  it("list remains untouched", async () => {
     const adapter = new XDmAdapter();
     const runtime = runtimeWithXService();
     await adapter.listMessages(runtime, { limit: 5 });

--- a/plugins/plugin-x/src/lifeops-message-adapter.encoding.test.ts
+++ b/plugins/plugin-x/src/lifeops-message-adapter.encoding.test.ts
@@ -6,15 +6,15 @@
  * createDraft stay untouched.
  */
 import type { IAgentRuntime } from "@elizaos/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { XDmAdapter } from "./lifeops-message-adapter.js";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { XDmAdapter } from "./lifeops-message-adapter.ts";
 
-const sendDirectMessageForAccount = vi.fn(async () => ({
+const sendDirectMessageForAccount = mock(async () => ({
   ok: true,
   status: 201,
   messageId: "sent-1",
 }));
-const fetchDirectMessagesForAccount = vi.fn(async () => []);
+const fetchDirectMessagesForAccount = mock(async () => []);
 
 function runtimeWithXService(): IAgentRuntime {
   return {
@@ -36,7 +36,7 @@ describe("x dm draft participant encoding", () => {
     fetchDirectMessagesForAccount.mockClear();
   });
 
-  it("canonical createDraft still reaches sendDirectMessageForAccount", async () => {
+  test("canonical createDraft still reaches sendDirectMessageForAccount", async () => {
     const adapter = new XDmAdapter();
     const runtime = runtimeWithXService();
     const draft = await adapter.createDraft(runtime, {
@@ -51,7 +51,7 @@ describe("x dm draft participant encoding", () => {
     expect(sent).toEqual({ externalId: "sent-1" });
   });
 
-  it("canonical percent-encoded hyphen still decodes before send", async () => {
+  test("canonical percent-encoded hyphen still decodes before send", async () => {
     const adapter = new XDmAdapter();
     const runtime = runtimeWithXService();
     await adapter.sendDraft(runtime, draftId("user%2D1"));
@@ -61,7 +61,7 @@ describe("x dm draft participant encoding", () => {
     });
   });
 
-  it.each(["%", "%2", "%ZZ", "%E0%A4"])(
+  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
     "rejects malformed recipient encoding %s before the X service",
     async (token) => {
       const adapter = new XDmAdapter();
@@ -73,7 +73,7 @@ describe("x dm draft participant encoding", () => {
     },
   );
 
-  it("list remains untouched", async () => {
+  test("list remains untouched", async () => {
     const adapter = new XDmAdapter();
     const runtime = runtimeWithXService();
     await adapter.listMessages(runtime, { limit: 5 });

--- a/plugins/plugin-x/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-x/src/lifeops-message-adapter.ts
@@ -113,7 +113,15 @@ function parseDraftId(draftId: string): {
   if (parts.length !== 4 || parts[0] !== "twitter") {
     throw new Error(`[XDmAdapter] malformed draftId ${draftId}`);
   }
-  const participantId = parts[1] ? decodeURIComponent(parts[1]) : "";
+  let participantId = "";
+  try {
+    participantId = parts[1] ? decodeURIComponent(parts[1]) : "";
+  } catch {
+    // error-policy:J3 draft ids are untrusted client input: a lone "%" or
+    // "%ZZ" recipient segment makes decodeURIComponent throw URIError,
+    // which would escape sendDraft before the X service is even reached.
+    throw new Error(`[XDmAdapter] malformed draftId encoding ${draftId}`);
+  }
   const text = parts[3] ? decodeDraftBody(parts[3]) : "";
   if (!participantId) {
     throw new Error(


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
X DM draft participant percent-encoding. Encoding class,
leftover tax after LifeOps relationship id decode
(#21395). Not a twin of those parsers — this is
`parseDraftId` / `sendDraft` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Draft-id recipient decode only. Canonical `user%2D1`
still decodes to `user-1` and reaches
`sendDirectMessageForAccount`. Malformed `%` / `%2` / `%ZZ`
become the existing malformed-draftId Error instead of an
uncaught `URIError`. List and createDraft stay untouched.

# Background

## What does this PR do?

`parseDraftId` called `decodeURIComponent` on the recipient
segment of an X DM draft id. Illegal percent-encoding threw
`URIError` instead of the adapter's typed malformed-draftId
Error before the X service was reached.

- `twitter:%:…` / `%2` / `%ZZ` → **malformed draftId encoding**
- `twitter:%E0%A4:…` → **malformed draftId encoding**
- `twitter:user%2D1:…` → still decodes to `user-1`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded
recipient in a draft id should get a request error, not an
uncaught `URIError` that looks like an X-service outage.
Leftover tax after LifeOps relationship id decode (#21395).
Disjoint files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/lifeops-message-adapter.encoding.test.ts`

## Detailed testing steps

```bash
bun test plugins/plugin-x/src/lifeops-message-adapter.encoding.test.ts
```

7 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; X DM draft participant decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; X DM draft participant decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; X DM draft participant decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused adapter tests drive the real percent-encoding tokens and assert the typed Error before the X service; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens fail before X service send.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real adapter.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded recipient
ids still decode. Malformed tokens that previously threw now
fail as malformed draftId encoding.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:240c88f2dd7ba8e27133709d9a4f3b48e7ef1023 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
