### PR TITLE
fix(cloud): source-alias core in e2e typecheck

### DIFF
--- a/packages/cloud/e2e/tsconfig.json
+++ b/packages/cloud/e2e/tsconfig.json
@@ -15,6 +15,8 @@
     "paths": {
       "@elizaos/cloud-shared/*": ["../../cloud/shared/src/*"],
       "@elizaos/cloud-test-mocks/*": ["../cloud-mocks/src/*"],
+      "@elizaos/core": ["../../../packages/core/src/index.node.ts"],
+      "@elizaos/core/*": ["../../../packages/core/src/*"],
       "@elizaos/core/edge": ["../../../packages/core/src/index.edge.ts"],
       "@elizaos/plugin-scheduling/edge": [
         "../../../plugins/plugin-scheduling/src/edge.ts"

--- a/packages/scripts/__tests__/cloud-shared-source-consumer-paths.test.ts
+++ b/packages/scripts/__tests__/cloud-shared-source-consumer-paths.test.ts
@@ -1,7 +1,7 @@
 /**
- * Guards edge-module resolution for packages that typecheck Cloud Shared source.
- * Each consumer must resolve the Worker-safe scheduling and web-search entrypoints
- * from source instead of depending on a concurrently generated dist directory.
+ * Guards workspace resolution for packages that typecheck Cloud Shared source.
+ * Each consumer must resolve core and Worker-safe plugin entrypoints from source
+ * instead of depending on a concurrently generated dist directory.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -16,6 +16,11 @@ const edgeModules = [
   "@elizaos/plugin-todos/edge",
   "@elizaos/plugin-web-search/edge",
 ] as const;
+const coreModules = {
+  "@elizaos/core": "src/index.node.ts",
+  "@elizaos/core/*": "src/*",
+  "@elizaos/core/edge": "src/index.edge.ts",
+} as const;
 
 type Tsconfig = {
   compilerOptions?: {
@@ -58,6 +63,15 @@ describe("Cloud Shared source-consumer edge paths", () => {
 
     for (const path of consumers) {
       const config = JSON5.parse(readFileSync(path, "utf8")) as Tsconfig;
+      for (const [moduleName, expectedSuffix] of Object.entries(coreModules)) {
+        const targets = config.compilerOptions?.paths?.[moduleName];
+        expect(
+          targets,
+          `${relative(repoRoot, path)} maps ${moduleName}`,
+        ).toHaveLength(1);
+        const target = resolve(dirname(path), targets?.[0] ?? "");
+        expect(target.endsWith(expectedSuffix)).toBe(true);
+      }
       for (const moduleName of edgeModules) {
         const targets = config.compilerOptions?.paths?.[moduleName];
         expect(


### PR DESCRIPTION
# Relates to

Fixes #21434.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto `origin/develop` at `cac31eb8f1aac8a0a1c60f1089dc35eb146e9819` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; exact validation is recorded below.
- [x] A reviewer can confirm the compiler-boundary repair from the exact-head typecheck and resolution audit.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@cac31eb8f1aac8a0a1c60f1089dc35eb146e9819:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebasing onto `cac31eb8f1aac8a0a1c60f1089dc35eb146e9819` completed with zero conflicts.
- [x] Exact head `7af3325750e6f5d6930d798ba482b67b801d17b3`; tree `add2a4b481cff7e3011ab788bc8477c939259f19`.

# Risks

Low. The change is limited to TypeScript path resolution for the private Cloud E2E package and a deterministic configuration regression. It does not alter runtime bundles or production behavior.

# Background

## What does this PR do?

It maps bare `@elizaos/core` and wildcard core subpaths to tracked source whenever Cloud E2E typechecks Cloud Shared source. This prevents TypeScript from loading both source and generated-dist copies of core, whose private `ServiceClass` members make classes such as `NotificationService` nominally incompatible.

The existing Cloud Shared source-consumer regression now requires bare, wildcard, and edge core aliases across all four consumers.

## What kind of change is this?

Bug fix (non-breaking compiler configuration correction).

# Documentation changes needed?

No. This repairs an internal TypeScript project boundary and is covered by a configuration regression.

# Testing

## Where should a reviewer start?

- `packages/cloud/e2e/tsconfig.json`
- `packages/scripts/__tests__/cloud-shared-source-consumer-paths.test.ts`

## Detailed testing steps

- `bun run --cwd packages/cloud/e2e typecheck` — pass on exact head.
- `bun test packages/scripts/__tests__/cloud-shared-source-consumer-paths.test.ts` — 1 test, 61 assertions pass on exact head.
- `bun run audit:tsconfig-workspace-resolution` — 135 projects inspected, pass on exact head.
- `bunx @biomejs/biome check packages/cloud/e2e/tsconfig.json packages/scripts/__tests__/cloud-shared-source-consumer-paths.test.ts` — pass.
- `git diff --check origin/develop...HEAD` — pass.
- `bun run verify` — pass, 356/356 Turbo tasks plus all trailing audits, on the same patch before the final base-only rebase.

# Evidence Gate

<!-- evidence-head:7af3325750e6f5d6930d798ba482b67b801d17b3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - compiler-only configuration; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - compiler-only configuration; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - compiler-only configuration; no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime backend path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, model, or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain-state artifact; exact-head compiler output is recorded under Testing.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior.

## Backend + frontend logs

N/A - no runtime request path.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio or voice change.

## Known gaps / failures

The full root verify completed before the final base-only rebase. Exact-head focused typecheck, resolution regression, workspace-resolution audit, Biome, and diff checks all pass; GitHub exact-head checks remain authoritative before merge.

— [codex/workflow-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@cac31eb8f1aac8a0a1c60f1089dc35eb146e9819:packages/skills/skills/contribute-to-eliza"} -->