### PR TITLE
fix(core): export NotificationService from the edge barrel

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -17,6 +17,7 @@ import {
   InMemoryDatabaseAdapter,
   ModelType,
   NOTIFICATION_STREAM,
+  NotificationService,
   type Plugin,
   ServiceType,
   type StreamingContext,
@@ -27,7 +28,6 @@ import {
   type ToolDefinition,
   type UUID,
 } from "@elizaos/core/edge";
-import { NotificationService } from "@elizaos/core/services/notification";
 import { createSharedRemindersEdgePlugin } from "@elizaos/plugin-scheduling/edge";
 import { createTodosEdgePlugin } from "@elizaos/plugin-todos/edge";
 import { webSearchEdgeAction, webSearchEdgePlugin } from "@elizaos/plugin-web-search/edge";

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -68,6 +68,7 @@ export * from "./services";
 export * from "./services/agentEvent";
 export * from "./services/approval";
 export * from "./services/message";
+export { NotificationService } from "./services/notification";
 export * from "./services/pairing";
 export * from "./services/pairing-integration";
 export * from "./services/post-delivery-task-tracker";


### PR DESCRIPTION
The shared Workerd runtime imports NotificationService via the @elizaos/core/services/notification subpath, which resolves to core DIST types under cloud-e2e's tsconfig while every sibling import resolves to edge SRC types — mixed type identities fail cloud-e2e typecheck (release candidate run 32060394835). The edge barrel now exports the service (edge-safe: logger + types only) and the runtime imports it alongside its other edge imports. cloud-e2e, cloud-shared, and core typecheck all 0 errors; shared-eliza-runtime suite 10/10; Biome clean.