### PR TITLE
ci: automate Snap, Google Play, and iOS releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -73,7 +73,25 @@ Representative examples:
   and gates every signing, release-upload, and OTA-publish job behind the
   reviewer-approved `production-release` environment; a tag protection
   ruleset restricting `v*` creation completes that boundary.
-  `snap-publish.yml` owns Snap Store publication.
+  After finalization, the canonical workflow also calls the reusable,
+  callable-only `snap-publish.yml` and `store-mobile-publish.yml` legs with the
+  exact finalized source SHA, version, channel, and tag. Those legs re-resolve
+  the tag to the supplied commit before using credentials and run behind the
+  `production-release` environment. Snap uploads the registered `eliza` name;
+  Android builds and audits the cloud-only AAB before Google Play upload; iOS
+  embeds the store runtime and uses an App Store Connect API key for signing
+  and delivery. Missing credentials fail the affected store job with the exact
+  secret names instead of silently skipping publication.
+
+  Store credentials are environment-owned. Snap needs
+  `SNAPCRAFT_STORE_CREDENTIALS`. Google Play needs the four
+  `ANDROID_KEYSTORE_*` secrets plus `PLAY_STORE_SERVICE_ACCOUNT_JSON` (raw
+  service-account JSON or its base64 encoding). Apple
+  needs `APPLE_ID`, `APPLE_TEAM_ID`, `ITC_TEAM_ID`, `APP_STORE_APP_ID`, the
+  three `MATCH_*` values, and `APP_STORE_API_KEY_ID`,
+  `APP_STORE_API_ISSUER_ID`, and `APP_STORE_API_KEY_P8`. The API-backed first
+  upload still depends on the corresponding organization account, application
+  record, agreements, and roles already existing in each publisher portal.
 - `infra.yml` is the only Terraform plan, apply, and state-edit entry point.
   Each protected Environment supplies a distinct RSA public-key variable
   `TERRAFORM_PLAN_ARTIFACT_PUBLIC_KEY` and apply-only private-key secret

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -547,3 +547,29 @@ jobs:
             echo "- Tag: \`$RELEASE_TAG\`"
             echo "- Registry cohort: verified before Git/GitHub finalization"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  publish-snap:
+    name: Publish Snap Store release
+    needs: finalize
+    permissions:
+      contents: read
+    uses: ./.github/workflows/snap-publish.yml
+    with:
+      source_sha: ${{ needs.finalize.outputs.source_sha }}
+      version: ${{ needs.finalize.outputs.version }}
+      tag: ${{ format('v{0}', needs.finalize.outputs.version) }}
+      channel: ${{ needs.finalize.outputs.channel == 'latest' && 'stable' || 'beta' }}
+    secrets: inherit
+
+  publish-mobile-stores:
+    name: Publish Google Play and Apple App Store releases
+    needs: finalize
+    permissions:
+      contents: read
+    uses: ./.github/workflows/store-mobile-publish.yml
+    with:
+      source_sha: ${{ needs.finalize.outputs.source_sha }}
+      version: ${{ needs.finalize.outputs.version }}
+      tag: ${{ format('v{0}', needs.finalize.outputs.version) }}
+      channel: ${{ needs.finalize.outputs.channel }}
+    secrets: inherit

--- a/.github/workflows/snap-publish.yml
+++ b/.github/workflows/snap-publish.yml
@@ -1,4 +1,4 @@
-# SNAPCRAFT_STORE_CREDENTIALS: generate with: snapcraft export-login --snaps elizaos-app --acls package_upload,package_push,package_register -
+# SNAPCRAFT_STORE_CREDENTIALS: generate with: snapcraft export-login --snaps eliza --channels edge,beta,candidate,stable --acls package_access,package_push,package_release -
 
 name: Publish Snap to Snap Store
 
@@ -18,36 +18,16 @@ on:
         description: Git tag e.g. v2.0.1
         required: true
         type: string
+      source_sha:
+        description: Exact canonical release commit
+        required: true
+        type: string
     secrets:
-      # Marked `required: false` so this reusable workflow's secret contract
-      # validates even when SNAPCRAFT_STORE_CREDENTIALS is unset. GitHub
-      # validates the contract before any job runs, so `required: true` on an
-      # unset secret aborts a reusable caller at startup with no logs. The body's
-      # creds_check guard already skips the Store upload (build still runs) when
-      # the credential is empty.
+      # The callable contract remains optional so GitHub starts the job and the
+      # explicit preflight can report the missing environment credential. The
+      # canonical release still fails closed before any build or upload.
       SNAPCRAFT_STORE_CREDENTIALS:
         required: false
-
-  workflow_dispatch:
-    inputs:
-      version:
-        description: Semver string e.g. 2.0.1
-        required: true
-        type: string
-      channel:
-        description: Snap Store channel (edge | beta | candidate | stable)
-        required: false
-        type: choice
-        options:
-          - stable
-          - candidate
-          - beta
-          - edge
-        default: stable
-      tag:
-        description: Git tag e.g. v2.0.1
-        required: true
-        type: string
 
 # Default to least privilege. Override per-job where needed.
 permissions:
@@ -56,6 +36,9 @@ permissions:
 jobs:
   build-and-publish:
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 120
+    environment:
+      name: production-release
 
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
@@ -63,21 +46,36 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
           submodules: false
+
+      - name: Bind Snap build to the finalized tag
+        env:
+          EXPECTED_SHA: ${{ inputs.source_sha }}
+          EXPECTED_TAG: ${{ inputs.tag }}
+          EXPECTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          test "$EXPECTED_SHA" = "$(git rev-parse HEAD)"
+          test "$EXPECTED_TAG" = "v$EXPECTED_VERSION"
+          tag_sha="$(git rev-parse "refs/tags/$EXPECTED_TAG^{commit}")"
+          if [ "$tag_sha" != "$EXPECTED_SHA" ]; then
+            echo "::error::Snap tag $EXPECTED_TAG resolves to $tag_sha, expected $EXPECTED_SHA."
+            exit 1
+          fi
 
       - name: Normalize runner root ownership for snapd
         uses: ./.github/actions/normalize-snapd-root
 
       - name: Check Snap Store credentials
-        id: creds_check
         run: |
           if [[ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]]; then
-            echo "::warning::SNAPCRAFT_STORE_CREDENTIALS not configured. Snap build will run but Store upload will be skipped."
-            echo "can_publish=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "can_publish=true" >> "$GITHUB_OUTPUT"
+            echo "::error::SNAPCRAFT_STORE_CREDENTIALS is required for the canonical store release."
+            exit 1
           fi
+          echo "can_publish=true" >> "$GITHUB_OUTPUT"
 
       - name: Install snapcraft
         run: sudo snap install snapcraft --classic
@@ -86,9 +84,10 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          case "$VERSION" in
-            *[!0-9.]*|.*|*..*|*.) echo "::error::version must be numeric dotted, got: $VERSION"; exit 1 ;;
-          esac
+          node packages/scripts/store-release-plan.mjs \
+            --version "$VERSION" \
+            --channel "${{ inputs.channel == 'stable' && 'latest' || 'beta' }}" \
+            --source-sha "${{ inputs.source_sha }}" >/dev/null
           # Update the version in snapcraft.yaml to match the release
           sed -i "s/^version: .*/version: \"${VERSION}\"/" packages/app-core/packaging/snap/snapcraft.yaml
 
@@ -101,8 +100,10 @@ jobs:
           echo "Built: $SNAP_FILE"
           ls -la "$SNAP_FILE"
 
+      - name: Verify Snap Store credentials
+        run: snapcraft whoami
+
       - name: Publish to Snap Store
-        if: steps.creds_check.outputs.can_publish == 'true'
         env:
           CHANNEL: ${{ inputs.channel }}
         run: |
@@ -117,6 +118,6 @@ jobs:
       - name: Upload snap artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: elizaos-snap-${{ inputs.version }}
+          name: eliza-snap-${{ inputs.version }}
           path: packages/app-core/packaging/snap/*.snap
           retention-days: 30

--- a/.github/workflows/store-mobile-publish.yml
+++ b/.github/workflows/store-mobile-publish.yml
@@ -260,11 +260,19 @@ jobs:
         working-directory: packages/app
         run: |
           set -euo pipefail
-          app_id="$(grep -m1 -E 'PRODUCT_BUNDLE_IDENTIFIER = [^.]+\.' ios/App/App.xcodeproj/project.pbxproj \
-            | grep -v WebsiteBlockerContentExtension | awk '{print $3}' | tr -d ';')"
+          identifiers="$(sed -nE 's/.*PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);/\1/p' \
+            ios/App/App.xcodeproj/project.pbxproj | sort -u)"
+          app_id="$(printf '%s\n' "$identifiers" | awk '
+            !/\.AppUITests$/ && (shortest == "" || length($0) < length(shortest)) { shortest = $0 }
+            END { print shortest }
+          ')"
           test -n "$app_id"
+          extension_ids="$(printf '%s\n' "$identifiers" | awk -v app="$app_id" '
+            $0 != app && index($0, app ".") == 1 && $0 !~ /\.AppUITests$/ { print }
+          ' | paste -sd, -)"
+          test -n "$extension_ids"
           echo "APP_IDENTIFIER=$app_id" >> "$GITHUB_ENV"
-          echo "APP_IDENTIFIER_EXTRA=$app_id.WebsiteBlockerContentExtension" >> "$GITHUB_ENV"
+          echo "APP_IDENTIFIER_EXTRA=$extension_ids" >> "$GITHUB_ENV"
 
       - name: Run iOS store preflight
         working-directory: packages/app

--- a/.github/workflows/store-mobile-publish.yml
+++ b/.github/workflows/store-mobile-publish.yml
@@ -1,0 +1,292 @@
+name: Publish Mobile Stores
+
+# This workflow has no independent trigger. The canonical transactional release
+# calls it only after npm, the exact Git tag, and the GitHub Release finalize.
+
+on:
+  workflow_call:
+    inputs:
+      source_sha:
+        description: Exact canonical release commit
+        required: true
+        type: string
+      version:
+        description: Canonical release semver
+        required: true
+        type: string
+      channel:
+        description: Canonical release channel (beta or latest)
+        required: true
+        type: string
+      tag:
+        description: Finalized Git tag
+        required: true
+        type: string
+    secrets:
+      ANDROID_KEYSTORE_BASE64:
+        required: false
+      ANDROID_KEYSTORE_PASSWORD:
+        required: false
+      ANDROID_KEY_ALIAS:
+        required: false
+      ANDROID_KEY_PASSWORD:
+        required: false
+      PLAY_STORE_SERVICE_ACCOUNT_JSON:
+        required: false
+      APPLE_ID:
+        required: false
+      APPLE_TEAM_ID:
+        required: false
+      ITC_TEAM_ID:
+        required: false
+      APP_STORE_APP_ID:
+        required: false
+      MATCH_PASSWORD:
+        required: false
+      MATCH_GIT_URL:
+        required: false
+      MATCH_GIT_BASIC_AUTHORIZATION:
+        required: false
+      APP_STORE_API_KEY_ID:
+        required: false
+      APP_STORE_API_ISSUER_ID:
+        required: false
+      APP_STORE_API_KEY_P8:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  android:
+    name: Build, audit, and publish Google Play AAB
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    environment:
+      name: production-release
+    env:
+      ELIZAOS_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ELIZAOS_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ELIZAOS_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+    steps:
+      - name: Checkout exact release
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bind build to finalized release and derive store plan
+        id: plan
+        env:
+          EXPECTED_SHA: ${{ inputs.source_sha }}
+          EXPECTED_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          test "$EXPECTED_SHA" = "$(git rev-parse HEAD)"
+          test "$EXPECTED_TAG" = "v${{ inputs.version }}"
+          test "$(git rev-parse "refs/tags/$EXPECTED_TAG^{commit}")" = "$EXPECTED_SHA"
+          node packages/scripts/store-release-plan.mjs \
+            --version "${{ inputs.version }}" \
+            --channel "${{ inputs.channel }}" \
+            --source-sha "$EXPECTED_SHA" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Require Android signing and Play credentials
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -z "$ANDROID_KEYSTORE_BASE64" ]] && missing+=(ANDROID_KEYSTORE_BASE64)
+          [[ -z "$ELIZAOS_KEYSTORE_PASSWORD" ]] && missing+=(ANDROID_KEYSTORE_PASSWORD)
+          [[ -z "$ELIZAOS_KEY_ALIAS" ]] && missing+=(ANDROID_KEY_ALIAS)
+          [[ -z "$ELIZAOS_KEY_PASSWORD" ]] && missing+=(ANDROID_KEY_PASSWORD)
+          [[ -z "$PLAY_STORE_SERVICE_ACCOUNT_JSON" ]] && missing+=(PLAY_STORE_SERVICE_ACCOUNT_JSON)
+          if (( ${#missing[@]} )); then
+            echo "::error::Missing required Google Play release secrets: ${missing[*]}"
+            exit 1
+          fi
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/eliza-upload.jks"
+          chmod 600 "$RUNNER_TEMP/eliza-upload.jks"
+          test -s "$RUNNER_TEMP/eliza-upload.jks"
+          if [[ "$PLAY_STORE_SERVICE_ACCOUNT_JSON" == \{* ]]; then
+            printf '%s' "$PLAY_STORE_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/play-store-key.json"
+          else
+            printf '%s' "$PLAY_STORE_SERVICE_ACCOUNT_JSON" | base64 --decode > "$RUNNER_TEMP/play-store-key.json"
+          fi
+          node -e 'const fs=require("node:fs"); const p=process.argv[1]; const v=JSON.parse(fs.readFileSync(p,"utf8")); if(v.type!=="service_account"||!v.client_email||!v.private_key) process.exit(1)' "$RUNNER_TEMP/play-store-key.json"
+          chmod 600 "$RUNNER_TEMP/play-store-key.json"
+
+      - name: Setup Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Build and audit signed Play bundle
+        working-directory: packages/app
+        env:
+          ELIZAOS_VERSION_NAME: ${{ steps.plan.outputs.ios_marketing_version }}
+          ELIZAOS_VERSION_CODE: ${{ steps.plan.outputs.android_version_code }}
+          ELIZAOS_KEYSTORE_PATH: ${{ runner.temp }}/eliza-upload.jks
+        run: |
+          bun run preflight:android:store
+          bun run build:android:cloud
+
+      - name: Setup Fastlane
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b
+        with:
+          ruby-version: "4.0.3"
+          bundler-cache: true
+          working-directory: packages/app-core/platforms/android
+
+      - name: Publish exact AAB to Google Play
+        working-directory: packages/app-core/platforms/android
+        env:
+          PLAY_STORE_TRACK: ${{ steps.plan.outputs.android_track }}
+          PLAY_STORE_AAB_PATH: ${{ github.workspace }}/packages/app-core/platforms/android/app/build/outputs/bundle/release/app-release.aab
+          PLAY_STORE_JSON_KEY: ${{ runner.temp }}/play-store-key.json
+        run: bundle exec fastlane publish_aab
+
+      - name: Upload Android release evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: eliza-google-play-${{ inputs.version }}
+          path: packages/app-core/platforms/android/app/build/outputs/bundle/release/app-release.aab
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Remove Android signing material
+        if: always()
+        run: rm -f "$RUNNER_TEMP/eliza-upload.jks" "$RUNNER_TEMP/play-store-key.json"
+
+  ios:
+    name: Build and publish Apple iOS app
+    runs-on: macos-15
+    timeout-minutes: 120
+    environment:
+      name: production-release
+    env:
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+      ELIZA_BUILD_VARIANT: store
+      ELIZA_RELEASE_AUTHORITY: apple-app-store
+      ELIZA_IOS_FULL_BUN_ENGINE: "1"
+      VITE_ELIZA_IOS_FULL_BUN_AVAILABLE: "1"
+      VITE_ELIZA_IOS_RUNTIME_MODE: cloud-hybrid
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      ITC_TEAM_ID: ${{ secrets.ITC_TEAM_ID }}
+      APP_STORE_APP_ID: ${{ secrets.APP_STORE_APP_ID }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+      MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+      APP_STORE_API_KEY_ID: ${{ secrets.APP_STORE_API_KEY_ID }}
+      APP_STORE_API_ISSUER_ID: ${{ secrets.APP_STORE_API_ISSUER_ID }}
+      APP_STORE_API_KEY_P8: ${{ secrets.APP_STORE_API_KEY_P8 }}
+    steps:
+      - name: Checkout exact release
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bind build to finalized release and derive store plan
+        id: plan
+        env:
+          EXPECTED_SHA: ${{ inputs.source_sha }}
+          EXPECTED_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          test "$EXPECTED_SHA" = "$(git rev-parse HEAD)"
+          test "$EXPECTED_TAG" = "v${{ inputs.version }}"
+          test "$(git rev-parse "refs/tags/$EXPECTED_TAG^{commit}")" = "$EXPECTED_SHA"
+          node packages/scripts/store-release-plan.mjs \
+            --version "${{ inputs.version }}" \
+            --channel "${{ inputs.channel }}" \
+            --source-sha "$EXPECTED_SHA" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Require Apple signing and API credentials
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in APPLE_ID APPLE_TEAM_ID ITC_TEAM_ID APP_STORE_APP_ID \
+            MATCH_PASSWORD MATCH_GIT_URL MATCH_GIT_BASIC_AUTHORIZATION \
+            APP_STORE_API_KEY_ID APP_STORE_API_ISSUER_ID APP_STORE_API_KEY_P8; do
+            [[ -z "${!name}" ]] && missing+=("$name")
+          done
+          if (( ${#missing[@]} )); then
+            echo "::error::Missing required Apple release secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Build store web assets
+        working-directory: packages/app
+        run: bun run build
+
+      - name: Prepare and sync native iOS project
+        run: |
+          bash packages/app-core/scripts/prepare-ios-cocoapods.sh
+          bun run --cwd packages/app cap:sync:ios
+          bun run --cwd packages/agent build:ios-bun
+          node packages/app-core/scripts/run-mobile-build.mjs ios-overlay
+        env:
+          ELIZAOS_VERSION_NAME: ${{ steps.plan.outputs.ios_marketing_version }}
+          ELIZAOS_VERSION_CODE: ${{ steps.plan.outputs.ios_build_number }}
+
+      - name: Install CocoaPods
+        working-directory: packages/app/ios/App
+        run: pod install
+
+      - name: Resolve app identifiers
+        working-directory: packages/app
+        run: |
+          set -euo pipefail
+          app_id="$(grep -m1 -E 'PRODUCT_BUNDLE_IDENTIFIER = [^.]+\.' ios/App/App.xcodeproj/project.pbxproj \
+            | grep -v WebsiteBlockerContentExtension | awk '{print $3}' | tr -d ';')"
+          test -n "$app_id"
+          echo "APP_IDENTIFIER=$app_id" >> "$GITHUB_ENV"
+          echo "APP_IDENTIFIER_EXTRA=$app_id.WebsiteBlockerContentExtension" >> "$GITHUB_ENV"
+
+      - name: Run iOS store preflight
+        working-directory: packages/app
+        run: bun run preflight:ios:store
+
+      - name: Setup Fastlane
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b
+        with:
+          ruby-version: "4.0.3"
+          bundler-cache: true
+          working-directory: packages/app/ios
+
+      - name: Build and publish iOS release
+        working-directory: packages/app/ios
+        env:
+          APPLE_LANE: ${{ steps.plan.outputs.apple_lane }}
+        run: bundle exec fastlane "$APPLE_LANE"
+
+      - name: Upload iOS release evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: eliza-ios-${{ inputs.version }}
+          path: packages/app/ios/build/Eliza.ipa
+          if-no-files-found: error
+          retention-days: 90

--- a/packages/app-core/packaging/snap/snapcraft.yaml
+++ b/packages/app-core/packaging/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
-name: elizaos-app
+name: eliza
+title: Eliza
 version: "2.0.0-beta.0"
 summary: Personal AI assistant built on elizaOS
 description: |
@@ -15,9 +16,9 @@ description: |
   - Web3 wallet integration (EVM + Solana)
   - Desktop apps for macOS, Windows, and Linux
 
-  Quick start: sudo snap install elizaos-app && elizaos-app setup
+  Quick start: sudo snap install eliza && eliza setup
 
-grade: devel
+grade: stable
 confinement: strict
 base: core22
 license: MIT
@@ -36,7 +37,7 @@ layout:
     symlink: $SNAP/usr/lib/x86_64-linux-gnu/libatomic.so.1
 
 apps:
-  elizaos-app:
+  eliza:
     command: bin/elizaos-app-wrapper
     plugs:
       - network

--- a/packages/app-core/platforms/android/fastlane/Fastfile
+++ b/packages/app-core/platforms/android/fastlane/Fastfile
@@ -2,6 +2,30 @@ default_platform(:android)
 
 platform :android do
 
+  desc "Upload the already-built, audited AAB to the release plan track"
+  lane :publish_aab do
+    track = ENV.fetch("PLAY_STORE_TRACK")
+    aab_path = ENV.fetch("PLAY_STORE_AAB_PATH")
+    json_key = ENV.fetch("PLAY_STORE_JSON_KEY")
+
+    unless ["internal", "beta", "production"].include?(track)
+      UI.user_error!("PLAY_STORE_TRACK must be internal, beta, or production")
+    end
+    UI.user_error!("AAB not found at #{aab_path}") unless File.file?(aab_path)
+    UI.user_error!("Play service-account key not found at #{json_key}") unless File.file?(json_key)
+
+    upload_to_play_store(
+      package_name: ENV.fetch("PLAY_STORE_PACKAGE_NAME", "ai.elizaos.app"),
+      track: track,
+      aab: aab_path,
+      json_key: json_key,
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      skip_upload_changelogs: true
+    )
+  end
+
   desc "Build a signed AAB for Play Store"
   lane :build do
     gradle(

--- a/packages/app-core/platforms/ios/fastlane/Fastfile
+++ b/packages/app-core/platforms/ios/fastlane/Fastfile
@@ -7,6 +7,12 @@ EXTENSION_IDS = (ENV["APP_IDENTIFIER_EXTRA"] || "")
   .reject(&:empty?)
 ALL_IDS = [APP_ID, *EXTENSION_IDS].uniq
 
+def required_connect_value(name)
+  value = ENV[name].to_s.strip
+  UI.user_error!("#{name} is required") if value.empty?
+  value
+end
+
 def match_profile_mapping(type_label)
   ALL_IDS.each_with_object({}) do |bundle_id, mapping|
     mapping[bundle_id] = "match #{type_label} #{bundle_id}"
@@ -15,20 +21,32 @@ end
 
 platform :ios do
 
+  private_lane :connect_api_key do
+    app_store_connect_api_key(
+      key_id: required_connect_value("APP_STORE_API_KEY_ID"),
+      issuer_id: required_connect_value("APP_STORE_API_ISSUER_ID"),
+      key_content: required_connect_value("APP_STORE_API_KEY_P8"),
+      is_key_content_base64: false,
+      in_house: false
+    )
+  end
+
   desc "Sync certificates and provisioning profiles"
-  lane :certs do
+  lane :certs do |options|
     setup_ci if ENV["CI"]
 
     match(
       type: "appstore",
       app_identifier: ALL_IDS,
-      readonly: is_ci
+      readonly: is_ci,
+      api_key: options[:api_key] || connect_api_key
     )
   end
 
   desc "Build the iOS app for App Store submission"
-  lane :build do
-    certs
+  lane :build do |options|
+    api_key = options[:api_key] || connect_api_key
+    certs(api_key: api_key)
 
     build_app(
       workspace: "App/App.xcworkspace",
@@ -46,7 +64,8 @@ platform :ios do
 
   desc "Upload to TestFlight"
   lane :beta do
-    build
+    api_key = connect_api_key
+    build(api_key: api_key)
 
     if ENV["APP_STORE_APP_ID"].to_s.strip.empty?
       UI.important(
@@ -57,6 +76,7 @@ platform :ios do
       )
     else
       upload_to_testflight(
+        api_key: api_key,
         skip_waiting_for_build_processing: true,
         apple_id: ENV["APP_STORE_APP_ID"]
       )
@@ -65,9 +85,11 @@ platform :ios do
 
   desc "Submit to App Store for review"
   lane :release do
-    build
+    api_key = connect_api_key
+    build(api_key: api_key)
 
     upload_to_app_store(
+      api_key: api_key,
       skip_screenshots: true,
       skip_metadata: false,
       force: true,
@@ -84,7 +106,9 @@ platform :ios do
 
   desc "Upload metadata and screenshots only"
   lane :metadata do
+    api_key = connect_api_key
     upload_to_app_store(
+      api_key: api_key,
       skip_binary_upload: true,
       skip_screenshots: false,
       force: true

--- a/packages/scripts/__tests__/store-release-plan.test.ts
+++ b/packages/scripts/__tests__/store-release-plan.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Proves that one canonical semver maps monotonically and deterministically to
+ * every store's version and promotion channel without publisher credentials.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  createStoreReleasePlan,
+  parseStoreSemver,
+} from "../store-release-plan.mjs";
+
+const SOURCE_SHA = "0123456789abcdef0123456789abcdef01234567";
+
+describe("store release plan", () => {
+  test("maps a stable release to production channels", () => {
+    expect(
+      createStoreReleasePlan({
+        version: "2.3.4",
+        channel: "latest",
+        sourceSha: SOURCE_SHA,
+      }),
+    ).toMatchObject({
+      tag: "v2.3.4",
+      stable: true,
+      android_version_code: "203049000",
+      android_track: "production",
+      ios_marketing_version: "2.3.4",
+      ios_build_number: "203049000",
+      apple_lane: "release",
+      snap_channel: "stable",
+      extension_version: "2.3.4.60000",
+      chrome_publish_target: "default",
+      flathub_branch: "stable",
+    });
+  });
+
+  test("maps beta releases to testing channels and monotonic build numbers", () => {
+    const beta0 = createStoreReleasePlan({
+      version: "2.3.4-beta.0",
+      channel: "beta",
+      sourceSha: SOURCE_SHA,
+    });
+    const beta9 = createStoreReleasePlan({
+      version: "2.3.4-beta.9",
+      channel: "beta",
+      sourceSha: SOURCE_SHA,
+    });
+    const stable = createStoreReleasePlan({
+      version: "2.3.4",
+      channel: "latest",
+      sourceSha: SOURCE_SHA,
+    });
+
+    expect(beta0).toMatchObject({
+      android_track: "internal",
+      apple_lane: "beta",
+      snap_channel: "beta",
+      extension_version: "2.3.4.20000",
+      chrome_publish_target: "trustedTesters",
+      flathub_branch: "beta",
+    });
+    expect(Number(beta9.android_version_code)).toBeGreaterThan(
+      Number(beta0.android_version_code),
+    );
+    expect(Number(stable.android_version_code)).toBeGreaterThan(
+      Number(beta9.android_version_code),
+    );
+  });
+
+  test("rejects ambiguous or mismatched release identities", () => {
+    expect(() => parseStoreSemver("2.3.4-beta.one")).toThrow();
+    expect(() =>
+      createStoreReleasePlan({
+        version: "2.3.4-beta.0",
+        channel: "latest",
+        sourceSha: SOURCE_SHA,
+      }),
+    ).toThrow("does not match");
+    expect(() =>
+      createStoreReleasePlan({
+        version: "2.3.4",
+        channel: "latest",
+        sourceSha: "deadbeef",
+      }),
+    ).toThrow("40 lowercase hex");
+  });
+});

--- a/packages/scripts/__tests__/store-release-workflow.test.ts
+++ b/packages/scripts/__tests__/store-release-workflow.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Guards the first canonical store-distribution leg: exact release identity,
+ * protected publication, registered Snap name, and fail-closed credentials.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const releaseSource = readFileSync(
+  new URL(".github/workflows/release.yaml", repoRoot),
+  "utf8",
+);
+const snapSource = readFileSync(
+  new URL(".github/workflows/snap-publish.yml", repoRoot),
+  "utf8",
+);
+const snapcraftSource = readFileSync(
+  new URL("packages/app-core/packaging/snap/snapcraft.yaml", repoRoot),
+  "utf8",
+);
+const mobileSource = readFileSync(
+  new URL(".github/workflows/store-mobile-publish.yml", repoRoot),
+  "utf8",
+);
+
+describe("canonical store release workflow", () => {
+  test("calls Snap only after exact release finalization", () => {
+    const workflow = Bun.YAML.parse(releaseSource) as {
+      jobs?: Record<
+        string,
+        {
+          needs?: string | string[];
+          uses?: string;
+          with?: Record<string, string>;
+          secrets?: string;
+        }
+      >;
+    };
+    const snap = workflow.jobs?.["publish-snap"];
+    expect(snap?.needs).toBe("finalize");
+    expect(snap?.uses).toBe("./.github/workflows/snap-publish.yml");
+    expect(snap?.with?.source_sha).toContain("needs.finalize.outputs.source_sha");
+    expect(snap?.with?.version).toContain("needs.finalize.outputs.version");
+    expect(snap?.secrets).toBe("inherit");
+  });
+
+  test("keeps Snap callable-only, protected, exact-tag-bound, and fail-closed", () => {
+    const workflow = Bun.YAML.parse(snapSource) as {
+      on?: Record<string, unknown>;
+      jobs?: Record<string, { environment?: { name?: string } }>;
+    };
+    expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_call"]);
+    expect(workflow.jobs?.["build-and-publish"]?.environment?.name).toBe(
+      "production-release",
+    );
+    expect(snapSource).toContain('ref: ${{ inputs.source_sha }}');
+    expect(snapSource).toContain('refs/tags/$EXPECTED_TAG^{commit}');
+    expect(snapSource).toContain(
+      "SNAPCRAFT_STORE_CREDENTIALS is required for the canonical store release",
+    );
+    expect(snapSource).toContain("snapcraft whoami");
+    expect(snapSource).toContain('snapcraft upload "$SNAP_FILE" --release "$CHANNEL"');
+  });
+
+  test("publishes the registered stable-grade snap identity", () => {
+    expect(snapcraftSource).toMatch(/^name: eliza$/m);
+    expect(snapcraftSource).toMatch(/^title: Eliza$/m);
+    expect(snapcraftSource).toMatch(/^grade: stable$/m);
+    expect(snapcraftSource).toMatch(/^  eliza:$/m);
+  });
+
+  test("calls mobile stores only after exact release finalization", () => {
+    const workflow = Bun.YAML.parse(releaseSource) as {
+      jobs?: Record<string, { needs?: string; uses?: string; with?: Record<string, string>; secrets?: string }>;
+    };
+    const mobile = workflow.jobs?.["publish-mobile-stores"];
+    expect(mobile?.needs).toBe("finalize");
+    expect(mobile?.uses).toBe("./.github/workflows/store-mobile-publish.yml");
+    expect(mobile?.with?.source_sha).toContain("needs.finalize.outputs.source_sha");
+    expect(mobile?.with?.version).toContain("needs.finalize.outputs.version");
+    expect(mobile?.secrets).toBe("inherit");
+  });
+
+  test("keeps mobile stores callable-only, protected, exact-bound, and fail-closed", () => {
+    const workflow = Bun.YAML.parse(mobileSource) as {
+      on?: Record<string, unknown>;
+      jobs?: Record<string, { environment?: { name?: string } }>;
+    };
+    expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_call"]);
+    expect(workflow.jobs?.android?.environment?.name).toBe("production-release");
+    expect(workflow.jobs?.ios?.environment?.name).toBe("production-release");
+    expect(mobileSource).toContain('ref: ${{ inputs.source_sha }}');
+    expect(mobileSource).toContain('refs/tags/$EXPECTED_TAG^{commit}');
+    expect(mobileSource).toContain("Missing required Google Play release secrets");
+    expect(mobileSource).toContain("Missing required Apple release secrets");
+    expect(mobileSource).toContain("bun run build:android:cloud");
+    expect(mobileSource).toContain('bundle exec fastlane "$APPLE_LANE"');
+  });
+});

--- a/packages/scripts/__tests__/store-release-workflow.test.ts
+++ b/packages/scripts/__tests__/store-release-workflow.test.ts
@@ -97,4 +97,18 @@ describe("canonical store release workflow", () => {
     expect(mobileSource).toContain("bun run build:android:cloud");
     expect(mobileSource).toContain('bundle exec fastlane "$APPLE_LANE"');
   });
+
+  test("provisions every shipping iOS extension from the generated project", () => {
+    expect(mobileSource).toContain(
+      "PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);",
+    );
+    expect(mobileSource).toContain("index($0, app \".\") == 1");
+    expect(mobileSource).toContain('$0 !~ /\\.AppUITests$/');
+    expect(mobileSource).toContain(
+      'echo "APP_IDENTIFIER_EXTRA=$extension_ids" >> "$GITHUB_ENV"',
+    );
+    expect(mobileSource).not.toContain(
+      'APP_IDENTIFIER_EXTRA=$app_id.WebsiteBlockerContentExtension',
+    );
+  });
 });

--- a/packages/scripts/store-release-plan.mjs
+++ b/packages/scripts/store-release-plan.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Derives immutable cross-store version and channel identities from the
+ * canonical npm release transaction without contacting publisher services.
+ */
+
+import { appendFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+)(?:\.(0|[1-9]\d*))?)?$/;
+
+const CHANNEL_OFFSETS = Object.freeze({
+  alpha: 1000,
+  beta: 3000,
+  rc: 5000,
+  nightly: 7000,
+});
+
+const EXTENSION_CHANNEL_OFFSETS = Object.freeze({
+  alpha: 10000,
+  beta: 20000,
+  rc: 30000,
+  nightly: 40000,
+});
+
+function requireArgument(args, name) {
+  const index = args.indexOf(name);
+  if (index < 0 || !args[index + 1] || args[index + 1].startsWith("--")) {
+    throw new Error(`${name} is required`);
+  }
+  return args[index + 1];
+}
+
+export function parseStoreSemver(version) {
+  const match = SEMVER_PATTERN.exec(version);
+  if (!match) {
+    throw new Error(
+      `Store release version must be canonical semver with at most one numeric prerelease component: ${version}`,
+    );
+  }
+  const [, majorRaw, minorRaw, patchRaw, prerelease = "", sequenceRaw = "0"] =
+    match;
+  const major = Number(majorRaw);
+  const minor = Number(minorRaw);
+  const patch = Number(patchRaw);
+  const sequence = Number(sequenceRaw);
+  if (sequence > 999) {
+    throw new Error(`Store prerelease sequence must not exceed 999: ${version}`);
+  }
+  return { major, minor, patch, prerelease, sequence };
+}
+
+function numericBuild({ major, minor, patch, prerelease, sequence }) {
+  if (major > 20 || minor > 99 || patch > 99) {
+    throw new Error(
+      "Store release version exceeds the Android versionCode allocation (major <= 20, minor/patch <= 99)",
+    );
+  }
+  const offset = prerelease
+    ? (CHANNEL_OFFSETS[prerelease] ?? 8000)
+    : 9000;
+  const value =
+    major * 100000000 + minor * 1000000 + patch * 10000 + offset + sequence;
+  if (value > 2100000000) {
+    throw new Error(`Android versionCode ${value} exceeds the Play limit`);
+  }
+  return value;
+}
+
+function extensionVersion(parsed) {
+  const { major, minor, patch, prerelease, sequence } = parsed;
+  if ([major, minor, patch].some((value) => value > 65535)) {
+    throw new Error("Browser extension version components must not exceed 65535");
+  }
+  const fourth = prerelease
+    ? (EXTENSION_CHANNEL_OFFSETS[prerelease] ?? 50000) + sequence
+    : 60000;
+  if (fourth > 65535) {
+    throw new Error(`Browser extension build component ${fourth} exceeds 65535`);
+  }
+  return `${major}.${minor}.${patch}.${fourth}`;
+}
+
+export function createStoreReleasePlan({ version, channel, sourceSha }) {
+  if (!/^[0-9a-f]{40}$/.test(sourceSha)) {
+    throw new Error(`Store release source SHA must be 40 lowercase hex characters: ${sourceSha}`);
+  }
+  if (channel !== "beta" && channel !== "latest") {
+    throw new Error(`Store release channel must be beta or latest: ${channel}`);
+  }
+  const parsed = parseStoreSemver(version);
+  const stable = !parsed.prerelease;
+  if ((channel === "latest") !== stable) {
+    throw new Error(
+      `Store release channel ${channel} does not match ${stable ? "stable" : "prerelease"} version ${version}`,
+    );
+  }
+  const buildNumber = numericBuild(parsed);
+  return Object.freeze({
+    source_sha: sourceSha,
+    version,
+    tag: `v${version}`,
+    channel,
+    stable,
+    android_version_code: String(buildNumber),
+    android_track: stable ? "production" : "internal",
+    amazon_track: stable ? "production" : "testing",
+    samsung_track: stable ? "production" : "beta",
+    solana_track: stable ? "production" : "review",
+    ios_marketing_version: `${parsed.major}.${parsed.minor}.${parsed.patch}`,
+    ios_build_number: String(buildNumber),
+    apple_lane: stable ? "release" : "beta",
+    snap_channel: stable ? "stable" : "beta",
+    extension_version: extensionVersion(parsed),
+    chrome_publish_target: stable ? "default" : "trustedTesters",
+    firefox_channel: "listed",
+    flathub_branch: stable ? "stable" : "beta",
+  });
+}
+
+function writeGitHubOutputs(filePath, plan) {
+  const lines = Object.entries(plan).map(([name, value]) => {
+    if (!["string", "boolean"].includes(typeof value)) {
+      throw new Error(`Store release output ${name} must be scalar`);
+    }
+    return `${name}=${value}`;
+  });
+  appendFileSync(filePath, `${lines.join("\n")}\n`, "utf8");
+}
+
+export function main(args = process.argv.slice(2)) {
+  const plan = createStoreReleasePlan({
+    version: requireArgument(args, "--version"),
+    channel: requireArgument(args, "--channel"),
+    sourceSha: requireArgument(args, "--source-sha"),
+  });
+  const outputIndex = args.indexOf("--github-output");
+  if (outputIndex >= 0) {
+    if (!args[outputIndex + 1]) throw new Error("--github-output requires a path");
+    writeGitHubOutputs(args[outputIndex + 1], plan);
+  }
+  console.log(`${JSON.stringify(plan, null, 2)}\n`);
+  return plan;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    // error-policy:J1 command boundary reports invalid release identity
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
# Relates to

Relates to #20883, #20886, #20887, and #20917.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact-head capacity failure is recorded below.
- [x] A reviewer can confirm the workflow contract from the exact-head tests and static validation below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [x] Rebased review head passes focused workflow validation. The full gate reached workspace lint and failed on an unchanged `plugin-wallet` formatting error documented below; the pre-repair remote Quality job is green.

# Risks

Medium. This changes release automation and future store submissions. Every publisher leg remains bound to the finalized tag and source SHA, runs behind `production-release`, and fails closed on missing credentials. No store upload was executed by this PR.

# Background

## What does this PR do?

- Adds one deterministic cross-store release plan for semver, Android/iOS build numbers, channels, and extension-ready versions.
- Makes Snap publication callable-only from the canonical transactional release, corrects the registered snap identity to `eliza`, upgrades the manifest to stable grade, validates credentials, and binds the build to the exact finalized tag.
- Adds a callable-only mobile workflow invoked after canonical finalization.
- Builds and audits the Play-safe cloud AAB, validates raw or base64 service-account JSON, and uploads the exact artifact to the planned Play track.
- Builds the App Store iOS variant with the embedded runtime and deterministic version, uses App Store Connect API-key authentication, and selects TestFlight vs App Store review from the canonical channel.
- Documents every environment-owned secret and the first-listing prerequisite.

## What kind of change is this?

Improvement to release infrastructure.

# Documentation changes needed?

Updated `.github/workflows/README.md` with the canonical flow and secret contract.

# Testing

## Where should a reviewer start?

- `packages/scripts/store-release-plan.mjs`
- `.github/workflows/store-mobile-publish.yml`
- `.github/workflows/snap-publish.yml`
- `packages/scripts/__tests__/store-release-workflow.test.ts`

## Detailed testing steps

Exact head: `36e0603020c207dd9a821079c5eec145d03c160e`

- `ruby -c` on both Fastfiles: PASS.
- Pinned `actionlint` configuration against all three changed workflows: PASS.
- Release plan + workflow authority + existing release authority: 12 tests PASS, 0 fail. The reviewer repair now derives every shipping iOS extension identifier from the generated Xcode project instead of provisioning only Website Blocker.
- Snap workspace contract: PASS.
- `git diff --check`: PASS.
- `bun run verify`: the rebased review head completed repository preflight and entered the 143-package typecheck/lint lane; it stopped on unchanged `plugins/plugin-wallet/src/analytics/dexscreener/service.ts` formatting outside this PR diff.
- Pre-repair remote diagnostic (`ae6bebb6d3430ac3a72ea7532d9ce476f0fcda58`): [run 32068045085](https://github.com/elizaOS/eliza/actions/runs/32068045085). `Quality` (including repository verification) PASS; `Android release AAB` PASS with the canonical Cloud AAB build/audit and uploaded evidence. The aggregate diagnostic is red only in unchanged repository surfaces outside this PR diff: three script-contract failures, the same canonical deploy-source failure in Cloud smoke, and existing UI smoke console failures.

# Evidence Gate

<!-- evidence-head:36e0603020c207dd9a821079c5eec145d03c160e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow and packaging metadata only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow and packaging metadata only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime backend path changed; publisher logs require a future credentialed canonical release.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, model, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain mutation was performed; this PR changes future release automation only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - release infrastructure only.

## Backend + frontend logs

N/A - no runtime backend/frontend path changed. Workflow validation results are listed under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changed.

## Audio / voice walkthrough

N/A - no voice behavior changed.

## Known gaps / failures

- The rebased review head's full local `bun run verify` reached workspace lint and failed on unchanged `plugins/plugin-wallet/src/analytics/dexscreener/service.ts` formatting outside this PR diff. The pre-repair remote `Quality` and `Android release AAB` jobs are green; their evidence is historical after the reviewer repair.
- Apple and Google Play cannot execute real uploads until organization enrollment, first app records, agreements, roles, and environment secrets exist. Those external prerequisites remain in the linked issues.
- This scoped PR does not claim Microsoft, Amazon, Samsung, Solana Mobile, Flathub, Chrome, Firefox, Safari, or Edge publication complete; the epic continues to track them.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza"} -->

