### PR TITLE
perf(cloud): authenticate Discord Shared turns once

### DIFF
--- a/packages/cloud/api/internal/discord/eliza-app/messages/route.test.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/messages/route.test.ts
@@ -1,6 +1,7 @@
 /** Verifies that the Discord service wrapper preserves Personal Shared timing. */
 
-import { expect, mock, test } from "bun:test";
+import { beforeEach, expect, mock, test } from "bun:test";
+import { consumePreverifiedPersonalSharedRequest } from "../../../eliza-app/personal-shared/preverified-auth";
 
 mock.module("@/lib/api/cloud-worker-errors", () => ({
   failureResponse: () => Response.json({ success: false }, { status: 500 }),
@@ -28,37 +29,44 @@ mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
 mock.module("@/lib/utils/logger", () => ({
   logger: { error: mock(() => undefined) },
 }));
-mock.module("../../../_auth", () => ({
-  requireInternalAuth: mock(async () => ({ service: "discord-gateway" })),
-}));
+const authResult: { podName: string; service: string } | Response = {
+  podName: "gateway-1",
+  service: "discord-gateway",
+};
+const requireInternalAuth = mock(async () => authResult);
+mock.module("../../../_auth", () => ({ requireInternalAuth }));
 
-const personalSharedRequest = mock(
-  async () =>
-    new Response(
-      JSON.stringify({
-        success: true,
-        data: {
-          identity: { id: "11111111-1111-4111-8111-111111111111" },
-          account: {
-            userId: "22222222-2222-4222-8222-222222222222",
-            organizationId: "33333333-3333-4333-8333-333333333333",
-          },
-          reply: "ready",
+const personalSharedFetch = mock(async (request: Request) => {
+  expect(consumePreverifiedPersonalSharedRequest(request)).toEqual({
+    podName: "gateway-1",
+    service: "discord-gateway",
+  });
+  expect(request.headers.get("authorization")).toBeNull();
+  return new Response(
+    JSON.stringify({
+      success: true,
+      data: {
+        identity: { id: "11111111-1111-4111-8111-111111111111" },
+        account: {
+          userId: "22222222-2222-4222-8222-222222222222",
+          organizationId: "33333333-3333-4333-8333-333333333333",
         },
-      }),
-      {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-          "Server-Timing":
-            'account;dur=14.2;desc="sender-projection-hit", prewarm;dur=1.1, shared;dur=472.8',
-        },
+        reply: "ready",
       },
-    ),
-);
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Server-Timing":
+          'account;dur=14.2;desc="sender-projection-hit", prewarm;dur=1.1, shared;dur=472.8',
+      },
+    },
+  );
+});
 
 mock.module("../../../eliza-app/personal-shared/messages/route", () => ({
-  default: { request: personalSharedRequest },
+  default: { fetch: personalSharedFetch },
 }));
 
 const { default: app } = await import("./route");
@@ -67,6 +75,11 @@ const executionCtx = {
   passThroughOnException() {},
   props: {},
 };
+
+beforeEach(() => {
+  requireInternalAuth.mockClear();
+  personalSharedFetch.mockClear();
+});
 
 test("forwards the Personal Shared account, prewarm, and runtime split", async () => {
   const response = await app.request(
@@ -89,8 +102,9 @@ test("forwards the Personal Shared account, prewarm, and runtime split", async (
   );
 
   expect(response.status).toBe(200);
-  expect(response.headers.get("Server-Timing")).toBe(
-    'account;dur=14.2;desc="sender-projection-hit", prewarm;dur=1.1, shared;dur=472.8',
+  expect(response.headers.get("Server-Timing")).toMatch(
+    /^discord_auth;dur=\d+\.\d, discord_validation;dur=\d+\.\d, account;dur=14\.2;desc="sender-projection-hit", prewarm;dur=1\.1, shared;dur=472\.8, discord_inner;dur=\d+\.\d, discord_wrapper;dur=\d+\.\d$/,
   );
-  expect(personalSharedRequest).toHaveBeenCalledTimes(1);
+  expect(requireInternalAuth).toHaveBeenCalledTimes(1);
+  expect(personalSharedFetch).toHaveBeenCalledTimes(1);
 });

--- a/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
@@ -1,4 +1,9 @@
-// Handles internal cloud API internal discord eliza app messages route traffic with service-to-service auth.
+/**
+ * Routes authenticated managed Discord messages to Dedicated or Personal
+ * Shared Eliza. A private Request-identity capability carries the verified
+ * gateway identity across the nested Shared dispatch exactly once.
+ */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
@@ -12,6 +17,7 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
 import personalSharedMessagesApp from "../../../eliza-app/personal-shared/messages/route";
+import { markPreverifiedPersonalSharedRequest } from "../../../eliza-app/personal-shared/preverified-auth";
 
 const messageSchema = z.object({
   guildId: z.string().trim().min(1).optional(),
@@ -30,10 +36,15 @@ const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   try {
+    const wrapperStartedAt = performance.now();
+    const authStartedAt = performance.now();
     const auth = await requireInternalAuth(c);
     if (auth instanceof Response) return auth;
+    const authMs = performance.now() - authStartedAt;
 
+    const validationStartedAt = performance.now();
     const body = messageSchema.parse(await c.req.json());
+    const validationMs = performance.now() - validationStartedAt;
     if (body.guildId) {
       const result = await agentGatewayRouterService.routeDiscordMessage({
         guildId: body.guildId,
@@ -86,12 +97,11 @@ app.post("/", async (c) => {
       return c.json({ handled: true, ...shared });
     }
 
-    const response = await personalSharedMessagesApp.request(
-      "/",
+    const personalSharedRequest = new Request(
+      "https://personal-shared.internal/",
       {
         method: "POST",
         headers: {
-          authorization: c.req.header("authorization") ?? "",
           "content-type": "application/json",
         },
         body: JSON.stringify({
@@ -104,15 +114,15 @@ app.post("/", async (c) => {
           message: body.content,
         }),
       },
+    );
+    markPreverifiedPersonalSharedRequest(personalSharedRequest, auth);
+    const innerStartedAt = performance.now();
+    const response = await personalSharedMessagesApp.fetch(
+      personalSharedRequest,
       c.env,
       c.executionCtx,
     );
-    const personalSharedTiming = response.headers.get("Server-Timing");
-    if (personalSharedTiming) {
-      // The Discord gateway cannot optimize a slow turn if the internal
-      // wrapper erases the account, prewarm, and Shared runtime split.
-      c.header("Server-Timing", personalSharedTiming);
-    }
+    const innerMs = performance.now() - innerStartedAt;
     const payload = (await response.json()) as {
       success?: boolean;
       error?: string;
@@ -123,6 +133,20 @@ app.post("/", async (c) => {
         reply: string;
       };
     };
+    const personalSharedTiming = response.headers.get("Server-Timing");
+    const wrapperMs = performance.now() - wrapperStartedAt;
+    c.header(
+      "Server-Timing",
+      [
+        `discord_auth;dur=${authMs.toFixed(1)}`,
+        `discord_validation;dur=${validationMs.toFixed(1)}`,
+        personalSharedTiming,
+        `discord_inner;dur=${innerMs.toFixed(1)}`,
+        `discord_wrapper;dur=${wrapperMs.toFixed(1)}`,
+      ]
+        .filter((metric): metric is string => metric !== null)
+        .join(", "),
+    );
     if (!response.ok || !payload.success || !payload.data) {
       return c.json(
         payload,

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { OnboardingChatInput } from "@/lib/services/eliza-app/onboarding-chat";
 import { logger } from "@/lib/utils/logger";
+import { markPreverifiedPersonalSharedRequest } from "../preverified-auth";
 
 let activeTarget: {
   id: string;
@@ -224,6 +225,74 @@ describe("personal Shared messaging deliveries", () => {
 
   test("requires internal gateway authentication", async () => {
     expect((await request(valid, "")).status).toBe(401);
+    expect(resolvePersonalDelivery).not.toHaveBeenCalled();
+  });
+
+  test("accepts an in-isolate preverified identity at the real route boundary", async () => {
+    const preverifiedRequest = new Request("http://localhost/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(valid),
+    });
+    markPreverifiedPersonalSharedRequest(preverifiedRequest, {
+      podName: "gateway-1",
+      service: "discord-gateway",
+    });
+    const env = {
+      INTERNAL_SECRET: "test-secret",
+      SHARED_RUNTIME_CONVERSATIONS: namespace,
+      WHISPER_STT_URL: "https://whisper.test",
+    } as never;
+
+    expect(
+      (
+        await app.request(
+          preverifiedRequest,
+          undefined,
+          env,
+          executionCtx as never,
+        )
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await app.request(
+          new Request("http://localhost/", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(valid),
+          }),
+          undefined,
+          env,
+          executionCtx as never,
+        )
+      ).status,
+    ).toBe(401);
+  });
+
+  test("keeps the caller allowlist fail-closed for a preverified identity", async () => {
+    const preverifiedRequest = new Request("http://localhost/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(valid),
+    });
+    markPreverifiedPersonalSharedRequest(preverifiedRequest, {
+      podName: "agent-server-1",
+      service: "agent-server",
+    });
+
+    const response = await app.request(
+      preverifiedRequest,
+      undefined,
+      {
+        INTERNAL_SECRET: "test-secret",
+        SHARED_RUNTIME_CONVERSATIONS: namespace,
+        WHISPER_STT_URL: "https://whisper.test",
+      } as never,
+      executionCtx as never,
+    );
+
+    expect(response.status).toBe(403);
     expect(resolvePersonalDelivery).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -21,6 +21,7 @@ import { SharedRuntimeCacheWarmingError } from "@/lib/services/shared-runtime/sh
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
+import { consumePreverifiedPersonalSharedRequest } from "../preverified-auth";
 
 // Telegram's hosted Bot API download ceiling is 20 MiB. This stricter product
 // ceiling keeps the base64 JSON body (~10.7 MiB) and decoded copies bounded in
@@ -201,7 +202,9 @@ const app = new Hono<AppEnv>();
 app.post("/", async (c) => {
   let stage: DeliveryStage = "authentication";
   try {
-    const auth = await requireInternalAuth(c);
+    const auth =
+      consumePreverifiedPersonalSharedRequest(c.req.raw) ??
+      (await requireInternalAuth(c));
     if (auth instanceof Response) return auth;
     if (
       auth.service !== "webhook-gateway" &&

--- a/packages/cloud/api/internal/eliza-app/personal-shared/preverified-auth.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/preverified-auth.test.ts
@@ -1,0 +1,36 @@
+/** Proves the in-isolate Personal Shared auth capability is identity-bound and one-shot. */
+
+import { expect, test } from "bun:test";
+import {
+  consumePreverifiedPersonalSharedRequest,
+  markPreverifiedPersonalSharedRequest,
+} from "./preverified-auth";
+
+test("consumes a preverified request exactly once", () => {
+  const request = new Request("https://personal-shared.internal/");
+  const lookalike = new Request(request.url);
+  const auth = { podName: "gateway-1", service: "discord-gateway" };
+
+  markPreverifiedPersonalSharedRequest(request, auth);
+
+  expect(consumePreverifiedPersonalSharedRequest(lookalike)).toBeUndefined();
+  expect(consumePreverifiedPersonalSharedRequest(request)).toEqual(auth);
+  expect(consumePreverifiedPersonalSharedRequest(request)).toBeUndefined();
+});
+
+test("rejects two identities claiming the same request", () => {
+  const request = new Request("https://personal-shared.internal/");
+  markPreverifiedPersonalSharedRequest(request, {
+    podName: "gateway-1",
+    service: "discord-gateway",
+  });
+
+  expect(() =>
+    markPreverifiedPersonalSharedRequest(request, {
+      podName: "gateway-2",
+      service: "webhook-gateway",
+    }),
+  ).toThrow("already preverified");
+
+  consumePreverifiedPersonalSharedRequest(request);
+});

--- a/packages/cloud/api/internal/eliza-app/personal-shared/preverified-auth.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/preverified-auth.ts
@@ -1,0 +1,27 @@
+/**
+ * Carries a gateway identity across an in-isolate Hono dispatch without
+ * re-verifying the same external credential. Request-object identity is the
+ * capability: network callers cannot manufacture or replay an entry.
+ */
+
+import type { InternalServiceAuth } from "../../_auth";
+
+const preverifiedRequests = new WeakMap<Request, InternalServiceAuth>();
+
+export function markPreverifiedPersonalSharedRequest(
+  request: Request,
+  auth: InternalServiceAuth,
+): void {
+  if (preverifiedRequests.has(request)) {
+    throw new Error("Personal Shared request was already preverified");
+  }
+  preverifiedRequests.set(request, auth);
+}
+
+export function consumePreverifiedPersonalSharedRequest(
+  request: Request,
+): InternalServiceAuth | undefined {
+  const auth = preverifiedRequests.get(request);
+  if (auth) preverifiedRequests.delete(request);
+  return auth;
+}


### PR DESCRIPTION
Part of #21421

Removes the duplicate internal JWT verification when the authenticated Discord wrapper dispatches to the in-isolate Personal Shared route. The verified service identity crosses that single nested boundary through a one-shot Request-identity capability; no bearer is forwarded, and the existing Personal Shared caller allowlist remains the fail-closed authority.

Also exposes discord_auth, discord_validation, discord_inner, and discord_wrapper Server-Timing slices while retaining account, prewarm, and shared timings.

Evidence:
- 31/31 focused tests, 129 assertions
- genuine nested Hono route acceptance and fail-closed allowlist regression
- Cloud API typecheck PASS
- production Worker dry bundle PASS
- exact six-file Biome PASS
- diff-check PASS

Live staging latency proof remains required after independent review, merge, and protected exact-current deployment.