### PR TITLE
fix(plugin-agent-orchestrator): reject malformed mapped route path encoding

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.encoding.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.encoding.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Malformed percent-escapes in mapped route relative paths must not throw.
+ * decodeURIComponent("%") used to escape mappedLocalTarget after new URL
+ * succeeded.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core/client-public", () => ({
+  resolveAliasedEnvValue: (value: unknown) => value,
+}));
+
+import { decodeMappedRelativePath } from "../../src/services/sub-agent-router.js";
+
+describe("decodeMappedRelativePath", () => {
+  it("returns undefined for a lone % instead of throwing", () => {
+    expect(decodeMappedRelativePath("%")).toBeUndefined();
+  });
+
+  it("returns undefined for %ZZ instead of throwing", () => {
+    expect(decodeMappedRelativePath("%ZZ")).toBeUndefined();
+  });
+
+  it("returns undefined for truncated UTF-8 instead of throwing", () => {
+    expect(decodeMappedRelativePath("%E0%A4%A")).toBeUndefined();
+  });
+
+  it("still decodes a canonical relative path", () => {
+    expect(decodeMappedRelativePath("docs%2Freadme.md")).toBe("docs/readme.md");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -4018,7 +4018,8 @@ function routePageAliasesForUrl(
 ): string[] {
   const match = routeMatchForUrl(url, routeVerification.mappings);
   if (!match) return [];
-  const relativePath = decodeURIComponent(match.relativePath);
+  const relativePath = decodeMappedRelativePath(match.relativePath);
+  if (!relativePath) return [];
   const directory = pageDirectoryForRelativePath(relativePath);
   if (!directory) return [];
   const representative = urlForRouteMapping(match.mapping, directory);
@@ -4069,6 +4070,21 @@ function verifyMappedLocalUrl(
   return undefined;
 }
 
+/**
+ * Percent-decode a mapped route relative path. Malformed escapes (`%`, `%ZZ`)
+ * used to throw URIError out of mappedLocalTarget after `new URL` succeeded.
+ */
+export function decodeMappedRelativePath(raw: string): string | undefined {
+  try {
+    const decoded = decodeURIComponent(raw);
+    return decoded || undefined;
+  } catch {
+    // error-policy:J3 untrusted narration URL path; malformed percent-encoding
+    // is not a mapped local target.
+    return undefined;
+  }
+}
+
 function mappedLocalTarget(
   url: string,
   workdir: string,
@@ -4088,7 +4104,7 @@ function mappedLocalTarget(
     ? prefix.pathname
     : `${prefix.pathname}/`;
   if (!parsed.pathname.startsWith(prefixPath)) return undefined;
-  const relativePath = decodeURIComponent(
+  const relativePath = decodeMappedRelativePath(
     parsed.pathname.slice(prefixPath.length),
   );
   if (!relativePath) return undefined;


### PR DESCRIPTION

# PI eliza sub-agent-router-encoding — 2026-08-18

**Repo:** `elizaOS/eliza`
**Public writes:** (pending)
**Worktree:** `/Users/thescoho/Developer/worktrees/eliza-sub-agent-router-encoding-20260818`
**Branch:** `fix/sub-agent-router-encoding`
**HEAD:** `6689fa70cdd4568524a3d90e1c2c201418f9b383`
**Provider/model/client:** xAI / grok-4.6 / Cursor

## Defect
`mappedLocalTarget` / `routePageAliasesForUrl` used raw `decodeURIComponent` on mapped route relative paths. A lone `%` / `%ZZ` threw URIError after `new URL` succeeded.

## Paths
- `plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts`
- `plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.encoding.test.ts`

## Occupancy
FREE as of 2026-08-17T22:15Z. `#21449` owns `orchestrator-routes.ts`, not this file.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6689fa70cdd4568524a3d90e1c2c201418f9b383 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
