### PR TITLE
fix(agent): dedupe concurrent cacheable tool-call misses

### DIFF
--- a/packages/agent/src/runtime/tool-call-cache-wrapper.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache-wrapper.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Action, ActionResult } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
+import { resolveToolDescriptor } from "./tool-call-cache/registry.ts";
 import {
   createToolCallCacheFromConfig,
   wrapActionWithCache,
@@ -30,7 +30,9 @@ afterEach(() => {
 
 function makeFakeAction(
   name: string,
-  impl: (parameters: Record<string, unknown>) => ActionResult,
+  impl: (
+    parameters: Record<string, unknown>,
+  ) => ActionResult | Promise<ActionResult>,
 ): { action: Action; calls: () => number } {
   let count = 0;
   const action: Action = {
@@ -66,6 +68,48 @@ describe("wrapActionWithCache", () => {
 
     expect(calls()).toBe(1);
     expect(r1).toEqual(r2);
+  });
+
+  it("deduplicates concurrent cacheable action misses", async () => {
+    const cache = createToolCallCacheFromConfig({ diskRoot: tempRoot });
+    if (!cache) throw new Error("cache must be enabled");
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { action, calls } = makeFakeAction("web_search", async () => {
+      await gate;
+      return { success: true, text: "shared" };
+    });
+    const wrapped = wrapActionWithCache(action, cache, { diskRoot: tempRoot });
+    const opts = { parameters: { q: "same" } };
+    const first = wrapped.handler({} as never, {} as never, undefined, opts);
+    const second = wrapped.handler({} as never, {} as never, undefined, opts);
+    release();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { success: true, text: "shared" },
+      { success: true, text: "shared" },
+    ]);
+    expect(calls()).toBe(1);
+  });
+
+  it("ignores a legacy cache entry that is not an ActionResult", async () => {
+    const cache = createToolCallCacheFromConfig({ diskRoot: tempRoot });
+    if (!cache) throw new Error("cache must be enabled");
+    const descriptor = resolveToolDescriptor("web_search");
+    const opts = { parameters: { q: "legacy" } };
+    cache.set(descriptor, opts.parameters, { stale: "legacy-value" });
+
+    const { action, calls } = makeFakeAction("web_search", () => ({
+      success: true,
+      text: "fresh",
+    }));
+    const wrapped = wrapActionWithCache(action, cache, { diskRoot: tempRoot });
+
+    await expect(
+      wrapped.handler({} as never, {} as never, undefined, opts),
+    ).resolves.toEqual({ success: true, text: "fresh" });
+    expect(calls()).toBe(1);
   });
 
   it("leaves non-cacheable actions untouched", async () => {

--- a/packages/agent/src/runtime/tool-call-cache-wrapper.ts
+++ b/packages/agent/src/runtime/tool-call-cache-wrapper.ts
@@ -32,8 +32,6 @@ interface PerToolOverride {
   version?: string;
 }
 
-type CachedActionResult = ActionResult & { [key: string]: ToolOutput };
-
 export interface ToolCacheConfig {
   enabled?: boolean;
   memoryCapacity?: number;
@@ -106,15 +104,6 @@ function isToolOutput(
   return Object.values(value).every((entry) => isToolOutput(entry, seen));
 }
 
-function isCachedActionResult(value: ToolOutput): value is CachedActionResult {
-  return (
-    !!value &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    typeof value.success === "boolean"
-  );
-}
-
 /**
  * Wrap an Action's handler so cacheable tools route through the cache.
  * Non-cacheable actions are returned unchanged.
@@ -136,14 +125,18 @@ export function wrapActionWithCache(
     ...rest
   ) => {
     const args = extractArgs(options);
-    const hit = cache.get(descriptor, args);
-    if (hit && isCachedActionResult(hit.output)) return hit.output;
-
-    const result = await original(runtime, message, state, options, ...rest);
-    if (result !== undefined && isToolOutput(result)) {
-      cache.set(descriptor, args, result);
-    }
-    return result;
+    return cache.run(
+      descriptor,
+      args,
+      async () => original(runtime, message, state, options, ...rest),
+      (result): result is ActionResult & ToolOutput =>
+        typeof result === "object" &&
+        result !== null &&
+        !Array.isArray(result) &&
+        "success" in result &&
+        typeof result.success === "boolean" &&
+        isToolOutput(result),
+    );
   };
 
   return { ...action, handler: wrapped };

--- a/packages/agent/src/runtime/tool-call-cache/cache.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/cache.test.ts
@@ -81,6 +81,78 @@ describe("ToolCallCache", () => {
     expect(calls).toBe(1);
   });
 
+  it("deduplicates concurrent misses for the same key", async () => {
+    const cache = makeCache();
+    const desc = resolveToolDescriptor("web_search");
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const execute = async () => {
+      calls += 1;
+      await gate;
+      return { result: "shared" };
+    };
+    const first = cache.run(desc, { q: "same" }, execute);
+    const second = cache.run(desc, { q: "same" }, execute);
+    release();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { result: "shared" },
+      { result: "shared" },
+    ]);
+    expect(calls).toBe(1);
+  });
+
+  it("does not share in-flight results across tool versions", async () => {
+    const cache = makeCache();
+    const args = { q: "same" };
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let calls = 0;
+
+    const first = cache.run(
+      { name: "web_search", version: "1", ttlMs: 1_000, cacheable: true },
+      args,
+      async () => {
+        calls += 1;
+        await gate;
+        return "v1";
+      },
+    );
+    const second = cache.run(
+      { name: "web_search", version: "2", ttlMs: 1_000, cacheable: true },
+      args,
+      async () => {
+        calls += 1;
+        return "v2";
+      },
+    );
+    release();
+
+    await expect(Promise.all([first, second])).resolves.toEqual(["v1", "v2"]);
+    expect(calls).toBe(2);
+  });
+
+  it("allows a retry after an in-flight execution rejects", async () => {
+    const cache = makeCache();
+    const desc = resolveToolDescriptor("web_search");
+    const args = { q: "retry" };
+
+    await expect(
+      cache.run(desc, args, async () => {
+        throw new Error("temporary failure");
+      }),
+    ).rejects.toThrow("temporary failure");
+    await expect(cache.run(desc, args, async () => "recovered")).resolves.toBe(
+      "recovered",
+    );
+  });
+
   it("expires entries after TTL", async () => {
     let now = 1_000;
     const cache = makeCache(() => now);

--- a/packages/agent/src/runtime/tool-call-cache/cache.ts
+++ b/packages/agent/src/runtime/tool-call-cache/cache.ts
@@ -40,10 +40,34 @@ export interface ToolCallCacheOptions {
   now?: () => number;
 }
 
+type CacheOutputValidator<T> = (output: unknown) => output is T & ToolOutput;
+
+function isToolOutput(
+  value: unknown,
+  seen = new WeakSet<object>(),
+): value is ToolOutput {
+  if (value === null) return true;
+  if (typeof value === "string" || typeof value === "boolean") return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value !== "object") return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.every((entry) => isToolOutput(entry, seen));
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return (
+    (prototype === Object.prototype || prototype === null) &&
+    Object.values(value).every((entry) => isToolOutput(entry, seen))
+  );
+}
+
 export class ToolCallCache {
   private readonly memory: Lru<string, ToolCacheEntry>;
   private readonly disk: DiskStore;
   private readonly now: () => number;
+  private readonly inFlight = new Map<string, Promise<unknown>>();
 
   constructor(options: ToolCallCacheOptions) {
     const root = options.diskRoot ?? path.join(resolveStateDir(), "tool-cache");
@@ -146,11 +170,40 @@ export class ToolCallCache {
     descriptor: CacheableToolDescriptor,
     args: ToolArgs,
     execute: () => Promise<ToolOutput>,
-  ): Promise<ToolOutput> {
+  ): Promise<ToolOutput>;
+  async run<T>(
+    descriptor: CacheableToolDescriptor,
+    args: ToolArgs,
+    execute: () => Promise<T>,
+    shouldCache: CacheOutputValidator<T>,
+  ): Promise<T>;
+  async run(
+    descriptor: CacheableToolDescriptor,
+    args: ToolArgs,
+    execute: () => Promise<unknown>,
+    shouldCache: (output: unknown) => output is ToolOutput = isToolOutput,
+  ): Promise<unknown> {
     const hit = this.get(descriptor, args);
-    if (hit) return hit.output;
-    const output = await execute();
-    this.set(descriptor, args, output);
-    return output;
+    if (hit && shouldCache(hit.output)) return hit.output;
+    if (hit) this.invalidate(descriptor.name, hit.key);
+    if (!descriptor.cacheable) return execute();
+
+    const cacheKey = buildCacheKey(descriptor.name, args);
+    const inFlightKey = `${cacheKey}:${descriptor.version}`;
+    const existing = this.inFlight.get(inFlightKey);
+    if (existing) return existing;
+
+    const pending = execute()
+      .then((output) => {
+        if (shouldCache(output)) this.set(descriptor, args, output);
+        return output;
+      })
+      .finally(() => {
+        if (this.inFlight.get(inFlightKey) === pending) {
+          this.inFlight.delete(inFlightKey);
+        }
+      });
+    this.inFlight.set(inFlightKey, pending);
+    return pending;
   }
 }


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
- AI assistance: Yes - initial author assistance plus maintainer review and remediation
<!-- attribution-row:models -->
- Models: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client/tooling: Codex CLI, Claude Code, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - the contribution skill was not used for this maintainer review and remediation
<!-- attribution-row:status -->
- Provenance status: self-reported

AI-assisted, with a real correction on my end before shipping. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: reproduced the race myself, ran the full mutation check myself, reran tests/lint myself — and running typecheck myself (the draft's own report showed the *command* but never showed its *output*, which was the tell) turned up two real `tsc` errors the draft never caught: `run()`'s signature was hard-typed to `Promise<ToolOutput>`, but the real caller's `Handler` returns `Promise<ActionResult | undefined>`, which isn't structurally a `ToolOutput`. I made `run()` generic over the execute/output type and turned `shouldCache` into a type predicate (`output is T & ToolOutput`) so the cache-write path narrows correctly without an unsound cast, re-ran the full mutation check, tests, lint, and typecheck against that corrected version, and confirmed typecheck is back to the same 19 pre-existing, unrelated errors in 7 other files (missing optional workspace modules) with zero errors in either touched file.

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low-to-moderate — this touches a shared cache class, so I reviewed the concurrency logic by hand in addition to the automated checks: the in-flight map is registered synchronously (no `await`) between the miss check and `inFlight.set()`, so under JS's single-threaded execution model a second concurrent `run()` call for the same key cannot slip past the check before the first call registers its promise — this is race-free by construction, not by timing luck. The new `if (!descriptor.cacheable) return execute();` early-return changes nothing observable: `get()`/`set()` already no-op internally for non-cacheable descriptors, so the old unconditional get→execute→set path was already a pure pass-through for those tools; the new branch just skips the redundant no-op calls. The wrapper's new `shouldCache` write-gate (`isToolOutput` + `.success` boolean check) is the *intersection* of the old write gate (`isToolOutput` only) and the old, separately-applied read gate (`.success` boolean only) — so the set of results that ever actually get served as cache hits is unchanged; this fix just moves the redundant filter to the write side and removes dead writes that could never have been served anyway.

# Background

## What does this PR do?

`ToolCallCache.run` (and the production wrapper's independent hand-rolled equivalent, `get` → await original → `set`) had a check-then-act race: two concurrent callers for the same `(tool, args)` cache key could both observe a miss and both execute the underlying tool — duplicate work, and for tools with real side effects (a live web search, an API call), duplicate externally-visible requests.

Before fix: two concurrent calls to the same cacheable action with identical args each invoke the real handler once (2 total calls) even though only one result is needed.

After fix: the second concurrent call for the same key awaits the first call's in-flight promise instead of re-invoking the handler (1 total call), and both resolve to the same result.

## What kind of change is this?

Bug fix — no new capability, no schema change. (`ToolCallCache.run`'s signature became generic, but its only caller is the wrapper in this same PR, so nothing else is affected.)

# Documentation changes needed?

No.

# Testing

New `deduplicates concurrent cacheable action misses` in `tool-call-cache-wrapper.test.ts`: gates a fake action's completion on a manually-controlled promise, fires two concurrent calls before releasing the gate, and asserts both resolve to the same result while the underlying action was invoked exactly once.

# Evidence Gate

<!-- evidence-head:2d487f238d85d67874eb30b95996447cf91b5e67 -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend logic fix, no UI surface
- <!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual behavior changed

## Known gaps / failures

None in the touched files. Package typecheck has 19 pre-existing, unrelated failures noted above (unchanged before/after this diff).

## Reachability

`packages/agent/src/runtime/plugin-lifecycle.ts` builds a `ToolCallCache` from runtime config and calls `wrapActionWithCache` for every registered cacheable action (`getOrBuildToolCallCache` / call site at line 1020-1022). Confirmed `ToolCallCache.run` has exactly one caller in the entire repo (the wrapper touched here), including the `@elizaos/app-core` re-export shim, so the generic signature change has no other call sites to affect.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, typecheck fix, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/correction/shipping)
Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic focused regression tests are documented in the Testing section and produce no persistent backend log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by this logic change

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered interface changed
