### PR TITLE
fix(plugin-computeruse): reject malformed Wayland portal file URI encoding

### DIFF
--- a/plugins/plugin-computeruse/src/platform/wayland-portal.encoding.test.ts
+++ b/plugins/plugin-computeruse/src/platform/wayland-portal.encoding.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Wayland portal file-URI encoding is leftover tax after computer-use
+ * approval id decode (#21326 / #21331). Stock develop called
+ * decodeURIComponent on the portal pathname, so `file:///%` / `%2` /
+ * `%ZZ` threw URIError instead of the typed malformed-URI Error.
+ * Session detection and response parsing stay untouched.
+ */
+import { describe, expect, test } from "bun:test";
+import { portalFileUriToPath } from "./wayland-portal.ts";
+
+describe("wayland portal file URI encoding", () => {
+  test("canonical percent-encoded space still decodes to a local path", () => {
+    expect(portalFileUriToPath("file:///tmp/wayland%20shot.png")).toBe(
+      "/tmp/wayland shot.png",
+    );
+  });
+
+  test("canonical percent-encoded hyphen still decodes", () => {
+    expect(portalFileUriToPath("file:///tmp/shot%2D1.png")).toBe(
+      "/tmp/shot-1.png",
+    );
+  });
+
+  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "rejects malformed path encoding %s as a typed portal URI error",
+    (token) => {
+      expect(() => portalFileUriToPath(`file:///tmp/${token}`)).toThrow(
+        /malformed file URI/i,
+      );
+      try {
+        portalFileUriToPath(`file:///tmp/${token}`);
+        throw new Error("expected throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect(error).not.toBeInstanceOf(URIError);
+      }
+    },
+  );
+
+  test("non-file URIs remain a typed non-file error", () => {
+    expect(() => portalFileUriToPath("document://portal/shot.png")).toThrow(
+      /non-file URI/i,
+    );
+  });
+});

--- a/plugins/plugin-computeruse/src/platform/wayland-portal.ts
+++ b/plugins/plugin-computeruse/src/platform/wayland-portal.ts
@@ -242,7 +242,16 @@ export function portalFileUriToPath(uri: string): string {
       `Wayland screenshot portal returned a non-local file URI: ${uri}`,
     );
   }
-  return decodeURIComponent(pathname);
+  try {
+    return decodeURIComponent(pathname);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — a portal file URI with
+    // `%` / `%2` / `%ZZ` throws URIError. Malformed encoding is a typed
+    // portal URI error, not an uncaught decode crash.
+    throw new Error(
+      `Wayland screenshot portal returned a malformed file URI: ${uri}`,
+    );
+  }
 }
 
 export const WAYLAND_PORTAL_DBUS_TARGET = {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
Wayland portal file-URI percent-encoding. Encoding class,
leftover tax after computer-use approval id decode
(#21326 / #21331). Not a twin of those parsers — this is
`portalFileUriToPath` only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Portal file-URI pathname decode only. Canonical
`file:///tmp/wayland%20shot.png` still decodes to
`/tmp/wayland shot.png`. Malformed `%` / `%2` / `%ZZ`
become a typed malformed-URI Error instead of an uncaught
`URIError`. Session detection and response parsing stay
untouched.

# Background

## What does this PR do?

`portalFileUriToPath` called `decodeURIComponent` on the
pathname of a Wayland screenshot portal `file://` URI.
Illegal percent-encoding threw `URIError` instead of the
helper's typed URI error.

- `file:///tmp/%` / `%2` / `%ZZ` → **malformed file URI**
- `file:///tmp/%E0%A4` → **malformed file URI**
- `file:///tmp/shot%2D1.png` → still decodes to `/tmp/shot-1.png`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A portal that emits a broken percent-encoded file URI should
get a typed helper error, not an uncaught `URIError` that
looks like a screenshot-capture crash. Leftover tax after
computer-use approval id decode (#21326 / #21331). Disjoint
files from those parsers.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-computeruse/src/platform/wayland-portal.encoding.test.ts`

## Detailed testing steps

```bash
bun test plugins/plugin-computeruse/src/platform/wayland-portal.encoding.test.ts
```

7 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; Wayland portal file-URI decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; Wayland portal file-URI decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; Wayland portal file-URI decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused helper tests plant the real percent-encoding tokens and assert a typed Error; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens throw before a path is invented.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real helper.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded portal
paths still decode. Malformed tokens that previously threw
`URIError` now throw a typed malformed-URI Error.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2a828418baf120b109505d4575da189a3fe131fa -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
