### PR TITLE
fix(cloud): require staging Blooio config

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -442,6 +442,33 @@ jobs:
             require_exact RELAY_ORIGIN "$RELAY_ORIGIN" "https://relay-staging.eliza.app"
           fi
 
+      - name: Validate protected staging Blooio configuration
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
+        env:
+          DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
+          ELIZA_APP_BLOOIO_API_KEY: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_API_KEY || '' }}
+          ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER || '' }}
+          ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET || '' }}
+        run: |
+          set -euo pipefail
+          required_names=(
+            ELIZA_APP_BLOOIO_API_KEY
+            ELIZA_APP_BLOOIO_PHONE_NUMBER
+            ELIZA_APP_BLOOIO_WEBHOOK_SECRET
+          )
+          missing=()
+          for name in "${required_names[@]}"; do
+            value="${!name:-}"
+            if [ -z "${value//[[:space:]]/}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required protected staging Blooio secret name(s): ${missing[*]}"
+            exit 1
+          fi
+          echo "Verified ${#required_names[@]} protected staging Blooio secret names; values were not printed."
+
       - name: Disable staging session exchange before cutover
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api
@@ -581,6 +608,13 @@ jobs:
           # activation is a separate protected, live-proven rollout.
           ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
           ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
+          # Personal Shared Blooio is a staging acceptance surface. These
+          # protected values are mandatory in staging and are committed with
+          # the exact Worker source through the atomic secrets file below.
+          # Production keeps its existing bindings and never queues this source.
+          ELIZA_APP_BLOOIO_API_KEY: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_API_KEY || '' }}
+          ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER || '' }}
+          ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET || '' }}
           # Personal Shared APNs stays dormant unless the complete protected
           # environment config is present. Topic/environment are explicit so a
           # signed development build cannot silently receive production pushes.
@@ -917,6 +951,20 @@ jobs:
             queue_secret "$name" || exit 1
           done
 
+          if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then
+            for name in \
+              ELIZA_APP_BLOOIO_API_KEY \
+              ELIZA_APP_BLOOIO_PHONE_NUMBER \
+              ELIZA_APP_BLOOIO_WEBHOOK_SECRET
+            do
+              if ! has_nonblank_value "${!name:-}"; then
+                echo "::error::Required protected staging Blooio secret is absent or blank: $name"
+                exit 1
+              fi
+              queue_secret "$name" || exit 1
+            done
+          fi
+
           for name in \
             OPENROUTER_API_KEY \
             OPENAI_API_KEY \
@@ -1125,6 +1173,11 @@ jobs:
             ];
             if (process.env.DEPLOY_ENVIRONMENT === "staging") {
               required.push("LOCAL_EMBEDDINGS_API_KEY");
+              required.push(
+                "ELIZA_APP_BLOOIO_API_KEY",
+                "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+                "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+              );
             }
             if (
               process.env.DEPLOY_ENVIRONMENT === "production" &&

--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -212,6 +212,14 @@ jobs:
               AGENT_ROUTER_ORIGIN_HOST: .AGENT_ROUTER_ORIGIN_HOST,
               ELIZA_CLOUD_AGENT_BASE_DOMAIN: .ELIZA_CLOUD_AGENT_BASE_DOMAIN
             },
+            staging_blooio_nonblank_names: [
+              to_entries[] |
+              select(.key == "ELIZA_APP_BLOOIO_API_KEY" or
+                     .key == "ELIZA_APP_BLOOIO_PHONE_NUMBER" or
+                     .key == "ELIZA_APP_BLOOIO_WEBHOOK_SECRET") |
+              select((.value | type) == "string" and (.value | test("\\S"))) |
+              .key
+            ],
             nonblank_sensitive_names: [
               to_entries[] |
               select(.value | type == "string" and length > 0) |
@@ -238,6 +246,15 @@ jobs:
               exit 1
             fi
           }
+          require_staging_blooio_name() {
+            local name="$1"
+            if ! jq -e --arg name "$name" \
+              '.staging_blooio_nonblank_names | index($name) != null' \
+              "$variables_path" >/dev/null; then
+              echo "::error::Required sensitive Railway variable name is absent or blank: $name"
+              exit 1
+            fi
+          }
 
           require_exact_variable ELIZA_CLOUD_URL "$EXPECTED_CLOUD_URL"
           require_exact_variable AGENT_ROUTER_ORIGIN_HOST "$EXPECTED_ROUTER_ORIGIN"
@@ -249,6 +266,14 @@ jobs:
             ELIZA_APP_WEBHOOK_GATEWAY_SECRET; do
             require_sensitive_name "$name"
           done
+          if [ "$TARGET_ENVIRONMENT" = "staging" ]; then
+            for name in \
+              ELIZA_APP_BLOOIO_API_KEY \
+              ELIZA_APP_BLOOIO_PHONE_NUMBER \
+              ELIZA_APP_BLOOIO_WEBHOOK_SECRET; do
+              require_staging_blooio_name "$name"
+            done
+          fi
           if ! jq -e '.nonblank_sensitive_names as $names |
             (($names | index("REDIS_URL")) != null or
              ((($names | index("KV_REST_API_URL")) != null) and

--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -115,9 +115,17 @@ The workflow validates the existing Railway variable names and canonical
 non-secret values without printing or rewriting sensitive values. Keep runtime
 secrets in Railway; do not copy their values into workflow YAML or logs. The
 names-only inventory requires `ELIZA_APP_WEBHOOK_GATEWAY_SECRET`, which keeps
-the cloud BFF forwarding trust gate enabled. Staging is branch/configuration
-gated but currently has no required reviewer; production retains reviewer
-approval.
+the cloud BFF forwarding trust gate enabled. Staging additionally requires the
+complete `ELIZA_APP_BLOOIO_API_KEY`, `ELIZA_APP_BLOOIO_PHONE_NUMBER`, and
+`ELIZA_APP_BLOOIO_WEBHOOK_SECRET` set before a deployment can start; production
+keeps its existing contract. Provision staging values out of band through
+`railway variable set --stdin --skip-deploys` so an incomplete update cannot
+trigger a release, then use the protected dispatcher once all three names are
+present. Restore or remove only those staged names before dispatch if setup
+fails. The webhook secret must match the Worker protected-environment source;
+the workflows verify names without reading or comparing values. Staging is
+branch/configuration gated but currently has no required reviewer; production
+retains reviewer approval.
 
 `__tests__/dockerfile-workspace-context.test.ts` guards the workspace build
 context. The repository-level

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -115,9 +115,17 @@ The workflow validates the existing Railway variable names and canonical
 non-secret values without printing or rewriting sensitive values. Keep runtime
 secrets in Railway; do not copy their values into workflow YAML or logs. The
 names-only inventory requires `ELIZA_APP_WEBHOOK_GATEWAY_SECRET`, which keeps
-the cloud BFF forwarding trust gate enabled. Staging is branch/configuration
-gated but currently has no required reviewer; production retains reviewer
-approval.
+the cloud BFF forwarding trust gate enabled. Staging additionally requires the
+complete `ELIZA_APP_BLOOIO_API_KEY`, `ELIZA_APP_BLOOIO_PHONE_NUMBER`, and
+`ELIZA_APP_BLOOIO_WEBHOOK_SECRET` set before a deployment can start; production
+keeps its existing contract. Provision staging values out of band through
+`railway variable set --stdin --skip-deploys` so an incomplete update cannot
+trigger a release, then use the protected dispatcher once all three names are
+present. Restore or remove only those staged names before dispatch if setup
+fails. The webhook secret must match the Worker protected-environment source;
+the workflows verify names without reading or comparing values. Staging is
+branch/configuration gated but currently has no required reviewer; production
+retains reviewer approval.
 
 `__tests__/dockerfile-workspace-context.test.ts` guards the workspace build
 context. The repository-level

--- a/packages/scripts/__tests__/cloud-cf-blooio-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-blooio-deploy-workflow.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Guards staging-only Blooio secret sourcing, atomic Worker publication, and
+ * names-only post-deploy verification in the protected Cloud release.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const source = readFileSync(
+  new URL(".github/workflows/cloud-cf-release.yml", repoRoot),
+  "utf8",
+);
+
+interface WorkflowStep {
+  env?: Record<string, string>;
+  id?: string;
+  if?: string;
+  name?: string;
+  run?: string;
+}
+
+interface Workflow {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+const workflow = Bun.YAML.parse(source) as Workflow;
+const steps = workflow.jobs?.["deploy-api"]?.steps ?? [];
+const blooioNames = [
+  "ELIZA_APP_BLOOIO_API_KEY",
+  "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+  "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+] as const;
+const stagingValues: Record<(typeof blooioNames)[number], string> = {
+  ELIZA_APP_BLOOIO_API_KEY: "api-key-private-canary",
+  ELIZA_APP_BLOOIO_PHONE_NUMBER: "+15555550199",
+  ELIZA_APP_BLOOIO_WEBHOOK_SECRET: "webhook-secret-private-canary",
+};
+
+function step(name: string): WorkflowStep {
+  const found = steps.find((candidate) => candidate.name === name);
+  if (!found?.run) throw new Error(`Missing executable workflow step: ${name}`);
+  return found;
+}
+
+function index(name: string): number {
+  return steps.findIndex((candidate) => candidate.name === name);
+}
+
+function githubExpression(body: string): string {
+  return ["$", "{{ ", body, " }}"].join("");
+}
+
+function runValidation(
+  overrides: Partial<typeof stagingValues> = {},
+): ReturnType<typeof Bun.spawnSync> {
+  const validation = step("Validate protected staging Blooio configuration");
+  return Bun.spawnSync(["bash", "-c", validation.run ?? ""], {
+    env: {
+      ...process.env,
+      DEPLOY_ENVIRONMENT: "staging",
+      ...stagingValues,
+      ...overrides,
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+}
+
+describe("protected Cloud staging Blooio configuration", () => {
+  test("fails closed before Worker mutation without exposing protected values", () => {
+    const validation = step("Validate protected staging Blooio configuration");
+    expect(validation.if).toContain(
+      "steps.env.outputs.deploy_environment == 'staging'",
+    );
+    expect(index("Validate canonical routing contract")).toBeLessThan(
+      index("Validate protected staging Blooio configuration"),
+    );
+    expect(
+      index("Validate protected staging Blooio configuration"),
+    ).toBeLessThan(index("Disable staging session exchange before cutover"));
+
+    const complete = runValidation();
+    expect(complete.exitCode).toBe(0);
+    expect(complete.stdout.toString()).toContain(
+      "Verified 3 protected staging Blooio secret names",
+    );
+    const completeOutput = `${complete.stdout.toString()}${complete.stderr.toString()}`;
+    for (const value of Object.values(stagingValues)) {
+      expect(completeOutput).not.toContain(value);
+    }
+
+    for (const name of blooioNames) {
+      for (const missingValue of ["", " \t "]) {
+        const missing = runValidation({ [name]: missingValue });
+        expect(missing.exitCode).toBe(1);
+        const output = `${missing.stdout.toString()}${missing.stderr.toString()}`;
+        expect(output).toContain(name);
+        for (const value of Object.values(stagingValues)) {
+          expect(output).not.toContain(value);
+        }
+      }
+    }
+  });
+
+  test("sources only protected staging values and commits them atomically", () => {
+    const validation = step("Validate protected staging Blooio configuration");
+    const prepare = step("Prepare Worker secrets for atomic deploy");
+    const deploy = step("Deploy to Cloudflare Workers");
+    const cleanup = step("Remove atomic Worker secrets file");
+
+    for (const name of blooioNames) {
+      const expected = githubExpression(
+        `steps.env.outputs.deploy_environment == 'staging' && secrets.${name} || ''`,
+      );
+      expect(validation.env?.[name]).toBe(expected);
+      expect(prepare.env?.[name]).toBe(expected);
+      expect(prepare.run).toContain(`\n    ${name}`);
+    }
+    expect(prepare.run).toContain('if [ "$DEPLOY_ENVIRONMENT" = "staging" ]');
+    expect(prepare.run).toContain('queue_secret "$name" || exit 1');
+    expect(prepare.run).toContain("worker-secrets-file.mjs");
+    expect(prepare.run).toContain('create "$RUNNER_TEMP"');
+    expect(prepare.run).not.toMatch(/^\s*bunx wrangler secret put/m);
+    expect(deploy.run).toContain('--secrets-file "$WORKER_SECRETS_FILE"');
+    expect(cleanup.if).toContain("always()");
+    expect(cleanup.run).toContain('remove-all "$RUNNER_TEMP"');
+  });
+
+  test("verifies staging names after deploy while leaving production isolated", () => {
+    const verify = step("Verify required Worker secret binding names");
+    expect(verify.run).toContain(
+      'process.env.DEPLOY_ENVIRONMENT === "staging"',
+    );
+    for (const name of blooioNames) {
+      expect(verify.run).toContain(`"${name}"`);
+    }
+    expect(verify.run).toContain("values were not read");
+
+    const validation = step("Validate protected staging Blooio configuration");
+    expect(validation.if).not.toContain("production");
+    for (const name of blooioNames) {
+      expect(validation.env?.[name]).not.toContain(
+        `deploy_environment == 'production' && secrets.${name}`,
+      );
+      expect(
+        step("Prepare Worker secrets for atomic deploy").env?.[name],
+      ).not.toContain(`deploy_environment == 'production' && secrets.${name}`);
+    }
+  });
+});

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -465,7 +465,7 @@ describe("protected gateway-webhook deployment workflow", () => {
     expect(production.stdout.toString()).toContain(
       "required sensitive variable names are present",
     );
-  });
+  }, 15_000);
 
   test("binds the exact root source and manifest to its new deployment id", () => {
     const exactSource = step("Deploy exact gateway-webhook source");

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -27,6 +28,16 @@ const workflowReadme = readFileSync(
   new URL(".github/workflows/README.md", repoRoot),
   "utf8",
 );
+const blooioNames = [
+  "ELIZA_APP_BLOOIO_API_KEY",
+  "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+  "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+] as const;
+const blooioValues: Record<(typeof blooioNames)[number], string> = {
+  ELIZA_APP_BLOOIO_API_KEY: "railway-api-key-private-canary",
+  ELIZA_APP_BLOOIO_PHONE_NUMBER: "+15555550200",
+  ELIZA_APP_BLOOIO_WEBHOOK_SECRET: "railway-webhook-private-canary",
+};
 interface WorkflowStep {
   env?: Record<string, string>;
   id?: string;
@@ -127,6 +138,86 @@ function railwayUpPathArgument(run: string): string | undefined {
   return firstArgument && !firstArgument.startsWith("-")
     ? firstArgument
     : undefined;
+}
+
+function verifyRailwayVariableInventory(
+  target: "staging" | "production",
+  overrides: Record<string, string | undefined> = {},
+): ReturnType<typeof Bun.spawnSync> {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "gateway-webhook-vars-"));
+  const binRoot = join(fixtureRoot, "bin");
+  mkdirSync(binRoot, { recursive: true });
+  const canonical =
+    target === "staging"
+      ? {
+          ELIZA_CLOUD_URL: "https://api-staging.eliza.app",
+          AGENT_ROUTER_ORIGIN_HOST: "eliza-staging-1.eliza.app",
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud-staging.eliza.app",
+        }
+      : {
+          ELIZA_CLOUD_URL: "https://api.eliza.app",
+          AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.eliza.app",
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+        };
+  const variables: Record<string, string | undefined> = {
+    ...canonical,
+    GATEWAY_BOOTSTRAP_SECRET: "bootstrap-private-canary",
+    GATEWAY_INTERNAL_SECRET: "internal-private-canary",
+    AGENT_SERVER_SHARED_SECRET: "server-private-canary",
+    ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "forwarder-private-canary",
+    REDIS_URL: "redis-private-canary",
+    ...(target === "staging" ? blooioValues : {}),
+    ...overrides,
+  };
+  writeFileSync(
+    join(binRoot, "railway"),
+    `#!/bin/sh
+set -eu
+if [ "$1" = "variable" ] && [ "$2" = "list" ]; then
+  printf '%s' "$RAILWAY_VARIABLES_FIXTURE"
+  exit 0
+fi
+exit 97
+`,
+  );
+  writeFileSync(
+    join(binRoot, "shred"),
+    `#!/bin/sh
+set -eu
+if [ "$1" = "-u" ]; then
+  rm -f "$2"
+  exit 0
+fi
+exit 98
+`,
+  );
+  chmodSync(join(binRoot, "railway"), 0o755);
+  chmodSync(join(binRoot, "shred"), 0o755);
+
+  try {
+    const verification = step(
+      "Verify canonical Railway variables and sensitive names",
+    );
+    return Bun.spawnSync(["bash", "-c", verification.run ?? ""], {
+      env: {
+        ...process.env,
+        EXPECTED_AGENT_BASE_DOMAIN: canonical.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
+        EXPECTED_CLOUD_URL: canonical.ELIZA_CLOUD_URL,
+        EXPECTED_ROUTER_ORIGIN: canonical.AGENT_ROUTER_ORIGIN_HOST,
+        PATH: `${binRoot}:${process.env.PATH ?? ""}`,
+        RAILWAY_ENVIRONMENT_ID: "22222222-2222-4222-8222-222222222222",
+        RAILWAY_PROJECT_ID: "11111111-1111-4111-8111-111111111111",
+        RAILWAY_SERVICE_ID: "33333333-3333-4333-8333-333333333333",
+        RAILWAY_VARIABLES_FIXTURE: JSON.stringify(variables),
+        RUNNER_TEMP: fixtureRoot,
+        TARGET_ENVIRONMENT: target,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
 }
 
 /**
@@ -334,9 +425,46 @@ describe("protected gateway-webhook deployment workflow", () => {
     expect(variables.run).toContain("KV_REST_API_TOKEN");
     expect(variables.run).toContain("AGENT_ROUTER_ORIGIN_HOST");
     expect(variables.run).toContain("ELIZA_CLOUD_AGENT_BASE_DOMAIN");
+    expect(variables.run).toContain("staging_blooio_nonblank_names");
+    expect(variables.run).toContain('if [ "$TARGET_ENVIRONMENT" = "staging" ]');
+    for (const name of blooioNames) {
+      expect(variables.run).toContain(name);
+    }
     expect(source).not.toContain("railway variable set");
     expect(source).not.toContain('cat "$variables_path"');
     expect(source).not.toContain('echo "$RAILWAY_TOKEN"');
+  });
+
+  test("requires the complete staging Blooio set without changing production", () => {
+    const complete = verifyRailwayVariableInventory("staging");
+    expect(complete.exitCode).toBe(0);
+    expect(complete.stdout.toString()).toContain(
+      "required sensitive variable names are present",
+    );
+    const completeOutput = `${complete.stdout.toString()}${complete.stderr.toString()}`;
+    for (const value of Object.values(blooioValues)) {
+      expect(completeOutput).not.toContain(value);
+    }
+
+    for (const name of blooioNames) {
+      for (const missingValue of [undefined, "", " \t "]) {
+        const missing = verifyRailwayVariableInventory("staging", {
+          [name]: missingValue,
+        });
+        expect(missing.exitCode).toBe(1);
+        const output = `${missing.stdout.toString()}${missing.stderr.toString()}`;
+        expect(output).toContain(name);
+        for (const value of Object.values(blooioValues)) {
+          expect(output).not.toContain(value);
+        }
+      }
+    }
+
+    const production = verifyRailwayVariableInventory("production");
+    expect(production.exitCode).toBe(0);
+    expect(production.stdout.toString()).toContain(
+      "required sensitive variable names are present",
+    );
   });
 
   test("binds the exact root source and manifest to its new deployment id", () => {


### PR DESCRIPTION
# Relates to

Closes #21426.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@20429f36c6e81d700e160faf495b71aa47a1f973:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Exact reviewed head `20429f36c6e81d700e160faf495b71aa47a1f973`, tree `3ee733fa8da2bb91c11e242a5d8656e2a484f8c1`, rebased on `d288815c91198b4cf8021e90ace4183c06feba51`.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Medium operational risk, low source risk. Staging Cloud and gateway releases now fail closed until the three protected Blooio names are provisioned and nonblank. That is intentional: a green release must no longer imply Blooio readiness when the deployment cannot receive or deliver iMessage traffic. Production requirements and values are unchanged.

# Background

## What does this PR do?

- Requires the canonical staging names `ELIZA_APP_BLOOIO_API_KEY`, `ELIZA_APP_BLOOIO_PHONE_NUMBER`, and `ELIZA_APP_BLOOIO_WEBHOOK_SECRET` before protected Cloud Worker and `gateway-webhook` staging releases.
- Passes the Cloud values only through the existing mode-0600 atomic Worker secrets file, then verifies the deployed binding **names** without printing values.
- Makes the Railway gateway preflight reject absent, empty, and whitespace-only staging values using its existing private names-only inventory; the workflow still never writes Railway variables.
- Leaves production requirements and bindings unchanged.
- Documents the out-of-band, `--stdin --skip-deploys` staging provisioning and rollback contract and the requirement that the provider webhook secret match the Worker source.

The names-only discovery receipt is recorded at [Fleet HQ](https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18055700).

## What kind of change is this?

Bug fix and deployment hardening.

# Documentation changes needed?

The gateway package documentation is updated, with `CLAUDE.md` and `AGENTS.md` kept byte-identical.

# Testing

## Where should a reviewer start?

1. `.github/workflows/cloud-cf-release.yml`
2. `.github/workflows/deploy-gateway-webhook.yml`
3. `packages/scripts/__tests__/cloud-cf-blooio-deploy-workflow.test.ts`
4. `packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts`

## Detailed testing steps

```bash
bun test \
  packages/scripts/__tests__/cloud-cf-blooio-deploy-workflow.test.ts \
  packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts \
  packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts \
  packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts \
  packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts \
  packages/scripts/__tests__/cloud-cf-canonical-source-guard-workflow.test.ts

actionlint \
  .github/workflows/cloud-cf-release.yml \
  .github/workflows/deploy-gateway-webhook.yml

bunx biome check \
  packages/scripts/__tests__/cloud-cf-blooio-deploy-workflow.test.ts \
  packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts

bun run --cwd packages/cloud/services/gateway-webhook typecheck
bun run --cwd packages/cloud/services/gateway-webhook build
bun run --cwd packages/core build
bun run --cwd packages/cloud/api typecheck
git diff --check d288815c91198b4cf8021e90ace4183c06feba51...HEAD
cmp packages/cloud/services/gateway-webhook/CLAUDE.md packages/cloud/services/gateway-webhook/AGENTS.md
```

Exact-head results after independent review and the bounded test-timeout repair:

- 44\/44 focused and adjacent workflow tests, 705 assertions. The independent review reproduced a 5-second default-timeout failure in the 11-process Railway harness; the second commit bounds that test at 15 seconds, and it passes in 6.0 seconds under the default command.
- Both workflows pass `actionlint`.
- Gateway typecheck and build pass (196 modules, 1.10 MB bundle).
- Cloud API TypeScript and production Worker dry bundle pass after the canonical Core build.
- Exact changed-file Biome and diff checks pass. Biome reports two inherited warning-only `${{ ... }}` fixture strings in the pre-existing gateway workflow test; this PR does not alter those lines.
- Documentation parity passes.

# Evidence Gate

<!-- evidence-head:20429f36c6e81d700e160faf495b71aa47a1f973 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow, test, and package documentation changes have no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow, test, and package documentation changes have no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - source-only deployment contract; no UI or live deployment is changed by this draft.
<!-- evidence-row:backend-logs -->
- [x] N/A - live staging execution is intentionally blocked until protected configuration is provisioned; executable workflow harness output is included below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - this source-only workflow contract produces no runtime domain artifact; executable shell harness results are included below and real provider artifacts remain post-config acceptance work.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changes.

## Backend + frontend logs

N/A for live logs - this draft does not mutate staging. The executable workflow harness exercises the exact extracted shell preflights, including each absent/empty/whitespace-only value and secret-output canaries:

<details>
<summary>Exact-head workflow result</summary>

```text
44 pass
0 fail
705 expect() calls
Ran 44 tests across 6 files.
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

- `bun install --frozen-lockfile` passed.
- `bun run verify` reached 219/220 tasks, then the unrelated `@elizaos/plugin-wallet#build` could not acquire the shared package-build mutex on `127.0.0.1:31338` within 60 seconds. This six-path workflow/docs/test diff does not touch the wallet or native build-lock surface. All scoped and adjacent contract gates pass.
- Physical staging acceptance is deliberately **BLOCKED** pending the config owner provisioning the three protected GitHub staging secrets and the same three canonical Railway staging variables, plus provider webhook/signature agreement. No values were created, copied, or changed here.
- After that handoff, the exclusive live lease owner must run real Blooio ingress, reply, and reminder-delivery proof. This draft does not deploy or send channel traffic.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: elizaOS/eliza@20429f36c6e81d700e160faf495b71aa47a1f973:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-root/blooio-config]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"elizaOS/eliza@20429f36c6e81d700e160faf495b71aa47a1f973:packages/skills/skills/contribute-to-eliza"} -->