### PR TITLE
fix(ios): restore native local notification delivery

### DIFF
--- a/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		LCLZ00010000000000000002 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = LCLZ00010000000000000101 /* Localizable.xcstrings */; };
 		SHCT00010000000000000001 /* AppShortcuts.strings in Resources */ = {isa = PBXBuildFile; fileRef = SHCT00010000000000000101 /* AppShortcuts.strings */; };
 		MIPL00010000000000000001 /* ElizaIntentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = MIPL00010000000000000002 /* ElizaIntentPlugin.swift */; };
+		NTPY00010000000000000001 /* ElizaNotificationTriggerPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = NTPY00010000000000000003 /* ElizaNotificationTriggerPolicy.swift */; };
+		NTPY00010000000000000002 /* ElizaNotificationTriggerPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = NTPY00010000000000000003 /* ElizaNotificationTriggerPolicy.swift */; };
 		AWDG00010000000000000001 /* AgentWatchdog.swift in Sources */ = {isa = PBXBuildFile; fileRef = AWDG00010000000000000002 /* AgentWatchdog.swift */; };
 		NTRN00010000000000000001 /* NativeTranscriptReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = NTRN00010000000000000002 /* NativeTranscriptReducer.swift */; };
 		NTRN00010000000000000003 /* NativeTranscriptBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = NTRN00010000000000000004 /* NativeTranscriptBridge.swift */; };
@@ -140,6 +142,7 @@
 		SHCT00010000000000000103 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 		MIPL00010000000000000002 /* ElizaIntentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElizaIntentPlugin.swift; sourceTree = "<group>"; };
+		NTPY00010000000000000003 /* ElizaNotificationTriggerPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElizaNotificationTriggerPolicy.swift; sourceTree = "<group>"; };
 		AWDG00010000000000000002 /* AgentWatchdog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentWatchdog.swift; sourceTree = "<group>"; };
 		NTRN00010000000000000002 /* NativeTranscriptReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTranscriptReducer.swift; sourceTree = "<group>"; };
 		NTRN00010000000000000004 /* NativeTranscriptBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTranscriptBridge.swift; sourceTree = "<group>"; };
@@ -284,6 +287,7 @@
 				SCENEDEL00000000000002 /* SceneDelegate.swift */,
 				E1A5105A0000000000000002 /* ElizaAppIntents.swift */,
 				MIPL00010000000000000002 /* ElizaIntentPlugin.swift */,
+				NTPY00010000000000000003 /* ElizaNotificationTriggerPolicy.swift */,
 				ELIZALIVEACT000000000002 /* ElizaLiveActivityBridge.swift */,
 				ELIZAKBDBRIDGE0000000002 /* ElizaKeyboardBridge.swift */,
 				GLASSBRIDGE0000000000002 /* GlassBridge.swift */,
@@ -711,6 +715,7 @@
 				SCENEDEL00000000000001 /* SceneDelegate.swift in Sources */,
 				E1A5105A0000000000000001 /* ElizaAppIntents.swift in Sources */,
 				MIPL00010000000000000001 /* ElizaIntentPlugin.swift in Sources */,
+				NTPY00010000000000000001 /* ElizaNotificationTriggerPolicy.swift in Sources */,
 				ELIZALIVEACT000000000001 /* ElizaLiveActivityBridge.swift in Sources */,
 				ELIZAKBDBRIDGE0000000001 /* ElizaKeyboardBridge.swift in Sources */,
 				GLASSBRIDGE0000000000001 /* GlassBridge.swift in Sources */,
@@ -758,6 +763,7 @@
 				AUIT0001000000000000000B /* DeviceLifecycleUITests.swift in Sources */,
 				AUIT0001000000000000000D /* ChatFailureStrings.generated.swift in Sources */,
 				AUIT0001000000000000000F /* DeviceExtensionSurfaceUITests.swift in Sources */,
+				NTPY00010000000000000002 /* ElizaNotificationTriggerPolicy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/app-core/platforms/ios/App/App/ElizaIntentPlugin.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaIntentPlugin.swift
@@ -126,13 +126,8 @@ public class ElizaIntentPlugin: CAPPlugin, CAPBridgedPlugin {
                 content.userInfo = ["deepLinkOnTap": deepLinkOnTap]
             }
 
-            let triggerComponents = Calendar.current.dateComponents(
-                [.year, .month, .day, .hour, .minute, .second],
-                from: resolvedDate
-            )
-            let trigger = UNCalendarNotificationTrigger(
-                dateMatching: triggerComponents,
-                repeats: false
+            let trigger = ElizaNotificationTriggerPolicy.trigger(
+                fireDate: resolvedDate
             )
             let scheduledId = UUID().uuidString
             let request = UNNotificationRequest(

--- a/packages/app-core/platforms/ios/App/App/ElizaNotificationTriggerPolicy.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaNotificationTriggerPolicy.swift
@@ -1,0 +1,35 @@
+/**
+ Selects a fireable UserNotifications trigger after authorization completes.
+
+ Immediate intents can age into the past while the system permission sheet is
+ open, so they use a short interval trigger; genuinely future requests retain
+ their requested calendar date.
+ */
+import Foundation
+import UserNotifications
+
+enum ElizaNotificationTriggerPolicy {
+    static let immediateDelay: TimeInterval = 1
+
+    static func trigger(
+        fireDate: Date,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> UNNotificationTrigger {
+        if fireDate <= now.addingTimeInterval(immediateDelay) {
+            return UNTimeIntervalNotificationTrigger(
+                timeInterval: immediateDelay,
+                repeats: false
+            )
+        }
+
+        let components = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: fireDate
+        )
+        return UNCalendarNotificationTrigger(
+            dateMatching: components,
+            repeats: false
+        )
+    }
+}

--- a/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
@@ -9,6 +9,7 @@
  keyboard enablement still require the provisioned-device lane called out in
  #13567/#13563.
  */
+import UserNotifications
 import XCTest
 
 final class DeviceExtensionSurfaceUITests: XCTestCase {
@@ -17,6 +18,34 @@ final class DeviceExtensionSurfaceUITests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
+    }
+
+    func testLocalNotificationTriggerStaysFireableAcrossPermissionDelay() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let immediateDates = [
+            now.addingTimeInterval(-30),
+            now,
+            now.addingTimeInterval(0.5),
+        ]
+
+        for fireDate in immediateDates {
+            let trigger = ElizaNotificationTriggerPolicy.trigger(
+                fireDate: fireDate,
+                now: now
+            )
+            let interval = trigger as? UNTimeIntervalNotificationTrigger
+            XCTAssertEqual(interval?.timeInterval, 1)
+            XCTAssertEqual(interval?.repeats, false)
+        }
+
+        let future = ElizaNotificationTriggerPolicy.trigger(
+            fireDate: now.addingTimeInterval(60),
+            now: now,
+            calendar: Calendar(identifier: .gregorian)
+        )
+        let calendar = future as? UNCalendarNotificationTrigger
+        XCTAssertNotNil(calendar)
+        XCTAssertEqual(calendar?.repeats, false)
     }
 
     func testControlCenterGalleryListsElizaControls() throws {

--- a/packages/app-core/scripts/mobile/ios-pods.mjs
+++ b/packages/app-core/scripts/mobile/ios-pods.mjs
@@ -93,6 +93,16 @@ export const MOBILE_CAPACITOR_PLUGIN_MANIFEST = [
     ],
   },
   {
+    packageName: "@capacitor/local-notifications",
+    iosPods: [
+      {
+        name: "CapacitorLocalNotifications",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
     packageName: "@capacitor/push-notifications",
     android: { patchAgp9: true },
     iosPods: [

--- a/packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
@@ -34,6 +34,12 @@ it("derives the Android and iOS official package tables from the mobile plugin m
   expect(ANDROID_OFFICIAL_CAPACITOR_PACKAGES).not.toContain(
     "@capacitor/network",
   );
+  expect(new Map(IOS_OFFICIAL_PODS).get("CapacitorLocalNotifications")).toBe(
+    "@capacitor/local-notifications",
+  );
+  expect(ANDROID_OFFICIAL_CAPACITOR_PACKAGES).not.toContain(
+    "@capacitor/local-notifications",
+  );
 });
 
 it("keeps the existing iOS custom pod include gates", () => {

--- a/packages/ui/src/bridge/native-notifications.test.ts
+++ b/packages/ui/src/bridge/native-notifications.test.ts
@@ -26,6 +26,8 @@ vi.mock("./native-plugins", () => ({
 
 import {
   __resetEnsuredChannelsForTests,
+  __resetLocalNotificationTapRoutingForTests,
+  initLocalNotificationTapRouting,
   showNativeNotification,
   showWebNotification,
 } from "./native-notifications";
@@ -36,6 +38,7 @@ interface ScheduleArg {
     title: string;
     body: string;
     channelId?: string;
+    extra?: Record<string, unknown>;
   }>;
 }
 interface ChannelArg {
@@ -43,6 +46,11 @@ interface ChannelArg {
   name: string;
   importance: number;
   visibility?: number;
+}
+interface ElizaIntentArg {
+  kind: "reminder";
+  payload: Record<string, unknown>;
+  issuedAtIso: string;
 }
 
 function makeLocalNotifications(overrides: Record<string, unknown> = {}) {
@@ -60,6 +68,7 @@ beforeEach(() => {
   for (const key of Object.keys(plugins)) delete plugins[key];
   // Channel cache is module-level; clear it so each case exercises createChannel.
   __resetEnsuredChannelsForTests();
+  __resetLocalNotificationTapRoutingForTests();
 });
 
 afterEach(() => {
@@ -196,6 +205,257 @@ describe("showNativeNotification (web platform)", () => {
     });
     expect(result).toBe("none");
     expect(constructed).not.toHaveBeenCalled();
+  });
+});
+
+describe("showNativeNotification (iOS fallback)", () => {
+  it("keeps a safe app route for the Capacitor tap listener", async () => {
+    platform.value = "ios";
+    const local = makeLocalNotifications();
+    plugins.LocalNotifications = local;
+
+    const result = await showNativeNotification({
+      id: "ios-local",
+      title: "Reminder",
+      priority: "normal",
+      deepLink: "/apps/scheduled?source=notification",
+    });
+
+    expect(result).toBe("local");
+    expect(local.schedule.mock.calls[0]?.[0]?.notifications[0]?.extra).toEqual({
+      deepLink: "/apps/scheduled?source=notification",
+    });
+  });
+
+  it("does not hand an unsafe tap scheme to native iOS", async () => {
+    platform.value = "ios";
+    const local = makeLocalNotifications();
+    plugins.LocalNotifications = local;
+
+    await showNativeNotification({
+      id: "ios-unsafe",
+      title: "Reminder",
+      priority: "normal",
+      deepLink: "javascript:alert(1)",
+    });
+
+    expect(
+      local.schedule.mock.calls[0]?.[0]?.notifications[0]?.extra,
+    ).toBeUndefined();
+  });
+
+  it("supplies the required immediate schedule time to ElizaIntent", async () => {
+    platform.value = "ios";
+    const receiveIntent = vi.fn(async (_intent: ElizaIntentArg) => ({
+      accepted: true,
+      reason: "scheduled",
+    }));
+    plugins.ElizaIntent = { receiveIntent };
+
+    const result = await showNativeNotification({
+      id: "ios-fallback",
+      title: "Reminder",
+      body: "Time to stretch",
+      priority: "normal",
+      deepLink: "/apps/scheduled",
+    });
+
+    expect(result).toBe("intent");
+    const intent = receiveIntent.mock.calls[0]?.[0];
+    expect(intent).toEqual({
+      kind: "reminder",
+      issuedAtIso: expect.any(String),
+      payload: {
+        timeIso: expect.any(String),
+        title: "Reminder",
+        body: "Time to stretch",
+        priority: "normal",
+        deepLinkOnTap: "elizaos://apps/scheduled",
+      },
+    });
+    expect(intent?.payload.timeIso).toBe(intent?.issuedAtIso);
+    expect(Number.isNaN(Date.parse(intent?.issuedAtIso ?? ""))).toBe(false);
+  });
+});
+
+describe("initLocalNotificationTapRouting", () => {
+  it("accepts a native listener handle returned synchronously", async () => {
+    const navigate = vi.fn();
+    const addListener = vi.fn(
+      (
+        _event: string,
+        callback: (action: {
+          actionId: string;
+          notification: { extra?: unknown };
+        }) => void,
+      ) => {
+        callback({
+          actionId: "tap",
+          notification: { extra: { deepLink: "/notifications" } },
+        });
+        return { remove: async () => {} };
+      },
+    );
+
+    await expect(
+      initLocalNotificationTapRouting({
+        getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+        navigate,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(addListener).toHaveBeenCalledOnce();
+    expect(navigate).toHaveBeenCalledWith("/notifications");
+  });
+
+  it("deduplicates concurrent initialization before invoking the bridge", async () => {
+    const addListener = vi.fn(() => ({ remove: async () => {} }));
+    const deps = {
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate: vi.fn(),
+    };
+
+    const first = initLocalNotificationTapRouting(deps);
+    const second = initLocalNotificationTapRouting(deps);
+
+    expect(first).toBe(second);
+    await first;
+    expect(addListener).toHaveBeenCalledOnce();
+  });
+
+  it("consumes a retained cold-launch tap while the listener is attaching", async () => {
+    const navigate = vi.fn();
+    const addListener = vi.fn(
+      async (
+        _event: string,
+        callback: (action: {
+          actionId: string;
+          notification: { extra?: unknown };
+        }) => void,
+      ) => {
+        callback({
+          actionId: "tap",
+          notification: { extra: { deepLink: "/apps/scheduled" } },
+        });
+        return { remove: async () => {} };
+      },
+    );
+
+    await initLocalNotificationTapRouting({
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate,
+    });
+
+    expect(navigate).toHaveBeenCalledWith("/apps/scheduled");
+  });
+
+  it("routes a retained Capacitor tap through the canonical safe navigator", async () => {
+    let listener:
+      | ((action: {
+          actionId: string;
+          notification: { extra?: unknown };
+        }) => void)
+      | undefined;
+    const addListener = vi.fn(
+      async (
+        _event: string,
+        callback: NonNullable<typeof listener>,
+      ): Promise<{ remove: () => Promise<void> }> => {
+        listener = callback;
+        return { remove: async () => {} };
+      },
+    );
+    const navigate = vi.fn();
+    const deps = {
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate,
+    };
+
+    await initLocalNotificationTapRouting(deps);
+    await initLocalNotificationTapRouting(deps);
+    listener?.({
+      actionId: "tap",
+      notification: { extra: { deepLink: "/notifications" } },
+    });
+
+    expect(addListener).toHaveBeenCalledOnce();
+    expect(addListener).toHaveBeenCalledWith(
+      "localNotificationActionPerformed",
+      expect.any(Function),
+    );
+    expect(navigate).toHaveBeenCalledWith("/notifications");
+  });
+
+  it("drops dismisses, malformed payloads, and unsafe schemes", async () => {
+    let listener:
+      | ((action: {
+          actionId: string;
+          notification: { extra?: unknown };
+        }) => void)
+      | undefined;
+    const addListener = vi.fn(
+      async (_event: string, callback: typeof listener) => {
+        listener = callback;
+        return { remove: async () => {} };
+      },
+    );
+    const navigate = vi.fn();
+
+    await initLocalNotificationTapRouting({
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate,
+    });
+    listener?.({
+      actionId: "dismiss",
+      notification: { extra: { deepLink: "/notifications" } },
+    });
+    listener?.({
+      actionId: "tap",
+      notification: { extra: { deepLink: "javascript:alert(1)" } },
+    });
+    listener?.({ actionId: "tap", notification: { extra: "invalid" } });
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("can retry listener registration after a native bridge failure", async () => {
+    const addListener = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("bridge unavailable"))
+      .mockResolvedValueOnce({ remove: async () => {} });
+    const deps = {
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate: vi.fn(),
+    };
+
+    await expect(initLocalNotificationTapRouting(deps)).rejects.toThrow(
+      "bridge unavailable",
+    );
+    await expect(
+      initLocalNotificationTapRouting(deps),
+    ).resolves.toBeUndefined();
+    expect(addListener).toHaveBeenCalledTimes(2);
+  });
+
+  it("can retry after the native bridge throws synchronously", async () => {
+    const addListener = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("native attach threw");
+      })
+      .mockReturnValueOnce({ remove: async () => {} });
+    const deps = {
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate: vi.fn(),
+    };
+
+    await expect(initLocalNotificationTapRouting(deps)).rejects.toThrow(
+      "native attach threw",
+    );
+    await expect(
+      initLocalNotificationTapRouting(deps),
+    ).resolves.toBeUndefined();
+    expect(addListener).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/ui/src/bridge/native-notifications.ts
+++ b/packages/ui/src/bridge/native-notifications.ts
@@ -25,9 +25,12 @@
  * make backups heads-up or approvals silent, with no way for the user to tune
  * them apart. Web maps low priority to a silent notification.
  */
-import { Capacitor } from "@capacitor/core";
+import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
 import type { NotificationPriority } from "@elizaos/core";
-import { navigateDeepLink } from "../state/notifications/navigate-deep-link";
+import {
+  isSafeDeepLink,
+  navigateDeepLink,
+} from "../state/notifications/navigate-deep-link";
 import { getNativePlugin } from "./native-plugins";
 
 export interface NativeNotificationRequest {
@@ -66,6 +69,20 @@ interface LocalNotificationsPluginLike extends Record<string, unknown> {
     importance: number;
     visibility?: number;
   }) => Promise<void>;
+  addListener?: (
+    eventName: "localNotificationActionPerformed",
+    listenerFunc: (action: LocalNotificationActionPerformed) => void,
+  ) => PluginListenerHandle | Promise<PluginListenerHandle>;
+}
+
+interface LocalNotificationActionPerformed {
+  actionId?: unknown;
+  notification?: { extra?: unknown };
+}
+
+export interface LocalNotificationTapRoutingDeps {
+  getPlugin: () => LocalNotificationsPluginLike;
+  navigate: (deepLink: string) => void;
 }
 
 interface ElizaIntentPluginLike extends Record<string, unknown> {
@@ -83,6 +100,30 @@ function numericId(id: string): number {
     hash = (hash * 31 + id.charCodeAt(i)) | 0;
   }
   return Math.abs(hash) % 2_000_000_000 || 1;
+}
+
+/**
+ * Convert the notification store's safe app-route vocabulary into the custom
+ * URL shape that iOS can reopen through UIApplication. External http(s) links
+ * remain external; every other scheme is rejected before it reaches native
+ * userInfo.
+ */
+function iosTapDeepLink(deepLink: string | undefined): string | undefined {
+  if (!deepLink || !isSafeDeepLink(deepLink)) return undefined;
+  if (/^https?:\/\//i.test(deepLink)) return deepLink;
+  return `elizaos://${deepLink.slice(1)}`;
+}
+
+function localNotificationTapDeepLink(
+  action: LocalNotificationActionPerformed,
+): string | undefined {
+  if (action.actionId !== "tap") return undefined;
+  const extra = action.notification?.extra;
+  if (typeof extra !== "object" || extra === null) return undefined;
+  const deepLink = (extra as Record<string, unknown>).deepLink;
+  return typeof deepLink === "string" && isSafeDeepLink(deepLink)
+    ? deepLink
+    : undefined;
 }
 
 function hasMethod<T>(value: unknown, method: keyof T): value is T {
@@ -111,6 +152,53 @@ const ANDROID_CHANNELS: Record<
 };
 
 const ensuredChannels = new Set<string>();
+let localNotificationTapListenerPromise: Promise<void> | null = null;
+
+const defaultTapRoutingDeps: LocalNotificationTapRoutingDeps = {
+  getPlugin: () =>
+    getNativePlugin<LocalNotificationsPluginLike>("LocalNotifications"),
+  navigate: navigateDeepLink,
+};
+
+/**
+ * Attach the one app-lifetime handler for taps on Capacitor local
+ * notifications. Capacitor retains a cold-launch action until this listener is
+ * registered, so shell boot can consume both warm and terminated-app taps
+ * without a second native delegate or route authority.
+ */
+export function initLocalNotificationTapRouting(
+  deps: LocalNotificationTapRoutingDeps = defaultTapRoutingDeps,
+): Promise<void> {
+  if (localNotificationTapListenerPromise) {
+    return localNotificationTapListenerPromise;
+  }
+  const plugin = deps.getPlugin();
+  const addListener = plugin.addListener;
+  if (typeof addListener !== "function") {
+    return Promise.resolve();
+  }
+
+  // Capacitor's web proxy returns a Promise, while the installed native bridge
+  // may return its listener handle directly. Invoke in a deferred Promise so
+  // the singleton is installed first and synchronous native throws reach the
+  // shell's rejection boundary just like asynchronous bridge failures.
+  const attempt = Promise.resolve()
+    .then(() =>
+      addListener.call(plugin, "localNotificationActionPerformed", (action) => {
+        const deepLink = localNotificationTapDeepLink(action);
+        if (deepLink) deps.navigate(deepLink);
+      }),
+    )
+    .then(() => undefined)
+    .catch((error: unknown) => {
+      if (localNotificationTapListenerPromise === attempt) {
+        localNotificationTapListenerPromise = null;
+      }
+      throw error;
+    });
+  localNotificationTapListenerPromise = attempt;
+  return attempt;
+}
 
 /**
  * Test-only: clear the per-tier channel-creation cache between tests so a
@@ -118,6 +206,11 @@ const ensuredChannels = new Set<string>();
  */
 export function __resetEnsuredChannelsForTests(): void {
   ensuredChannels.clear();
+}
+
+/** Test-only: permit an isolated listener registration in each test case. */
+export function __resetLocalNotificationTapRoutingForTests(): void {
+  localNotificationTapListenerPromise = null;
 }
 
 /**
@@ -187,6 +280,9 @@ async function tryLocalNotifications(
   // the post — don't claim success; let the store's glass fallback deliver.
   if (channel.unusable) return false;
 
+  const safeDeepLink =
+    req.deepLink && isSafeDeepLink(req.deepLink) ? req.deepLink : undefined;
+
   await plugin.schedule({
     notifications: [
       {
@@ -196,7 +292,7 @@ async function tryLocalNotifications(
         title: req.title,
         body: req.body ?? "",
         ...(channel.channelId ? { channelId: channel.channelId } : {}),
-        ...(req.deepLink ? { extra: { deepLink: req.deepLink } } : {}),
+        ...(safeDeepLink ? { extra: { deepLink: safeDeepLink } } : {}),
       },
     ],
   });
@@ -211,15 +307,22 @@ async function tryElizaIntent(
   if (!hasMethod<ElizaIntentPluginLike>(plugin, "receiveIntent")) {
     return false;
   }
+  const issuedAtIso = new Date().toISOString();
+  const deepLinkOnTap = iosTapDeepLink(req.deepLink);
   const result = await plugin.receiveIntent({
     kind: "reminder",
     payload: {
+      // This bridge displays an immediate notification. The native intent
+      // contract still requires an explicit schedule time, so use the same
+      // instant as the issued-at receipt rather than sending an invalid
+      // reminder payload or inventing a user-visible delay.
+      timeIso: issuedAtIso,
       title: req.title,
       body: req.body ?? "",
       priority: req.priority,
-      ...(req.deepLink ? { deepLinkOnTap: req.deepLink } : {}),
+      ...(deepLinkOnTap ? { deepLinkOnTap } : {}),
     },
-    issuedAtIso: new Date().toISOString(),
+    issuedAtIso,
   });
   return result.accepted === true;
 }

--- a/packages/ui/src/components/shell/notifications-boot.test.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   init: vi.fn(),
+  localTap: vi.fn(async () => undefined),
   push: vi.fn(async () => undefined),
   refreshPush: vi.fn(async () => undefined),
   unsubscribeBase: vi.fn(),
@@ -18,6 +19,9 @@ vi.mock("../../api/client", () => ({
 }));
 
 vi.mock("../../state", () => ({ useAppSelector: () => mocks.setTab }));
+vi.mock("../../bridge/native-notifications", () => ({
+  initLocalNotificationTapRouting: mocks.localTap,
+}));
 vi.mock("../../state/notifications/notification-store", () => ({
   initNotifications: mocks.init,
   seedDevNotificationsIfEmpty: mocks.seed,
@@ -47,11 +51,24 @@ describe("notification boot boundaries", () => {
     expect(mocks.init).toHaveBeenCalledOnce();
   });
 
-  it("boots native push and routes notification-center ingress to chat", async () => {
+  it("boots native push and local-tap routing, then routes notification-center ingress to chat", async () => {
     render(<NotificationsShellBoot />);
     await waitFor(() => expect(mocks.push).toHaveBeenCalledOnce());
+    expect(mocks.localTap).toHaveBeenCalledOnce();
 
     act(() => window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT)));
+    expect(mocks.setTab).toHaveBeenCalledWith("chat");
+  });
+
+  it("routes a retained cold-launch tap replayed during native listener attachment", async () => {
+    mocks.localTap.mockImplementationOnce(async () => {
+      window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT));
+    });
+
+    render(<NotificationsShellBoot />);
+
+    await waitFor(() => expect(mocks.localTap).toHaveBeenCalledOnce());
+    expect(mocks.setTab).toHaveBeenCalledTimes(1);
     expect(mocks.setTab).toHaveBeenCalledWith("chat");
   });
 

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -11,6 +11,7 @@
 import { logger } from "@elizaos/logger";
 import { useEffect } from "react";
 import { client } from "../../api/client";
+import { initLocalNotificationTapRouting } from "../../bridge/native-notifications";
 import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
 import { useAppSelector } from "../../state";
 import {
@@ -39,6 +40,22 @@ export function NotificationsShellBoot(): null {
   const setTab = useAppSelector((s) => s.setTab);
 
   useEffect(() => {
+    // Install the in-app destination before attaching the native bridge.
+    // Capacitor may synchronously replay a retained cold-launch tap from
+    // addListener(), so reversing this order would drop that first event.
+    const onOpen = () => {
+      setTab("chat");
+    };
+    window.addEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
+
+    void initLocalNotificationTapRouting().catch((error: unknown) => {
+      // error-policy:J1 native notification tap registration is a transport
+      // boundary; a later shell mount may retry after the bridge recovers.
+      logger.error(
+        { src: "local-notification-tap", error },
+        "[local-notification-tap] failed to register native tap routing",
+      );
+    });
     // Native-only, gated on granted permission, guarded against double-register.
     // The token POST is what makes the server's APNs/FCM stack a live pipeline.
     void initPushRegistration();
@@ -69,18 +86,8 @@ export function NotificationsShellBoot(): null {
     return () => {
       unsubscribeBase();
       window.removeEventListener("steward-token-sync", onTokenAuthorityChange);
-    };
-  }, []);
-
-  // Route every "open notifications" entry point to the combined home/apps
-  // dashboard, where the notification widget is always inline.
-  useEffect(() => {
-    const onOpen = () => {
-      setTab("chat");
-    };
-    window.addEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
-    return () =>
       window.removeEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
+    };
   }, [setTab]);
 
   return null;

--- a/packages/ui/src/state/notifications/navigate-deep-link.test.ts
+++ b/packages/ui/src/state/notifications/navigate-deep-link.test.ts
@@ -84,6 +84,16 @@ describe("navigateDeepLink", () => {
     expect(types).not.toContain("eliza:navigate:view");
   });
 
+  it("opens the Home notification center for /notifications", () => {
+    navigateDeepLink("/notifications");
+    const types = dispatchSpy.mock.calls
+      .map((c: unknown[]) => c[0])
+      .filter((e: unknown): e is CustomEvent => e instanceof CustomEvent)
+      .map((e: CustomEvent) => e.type);
+    expect(types).toContain("eliza:notifications:open");
+    expect(types).not.toContain("eliza:navigate:view");
+  });
+
   it("prefills the chat composer for /chat?prefill=<text> (never auto-sends)", () => {
     navigateDeepLink("/chat?prefill=Connect%20my%20calendar");
     const evt = dispatchSpy.mock.calls

--- a/packages/ui/src/state/notifications/navigate-deep-link.ts
+++ b/packages/ui/src/state/notifications/navigate-deep-link.ts
@@ -25,6 +25,7 @@ import {
   dispatchChatOpen,
   dispatchChatPrefill,
   dispatchNavigateViewEvent,
+  dispatchOpenNotificationCenter,
 } from "../../events";
 
 /** Whether a deep link is a safe navigation target (see module doc). */
@@ -58,6 +59,10 @@ export function navigateDeepLink(deepLink: string): void {
       const prefill = new URLSearchParams(query).get("prefill")?.trim();
       if (prefill) dispatchChatPrefill({ text: prefill });
       else dispatchChatOpen();
+      return;
+    }
+    if (viewId === "notifications") {
+      dispatchOpenNotificationCenter();
       return;
     }
     dispatchNavigateViewEvent({ viewId, viewPath: deepLink });


### PR DESCRIPTION
Closes #21402

## What changed

- add the official `@capacitor/local-notifications` plugin to the canonical iOS mobile manifest while leaving Android unchanged
- keep the typed Capacitor notification path primary and provide the required `timeIso` to the native fallback
- centralize native trigger selection after permission completes: past/current/permission-delayed requests use a fireable one-second interval trigger; genuine future dates retain a calendar trigger
- install one app-lifetime notification-action listener that supports direct or Promise listener handles, catches synchronous bridge throws, resets after failed registration, and preserves retry
- order Home notification-center routing before retained cold-launch replay
- validate notification deep links once and route `/notifications` to the existing Home notification center

## Exact revision and scope

- head: `0273e156e0aa50f839a8e7f5b982ec2dd46a7174`
- tree: `774f25c33842ec4623cac3cbb5342595fb7e5f71`
- base/current develop: `ae8a99bfacf9aef377f4a2dfe6b8e41872b29aeb`
- final range-diff from the exact installed patch: `=`
- exact 12 paths, +507/-24; diff-check clean; no current-develop path overlap

## Verification

- UI focused Vitest: **37/37 PASS**
- app-core plugin-manifest Vitest: **3/3 PASS**
- `packages/ui`, `packages/app-core`, and `packages/app` typechecks: **PASS**
- exact Biome: **PASS**
- canonical direct/remote-mac iOS build: **BUILD SUCCEEDED**
- cloud artifact audit: **PASS**
- official `CapacitorLocalNotifications.framework` present
- forbidden local-runtime frameworks absent
- independent exact-head review: **APPROVE / no P0-P3** - https://github.com/elizaOS/eliza/pull/21429#issuecomment-5320727378

## Exact installed artifact

Built and installed at patch-equivalent head `60e3e17ac1d0573dfba560c82001d7975a90fbf5` immediately before the final disjoint rebase. Final range-diff is `=` and all 12 candidate blobs/routing bytes are unchanged.

- renderer buildId: `46658d8c8ea818b363e18deb1909a81d7982c6ce5afb89d6390ac85adcb43052`
- variant `direct`; target `ios`; runtime `remote-mac`; APNs `false`
- installed manifest SHA-256: `d5df2743b4d19b9363541d6063e5182fc83e5b3c93eea19f7a47c4c9fcf3c1a9`
- canonical build log SHA-256: `b7bac898520f6fd0f3ea4e84449517e22d028781099bacc4a4096c7087b26e24`

## Real killed-app banner -> tap -> Home notification center

Simulator `95345F24-0005-46A4-9FC8-A2D96EB022A9`, notification ID `2142915`:

1. scheduled through the installed Capacitor JS/native bridge
2. app terminated
3. SpringBoard delivered and visibly presented the banner
4. Computer Use clicked the real visible banner
5. SpringBoard logged the default notification action for record `2142915`
6. iOS cold-launched `ai.elizaos.app` (PID `88347`) and retained `/notifications` routing opened the existing Home notification center

Actual screenshots and sanitized native receipt are attached in the publication-evidence comment. Durable evidence receipt: https://github.com/elizaOS/eliza/pull/21429#issuecomment-5320713195

## App audit

`audit:app`: **218/219 PASS**. The sole aggregate failure is inherited current-develop minimalism/hover debt in untouched `builtin-plugins`, `builtin-runtime`, and `builtin-background` views. This PR changes none of those surfaces.

## Boundary

- This is iOS local-notification transport and navigation truth.
- Physical-device APNs signing, token upload, and background/killed remote-push delivery are not claimed; they remain in #21407 and #21408.
- No credentials, staging, production, Worker, gateway, macOS runtime, or shared Home/chat source was mutated.
- Five pre-existing generated `packages/app/public` brand/favicon assets remain untracked and excluded.