### PR TITLE
fix(plugin-wallet): reject prefix-coerced EVM sign chainId

### DIFF
--- a/plugins/plugin-wallet/src/chains/evm/routes/sign.limit.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/routes/sign.limit.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Prefix-coerced EVM sign chainId must be invalid.
+ * Number("1e2") === 100 used to select Gnosis instead of 400.
+ */
+import type { IAgentRuntime, RouteRequest, RouteResponse } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { evmSignRoutes } from "./sign";
+
+const walletBackendMocks = vi.hoisted(() => ({
+  resolveWalletBackend: vi.fn(),
+}));
+
+vi.mock("../../../wallet/select-backend", () => ({
+  resolveWalletBackend: walletBackendMocks.resolveWalletBackend,
+}));
+
+function runtime(token: string | null): IAgentRuntime {
+  return {
+    getSetting: vi.fn((key: string) =>
+      key === "WALLET_BROWSER_SIGN_TOKEN" ? token : undefined,
+    ),
+  } as unknown as IAgentRuntime;
+}
+
+function req(body: unknown): RouteRequest {
+  return {
+    method: "POST",
+    headers: { authorization: "Bearer 1234567890abcdef" },
+    body,
+  } as unknown as RouteRequest;
+}
+
+function res(): RouteResponse & {
+  statusCode?: number;
+  body?: unknown;
+} {
+  const response = {
+    statusCode: undefined as number | undefined,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+    },
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+    },
+  };
+  return response as unknown as RouteResponse & {
+    statusCode?: number;
+    body?: unknown;
+  };
+}
+
+function route(name: string) {
+  const found = evmSignRoutes.find((candidate) => candidate.name === name);
+  if (!found?.handler) throw new Error(`missing route ${name}`);
+  return found.handler;
+}
+
+describe("EVM sign chainId leftover identities", () => {
+  beforeEach(() => {
+    walletBackendMocks.resolveWalletBackend.mockReset();
+  });
+
+  it.each(["1e2", "007", "0x10junk", "12px"])(
+    "rejects leftover chainId %s before resolving the backend",
+    async (chainId) => {
+      const response = res();
+      await route("wallet-evm-sign-transaction")(
+        req({
+          chainId,
+          tx: { to: "0x0000000000000000000000000000000000000000" },
+        }),
+        response,
+        runtime("1234567890abcdef"),
+      );
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body).toEqual({
+        error: "chainId must be a number or hex string",
+      });
+      expect(walletBackendMocks.resolveWalletBackend).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["1", "0x1"])(
+    "still accepts canonical chainId %s and reaches the backend",
+    async (chainId) => {
+      const getEvmAccount = vi.fn(() => ({
+        address: "0x0000000000000000000000000000000000000001",
+      }));
+      walletBackendMocks.resolveWalletBackend.mockResolvedValueOnce({
+        getEvmAccount,
+      });
+      const response = res();
+      await route("wallet-evm-sign-transaction")(
+        req({
+          chainId,
+          tx: {
+            to: "0x0000000000000000000000000000000000000000",
+            value: "not-a-bigint",
+          },
+        }),
+        response,
+        runtime("1234567890abcdef"),
+      );
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body).toEqual({
+        error: "invalid bigint value: not-a-bigint",
+      });
+      expect(walletBackendMocks.resolveWalletBackend).toHaveBeenCalledTimes(1);
+      expect(getEvmAccount).toHaveBeenCalledWith(1);
+    },
+  );
+});

--- a/plugins/plugin-wallet/src/chains/evm/routes/sign.ts
+++ b/plugins/plugin-wallet/src/chains/evm/routes/sign.ts
@@ -138,8 +138,16 @@ function readChainId(body: unknown): number {
   const c = (body as { chainId?: unknown }).chainId;
   if (typeof c === "number") return c;
   if (typeof c === "string") {
-    const n = c.startsWith("0x") ? Number.parseInt(c.slice(2), 16) : Number(c);
-    if (Number.isFinite(n)) return n;
+    const raw = c.trim();
+    // Canonical hex or decimal only. Number("1e2") === 100 used to sign on
+    // Gnosis instead of rejecting leftover scientific / prefix identities.
+    if (/^0x[0-9a-fA-F]+$/.test(raw)) {
+      const n = Number.parseInt(raw.slice(2), 16);
+      if (Number.isFinite(n)) return n;
+    } else if (/^(0|[1-9]\d*)$/.test(raw)) {
+      const n = Number(raw);
+      if (Number.isFinite(n)) return n;
+    }
   }
   throw new EvmSignInputError("chainId must be a number or hex string");
 }


### PR DESCRIPTION

# PI eliza evm-sign-chainid — 2026-08-18

**Repo:** `elizaOS/eliza`
**Public writes:** (pending)
**Worktree:** `/Users/thescoho/Developer/worktrees/eliza-evm-sign-chainid-20260818`
**Branch:** `fix/evm-sign-chainid`
**HEAD:** `1e8c75c6076d59cad13c42cb48a7d4f2e82b69ad`
**Provider/model/client:** xAI / grok-4.6 / Cursor

## Defect
Browser EVM `sign-transaction` / `send-transaction` parsed string `chainId` with `Number()`. `1e2` became 100 (Gnosis) and `007` became 7 instead of 400.

## Paths
- `plugins/plugin-wallet/src/chains/evm/routes/sign.ts`
- `plugins/plugin-wallet/src/chains/evm/routes/sign.limit.test.ts`

## Occupancy
FREE as of 2026-08-17T23:20Z. Not a twin of `#21325` (EVM swap/bridge slippageBps) or `#21322` (wallet-router slippageBps) or `#21260` (cloud onchain chainId).

# Risks

Low. Request-facing leftover-tax only. Canonical decimal and `0x` hex chain IDs still apply. Prefix-coerced junk (`1e2`, `007`) now 400s before the wallet backend.

# Background

## What does this PR do?

Browser EVM sign/send parsed string `chainId` with `Number()`. `1e2` silently selected chain 100 and `007` selected chain 7. This PR requires a canonical decimal integer or `0x` hex string and 400s otherwise.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/chains/evm/routes/sign.limit.test.ts` and `readChainId` in `sign.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-wallet && bun --conditions=eliza-source ../../node_modules/.bin/vitest run --config vitest.config.ts src/chains/evm/routes/sign.limit.test.ts --coverage.enabled=false
```

6 passed on `1e8c75c6076d59cad13c42cb48a7d4f2e82b69ad`.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on EVM sign `chainId`. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Vitest asserts leftover chainId identities 400 before the wallet backend and canonical `1` / `0x1` still reach it.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the browser signing HTTP boundary.

## Domain artifacts

N/A - no DB / memory / wallet-broadcast / generated-file change. Invalid chainId never reaches signing.

## OCR visual-text review

N/A - no rendered visual surface.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Request-facing leftover-tax only. Canonical decimal and `0x` hex chain IDs still apply. Prefix-coerced junk (`1e2`, `007`) now 400s before the wallet backend.

# Background

## What does this PR do?

Browser EVM sign/send parsed string `chainId` with `Number()`. `1e2` silently selected chain 100 and `007` selected chain 7. This PR requires a canonical decimal integer or `0x` hex string and 400s otherwise.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical callers unchanged.

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/chains/evm/routes/sign.limit.test.ts` and `readChainId` in `sign.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-wallet && bun --conditions=eliza-source ../../node_modules/.bin/vitest run --config vitest.config.ts src/chains/evm/routes/sign.limit.test.ts --coverage.enabled=false
```

6 passed on `1e8c75c6076d59cad13c42cb48a7d4f2e82b69ad`.

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:1e8c75c6076d59cad13c42cb48a7d4f2e82b69ad -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on EVM sign `chainId`. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Vitest asserts leftover chainId identities 400 before the wallet backend and canonical `1` / `0x1` still reach it.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - no rendered UI surface. Plugin-wallet EVM sign leftover-tax only.

### After

N/A - no rendered UI surface. Plugin-wallet EVM sign leftover-tax only.

### Walkthrough video

N/A - no rendered UI surface. Plugin-wallet EVM sign leftover-tax only.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT / omnivoice change.

## Known gaps / failures

`bun run verify` not re-run on this leftover-tax slice. Scoped vitest on `sign.limit.test.ts` is the proof (6 passed). Evidence rows are N/A because this is a request-facing API parser, not a UI or LLM path.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
