### PR TITLE
perf(cloud): isolate managed Discord ingress

### DIFF
--- a/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
@@ -7,17 +7,9 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { agentGatewayRouterService } from "@/lib/services/agent-gateway-router";
-import {
-  authorizeManagedDiscordGuildVoice,
-  runManagedDiscordGuildTextTurn,
-} from "@/lib/services/managed-discord-guild-voice";
-import { resolveSharedRuntimeWorkerRequestContext } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
-import personalSharedMessagesApp from "../../../eliza-app/personal-shared/messages/route";
-import { markPreverifiedPersonalSharedRequest } from "../../../eliza-app/personal-shared/preverified-auth";
 
 const messageSchema = z.object({
   guildId: z.string().trim().min(1).optional(),
@@ -46,6 +38,17 @@ app.post("/", async (c) => {
     const body = messageSchema.parse(await c.req.json());
     const validationMs = performance.now() - validationStartedAt;
     if (body.guildId) {
+      const [gatewayRouter, guildText, sharedWorker] = await Promise.all([
+        import("@/lib/services/agent-gateway-router"),
+        import("@/lib/services/managed-discord-guild-voice"),
+        import("@/lib/services/shared-runtime/resolve-shared-agent"),
+      ]);
+      const { agentGatewayRouterService } = gatewayRouter;
+      const {
+        authorizeManagedDiscordGuildVoice,
+        runManagedDiscordGuildTextTurn,
+      } = guildText;
+      const { resolveSharedRuntimeWorkerRequestContext } = sharedWorker;
       const result = await agentGatewayRouterService.routeDiscordMessage({
         guildId: body.guildId,
         channelId: body.channelId,
@@ -97,6 +100,12 @@ app.post("/", async (c) => {
       return c.json({ handled: true, ...shared });
     }
 
+    const [personalSharedRoute, preverifiedAuth] = await Promise.all([
+      import("../../../eliza-app/personal-shared/messages/route"),
+      import("../../../eliza-app/personal-shared/preverified-auth"),
+    ]);
+    const personalSharedMessagesApp = personalSharedRoute.default;
+    const { markPreverifiedPersonalSharedRequest } = preverifiedAuth;
     const personalSharedRequest = new Request(
       "https://personal-shared.internal/",
       {

--- a/packages/cloud/api/src/discord-gateway-app.ts
+++ b/packages/cloud/api/src/discord-gateway-app.ts
@@ -1,0 +1,105 @@
+/**
+ * Dependency-bounded Hono shell for authenticated managed Discord turns.
+ *
+ * The Railway gateway already owns provider ingress and retries. This shell
+ * preserves the Cloud request context, security headers, and internal JWT
+ * boundary without evaluating the generated application router before every
+ * ordinary channel message.
+ */
+
+import { Hono } from "hono";
+import { requestId } from "hono/request-id";
+import { secureHeaders } from "hono/secure-headers";
+import { runWithDbCacheAsync } from "@/db/client";
+import {
+  getIpKey,
+  getRequestIp,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { httpTelemetryMiddleware } from "@/lib/observability/http-telemetry-hono";
+import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { runWithRequestContext } from "@/lib/runtime/request-context";
+import { setRuntimeR2Bucket } from "@/lib/storage/r2-runtime-binding";
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import managedDiscordMessages from "../internal/discord/eliza-app/messages/route";
+
+export function createDiscordGatewayApp(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>({ strict: false });
+
+  app.use("*", async (c, next) => {
+    setRuntimeR2Bucket(c.env.BLOB);
+    await runWithCloudBindingsAsync(c.env, async () =>
+      runWithRequestContext(
+        {
+          clientIp: getRequestIp(c),
+          idempotencyKey:
+            c.req.header("idempotency-key") ??
+            c.req.header("x-request-id") ??
+            crypto.randomUUID(),
+          defer: (task) => c.executionCtx.waitUntil(task),
+        },
+        async () => runWithDbCacheAsync(async () => next()),
+      ),
+    );
+  });
+  app.use("*", requestId());
+  app.use("*", httpTelemetryMiddleware());
+  app.use(
+    "*",
+    secureHeaders({
+      xContentTypeOptions: "nosniff",
+      strictTransportSecurity: "max-age=63072000; includeSubDomains; preload",
+      xFrameOptions: "DENY",
+      referrerPolicy: "strict-origin-when-cross-origin",
+      crossOriginResourcePolicy: "cross-origin",
+      crossOriginEmbedderPolicy: false,
+      crossOriginOpenerPolicy: false,
+    }),
+  );
+  app.use("*", async (c, next) => {
+    await next();
+    if (
+      !c.res.headers.has("Cache-Control") &&
+      c.res.headers.get("Content-Type")?.includes("application/json")
+    ) {
+      c.res.headers.set("Cache-Control", "no-store");
+    }
+  });
+  app.use(
+    "*",
+    rateLimit(
+      {
+        windowMs: 60_000,
+        maxRequests: 600,
+        keyGenerator: (c) => `global:${getIpKey(c)}`,
+      },
+      { bindingName: "GLOBAL_RATE_LIMITER" },
+    ),
+  );
+
+  app.route("/api/internal/discord/eliza-app/messages", managedDiscordMessages);
+
+  app.notFound((c) =>
+    c.json(
+      { success: false, error: "Not found", code: "resource_not_found" },
+      404,
+    ),
+  );
+  // error-policy:J1 internal gateway transport boundary returns a structured failure.
+  app.onError((error, c) => {
+    logger.error("[DiscordGatewayApp] Unhandled error", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return c.json(
+      {
+        success: false,
+        error: "Internal server error",
+        code: "internal_error",
+      },
+      500,
+    );
+  });
+
+  return app;
+}

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -9,6 +9,7 @@ import cloudApiWorker, {
   getHostedFrontendServeRewrite,
   isCanonicalInferencePath,
   isElizaAppWebhookPath,
+  isInternalDiscordGatewayPath,
   isThinInferenceEnabled,
   isThinStewardPublicPath,
   isUnsupportedLegacyWildcardHostname,
@@ -105,6 +106,78 @@ test("matches only supported provider webhook routes", () => {
   );
   expect(isElizaAppWebhookPath("/api/eliza-app/webhook/unknown")).toBe(false);
   expect(isElizaAppWebhookPath("/api/eliza-app/webhook")).toBe(false);
+});
+
+test("matches only the managed Discord gateway route", () => {
+  expect(
+    isInternalDiscordGatewayPath("/api/internal/discord/eliza-app/messages"),
+  ).toBe(true);
+  expect(
+    isInternalDiscordGatewayPath("/api/internal/discord/eliza-app/messages/"),
+  ).toBe(false);
+  expect(
+    isInternalDiscordGatewayPath(
+      "/api/internal/discord/eliza-app/messages/admin",
+    ),
+  ).toBe(false);
+});
+
+test("dispatches managed Discord turns without full-app bootstrap", async () => {
+  const traceId = "33333333-3333-4333-8333-333333333333";
+  const env = {
+    ENVIRONMENT: "test",
+    NODE_ENV: "test",
+    REDIS_RATE_LIMITING: "false",
+    CACHE_ENABLED: "false",
+    THIN_INFERENCE_ENTRY_ENABLED: "false",
+    BLOB: {},
+  } as unknown as AppEnv["Bindings"];
+  const executionCtx = {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as ExecutionContext;
+  const makeRequest = () =>
+    new Request(
+      "https://api.eliza.app/api/internal/discord/eliza-app/messages",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-eliza-trace-id": traceId,
+        },
+        body: "{}",
+      },
+    );
+
+  const response = await cloudApiWorker.fetch(makeRequest(), env, executionCtx);
+
+  expect(response.status).toBe(401);
+  expect(response.headers.get("x-eliza-trace-id")).toBe(traceId);
+  expect(response.headers.get("x-eliza-discord-path")).toBe("thin");
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  expect(response.headers.get("server-timing")).toMatch(
+    /discord_entry_dispatch;dur=\d+(?:\.\d+)?/,
+  );
+  expect(response.headers.get("server-timing")).toMatch(
+    /discord_module_init;dur=\d+(?:\.\d+)?/,
+  );
+  expect(response.headers.get("server-timing")).not.toContain(
+    "full_app_dispatch",
+  );
+
+  const warmResponse = await cloudApiWorker.fetch(
+    makeRequest(),
+    env,
+    executionCtx,
+  );
+  expect(warmResponse.status).toBe(401);
+  expect(warmResponse.headers.get("server-timing")).toContain(
+    "discord_entry_dispatch",
+  );
+  expect(warmResponse.headers.get("server-timing")).not.toContain(
+    "discord_module_init",
+  );
 });
 
 test("preserves provider authentication on the thin webhook path", async () => {

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -1,9 +1,10 @@
 /**
  * Cloud API — Cloudflare Workers entrypoint (thin bootstrap).
  *
- * The full Hono stack lives in `./bootstrap-app.ts` and is loaded on first
- * `fetch` / `scheduled` invocation so Worker startup stays under Cloudflare's
- * CPU budget (error 10021).
+ * The full Hono stack lives in `./bootstrap-app.ts` and is loaded only for
+ * unmatched `fetch` / `scheduled` invocations. Latency-critical provider,
+ * inference, and internal gateway routes use bounded shells so ordinary turns
+ * do not evaluate the generated application router.
  *
  *   bun run codegen   # regen the router after adding/removing routes
  *   bun run dev       # wrangler dev
@@ -48,6 +49,8 @@ const inferenceAppPromises = new Map<string, Promise<Hono<AppEnv>>>();
 let stewardThinAppPromise: Promise<Hono<AppEnv>> | undefined;
 /** Lazy provider-webhook shell that avoids the generated application router. */
 let webhookAppPromise: Promise<Hono<AppEnv>> | undefined;
+/** Lazy authenticated Discord shell that avoids the generated application router. */
+let discordGatewayAppPromise: Promise<Hono<AppEnv>> | undefined;
 
 const STAGING_SESSION_UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -322,6 +325,72 @@ async function dispatchWebhook(
     );
   } else {
     logger.info("[CloudEntrypoint] webhook dispatch completed", logContext);
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  });
+}
+
+const INTERNAL_DISCORD_GATEWAY_PATH =
+  "/api/internal/discord/eliza-app/messages";
+
+export function isInternalDiscordGatewayPath(pathname: string): boolean {
+  return pathname === INTERNAL_DISCORD_GATEWAY_PATH;
+}
+
+async function getDiscordGatewayApp(): Promise<Hono<AppEnv>> {
+  discordGatewayAppPromise ??= import("./discord-gateway-app").then((module) =>
+    module.createDiscordGatewayApp(),
+  );
+  return discordGatewayAppPromise;
+}
+
+async function dispatchDiscordGateway(
+  request: Request,
+  env: AppEnv["Bindings"],
+  ctx: ExecutionContext,
+): Promise<Response | null> {
+  const pathname = new URL(request.url).pathname;
+  if (!isInternalDiscordGatewayPath(pathname)) return null;
+
+  const startedAt = performance.now();
+  const moduleWasInitialized = discordGatewayAppPromise !== undefined;
+  const traceId = resolveElizaTraceId(request.headers);
+  const headers = new Headers(request.headers);
+  headers.set(ELIZA_TRACE_ID_HEADER, traceId);
+  const app = await getDiscordGatewayApp();
+  const moduleInitMs = performance.now() - startedAt;
+  const response = await app.fetch(new Request(request, { headers }), env, ctx);
+  const dispatchMs = performance.now() - startedAt;
+  const responseHeaders = new Headers(response.headers);
+  setHttpTelemetryHeaders(responseHeaders, traceId, [
+    { name: "discord_entry_dispatch", durationMs: dispatchMs },
+    ...(!moduleWasInitialized
+      ? [{ name: "discord_module_init", durationMs: moduleInitMs }]
+      : []),
+  ]);
+  responseHeaders.set("X-Eliza-Discord-Path", "thin");
+
+  const logContext = {
+    traceId,
+    status: response.status,
+    moduleWasInitialized,
+    moduleInitMs: Math.round(moduleInitMs * 100) / 100,
+    durationMs: Math.round(dispatchMs * 100) / 100,
+  };
+  if (response.status >= 500 || dispatchMs >= 1_000 || moduleInitMs >= 250) {
+    logger.warn(
+      "[CloudEntrypoint] Discord gateway dispatch slow or failed",
+      logContext,
+    );
+  } else {
+    logger.info(
+      "[CloudEntrypoint] Discord gateway dispatch completed",
+      logContext,
+    );
   }
 
   return new Response(response.body, {
@@ -803,6 +872,12 @@ export default {
       );
       const webhookResponse = await dispatchWebhook(apiRequest, env, ctx);
       if (webhookResponse) return webhookResponse;
+      const discordGatewayResponse = await dispatchDiscordGateway(
+        apiRequest,
+        env,
+        ctx,
+      );
+      if (discordGatewayResponse) return discordGatewayResponse;
       const stewardThinResponse = await dispatchThinSteward(
         apiRequest,
         env,
@@ -842,6 +917,13 @@ export default {
 
     const webhookResponse = await dispatchWebhook(request, env, ctx);
     if (webhookResponse) return webhookResponse;
+
+    const discordGatewayResponse = await dispatchDiscordGateway(
+      request,
+      env,
+      ctx,
+    );
+    if (discordGatewayResponse) return discordGatewayResponse;
 
     // Login-critical Steward GETs before full-app bootstrap (#18049).
     const stewardThinResponse = await dispatchThinSteward(request, env, ctx);


### PR DESCRIPTION
Closes #21448

## What changed

- dispatches only the exact managed Discord message route through a dependency-bounded Hono shell before the generated Cloud application router
- preserves internal JWT auth, request context, native rate limiting, secure/no-store headers, trace propagation, and explicit entry/module timing
- lazy-loads guild-only and Personal Shared dependencies after the authenticated route has selected the delivery mode

## Ground truth

On staging source `06c2f911dfcf94f4c33b6aeb7758fe1fcd105490`, a natural Discord turn showed the projection DO at 219 ms and the Cerebras model at 393 ms, while the main internal Worker request spent 7.705 s with 3.271 s CPU and `moduleWasInitialized:false`. The exact endpoint was entering `dispatchFullApp` and evaluating the generated 580-route Cloud app.

Clean-process import measurements on this head:

- full `bootstrap-app`: 14,941 ms
- new Discord shell: 784 ms
- Personal Shared route on first authenticated DM: 2,071 ms

## Verification

- focused entry + Discord route: 45/45 tests, 239 assertions
- `bun run --cwd packages/cloud/api typecheck`: PASS
- production Wrangler dry bundle: PASS, 26.27 MiB / 6.36 MiB gzip
- Biome exact four paths: PASS
- `git diff --check`: PASS

No production, staging, provider, credential, or channel mutation was performed for this source change. A protected exact-source staging deploy and one natural Discord retest remain the live acceptance gate.

Agent provenance: OpenAI gpt-5.6-sol via Codex Desktop. Repository guidance: `AGENTS.md`, `CONTRIBUTING.md`, and `packages/cloud/api/CLAUDE.md`. Cloudflare and Wrangler skills were used for Worker boundary and bundle validation.