### PR TITLE
fix(plugin-agent-orchestrator): reserve suffix length in captureChangeSet

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/workspace-diff-trunc.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-diff-trunc.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+describe("workspace-diff trunc reserve", ()=>{
+  it("reserve 19 for \\n… [diff truncated]", ()=>{
+    const src=fs.readFileSync("plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts","utf8");
+    expect(src).toContain("slice(0, MAX_DIFF_CHARS - 19)}");
+  });
+  it("no bare slice(0, MAX_DIFF_CHARS) remains with suffix", ()=>{
+    const src=fs.readFileSync("plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts","utf8");
+    // should not contain the old pattern without -19
+    expect(src).not.toContain("slice(0, MAX_DIFF_CHARS)}\n… [diff truncated]");
+  });
+  it("count 2 reserved sites", ()=>{
+    const src=fs.readFileSync("plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts","utf8");
+    const m=src.match(/MAX_DIFF_CHARS - 19/g)||[];
+    expect(m.length).toBe(2);
+  });
+  it("payload weak 19 over vs fixed capped sibling correct", ()=>{
+    const MAX=100;
+    const suffix="\n… [diff truncated]";
+    expect(suffix.length).toBe(19);
+    const weak=("a".repeat(101).slice(0,MAX)+suffix).length;
+    const fixed=("a".repeat(101).slice(0,MAX-19)+suffix).length;
+    expect(weak).toBe(119);
+    expect(fixed).toBe(100);
+    const sibling=fs.readFileSync("packages/agent/src/providers/workspace-provider.ts","utf8");
+    expect(sibling).toContain("slice(0, max - suffix.length)");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
@@ -387,7 +387,7 @@ export async function captureChangeSet(
     if (diff.length > MAX_DIFF_CHARS) break;
   }
   const overLength = diff.length > MAX_DIFF_CHARS;
-  if (overLength) diff = `${diff.slice(0, MAX_DIFF_CHARS)}\n… [diff truncated]`;
+  if (overLength) diff = `${diff.slice(0, MAX_DIFF_CHARS - 19)}\n… [diff truncated]`;
 
   return {
     changedFiles,
@@ -439,7 +439,7 @@ function captureToolPathOnlyChangeSet(
   }
 
   const overLength = diff.length > MAX_DIFF_CHARS;
-  if (overLength) diff = `${diff.slice(0, MAX_DIFF_CHARS)}\n… [diff truncated]`;
+  if (overLength) diff = `${diff.slice(0, MAX_DIFF_CHARS - 19)}\n… [diff truncated]`;
 
   return {
     changedFiles,


### PR DESCRIPTION
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","skill_revision":"elizaOS/eliza@ae8a99bf","agent":"eliza-computer"} -->
## Summary
Reserve suffix length in `captureChangeSet` / `captureToolPathOnlyChangeSet` (`plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts:390,442`). Functions claim `MAX_DIFF_CHARS` cap but `slice(0,MAX)+"\n… [diff truncated]"` (19 chars) overflows to `MAX+19`; fixed to `slice(0,MAX-19)+suffix` so final length never exceeds cap. Proven via file-grep Vitest (4 checks: 2 sites reserved, no bare, payload weak 119 vs fixed 100 + sibling correct).

## Root Cause
`slice(0,MAX)+suffix` overflow: 19-char suffix not reserved.

## Fix
Two-line reserve: `MAX_DIFF_CHARS` → `MAX_DIFF_CHARS - 19` before appending `"\n… [diff truncated]"`.

## Sibling Correct
`packages/agent/src/providers/workspace-provider.ts:62` `max - suffix.length` already reserves correctly for similar trunc suffix.

## Proof
`bun test plugins/plugin-agent-orchestrator/src/services/workspace-diff-trunc.test.ts` — 4 checks pass:
- `MAX_DIFF_CHARS - 19` present (2 sites)
- no bare `MAX)}…` remains
- payload `("a".repeat(101).slice(0,100)+suffix).length=119` vs `slice(0,81)+suffix=100`
- sibling correct

## Evidence

| Check | Result |
|-------|--------|
| Reserve -19 site1 | PASSED - slice(0, MAX_DIFF_CHARS -19) at 390 |
| Reserve -19 site2 | PASSED - slice(0, MAX_DIFF_CHARS -19) at 442 |
| No bare overflow | PASSED - no bare MAX)} |
| Payload weak vs fixed | PASSED - 119 vs 100 |
| Sibling correct | PASSED - workspace-provider - suffix.length |
| Count 2 | PASSED - exactly 2 sites |
| git diff --check | PASSED - 0 errors |
| Proven locally | PASSED - Vitest 4/4 |

<details><summary>Payload → Effect: 101-char diff with MAX 100 overflows to 119 at 100+19 vs 100 at 81+19; sibling reserves suffix.length.</summary>
Diff capture is a bounded IPC contract: callers expect at most MAX_DIFF_CHARS inclusive of truncation marker. Without reserving 19, truncated diffs exceed budget, bloating context and breaking the cap. Reserving ensures exactly MAX inclusive.
</details>

<details><summary>Sibling Correct: workspace-provider.ts:62 uses max - suffix.length with similar marker</summary>
Identical reserve discipline for variable-length suffix proves required pattern; this PR applies numeric equivalent (19) to fixed suffix.
</details>

<details><summary>Fix Scope: two lines, no API change — narrows overflow MAX+19→MAX</summary>
Both `captureChangeSet` paths corrected; under-cap diffs unchanged, over-cap diffs exactly capped.
</details>

| eliza-computer | `elizaOS/eliza@ae8a99bf` | `claude-fable-5` |

---
 — [eliza-computer]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","skill_revision":"elizaOS/eliza@ae8a99bf","agent":"eliza-computer"} -->
