### PR TITLE
fix(cloud): reject malformed app characters JSON body

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/characters/route.json.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/characters/route.json.test.ts
@@ -1,0 +1,68 @@
+/**
+ * PUT /api/v1/apps/:id/characters used to let request.json() throw into the
+ * route-wide catch, which returned 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+  user: { id: "user-1", organization_id: "org-1" },
+  apiKey: null,
+}));
+const isAppKeyOutOfScope = mock(async () => false);
+const getById = mock(async () => ({
+  id: "app-1",
+  organization_id: "org-1",
+  linked_character_ids: [],
+}));
+const update = mock(async () => undefined);
+const getCharacterById = mock(async () => null);
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg,
+}));
+mock.module("@/lib/auth/app-key-scope", () => ({
+  isAppKeyOutOfScope,
+}));
+mock.module("@/lib/services/apps", () => ({
+  appsService: { getById, update },
+}));
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: { getById: getCharacterById },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id", route);
+
+describe("PUT /api/v1/apps/:id/characters malformed JSON", () => {
+  test("returns 400 instead of 500 and never writes linked characters", async () => {
+    const response = await app.request("/app-1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "Invalid JSON in request body",
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still links an empty character list", async () => {
+    const response = await app.request("/app-1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ character_ids: [] }),
+    });
+    expect(response.status).toBe(200);
+    expect(update).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/apps/[id]/characters/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/characters/route.ts
@@ -163,7 +163,17 @@ async function __hono_PUT(
       );
     }
 
-    const rawBody = await request.json();
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not the route-wide 500 used for service failures.
+      return Response.json(
+        { success: false, error: "Invalid JSON in request body" },
+        { status: 400 },
+      );
+    }
     const parsedBody = LinkCharactersBody.safeParse(rawBody);
     if (!parsedBody.success) {
       return Response.json(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on app characters PUT currently 500s. Not a list-limit / canonical-text / one-flag boolean change. Not tracker #21541 close-bait.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still link characters. Malformed JSON (`{`, truncated objects) now 400s before `appsService.update` instead of falling into the route-wide 500 catch. Proven on the unfixed head: the same test received **500**.

# Background

## What does this PR do?

`PUT /api/v1/apps/:id/characters` called `await request.json()` inside a try that maps every throw to HTTP 500. A truncated or non-JSON body therefore looked like a service failure. This PR catches JSON parse errors and returns `{ success: false, error: "Invalid JSON in request body" }` with status 400 before Zod or the apps service write.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/apps/[id]/characters/route.json.test.ts` and the `request.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'v1/apps/[id]/characters/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500**. After the fix: 2 passed on `6ddda302f182af83f0ebea9eed00e5f4e44c499a`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:6ddda302f182af83f0ebea9eed00e5f4e44c499a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the characters HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before the linked-character write.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that `appsService.update` is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches `appsService.update`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on app characters JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and canonical `{ character_ids: [] }` still updates.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the characters HTTP boundary.

## Audio / voice walkthrough

N/A - not a voice / TTS / STT change.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `6ddda302f1`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
