### PR TITLE
fix(cloud): observe abandoned runtime stream promises on barge-in

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -657,10 +657,7 @@ export async function runSharedAgentTurnStream(
     ] as const;
     for (const prop of settledResultProps) {
       const pending = (result as unknown as Record<string, unknown>)[prop];
-      if (
-        pending &&
-        typeof (pending as PromiseLike<unknown>).then === "function"
-      ) {
+      if (pending && typeof (pending as PromiseLike<unknown>).then === "function") {
         void Promise.resolve(pending as PromiseLike<unknown>).catch(() => {});
       }
     }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -423,17 +423,27 @@ async function executeSharedElizaRuntimeTurn(
         usage = addUsage(usage, normalized);
         return normalized;
       });
+      const streamText_ = Promise.resolve(result.text);
+      const streamToolCalls = Promise.resolve(result.toolCalls).then((calls) =>
+        calls.map((call) => ({
+          id: call.toolCallId,
+          name: call.toolName,
+          arguments: call.input,
+        })),
+      );
+      const streamFinishReason = Promise.resolve(result.finishReason);
+      // error-policy:J5 a barge-in abandons the turn, rejecting these four
+      // result promises with the cancellation reason while no consumer is
+      // left to await them; textStream remains the observed failure channel,
+      // so mark the abandoned promises handled here.
+      for (const settled of [streamText_, streamToolCalls, streamFinishReason, streamUsage]) {
+        void settled.catch(() => {});
+      }
       return {
         textStream,
-        text: Promise.resolve(result.text),
-        toolCalls: Promise.resolve(result.toolCalls).then((calls) =>
-          calls.map((call) => ({
-            id: call.toolCallId,
-            name: call.toolName,
-            arguments: call.input,
-          })),
-        ),
-        finishReason: Promise.resolve(result.finishReason),
+        text: streamText_,
+        toolCalls: streamToolCalls,
+        finishReason: streamFinishReason,
         usage: streamUsage,
         providerMetadata: { modelName: input.model },
       } as TextStreamResult;


### PR DESCRIPTION
The four unhandled 'confirmed caller speech' rejections in CI came from the eliza-runtime engine path, not the direct-model path patched in #21439: the shared model handler returns text/toolCalls/finishReason/usage promises in its TextStreamResult, and a barge-in abandons the turn before any consumer awaits them, so the abort rejects all four with the cancellation reason (release candidate runs 32062031192, 32066651628, 32067330480 — the only red left in the full test lane). They are now marked handled at creation (error-policy:J5); textStream stays the observed failure channel. Suite 10/10; cloud-shared typecheck 0; Biome clean.