### PR TITLE
fix(app-core): reject prefix-coerced embed-handshake auth_date

### DIFF
--- a/packages/app-core/src/api/auth/embed-handshake.limit.test.ts
+++ b/packages/app-core/src/api/auth/embed-handshake.limit.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Prefix-coerced Telegram auth_date must fail closed before role checks.
+ * Number("1.7e9") === 1700000000 used to pass the stale-replay window.
+ */
+import { createHmac } from "node:crypto";
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type EmbedLaunchInput, verifyEmbedLaunch } from "./embed-handshake";
+
+const hasRoleAccess = vi.fn(
+  async (_r: unknown, _m: unknown, _role: string) => true,
+);
+
+const TEST_BOT_TOKEN = "123456:test-bot-token-abc";
+const TELEGRAM_USER_ID = "987654321";
+const NOW = 1_700_000_000_000;
+const FRESH_AUTH_DATE = String(Math.floor(NOW / 1000) - 60);
+
+function makeRuntime(): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-0000-0000-0000000000aa",
+    getSetting: (key: string) =>
+      key === "TELEGRAM_BOT_TOKEN" ? TEST_BOT_TOKEN : null,
+    character: { name: "TestAgent" },
+  } as unknown as IAgentRuntime;
+}
+
+function buildTelegramInitData(authDate: string): string {
+  const fields: Record<string, string> = {
+    auth_date: authDate,
+    query_id: "AAEturnstile",
+    user: JSON.stringify({ id: Number(TELEGRAM_USER_ID), first_name: "Ada" }),
+  };
+  const dataCheckString = Object.keys(fields)
+    .sort()
+    .map((key) => `${key}=${fields[key]}`)
+    .join("\n");
+  const secretKey = createHmac("sha256", "WebAppData")
+    .update(TEST_BOT_TOKEN)
+    .digest();
+  const hash = createHmac("sha256", secretKey)
+    .update(dataCheckString)
+    .digest("hex");
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(fields)) {
+    params.set(key, value);
+  }
+  params.set("hash", hash);
+  return params.toString();
+}
+
+function telegramInput(authDate: string): EmbedLaunchInput {
+  return {
+    platform: "telegram",
+    signedLaunchPayload: buildTelegramInitData(authDate),
+  };
+}
+
+describe("embed handshake auth_date integers", () => {
+  beforeEach(() => {
+    hasRoleAccess.mockReset();
+    hasRoleAccess.mockResolvedValue(true);
+  });
+
+  it("auth_date=1.7e9 is 403 before role checks", async () => {
+    const result = await verifyEmbedLaunch(
+      telegramInput("1.7e9"),
+      makeRuntime(),
+      NOW,
+      { hasRoleAccess },
+    );
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      reason: "telegram_invalid_auth_date",
+    });
+    expect(hasRoleAccess).not.toHaveBeenCalled();
+  });
+
+  it("auth_date=1e2 is 403 before role checks", async () => {
+    const result = await verifyEmbedLaunch(
+      telegramInput("1e2"),
+      makeRuntime(),
+      NOW,
+      { hasRoleAccess },
+    );
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      reason: "telegram_invalid_auth_date",
+    });
+    expect(hasRoleAccess).not.toHaveBeenCalled();
+  });
+
+  it("auth_date=007 is 403 before role checks", async () => {
+    const result = await verifyEmbedLaunch(
+      telegramInput("007"),
+      makeRuntime(),
+      NOW,
+      { hasRoleAccess },
+    );
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      reason: "telegram_invalid_auth_date",
+    });
+    expect(hasRoleAccess).not.toHaveBeenCalled();
+  });
+
+  it("auth_date=0x10 is 403 before role checks", async () => {
+    const result = await verifyEmbedLaunch(
+      telegramInput("0x10"),
+      makeRuntime(),
+      NOW,
+      { hasRoleAccess },
+    );
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      reason: "telegram_invalid_auth_date",
+    });
+    expect(hasRoleAccess).not.toHaveBeenCalled();
+  });
+
+  it("canonical auth_date still reaches role checks", async () => {
+    const result = await verifyEmbedLaunch(
+      telegramInput(FRESH_AUTH_DATE),
+      makeRuntime(),
+      NOW,
+      { hasRoleAccess },
+    );
+    expect(result.ok).toBe(true);
+    expect(hasRoleAccess).toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/src/api/auth/embed-handshake.ts
+++ b/packages/app-core/src/api/auth/embed-handshake.ts
@@ -129,9 +129,13 @@ function verifyTelegramInitData(
     return { ok: false, reason: "telegram_bad_signature" };
   }
 
-  const authDateSeconds = Number(params.get("auth_date"));
-  if (!Number.isFinite(authDateSeconds) || authDateSeconds <= 0) {
-    return { ok: false, reason: "telegram_missing_auth_date" };
+  const authDateSeconds = parseTelegramAuthDateSeconds(params.get("auth_date"));
+  if (authDateSeconds === null) {
+    const raw = params.get("auth_date");
+    if (raw === null || raw === "") {
+      return { ok: false, reason: "telegram_missing_auth_date" };
+    }
+    return { ok: false, reason: "telegram_invalid_auth_date" };
   }
   if (now - authDateSeconds * 1000 > TELEGRAM_INITDATA_MAX_AGE_MS) {
     return { ok: false, reason: "telegram_stale_auth_date" };
@@ -142,6 +146,16 @@ function verifyTelegramInitData(
     return { ok: false, reason: "telegram_missing_user" };
   }
   return { ok: true, userId };
+}
+
+function parseTelegramAuthDateSeconds(raw: string | null): number | null {
+  if (raw === null || raw === "") return null;
+  // Canonical positive unix seconds only. Number("1.7e9") === 1700000000
+  // used to pass the stale-replay window as a real auth_date.
+  if (!/^[1-9]\d*$/.test(raw)) return null;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return null;
+  return parsed;
 }
 
 function parseTelegramUserId(userField: string | null): string | null {


### PR DESCRIPTION

# PI eliza embed-auth-date-limit — 2026-08-18

**Repo:** `elizaOS/eliza`
**Public writes:** (pending)
**Worktree:** `/Users/thescoho/Developer/worktrees/eliza-embed-auth-date-limit-20260818`
**Branch:** `fix/embed-auth-date-limit`
**HEAD:** `beccf17da61cb8a30dfcf13aef8df3de772c1565`
**Provider/model/client:** xAI / grok-4.6 / Cursor

## Defect
Telegram embed handshake parsed `auth_date` with `Number()`. `1.7e9` silently became a real unix timestamp that passed the stale-replay window instead of 403.

## Paths
- `packages/app-core/src/api/auth/embed-handshake.ts`
- `packages/app-core/src/api/auth/embed-handshake.limit.test.ts`

## Proof
`cd packages/app-core && node ../scripts/run-vitest.mjs run --config vitest.config.ts src/api/auth/embed-handshake.limit.test.ts`

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:beccf17da61cb8a30dfcf13aef8df3de772c1565 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
