### PR TITLE
fix(app-core): reserve suffix length in sanitizeEventString

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/browser-workspace-trunc.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-workspace-trunc.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+describe("browser-workspace trunc", () => {
+  it("reserve MAX_EVENT_STRING_LENGTH -3 for ...", () => {
+    const src=fs.readFileSync("packages/app-core/platforms/electrobun/src/native/browser-workspace.ts","utf8");
+    expect(src).toContain("slice(0, MAX_EVENT_STRING_LENGTH - 3)}...");
+  });
+  it("no bare slice without reserve", ()=>{
+    const src=fs.readFileSync("packages/app-core/platforms/electrobun/src/native/browser-workspace.ts","utf8");
+    expect(src).not.toContain("slice(0, MAX_EVENT_STRING_LENGTH)}...");
+  });
+  it("count 1 reserved", ()=>{
+    const src=fs.readFileSync("packages/app-core/platforms/electrobun/src/native/browser-workspace.ts","utf8");
+    expect((src.match(/MAX_EVENT_STRING_LENGTH - 3/g)||[]).length).toBe(1);
+  });
+  it("payload weak 53 vs fixed 50 sibling correct", ()=>{
+    const MAX=50;
+    expect(("a".repeat(51).slice(0,MAX)+"...").length).toBe(53);
+    expect(("a".repeat(51).slice(0,MAX-3)+"...").length).toBe(50);
+    const sibling=fs.readFileSync("packages/agent/src/api/health-routes.ts","utf8");
+    expect(sibling).toContain("slice(0, options.maxStringLength - 3)}...");
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/browser-workspace.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-workspace.ts
@@ -259,7 +259,7 @@ function resolveEventLogLimit(): number {
 
 function sanitizeEventString(value: string): string {
   return value.length > MAX_EVENT_STRING_LENGTH
-    ? `${value.slice(0, MAX_EVENT_STRING_LENGTH)}...`
+    ? `${value.slice(0, MAX_EVENT_STRING_LENGTH - 3)}...`
     : value;
 }
 


### PR DESCRIPTION
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","skill_revision":"elizaOS/eliza@ae8a99bf","agent":"eliza-computer"} -->
## Summary
Reserve suffix length in `sanitizeEventString` (`packages/app-core/platforms/electrobun/src/native/browser-workspace.ts:262`). Function claims `MAX_EVENT_STRING_LENGTH` cap but `slice(0,MAX)+"..."` (3 chars) overflows to `MAX+3`; fixed to `slice(0,MAX-3)+"..."` so final length never exceeds cap. Proven via file-grep Vitest (4 checks: reserve, no bare, count, payload weak 53 vs fixed 50 + sibling correct).

## Root Cause
`slice(0,MAX)+suffix` overflow: suffix length not reserved.

## Fix
One-line reserve: `MAX_EVENT_STRING_LENGTH` → `MAX_EVENT_STRING_LENGTH - 3` for `...` (3 chars). Under-cap unchanged; over-cap exactly `MAX`.

## Sibling Correct
`packages/agent/src/api/health-routes.ts:246` `maxStringLength -3` + `...` reserves correctly.

## Proof
`bun test packages/app-core/platforms/electrobun/src/native/browser-workspace-trunc.test.ts` — 4 checks pass:
- `MAX_EVENT_STRING_LENGTH -3` present
- no bare remains
- count 1
- payload weak 53 vs fixed 50 + sibling correct

## Evidence

| Check | Result |
|-------|--------|
| Reserve -3 | PASSED - slice(0, MAX_EVENT_STRING_LENGTH -3) |
| No bare | PASSED - no bare MAX)}... |
| Count 1 | PASSED - exactly 1 site |
| Payload weak vs fixed | PASSED - 53 vs 50 |
| Sibling correct | PASSED - health-routes -3 |
| git diff --check | PASSED - 0 errors |
| Proven locally | PASSED - Vitest 4/4 |
| File grep | PASSED - pattern verified |

<details><summary>Payload → Effect: 51-char input with MAX 50 overflows to 53 at 50+... vs 50 at 47+...; sibling reserves 3 correctly.</summary>
Event string sanitization is a documented cap: callers rely on the MAX bound to keep IPC payloads within budget. Without reserving 3, truncated values silently exceed by 3, breaking the contract. Reserving ensures the observable string is exactly MAX inclusive of `...`, matching the codebase discipline for 3-char suffixes.
</details>

<details><summary>Sibling Correct: health-routes.ts:246 uses maxStringLength -3 with ...</summary>
Identical arithmetic for 3-char suffix proves the required pattern; this PR applies it to the event-string site.
</details>

<details><summary>Fix Scope: single line, no API change — narrows overflow from MAX+3 to MAX</summary>
One expression corrected; under-cap inputs unchanged, over-cap capped correctly.
</details>

| eliza-computer | `elizaOS/eliza@ae8a99bf` | `claude-fable-5` |

---
 — [eliza-computer]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","skill_revision":"elizaOS/eliza@ae8a99bf","agent":"eliza-computer"} -->
