### PR TITLE
fix(app-core): reject prefix-coerced /api/dev query tunables

### DIFF
--- a/packages/app-core/src/api/dev-compat-routes.limit.test.ts
+++ b/packages/app-core/src/api/dev-compat-routes.limit.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Prefix-coerced /api/dev query tunables must be invalid.
+ * Number("1e2") === 100 used to become a real maxLines / limit.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/agent", () => ({
+  loadElizaConfig: () => ({ meta: {}, agents: {} }),
+}));
+
+import { parseDevPositiveInt } from "./dev-compat-routes";
+
+describe("dev-compat query integers", () => {
+  it("1e2 is invalid instead of becoming 100", () => {
+    expect(parseDevPositiveInt("1e2")).toBe("invalid");
+  });
+
+  it("007 is invalid instead of becoming 7", () => {
+    expect(parseDevPositiveInt("007")).toBe("invalid");
+  });
+
+  it("0x10 is invalid instead of becoming 16", () => {
+    expect(parseDevPositiveInt("0x10")).toBe("invalid");
+  });
+
+  it("canonical 50 still parses", () => {
+    expect(parseDevPositiveInt("50")).toBe(50);
+  });
+
+  it("omitted tunable stays omit", () => {
+    expect(parseDevPositiveInt(null)).toBe("omit");
+  });
+});

--- a/packages/app-core/src/api/dev-compat-routes.ts
+++ b/packages/app-core/src/api/dev-compat-routes.ts
@@ -35,6 +35,20 @@ function finiteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+/**
+ * Canonical positive integer for untrusted /api/dev query tunables.
+ * Number("1e2") === 100 used to become a real maxLines / maxBytes / limit.
+ */
+export function parseDevPositiveInt(
+  raw: string | null,
+): number | "omit" | "invalid" {
+  if (raw === null || raw === "") return "omit";
+  if (!/^[1-9]\d*$/.test(raw)) return "invalid";
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return "invalid";
+  return parsed;
+}
+
 function parseInferenceTimingLog(log: Log): InferenceTurnSummary | null {
   const body = asRecord(log.body);
   const metadata = asRecord(body?.metadata);
@@ -278,13 +292,19 @@ export async function handleDevCompatRoutes(
       });
       return true;
     }
-    const maxLinesRaw = url.searchParams.get("maxLines");
-    const maxBytesRaw = url.searchParams.get("maxBytes");
-    const maxLines = maxLinesRaw ? Number(maxLinesRaw) : undefined;
-    const maxBytes = maxBytesRaw ? Number(maxBytesRaw) : undefined;
+    const maxLines = parseDevPositiveInt(url.searchParams.get("maxLines"));
+    const maxBytes = parseDevPositiveInt(url.searchParams.get("maxBytes"));
+    if (maxLines === "invalid" || maxBytes === "invalid") {
+      sendJsonErrorResponse(
+        res,
+        400,
+        "maxLines and maxBytes must be canonical positive integers",
+      );
+      return true;
+    }
     const result = readDevConsoleLogTail(logPath, {
-      maxLines: Number.isFinite(maxLines) ? maxLines : undefined,
-      maxBytes: Number.isFinite(maxBytes) ? maxBytes : undefined,
+      maxLines: maxLines === "omit" ? undefined : maxLines,
+      maxBytes: maxBytes === "omit" ? undefined : maxBytes,
     });
     if (result.ok === false) {
       sendJsonResponse(res, 404, { error: result.error });
@@ -311,16 +331,21 @@ export async function handleDevCompatRoutes(
     if (!(await ensureRouteAuthorized(req, res, state))) {
       return true;
     }
-    const limitRaw = url.searchParams.get("limit");
-    const limit = limitRaw ? Number(limitRaw) : undefined;
+    const limit = parseDevPositiveInt(url.searchParams.get("limit"));
+    if (limit === "invalid") {
+      sendJsonErrorResponse(
+        res,
+        400,
+        "limit must be a canonical positive integer",
+      );
+      return true;
+    }
     const { buildVoiceLatencyDevPayload } = await import(
       "@elizaos/plugin-local-inference/services"
     );
     const payload = buildVoiceLatencyDevPayload(
       undefined,
-      Number.isFinite(limit) && (limit as number) > 0
-        ? (limit as number)
-        : undefined,
+      limit === "omit" ? undefined : limit,
     );
     sendJsonResponse(res, 200, payload);
     return true;
@@ -341,16 +366,21 @@ export async function handleDevCompatRoutes(
     if (!(await ensureRouteAuthorized(req, res, state))) {
       return true;
     }
-    const limitRaw = url.searchParams.get("limit");
-    const limit = limitRaw ? Number(limitRaw) : undefined;
+    const limit = parseDevPositiveInt(url.searchParams.get("limit"));
+    if (limit === "invalid") {
+      sendJsonErrorResponse(
+        res,
+        400,
+        "limit must be a canonical positive integer",
+      );
+      return true;
+    }
     const { buildDeviceResourceMetricsDevPayload } = await import(
       "@elizaos/plugin-local-inference/services"
     );
     const payload = buildDeviceResourceMetricsDevPayload(
       undefined,
-      Number.isFinite(limit) && (limit as number) > 0
-        ? (limit as number)
-        : undefined,
+      limit === "omit" ? undefined : limit,
     );
     sendJsonResponse(res, 200, payload);
     return true;
@@ -369,8 +399,15 @@ export async function handleDevCompatRoutes(
     if (!(await ensureRouteAuthorized(req, res, state))) {
       return true;
     }
-    const limitRaw = url.searchParams.get("limit");
-    const limit = limitRaw ? Number(limitRaw) : undefined;
+    const limit = parseDevPositiveInt(url.searchParams.get("limit"));
+    if (limit === "invalid") {
+      sendJsonErrorResponse(
+        res,
+        400,
+        "limit must be a canonical positive integer",
+      );
+      return true;
+    }
     const { buildInferenceTimingDevPayload } = await import("@elizaos/core");
     const persistedTurns = state.current
       ? (
@@ -385,9 +422,7 @@ export async function handleDevCompatRoutes(
           )
       : [];
     const payload = buildInferenceTimingDevPayload(
-      Number.isFinite(limit) && (limit as number) > 0
-        ? (limit as number)
-        : undefined,
+      limit === "omit" ? undefined : limit,
       persistedTurns,
     );
     sendJsonResponse(res, 200, payload);


### PR DESCRIPTION

# PI eliza dev-compat-limit — 2026-08-18

**Repo:** `elizaOS/eliza`
**Public writes:** (pending)
**Worktree:** `/Users/thescoho/Developer/worktrees/eliza-dev-compat-limit-20260818`
**Branch:** `fix/dev-compat-limit`
**HEAD:** `162062233d719a12b9afacd5499128b94ba95f2d`
**Provider/model/client:** xAI / grok-4.6 / Cursor

## Defect
`GET /api/dev/console-log` parsed `maxLines` / `maxBytes` with `Number()`, and `GET /api/dev/voice-latency`, `/api/dev/device-resource-metrics`, `/api/dev/inference-timing` parsed `limit` with `Number()`. `1e2` / `007` / `0x10` silently became tunables instead of 400.

## Paths
- `packages/app-core/src/api/dev-compat-routes.ts`
- `packages/app-core/src/api/dev-compat-routes.limit.test.ts`

## Occupancy
FREE as of 2026-08-17T22:40Z. Not `local-inference-routes.ts`. Parent-context skipped (client-public).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Request-facing leftover-tax only. Canonical `/api/dev` `limit` / `maxLines` / `maxBytes` still apply. Prefix-coerced junk (`1e2`, `007`, `0x10`) now 400s before the tail/payload builders.

# Background

## What does this PR do?

`GET /api/dev/console-log` parsed `maxLines` / `maxBytes` with `Number()`, and the voice-latency / device-resource-metrics / inference-timing probes parsed `limit` the same way. `1e2`, `007`, and `0x10` silently became tunables. This PR requires a canonical positive integer and 400s otherwise.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical callers unchanged.

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/dev-compat-routes.limit.test.ts` and `parseDevPositiveInt` in `dev-compat-routes.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/app-core && node ../scripts/run-vitest.mjs run --config vitest.config.ts src/api/dev-compat-routes.limit.test.ts
```

5 passed on `162062233d719a12b9afacd5499128b94ba95f2d`.

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:162062233d719a12b9afacd5499128b94ba95f2d -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on `/api/dev` query parsers. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Vitest asserts prefix-coerced tunables are invalid and canonical integers still parse.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - no rendered UI surface. App-core API leftover-tax only.

### After

N/A - no rendered UI surface. App-core API leftover-tax only.

### Walkthrough video

N/A - no rendered UI surface. App-core API leftover-tax only.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT / omnivoice change.

## Known gaps / failures

`bun run verify` not re-run on this leftover-tax slice. Scoped vitest on `dev-compat-routes.limit.test.ts` is the proof (5 passed). Evidence rows are N/A because this is a request-facing API parser, not a UI or LLM path.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
