### PR TITLE
fix(cloud): reject prefix-coerced agent-backups cron limits

### DIFF
--- a/packages/cloud/api/v1/cron/agent-backups/route.limit.test.ts
+++ b/packages/cloud/api/v1/cron/agent-backups/route.limit.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Prefix-coerced cron tunables must 400 before enqueueScheduledBackups.
+ * Number("1e2") === 100 used to become a real interval/max.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const enqueueScheduledBackups = mock(async () => ({
+  candidates: 0,
+  enqueued: 0,
+}));
+const reEnqueueFailedDeletions = mock(async () => ({
+  candidates: 0,
+  enqueued: 0,
+}));
+
+mock.module("@/lib/auth/cron", () => ({
+  verifyCronSecret: () => null,
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueScheduledBackups,
+    reEnqueueFailedDeletions,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: () => undefined, error: () => undefined },
+}));
+
+const { default: app } = await import("./route");
+
+function hit(query = "") {
+  return app.fetch(
+    new Request(`https://api.example.test/${query}`, { method: "POST" }),
+    { CRON_SECRET: "cron-secret" },
+  );
+}
+
+beforeEach(() => {
+  enqueueScheduledBackups.mockClear();
+  reEnqueueFailedDeletions.mockClear();
+});
+
+describe("agent-backups cron query integers", () => {
+  test("omitted tunables still run the sweep", async () => {
+    const response = await hit();
+    expect(response.status).toBe(200);
+    expect(enqueueScheduledBackups).toHaveBeenCalledTimes(1);
+  });
+
+  test("max=1e2 is 400 before enqueueScheduledBackups", async () => {
+    const response = await hit("?max=1e2");
+    expect(response.status).toBe(400);
+    expect(enqueueScheduledBackups).not.toHaveBeenCalled();
+  });
+
+  test("intervalMs=007 is 400 before enqueueScheduledBackups", async () => {
+    const response = await hit("?intervalMs=007");
+    expect(response.status).toBe(400);
+    expect(enqueueScheduledBackups).not.toHaveBeenCalled();
+  });
+
+  test("max=0x10 is 400 before enqueueScheduledBackups", async () => {
+    const response = await hit("?max=0x10");
+    expect(response.status).toBe(400);
+    expect(enqueueScheduledBackups).not.toHaveBeenCalled();
+  });
+
+  test("canonical max=3 still reaches the sweep", async () => {
+    const response = await hit("?max=3");
+    expect(response.status).toBe(200);
+    expect(enqueueScheduledBackups).toHaveBeenCalledWith(
+      expect.objectContaining({ maxAgents: 3 }),
+    );
+  });
+});

--- a/packages/cloud/api/v1/cron/agent-backups/route.ts
+++ b/packages/cloud/api/v1/cron/agent-backups/route.ts
@@ -25,20 +25,46 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
  * Tunables via query string: `?intervalMs=<n>&max=<n>` (snapshots),
  * `?deletionMinAgeMs=<n>&deletionMax=<n>` (deletion recovery).
  */
+function parseCronPositiveInt(
+  raw: string | null,
+): number | undefined | "invalid" {
+  if (raw === null || raw === "") return undefined;
+  if (!/^[1-9]\d*$/.test(raw)) return "invalid";
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return "invalid";
+  return parsed;
+}
+
 async function handle(c: AppContext, env?: AppEnv["Bindings"]) {
   const authError = verifyCronSecret(c.req.raw, "[Agent Backups]", env);
   if (authError) return authError;
 
   const url = new URL(c.req.url);
-  const intervalMs = Number(url.searchParams.get("intervalMs"));
-  const max = Number(url.searchParams.get("max"));
-  const deletionMinAgeMs = Number(url.searchParams.get("deletionMinAgeMs"));
-  const deletionMax = Number(url.searchParams.get("deletionMax"));
+  const intervalMs = parseCronPositiveInt(url.searchParams.get("intervalMs"));
+  const max = parseCronPositiveInt(url.searchParams.get("max"));
+  const deletionMinAgeMs = parseCronPositiveInt(
+    url.searchParams.get("deletionMinAgeMs"),
+  );
+  const deletionMax = parseCronPositiveInt(url.searchParams.get("deletionMax"));
+  if (
+    intervalMs === "invalid" ||
+    max === "invalid" ||
+    deletionMinAgeMs === "invalid" ||
+    deletionMax === "invalid"
+  ) {
+    return c.json(
+      {
+        success: false,
+        error:
+          "intervalMs, max, deletionMinAgeMs, and deletionMax must be canonical positive integers",
+      },
+      400,
+    );
+  }
 
   const result = await provisioningJobService.enqueueScheduledBackups({
-    minIntervalMs:
-      Number.isFinite(intervalMs) && intervalMs > 0 ? intervalMs : undefined,
-    maxAgents: Number.isFinite(max) && max > 0 ? max : undefined,
+    minIntervalMs: intervalMs,
+    maxAgents: max,
   });
 
   // Recover stuck `deletion_failed` sandboxes on the same tick. Conservative,
@@ -50,14 +76,9 @@ async function handle(c: AppContext, env?: AppEnv["Bindings"]) {
   > | null = null;
   try {
     deletionRecovery = await provisioningJobService.reEnqueueFailedDeletions({
-      minAgeMs:
-        Number.isFinite(deletionMinAgeMs) && deletionMinAgeMs > 0
-          ? deletionMinAgeMs
-          : undefined,
+      minAgeMs: deletionMinAgeMs,
       maxAgents:
-        Number.isFinite(deletionMax) && deletionMax > 0
-          ? Math.min(deletionMax, 50)
-          : undefined,
+        typeof deletionMax === "number" ? Math.min(deletionMax, 50) : undefined,
     });
   } catch (error) {
     logger.error("[Agent Backups] deletion-recovery sweep failed", {


### PR DESCRIPTION

# PI eliza cron-backups-limit — 2026-08-18

**Repo:** `elizaOS/eliza`
**Public writes:** none
**Worktree:** `/Users/thescoho/Developer/worktrees/eliza-cron-backups-limit-20260818`
**Branch:** `fix/cron-backups-limit`
**HEAD:** `6421db21e31912298f5c55dd8aeb8416e3ef6289`
**Provider/model/client:** xAI / grok-4.6 / Cursor

## Defect
Agent-backups cron parsed `intervalMs` / `max` / `deletionMinAgeMs` / `deletionMax` with `Number()`. `1e2` / `007` / `0x10` silently became sweep tunables instead of 400.

## Paths
- `packages/cloud/api/v1/cron/agent-backups/route.ts`
- `packages/cloud/api/v1/cron/agent-backups/route.limit.test.ts`

## Proof
`cd packages/cloud && bun test api/v1/cron/agent-backups/route.limit.test.ts`

Green: 5 passed. Canonical `max=3` still reaches `enqueueScheduledBackups`.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6421db21e31912298f5c55dd8aeb8416e3ef6289 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
