### PR TITLE
fix(plugin-agent-skills): harden skill zip extraction against path traversal and oversized archives

### DIFF
--- a/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
+++ b/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
@@ -111,6 +111,31 @@ vi.mock("@elizaos/core", () => {
 
 	return {
 		annotateActiveTrajectoryStep: vi.fn(async () => true),
+		// Faithful double of core's structured error (errors.ts): preserves the
+		// code/context/severity fields tests assert on.
+		ElizaError: class ElizaError extends Error {
+			readonly code: string;
+			readonly context?: Record<string, unknown>;
+			readonly severity?: string;
+			constructor(
+				message: string,
+				options: {
+					code: string;
+					cause?: unknown;
+					context?: Record<string, unknown>;
+					severity?: string;
+				},
+			) {
+				super(
+					message,
+					options.cause !== undefined ? { cause: options.cause } : undefined,
+				);
+				this.name = "ElizaError";
+				this.code = options.code;
+				this.context = options.context;
+				this.severity = options.severity;
+			}
+		},
 		// Confirmation double: tests exercising confirm-gated paths get an
 		// immediate "confirmed" so handlers run to completion in one call.
 		requireConfirmation: vi.fn(async () => ({ status: "confirmed" })),

--- a/plugins/plugin-agent-skills/src/storage.test.ts
+++ b/plugins/plugin-agent-skills/src/storage.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for skill zip extraction hardening — the sinks for W5-007 (zip-slip:
+ * backslash, absolute, and `..` entry names escaping the skill directory on
+ * extraction) and W5-031 (zip-bomb: uncompressed expansion previously bounded
+ * only by the 10 MB compressed download cap). Uses real fflate-produced
+ * archives, a real tmpdir-backed FileSystemSkillStore, and forged
+ * central-directory sizes. No mocks beyond the shared @elizaos/core double.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { strToU8, zipSync } from "fflate";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	FileSystemSkillStore,
+	MAX_ZIP_UNCOMPRESSED_SIZE,
+	MemorySkillStore,
+} from "./storage";
+
+const encoder = new TextEncoder();
+
+function makeZip(entries: Record<string, string>): Uint8Array {
+	const input: Record<string, Uint8Array> = {};
+	for (const [name, content] of Object.entries(entries)) {
+		input[name] = strToU8(content);
+	}
+	return zipSync(input);
+}
+
+/**
+ * Overwrite the uncompressed-size field of every central-directory entry,
+ * simulating a zip whose declared sizes do not match its real payload.
+ */
+function forgeUncompressedSizes(zip: Uint8Array, size: number): Uint8Array {
+	const out = new Uint8Array(zip);
+	const view = new DataView(out.buffer, out.byteOffset, out.byteLength);
+	let eocd = -1;
+	for (let i = out.length - 22; i >= 0; i--) {
+		if (
+			out[i] === 0x50 &&
+			out[i + 1] === 0x4b &&
+			out[i + 2] === 0x05 &&
+			out[i + 3] === 0x06
+		) {
+			eocd = i;
+			break;
+		}
+	}
+	expect(eocd).toBeGreaterThanOrEqual(0);
+	const entryCount = view.getUint16(eocd + 10, true);
+	let offset = view.getUint32(eocd + 16, true);
+	for (let i = 0; i < entryCount; i++) {
+		expect(view.getUint32(offset, true)).toBe(0x02014b50);
+		view.setUint32(offset + 24, size, true);
+		offset +=
+			46 +
+			view.getUint16(offset + 28, true) +
+			view.getUint16(offset + 30, true) +
+			view.getUint16(offset + 32, true);
+	}
+	return out;
+}
+
+const traversalEntries: Array<[label: string, entryName: string]> = [
+	["backslash traversal", "..\\..\\..\\escape.bat"],
+	["forward-slash traversal", "../../../escape.txt"],
+	["absolute POSIX path", "/etc/eliza-escape.txt"],
+	["drive-letter path", "C:/Windows/eliza-escape.dll"],
+	["drive-relative path", "C:eliza-escape.txt"],
+	["mixed separators", "subdir\\../../escape.txt"],
+	["backslash-only parent", "..\\escape.txt"],
+];
+
+describe("zip entry path validation", () => {
+	let basePath: string;
+	let fsStore: FileSystemSkillStore;
+	let memStore: MemorySkillStore;
+
+	beforeEach(async () => {
+		basePath = fs.mkdtempSync(path.join(os.tmpdir(), "w6-skills-test-"));
+		fsStore = new FileSystemSkillStore(basePath);
+		await fsStore.initialize();
+		memStore = new MemorySkillStore();
+	});
+
+	afterEach(() => {
+		fs.rmSync(basePath, { recursive: true, force: true });
+	});
+
+	const stores = () => [
+		{
+			name: "FileSystemSkillStore.saveFromZip",
+			extract: (zip: Uint8Array) => fsStore.saveFromZip("demo", zip),
+		},
+		{
+			name: "MemorySkillStore.loadFromZip",
+			extract: (zip: Uint8Array) => memStore.loadFromZip("demo", zip),
+		},
+	];
+
+	for (const [label, entryName] of traversalEntries) {
+		it(`rejects ${label} entries in both stores`, async () => {
+			const zip = makeZip({ "SKILL.md": "# demo", [entryName]: "payload" });
+			for (const store of stores()) {
+				await expect(store.extract(zip)).rejects.toMatchObject({
+					code: "SKILL_ZIP_ENTRY_UNSAFE",
+				});
+			}
+			// The rejection happens before any write: no skill directory, no
+			// escaped file anywhere near the base path.
+			expect(fs.existsSync(path.join(basePath, "demo"))).toBe(false);
+			expect(fs.existsSync(path.join(basePath, "escape.txt"))).toBe(false);
+			expect(memStore.getPackage("demo")).toBeUndefined();
+		});
+	}
+
+	it("rejects an entry consisting only of a parent segment", async () => {
+		const zip = makeZip({ "..": "payload", "SKILL.md": "# demo" });
+		for (const store of stores()) {
+			await expect(store.extract(zip)).rejects.toMatchObject({
+				code: "SKILL_ZIP_ENTRY_UNSAFE",
+			});
+		}
+	});
+
+	it("installs a well-formed skill zip end to end", async () => {
+		const zip = makeZip({
+			"SKILL.md": "# demo skill",
+			"scripts/run.sh": "echo hi",
+			"references/doc.md": "docs",
+		});
+		await fsStore.saveFromZip("demo", zip);
+		expect(fs.readFileSync(path.join(basePath, "demo", "SKILL.md"), "utf-8")).toBe(
+			"# demo skill",
+		);
+		expect(
+			fs.readFileSync(path.join(basePath, "demo", "scripts", "run.sh"), "utf-8"),
+		).toBe("echo hi");
+		expect(await fsStore.loadSkillContent("demo")).toBe("# demo skill");
+
+		await memStore.loadFromZip("demo", zip);
+		expect(await memStore.loadSkillContent("demo")).toBe("# demo skill");
+		expect(await memStore.loadFile("demo", "scripts/run.sh")).toBe("echo hi");
+	});
+
+	it("skips directory entries without rejecting the archive", async () => {
+		const input: Record<string, Uint8Array> = {
+			"SKILL.md": strToU8("# demo"),
+			"scripts/": new Uint8Array(0),
+			"scripts/run.sh": strToU8("echo hi"),
+		};
+		const zip = zipSync(input);
+		await fsStore.saveFromZip("demo", zip);
+		expect(
+			fs.existsSync(path.join(basePath, "demo", "scripts", "run.sh")),
+		).toBe(true);
+	});
+});
+
+describe("zip uncompressed-size limit", () => {
+	let basePath: string;
+	let fsStore: FileSystemSkillStore;
+	let memStore: MemorySkillStore;
+
+	beforeEach(async () => {
+		basePath = fs.mkdtempSync(path.join(os.tmpdir(), "w6-skills-test-"));
+		fsStore = new FileSystemSkillStore(basePath);
+		await fsStore.initialize();
+		memStore = new MemorySkillStore();
+	});
+
+	afterEach(() => {
+		fs.rmSync(basePath, { recursive: true, force: true });
+	});
+
+	it("rejects a zip whose forged central directory declares a huge entry", async () => {
+		// Real payload is tiny; the central directory claims a single entry
+		// expands past the cap. Rejection must happen before decompression.
+		const zip = forgeUncompressedSizes(
+			makeZip({ "SKILL.md": "# demo" }),
+			MAX_ZIP_UNCOMPRESSED_SIZE + 1,
+		);
+		await expect(fsStore.saveFromZip("demo", zip)).rejects.toMatchObject({
+			code: "SKILL_ZIP_TOO_LARGE",
+		});
+		await expect(memStore.loadFromZip("demo", zip)).rejects.toMatchObject({
+			code: "SKILL_ZIP_TOO_LARGE",
+		});
+		expect(fs.existsSync(path.join(basePath, "demo"))).toBe(false);
+	});
+
+	it("rejects when the sum of entry sizes exceeds the cap", async () => {
+		const perEntry = Math.floor(MAX_ZIP_UNCOMPRESSED_SIZE / 2) + 1;
+		const zip = forgeUncompressedSizes(
+			makeZip({ "SKILL.md": "# demo", "data.bin": "x" }),
+			perEntry,
+		);
+		await expect(fsStore.saveFromZip("demo", zip)).rejects.toMatchObject({
+			code: "SKILL_ZIP_TOO_LARGE",
+		});
+	});
+
+	it("rejects a buffer that is not a zip archive", async () => {
+		const garbage = encoder.encode("this is not a zip file at all");
+		await expect(fsStore.saveFromZip("demo", garbage)).rejects.toMatchObject({
+			code: "SKILL_ZIP_INVALID",
+		});
+	});
+
+	it("accepts a zip whose declared sizes are within the cap", async () => {
+		const zip = makeZip({ "SKILL.md": "# demo", "data.txt": "small" });
+		await fsStore.saveFromZip("demo", zip);
+		expect(await fsStore.loadSkillContent("demo")).toBe("# demo");
+	});
+});
+
+describe("filesystem path containment", () => {
+	let outerDir: string;
+	let basePath: string;
+	let store: FileSystemSkillStore;
+
+	beforeEach(async () => {
+		// Two-level fixture: the store root sits in its own sandbox parent so a
+		// containment regression can only ever delete this test's own directory.
+		outerDir = fs.mkdtempSync(path.join(os.tmpdir(), "w6-skills-outer-"));
+		basePath = path.join(outerDir, "skills");
+		store = new FileSystemSkillStore(basePath);
+		await store.initialize();
+	});
+
+	afterEach(() => {
+		fs.rmSync(outerDir, { recursive: true, force: true });
+	});
+
+	it("refuses to write a package file outside the skill directory", async () => {
+		await expect(
+			store.saveSkill({
+				slug: "demo",
+				files: new Map([
+					[
+						"../../escape.txt",
+						{ path: "../../escape.txt", content: "payload", isText: true },
+					],
+				]),
+			}),
+		).rejects.toMatchObject({ code: "SKILL_PATH_TRAVERSAL" });
+		expect(fs.existsSync(path.join(outerDir, "escape.txt"))).toBe(false);
+		expect(fs.existsSync(path.join(basePath, "escape.txt"))).toBe(false);
+	});
+
+	it("refuses to save a package whose slug escapes the base directory", async () => {
+		await expect(
+			store.saveSkill({
+				slug: "../escaped",
+				files: new Map([
+					["SKILL.md", { path: "SKILL.md", content: "# x", isText: true }],
+				]),
+			}),
+		).rejects.toMatchObject({ code: "SKILL_PATH_TRAVERSAL" });
+		expect(fs.existsSync(path.join(outerDir, "escaped"))).toBe(false);
+	});
+
+	it("refuses to delete outside the base directory", async () => {
+		const canary = path.join(outerDir, "canary.txt");
+		fs.writeFileSync(canary, "do not delete");
+		await expect(store.deleteSkill("..")).rejects.toMatchObject({
+			code: "SKILL_PATH_TRAVERSAL",
+		});
+		await expect(store.deleteSkill("../..")).rejects.toMatchObject({
+			code: "SKILL_PATH_TRAVERSAL",
+		});
+		expect(fs.readFileSync(canary, "utf-8")).toBe("do not delete");
+		// The store itself is untouched by the rejected deletes.
+		expect(fs.existsSync(basePath)).toBe(true);
+	});
+
+	it("still deletes a real skill directory", async () => {
+		await store.saveSkill({
+			slug: "demo",
+			files: new Map([
+				[
+					"SKILL.md",
+					{ path: "SKILL.md", content: "# demo", isText: true },
+				],
+			]),
+		});
+		expect(await store.hasSkill("demo")).toBe(true);
+		expect(await store.deleteSkill("demo")).toBe(true);
+		expect(fs.existsSync(path.join(basePath, "demo"))).toBe(false);
+		expect(await store.deleteSkill("demo")).toBe(false);
+	});
+});

--- a/plugins/plugin-agent-skills/src/storage.ts
+++ b/plugins/plugin-agent-skills/src/storage.ts
@@ -6,11 +6,27 @@
  * - FileSystemSkillStore: For Node.js/native environments (skills on disk)
  *
  * Both implement the same interface for seamless switching.
+ *
+ * Zip packages are untrusted input (registry downloads). Extraction rejects
+ * entries with backslashes, absolute paths, or `..` segments, refuses archives
+ * whose central directory declares an uncompressed total over
+ * MAX_ZIP_UNCOMPRESSED_SIZE, and asserts every filesystem write and delete
+ * resolves inside the target skill directory.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { unzipSync } from "fflate";
 import { parseFrontmatter, validateFrontmatter } from "./parser";
 import type { Skill } from "./types";
+
+/**
+ * Maximum total uncompressed size of a skill zip (100 MB). The download cap in
+ * services/skills.ts bounds only the compressed bytes; this bound stops
+ * zip-bomb expansion before any entry is materialized. fflate's `unzipSync`
+ * allocates exactly the per-entry uncompressed size declared in the central
+ * directory, so summing those declared sizes is a hard memory bound.
+ */
+export const MAX_ZIP_UNCOMPRESSED_SIZE = 100 * 1024 * 1024;
 
 // ============================================================
 // STORAGE INTERFACE
@@ -199,6 +215,7 @@ export class MemorySkillStore implements ISkillStorage {
 	 * Load a skill from a zip buffer (for registry downloads).
 	 */
 	async loadFromZip(slug: string, zipBuffer: Uint8Array): Promise<void> {
+		assertZipUncompressedSizeWithinLimit(zipBuffer);
 		const unzipped = unzipSync(zipBuffer);
 
 		const files = new Map<string, SkillFile>();
@@ -206,13 +223,9 @@ export class MemorySkillStore implements ISkillStorage {
 		for (const [fileName, data] of Object.entries(unzipped)) {
 			if (fileName.endsWith("/")) continue;
 
-			// Sanitize path
-			const parts = fileName
-				.split("/")
-				.filter((p) => p && p !== ".." && p !== ".");
-			if (parts.length === 0) continue;
+			const relativePath = sanitizeZipEntryPath(fileName);
+			if (relativePath === null) continue;
 
-			const relativePath = parts.join("/");
 			const isText = isTextFile(relativePath);
 
 			files.set(relativePath, {
@@ -380,6 +393,8 @@ export class FileSystemSkillStore implements ISkillStorage {
 		const { fs, path } = this.requireNodeModules();
 
 		const skillDir = path.join(this.basePath, pkg.slug);
+		assertContainedPath(path, path.resolve(this.basePath), skillDir, pkg.slug);
+		const resolvedSkillDir = path.resolve(skillDir);
 
 		// Create skill directory
 		if (!fs.existsSync(skillDir)) {
@@ -389,6 +404,7 @@ export class FileSystemSkillStore implements ISkillStorage {
 		// Write all files
 		for (const [relativePath, file] of pkg.files) {
 			const fullPath = path.join(skillDir, relativePath);
+			assertContainedPath(path, resolvedSkillDir, fullPath, relativePath);
 			const dir = path.dirname(fullPath);
 
 			// Ensure directory exists
@@ -409,6 +425,7 @@ export class FileSystemSkillStore implements ISkillStorage {
 		if (!this.fs || !this.path) await this.initialize();
 		const { fs, path } = this.requireNodeModules();
 		const skillDir = path.join(this.basePath, slug);
+		assertContainedPath(path, path.resolve(this.basePath), skillDir, slug);
 		if (!fs.existsSync(skillDir)) return false;
 
 		// Recursive delete
@@ -426,6 +443,7 @@ export class FileSystemSkillStore implements ISkillStorage {
 	 * Save a skill from a zip buffer.
 	 */
 	async saveFromZip(slug: string, zipBuffer: Uint8Array): Promise<void> {
+		assertZipUncompressedSizeWithinLimit(zipBuffer);
 		const unzipped = unzipSync(zipBuffer);
 
 		const files = new Map<string, SkillFile>();
@@ -433,12 +451,9 @@ export class FileSystemSkillStore implements ISkillStorage {
 		for (const [fileName, data] of Object.entries(unzipped)) {
 			if (fileName.endsWith("/")) continue;
 
-			const parts = fileName
-				.split("/")
-				.filter((p) => p && p !== ".." && p !== ".");
-			if (parts.length === 0) continue;
+			const relativePath = sanitizeZipEntryPath(fileName);
+			if (relativePath === null) continue;
 
-			const relativePath = parts.join("/");
 			const isText = isTextFile(relativePath);
 
 			files.set(relativePath, {
@@ -455,6 +470,131 @@ export class FileSystemSkillStore implements ISkillStorage {
 // ============================================================
 // HELPER FUNCTIONS
 // ============================================================
+
+/**
+ * Sum the uncompressed sizes declared in a zip's central directory and reject
+ * archives over MAX_ZIP_UNCOMPRESSED_SIZE before any entry is decompressed.
+ * `unzipSync` materializes every entry at its declared size, so the declared
+ * total is the exact peak allocation. Malformed and zip64 archives are
+ * rejected: a skill package under the 10 MB compressed cap never needs zip64.
+ */
+function assertZipUncompressedSizeWithinLimit(zipBuffer: Uint8Array): void {
+	const data = zipBuffer;
+	const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+
+	// Locate the End Of Central Directory record by scanning backwards through
+	// the maximum comment window, mirroring fflate's own search bounds.
+	let eocd = -1;
+	const scanFloor = Math.max(0, data.length - 22 - 0xffff);
+	for (let i = data.length - 22; i >= scanFloor; i--) {
+		if (
+			data[i] === 0x50 &&
+			data[i + 1] === 0x4b &&
+			data[i + 2] === 0x05 &&
+			data[i + 3] === 0x06
+		) {
+			eocd = i;
+			break;
+		}
+	}
+	if (eocd < 0) {
+		throw new ElizaError("Skill zip is not a valid archive", {
+			code: "SKILL_ZIP_INVALID",
+			context: { reason: "end of central directory not found" },
+		});
+	}
+
+	const entryCount = view.getUint16(eocd + 10, true);
+	const cdOffset = view.getUint32(eocd + 16, true);
+	if (entryCount === 0xffff || cdOffset === 0xffffffff) {
+		throw new ElizaError("Skill zip uses zip64, which skill packages do not support", {
+			code: "SKILL_ZIP_INVALID",
+			context: { reason: "zip64 central directory" },
+		});
+	}
+
+	let totalUncompressed = 0;
+	let offset = cdOffset;
+	for (let i = 0; i < entryCount; i++) {
+		if (offset + 46 > data.length || view.getUint32(offset, true) !== 0x02014b50) {
+			throw new ElizaError("Skill zip is not a valid archive", {
+				code: "SKILL_ZIP_INVALID",
+				context: { reason: "malformed central directory entry", entryIndex: i },
+			});
+		}
+		totalUncompressed += view.getUint32(offset + 24, true);
+		if (totalUncompressed > MAX_ZIP_UNCOMPRESSED_SIZE) {
+			throw new ElizaError("Skill zip expands beyond the uncompressed size limit", {
+				code: "SKILL_ZIP_TOO_LARGE",
+				context: {
+					declaredBytes: totalUncompressed,
+					maxBytes: MAX_ZIP_UNCOMPRESSED_SIZE,
+				},
+			});
+		}
+		const nameLen = view.getUint16(offset + 28, true);
+		const extraLen = view.getUint16(offset + 30, true);
+		const commentLen = view.getUint16(offset + 32, true);
+		offset += 46 + nameLen + extraLen + commentLen;
+	}
+}
+
+/**
+ * Normalize a zip entry name to a safe relative path, or return null for
+ * entries that carry no file (e.g. bare `.` segments). Throws on any entry
+ * that could escape the skill directory: backslashes (path separators on
+ * Windows, invisible to a `/`-split filter), absolute paths (POSIX root or
+ * drive letter), and `..` segments. Rejecting the whole archive rather than
+ * silently filtering keeps a malicious package from installing in a
+ * half-sanitized shape.
+ */
+function sanitizeZipEntryPath(fileName: string): string | null {
+	if (
+		fileName.includes("\\") ||
+		fileName.startsWith("/") ||
+		/^[A-Za-z]:/.test(fileName)
+	) {
+		throw new ElizaError("Skill zip entry has an unsafe path", {
+			code: "SKILL_ZIP_ENTRY_UNSAFE",
+			context: { entry: fileName },
+		});
+	}
+
+	const parts = fileName.split("/");
+	if (parts.some((p) => p === "..")) {
+		throw new ElizaError("Skill zip entry has an unsafe path", {
+			code: "SKILL_ZIP_ENTRY_UNSAFE",
+			context: { entry: fileName },
+		});
+	}
+
+	const kept = parts.filter((p) => p && p !== ".");
+	return kept.length === 0 ? null : kept.join("/");
+}
+
+/**
+ * Assert that a filesystem target resolves strictly inside a base directory.
+ * `path.resolve` collapses both separators on Windows, so this is the
+ * platform-correct backstop behind entry-name validation. Throws on equality
+ * too: the base directory itself is never a valid write/delete target.
+ */
+function assertContainedPath(
+	path: typeof import("path"),
+	resolvedBase: string,
+	target: string,
+	label: string,
+): void {
+	const resolvedTarget = path.resolve(target);
+	if (
+		resolvedTarget === resolvedBase ||
+		!resolvedTarget.startsWith(resolvedBase + path.sep)
+	) {
+		throw new ElizaError("Skill path escapes the skill directory", {
+			code: "SKILL_PATH_TRAVERSAL",
+			context: { path: label },
+		});
+	}
+}
 
 /**
  * Determine if a file is text-based by extension.


### PR DESCRIPTION
## Summary

Wave-6 security remediation for two findings in skill-package zip extraction (`plugins/plugin-agent-skills`). Skill zips downloaded from the registry are untrusted input; extraction previously trusted entry names and bounded only the compressed download size.

### W5-007 (MEDIUM) — zip entry path traversal in skill extraction

- Entry names are now validated against both path separators: any entry containing a backslash, an absolute path (POSIX root or drive letter), or a parent-directory segment rejects the whole archive before any byte is written — applied identically in `FileSystemSkillStore.saveFromZip` and `MemorySkillStore.loadFromZip`.
- `FileSystemSkillStore` now asserts `path.resolve` containment before every write in `saveSkill` (both the skill directory derived from the slug and each package file) and before the recursive delete in `deleteSkill`, so neither operation can act outside the store's base directory even for a hostile slug.

### W5-031 (LOW) — no uncompressed-size cap on skill zips (expansion DoS)

- Before decompression, the uncompressed sizes declared in the archive's central directory are summed and archives over a new 100 MB cap (`MAX_ZIP_UNCOMPRESSED_SIZE`) are rejected. Malformed and zip64 archives are rejected outright. The declared-total bound is exact for the extractor in use (fflate `unzipSync` allocates per-entry at the declared size), so this is a hard memory bound; the existing 10 MB compressed download cap is unchanged.

## Test evidence

New `src/storage.test.ts` (18 tests, real fflate-produced archives + real tmpdir-backed `FileSystemSkillStore`; the only mock is the shared `@elizaos/core` double, extended with a faithful `ElizaError`):

- Adversarial entry names rejected in both stores: backslash traversal, forward-slash traversal, absolute POSIX, drive-letter, drive-relative, mixed separators, bare parent segment — with no skill directory or escaped file created.
- Forged central directory (tiny real payload, huge declared sizes) rejected pre-decompression, as is a summed-over-cap multi-entry archive and a non-zip buffer; well-formed archives and directory entries still install end to end.
- Containment: package file write outside the skill dir, slug escaping the base dir, and `deleteSkill("..")`/`("../..")` all refused; canary file survives; legitimate delete still works.

Validation (review head `dda86e2af98fdc7490a1a7ac9b780d6e46961526`, rebased onto current `origin/develop`):

- `bunx vitest run --config ./vitest.config.ts src/storage.test.ts` — 18 focused storage tests pass on the exact review head. The aggregate package run reached 87 passing tests and failed 25 unchanged route tests because this shared machine resolves worktree dependencies through the dirty main checkout, whose built `@elizaos/shared` lacks the source export used by those tests.
- `bun run --cwd plugins/plugin-agent-skills typecheck` — clean
- `biome check` on the three changed files — clean

## Risk notes

- Rejection behavior changes from silent filtering to fail-closed: a malformed/hostile archive now aborts the install with `SKILL_ZIP_ENTRY_UNSAFE` / `SKILL_ZIP_TOO_LARGE` / `SKILL_ZIP_INVALID` / `SKILL_PATH_TRAVERSAL` instead of installing a sanitized subset. Legitimate cross-platform-authored archives with backslash separators will now be rejected rather than partially installed — that is the intended hardening.
- zip64 skill packages are rejected; none should exist under the 10 MB compressed cap.
- 100 MB uncompressed cap is generous for text-centric skill packages while capping worst-case extraction memory.
- No changes to services or routes; all guards live at the storage boundary both zip entry points already funnel through.

## Evidence Gate

<!-- evidence-head:dda86e2af98fdc7490a1a7ac9b780d6e46961526 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - storage boundary only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - storage boundary only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no service or route changed; exact-head focused test output is recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact; 18 real archive and tmpdir-backed storage tests pass at the exact head.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3b8ddfea9cd8272093423e1a8e6f5ca65f7a8ef3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@3b8ddfea9cd8272093423e1a8e6f5ca65f7a8ef3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3b8ddfea9cd8272093423e1a8e6f5ca65f7a8ef3:packages/skills/skills/contribute-to-eliza"} -->
