### PR TITLE
fix(cloud): reject malformed cookie-header value encoding

### DIFF
--- a/packages/cloud/shared/src/lib/http/cookie-header.encoding.test.ts
+++ b/packages/cloud/shared/src/lib/http/cookie-header.encoding.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Cookie-header value encoding is leftover tax after vault saved-login
+ * listing decode (#21378). Stock develop called decodeURIComponent on
+ * every Cookie value, so `session=%` / `%2` / `%ZZ` threw URIError on
+ * auth and anonymous-admission paths. Neighbor cookies stay readable.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  getCookieValueFromHeader,
+  getCookieValueFromRequest,
+} from "./cookie-header.ts";
+
+describe("cookie header value encoding", () => {
+  test("canonical cookie still decodes", () => {
+    expect(getCookieValueFromHeader("session=abc", "session")).toBe("abc");
+  });
+
+  test("canonical percent-encoded hyphen still decodes", () => {
+    expect(getCookieValueFromHeader("session=user%2D1", "session")).toBe(
+      "user-1",
+    );
+  });
+
+  test.each(["%", "%2", "%ZZ", "%E0%A4"])(
+    "treats malformed cookie encoding %s as absent",
+    (token) => {
+      expect(
+        getCookieValueFromHeader(`session=${token}`, "session"),
+      ).toBeUndefined();
+    },
+  );
+
+  test("neighbor cookies remain readable when one value is malformed", () => {
+    expect(
+      getCookieValueFromHeader("session=%ZZ; other=ok", "other"),
+    ).toBe("ok");
+  });
+
+  test("request helper still reads a canonical cookie", () => {
+    const request = new Request("https://example.test/", {
+      headers: { cookie: "session=abc" },
+    });
+    expect(getCookieValueFromRequest(request, "session")).toBe("abc");
+  });
+});

--- a/packages/cloud/shared/src/lib/http/cookie-header.ts
+++ b/packages/cloud/shared/src/lib/http/cookie-header.ts
@@ -8,7 +8,15 @@ export function getCookieValueFromHeader(header: string | null, name: string): s
   for (const segment of segments) {
     const trimmed = segment.trim();
     if (!trimmed.startsWith(`${name}=`)) continue;
-    return decodeURIComponent(trimmed.slice(name.length + 1).trimStart());
+    const raw = trimmed.slice(name.length + 1).trimStart();
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      // error-policy:J3 untrusted-input sanitizing — a cookie value with
+      // `%` / `%2` / `%ZZ` throws URIError. Malformed encoding is an
+      // absent cookie, not a request crash on auth/admission paths.
+      return undefined;
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza leftover-tax Fix on
Cookie-header value percent-encoding. Encoding class,
leftover tax after vault saved-login listing decode
(#21378). Not a twin of that parser — this is
`getCookieValueFromHeader` / `getCookieValueFromRequest`
only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Cookie-value decode only. Canonical `session=user%2D1`
still decodes to `user-1`. Malformed `%` / `%2` / `%ZZ`
become an absent cookie instead of an uncaught `URIError`
on auth and anonymous-admission paths. Neighbor cookies
stay readable.

# Background

## What does this PR do?

`getCookieValueFromHeader` called `decodeURIComponent` on
every Cookie value. Illegal percent-encoding threw
`URIError` and aborted auth / anonymous-admission /
steward-cookie reads.

- `session=%` / `%2` / `%ZZ` → **absent**
- `session=%E0%A4` → **absent**
- `session=user%2D1` → still decodes to `user-1`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded
cookie should look unauthenticated, not crash the request
as if the auth helper failed. Leftover tax after vault
saved-login listing decode (#21378). Disjoint files from
that parser.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/http/cookie-header.encoding.test.ts`

## Detailed testing steps

```bash
bun test packages/cloud/shared/src/lib/http/cookie-header.encoding.test.ts
```

8 identity tests passed at this head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; cookie-header value decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; cookie-header value decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; cookie-header value decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused helper tests plant the real percent-encoding tokens and assert absent-cookie; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no agent write; illegal tokens are treated as absent before a cookie is invented.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - encoding contract is asserted in-process against the real helper.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical percent-encoded cookie
values still decode. Malformed tokens that previously threw
`URIError` are now absent.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:bfaa69313d19ebc17d5c78deba738dc15c900fcc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
