### PR TITLE
fix(agent): reject fractional retention counts instead of flooring to zero

### DIFF
--- a/packages/agent/src/runtime/memory-retention.test.ts
+++ b/packages/agent/src/runtime/memory-retention.test.ts
@@ -189,6 +189,19 @@ describe("resolveRetentionConfig — config parsing", () => {
       intervalMinutes: undefined,
     });
   });
+
+  it("rejects fractional row and deletion counts instead of rounding to zero", () => {
+    const config = cfg({
+      ELIZA_MEMORY_RETENTION_MAX_ROWS_PER_ROOM: "0.5",
+      ELIZA_MEMORY_RETENTION_MAX_DELETE_PER_SWEEP: "2.5",
+    });
+
+    expect(config.maxRowsPerRoom).toBeUndefined();
+    expect(config.maxDeletePerSweep).toBeUndefined();
+    expect(
+      planRetention([row("keep", "r1", 1)], config, NOW).deleteIds,
+    ).toEqual([]);
+  });
 });
 
 /** In-memory adapter that records every table it is asked about + deletes. */

--- a/packages/agent/src/runtime/memory-retention.ts
+++ b/packages/agent/src/runtime/memory-retention.ts
@@ -198,10 +198,10 @@ export function resolveRetentionConfigWithPrefix(
 ): ResolvedRetentionConfig {
   return {
     retentionDays: positiveNumberOrUndefined(get(`${prefix}_DAYS`)),
-    maxRowsPerRoom: positiveNumberOrUndefined(
+    maxRowsPerRoom: positiveIntegerOrUndefined(
       get(`${prefix}_MAX_ROWS_PER_ROOM`),
     ),
-    maxDeletePerSweep: positiveNumberOrUndefined(
+    maxDeletePerSweep: positiveIntegerOrUndefined(
       get(`${prefix}_MAX_DELETE_PER_SWEEP`),
     ),
     intervalMinutes: positiveNumberOrUndefined(
@@ -219,4 +219,11 @@ function positiveNumberOrUndefined(
   const n = Number(trimmed);
   if (!Number.isFinite(n) || n <= 0) return undefined;
   return n;
+}
+
+function positiveIntegerOrUndefined(
+  raw: string | undefined,
+): number | undefined {
+  const value = positiveNumberOrUndefined(raw);
+  return value !== undefined && Number.isInteger(value) ? value : undefined;
 }


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
- AI assistance: Yes - initial author assistance plus maintainer review and remediation
<!-- attribution-row:models -->
- Models: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client/tooling: Codex CLI, Claude Code, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - the contribution skill was not used for this maintainer review and remediation
<!-- attribution-row:status -->
- Provenance status: self-reported

AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping given the severity (a config-driven deletion path): reproduced the floor-to-zero collapse myself, ran the full mutation check myself (revert source, keep test, confirm red; restore, confirm green), reran the package's lint and typecheck myself, confirmed the 19 typecheck errors are pre-existing and unrelated to either changed file (missing optional workspace modules — `@elizaos/plugin-capacitor-bridge`, `@elizaos/plugin-notes`, `@elizaos/plugin-todos`, etc.), and re-traced reachability myself by confirming `MemoryRetentionService` is registered as a live `Service` in `eliza-plugin.ts`, not just exported dead code.

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low, and risk-reducing: `MAX_ROWS_PER_ROOM`/`MAX_DELETE_PER_SWEEP` are documented discrete counts (a row count, a delete count) — no legitimate operator config needs a fractional value here, so requiring integers rejects nothing that was ever meaningful. Day/interval settings are untouched since those are genuinely continuous. A rejected value now resolves to `undefined` (bound disabled), matching this module's own documented "fail safe: OFF, never zero-retention-delete-everything" contract in its top-of-file comment — this fix makes the code match its own stated invariant.

# Background

## What does this PR do?

`resolveRetentionConfigWithPrefix` accepted any positive finite number for the discrete `MAX_ROWS_PER_ROOM` and `MAX_DELETE_PER_SWEEP` settings. `planRetention` later applies `Math.floor()` to that value, so a fractional setting like `MAX_ROWS_PER_ROOM=0.5` (e.g. a copy-paste or unit-conversion typo) floors to a row cap of zero — and since the policy is still considered "active" (`0.5 > 0`), every row in every room gets scheduled for deletion on the next sweep, instead of the setting being rejected as invalid.

Before fix (reproduced against the unmodified tree):
```text
config: { maxRowsPerRoom: 0.5, ... }
plan:   { deleteIds: [ "old", "new" ], evictable: 2, clamped: false }
```

After fix:
```text
config: {}
plan:   { deleteIds: [], evictable: 0, clamped: false }
```

## What kind of change is this?

Bug fix — no new capability, no schema change.

# Documentation changes needed?

No.

# Testing

New test `rejects fractional row and deletion counts instead of rounding to zero` in `packages/agent/src/runtime/memory-retention.test.ts`, asserting both fractional settings resolve to `undefined` and the resulting policy is inactive (deletes nothing).

# Evidence Gate

<!-- evidence-head:0500569cac4b2e60c8c8cd8f2559e142f8a9523c -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend logic fix, no UI surface
- <!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual behavior changed

## Known gaps / failures

None in the touched files. The package's full test lane and typecheck have pre-existing, unrelated failures (missing optional workspace modules for typecheck; `EPERM` on a localhost bind and an unresolved `@elizaos/plugin-meetings` import for two unrelated test files in the full lane) — independently confirmed unrelated to this change.

## Reachability

`resolveRetentionConfigWithPrefix` is called by both `MemoryRetentionService.start` (with prefix `ELIZA_MEMORY_RETENTION`) and `LogsRetentionService.start` (with prefix `ELIZA_LOGS_RETENTION`), both reading through `runtime.getSetting` — real, operator-controlled configuration, not hardcoded-safe test input. `MemoryRetentionService` is registered as a live `Service` in `packages/agent/src/runtime/eliza-plugin.ts` (confirmed by reading the registration site directly, not just its export), so this is reachable in any deployed instance with `ELIZA_MEMORY_RETENTION_MAX_ROWS_PER_ROOM` or `_MAX_DELETE_PER_SWEEP` (or the logs-retention equivalents) set to a fractional value.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic focused regression tests are documented in the Testing section and produce no persistent backend log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by this logic change

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered interface changed
