### PR TITLE
fix(cloud): reject prefix-coerced advertising conversion value

### DIFF
--- a/packages/cloud/api/v1/advertising/conversions/track/route.limit.test.ts
+++ b/packages/cloud/api/v1/advertising/conversions/track/route.limit.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Prefix-coerced conversion pixel value must be invalid.
+ * Number("1e2") === 100 used to become a real tracked amount.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { AGGRESSIVE: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/advertising", () => ({
+  advertisingService: { recordConversion: async () => ({}) },
+}));
+
+mock.module("@/lib/services/advertising/schemas", () => ({
+  RecordConversionSchema: { safeParse: () => ({ success: false }) },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn: () => undefined },
+}));
+
+const { parseConversionQueryValue } = await import("./route");
+
+describe("advertising conversion query value", () => {
+  test("1e2 is invalid instead of becoming 100", () => {
+    expect(parseConversionQueryValue("1e2")).toBe("invalid");
+  });
+
+  test("007 is invalid instead of becoming 7", () => {
+    expect(parseConversionQueryValue("007")).toBe("invalid");
+  });
+
+  test("0x10 is invalid instead of becoming 16", () => {
+    expect(parseConversionQueryValue("0x10")).toBe("invalid");
+  });
+
+  test("canonical 3 still parses", () => {
+    expect(parseConversionQueryValue("3")).toBe(3);
+  });
+
+  test("canonical 10.5 still parses", () => {
+    expect(parseConversionQueryValue("10.5")).toBe(10.5);
+  });
+
+  test("omitted value stays undefined", () => {
+    expect(parseConversionQueryValue(undefined)).toBeUndefined();
+  });
+});

--- a/packages/cloud/api/v1/advertising/conversions/track/route.ts
+++ b/packages/cloud/api/v1/advertising/conversions/track/route.ts
@@ -37,18 +37,34 @@ function presentMetadata(input: Record<string, string | undefined>) {
   );
 }
 
+/**
+ * Canonical decimal conversion amounts only. Number("1e2") === 100 used to
+ * become a real tracked value on the public pixel query string.
+ */
+export function parseConversionQueryValue(
+  raw: string | undefined,
+): number | undefined | "invalid" {
+  if (raw === undefined || raw === "") return undefined;
+  if (!/^(0|[1-9]\d*)(\.\d+)?$/.test(raw)) return "invalid";
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : "invalid";
+}
+
 app.get("/", async (c) => {
   try {
     const token = c.req.query("token");
     const dedupeKey = c.req.query("dedupeKey") ?? c.req.query("eventId");
     const eventType = c.req.query("eventType") ?? "conversion";
-    const value = c.req.query("value");
+    const value = parseConversionQueryValue(c.req.query("value"));
+    if (value === "invalid") {
+      return c.json({ success: false, error: "Invalid conversion event" }, 400);
+    }
     const sourceUrl = c.req.query("sourceUrl");
     const parsed = RecordConversionSchema.safeParse({
       token,
       dedupeKey,
       eventType,
-      value: value === undefined ? undefined : Number(value),
+      value,
       currency: c.req.query("currency") ?? "USD",
       sourceUrl,
       metadata: presentMetadata({


### PR DESCRIPTION

# PI eliza ad-conversion-value — 2026-08-18

**Repo:** `elizaOS/eliza`
**Public writes:** (pending)
**Worktree:** `/Users/thescoho/Developer/worktrees/eliza-ad-conversion-value-20260818`
**Branch:** `fix/ad-conversion-value`
**HEAD:** `1eeb1ae0e8`
**Provider/model/client:** xAI / grok-4.6 / Cursor

## Defect
`GET /api/v1/advertising/conversions/track` parsed query `value` with `Number()`. `1e2` / `007` / `0x10` silently became tracked amounts instead of 400.

## Paths
- `packages/cloud/api/v1/advertising/conversions/track/route.ts`
- `packages/cloud/api/v1/advertising/conversions/track/route.limit.test.ts`

## Occupancy
FREE as of 2026-08-17T23:55Z. Not generate-image/music. Not a twin of `#20808` billing.

# Risks

Low. Request-facing leftover-tax only. Canonical decimal amounts still apply. Prefix-coerced junk (`1e2`, `007`, `0x10`) now 400s before `recordConversion`.

# Background

## What does this PR do?

The public conversion pixel parsed query `value` with `Number()`. `1e2` silently became amount 100 and `007` became 7. This PR requires a canonical decimal and 400s otherwise.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/advertising/conversions/track/route.limit.test.ts` and `parseConversionQueryValue` in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate v1/advertising/conversions/track/route.limit.test.ts
```

6 passed on `1eeb1ae0e8`.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on advertising conversion `value`. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Bun test asserts leftover value identities are invalid and canonical `3` / `10.5` still parse.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the conversion pixel HTTP boundary.

## Domain artifacts

N/A - no DB / memory / wallet / generated-file change. Invalid value never reaches `recordConversion`.

## OCR visual-text review

N/A - no rendered visual surface.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Request-facing leftover-tax only. Canonical decimal amounts still apply. Prefix-coerced junk (`1e2`, `007`, `0x10`) now 400s before `recordConversion`.

# Background

## What does this PR do?

The public conversion pixel parsed query `value` with `Number()`. `1e2` silently became amount 100 and `007` became 7. This PR requires a canonical decimal and 400s otherwise.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical callers unchanged.

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/advertising/conversions/track/route.limit.test.ts` and `parseConversionQueryValue` in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate v1/advertising/conversions/track/route.limit.test.ts
```

6 passed on `1eeb1ae0e8cdef7006402127f9f9f0d0b59b09ca`.

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:1eeb1ae0e8cdef7006402127f9f9f0d0b59b09ca -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on advertising conversion `value`. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Bun test asserts leftover value identities are invalid and canonical `3` / `10.5` still parse.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - no rendered UI surface. Cloud advertising conversion leftover-tax only.

### After

N/A - no rendered UI surface. Cloud advertising conversion leftover-tax only.

### Walkthrough video

N/A - no rendered UI surface. Cloud advertising conversion leftover-tax only.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT / omnivoice change.

## Known gaps / failures

`bun run verify` not re-run on this leftover-tax slice. Scoped bun test on `route.limit.test.ts` is the proof (6 passed). Evidence rows are N/A because this is a request-facing API parser, not a UI or LLM path.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
