### PR TITLE
fix(ui): honest fail-closed UX when the system WebView cannot isolate browser surfaces

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -59,6 +59,7 @@
     "test:suggestions-e2e": "bun --conditions=eliza-source run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-suggestions-e2e.mjs",
     "test:launcher-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-launcher-e2e.mjs",
     "test:connectors-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-connectors-e2e.mjs",
+    "test:browser-surface-error-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-browser-surface-error-e2e.mjs",
     "test:view-lifecycle-e2e": "bun run --cwd ../.. packages/ui/src/components/views/__e2e__/run-view-lifecycle-e2e.mjs",
     "test:frontend-hosting-e2e": "bun run --cwd ../.. packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs",
     "test:credentials-e2e": "bun run --cwd ../.. packages/ui/src/cloud/organization/__e2e__/run-credentials-e2e.mjs",

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.native-surface-error.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.native-surface-error.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Verifies the native-mobile-webview error surface distinguishes a permanent
+ * WebView capability denial (LP3: system WebView 113 without multi-profile)
+ * from a transient transport fault. Permanent shows honest "not supported"
+ * copy with an Open-external escape hatch and NO Retry; transient keeps the
+ * existing retryable state. The real component renders in jsdom; the surface
+ * hook is harness-driven because the native transport does not exist here.
+ */
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MobileNativeSurfaceError } from "../../surface/use-mobile-native-tab-surfaces";
+
+const surfaceHarness = vi.hoisted(() => ({
+  error: null as MobileNativeSurfaceError | null,
+  retry: vi.fn(),
+}));
+
+const openExternalHarness = vi.hoisted(() => ({
+  openExternalUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Force the native mobile shell so resolveBrowserTabRenderPath picks
+// `native-mobile-webview` for the manifest's `native-webview` isolation.
+vi.mock("@capacitor/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@capacitor/core")>();
+  return {
+    ...actual,
+    Capacitor: {
+      ...actual.Capacitor,
+      isNativePlatform: () => true,
+      getPlatform: () => "android",
+    },
+  };
+});
+
+vi.mock("../../bridge/electrobun-runtime", () => ({
+  isElectrobunRuntime: () => false,
+}));
+
+vi.mock(
+  "../../surface/use-mobile-native-tab-surfaces",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../surface/use-mobile-native-tab-surfaces")
+      >();
+    return {
+      ...actual,
+      useMobileNativeTabSurfaces: () => ({
+        registerSurfaceElement: vi.fn(),
+        navigateSurface: vi.fn(),
+        reloadSurface: vi.fn(),
+        error: surfaceHarness.error,
+        retry: surfaceHarness.retry,
+      }),
+    };
+  },
+);
+
+vi.mock("../../utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../utils")>();
+  return {
+    ...actual,
+    openExternalUrl: openExternalHarness.openExternalUrl,
+  };
+});
+
+vi.mock("../../state", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../state")>();
+  const state = {
+    getStewardPending: async () => [],
+    getStewardStatus: async () => null,
+    setActionNotice: vi.fn(),
+    t: (
+      _key: string,
+      options?: { defaultValue?: string } | Record<string, unknown>,
+    ) =>
+      typeof options === "object" &&
+      options !== null &&
+      "defaultValue" in options &&
+      typeof options.defaultValue === "string"
+        ? options.defaultValue
+        : _key,
+    plugins: [],
+    uiTheme: "dark",
+    walletAddresses: [],
+    walletConfig: null,
+  };
+  return {
+    ...actual,
+    useAppSelector: (selector: (s: typeof state) => unknown) => selector(state),
+    useAppSelectorShallow: (selector: (s: typeof state) => unknown) =>
+      selector(state),
+  };
+});
+
+vi.mock("../../api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api")>();
+  return {
+    ...actual,
+    client: {
+      ...actual.client,
+      fetch: vi.fn().mockRejectedValue(new Error("no api in test")),
+      getWalletConfig: vi.fn().mockRejectedValue(new Error("no api in test")),
+      getBrowserWorkspace: vi.fn().mockResolvedValue({
+        mode: "web",
+        tabs: [
+          {
+            id: "tab-1",
+            title: "Example",
+            url: "https://example.com/",
+            partition: "persist:test",
+            visible: true,
+            createdAt: "2026-08-17T00:00:00.000Z",
+            updatedAt: "2026-08-17T00:00:00.000Z",
+            lastFocusedAt: null,
+          },
+        ],
+      }),
+      openBrowserWorkspaceTab: vi
+        .fn()
+        .mockRejectedValue(new Error("no api in test")),
+      navigateBrowserWorkspaceTab: vi
+        .fn()
+        .mockRejectedValue(new Error("no api in test")),
+      closeBrowserWorkspaceTab: vi
+        .fn()
+        .mockRejectedValue(new Error("no api in test")),
+      snapshotBrowserWorkspaceTab: vi
+        .fn()
+        .mockRejectedValue(new Error("no api in test")),
+    },
+  };
+});
+
+import { BrowserWorkspaceView } from "./BrowserWorkspaceView";
+
+beforeEach(() => {
+  surfaceHarness.error = null;
+  surfaceHarness.retry.mockClear();
+  openExternalHarness.openExternalUrl.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BrowserWorkspaceView native surface error states", () => {
+  it("permanent capability denial: honest copy + Open external, NO Retry", async () => {
+    surfaceHarness.error = {
+      key: "browser-tab:tab-1:lifecycle",
+      message:
+        "isolated storage requires WebView multi-profile support; system WebView is too old",
+      permanent: true,
+    };
+    render(<BrowserWorkspaceView />);
+    expect(
+      await screen.findByText("Secure browsing not supported here"),
+    ).not.toBeNull();
+    expect(
+      screen.getByText(/system WebView is too old to isolate web pages/),
+    ).not.toBeNull();
+    // Fail-closed with an escape hatch: no Retry that can never succeed.
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    // Scope to the error card: the toolbar renders its own always-present
+    // "Open external" icon button with the same accessible name.
+    const alertCard = screen.getByRole("alert");
+    const openExternal = within(alertCard).getByRole("button", {
+      name: "Open external",
+    });
+    await act(async () => {
+      fireEvent.click(openExternal);
+    });
+    expect(openExternalHarness.openExternalUrl).toHaveBeenCalledWith(
+      "https://example.com/",
+    );
+    expect(surfaceHarness.retry).not.toHaveBeenCalled();
+  });
+
+  it("transient transport fault: existing retryable state is unchanged", async () => {
+    surfaceHarness.error = {
+      key: "browser-tab:tab-1:bounds",
+      message: "bounds rejected",
+      permanent: false,
+    };
+    render(<BrowserWorkspaceView />);
+    expect(await screen.findByText("Browser view unavailable")).not.toBeNull();
+    expect(screen.queryByText("Secure browsing not supported here")).toBeNull();
+    const retry = screen.getByRole("button", { name: "Retry" });
+    fireEvent.click(retry);
+    expect(surfaceHarness.retry).toHaveBeenCalledTimes(1);
+    expect(openExternalHarness.openExternalUrl).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.native-surface-error.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.native-surface-error.test.tsx
@@ -167,7 +167,7 @@ describe("BrowserWorkspaceView native surface error states", () => {
       await screen.findByText("Secure browsing not supported here"),
     ).not.toBeNull();
     expect(
-      screen.getByText(/system WebView is too old to isolate web pages/),
+      screen.getByText(/system WebView cannot provide the isolation/),
     ).not.toBeNull();
     // Fail-closed with an escape hatch: no Retry that can never succeed.
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -2998,7 +2998,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
                 {nativeTabSurfaces.error.permanent
                   ? t("browserworkspace.NativeSurfaceUnsupportedDescription", {
                       defaultValue:
-                        "This device's system WebView is too old to isolate web pages safely, so Eliza will not open them inside the app. You can open the page in the device browser instead.",
+                        "This device's system WebView cannot provide the isolation Eliza requires, so Eliza will not open pages inside the app. You can open the page in the device browser instead.",
                     })
                   : t("browserworkspace.NativeSurfaceUnavailableDescription", {
                       defaultValue:

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -2986,24 +2986,57 @@ export function BrowserWorkspaceView(): React.JSX.Element {
           >
             <div className="flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-border bg-bg-elevated p-6 shadow-lg">
               <div className="text-sm font-semibold text-txt">
-                {t("browserworkspace.NativeSurfaceUnavailable", {
-                  defaultValue: "Browser view unavailable",
-                })}
+                {nativeTabSurfaces.error.permanent
+                  ? t("browserworkspace.NativeSurfaceUnsupported", {
+                      defaultValue: "Secure browsing not supported here",
+                    })
+                  : t("browserworkspace.NativeSurfaceUnavailable", {
+                      defaultValue: "Browser view unavailable",
+                    })}
               </div>
               <div className="text-xs leading-5 text-muted">
-                {t("browserworkspace.NativeSurfaceUnavailableDescription", {
-                  defaultValue:
-                    "The secure browser surface could not connect. Retry without losing your tabs.",
-                })}
+                {nativeTabSurfaces.error.permanent
+                  ? t("browserworkspace.NativeSurfaceUnsupportedDescription", {
+                      defaultValue:
+                        "This device's system WebView is too old to isolate web pages safely, so Eliza will not open them inside the app. You can open the page in the device browser instead.",
+                    })
+                  : t("browserworkspace.NativeSurfaceUnavailableDescription", {
+                      defaultValue:
+                        "The secure browser surface could not connect. Retry without losing your tabs.",
+                    })}
               </div>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                onClick={nativeTabSurfaces.retry}
-              >
-                {t("common.retry", { defaultValue: "Retry" })}
-              </Button>
+              {nativeTabSurfaces.error.permanent ? (
+                selectedTab ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={busyAction !== null}
+                    onClick={() =>
+                      void runBrowserWorkspaceAction(
+                        `open:external:${selectedTab.id}`,
+                        async () => {
+                          await openExternalUrl(selectedTab.url);
+                        },
+                      )
+                    }
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    {t("browserworkspace.OpenExternal", {
+                      defaultValue: "Open external",
+                    })}
+                  </Button>
+                ) : null
+              ) : (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={nativeTabSurfaces.retry}
+                >
+                  {t("common.retry", { defaultValue: "Retry" })}
+                </Button>
+              )}
             </div>
           </div>
         ) : (

--- a/packages/ui/src/components/pages/__e2e__/browser-surface-error-api-stub.ts
+++ b/packages/ui/src/components/pages/__e2e__/browser-surface-error-api-stub.ts
@@ -1,0 +1,38 @@
+/**
+ * Fixture stand-in for the `src/api` barrel used by
+ * run-browser-surface-error-e2e.mjs. Supplies one open example.com tab so the
+ * native error card has a selected tab for its Open-external escape hatch;
+ * everything else rejects like an absent backend. Types are structural — the
+ * fixture bundle never loads the real client.
+ */
+
+const TAB = {
+  id: "tab-1",
+  title: "Example",
+  url: "https://example.com/",
+  partition: "persist:fixture",
+  visible: true,
+  createdAt: "2026-08-17T00:00:00.000Z",
+  updatedAt: "2026-08-17T00:00:00.000Z",
+  lastFocusedAt: null,
+};
+
+const reject = () => Promise.reject(new Error("no api in fixture"));
+
+export const client: Record<string, unknown> = {
+  getBrowserWorkspace: async () => ({ mode: "web", tabs: [TAB] }),
+  fetch: reject,
+  getWalletConfig: reject,
+  getAutofillAllowed: reject,
+  listSavedLogins: reject,
+  revealSavedLogin: reject,
+  openBrowserWorkspaceTab: reject,
+  navigateBrowserWorkspaceTab: reject,
+  closeBrowserWorkspaceTab: reject,
+  showBrowserWorkspaceTab: reject,
+  snapshotBrowserWorkspaceTab: reject,
+  sendBrowserSolanaTransaction: reject,
+  sendBrowserWalletTransaction: reject,
+  signBrowserSolanaMessage: reject,
+  signBrowserWalletMessage: reject,
+};

--- a/packages/ui/src/components/pages/__e2e__/browser-surface-error-fixture.tsx
+++ b/packages/ui/src/components/pages/__e2e__/browser-surface-error-fixture.tsx
@@ -1,0 +1,16 @@
+/**
+ * Self-contained fixture for the native-surface error-card e2e: mounts the
+ * REAL `BrowserWorkspaceView` with the surface hook harness-driven through
+ * `location.hash` (#permanent = WebView multi-profile capability denial,
+ * #transient = transport fault, empty = healthy). Only the `state`/`api`
+ * barrels, `@capacitor/core`, and the surface hook module are stubbed (see
+ * run-browser-surface-error-e2e.mjs); every rendered component is real. No app
+ * server, no network. Paired with run-browser-surface-error-e2e.mjs.
+ */
+
+import { createRoot } from "react-dom/client";
+import { BrowserWorkspaceView } from "../BrowserWorkspaceView";
+
+const container = document.getElementById("root");
+if (!container) throw new Error("fixture root missing");
+createRoot(container).render(<BrowserWorkspaceView />);

--- a/packages/ui/src/components/pages/__e2e__/browser-surface-error-hook-stub.ts
+++ b/packages/ui/src/components/pages/__e2e__/browser-surface-error-hook-stub.ts
@@ -1,0 +1,60 @@
+/**
+ * Fixture stand-in for `surface/use-mobile-native-tab-surfaces` used by
+ * run-browser-surface-error-e2e.mjs. The harness drives the hook's rendered
+ * error through `location.hash` so one bundle exercises all three states the
+ * REAL BrowserWorkspaceView renders:
+ *
+ *   #permanent — the LP3 WebView multi-profile capability denial (permanent)
+ *   #transient — an ordinary transport fault (retryable)
+ *   (empty)    — healthy surface path
+ *
+ * The native transport itself cannot exist in a desktop browser, which is the
+ * one reason this module is stubbed; the component under test stays real.
+ */
+
+import type {
+  MobileNativeSurfaceError,
+  MobileNativeTabSurfaces,
+  UseMobileNativeTabSurfacesArgs,
+} from "../../../surface/use-mobile-native-tab-surfaces";
+
+declare global {
+  interface Window {
+    __surfaceRetries: number;
+  }
+}
+
+function currentError(): MobileNativeSurfaceError | null {
+  const hash =
+    typeof window !== "undefined" ? window.location.hash.replace("#", "") : "";
+  if (hash === "permanent") {
+    return {
+      key: "browser-tab:tab-1:lifecycle",
+      message:
+        "createSurface(browser-tab:tab-1) failed after 3 attempts: isolated storage requires WebView multi-profile support; system WebView is too old",
+      permanent: true,
+    };
+  }
+  if (hash === "transient") {
+    return {
+      key: "browser-tab:tab-1:bounds",
+      message: "setBounds(browser-tab:tab-1) failed after 3 attempts",
+      permanent: false,
+    };
+  }
+  return null;
+}
+
+export function useMobileNativeTabSurfaces(
+  _args: UseMobileNativeTabSurfacesArgs,
+): MobileNativeTabSurfaces {
+  return {
+    registerSurfaceElement: () => {},
+    navigateSurface: () => {},
+    reloadSurface: () => {},
+    error: currentError(),
+    retry: () => {
+      window.__surfaceRetries = (window.__surfaceRetries ?? 0) + 1;
+    },
+  };
+}

--- a/packages/ui/src/components/pages/__e2e__/browser-surface-error-state-stub.ts
+++ b/packages/ui/src/components/pages/__e2e__/browser-surface-error-state-stub.ts
@@ -1,0 +1,44 @@
+/**
+ * Fixture stand-in for the `src/state` barrel used by
+ * run-browser-surface-error-e2e.mjs. BrowserWorkspaceView reads
+ * `{ getStewardPending, getStewardStatus, setActionNotice, t, plugins,
+ * uiTheme, walletAddresses, walletConfig }` through the selector hooks;
+ * supplying them from a plain object keeps the browser bundle free of the full
+ * app store while the component under test stays real. The real English
+ * translator is used so the error-card copy renders exactly as in the app.
+ */
+
+import {
+  appNameInterpolationVars,
+  DEFAULT_BRANDING,
+} from "../../../config/branding-base";
+import { createTranslator } from "../../../i18n";
+
+const t = createTranslator("en", appNameInterpolationVars(DEFAULT_BRANDING));
+
+const fixtureState: Record<string, unknown> = {
+  t,
+  getStewardPending: async () => [],
+  getStewardStatus: async () => null,
+  setActionNotice: () => {},
+  plugins: [],
+  uiTheme: "dark",
+  walletAddresses: [],
+  walletConfig: null,
+};
+
+export function useApp(): Record<string, unknown> {
+  return fixtureState;
+}
+
+export function useAppSelector<T>(
+  selector: (state: Record<string, unknown>) => T,
+): T {
+  return selector(fixtureState);
+}
+
+export function useAppSelectorShallow<T>(
+  selector: (state: Record<string, unknown>) => T,
+): T {
+  return selector(fixtureState);
+}

--- a/packages/ui/src/components/pages/__e2e__/run-browser-surface-error-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-browser-surface-error-e2e.mjs
@@ -1,0 +1,345 @@
+/**
+ * Real-browser e2e + screenshots for the native-surface error cards on the
+ * `native-mobile-webview` render path — no app server, no device. Bundles
+ * browser-surface-error-fixture.tsx with esbuild (REAL BrowserWorkspaceView;
+ * state/api barrels, the native surface hook, @capacitor/core, and
+ * @elizaos/core stubbed), compiles the real Tailwind v4 theme, loads it in
+ * headless chromium via Playwright at the Light Phone 3 CSS viewport
+ * (360×414), and asserts:
+ *
+ *   - #permanent (WebView multi-profile capability denial): honest
+ *     "Secure browsing not supported here" copy renders, the Open-external
+ *     escape hatch is present, and NO Retry button exists,
+ *   - #transient (transport fault): the existing "Browser view unavailable"
+ *     retryable card renders, Retry works (hook retry invoked), and the
+ *     permanent copy is absent,
+ *   - screenshots of both cards at 360×414 (LP3) and 390×844 (phone).
+ *
+ * Exits non-zero on any failed assertion. Run:
+ *   bun run --cwd packages/ui test:browser-surface-error-e2e
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { builtinModules } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import tailwindPostcss from "@tailwindcss/postcss";
+import { build } from "esbuild";
+import { chromium } from "playwright";
+import postcss from "postcss";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const uiSrc = resolve(here, "../../..");
+const repoRoot = resolve(uiSrc, "../../..");
+const outDir = join(here, "output-browser-surface-error");
+await mkdir(outDir, { recursive: true });
+
+let failures = 0;
+function assert(cond, msg) {
+  console.log(`${cond ? "✓" : "✗"} ${msg}`);
+  if (!cond) failures += 1;
+  return cond;
+}
+
+// ── esbuild stubs (mirrors run-connectors-e2e.mjs) ──────────────────────────
+const stubElizaCore = {
+  name: "stub-eliza-core",
+  setup(b) {
+    b.onResolve({ filter: /^@elizaos\/core$/ }, (args) => ({
+      path: args.path,
+      namespace: "eliza-core-stub",
+    }));
+    b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
+      contents: `
+        const noop = new Proxy(() => noop, { get: () => noop });
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
+        // Real surface-manifest resolution (mirrors
+        // packages/core/src/types/surface-manifest.ts): BrowserWorkspaceView
+        // derives its native-webview render path from the resolved builtin
+        // manifest, so these must be faithful, not noop — and they must be
+        // concrete own properties (esbuild's CJS->ESM interop copies own keys;
+        // Proxy-getter-only exports come through undefined).
+        function resolveSurfaceManifest(decl) {
+          const surface = decl == null ? undefined : decl.surface;
+          const capabilities = new Set(
+            (surface && surface.capabilities) || [],
+          );
+          const declaredBackground =
+            (surface && surface.background) ||
+            (decl && decl.backgroundPolicy) ||
+            "opaque";
+          const background =
+            declaredBackground === "shared" && capabilities.has("wallpaper")
+              ? "shared"
+              : "opaque";
+          return {
+            background,
+            header:
+              (surface && surface.header) ||
+              (decl && decl.headerPolicy) ||
+              "normal",
+            isolation: (surface && surface.isolation) || "in-process",
+            lifecycle: (surface && surface.lifecycle) || "ephemeral",
+            capabilities,
+          };
+        }
+        module.exports = new Proxy(
+          {
+            ElizaError,
+            isElizaError: (v) => v instanceof ElizaError,
+            resolveSurfaceManifest,
+            resolveSurfaceBackgroundPolicy: (decl) =>
+              resolveSurfaceManifest(decl).background,
+            surfaceGrants: (manifest, capability) =>
+              manifest.capabilities.has(capability),
+            IMMERSIVE_WALLPAPER_SURFACE: {
+              background: "shared",
+              header: "immersive",
+              isolation: "immersive",
+              capabilities: ["wallpaper", "background:apply"],
+            },
+          },
+          { get: (t, p) => (p in t ? t[p] : noop) },
+        );
+      `,
+      loader: "js",
+    }));
+  },
+};
+
+// @capacitor/core: report a native Android platform so the REAL
+// resolveBrowserTabRenderPath picks `native-mobile-webview` — the exact LP3
+// production path. openExternalUrl's Browser plugin call records into a
+// window hook the assertions read.
+const stubCapacitor = {
+  name: "stub-capacitor-core",
+  setup(b) {
+    b.onResolve({ filter: /^@capacitor\/core$/ }, (args) => ({
+      path: args.path,
+      namespace: "capacitor-stub",
+    }));
+    b.onLoad({ filter: /.*/, namespace: "capacitor-stub" }, () => ({
+      contents: [
+        "export const Capacitor = {",
+        "  isNativePlatform: function () { return true; },",
+        '  getPlatform: function () { return "android"; },',
+        "  Plugins: {",
+        "    Browser: {",
+        "      open: function (options) {",
+        "        window.__openedExternally = window.__openedExternally || [];",
+        "        window.__openedExternally.push(options.url);",
+        "        return Promise.resolve();",
+        "      },",
+        "    },",
+        "  },",
+        "};",
+        "export const CapacitorHttp = {",
+        "  request: function () { return Promise.reject(new Error('no http in fixture')); },",
+        "  get: function () { return Promise.reject(new Error('no http in fixture')); },",
+        "  post: function () { return Promise.reject(new Error('no http in fixture')); },",
+        "};",
+        "export function registerPlugin(name) {",
+        "  if (name === 'Browser') { return Capacitor.Plugins.Browser; }",
+        "  return new Proxy({}, { get: function () { return function () { return Promise.resolve(); }; } });",
+        "}",
+        "export class WebPlugin {}",
+      ].join("\n"),
+      loader: "js",
+    }));
+  },
+};
+
+const nodeBuiltins = new Set([
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+]);
+const stubNodeBuiltins = {
+  name: "stub-node-builtins",
+  setup(b) {
+    b.onResolve({ filter: /.*/ }, (args) => {
+      const bare = args.path.replace(/^node:/, "").split("/")[0];
+      if (
+        args.path.startsWith("node:") ||
+        nodeBuiltins.has(args.path) ||
+        builtinModules.includes(bare)
+      ) {
+        return { path: args.path, namespace: "node-stub" };
+      }
+      return null;
+    });
+    b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
+      contents:
+        "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
+      loader: "js",
+    }));
+  },
+};
+
+// Swap the `state`/`api` barrels and the surface hook for the fixture stubs.
+const stubBarrels = {
+  name: "stub-state-api-surface",
+  setup(b) {
+    b.onResolve({ filter: /^(\.\.\/)+state$/ }, () => ({
+      path: join(here, "browser-surface-error-state-stub.ts"),
+    }));
+    b.onResolve({ filter: /^(\.\.\/)+api$/ }, () => ({
+      path: join(here, "browser-surface-error-api-stub.ts"),
+    }));
+    b.onResolve(
+      { filter: /surface\/use-mobile-native-tab-surfaces$/ },
+      (args) => {
+        if (args.importer.endsWith("BrowserWorkspaceView.tsx")) {
+          return { path: join(here, "browser-surface-error-hook-stub.ts") };
+        }
+        return null;
+      },
+    );
+  },
+};
+
+const result = await build({
+  entryPoints: [join(here, "browser-surface-error-fixture.tsx")],
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  conditions: ["eliza-source", "browser"],
+  jsx: "automatic",
+  loader: { ".tsx": "tsx", ".ts": "ts" },
+  define: { "process.env.NODE_ENV": '"production"' },
+  plugins: [stubBarrels, stubCapacitor, stubElizaCore, stubNodeBuiltins],
+  write: false,
+  absWorkingDir: repoRoot,
+});
+const js = result.outputFiles[0].text;
+console.log(`✓ fixture bundled (${js.length} bytes)`);
+const jsPath = join(outDir, "fixture.js");
+await writeFile(jsPath, js);
+
+const cssInput = `
+@import "tailwindcss";
+@import "${join(uiSrc, "styles/base.css")}";
+@import "${join(uiSrc, "styles/tailwind-theme.css")}";
+@source "${jsPath}";
+`;
+const css = (
+  await postcss([tailwindPostcss()]).process(cssInput, {
+    from: join(outDir, "fixture-input.css"),
+  })
+).css;
+console.log(`✓ tailwind theme compiled (${css.length} bytes)`);
+
+const html = `<!doctype html><html class="dark"><head><meta charset="utf-8"><title>browser surface error e2e</title>
+<style>${css}</style>
+<style>html,body,#root{margin:0;height:100%;background:var(--bg,#000);color:var(--text,#fff)}</style>
+<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+</head><body><div id="root"></div><script>${js}</script></body></html>`;
+const htmlPath = join(outDir, "fixture.html");
+await writeFile(htmlPath, html);
+
+const PERMANENT_TITLE = "Secure browsing not supported here";
+const TRANSIENT_TITLE = "Browser view unavailable";
+
+const browser = await chromium.launch();
+let shot = 0;
+async function snap(page, name) {
+  await page.screenshot({
+    path: join(outDir, `${name}.png`),
+    animations: "disabled",
+  });
+  shot += 1;
+  console.log(`  📸 ${name}.png`);
+}
+
+// LP3 CSS viewport (measured on device: 360×414) + a generic phone size.
+for (const [vpName, viewport] of [
+  ["lp3-360x414", { width: 360, height: 414 }],
+  ["phone-390x844", { width: 390, height: 844 }],
+]) {
+  const errors = [];
+  const page = await browser.newPage({ viewport, deviceScaleFactor: 2 });
+  page.on("pageerror", (e) => errors.push(String(e)));
+
+  // ── permanent: capability denial ──────────────────────────────────────────
+  await page.goto(`file://${htmlPath}#permanent`);
+  await page.waitForSelector(`text=${PERMANENT_TITLE}`);
+  assert(
+    (await page.locator(`text=${PERMANENT_TITLE}`).count()) === 1,
+    `${vpName}/permanent: honest unsupported title renders`,
+  );
+  assert(
+    (await page
+      .locator("text=system WebView is too old to isolate web pages")
+      .count()) === 1,
+    `${vpName}/permanent: capability explanation renders`,
+  );
+  const alertRegion = page.locator('[role="alert"]');
+  assert(
+    (await alertRegion
+      .locator('button:has-text("Retry")')
+      .count()) === 0,
+    `${vpName}/permanent: NO Retry button inside the error card`,
+  );
+  const openExternal = alertRegion.locator(
+    'button:has-text("Open external")',
+  );
+  assert(
+    (await openExternal.count()) === 1,
+    `${vpName}/permanent: Open-external escape hatch renders`,
+  );
+  await snap(page, `${vpName}-permanent`);
+  await openExternal.click();
+  await page.waitForTimeout(200);
+  const opens = await page.evaluate(() => window.__openedExternally ?? []);
+  assert(
+    opens.includes("https://example.com/"),
+    `${vpName}/permanent: Open external routes the selected tab URL to the device browser`,
+  );
+
+  // ── transient: transport fault stays retryable ────────────────────────────
+  await page.goto(`file://${htmlPath}#transient`);
+  await page.waitForSelector(`text=${TRANSIENT_TITLE}`);
+  assert(
+    (await page.locator(`text=${PERMANENT_TITLE}`).count()) === 0,
+    `${vpName}/transient: permanent copy absent`,
+  );
+  const retry = page
+    .locator('[role="alert"]')
+    .locator('button:has-text("Retry")');
+  assert(
+    (await retry.count()) === 1,
+    `${vpName}/transient: Retry button renders`,
+  );
+  await snap(page, `${vpName}-transient`);
+  await retry.click();
+  const retries = await page.evaluate(() => window.__surfaceRetries ?? 0);
+  assert(
+    retries === 1,
+    `${vpName}/transient: Retry invokes the surface hook retry`,
+  );
+
+  assert(errors.length === 0, `${vpName}: no page errors`);
+  for (const e of errors) console.error(`  ⚠ ${e}`);
+  await page.close();
+}
+
+await browser.close();
+
+console.log(`\nScreenshots (${shot}) → ${outDir}`);
+if (failures > 0) {
+  console.error(`\nBROWSER SURFACE ERROR E2E FAILED (${failures})`);
+  process.exit(1);
+}
+console.log("\nBROWSER SURFACE ERROR E2E PASSED");
+process.exit(0);

--- a/packages/ui/src/components/pages/__e2e__/run-browser-surface-error-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-browser-surface-error-e2e.mjs
@@ -280,7 +280,7 @@ for (const [vpName, viewport] of [
   );
   assert(
     (await page
-      .locator("text=system WebView is too old to isolate web pages")
+      .locator("text=system WebView cannot provide the isolation")
       .count()) === 1,
     `${vpName}/permanent: capability explanation renders`,
   );

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -8486,5 +8486,7 @@
   "cloud.security.pluginPermissionsLink": "Plugin permissions →",
   "cloud.security.pluginPermissionsManage": "Manage permissions",
   "browserworkspace.NativeSurfaceUnavailable": "Browser view unavailable",
-  "browserworkspace.NativeSurfaceUnavailableDescription": "The secure browser surface could not connect. Retry without losing your tabs."
+  "browserworkspace.NativeSurfaceUnavailableDescription": "The secure browser surface could not connect. Retry without losing your tabs.",
+  "browserworkspace.NativeSurfaceUnsupported": "Secure browsing not supported here",
+  "browserworkspace.NativeSurfaceUnsupportedDescription": "This device's system WebView is too old to isolate web pages safely, so Eliza will not open them inside the app. You can open the page in the device browser instead."
 }

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -8488,5 +8488,5 @@
   "browserworkspace.NativeSurfaceUnavailable": "Browser view unavailable",
   "browserworkspace.NativeSurfaceUnavailableDescription": "The secure browser surface could not connect. Retry without losing your tabs.",
   "browserworkspace.NativeSurfaceUnsupported": "Secure browsing not supported here",
-  "browserworkspace.NativeSurfaceUnsupportedDescription": "This device's system WebView is too old to isolate web pages safely, so Eliza will not open them inside the app. You can open the page in the device browser instead."
+  "browserworkspace.NativeSurfaceUnsupportedDescription": "This device's system WebView cannot provide the isolation Eliza requires, so Eliza will not open pages inside the app. You can open the page in the device browser instead."
 }

--- a/packages/ui/src/surface/native-surface-capability.test.ts
+++ b/packages/ui/src/surface/native-surface-capability.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Pins the permanent-denial classifier to the native plugin's literal reject
+ * strings and proves the cause-chain walk. The Android plugin source is read
+ * from the monorepo so a native message rewrite fails HERE instead of silently
+ * downgrading a permanent capability denial to a retryable transient fault.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { NativeSurfaceUnavailableError } from "./capacitor-native-surface-shell";
+import { isNativeSurfaceCapabilityDenial } from "./native-surface-capability";
+
+const REPO_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../..",
+);
+const ANDROID_PLUGIN_SOURCE = resolve(
+  REPO_ROOT,
+  "plugins/plugin-native-browser-surface/android/src/main/java/ai/eliza/plugins/browsersurface/BrowserSurfacePlugin.kt",
+);
+
+// The exact device-capability reject strings the Android plugin emits. LP3
+// (WebView 113, API 34) hits the first one: androidx.webkit MULTI_PROFILE
+// landed in system WebView 115+, so `storage: "isolated"` can never be
+// honoured on that device.
+const MULTI_PROFILE_DENIAL =
+  "isolated storage requires WebView multi-profile support; system WebView is too old";
+const RENDERER_DENIAL =
+  "isolated process policy requires an out-of-app WebView renderer, which is unavailable on this device";
+
+describe("isNativeSurfaceCapabilityDenial", () => {
+  it("stays pinned to the Android plugin's literal reject strings", () => {
+    // Hard fail (never a skip) when the native source moves or is renamed —
+    // the classifier's patterns would be matching nothing.
+    const source = readFileSync(ANDROID_PLUGIN_SOURCE, "utf8");
+    expect(source).toContain(`call.reject("${MULTI_PROFILE_DENIAL}")`);
+    expect(source).toContain(`call.reject("${RENDERER_DENIAL}")`);
+    expect(
+      isNativeSurfaceCapabilityDenial(new Error(MULTI_PROFILE_DENIAL)),
+    ).toBe(true);
+    expect(isNativeSurfaceCapabilityDenial(new Error(RENDERER_DENIAL))).toBe(
+      true,
+    );
+  });
+
+  it("classifies the denial when wrapped by the shell's typed transport error", () => {
+    // Production path: the Capacitor rejection becomes the `cause` of a
+    // NativeSurfaceUnavailableError whose own message is only the operation.
+    const wrapped = new NativeSurfaceUnavailableError({
+      surfaceId: "browser-tab:a",
+      generation: 1,
+      operation: "createSurface(browser-tab:a)",
+      revision: 1,
+      cause: new Error(MULTI_PROFILE_DENIAL),
+    });
+    expect(wrapped.message).not.toContain("multi-profile");
+    expect(isNativeSurfaceCapabilityDenial(wrapped)).toBe(true);
+  });
+
+  it("classifies a doubly nested cause chain and non-Error string causes", () => {
+    const deep = new Error("outer", {
+      cause: new Error("middle", { cause: MULTI_PROFILE_DENIAL }),
+    });
+    expect(isNativeSurfaceCapabilityDenial(deep)).toBe(true);
+  });
+
+  it("does NOT classify transient transport faults as permanent", () => {
+    expect(isNativeSurfaceCapabilityDenial(new Error("bounds rejected"))).toBe(
+      false,
+    );
+    expect(
+      isNativeSurfaceCapabilityDenial(
+        new NativeSurfaceUnavailableError({
+          surfaceId: "browser-tab:a",
+          generation: 1,
+          operation: "setBounds(browser-tab:a)",
+          revision: 1,
+          cause: new Error("native state unavailable"),
+        }),
+      ),
+    ).toBe(false);
+    expect(isNativeSurfaceCapabilityDenial(null)).toBe(false);
+    expect(isNativeSurfaceCapabilityDenial(undefined)).toBe(false);
+    expect(isNativeSurfaceCapabilityDenial(42)).toBe(false);
+  });
+
+  it("survives a self-referential cause cycle", () => {
+    const a = new Error("first");
+    const b = new Error("second", { cause: a });
+    a.cause = b; // deliberately create a cycle
+    expect(isNativeSurfaceCapabilityDenial(a)).toBe(false);
+  });
+});

--- a/packages/ui/src/surface/native-surface-capability.ts
+++ b/packages/ui/src/surface/native-surface-capability.ts
@@ -1,0 +1,57 @@
+/**
+ * Classifies native Browser-surface failures into permanent capability denials
+ * versus transient transport faults, so the renderer can stop offering a Retry
+ * that can never succeed (#15245 fail-closed posture, LP3 WebView 113).
+ *
+ * The Android plugin rejects `createSurface` when the system WebView cannot
+ * honour the requested isolation: no androidx.webkit multi-profile support for
+ * `storage: "isolated"`, or no out-of-app renderer for `process: "isolated"`.
+ * Both are properties of the device's system WebView, not of the current
+ * attempt; retrying reproduces the same rejection until the OS ships a newer
+ * WebView. Security stays fail-closed — this module only changes what the user
+ * is TOLD, never silently degrades to shared storage or an in-realm iframe.
+ *
+ * The patterns below are pinned against the exact Kotlin reject strings by
+ * `native-surface-capability.test.ts`, which reads the plugin source from the
+ * monorepo, so a message rewrite on the native side fails the test instead of
+ * silently reclassifying a permanent denial as transient.
+ */
+
+/**
+ * Permanent isolation-capability denials the native side can emit. Each entry
+ * must keep matching the literal `call.reject(...)` string in
+ * `plugins/plugin-native-browser-surface/android/.../BrowserSurfacePlugin.kt`.
+ */
+const CAPABILITY_DENIAL_PATTERNS: readonly RegExp[] = [
+  /isolated storage requires WebView multi-profile support/i,
+  /isolated process policy requires an out-of-app WebView renderer/i,
+];
+
+/**
+ * True when the failure (or anything on its `cause` chain) is a permanent
+ * device-capability denial rather than a transient transport fault. The shell
+ * wraps native rejections in `NativeSurfaceUnavailableError` with the original
+ * Capacitor rejection as `cause`, so the chain walk is what finds the native
+ * message; a cycle guard keeps adversarial cause chains finite.
+ */
+export function isNativeSurfaceCapabilityDenial(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current !== null && current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    const message =
+      current instanceof Error
+        ? current.message
+        : typeof current === "string"
+          ? current
+          : null;
+    if (
+      message !== null &&
+      CAPABILITY_DENIAL_PATTERNS.some((pattern) => pattern.test(message))
+    ) {
+      return true;
+    }
+    current = current instanceof Error ? current.cause : null;
+  }
+  return false;
+}

--- a/packages/ui/src/surface/use-mobile-native-tab-surfaces.test.ts
+++ b/packages/ui/src/surface/use-mobile-native-tab-surfaces.test.ts
@@ -17,6 +17,7 @@ import {
   CapacitorNativeSurfaceShell,
   type ElizaSurfaceManagerPlugin,
   type ElizaSurfaceManagerState,
+  NativeSurfaceUnavailableError,
 } from "./capacitor-native-surface-shell";
 import type {
   NativeSurfaceCreateRequest,
@@ -105,6 +106,27 @@ class DropFirstBoundsShell extends RecordingShell {
       return Promise.reject(new Error("bounds rejected"));
     }
     return super.setBounds(id, bounds);
+  }
+}
+
+class CapabilityDenyingShell extends RecordingShell {
+  attempts = 0;
+
+  override createSurface(req: NativeSurfaceCreateRequest): Promise<void> {
+    this.attempts += 1;
+    // The exact production shape: the shell's typed transport error wrapping
+    // the native Capacitor rejection as its cause.
+    return Promise.reject(
+      new NativeSurfaceUnavailableError({
+        surfaceId: req.id,
+        generation: 1,
+        operation: `createSurface(${req.id})`,
+        revision: 1,
+        cause: new Error(
+          "isolated storage requires WebView multi-profile support; system WebView is too old",
+        ),
+      }),
+    );
   }
 }
 
@@ -568,6 +590,72 @@ describe("useMobileNativeTabSurfaces", () => {
       shell.commands.filter((command) => command === "create:browser-tab:a"),
     ).toHaveLength(1);
     expect(shell.navigations).toEqual([]);
+  });
+
+  it("marks a WebView capability denial permanent while a transient fault stays retryable", async () => {
+    // Permanent direction: the multi-profile denial (LP3, WebView 113) is
+    // classified permanent so the renderer can suppress Retry.
+    const denying = new CapabilityDenyingShell();
+    const permanent = renderHook(() =>
+      useMobileNativeTabSurfaces({ ...base, shell: denying }),
+    );
+    await act(async () => Promise.resolve());
+    expect(permanent.result.current.error?.permanent).toBe(true);
+    expect(permanent.result.current.error?.message).toContain("createSurface");
+    permanent.unmount();
+
+    // Opposite direction: an ordinary transport fault must NOT be permanent —
+    // Retry stays meaningful and still converges.
+    const dropping = new DropFirstBoundsShell();
+    const surface = elementAt({ left: 12, top: 34, width: 300, height: 500 });
+    const transient = renderHook(() =>
+      useMobileNativeTabSurfaces({ ...base, shell: dropping }),
+    );
+    act(() => transient.result.current.registerSurfaceElement("a", surface));
+    await act(async () => Promise.resolve());
+    expect(transient.result.current.error?.permanent).toBe(false);
+    act(() => transient.result.current.retry());
+    await act(async () => Promise.resolve());
+    expect(transient.result.current.error).toBeNull();
+    transient.unmount();
+  });
+
+  it("surfaces the permanent denial over an earlier transient failure", async () => {
+    // Two tabs: tab a fails transiently on bounds, tab b hits the permanent
+    // capability denial on create. The rendered error must be the permanent
+    // one even though the transient failure was recorded first.
+    class MixedShell extends RecordingShell {
+      override setBounds(id: string, bounds: SurfaceBounds): Promise<void> {
+        if (id === "browser-tab:a") {
+          return Promise.reject(new Error("bounds rejected"));
+        }
+        return super.setBounds(id, bounds);
+      }
+      override createSurface(req: NativeSurfaceCreateRequest): Promise<void> {
+        if (req.id === "browser-tab:b") {
+          return Promise.reject(
+            new Error(
+              "isolated storage requires WebView multi-profile support; system WebView is too old",
+            ),
+          );
+        }
+        return super.createSurface(req);
+      }
+    }
+    const shell = new MixedShell();
+    const twoTabs = { ...base, tabs: [tab("a"), tab("b")] };
+    const { result } = renderHook(() =>
+      useMobileNativeTabSurfaces({ ...twoTabs, shell }),
+    );
+    act(() => {
+      result.current.registerSurfaceElement(
+        "a",
+        elementAt({ left: 0, top: 0, width: 300, height: 500 }),
+      );
+    });
+    await act(async () => Promise.resolve());
+    expect(result.current.error?.permanent).toBe(true);
+    expect(result.current.error?.key).toBe("browser-tab:b:lifecycle");
   });
 
   it("uses the app-resume edge as one bounded retry for failed desired state", async () => {

--- a/packages/ui/src/surface/use-mobile-native-tab-surfaces.ts
+++ b/packages/ui/src/surface/use-mobile-native-tab-surfaces.ts
@@ -30,6 +30,7 @@ import type { SurfaceLifecyclePolicy } from "@elizaos/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { APP_PAUSE_EVENT, APP_RESUME_EVENT } from "../events";
 import { CapacitorNativeSurfaceShell } from "./capacitor-native-surface-shell";
+import { isNativeSurfaceCapabilityDenial } from "./native-surface-capability";
 import type {
   NativeSurfacePolicy,
   NativeSurfaceShell,
@@ -104,6 +105,16 @@ export interface MobileNativeTabSurfaces {
 export interface MobileNativeSurfaceError {
   readonly key: string;
   readonly message: string;
+  /**
+   * True when the failure is a permanent device-capability denial (the system
+   * WebView cannot honour the surface's isolation policy) rather than a
+   * transient transport fault. Retrying a permanent denial reproduces the same
+   * native rejection, so the renderer should offer an escape hatch (open the
+   * page externally) instead of a Retry that can never succeed. The security
+   * posture stays fail-closed either way: no shared-storage or in-realm
+   * fallback is ever created.
+   */
+  readonly permanent: boolean;
 }
 
 /**
@@ -418,13 +429,19 @@ export function useMobileNativeTabSurfaces(
     ([, command]) =>
       command.status === "failed" || command.status === "recovering",
   );
-  const firstFailedCommand = failedCommands[0];
+  // A permanent capability denial outranks transient faults for display:
+  // when the device cannot host the surface at all, that is the state the
+  // user must see, not whichever transient command happened to fail first.
+  const firstFailedCommand =
+    failedCommands.find(([, command]) => command.permanent) ??
+    failedCommands[0];
   const surfaceError: MobileNativeSurfaceError | null = firstFailedCommand
     ? {
         key: firstFailedCommand[0],
         message:
           firstFailedCommand[1].error ??
           "The native Browser surface is unavailable.",
+        permanent: firstFailedCommand[1].permanent,
       }
     : null;
   const hasFailedCommands = failedCommands.length > 0;
@@ -480,6 +497,7 @@ export function useMobileNativeTabSurfaces(
         invoke,
         isAuthorized,
         error: replacesFailure ? existing.error : null,
+        permanent: replacesFailure ? existing.permanent : false,
         retry: () => run(true),
       };
       observedCommands.current.set(key, command);
@@ -521,6 +539,7 @@ export function useMobileNativeTabSurfaces(
               error instanceof Error
                 ? error.message
                 : "The native Browser surface is unavailable.";
+            command.permanent = isNativeSurfaceCapabilityDenial(error);
             notifyCommandStateChanged();
           },
         );
@@ -1075,5 +1094,7 @@ interface ObservedSurfaceCommand {
   readonly isAuthorized: () => boolean;
   status: "pending" | "recovering" | "succeeded" | "failed";
   error: string | null;
+  /** Whether the recorded failure is a permanent device-capability denial. */
+  permanent: boolean;
   retry(): void;
 }


### PR DESCRIPTION
## Problem

On devices whose system WebView lacks androidx.webkit MULTI_PROFILE (Light Phone 3: WebView 113, API 34), the native browser-surface plugin correctly rejects isolated-storage `createSurface` calls fail-closed. The renderer then showed a generic "Browser view unavailable" card with a Retry button that can never succeed, looping the user against a permanent device limitation.

Closes #21619

## Fix

- **`packages/ui/src/surface/native-surface-capability.ts` (new):** classifies the plugin's two permanent capability-denial reject strings (multi-profile storage, out-of-app renderer) by walking the error cause chain with a cycle guard. The patterns are pinned to the literal Kotlin reject strings by a monorepo-source-reading test, so a native message rewrite fails loud instead of silently reverting the UX.
- **`useMobileNativeTabSurfaces`:** marks failed commands permanent and surfaces a permanent denial ahead of transient faults in its rendered error.
- **`BrowserWorkspaceView`:** permanent denial renders honest "Secure browsing not supported here" copy with an Open-external escape hatch (device browser) instead of Retry; transient transport faults keep the existing retryable card unchanged.
- **Security posture unchanged:** no shared-storage or in-realm fallback is ever created; the surface stays fail-closed.

## Proof

**Bidirectional:** with the implementation files reverted to develop (tests kept), the 3 new targeted tests fail exactly as expected (permanent flag missing, denial not prioritized, UI shows Retry). On this head, all 80 tests across the 6 touched/adjacent suites pass:

```
bun run --cwd packages/ui vitest run \
  src/surface/native-surface-capability.test.ts \
  src/surface/use-mobile-native-tab-surfaces.test.ts \
  src/components/pages/BrowserWorkspaceView.native-surface-error.test.tsx \
  src/surface-embedding.test.ts \
  src/surface/native-surface-shell.test.ts \
  src/builtin-tab-registry.test.ts
# 6 files, 80 tests passed
```

**Real-browser e2e (new, `test:browser-surface-error-e2e`):** bundles the REAL `BrowserWorkspaceView` via esbuild (state/api barrels, the surface hook, `@capacitor/core`, and `@elizaos/core` stubbed; every rendered component real), compiles the real Tailwind v4 theme, and drives headless chromium at the LP3 CSS viewport (360x414) and a phone viewport (390x844). 22 assertions pass on both viewports: honest copy renders, NO Retry inside the permanent card, the escape hatch routes the selected tab URL through the Capacitor Browser plugin, transient keeps Retry wired to the hook, zero page errors.

No workflow files changed. No checks weakened.

# Evidence Gate

<!-- evidence-head:1f6b6ea13eb45cddded267e7009f90c9ec714384 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-lp3-permanent-denial-shows-retry](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21537-before-lp3-360x414-permanent.png)
- [x] ![before-phone-permanent-denial-shows-retry](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21537-before-phone-390x844-permanent.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21537-after-mobile-matrix-1f6b6ea.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21537-browser-surface-walkthrough-1f6b6ea.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - renderer-only change; no backend code touched

<!-- evidence-row:frontend-logs -->
- [x] [21537-frontend-e2e-log.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21537-frontend-e2e-log.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM in the changed path

<!-- evidence-row:domain-artifacts -->
- [x] [21537-vitest-suites-log.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21537-vitest-suites-log.txt)

<!-- evidence-row:ocr-review -->
- [x] [21537-ocr-current-mobile-matrix-1f6b6ea.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21537-ocr-current-mobile-matrix-1f6b6ea.txt)

### Native target scope

- **Physical Light Phone 3 evidence: N/A.** This renderer-only PR does not change the native plugin rejection contract; the exact Kotlin denial literals remain independently pinned by the monorepo-source-reading test. Current-head evidence exercises the real `BrowserWorkspaceView`, permanent/transient renderer handling, and Capacitor external-open call at LP3 and phone CSS viewports. These deterministic browser captures are not represented as hardware evidence.

## Contribution provenance

AI provider/model: anthropic-proxy / claude-fable-5
Client / agent tooling: moltbot
Contribution skill revision: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
Attribution status: self-reported

— [sol-lp3-nav-surface-r2]

<!-- eliza-computer-attribution:v1 {"provider":"anthropic-proxy","model":"claude-fable-5","client":"moltbot","skill_revision":"elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza"} -->
