### PR TITLE
fix(ci): restore zero-key active-view determinism

### DIFF
--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -49,7 +49,10 @@ import {
   startBundleStep,
 } from "./lib/device-e2e-bundle.mjs";
 import { acquireDeviceLease, isDeviceLeased } from "./lib/device-lease.mjs";
-import { startDeviceE2eHostAgent } from "./lib/host-agent.mjs";
+import {
+  DEFAULT_HOST_AGENT_PORT,
+  startDeviceE2eHostAgent,
+} from "./lib/host-agent.mjs";
 
 const appDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
 const elizaRoot = path.resolve(appDir, "..", "..");
@@ -533,7 +536,10 @@ async function main() {
         hostAgent = await startDeviceE2eHostAgent({
           repoRoot: elizaRoot,
           artifactDir: bundle.logsDir,
-          requestedPort: 31337,
+          requestedPort: val("--host-agent-port"),
+          preferredPort:
+            process.env.ELIZA_ANDROID_HOST_AGENT_PORT ??
+            DEFAULT_HOST_AGENT_PORT,
           log,
         });
         process.env.ELIZA_ANDROID_HOST_AGENT_PORT = String(hostAgent.port);

--- a/packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts
@@ -26,15 +26,14 @@ import type {
   ViewDeclaration,
 } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
-import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { stage1ResponseHandlerFixture } from "@elizaos/core/testing";
 import type { DeterministicModelCall } from "@elizaos/core/testing";
 import {
   finalMessageUserText,
-  matchesScenarioInput,
   type RuntimeWithScenarioModelFixtures,
+  stage1ResponseHandlerFixture,
 } from "@elizaos/core/testing";
+import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
 
 const VIEW_ID = "scenario-active-ledger";
 const VIEW_LABEL = "Scenario Active Ledger";
@@ -223,6 +222,40 @@ function promptHasActiveViewElements(value: string): boolean {
   ].every((needle) => value.includes(needle));
 }
 
+function evaluatorFixture({
+  capability,
+  elementId,
+  thought,
+}: {
+  capability: "agent-click" | "agent-fill";
+  elementId: string;
+  thought: string;
+}) {
+  return {
+    name: `active-view-evaluator-${capability}-${elementId}`,
+    match: (call: DeterministicModelCall) => {
+      if (call.modelType !== ModelType.TEXT_SMALL) return false;
+      const promptText =
+        call.params.prompt ??
+        (Array.isArray(call.params.messages)
+          ? call.params.messages
+              .map((m: { content?: string }) => m.content ?? "")
+              .join("\n")
+          : "");
+      return (
+        promptText.includes("task: Evaluate latest action") &&
+        promptText.includes(elementId)
+      );
+    },
+    response: {
+      success: true,
+      decision: "FINISH",
+      thought,
+    },
+    times: 1,
+  };
+}
+
 function plannerFixture({
   capability,
   elementId,
@@ -398,6 +431,11 @@ export default scenario({
             messageToUser: "Filled the active ledger title.",
             value: "Close Issue 11355",
           }),
+          evaluatorFixture({
+            capability: "agent-fill",
+            elementId: "ledger-title",
+            thought: "Filled the active ledger title element successfully.",
+          }),
           stage1ResponseHandlerFixture({
             actionName: "VIEWS",
             contextIds: ["active-view", "views"],
@@ -416,6 +454,11 @@ export default scenario({
             elementId: "save-ledger",
             input: CLICK_TEXT,
             messageToUser: "Saved the active ledger.",
+          }),
+          evaluatorFixture({
+            capability: "agent-click",
+            elementId: "save-ledger",
+            thought: "Clicked the save ledger element successfully.",
           }),
         );
         return undefined;


### PR DESCRIPTION
Resolves #21457

## Summary
- In `packages/app/scripts/android-e2e.mjs`, replaces hardcoded `requestedPort: 31337` with `val("--host-agent-port")` and `preferredPort: process.env.ELIZA_ANDROID_HOST_AGENT_PORT ?? DEFAULT_HOST_AGENT_PORT`, satisfying `packages/scripts/__tests__/e2e-port-hygiene.test.ts`.
- In `packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts`, registers strict `ModelType.TEXT_SMALL` `evaluatorFixture` responses for both active-view action turns (`agent-fill` on `ledger-title` and `agent-click` on `save-ledger`), preventing unmatched evaluator calls during zero-key runs.

## Verification
- `bun test packages/scripts/__tests__/e2e-port-hygiene.test.ts` passes (7/7).
- `bun x biome check packages/app/scripts/android-e2e.mjs packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts` passes clean with 0 errors/warnings.