### PR TITLE
fix(test): await browser voice shim readiness

### DIFF
--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -702,7 +702,27 @@ async function installChatSpeechRecognitionShim(page: Page): Promise<void> {
       });
       return true;
     };
+    (window as unknown as Record<string, unknown>).__homeVoiceReady = () =>
+      instances.some((instance) => instance.started);
   });
+}
+
+async function waitForChatSpeechRecognitionShim(page: Page): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const ready = (
+            window as unknown as { __homeVoiceReady?: () => boolean }
+          ).__homeVoiceReady;
+          return ready?.() ?? false;
+        }),
+      {
+        message: "home voice shim must start before the scripted turn",
+        timeout: 10_000,
+      },
+    )
+    .toBe(true);
 }
 
 test.describe("assistant home app flow", () => {
@@ -845,6 +865,7 @@ test.describe("assistant home app flow", () => {
     const mic = assistantMicButton(page);
     await expect(mic).toBeEnabled({ timeout: 30_000 });
     await mic.click();
+    await waitForChatSpeechRecognitionShim(page);
 
     const accepted = await page.evaluate(() => {
       const simulate = (
@@ -990,6 +1011,7 @@ test.describe("assistant home app flow", () => {
       pointerType: "mouse",
     });
     await mic.click();
+    await waitForChatSpeechRecognitionShim(page);
 
     // The release-click starts the same hands-free conversation a tap starts:
     // the scripted final transcript is auto-submitted as a turn, not inserted


### PR DESCRIPTION
Closes #21451.

## Root cause

At base `fc6ab2ab77f8f83ac207f37a3975d71941cd6941`, the assistant-home Playwright harness injected its scripted transcript immediately after the mic click. Production voice capture now awaits backend selection before it creates and starts `SpeechRecognition`, so a loaded runner could reach the injector first and receive `false` even though the production start path was still progressing normally.

## Repair

- expose a deterministic ready predicate from the fake browser recognizer
- poll that predicate before injecting speech in the scripted STT test
- apply the same readiness contract to the held-Talk test, which shared the race
- leave production voice code unchanged

## Validation

- `git diff --check`
- `bunx @biomejs/biome check packages/app/test/ui-smoke/assistant-home-flow.spec.ts`
- focused Playwright launch reached the real app renderer build, then the shared host exhausted disk during `rollup-plugin-visualizer` output (`ENOSPC`); the spec itself did not start

Exact browser execution remains pending on a host with working disk capacity. This is a test-only synchronization change; production source is untouched.

The original failure is Tests run `32067331306`, job `95502973008`. No deployment or workflow rerun was performed.

## Provenance

- Provider/model: OpenAI `gpt-5.6-sol`
- Client: Codex Desktop
- Attribution: self-reported
