### PR TITLE
fix(cloud): reject malformed shared-runtime catch-all path encoding

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.encoding.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.encoding.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Malformed view/greeting path percent-encoding must not throw.
+ * decodeURIComponent("%") used to crash the shared-runtime catch-all.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@/lib/mobile-push/types", () => ({
+  MAX_MOBILE_PUSH_TOKEN_CHARACTERS: 4096,
+}));
+mock.module("@/lib/services/proxy/cors", () => ({
+  applyCorsHeaders: (response: Response) => response,
+  handleCorsOptions: () => new Response(null, { status: 204 }),
+}));
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  coordinateSharedPushList: async () => ({}),
+  coordinateSharedPushRegister: async () => ({}),
+  coordinateSharedPushUnregister: async () => ({}),
+}));
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  resolveSharedAgent: async () => ({ error: "unauthorized", status: 401 }),
+  resolveSharedRuntimeWorkerRequestContext: () => ({
+    error: "unauthorized",
+    status: 401,
+  }),
+}));
+mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
+  sharedRestAgentEvents: () => ({}),
+  sharedRestAgentStart: () => ({}),
+  sharedRestAuthMe: () => ({}),
+  sharedRestCharacter: () => ({}),
+  sharedRestCommands: () => ({}),
+  sharedRestConfig: () => ({}),
+  sharedRestCustomActions: () => ({}),
+  sharedRestFirstRun: () => ({}),
+  sharedRestFirstRunStatus: () => ({}),
+  sharedRestFirstRunSubmit: () => ({}),
+  sharedRestGreeting: () => ({}),
+  sharedRestOverlayPresence: () => ({}),
+  sharedRestRuntimeMode: () => ({}),
+  sharedRestStatus: () => ({}),
+  sharedRestStreamSettings: () => ({}),
+  sharedRestViewNavigate: () => ({}),
+  sharedRestViews: () => ({}),
+}));
+mock.module("../../workflows/_shared", () => ({
+  workflowRuntimeUnavailableResponse: () =>
+    Response.json({ success: false }, { status: 409 }),
+}));
+
+const { greetingConversationId, viewNavigateTarget } = await import("./route");
+
+describe("shared-runtime catch-all path encoding", () => {
+  test("viewNavigateTarget returns null for a lone %", () => {
+    expect(viewNavigateTarget("views/%/navigate")).toBeNull();
+  });
+
+  test("viewNavigateTarget returns null for %ZZ", () => {
+    expect(viewNavigateTarget("views/%ZZ/navigate")).toBeNull();
+  });
+
+  test("viewNavigateTarget returns null for truncated UTF-8", () => {
+    expect(viewNavigateTarget("views/%E0%A4%A/navigate")).toBeNull();
+  });
+
+  test("viewNavigateTarget still decodes a valid %20 view id", () => {
+    expect(viewNavigateTarget("views/chat%20home/navigate")).toBe("chat home");
+  });
+
+  test("greetingConversationId returns null for a lone %", () => {
+    expect(greetingConversationId("conversations/%/greeting")).toBeNull();
+  });
+
+  test("greetingConversationId still decodes a valid %2D conversation id", () => {
+    expect(greetingConversationId("conversations/conv%2D1/greeting")).toBe(
+      "conv-1",
+    );
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -79,15 +79,27 @@ function isWorkflowApiPath(path: string): boolean {
 }
 
 /** `views/<viewId>/navigate` → `<viewId>`; null for any other shape. */
-function viewNavigateTarget(path: string): string | null {
+export function viewNavigateTarget(path: string): string | null {
   const m = /^views\/([^/]+)\/navigate$/.exec(path);
-  return m ? decodeURIComponent(m[1]) : null;
+  if (!m?.[1]) return null;
+  try {
+    return decodeURIComponent(m[1]);
+  } catch {
+    // error-policy:J3 malformed percent-escape is not a navigable view id.
+    return null;
+  }
 }
 
 /** `conversations/<id>/greeting` → `<id>`; null for any other shape. */
-function greetingConversationId(path: string): string | null {
+export function greetingConversationId(path: string): string | null {
   const m = /^conversations\/([^/]+)\/greeting$/.exec(path);
-  return m ? decodeURIComponent(m[1]) : null;
+  if (!m?.[1]) return null;
+  try {
+    return decodeURIComponent(m[1]);
+  } catch {
+    // error-policy:J3 malformed percent-escape is not a greeting conversation.
+    return null;
+  }
 }
 
 function pushTokenDeleteTarget(path: string): string | null {


### PR DESCRIPTION

# PI eliza catch-all-path-encoding — 2026-08-18

**Repo:** `elizaOS/eliza`
**Public writes:** none
**Worktree:** `/Users/thescoho/Developer/worktrees/eliza-catch-all-path-encoding-20260818`
**Branch:** `fix/catch-all-path-encoding`
**HEAD:** `95b32161e45e3d0a9027eee7bf77ee91523a320d`
**Provider/model/client:** xAI / grok-4.6 / Cursor

## Defect
Shared-runtime catch-all used raw `decodeURIComponent` on `views/<id>/navigate` and `conversations/<id>/greeting`. A lone `%`, `%ZZ`, or truncated UTF-8 threw URIError instead of "not a navigable target".

## Paths
- `packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts`
- `packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.encoding.test.ts`

## Proof
`cd packages/cloud && bun test 'api/v1/eliza/agents/[agentId]/api/[...path]/route.encoding.test.ts'`

Disjoint from `#21385` internal-eliza conversation path encoding.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:95b32161e45e3d0a9027eee7bf77ee91523a320d -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
