### PR TITLE
fix: restore deterministic current-develop Scenario gates

### DIFF
--- a/packages/cloud/scripts/__tests__/canonical-deploy-source-guard.test.ts
+++ b/packages/cloud/scripts/__tests__/canonical-deploy-source-guard.test.ts
@@ -312,7 +312,13 @@ describe("canonical deploy source CLI", () => {
         {
           cwd: clone,
           encoding: "utf8",
-          env: { ...process.env, GITHUB_OUTPUT: outputFile },
+          env: {
+            ...process.env,
+            GITHUB_OUTPUT: outputFile,
+            GITHUB_REPOSITORY: "",
+            GITHUB_RUN_ID: "",
+            GITHUB_TOKEN: "",
+          },
         },
       );
       expect(neutral.status).toBe(1);

--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -54,7 +54,7 @@ import {
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
 import { stringToUuid } from "./utils/string-to-uuid";
-import { resolvePgliteDir } from "./utils.node";
+import { resolvePgliteDir } from "./utils.node.ts";
 
 export type {
   AppendConnectorAccountAuditEventParams,


### PR DESCRIPTION
Closes #21450.

## What changed

- Resolve the Node-specific plugin-sql utility with its full `.ts` source extension. Node/tsx treats `.node` as a complete extension, so the former `./utils.node` specifier could not reach `utils.node.ts` through the source-mapped local provisioning path.
- Clear `GITHUB_REPOSITORY`, `GITHUB_RUN_ID`, and `GITHUB_TOKEN` in the missing-identity CLI fixture. The production guard remains unchanged and fail-closed; the test no longer inherits Actions identity and accidentally exercises a later missing-token branch.

## Validation

On the pre-rebase repair tree (the two changed file blobs are byte-identical at exact head `54f28a36e0b9c6522f4e7569ff1aa02cbc32bc27`):

- `bun run --cwd packages/app-core test:local-provisioning` — PASS; real PGlite migration, API health, running agent status, and first-run provisioning all completed.
- `GITHUB_REPOSITORY=elizaOS/eliza GITHUB_RUN_ID=123 GITHUB_TOKEN='' bun test packages/cloud/scripts/__tests__/canonical-deploy-source-guard.test.ts` — PASS, 8 tests / 48 assertions.
- `bun run --cwd plugins/plugin-sql typecheck` — PASS.
- `bun run --cwd plugins/plugin-sql build` — PASS for Node ESM, browser ESM, CJS, and declarations.
- `bunx biome check plugins/plugin-sql/src/index.node.ts packages/cloud/scripts/__tests__/canonical-deploy-source-guard.test.ts` — PASS.
- `git diff --check` — PASS on the exact head.

The stack was rebased cleanly onto `origin/develop@1ef62ce15680bd4f88d03fbc43d0c484748b95ab`. The two repaired file blobs remain byte-identical to the validated pre-rebase versions. Exact-head dependency-backed gates were not repeated because the shared host reached ENOSPC during the rebase; this is an explicit evidence limitation, not a claimed exact-head rerun.

## Evidence matrix

- UI screenshots/video: N/A — no rendered UI changes.
- Live-model trajectories: N/A — no model or prompt behavior changes.
- Native/device evidence: N/A — no native/device behavior changes.
- Domain artifact: real local-provisioning stdout confirmed PGlite migrations, `health.ready=true`, database `ok`, six loaded plugins / zero failed, running agent identity, and persisted first-run completion.

## Contribution provenance

| Field | Value |
| --- | --- |
| AI provider/model | OpenAI / gpt-5.6-sol |
| Client / agent tooling | Codex |
| Contribution skill revision | `elizaOS/eliza@fc6ab2ab77f8f83ac207f37a3975d71941cd6941:packages/skills/skills/contribute-to-eliza` |
| Attribution status | self-reported |

— [recent-merge-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@fc6ab2ab77f8f83ac207f37a3975d71941cd6941:packages/skills/skills/contribute-to-eliza"} -->
