### PR TITLE
fix(ios): restore native local notification delivery in canonical builds

### DIFF
--- a/packages/app-core/scripts/mobile/ios-pods.mjs
+++ b/packages/app-core/scripts/mobile/ios-pods.mjs
@@ -44,6 +44,17 @@ export const MOBILE_CAPACITOR_PLUGIN_MANIFEST = [
     ],
   },
   {
+    packageName: "@capacitor/local-notifications",
+    android: { patchAgp9: true },
+    iosPods: [
+      {
+        name: "CapacitorLocalNotifications",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
     packageName: "@capacitor-community/background-runner",
     android: { patchAgp9: true },
   },

--- a/packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
@@ -34,6 +34,10 @@ it("derives the Android and iOS official package tables from the mobile plugin m
   expect(ANDROID_OFFICIAL_CAPACITOR_PACKAGES).not.toContain(
     "@capacitor/network",
   );
+  expect(IOS_OFFICIAL_PODS).toContainEqual([
+    "CapacitorLocalNotifications",
+    "@capacitor/local-notifications",
+  ]);
 });
 
 it("keeps the existing iOS custom pod include gates", () => {

--- a/packages/ui/src/bridge/native-notifications.test.ts
+++ b/packages/ui/src/bridge/native-notifications.test.ts
@@ -245,3 +245,66 @@ describe("showWebNotification", () => {
     ).toBe(false);
   });
 });
+
+describe("showNativeNotification (ios platform)", () => {
+  beforeEach(() => {
+    platform.value = "ios";
+  });
+
+  it("prefers LocalNotifications plugin when available and permitted", async () => {
+    const local = makeLocalNotifications();
+    plugins.LocalNotifications = local;
+    const result = await showNativeNotification({
+      id: "ios-1",
+      title: "Incoming message",
+      priority: "high",
+    });
+    expect(result).toBe("local");
+    expect(local.schedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notifications: [
+          expect.objectContaining({
+            title: "Incoming message",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("falls back to ElizaIntent with valid timeIso when LocalNotifications is unavailable", async () => {
+    const receiveIntent = vi.fn(async () => ({ accepted: true }));
+    plugins.ElizaIntent = { receiveIntent };
+    const result = await showNativeNotification({
+      id: "ios-2",
+      title: "Timer expired",
+      body: "Check timer",
+      priority: "urgent",
+      deepLink: "eliza://app/timers",
+    });
+    expect(result).toBe("intent");
+    expect(receiveIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "reminder",
+        payload: expect.objectContaining({
+          title: "Timer expired",
+          body: "Check timer",
+          priority: "urgent",
+          timeIso: expect.any(String),
+          deepLinkOnTap: "eliza://app/timers",
+        }),
+        issuedAtIso: expect.any(String),
+      }),
+    );
+  });
+
+  it("returns none when ElizaIntent rejects or returns accepted false", async () => {
+    const receiveIntent = vi.fn(async () => ({ accepted: false }));
+    plugins.ElizaIntent = { receiveIntent };
+    const result = await showNativeNotification({
+      id: "ios-3",
+      title: "Missed alert",
+      priority: "normal",
+    });
+    expect(result).toBe("none");
+  });
+});

--- a/packages/ui/src/bridge/native-notifications.ts
+++ b/packages/ui/src/bridge/native-notifications.ts
@@ -211,15 +211,17 @@ async function tryElizaIntent(
   if (!hasMethod<ElizaIntentPluginLike>(plugin, "receiveIntent")) {
     return false;
   }
+  const nowIso = new Date().toISOString();
   const result = await plugin.receiveIntent({
     kind: "reminder",
     payload: {
       title: req.title,
       body: req.body ?? "",
       priority: req.priority,
+      timeIso: nowIso,
       ...(req.deepLink ? { deepLinkOnTap: req.deepLink } : {}),
     },
-    issuedAtIso: new Date().toISOString(),
+    issuedAtIso: nowIso,
   });
   return result.accepted === true;
 }


### PR DESCRIPTION
## Summary
- Resolves #21402.
- Restores `@capacitor/local-notifications` to `MOBILE_CAPACITOR_PLUGIN_MANIFEST` in `packages/app-core/scripts/mobile/ios-pods.mjs` so that generated iOS Podfiles and CocoaPods builds include `CapacitorLocalNotifications`.
- Fixes the iOS custom `ElizaIntent` fallback in `packages/ui/src/bridge/native-notifications.ts` by including the required `payload.timeIso` timestamp when dispatching reminder intents.
- Adds focused contract tests in `packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs` and `packages/ui/src/bridge/native-notifications.test.ts`.

## Verification
- `vitest run packages/ui/src/bridge/native-notifications.test.ts`: 13/13 passed
- `vitest run packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs`: 3/3 passed
- `bun x biome check`: clean on all modified files