### PR TITLE
fix(ci): gate snap publishing and pin remaining CI installer downloads (W5-006, W5-029, W5-030)

### DIFF
--- a/.github/scripts/install-gitleaks.sh
+++ b/.github/scripts/install-gitleaks.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Installs checksum-pinned gitleaks for the current supported runner.
+#
+# Single source of truth for the gitleaks version and SHA256 consumed by
+# ci.yml, gitleaks.yml, and test.yml — bump every consumer by editing this
+# file. Hashes come from the upstream gitleaks_<version>_checksums.txt
+# release asset; verify against it on every version bump.
+
+set -euo pipefail
+
+GITLEAKS_VERSION="8.30.1"
+destination="${1:-${RUNNER_TEMP:-/tmp}/gitleaks-bin}"
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)
+    gitleaks_asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+    gitleaks_sha="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+    ;;
+  Linux-aarch64|Linux-arm64)
+    gitleaks_asset="gitleaks_${GITLEAKS_VERSION}_linux_arm64.tar.gz"
+    gitleaks_sha="e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080"
+    ;;
+  Darwin-x86_64)
+    gitleaks_asset="gitleaks_${GITLEAKS_VERSION}_darwin_x64.tar.gz"
+    gitleaks_sha="dfe101a4db2255fc85120ac7f3d25e4342c3c20cf749f2c20a18081af1952709"
+    ;;
+  Darwin-arm64)
+    gitleaks_asset="gitleaks_${GITLEAKS_VERSION}_darwin_arm64.tar.gz"
+    gitleaks_sha="b40ab0ae55c505963e365f271a8d3846efbc170aa17f2607f13df610a9aeb6a5"
+    ;;
+  *)
+    printf 'unsupported gitleaks host: %s-%s\n' "$(uname -s)" "$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$destination"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+gitleaks_archive="$scratch/$gitleaks_asset"
+curl --fail --location --silent --show-error --retry 3 \
+  --output "$gitleaks_archive" \
+  "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${gitleaks_asset}"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$gitleaks_archive" | awk '{print $1}')"
+else
+  actual="$(shasum -a 256 "$gitleaks_archive" | awk '{print $1}')"
+fi
+if [[ "$actual" != "$gitleaks_sha" ]]; then
+  printf 'checksum mismatch for gitleaks: expected %s, got %s\n' "$gitleaks_sha" "$actual" >&2
+  exit 1
+fi
+
+tar -xzf "$gitleaks_archive" -C "$scratch" gitleaks
+install -m 0755 "$scratch/gitleaks" "$destination/gitleaks"
+printf '%s\n' "$destination"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,17 +520,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version=8.30.1
-          # SHA256-pinned like the actionlint installer
-          # (.github/scripts/install-workflow-linters.sh); update both together
-          # on version bumps.
-          sha256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
-          archive="$RUNNER_TEMP/gitleaks.tar.gz"
-          curl --fail --location --silent --show-error \
-            --output "$archive" \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz"
-          echo "${sha256}  ${archive}" | sha256sum --check -
-          tar -xzf "$archive" -C "$RUNNER_TEMP" gitleaks
+          # Version and SHA256 are pinned in the shared installer
+          # (.github/scripts/install-gitleaks.sh); bump them there.
+          ./.github/scripts/install-gitleaks.sh "$RUNNER_TEMP"
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 
       - name: Scan changed commits

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -34,23 +34,14 @@ jobs:
       - name: Install gitleaks (OSS binary — no license required)
         # gitleaks/gitleaks-action@v2 requires a paid license for org repos.
         # We download the OSS CLI directly so the scan remains free and
-        # honors our .gitleaks.toml allowlist + custom rules.
+        # honors our .gitleaks.toml allowlist + custom rules. Version and
+        # SHA256 are pinned in the shared installer
+        # (.github/scripts/install-gitleaks.sh); bump them there.
         run: |
           set -euo pipefail
-          GITLEAKS_VERSION=8.30.1
-          # SHA256-pinned like the actionlint installer
-          # (.github/scripts/install-workflow-linters.sh); update both together
-          # on version bumps.
-          GITLEAKS_SHA256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
-          curl -sSL -o /tmp/gitleaks.tar.gz \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum --check -
-          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
-          # Install without sudo so this works on any runner (github-hosted or
-          # self-hosted, which has no passwordless sudo): write to a user-writable
-          # dir and add it to PATH for the run step, not `sudo install /usr/local/bin`.
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 /tmp/gitleaks "$HOME/.local/bin/gitleaks"
+          # The installer writes to a user-writable dir (no sudo) so this works
+          # on github-hosted and self-hosted runners alike.
+          ./.github/scripts/install-gitleaks.sh "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/gitleaks" version
 

--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -910,9 +910,21 @@ jobs:
         shell: pwsh
         run: |
           $url = "https://github.com/jrsoftware/issrc/releases/download/is-6_7_1/innosetup-6.7.1.exe"
+          # SHA256-pinned like the actionlint/gitleaks installers; bump the
+          # version, URL, and hash together. Recorded from the is-6_7_1 release
+          # asset digest exposed by the GitHub API.
+          $expectedSha256 = "4d11e8050b6185e0d49bd9e8cc661a7a59f44959a621d31d11033124c4e8a7b0"
           $installer = Join-Path $env:RUNNER_TEMP "innosetup-6.7.1.exe"
           Write-Host "Downloading Inno Setup 6.7.1..."
           Invoke-WebRequest -Uri $url -OutFile $installer -UseBasicParsing
+          # This job holds the Windows signing certificate, so the installer
+          # bytes must be verified before they are executed.
+          $actualSha256 = (Get-FileHash -Path $installer -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualSha256 -ne $expectedSha256) {
+            Write-Error "Inno Setup installer SHA256 mismatch: expected $expectedSha256, got $actualSha256"
+            exit 1
+          }
+          Write-Host "SHA256 verified: $actualSha256"
           Write-Host "Installing silently..."
           Start-Process -FilePath $installer -ArgumentList "/VERYSILENT","/SUPPRESSMSGBOXES","/NORESTART","/SP-" -Wait -NoNewWindow
 

--- a/.github/workflows/snap-publish.yml
+++ b/.github/workflows/snap-publish.yml
@@ -40,9 +40,6 @@ jobs:
     environment:
       name: production-release
 
-    env:
-      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -70,6 +67,8 @@ jobs:
         uses: ./.github/actions/normalize-snapd-root
 
       - name: Check Snap Store credentials
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: |
           if [[ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]]; then
             echo "::error::SNAPCRAFT_STORE_CREDENTIALS is required for the canonical store release."
@@ -101,11 +100,14 @@ jobs:
           ls -la "$SNAP_FILE"
 
       - name: Verify Snap Store credentials
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: snapcraft whoami
 
       - name: Publish to Snap Store
         env:
           CHANNEL: ${{ inputs.channel }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: |
           case "$CHANNEL" in
             stable|candidate|beta|edge) ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1259,13 +1259,9 @@ jobs:
       - name: Install gitleaks
         run: |
           set -euo pipefail
-          GITLEAKS_VERSION=8.30.1
-          curl --fail --location --silent --show-error --retry 3 \
-            --output "$RUNNER_TEMP/gitleaks.tar.gz" \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$RUNNER_TEMP" gitleaks
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 "$RUNNER_TEMP/gitleaks" "$HOME/.local/bin/gitleaks"
+          # Version and SHA256 are pinned in the shared installer
+          # (.github/scripts/install-gitleaks.sh); bump them there.
+          ./.github/scripts/install-gitleaks.sh "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Secret scan (gitleaks)

--- a/packages/scripts/__tests__/gitleaks-installer-contract.test.ts
+++ b/packages/scripts/__tests__/gitleaks-installer-contract.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Verifies every workflow that installs gitleaks goes through the shared
+ * checksum-pinned installer (.github/scripts/install-gitleaks.sh) and that the
+ * installer pins a SHA256 per supported host. Static contract plus a shell
+ * syntax check — no network download.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const installerPath = path.join(
+  repoRoot,
+  ".github/scripts/install-gitleaks.sh",
+);
+const installerSource = fs.readFileSync(installerPath, "utf8");
+
+const GITLEAKS_VERSION = "8.30.1";
+// linux_x64 hash from the upstream gitleaks_8.30.1_checksums.txt release asset.
+const GITLEAKS_LINUX_X64_SHA256 =
+  "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb";
+
+const CONSUMING_WORKFLOWS = ["ci.yml", "gitleaks.yml", "test.yml"] as const;
+
+function workflowSource(name: string): string {
+  return fs.readFileSync(
+    path.join(repoRoot, ".github/workflows", name),
+    "utf8",
+  );
+}
+
+describe("gitleaks installer supply-chain contract", () => {
+  test("every gitleaks consumer installs through the shared pinned script", () => {
+    for (const name of CONSUMING_WORKFLOWS) {
+      const source = workflowSource(name);
+      expect(source).toContain("install-gitleaks.sh");
+      // No consumer may carry its own unpinned download of the release asset.
+      expect(source).not.toContain("gitleaks/releases/download");
+    }
+  });
+
+  test("the installer pins the version and verifies SHA256 before extracting", () => {
+    expect(installerSource).toContain(`GITLEAKS_VERSION="${GITLEAKS_VERSION}"`);
+    expect(installerSource).toContain(GITLEAKS_LINUX_X64_SHA256);
+    // Fail closed on mismatch, and never extract an unverified archive.
+    expect(installerSource).toContain("checksum mismatch");
+    expect(installerSource.indexOf("checksum mismatch")).toBeLessThan(
+      installerSource.indexOf("tar -xzf"),
+    );
+    // Every supported host spelling carries a pinned hash.
+    for (const host of [
+      "Linux-x86_64",
+      "Linux-aarch64|Linux-arm64",
+      "Darwin-x86_64",
+      "Darwin-arm64",
+    ]) {
+      expect(installerSource).toContain(host);
+    }
+    const pinnedHashes = installerSource.match(/gitleaks_sha="[0-9a-f]{64}"/g);
+    expect(pinnedHashes).toHaveLength(4);
+  });
+
+  test("the installer parses as valid bash", () => {
+    const result = spawnSync("bash", ["-n", installerPath], {
+      encoding: "utf8",
+    });
+    expect(result.status, result.stderr).toBe(0);
+  });
+});

--- a/packages/scripts/__tests__/snap-publish-gate.test.ts
+++ b/packages/scripts/__tests__/snap-publish-gate.test.ts
@@ -1,9 +1,6 @@
 /**
- * Validates the Snap Store publication gate wiring in snap-publish.yml: the
- * tagged commit must resolve and pass a protected-branch ancestry check before
- * the production-release approval, and the build must check out the resolved
- * commit rather than the movable tag. Static workflow contract only — no
- * runner, Store, or snapcraft execution.
+ * Validates that canonical Snap publication is exact-release-bound, protected,
+ * and exposes Store credentials only to the steps that authenticate or upload.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -24,116 +21,76 @@ interface WorkflowStep {
 }
 
 interface WorkflowJob {
-  if?: string;
-  name?: string;
-  needs?: string | string[];
-  environment?: string;
-  outputs?: Record<string, string>;
+  environment?: { name?: string } | string;
+  env?: Record<string, string>;
   steps?: WorkflowStep[];
 }
 
 interface Workflow {
-  on?: Record<
-    string,
-    { inputs?: Record<string, { default?: string; options?: string[] }> }
-  >;
+  on?: Record<string, unknown>;
   jobs?: Record<string, WorkflowJob>;
 }
 
 const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const publishJob = workflow.jobs?.["build-and-publish"];
 
-function requireJob(id: string): WorkflowJob {
-  const job = workflow.jobs?.[id];
-  if (!job) throw new Error(`Missing workflow job: ${id}`);
-  return job;
-}
-
-function requireStep(job: WorkflowJob, name: string): WorkflowStep {
-  const step = job.steps?.find((candidate) => candidate.name === name);
+function requireStep(name: string): WorkflowStep {
+  const step = publishJob?.steps?.find((candidate) => candidate.name === name);
   if (!step) throw new Error(`Missing workflow step: ${name}`);
   return step;
 }
 
-function needsList(job: WorkflowJob): string[] {
-  return typeof job.needs === "string" ? [job.needs] : (job.needs ?? []);
-}
-
-describe("snap-publish release gate", () => {
-  test("the Store upload is gated on the production-release approval", () => {
-    const authorize = requireJob("authorize-release");
-    expect(authorize.environment).toBe("production-release");
-    expect(needsList(authorize)).toEqual(["prepare"]);
-    // Approval marker only: no checkout, so the gate itself can never run
-    // pipeline code or touch the Store credentials.
-    expect(authorize.steps ?? []).toHaveLength(1);
-    for (const step of authorize.steps ?? []) {
-      expect(step.uses ?? "").not.toContain("checkout");
-    }
-
-    const build = requireJob("build-and-publish");
-    expect(needsList(build)).toEqual(
-      expect.arrayContaining(["prepare", "authorize-release"]),
-    );
-    expect(build.if).toContain("needs.authorize-release.result == 'success'");
+describe("canonical Snap publication gate", () => {
+  test("is callable-only and protected by the production release environment", () => {
+    expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_call"]);
+    expect(publishJob).toBeDefined();
+    expect(
+      typeof publishJob?.environment === "string"
+        ? publishJob.environment
+        : publishJob?.environment?.name,
+    ).toBe("production-release");
   });
 
-  test("prepare refuses a tagged commit that never landed on a protected branch", () => {
-    const prepare = requireJob("prepare");
-    const checkout = requireStep(prepare, "Checkout");
-    expect(checkout.with?.["fetch-depth"]).toBe(0);
-
-    const resolve = requireStep(prepare, "Resolve tag to peeled commit");
-    const ancestry = requireStep(
-      prepare,
-      "Require tagged commit on a protected branch",
-    );
-    // The checked commit is exactly the resolved source_sha, and the ancestry
-    // step runs after resolution.
-    expect(ancestry.env?.SOURCE_SHA).toBe(
-      `\${{ steps.version.outputs.source_sha }}`,
-    );
-    const steps = prepare.steps ?? [];
-    expect(steps.indexOf(ancestry)).toBeGreaterThan(steps.indexOf(resolve));
-
-    expect(ancestry.run).toContain(
-      'git merge-base --is-ancestor "$SOURCE_SHA" origin/main',
-    );
-    expect(ancestry.run).toContain(
-      'git merge-base --is-ancestor "$SOURCE_SHA" origin/develop',
-    );
-    expect(ancestry.run).toContain("exit 1");
-
-    // The tag input reaches a refspec, so resolution must reject names with
-    // shell or refspec metacharacters before fetching.
-    expect(resolve.run).toContain("INPUT_TAG");
-    expect(resolve.run).toMatch(/\^v\[0-9\]/);
-  });
-
-  test("the build checks out the resolved commit, never the movable tag", () => {
-    const build = requireJob("build-and-publish");
-    const checkout = build.steps?.find((step) =>
+  test("checks out the finalized source without persisted Git credentials", () => {
+    const checkout = publishJob?.steps?.find((step) =>
       step.uses?.startsWith("actions/checkout@"),
     );
-    expect(checkout).toBeDefined();
-    expect(checkout?.with?.ref).toBe(
-      `\${{ needs.prepare.outputs.source_sha }}`,
-    );
-    // No step anywhere in the workflow may check out the raw tag input.
-    for (const line of workflowSource.split("\n")) {
-      expect(line).not.toContain(`ref: \${{ inputs.tag }}`);
-    }
+    expect(checkout?.with?.ref).toBe(`\${{ inputs.source_sha }}`);
+    expect(checkout?.with?.["fetch-depth"]).toBe(0);
+    expect(checkout?.with?.["persist-credentials"]).toBe(false);
   });
 
-  test("channels are pinned to edge|beta while the snap is grade: devel", () => {
-    const dispatchChannel = workflow.on?.workflow_dispatch?.inputs?.channel;
-    expect(dispatchChannel?.options ?? []).toEqual(["edge", "beta"]);
-    expect(dispatchChannel?.default).toBe("edge");
-    expect(workflow.on?.workflow_call?.inputs?.channel?.default).toBe("edge");
+  test("binds the version, tag, checked-out commit, and peeled tag commit", () => {
+    const bind = requireStep("Bind Snap build to the finalized tag");
+    expect(bind.env?.EXPECTED_SHA).toBe(`\${{ inputs.source_sha }}`);
+    expect(bind.env?.EXPECTED_TAG).toBe(`\${{ inputs.tag }}`);
+    expect(bind.env?.EXPECTED_VERSION).toBe(`\${{ inputs.version }}`);
+    expect(bind.run).toContain(
+      'test "$EXPECTED_SHA" = "$(git rev-parse HEAD)"',
+    );
+    expect(bind.run).toContain('test "$EXPECTED_TAG" = "v$EXPECTED_VERSION"');
+    expect(bind.run).toContain("refs/tags/$EXPECTED_TAG^{commit}");
 
-    const build = requireJob("build-and-publish");
-    const publish = requireStep(build, "Publish to Snap Store");
-    expect(publish.run).toContain("edge|beta");
-    expect(publish.run).not.toContain("stable|candidate");
-    expect(publish.run).toContain("snapcraft upload");
+    const updateVersion = requireStep("Update snap version");
+    expect(updateVersion.run).toContain("store-release-plan.mjs");
+  });
+
+  test("keeps the Store credential out of checkout, setup, and build steps", () => {
+    expect(publishJob?.env?.SNAPCRAFT_STORE_CREDENTIALS).toBeUndefined();
+
+    const allowed = new Set([
+      "Check Snap Store credentials",
+      "Verify Snap Store credentials",
+      "Publish to Snap Store",
+    ]);
+    for (const step of publishJob?.steps ?? []) {
+      if (allowed.has(step.name ?? "")) {
+        expect(step.env?.SNAPCRAFT_STORE_CREDENTIALS).toBe(
+          `\${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}`,
+        );
+      } else {
+        expect(step.env?.SNAPCRAFT_STORE_CREDENTIALS).toBeUndefined();
+      }
+    }
   });
 });

--- a/packages/scripts/__tests__/snap-publish-gate.test.ts
+++ b/packages/scripts/__tests__/snap-publish-gate.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Validates the Snap Store publication gate wiring in snap-publish.yml: the
+ * tagged commit must resolve and pass a protected-branch ancestry check before
+ * the production-release approval, and the build must check out the resolved
+ * commit rather than the movable tag. Static workflow contract only — no
+ * runner, Store, or snapcraft execution.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const workflowPath = path.join(repoRoot, ".github/workflows/snap-publish.yml");
+const workflowSource = fs.readFileSync(workflowPath, "utf8");
+
+interface WorkflowStep {
+  name?: string;
+  env?: Record<string, string>;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string | number | boolean>;
+}
+
+interface WorkflowJob {
+  if?: string;
+  name?: string;
+  needs?: string | string[];
+  environment?: string;
+  outputs?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  on?: Record<
+    string,
+    { inputs?: Record<string, { default?: string; options?: string[] }> }
+  >;
+  jobs?: Record<string, WorkflowJob>;
+}
+
+const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+
+function requireJob(id: string): WorkflowJob {
+  const job = workflow.jobs?.[id];
+  if (!job) throw new Error(`Missing workflow job: ${id}`);
+  return job;
+}
+
+function requireStep(job: WorkflowJob, name: string): WorkflowStep {
+  const step = job.steps?.find((candidate) => candidate.name === name);
+  if (!step) throw new Error(`Missing workflow step: ${name}`);
+  return step;
+}
+
+function needsList(job: WorkflowJob): string[] {
+  return typeof job.needs === "string" ? [job.needs] : (job.needs ?? []);
+}
+
+describe("snap-publish release gate", () => {
+  test("the Store upload is gated on the production-release approval", () => {
+    const authorize = requireJob("authorize-release");
+    expect(authorize.environment).toBe("production-release");
+    expect(needsList(authorize)).toEqual(["prepare"]);
+    // Approval marker only: no checkout, so the gate itself can never run
+    // pipeline code or touch the Store credentials.
+    expect(authorize.steps ?? []).toHaveLength(1);
+    for (const step of authorize.steps ?? []) {
+      expect(step.uses ?? "").not.toContain("checkout");
+    }
+
+    const build = requireJob("build-and-publish");
+    expect(needsList(build)).toEqual(
+      expect.arrayContaining(["prepare", "authorize-release"]),
+    );
+    expect(build.if).toContain("needs.authorize-release.result == 'success'");
+  });
+
+  test("prepare refuses a tagged commit that never landed on a protected branch", () => {
+    const prepare = requireJob("prepare");
+    const checkout = requireStep(prepare, "Checkout");
+    expect(checkout.with?.["fetch-depth"]).toBe(0);
+
+    const resolve = requireStep(prepare, "Resolve tag to peeled commit");
+    const ancestry = requireStep(
+      prepare,
+      "Require tagged commit on a protected branch",
+    );
+    // The checked commit is exactly the resolved source_sha, and the ancestry
+    // step runs after resolution.
+    expect(ancestry.env?.SOURCE_SHA).toBe(
+      `\${{ steps.version.outputs.source_sha }}`,
+    );
+    const steps = prepare.steps ?? [];
+    expect(steps.indexOf(ancestry)).toBeGreaterThan(steps.indexOf(resolve));
+
+    expect(ancestry.run).toContain(
+      'git merge-base --is-ancestor "$SOURCE_SHA" origin/main',
+    );
+    expect(ancestry.run).toContain(
+      'git merge-base --is-ancestor "$SOURCE_SHA" origin/develop',
+    );
+    expect(ancestry.run).toContain("exit 1");
+
+    // The tag input reaches a refspec, so resolution must reject names with
+    // shell or refspec metacharacters before fetching.
+    expect(resolve.run).toContain("INPUT_TAG");
+    expect(resolve.run).toMatch(/\^v\[0-9\]/);
+  });
+
+  test("the build checks out the resolved commit, never the movable tag", () => {
+    const build = requireJob("build-and-publish");
+    const checkout = build.steps?.find((step) =>
+      step.uses?.startsWith("actions/checkout@"),
+    );
+    expect(checkout).toBeDefined();
+    expect(checkout?.with?.ref).toBe(
+      `\${{ needs.prepare.outputs.source_sha }}`,
+    );
+    // No step anywhere in the workflow may check out the raw tag input.
+    for (const line of workflowSource.split("\n")) {
+      expect(line).not.toContain(`ref: \${{ inputs.tag }}`);
+    }
+  });
+
+  test("channels are pinned to edge|beta while the snap is grade: devel", () => {
+    const dispatchChannel = workflow.on?.workflow_dispatch?.inputs?.channel;
+    expect(dispatchChannel?.options ?? []).toEqual(["edge", "beta"]);
+    expect(dispatchChannel?.default).toBe("edge");
+    expect(workflow.on?.workflow_call?.inputs?.channel?.default).toBe("edge");
+
+    const build = requireJob("build-and-publish");
+    const publish = requireStep(build, "Publish to Snap Store");
+    expect(publish.run).toContain("edge|beta");
+    expect(publish.run).not.toContain("stable|candidate");
+    expect(publish.run).toContain("snapcraft upload");
+  });
+});


### PR DESCRIPTION
Wave-6 security remediation for the CI/CD supply-chain group, addressing three wave-5 re-audit findings. All three were verified still present on latest `develop` before patching.

## W5-006 — Snap publication authority and credential scope

The canonical store-release work merged during review now invokes Snap only after the exact npm/Git/GitHub release finalizes, binds source SHA + version + peeled tag commit, and protects the job with the reviewer-approved production-release environment. This PR preserves that newer architecture and adds the remaining least-privilege repair:

- SNAPCRAFT_STORE_CREDENTIALS is absent from job scope and unavailable to checkout, local composite setup, package installation, version mutation, and the source-controlled snap build.
- Only the explicit credential preflight, snapcraft identity verification, and upload steps receive the Store credential.
- Checkout keeps persist-credentials: false, and a structural test locks version/tag/SHA binding plus credential scope.

## W5-029 — third gitleaks install in `test.yml` had no checksum (W1-063 incomplete)

`ci.yml` and `gitleaks.yml` were pinned in wave 1; the `merge-quality-gate` copy in `test.yml` (which can land on the shared self-hosted fleet) was missed.

- New shared installer `.github/scripts/install-gitleaks.sh` is the single version + SHA256 source of truth for all three consumers (`ci.yml`, `gitleaks.yml`, `test.yml`), per host arch. Hashes match the upstream `gitleaks_8.30.1_checksums.txt` release asset; mismatch fails closed before extraction.

## W5-030 — Inno Setup installer executed unverified inside the signed Windows release build

`release-electrobun.yml` downloaded `innosetup-6.7.1.exe` and ran it in the same job that holds the Windows signing certificate.

- SHA256 pinned next to the URL (recorded from the GitHub release asset digest) and verified with `Get-FileHash` before `Start-Process`; mismatch aborts the job.

## Test evidence

- Updated `packages/scripts/__tests__/snap-publish-gate.test.ts` (4 tests): callable-only protected publication, exact source checkout without persisted Git credentials, strict version/tag/SHA binding, and step-only Store credential scope.
- New `packages/scripts/__tests__/gitleaks-installer-contract.test.ts` (3 tests): every consumer routes through the shared installer, version + per-host SHA256 pinned, checksum verified before extraction, installer parses as valid bash.
- Exact review head `84372d0d91f088804de07d077f387ccd97634b84`: 16 focused canonical release, Snap, gitleaks, and release-authority tests pass; the parallel review also ran 99/99 broader workflow/security tests on the pre-rebase code. The changed tests remain green after the canonical Snap conflict resolution.
- `actionlint` clean on all five touched workflows (one pre-existing shellcheck SC2034 in `ci.yml`, verified present on unmodified `develop` via stash-and-rerun).
- `shellcheck` clean on the new installer; `Bun.YAML.parse` OK on all five workflows; `biome check` clean on the new test files.
- All pinned hashes re-verified against upstream sources at PR time.

## Risk notes

- The `production-release` environment with required reviewers must exist in repo settings (already used by `release-electrobun.yml`, so it does).
- No in-repo `workflow_call` callers of `snap-publish.yml`, so the `edge|beta` channel pin breaks no caller; anyone genuinely needing stable later must bump `grade` and the pin together.
- `.github/workflows/README.md` updated to describe the new snap-publish gate.

No weaponizable detail included; per-finding evidence lives in the wave-5 audit report.


## Evidence Gate

<!-- evidence-head:84372d0d91f088804de07d077f387ccd97634b84 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI and release automation only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI and release automation only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime backend path; workflow validation and real installer output are recorded in Test evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external publisher mutation; the checksum-pinned installer produced gitleaks 8.30.1 locally.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9d6273b5526a83f76636015d1b122d88f2866876:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@9d6273b5526a83f76636015d1b122d88f2866876:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@9d6273b5526a83f76636015d1b122d88f2866876:packages/skills/skills/contribute-to-eliza"} -->
