### PR TITLE
fix(ui): reject malformed wallet-keys agent-id encoding

### DIFF
--- a/packages/ui/src/components/settings/WalletKeysSection.encoding.test.ts
+++ b/packages/ui/src/components/settings/WalletKeysSection.encoding.test.ts
@@ -1,0 +1,57 @@
+/** Malformed wallet-key agent-id percent-encoding must not throw. */
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../agent-surface", () => ({ useAgentElement: () => undefined }));
+vi.mock("../../api/client", () => ({ client: { rawRequest: vi.fn() } }));
+vi.mock("../../state/TranslationContext.hooks", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("../RoleGate", () => ({
+  RoleGate: ({ children }: { children: unknown }) => children,
+  OwnerOnlyNotice: () => null,
+}));
+vi.mock("../ui/button", () => ({ Button: () => null }));
+vi.mock("./settings-agent-rows", () => ({ SettingsInputRow: () => null }));
+vi.mock("./settings-layout", () => ({
+  SettingsGroup: () => null,
+  SettingsRow: () => null,
+  SettingsStack: () => null,
+}));
+
+import { entryDisplayLabel } from "./WalletKeysSection";
+import type { VaultEntryMeta } from "./vault-tabs/types";
+
+function meta(key: string): VaultEntryMeta {
+  return {
+    key,
+    label: key,
+    category: "wallet",
+    hasProfiles: false,
+    kind: "secret",
+  };
+}
+
+describe("entryDisplayLabel encoding", () => {
+  it("keeps the raw agent segment for a lone %", () => {
+    expect(() => entryDisplayLabel(meta("agent.%.wallet.evm"))).not.toThrow();
+    expect(entryDisplayLabel(meta("agent.%.wallet.evm"))).toBe("% (evm)");
+  });
+
+  it("keeps the raw agent segment for %ZZ", () => {
+    expect(entryDisplayLabel(meta("agent.%ZZ.wallet.sol"))).toBe("%ZZ (sol)");
+  });
+
+  it("keeps the raw agent segment for truncated UTF-8", () => {
+    expect(entryDisplayLabel(meta("agent.%E0%A4%A.wallet.evm"))).toBe(
+      "%E0%A4%A (evm)",
+    );
+  });
+
+  it("still decodes a valid %20 agent id", () => {
+    expect(entryDisplayLabel(meta("agent.my%20bot.wallet.evm"))).toBe(
+      "my bot (evm)",
+    );
+  });
+});

--- a/packages/ui/src/components/settings/WalletKeysSection.tsx
+++ b/packages/ui/src/components/settings/WalletKeysSection.tsx
@@ -89,12 +89,18 @@ function tryExtractAgentAddress(rawValue: string): string | null {
   return null;
 }
 
-function entryDisplayLabel(meta: VaultEntryMeta): string {
+export function entryDisplayLabel(meta: VaultEntryMeta): string {
   if (meta.label && meta.label !== meta.key) return meta.label;
   // Make the per-agent agent.<id>.wallet.<chain> shape human-friendly.
   const parts = meta.key.split(".");
   if (parts.length === 4 && parts[0] === "agent" && parts[2] === "wallet") {
-    const agentId = decodeURIComponent(parts[1] ?? "");
+    let agentId = parts[1] ?? "";
+    try {
+      agentId = decodeURIComponent(agentId);
+    } catch {
+      // error-policy:J3 malformed vault-key encoding keeps the raw segment
+      // rather than crashing the wallet-keys panel.
+    }
     return `${agentId} (${parts[3]})`;
   }
   return meta.key;


### PR DESCRIPTION

# PI eliza wallet-keys-encoding — 2026-08-18

**Repo:** `elizaOS/eliza`
**Public writes:** none
**Worktree:** `/Users/thescoho/Developer/worktrees/eliza-wallet-keys-encoding-20260818`
**Branch:** `fix/wallet-keys-encoding`
**HEAD:** `85435010143d441b897436fe507c6c2b7c3adc37`
**Provider/model/client:** xAI / grok-4.6 / Cursor

## Defect
`entryDisplayLabel` used raw `decodeURIComponent` on `agent.<id>.wallet.<chain>` key segments. A lone `%`, `%ZZ`, or truncated UTF-8 threw URIError in Settings → Wallet keys instead of keeping the raw segment.

## Paths
- `packages/ui/src/components/settings/WalletKeysSection.tsx`
- `packages/ui/src/components/settings/WalletKeysSection.encoding.test.ts`

## Proof
`cd packages/ui && npx vitest run --config ./vitest.config.ts src/components/settings/WalletKeysSection.encoding.test.ts`

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:85435010143d441b897436fe507c6c2b7c3adc37 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
