### PR TITLE
fix(cloud): satisfy the v2 source-authority shape in the verifier fixture

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
@@ -203,6 +203,12 @@ async function seedScheduledCatalogV2Placeholder(sandboxRecordId: string): Promi
       catalog_agent_id: sandboxRecordId,
       lifecycle_generation: randomUUID(),
       lifecycle_revision: 0n,
+      source_provider: "operator-onboarded",
+      source_node_record_id: randomUUID(),
+      source_node_id: "node-verifier-fixture-1",
+      source_node_incarnation: randomUUID(),
+      source_provider_handle: "verifier-fixture-handle",
+      source_container_id: "b".repeat(64),
       retention_reason: "schedule",
       retention_until: new Date("2030-01-01T00:00:00.000Z"),
     })


### PR DESCRIPTION
The catalogue v2 source and source-authority check constraints (merged today) require the full source identity on catalog_version=2 rows; agent-backup-verifier.test.ts's scheduled-placeholder fixture predates them and failed its insert (release candidate run 32072933298 — the only remaining red in the full test lane; the barge-in fix #21478 held). The fixture now carries a complete operator-onboarded source identity. Suite 42/42; Biome clean.