### PR TITLE
style(cloud): format the barge-in result-promise observer

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -657,10 +657,7 @@ export async function runSharedAgentTurnStream(
     ] as const;
     for (const prop of settledResultProps) {
       const pending = (result as unknown as Record<string, unknown>)[prop];
-      if (
-        pending &&
-        typeof (pending as PromiseLike<unknown>).then === "function"
-      ) {
+      if (pending && typeof (pending as PromiseLike<unknown>).then === "function") {
         void Promise.resolve(pending as PromiseLike<unknown>).catch(() => {});
       }
     }


### PR DESCRIPTION
Biome formatting for #21439's observer loop, which failed cloud-shared lint:check in release candidate run 32066651628. Package-wide biome check now clean (2023 files); suite 10/10.