### PR TITLE
fix(plugin-workflow): reject prefix-coerced workbench todo priority

### DIFF
--- a/plugins/plugin-workflow/src/routes/workbench-todos.limit.test.ts
+++ b/plugins/plugin-workflow/src/routes/workbench-todos.limit.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Prefix-coerced workbench todo priority must be invalid.
+ * Number("1e2") === 100 used to become a stored priority.
+ */
+import { describe, expect, it } from "vitest";
+import { parseNullableNumber } from "./workbench-todos";
+
+describe("workbench todo priority leftover identities", () => {
+  it("1e2 is invalid instead of becoming 100", () => {
+    expect(parseNullableNumber("1e2")).toBeNull();
+  });
+
+  it("007 is invalid instead of becoming 7", () => {
+    expect(parseNullableNumber("007")).toBeNull();
+  });
+
+  it("0x10 is invalid instead of becoming 16", () => {
+    expect(parseNullableNumber("0x10")).toBeNull();
+  });
+
+  it("canonical 3 still parses", () => {
+    expect(parseNullableNumber("3")).toBe(3);
+  });
+
+  it("canonical number 3 still parses", () => {
+    expect(parseNullableNumber(3)).toBe(3);
+  });
+
+  it("omitted priority stays null", () => {
+    expect(parseNullableNumber(null)).toBeNull();
+    expect(parseNullableNumber(undefined)).toBeNull();
+    expect(parseNullableNumber("")).toBeNull();
+  });
+});

--- a/plugins/plugin-workflow/src/routes/workbench-todos.ts
+++ b/plugins/plugin-workflow/src/routes/workbench-todos.ts
@@ -64,11 +64,15 @@ interface AgentEventEmitterLike {
   }): void;
 }
 
-function parseNullableNumber(value: unknown): number | null {
+export function parseNullableNumber(value: unknown): number | null {
   if (value === null || value === undefined || value === '') return null;
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (typeof value === 'string') {
-    const parsed = Number(value);
+    const raw = value.trim();
+    // Canonical decimal only. Number("1e2") === 100 used to store leftover
+    // scientific / hex / leading-zero identities as a real todo priority.
+    if (!/^-?(0|[1-9]\d*)(\.\d+)?$/.test(raw)) return null;
+    const parsed = Number(raw);
     if (Number.isFinite(parsed)) return parsed;
   }
   return null;


### PR DESCRIPTION

# PI eliza workbench-todo-priority — 2026-08-18

**Repo:** `elizaOS/eliza`
**Public writes:** (pending)
**Worktree:** `/Users/thescoho/Developer/worktrees/eliza-workbench-todo-priority-20260818`
**Branch:** `fix/workbench-todo-priority`
**HEAD:** `fdbfc4080d25ba6ed4950e7e4b0f05a03ea2c168`
**Provider/model/client:** xAI / grok-4.6 / Cursor

## Defect
`POST`/`PUT` `/api/workbench/todos` parsed string `priority` with `Number()`. `1e2` / `007` / `0x10` silently became stored priorities instead of null.

## Paths
- `plugins/plugin-workflow/src/routes/workbench-todos.ts`
- `plugins/plugin-workflow/src/routes/workbench-todos.limit.test.ts`

## Occupancy
FREE as of 2026-08-17T23:20Z. Not a twin of `#20808` (billing JSON) or workflow encoding leftovers. `validateLimit` in `_helpers.ts` is unused dead code — skipped.

# Risks

Low. Request-facing leftover-tax only. Canonical decimal priorities still apply. Prefix-coerced junk (`1e2`, `007`, `0x10`) now stores as null instead of a different priority.

# Background

## What does this PR do?

Workbench todo create/update parsed string `priority` with `Number()`. `1e2`, `007`, and `0x10` silently became stored priorities. This PR requires a canonical decimal and treats leftover identities as omitted.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-workflow/src/routes/workbench-todos.limit.test.ts` and `parseNullableNumber` in `workbench-todos.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-workflow && bun test --isolate src/routes/workbench-todos.limit.test.ts
```

6 passed on `fdbfc4080d25ba6ed4950e7e4b0f05a03ea2c168`.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on workbench todo `priority`. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Bun test asserts leftover priority identities are null and canonical `3` still parses.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the workbench todos HTTP boundary.

## Domain artifacts

N/A - no DB / memory / wallet / generated-file change beyond rejecting leftover priority strings.

## OCR visual-text review

N/A - no rendered visual surface.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Request-facing leftover-tax only. Canonical decimal priorities still apply. Prefix-coerced junk (`1e2`, `007`, `0x10`) now stores as null instead of a different priority.

# Background

## What does this PR do?

Workbench todo create/update parsed string `priority` with `Number()`. `1e2`, `007`, and `0x10` silently became stored priorities. This PR requires a canonical decimal and treats leftover identities as omitted.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical callers unchanged.

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`plugins/plugin-workflow/src/routes/workbench-todos.limit.test.ts` and `parseNullableNumber` in `workbench-todos.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-workflow && bun test --isolate src/routes/workbench-todos.limit.test.ts
```

6 passed on `fdbfc4080d25ba6ed4950e7e4b0f05a03ea2c168`.

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:fdbfc4080d25ba6ed4950e7e4b0f05a03ea2c168 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on workbench todo `priority`. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Bun test asserts leftover priority identities are null and canonical `3` still parses.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - no rendered UI surface. Plugin-workflow workbench todo leftover-tax only.

### After

N/A - no rendered UI surface. Plugin-workflow workbench todo leftover-tax only.

### Walkthrough video

N/A - no rendered UI surface. Plugin-workflow workbench todo leftover-tax only.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT / omnivoice change.

## Known gaps / failures

`bun run verify` not re-run on this leftover-tax slice. Scoped bun test on `workbench-todos.limit.test.ts` is the proof (6 passed). Evidence rows are N/A because this is a request-facing API parser, not a UI or LLM path.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
