### PR TITLE
fix(plugin-agent-orchestrator): reject malformed orchestrator path encoding

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.encoding.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.encoding.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Untrusted path-encoding contract for `/api/orchestrator/*` id segments.
+ *
+ * `handleOrchestratorRoutes` maps every throw to HTTP 500. Raw
+ * `decodeURIComponent` on built-app, task, and session path segments therefore
+ * reports client garbage (`%`, truncated UTF-8) as a server fault. These tests
+ * drive the real dispatcher with service/registry mocks so a malformed escape
+ * is 400 before `deleteBuiltApp`, `getTask`, or `stopTaskAgent`.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RouteContext } from "../../src/api/route-utils.js";
+
+const registry = vi.hoisted(() => ({
+  deleteBuiltApp: vi.fn(),
+  listBuiltApps: vi.fn(),
+}));
+
+const serviceFns = vi.hoisted(() => ({
+  getTask: vi.fn(),
+  stopTaskAgent: vi.fn(),
+}));
+
+vi.mock("../../src/services/built-apps-registry.js", () => ({
+  deleteBuiltApp: registry.deleteBuiltApp,
+  listBuiltApps: registry.listBuiltApps,
+}));
+
+vi.mock("../../src/services/orchestrator-task-service.js", () => ({
+  OrchestratorTaskService: { serviceType: "ORCHESTRATOR_TASK_SERVICE" },
+  RecoveryConflictError: class RecoveryConflictError extends Error {},
+}));
+
+vi.mock("../../src/services/goal-llm-verifier.js", () => ({
+  LLM_GOAL_VERIFIER_NAME: "goal-verifier",
+  verifyGoalCompletion: vi.fn(),
+}));
+
+vi.mock("../../src/services/orchestrator-widget-contract.js", () => ({
+  buildOrchestratorWidgetSnapshot: vi.fn(),
+}));
+
+vi.mock("../../src/services/types.js", () => ({
+  AdmissionQueueFullError: class AdmissionQueueFullError extends Error {},
+}));
+
+import { handleOrchestratorRoutes } from "../../src/api/orchestrator-routes.js";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+
+const fakeService = {
+  getTask: serviceFns.getTask,
+  stopTaskAgent: serviceFns.stopTaskAgent,
+};
+
+function ctxWithService(service: typeof fakeService | null): RouteContext {
+  return {
+    runtime: {
+      getService: () => service,
+      hasService: () => service !== null,
+      getServiceLoadPromise: () => Promise.resolve(undefined),
+      reportError: vi.fn(),
+    },
+    acpService: null,
+    workspaceService: null,
+  } as never;
+}
+
+function makeReq(method: string, url: string): IncomingMessage {
+  const stream = Readable.from([]);
+  return Object.assign(stream, { method, url }) as unknown as IncomingMessage;
+}
+
+class CapturingResponse {
+  statusCode = 0;
+  body = "";
+  writeHead(status: number): this {
+    this.statusCode = status;
+    return this;
+  }
+  end(chunk?: string): this {
+    if (chunk !== undefined) this.body = chunk;
+    return this;
+  }
+  json(): Record<string, unknown> {
+    return this.body ? (JSON.parse(this.body) as Record<string, unknown>) : {};
+  }
+}
+
+async function call(
+  method: string,
+  fullPath: string,
+  service: typeof fakeService | null = fakeService,
+): Promise<{
+  matched: boolean;
+  status: number;
+  json: Record<string, unknown>;
+}> {
+  const pathname = fullPath.split("?")[0] ?? fullPath;
+  const res = new CapturingResponse();
+  const matched = await handleOrchestratorRoutes(
+    makeReq(method, fullPath),
+    res as unknown as ServerResponse,
+    pathname,
+    ctxWithService(service),
+  );
+  return { matched, status: res.statusCode, json: res.json() };
+}
+
+describe("orchestrator routes — path encoding", () => {
+  beforeEach(() => {
+    registry.deleteBuiltApp.mockReset();
+    serviceFns.getTask.mockReset();
+    serviceFns.stopTaskAgent.mockReset();
+  });
+
+  it("returns 400 for a malformed built-app slug before deleteBuiltApp", async () => {
+    const result = await call(
+      "DELETE",
+      "/api/orchestrator/built-apps/custom/%",
+      null,
+    );
+    expect(result.matched).toBe(true);
+    expect(result.status).toBe(400);
+    expect(result.json.error).toBe(
+      "Invalid built-app path: malformed URL encoding",
+    );
+    expect(registry.deleteBuiltApp).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed built-app target", async () => {
+    const result = await call(
+      "DELETE",
+      "/api/orchestrator/built-apps/%E0%A4%A/launchpad",
+      null,
+    );
+    expect(result.matched).toBe(true);
+    expect(result.status).toBe(400);
+    expect(result.json.error).toBe(
+      "Invalid built-app path: malformed URL encoding",
+    );
+    expect(registry.deleteBuiltApp).not.toHaveBeenCalled();
+  });
+
+  it("still deletes a percent-encoded built-app slug", async () => {
+    registry.deleteBuiltApp.mockResolvedValue(true);
+    const result = await call(
+      "DELETE",
+      "/api/orchestrator/built-apps/custom/launch%20pad",
+      null,
+    );
+    expect(result.matched).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.json.deleted).toBe(true);
+    expect(registry.deleteBuiltApp).toHaveBeenCalledWith(
+      expect.anything(),
+      "custom",
+      "launch pad",
+    );
+  });
+
+  it("returns 400 for a malformed task id before getTask", async () => {
+    expect(OrchestratorTaskService.serviceType).toBe(
+      "ORCHESTRATOR_TASK_SERVICE",
+    );
+    const result = await call("GET", "/api/orchestrator/tasks/%ZZ");
+    expect(result.matched).toBe(true);
+    expect(result.status).toBe(400);
+    expect(result.json.error).toBe("Invalid task id: malformed URL encoding");
+    expect(serviceFns.getTask).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed session id before stopTaskAgent", async () => {
+    const result = await call(
+      "POST",
+      "/api/orchestrator/tasks/task-1/agents/%/stop",
+    );
+    expect(result.matched).toBe(true);
+    expect(result.status).toBe(400);
+    expect(result.json.error).toBe(
+      "Invalid session id: malformed URL encoding",
+    );
+    expect(serviceFns.stopTaskAgent).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -47,6 +47,16 @@ import {
 
 const PREFIX = "/api/orchestrator";
 
+function decodeOrchestratorPathSegment(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — a malformed percent-escape
+    // is client garbage; null tells the caller to 400, not the 500 boundary.
+    return null;
+  }
+}
+
 const PRIORITIES: ReadonlySet<string> = new Set([
   "low",
   "normal",
@@ -205,8 +215,12 @@ async function dispatchOrchestratorRoutes(
     builtAppsRest.length > 0
   ) {
     const segments = builtAppsRest.split("/").filter((s) => s.length > 0);
-    const target = decodeURIComponent(segments[0] ?? "");
-    const slug = decodeURIComponent(segments[1] ?? "");
+    const target = decodeOrchestratorPathSegment(segments[0] ?? "");
+    const slug = decodeOrchestratorPathSegment(segments[1] ?? "");
+    if (target === null || slug === null) {
+      sendError(res, "Invalid built-app path: malformed URL encoding", 400);
+      return true;
+    }
     if (segments.length !== 2 || !slug) {
       sendError(res, "target and slug are required", 400);
       return true;
@@ -435,9 +449,13 @@ async function dispatchOrchestratorRoutes(
   const rest = pathname.slice(`${PREFIX}/tasks/`.length);
   if (pathname.startsWith(`${PREFIX}/tasks/`) && rest.length > 0) {
     const segments = rest.split("/").filter((s) => s.length > 0);
-    const taskId = decodeURIComponent(segments[0] ?? "");
+    const taskId = decodeOrchestratorPathSegment(segments[0] ?? "");
     const sub = segments[1];
 
+    if (taskId === null) {
+      sendError(res, "Invalid task id: malformed URL encoding", 400);
+      return true;
+    }
     if (!taskId) {
       sendError(res, "taskId is required", 400);
       return true;
@@ -1116,7 +1134,11 @@ async function dispatchOrchestratorRoutes(
         segments.length === 4 &&
         segments[3] === "stop"
       ) {
-        const sessionId = decodeURIComponent(segments[2] ?? "");
+        const sessionId = decodeOrchestratorPathSegment(segments[2] ?? "");
+        if (sessionId === null) {
+          sendError(res, "Invalid session id: malformed URL encoding", 400);
+          return true;
+        }
         let stopped: boolean;
         try {
           stopped = await service.stopTaskAgent(taskId, sessionId);


### PR DESCRIPTION

# PI eliza encoding-leftover — 2026-08-18

**Repo:** `elizaOS/eliza`
**Public writes:** none
**Worktree:** `/Users/thescoho/Developer/worktrees/eliza-encoding-leftover-20260818`
**Branch:** `fix/orchestrator-path-encoding`
**HEAD:** `e03bf3eccf6f555a7504fd0e92dff0076d6b84c3`
**Provider/model/client:** xAI / grok-4.6 / Grok CLI

## Live pin
| Pin | Value |
| origin/develop | `4342b1b06472167b70cc371d432e8c34fa3d9ea3` |
| Method | local git only (no gh) + occupancy.json + LIVING.md hard skips |
| Ownership | unowned |

Occupancy `state/occupancy.json` (`scannedAt` 2026-08-17T20:01:44.076Z) does not claim `orchestrator-routes.ts`. Disjoint from persist-json `#20807`, first-run JSON, avatar URI, billing JSON, Wayland `#21405`, cookie-header `#21406`, and the cloud `parseInt` series.

## Defect
`handleOrchestratorRoutes` wraps every throw in HTTP 500. Built-app `target`/`slug`, task id, and session id used raw `decodeURIComponent`. A malformed percent-escape (`%`, `%ZZ`, truncated UTF-8) became a server fault instead of a client 400, before `deleteBuiltApp` / `getTask` / `stopTaskAgent`.

## Paths / symbols / contract
- `plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts` — `decodeOrchestratorPathSegment` / `dispatchOrchestratorRoutes`
- `plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.encoding.test.ts`

Malformed decode → 400 `Invalid …: malformed URL encoding`. Valid `%20` slug still deletes. Empty decoded task id still 400 `taskId is required`.

## Red proof
Stock decoder, tests only:

`cd plugins/plugin-agent-orchestrator && ../../node_modules/.bin/vitest run --config vitest.config.ts __tests__/unit/orchestrator-routes.encoding.test.ts --coverage.enabled=false`

4 failed / 1 passed. Failures were `%` / `%E0%A4%A` / `%ZZ` / session `%` — all **500**. Encoded `launch%20pad` still 200.

## Green proof
Same command at `e03bf3eccf` — 5 passed (1 file).

## Changed files
2 files vs `origin/develop` (`scope-check.sh --checkout … --max-files 2` PASS):

```text
 plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.encoding.test.ts | 186 +
 plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts                      |  30 +-
 2 files changed, 212 insertions(+), 4 deletions(-)
```

Local commit: `e03bf3eccf` with factory trailer (`attr-stamp.sh --commit-trailer`). No push. `cycle-gate.sh` needs `gh` — skipped.

## Do not publish if
Collision on `plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts`. None at mine time.

## Stop
Miner finished. Factory/Cursor may publish only via attended post.sh.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e03bf3eccf6f555a7504fd0e92dff0076d6b84c3 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
