### PR TITLE
fix(app-core): reject prefix-coerced account-pool usage query timestamps

### DIFF
--- a/packages/app-core/src/api/account-pool-broker-routes.limit.test.ts
+++ b/packages/app-core/src/api/account-pool-broker-routes.limit.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Prefix-coerced usage-window timestamps must 400 before
+ * queryAccountPoolConsumerUsage. Number("1e2") === 100 used to become a
+ * real startMs/endMs bound.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import * as http from "node:http";
+import { Socket } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetAccountPoolBrokerRoutesForTests,
+  handleAccountPoolBrokerRoute,
+} from "./account-pool-broker-routes.js";
+
+interface FakeRes {
+  res: http.ServerResponse;
+  body(): unknown;
+  status(): number;
+}
+
+const SECRET = "test-broker-fixture-test-broker-fixture-test";
+
+let home: string;
+let prevHome: string | undefined;
+let prevStateDir: string | undefined;
+let prevEnabled: string | undefined;
+let prevSecret: string | undefined;
+
+function fakeRes(): FakeRes {
+  let bodyText = "";
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.statusCode = 200;
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") bodyText += chunk;
+    else if (chunk) bodyText += chunk.toString("utf8");
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    body() {
+      return bodyText.length > 0 ? JSON.parse(bodyText) : null;
+    },
+    status() {
+      return res.statusCode;
+    },
+  };
+}
+
+function fakeReq(pathname: string): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = "GET";
+  req.url = pathname;
+  req.headers = {
+    host: "127.0.0.1:18792",
+    authorization: `Bearer ${SECRET}`,
+  };
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  return req;
+}
+
+async function getUsage(query: string): Promise<FakeRes> {
+  const res = fakeRes();
+  await handleAccountPoolBrokerRoute(
+    fakeReq(`/api/internal/account-pool/v1/usage${query}`),
+    res.res,
+  );
+  return res;
+}
+
+beforeEach(() => {
+  prevHome = process.env.ELIZA_HOME;
+  prevStateDir = process.env.ELIZA_STATE_DIR;
+  prevEnabled = process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED;
+  prevSecret = process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET;
+  home = mkdtempSync(path.join(tmpdir(), "account-pool-broker-limit-"));
+  process.env.ELIZA_HOME = home;
+  process.env.ELIZA_STATE_DIR = home;
+  process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED = "1";
+  process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET = SECRET;
+  __resetAccountPoolBrokerRoutesForTests();
+});
+
+afterEach(() => {
+  __resetAccountPoolBrokerRoutesForTests();
+  rmSync(home, { recursive: true, force: true });
+  if (prevHome === undefined) delete process.env.ELIZA_HOME;
+  else process.env.ELIZA_HOME = prevHome;
+  if (prevStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+  else process.env.ELIZA_STATE_DIR = prevStateDir;
+  if (prevEnabled === undefined) delete process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED;
+  else process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED = prevEnabled;
+  if (prevSecret === undefined) delete process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET;
+  else process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET = prevSecret;
+});
+
+describe("account-pool broker usage query integers", () => {
+  it("startMs=1e2 is 400 before a usage window is applied", async () => {
+    const res = await getUsage("?startMs=1e2");
+    expect(res.status()).toBe(400);
+    expect(res.body()).toEqual({ ok: false, error: "invalid_usage_query" });
+  });
+
+  it("endMs=007 is 400 before a usage window is applied", async () => {
+    const res = await getUsage("?endMs=007");
+    expect(res.status()).toBe(400);
+    expect(res.body()).toEqual({ ok: false, error: "invalid_usage_query" });
+  });
+
+  it("startMs=0x10 is 400 before a usage window is applied", async () => {
+    const res = await getUsage("?startMs=0x10");
+    expect(res.status()).toBe(400);
+    expect(res.body()).toEqual({ ok: false, error: "invalid_usage_query" });
+  });
+
+  it("canonical startMs=0 still reaches the usage query", async () => {
+    const res = await getUsage("?startMs=0");
+    expect(res.status()).toBe(200);
+    expect(res.body()).toMatchObject({ ok: true });
+  });
+});

--- a/packages/app-core/src/api/account-pool-broker-routes.ts
+++ b/packages/app-core/src/api/account-pool-broker-routes.ts
@@ -105,6 +105,9 @@ function methodAllowed(
 
 function parseOptionalMs(value: string | null): number | undefined | null {
   if (value === null || value === "") return undefined;
+  // Canonical non-negative integers only. Number("1e2") === 100 and
+  // Number("0x10") === 16 used to become real usage-window bounds.
+  if (!/^(0|[1-9]\d*)$/.test(value)) return null;
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed < 0) return null;
   return parsed;


### PR DESCRIPTION

# PI eliza broker-usage-limit — 2026-08-18

**Repo:** `elizaOS/eliza`
**Public writes:** (pending)
**Worktree:** `/Users/thescoho/Developer/worktrees/eliza-broker-usage-limit-20260818`
**Branch:** `fix/broker-usage-limit`
**HEAD:** `e694c4b77e2c3370a8a86fa6e44cecd24b25b186`
**Provider/model/client:** xAI / grok-4.6 / Cursor

## Defect
Account-pool broker `GET .../usage` parsed `startMs` / `endMs` with `Number()`. `1e2` / `007` / `0x10` silently became usage-window bounds instead of 400.

## Paths
- `packages/app-core/src/api/account-pool-broker-routes.ts`
- `packages/app-core/src/api/account-pool-broker-routes.limit.test.ts`

## Proof
`cd packages/app-core && node ../scripts/run-vitest.mjs run --config vitest.config.ts src/api/account-pool-broker-routes.limit.test.ts`

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e694c4b77e2c3370a8a86fa6e44cecd24b25b186 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
