### PR TITLE
fix(cloud): observe every SDK result promise on barge-in cancellation

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -627,11 +627,43 @@ export async function runSharedAgentTurnStream(
     const providerReader = result.fullStream.getReader();
     // error-policy:J5 cancel(reason) rejects the SDK's pending result
     // promises; the parts iterator below is the observed failure channel, so
-    // mark these handled here to keep a barge-in from surfacing its
-    // cancellation reason as an unhandled rejection on the event loop.
-    void Promise.resolve(result.text).catch(() => {});
-    void Promise.resolve(result.totalUsage).catch(() => {});
-    void Promise.resolve(result.finishReason).catch(() => {});
+    // mark every promise-typed result property handled here to keep a
+    // barge-in from surfacing its cancellation reason as unhandled
+    // rejections on the event loop. Stream-typed getters (fullStream,
+    // textStream, ...) are deliberately NOT touched — accessing them tees or
+    // locks the provider stream.
+    const settledResultProps = [
+      "content",
+      "text",
+      "reasoning",
+      "reasoningText",
+      "files",
+      "sources",
+      "toolCalls",
+      "staticToolCalls",
+      "dynamicToolCalls",
+      "staticToolResults",
+      "dynamicToolResults",
+      "toolResults",
+      "finishReason",
+      "rawFinishReason",
+      "usage",
+      "totalUsage",
+      "warnings",
+      "steps",
+      "request",
+      "response",
+      "providerMetadata",
+    ] as const;
+    for (const prop of settledResultProps) {
+      const pending = (result as unknown as Record<string, unknown>)[prop];
+      if (
+        pending &&
+        typeof (pending as PromiseLike<unknown>).then === "function"
+      ) {
+        void Promise.resolve(pending as PromiseLike<unknown>).catch(() => {});
+      }
+    }
     let providerStreamDone = false;
     let providerStreamCancelled = false;
     let providerCancelPromise: Promise<void> | null = null;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -17,6 +17,7 @@ import {
   InMemoryDatabaseAdapter,
   ModelType,
   NOTIFICATION_STREAM,
+  NotificationService,
   type Plugin,
   ServiceType,
   type StreamingContext,
@@ -27,7 +28,6 @@ import {
   type ToolDefinition,
   type UUID,
 } from "@elizaos/core/edge";
-import { NotificationService } from "@elizaos/core/services/notification";
 import { createSharedRemindersEdgePlugin } from "@elizaos/plugin-scheduling/edge";
 import { createTodosEdgePlugin } from "@elizaos/plugin-todos/edge";
 import { webSearchEdgeAction, webSearchEdgePlugin } from "@elizaos/plugin-web-search/edge";

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -68,6 +68,7 @@ export * from "./services";
 export * from "./services/agentEvent";
 export * from "./services/approval";
 export * from "./services/message";
+export { NotificationService } from "./services/notification";
 export * from "./services/pairing";
 export * from "./services/pairing-integration";
 export * from "./services/post-delivery-task-tracker";


### PR DESCRIPTION
Round two of #21401: observing only text/totalUsage/finishReason left four other SDK result promises to reject with the cancellation reason on CI runners (release candidate run 32062031192 — still the only red in the full test lane). Every promise-typed StreamTextResult property is now marked handled at stream setup, guarded by a then-check so SDK version drift cannot crash the turn; stream-typed getters stay untouched (accessing them tees or locks the provider stream). Suites 10/10 + 22/22; cloud-shared typecheck 0; Biome clean.