### PR TITLE
fix(anthropic-proxy): reject malformed/out-of-range CLAUDE_MAX_PROXY_PORT

### DIFF
--- a/plugins/plugin-anthropic-proxy/__tests__/proxy-service.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/proxy-service.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Configuration regression coverage for the Anthropic proxy service.
+ * Deterministic: resolves environment-backed configuration without starting a server.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveConfig } from "../src/services/proxy-service.ts";
+
+const originalMode = process.env.CLAUDE_MAX_PROXY_MODE;
+const originalPort = process.env.CLAUDE_MAX_PROXY_PORT;
+
+afterEach(() => {
+  if (originalMode === undefined) delete process.env.CLAUDE_MAX_PROXY_MODE;
+  else process.env.CLAUDE_MAX_PROXY_MODE = originalMode;
+  if (originalPort === undefined) delete process.env.CLAUDE_MAX_PROXY_PORT;
+  else process.env.CLAUDE_MAX_PROXY_PORT = originalPort;
+});
+
+describe("resolveConfig", () => {
+  it("rejects ports with a numeric prefix instead of silently truncating them", () => {
+    process.env.CLAUDE_MAX_PROXY_MODE = "inline";
+    process.env.CLAUDE_MAX_PROXY_PORT = "123junk";
+
+    const config = resolveConfig();
+
+    expect(config.port).toBe(18801);
+    expect(config.configError).toBe("Invalid CLAUDE_MAX_PROXY_PORT: 123junk");
+  });
+
+  it("rejects ports outside the TCP range while preserving port zero", () => {
+    process.env.CLAUDE_MAX_PROXY_MODE = "inline";
+    process.env.CLAUDE_MAX_PROXY_PORT = "65536";
+    expect(resolveConfig().configError).toBe("Invalid CLAUDE_MAX_PROXY_PORT: 65536");
+
+    process.env.CLAUDE_MAX_PROXY_PORT = "0";
+    expect(resolveConfig()).toMatchObject({ port: 0, configError: undefined });
+  });
+
+  it("ignores the inline-only port setting in shared and off modes", () => {
+    process.env.CLAUDE_MAX_PROXY_PORT = "not-a-port";
+
+    process.env.CLAUDE_MAX_PROXY_MODE = "shared";
+    expect(resolveConfig()).toMatchObject({
+      mode: "shared",
+      port: 18801,
+      configError: undefined,
+    });
+
+    process.env.CLAUDE_MAX_PROXY_MODE = "off";
+    expect(resolveConfig()).toMatchObject({
+      mode: "off",
+      port: 18801,
+      configError: undefined,
+    });
+  });
+});

--- a/plugins/plugin-anthropic-proxy/src/services/proxy-service.ts
+++ b/plugins/plugin-anthropic-proxy/src/services/proxy-service.ts
@@ -199,7 +199,14 @@ export function resolveConfig(): ProxyServiceConfig {
   const mode: ProxyMode = validMode ? modeRaw : "off";
 
   const portRaw = readEnv("CLAUDE_MAX_PROXY_PORT");
-  const port = portRaw ? Number.parseInt(portRaw, 10) || 18801 : 18801;
+  const parsedPort = portRaw !== undefined && /^\d+$/.test(portRaw) ? Number(portRaw) : NaN;
+  const validPort = Number.isSafeInteger(parsedPort) && parsedPort >= 0 && parsedPort <= 65535;
+  const port =
+    portRaw === undefined || validPort ? (portRaw === undefined ? 18801 : parsedPort) : 18801;
+  const portError =
+    mode === "inline" && portRaw !== undefined && !validPort
+      ? `Invalid CLAUDE_MAX_PROXY_PORT: ${portRaw}`
+      : undefined;
   const fingerprint = resolveFingerprintConfig();
 
   return {
@@ -215,7 +222,7 @@ export function resolveConfig(): ProxyServiceConfig {
     fingerprintConfig: fingerprint.fingerprintConfig,
     configError:
       fingerprint.configError ??
-      (validMode ? undefined : `Invalid CLAUDE_MAX_PROXY_MODE: ${modeRaw}`),
+      (validMode ? portError : `Invalid CLAUDE_MAX_PROXY_MODE: ${modeRaw}`),
   };
 }
 


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
- AI assistance: Yes - initial author assistance plus maintainer review and remediation
<!-- attribution-row:models -->
- Models: `openai/gpt-5.6-sol`, `anthropic/claude-sonnet-5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client/tooling: Codex CLI, Claude Code, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - the contribution skill was not used for this maintainer review and remediation
<!-- attribution-row:status -->
- Provenance status: self-reported

AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: reproduced both bugs myself, ran the full mutation check myself (revert source, keep test, confirm both cases red; restore, confirm green), reran typecheck/lint myself with the real output captured directly (exit 0, not just the command), and re-ran the full package test suite myself — it hit 4 worker-timeout errors (this environment's socket/process sandbox, not assertion failures) with all 53 real tests passing, confirming the draft's own "5 sandbox EPERM failures, 59 passed" characterization independently (exact failure count varies run to run, but it's consistently infra-level, never a real assertion failure), and re-traced reachability myself through `AnthropicProxyService.start` → `resolveConfig()`.

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low. Tightens port parsing to reject only genuinely invalid input (non-digit-only strings, out-of-TCP-range values); every previously-valid port value, including the `0` ephemeral-bind case, is preserved exactly. The plugin is opt-in and not enabled by default.

# Background

## What does this PR do?

`resolveConfig` parsed `CLAUDE_MAX_PROXY_PORT` with `Number.parseInt(portRaw, 10) || 18801`, which has two separate bugs: `parseInt` stops at the first non-digit character, so `"123junk"` silently selected port `123` instead of being rejected; and the `||` fallback treats the legitimate port `0` (ephemeral bind) as falsy, silently replacing it with the default `18801`.

Before fix: `CLAUDE_MAX_PROXY_PORT=123junk` resolves to `port: 123, configError: undefined`.

After fix: the port is accepted only when the entire env value is decimal digits and resolves to a safe integer in the TCP port range `0..65535`. Invalid input now produces an explicit `configError` and keeps the default port; port `0` is preserved correctly.

## What kind of change is this?

Bug fix — no new capability, no schema change.

# Documentation changes needed?

No.

# Testing

New `plugins/plugin-anthropic-proxy/__tests__/proxy-service.test.ts`, covering a numeric-prefix value (`"123junk"`) and an out-of-range value (`"65536"`) both rejecting with an explicit `configError`, while `"0"` still resolves to `port: 0` with no error.

# Evidence Gate

<!-- evidence-head:41f973de573d90d42f2ec8289f509724327c78e0 -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend logic fix, no UI surface
- <!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual behavior changed

## Known gaps / failures

None in the touched files. The package's full test lane has pre-existing, environment-level socket/worker-timeout flakiness unrelated to this change (confirmed by two separate runs producing different failure counts/signatures while the deterministic focused regression test stays green both times).

## Reachability

`AnthropicProxyService.start(runtime)` calls `resolveConfig()` directly during normal plugin service startup (`plugins/plugin-anthropic-proxy/src/services/proxy-service.ts:240`). `@elizaos/plugin-anthropic-proxy` is opt-in and not enabled by default, but when it runs in `inline` mode, `CLAUDE_MAX_PROXY_PORT` is a documented operator-supplied environment parameter, and the resolved `config.port` is passed straight to `ProxyServer`, which binds the Node HTTP server — so this is reachable from real, non-test operator configuration whenever the plugin is enabled.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-rendered logic change with no UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic focused regression tests are documented in the Testing section and produce no persistent backend log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by this logic change

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered interface changed
