### PR TITLE
fix(desktop): default Linux Electrobun to CEF

### DIFF
--- a/packages/app-core/platforms/electrobun/electrobun.config.ts
+++ b/packages/app-core/platforms/electrobun/electrobun.config.ts
@@ -84,10 +84,6 @@ function linuxCefChromiumFlags(): Record<string, string | true> {
   });
 }
 
-const linuxCefEnabled = isTruthyEnv(
-  process.env.ELIZA_ELECTROBUN_ENABLE_LINUX_CEF,
-);
-
 export function hasElectrobunWorkspaceRoot(candidateDir: string): boolean {
   return (
     fs.existsSync(path.join(candidateDir, "bun.lock")) &&
@@ -667,13 +663,15 @@ export function createElectrobunConfig(): ElectrobunConfig {
               },
       },
       linux: {
-        // Linux CEF remains opt-in until its helper processes are stable
-        // enough for the default desktop shell.
-        bundleCEF: linuxCefEnabled,
+        // The system WebKitGTK renderer can execute the packaged app while
+        // failing to composite any pixels, leaving a solid white client area.
+        // Bundle Chromium so Linux uses the same renderer that paints the
+        // packaged first-run page correctly outside the native GTK webview.
+        bundleCEF: true,
         bundleWGPU: true,
-        defaultRenderer: "native",
+        defaultRenderer: "cef",
         icon: "assets/appIcon.png",
-        chromiumFlags: linuxCefEnabled ? linuxCefChromiumFlags() : {},
+        chromiumFlags: linuxCefChromiumFlags(),
       },
       win: {
         bundleCEF: true,

--- a/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
@@ -9,6 +9,15 @@ import {
 } from "../electrobun.config";
 
 describe("Electrobun Store packaging", () => {
+  it("bundles CEF as the default Linux renderer", () => {
+    const config = createElectrobunConfig();
+
+    expect(config.build?.linux).toMatchObject({
+      bundleCEF: true,
+      defaultRenderer: "cef",
+    });
+  });
+
   it("omits the embedded local agent runtime tree for Mac App Store builds", () => {
     const copy = resolveElectrobunCopyMap({
       buildVariant: "store",


### PR DESCRIPTION
# Relates to

Operator-requested Linux desktop fix; no linked issue was supplied.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the changed Linux renderer path from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3920ae52eb6aabd6dad09d5d2686f3c5a1da148a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Medium. Linux desktop packages now include CEF and use it by default, increasing the Linux artifact size. The native GTK/WebKitGTK renderer remains available. macOS and Windows configuration is unchanged.

# Background

## What does this PR do?

Bundles CEF for Linux Electrobun builds and makes CEF the default Linux renderer. It also adds a configuration regression test.

This bypasses the native GTK/WebKitGTK path that executes the packaged renderer but can fail to composite it, producing a white client area. The same packaged renderer paints through Chromium/CEF.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is required. The renderer choice is an internal packaging default; native rendering remains available.

# Testing

## Where should a reviewer start?

Review `packages/app-core/platforms/electrobun/electrobun.config.ts`, then inspect the Linux evidence and runtime log.

## Detailed testing steps

1. On Linux, install WebKitGTK/AppIndicator runtime dependencies required by Electrobun's weak-linked wrapper.
2. Build the cloud-only desktop:
   ```bash
   ELIZA_DESKTOP_CLOUD_ONLY=1 node packages/app-core/scripts/desktop-build.mjs build --cloud-only
   ```
3. Leave `ELIZA_DESKTOP_BOTTOM_BAR` unset and launch the unpacked artifact under X11.
4. Verify `Resources/build.json` contains `"defaultRenderer":"cef"` and `"availableRenderers":["native","cef"]`.
5. Verify the Eliza tray icon appears and the transparent bottom-centered pill paints.
6. Hover the pill and verify the native host changes from 96x56 at `(672,944)` to 600x96 at `(420,904)` on a 1440x1000 display.
7. Confirm logs contain `window shell mode: chat-overlay`, the renderer build ID, and `phase=first-run-required` even while the local `:31337` agent is unavailable.

Validated in smolvm Ubuntu 24.04 ARM64 using a non-root desktop user, Xvfb, stalonetray, software GL, and the packaged cloud-only artifact from PR head `3920ae52eb6aabd6dad09d5d2686f3c5a1da148a`.

# Evidence Gate

<!-- evidence-head:3920ae52eb6aabd6dad09d5d2686f3c5a1da148a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Reporter supplied the pre-fix reproduction; no exact-head before capture exists because the native WebKitGTK failure predates this branch.
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21444-eliza-linux-pill-contact-sheet.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21444-eliza-linux-pill-interaction.webm
<!-- evidence-row:backend-logs -->
- [ ] N/A - Cloud-only first-run does not start a local agent backend.
<!-- evidence-row:frontend-logs -->
- [x] [21444-eliza-linux-pill-interaction.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21444-eliza-linux-pill-interaction.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model call occurs in the first-run shell paint path.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - This change affects the native desktop renderer selection only.
<!-- evidence-row:ocr-review -->
- [ ] N/A - The resting pill is intentionally an unlabeled handle; native window geometry and visible pixel evidence are attached.

# Evidence Details

## Backend + frontend logs

The attached frontend/native log records:

```text
[Renderer] Static server on http://127.0.0.1:5174
X11: Created transparent window with 32-bit ARGB visual
[Renderer:console] [shell] window shell mode: chat-overlay
[Renderer:console] [renderer-build] 7db457c990c3 ... (variant=direct, target=web/desktop)
[startup-coordinator] phase=first-run-required
Agent not ready (no port assigned yet)
```

Native diagnostics report `trayPresent: true`, a transparent hidden-titlebar main window, and the expected rest/hover frames. X11 shows the Eliza tray icon embedded into stalonetray and the CEF Chromium child process.

## Screenshots (before / after) + video walkthrough

### Before

N/A - see the reporter's white-window reproduction in the originating request.

### After

Attached through the evidence rows after PR creation.

### Walkthrough video

Attached through the evidence rows after PR creation. It starts before launch and shows the embedded tray icon and painted transparent pill.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changes.

## Known gaps / failures

- smolvm on Apple Silicon validates Linux ARM64. A Debian x64 release smoke test remains recommended.
- Xvfb plus stalonetray proves tray icon embedding and pill painting. Synthetic X11 clicks did not produce Electrobun's native `tray-clicked` event, so tray-menu click semantics remain unverified in this headless environment; validate that interaction on GNOME or KDE before release.
- Electrobun's bundled downloader intermittently reported `unknown certificate verification error`; the exact pinned 1.18.1 core/CEF release archives were fetched with Ubuntu `curl` and packaging then completed normally.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@3920ae52eb6aabd6dad09d5d2686f3c5a1da148a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [desktop-linux]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@3920ae52eb6aabd6dad09d5d2686f3c5a1da148a:packages/skills/skills/contribute-to-eliza"} -->


