### PR TITLE
fix(core,logger): close secret-redaction gaps in runtime scrub, log sinks, and CSPRNG fallbacks (W5-025, W5-026, W5-028, W5-032)

### DIFF
--- a/packages/core/src/providers/recent-errors.test.ts
+++ b/packages/core/src/providers/recent-errors.test.ts
@@ -1,13 +1,17 @@
 /**
  * Tests for the RECENT_ERRORS provider: renders nothing when clean, dedupes by
  * code (newest wins), caps the list, and ages out stale entries. Uses a fake
- * runtime that returns a controlled reported-error ring.
+ * runtime that returns a controlled reported-error ring — except the W5-025
+ * case, which drives a real AgentRuntime so the redactSecrets scrub under test
+ * is the production one.
  */
 
 import { describe, expect, it } from "vitest";
 import type { ReportedError } from "../errors";
+import { ElizaError } from "../errors";
+import { AgentRuntime } from "../runtime";
 import { redactWithSecrets } from "../security/redact";
-import type { IAgentRuntime, Memory, State } from "../types";
+import type { Character, IAgentRuntime, Memory, State } from "../types";
 import { QUIET_ERROR_CODES, recentErrorsProvider } from "./recent-errors";
 
 function runtimeWith(entries: ReportedError[]): IAgentRuntime {
@@ -238,5 +242,31 @@ describe("RECENT_ERRORS provider", () => {
 		// so assert the mask shape, not the exact marker format).
 		expect(result.text).toContain("[REDAC…ORD]");
 		expect(result.text).toContain("UPLOAD_FAILED");
+	});
+
+	it("scrubs credential patterns even when the character configures no secrets (W5-025)", async () => {
+		// A default/minimal character has no settings.secrets. The runtime's
+		// redactSecrets used to early-return unchanged text in that case, so the
+		// pattern library never engaged and reported errors carried API keys and
+		// Bearer tokens into the prompt verbatim. This drives the real
+		// AgentRuntime + provider path end to end.
+		const runtime = new AgentRuntime({
+			character: { name: "no-secrets-character" } as Character,
+		});
+		runtime.reportError(
+			"ThirdPartyPlugin",
+			new ElizaError(
+				"GET https://api.example.com/v1/data?key=AIzaSyD4iE4fZa1234567890abcdef failed with Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.c2lnbmF0dXJl",
+				{ code: "FETCH_FAILED" },
+			),
+		);
+
+		const result = await recentErrorsProvider.get(runtime, message, state);
+
+		expect(result.text).not.toContain("AIzaSyD4iE4fZa1234567890abcdef");
+		expect(result.text).not.toContain(
+			"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.c2lnbmF0dXJl",
+		);
+		expect(result.text).toContain("FETCH_FAILED");
 	});
 });

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -11359,15 +11359,19 @@ ${section_end}`;
 	/**
 	 * Redact secrets from text content.
 	 * This prevents character secrets from appearing in outputs or memories.
+	 *
+	 * The pattern library runs even when the character configures no secrets:
+	 * default/minimal characters are exactly the ones whose reported errors and
+	 * provider texts can still carry credential-shaped values (API keys, Bearer
+	 * tokens, URI userinfo). `redactWithSecrets` treats an empty secrets map as
+	 * a no-op for the literal pass, and its pattern regexps are compiled once at
+	 * module load, so the always-on scrub costs one pattern sweep per call.
 	 */
 	redactSecrets(text: string): string {
 		if (!text) {
 			return text;
 		}
 		const secrets = this.getSecretsForRedaction();
-		if (Object.keys(secrets).length === 0) {
-			return text;
-		}
 		return redactWithSecrets(text, { secrets, applyPatterns: true });
 	}
 

--- a/packages/core/src/security/pii-pseudonym-map.test.ts
+++ b/packages/core/src/security/pii-pseudonym-map.test.ts
@@ -15,7 +15,7 @@
  *   - empty/adversarial input and fail-closed snapshot validation.
  */
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import {
 	CorpusPseudonymMap,
 	PseudonymMapIntegrityError,
@@ -563,5 +563,18 @@ describe("snapshot validation is fail-closed", () => {
 				clusters: [{ ...cluster, rulesetVersion: "" }],
 			}),
 		).toThrow(PseudonymMapIntegrityError);
+	});
+
+	test("fails closed when no cryptographically secure random source exists (W5-032)", () => {
+		// The map salt seeds deterministic corpus-wide minting; a Math.random()
+		// fallback would let an observer reproduce corpus surrogates.
+		vi.stubGlobal("crypto", undefined);
+		try {
+			expect(() => new CorpusPseudonymMap()).toThrow(
+				/cryptographically secure random source/,
+			);
+		} finally {
+			vi.unstubAllGlobals();
+		}
 	});
 });

--- a/packages/core/src/security/pii-pseudonym-map.ts
+++ b/packages/core/src/security/pii-pseudonym-map.ts
@@ -44,6 +44,7 @@
  */
 
 import type { PiiPseudonymAssignment } from "../types/model.js";
+import { BufferUtils } from "../utils/buffer.js";
 import {
 	compileReplacer,
 	DEFAULT_PSEUDONYM_BLOCKLIST,
@@ -154,15 +155,10 @@ export class PseudonymMapIntegrityError extends Error {
 }
 
 function randomSalt(): string {
-	const bytes = new Uint8Array(16);
-	const cryptoObj = (globalThis as { crypto?: Crypto }).crypto;
-	if (typeof cryptoObj?.getRandomValues === "function") {
-		cryptoObj.getRandomValues(bytes);
-	} else {
-		for (let i = 0; i < bytes.length; i += 1) {
-			bytes[i] = Math.floor(Math.random() * 256);
-		}
-	}
+	// Fail closed through BufferUtils.randomBytes (the W1-066 policy): the salt
+	// seeds deterministic pseudonym minting, so a predictable Math.random()
+	// fallback would let an observer reproduce corpus surrogates.
+	const bytes = BufferUtils.randomBytes(16);
 	return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 

--- a/packages/core/src/security/pii-pseudonymizer.test.ts
+++ b/packages/core/src/security/pii-pseudonymizer.test.ts
@@ -5,7 +5,7 @@
  * boundary/prefix safety, and salt determinism vs unlinkability. Deterministic.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	GazetteerEntityRecognizer,
 	RegexEntityRecognizer,
@@ -353,5 +353,18 @@ describe("compileReplacer", () => {
 		};
 		const out = "call AT&T today".replace(regex, (m) => map.get(m) as string);
 		expect(out).toBe("call Globex today");
+	});
+
+	it("fails closed when no cryptographically secure random source exists (W5-032)", () => {
+		// The session salt seeds surrogate minting; a Math.random() fallback
+		// would make session pseudonyms reproducible by an observer.
+		vi.stubGlobal("crypto", undefined);
+		try {
+			expect(() => new PseudonymSession()).toThrow(
+				/cryptographically secure random source/,
+			);
+		} finally {
+			vi.unstubAllGlobals();
+		}
 	});
 });

--- a/packages/core/src/security/pii-pseudonymizer.ts
+++ b/packages/core/src/security/pii-pseudonymizer.ts
@@ -41,6 +41,7 @@
  * recognizer via {@link PseudonymSession.learn}.
  */
 
+import { BufferUtils } from "../utils/buffer";
 import type { EntitySpan, PiiEntityRecognizer } from "./entity-recognizer";
 
 /** A learned mapping between a real value and its session surrogate. */
@@ -333,15 +334,10 @@ function pick<T>(pool: readonly T[], seed: number): T {
 }
 
 function generateSessionSalt(): string {
-	const bytes = new Uint8Array(16);
-	const cryptoObj = (globalThis as { crypto?: Crypto }).crypto;
-	if (typeof cryptoObj?.getRandomValues === "function") {
-		cryptoObj.getRandomValues(bytes);
-	} else {
-		for (let i = 0; i < bytes.length; i += 1) {
-			bytes[i] = Math.floor(Math.random() * 256);
-		}
-	}
+	// Fail closed through BufferUtils.randomBytes (the W1-066 policy): the salt
+	// seeds surrogate minting, so a predictable Math.random() fallback would
+	// make session pseudonyms reproducible by an observer.
+	const bytes = BufferUtils.randomBytes(16);
 	return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -7,6 +7,7 @@
  * value must never survive in the output.
  */
 
+import { __loggerTestHooks } from "@elizaos/logger";
 import { describe, expect, it } from "vitest";
 import {
 	createSecretsRedactor,
@@ -45,6 +46,12 @@ describe("redactSecrets (known values)", () => {
 });
 
 describe("redactSensitiveText (pattern detection)", () => {
+	it("keeps the core and leaf logger credential-shape policies synchronized", () => {
+		expect(__loggerTestHooks.getSensitiveTextPatternsForTests()).toEqual(
+			getDefaultRedactPatterns(),
+		);
+	});
+
 	it("redacts credentials embedded in URI userinfo", () => {
 		const httpsUrl = "https://admin:hunter2hunter2@host.example.com/private";
 		const postgresUrl =

--- a/packages/core/src/security/secret-swap.test.ts
+++ b/packages/core/src/security/secret-swap.test.ts
@@ -3,7 +3,7 @@
  * deterministic placeholders for repeated values, and fail-loud on a fabricated
  * this-session placeholder. Deterministic and in-process — no model, no DB.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	SecretSwapSession,
 	SecretSwapUnresolvedPlaceholderError,
@@ -67,5 +67,19 @@ describe("SecretSwapSession", () => {
 				failOnUnresolved: true,
 			}),
 		).toBe("curl -H __ELIZA_SECRET_99__");
+	});
+
+	it("fails closed when no cryptographically secure random source exists (W5-032)", () => {
+		// The session nonce must never fall back to Math.random(): a predictable
+		// nonce is recoverable from observed outputs, making placeholders
+		// forgeable and re-enabling the restore-hijack the nonce prevents.
+		vi.stubGlobal("crypto", undefined);
+		try {
+			expect(() => new SecretSwapSession()).toThrow(
+				/cryptographically secure random source/,
+			);
+		} finally {
+			vi.unstubAllGlobals();
+		}
 	});
 });

--- a/packages/core/src/security/secret-swap.ts
+++ b/packages/core/src/security/secret-swap.ts
@@ -16,6 +16,7 @@
  * `…_999__`) can fail loud via SecretSwapUnresolvedPlaceholderError rather than
  * silently leak.
  */
+import { BufferUtils } from "../utils/buffer";
 import { detectPii } from "./pii-detectors";
 import { getDefaultRedactPatterns } from "./redact";
 
@@ -70,15 +71,10 @@ const PLACEHOLDER_PATTERN = /__ELIZA_SECRET_(?:[0-9a-f]{8,}_)?\d+__/g;
  * the nonce makes placeholders unforgeable and unguessable per turn.
  */
 function generateSessionNonce(): string {
-	const bytes = new Uint8Array(8);
-	const cryptoObj = (globalThis as { crypto?: Crypto }).crypto;
-	if (typeof cryptoObj?.getRandomValues === "function") {
-		cryptoObj.getRandomValues(bytes);
-	} else {
-		for (let i = 0; i < bytes.length; i += 1) {
-			bytes[i] = Math.floor(Math.random() * 256);
-		}
-	}
+	// Fail closed through BufferUtils.randomBytes (the W1-066 policy): a nonce
+	// from a predictable Math.random() fallback could be recovered from observed
+	// outputs, making placeholders forgeable and re-enabling restore-hijack.
+	const bytes = BufferUtils.randomBytes(8);
 	return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -533,6 +533,109 @@ describe("secret redaction", () => {
     expect(() => logger.info(cyclic, "ctx")).not.toThrow();
     expect(recentLogs()).toContain("[Circular]");
   });
+
+  it("masks webhook, connection-string, and concatenated key shapes (W5-026)", () => {
+    const logger = redactLogger();
+    logger.info(
+      {
+        webhookUrl: "https://discord.test/api/webhooks/111/hook-token-here",
+        connectionString: "Server=db;User=u;Pwd=hunter2",
+        MASTERKEY: "v-master-concat",
+        SIGNINGKEY: "v-signing-concat",
+        SSHKEY: "v-ssh-concat",
+        ENCRYPTIONKEY: "v-encryption-concat",
+      },
+      "ctx",
+    );
+    const logs = recentLogs();
+    for (const secret of [
+      "hook-token-here",
+      "hunter2",
+      "v-master-concat",
+      "v-signing-concat",
+      "v-ssh-concat",
+      "v-encryption-concat",
+    ]) {
+      expect(logs).not.toContain(secret);
+    }
+  });
+
+  it("scrubs credential-shaped string values under neutral keys (W5-026)", () => {
+    const logger = redactLogger();
+    logger.info(
+      {
+        url: "postgres://user:supersecretpassword@db.internal:5432/app",
+        payload: '{"apiKey":"sk-neutral-key-value-12345"}',
+      },
+      "ctx",
+    );
+    const logs = recentLogs();
+    expect(logs).not.toContain("supersecretpassword");
+    expect(logs).not.toContain("sk-neutral-key-value-12345");
+    // The non-secret remainder of the value survives the mask.
+    expect(logs).toContain("postgres://***@db.internal:5432/app");
+  });
+
+  it("scrubs credential patterns from the Error headline message (W5-026)", () => {
+    const logger = redactLogger();
+    logger.error(
+      new Error(
+        "request to https://x.test/?key=AIzaSyD4iE4fZa1234567890abcdef failed",
+      ),
+    );
+    const logs = recentLogs();
+    expect(logs).not.toContain("AIzaSyD4iE4fZa1234567890abcdef");
+    expect(logs).toContain("request to https://x.test/");
+  });
+
+  it("leaves ordinary prose strings untouched (W5-026 false-positive guard)", () => {
+    const logger = redactLogger();
+    logger.info(
+      { status: "connection retried twice", note: "all systems nominal" },
+      "plain headline",
+    );
+    const logs = recentLogs();
+    expect(logs).toContain("connection retried twice");
+    expect(logs).toContain("all systems nominal");
+    expect(logs).toContain("plain headline");
+  });
+
+  it("fails closed per key when a property getter throws (W5-028)", () => {
+    const logger = redactLogger();
+    const booby: Record<string, unknown> = { apiKey: "sk-booby-trap-secret" };
+    Object.defineProperty(booby, "lazy", {
+      enumerable: true,
+      get() {
+        throw new Error("lazy getter exploded");
+      },
+    });
+
+    expect(() => logger.info(booby, "ctx")).not.toThrow();
+    const logs = recentLogs();
+    // The sibling credential is still masked, the throwing key degrades to a
+    // marker, and the raw object never reaches the ring.
+    expect(logs).not.toContain("sk-booby-trap-secret");
+    expect(logs).toContain("[REDACTED: redaction failed]");
+  });
+
+  it("fails closed when the object cannot be walked at all (W5-028)", () => {
+    const logger = redactLogger();
+    const unwalkable = new Proxy(
+      { apiKey: "sk-proxy-hidden-secret" },
+      {
+        ownKeys() {
+          throw new Error("ownKeys exploded");
+        },
+      },
+    );
+
+    expect(() =>
+      logger.info(unwalkable as Record<string, unknown>, "ctx"),
+    ).not.toThrow();
+    const logs = recentLogs();
+    expect(logs).not.toContain("sk-proxy-hidden-secret");
+    expect(logs).toContain("[REDACTED: redaction failed]");
+  });
 });
 
 /**

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -5,9 +5,12 @@
  * `success`/`progress` levels. Redacts sensitive fields with a deep-walk
  * redactor that deep-clones log context objects (callers keep their live
  * objects unmutated) and masks every value under a credential-named key at any
- * nesting depth, matched case-insensitively. String messages are passed through
- * unredacted — value-shape scanning of free text is `@elizaos/core`'s
- * security/redact.ts job, which the model-bound sinks apply downstream. Keeps
+ * nesting depth, matched case-insensitively. String values — object properties,
+ * headline messages, and Error message/stack — are additionally scrubbed for
+ * credential shapes (API keys, Bearer tokens, URI userinfo, PEM blocks) with
+ * the pattern library mirrored from `@elizaos/core`'s security/redact.ts,
+ * because this process's ring buffer, file sinks, and WS stream have no
+ * downstream scrubber. Keeps
  * an in-memory ring buffer with real-time listeners for WebSocket streaming,
  * and lazily opens optional file sinks (`output.log`, `prompts.log`,
  * `chat.log`, all 0600) with prompt/response/chat instrumentation helpers.
@@ -309,6 +312,12 @@ const serverId =
 // ============================================================================
 
 const REDACTED_VALUE = "[REDACTED]";
+/**
+ * Marker substituted when the redactor itself fails on a value. Logging must
+ * never break the runtime, but it must fail CLOSED — never emit the original
+ * unredacted payload (W5-028).
+ */
+const REDACTION_FAILED_VALUE = "[REDACTED: redaction failed]";
 /** Bound on recursion so a pathological payload cannot hang the process. */
 const MAX_REDACT_DEPTH = 8;
 
@@ -334,6 +343,10 @@ const SENSITIVE_KEY_SUBSTRINGS: readonly string[] = [
   "credential",
   "authorization",
   "sessionkey",
+  // A webhook URL is a full post credential (Discord/Slack); covered by the
+  // /api/config classifier and core's policy, so it belongs here too.
+  "webhook",
+  "connectionstring",
 ];
 
 /** Whole-key names (normalized) too generic for substring matching. */
@@ -387,6 +400,10 @@ function isSensitiveLogKey(key: string): boolean {
   // Generic `*key` forms (encryptionKey, masterKey, sshKey, OPENAI_KEY) need a
   // word boundary before "key" so monkey/turnkey/hotkey stay visible.
   if (/(?:^|[_\-. ])key$/i.test(key) || /[a-z]Key$/.test(key)) return true;
+  // Separator-free all-caps concatenations (MASTERKEY, SSHKEY, SIGNINGKEY,
+  // ENCRYPTIONKEY) have no boundary for the rule above; a closed suffix set on
+  // the normalized name catches them without opening `key$` to lookalikes.
+  if (/(?:master|signing|ssh|encryption)key$/.test(normalized)) return true;
   // Same boundary treatment for the exact names in suffixed form
   // (sessionCookie, SESSION_JWT, x-bearer).
   if (
@@ -398,39 +415,181 @@ function isSensitiveLogKey(key: string): boolean {
   return false;
 }
 
+// ----------------------------------------------------------------------------
+// Credential-shape text scanning (string values, headlines, Error messages)
+// ----------------------------------------------------------------------------
+
+// RFC 9110 grammar fragments for the Authorization patterns, mirroring core.
+const HTTP_TOKEN_PATTERN = "[!#$%&'*+\\-.^_`|~0-9A-Za-z]+";
+const HTTP_BWS_PATTERN = String.raw`[ \t]*`;
+const HTTP_QUOTED_STRING_PATTERN = String.raw`"(?:[\t\x20\x21\x23-\x5B\x5D-\x7E\x80-\xFF]|\\[\t\x20-\x7E\x80-\xFF])*"`;
+const HTTP_AUTH_PARAM_PATTERN = `${HTTP_TOKEN_PATTERN}${HTTP_BWS_PATTERN}=${HTTP_BWS_PATTERN}(?:${HTTP_TOKEN_PATTERN}|${HTTP_QUOTED_STRING_PATTERN})`;
+const HTTP_AUTH_PARAM_LIST_PATTERN = `(?:,${HTTP_BWS_PATTERN})*${HTTP_AUTH_PARAM_PATTERN}(?:${HTTP_BWS_PATTERN},${HTTP_BWS_PATTERN}(?:${HTTP_AUTH_PARAM_PATTERN})?)*`;
+const HTTP_TOKEN68_PATTERN = String.raw`[A-Za-z0-9._~+/\-]+={0,}`;
+
+/**
+ * Credential-shaped value patterns, mirrored verbatim from `@elizaos/core`'s
+ * security/redact.ts DEFAULT_REDACT_PATTERNS — this leaf package cannot import
+ * core, so the two copies must be kept in sync by hand. Applied to every
+ * string that reaches the log sinks (object values, trailing args, headline
+ * messages, Error message/stack). The shapes require an assignment context or
+ * a known token prefix — no entropy heuristics — so ordinary prose does not
+ * false-positive, while credentials interpolated into free text are caught.
+ */
+const SENSITIVE_TEXT_PATTERNS: readonly string[] = [
+  // ENV-style assignments (incl. seed/mnemonic/passphrase/credential names).
+  String.raw`\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1`,
+  // JSON fields.
+  String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|mnemonic|seedPhrase|passphrase|privateKey|credential)"\s*:\s*"([^"]+)"`,
+  // CLI flags (space-separated and --flag=value forms).
+  String.raw`--(?:api[-_]?key|token|secret|password|passwd)(?:\s+|=)(["']?)([^\s"']+)\1`,
+  // Authorization headers (see core for the full grammar rationale: Basic
+  // first so trailing `=` reads as token68 padding; extension schemes use the
+  // complete token/quoted-string grammar; malformed assignment tails fail
+  // toward masking rather than leaking a likely credential into diagnostics).
+  String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=/~]+)`,
+  String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Basic[ \t]+(${HTTP_TOKEN68_PATTERN})(?=[ \t]|[\r\n]|$)`,
+  String.raw`(?:Proxy-)?Authorization\s*[:=]\s*(${HTTP_TOKEN_PATTERN})[ \t]+(${HTTP_AUTH_PARAM_LIST_PATTERN})(?=${HTTP_BWS_PATTERN}(?:[\r\n]|$))`,
+  String.raw`(?:Proxy-)?Authorization\s*[:=]\s*(${HTTP_TOKEN_PATTERN})[ \t]+(${HTTP_TOKEN68_PATTERN})(?=${HTTP_BWS_PATTERN}(?:[\r\n]|$))`,
+  String.raw`(?:Proxy-)?Authorization\s*[:=]\s*(?!(?:Basic|Bearer)(?:[ \t]|$))(${HTTP_TOKEN_PATTERN})[ \t]+((?=${HTTP_TOKEN_PATTERN}${HTTP_BWS_PATTERN}=)[^\r\n]+)(?=[\r\n]|$)`,
+  String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z0-9._~+/\-]{18,}={0,})(?=[\r\n]|$)`,
+  String.raw`\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b`,
+  // URI userinfo (database URLs, curl arguments, remotes carrying passwords).
+  String.raw`\b[a-z][a-z0-9+.-]*:\/\/([^\s/@]+)@`,
+  // PEM blocks.
+  String.raw`-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----`,
+  // Common token prefixes.
+  String.raw`\b(sk-[A-Za-z0-9_-]{8,})\b`,
+  String.raw`\b(csk-[A-Za-z0-9_-]{8,})\b`,
+  String.raw`\b((?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,})\b`,
+  // Case-sensitive on purpose: ordinary words beginning with "Asia" must not
+  // fold into the AWS credential-identifier shape.
+  String.raw`/\b((?:AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16})\b/g`,
+  String.raw`\b(ghp_[A-Za-z0-9]{20,})\b`,
+  String.raw`\b(github_pat_[A-Za-z0-9_]{20,})\b`,
+  String.raw`\b(xox[baprs]-[A-Za-z0-9-]{10,})\b`,
+  String.raw`\b(xapp-[A-Za-z0-9-]{10,})\b`,
+  String.raw`\b(gsk_[A-Za-z0-9_-]{10,})\b`,
+  String.raw`\b(AIza[0-9A-Za-z\-_]{20,})\b`,
+  String.raw`\b(pplx-[A-Za-z0-9_-]{10,})\b`,
+  String.raw`\b(npm_[A-Za-z0-9]{10,})\b`,
+  String.raw`\b(\d{6,}:[A-Za-z0-9_-]{20,})\b`,
+];
+
+function parseSensitiveTextPattern(raw: string): RegExp | null {
+  const match = raw.match(/^\/(.+)\/([gimsuy]*)$/);
+  try {
+    if (match) {
+      const flags = match[2].includes("g") ? match[2] : `${match[2]}g`;
+      return new RegExp(match[1], flags);
+    }
+    return new RegExp(raw, "gi");
+  } catch {
+    // error-policy:J3 a mirrored pattern that no longer compiles is excluded
+    // from the detector set rather than breaking logger module load.
+    return null;
+  }
+}
+
+// Compiled once at module load; String.prototype.replace resets a global
+// regex's lastIndex before each call, so the shared array is safe to reuse.
+const SENSITIVE_TEXT_REGEXPS: readonly RegExp[] = SENSITIVE_TEXT_PATTERNS.map(
+  parseSensitiveTextPattern,
+).filter((re): re is RegExp => Boolean(re));
+
+const SENSITIVE_TEXT_MIN_LENGTH = 18;
+const SENSITIVE_TEXT_KEEP_START = 6;
+const SENSITIVE_TEXT_KEEP_END = 4;
+
+/** Mask a matched credential, keeping short affixes for diagnostics. */
+function maskSensitiveToken(token: string): string {
+  if (token.length < SENSITIVE_TEXT_MIN_LENGTH) {
+    return "***";
+  }
+  const start = token.slice(0, SENSITIVE_TEXT_KEEP_START);
+  const end = token.slice(-SENSITIVE_TEXT_KEEP_END);
+  return `${start}…${end}`;
+}
+
+function redactSensitiveLogMatch(match: string, groups: string[]): string {
+  if (match.includes("PRIVATE KEY-----")) {
+    return "***";
+  }
+  const filteredGroups = groups.filter(
+    (value) => typeof value === "string" && value.length > 0,
+  );
+  const token = filteredGroups[filteredGroups.length - 1] ?? match;
+  // URI userinfo includes an account identifier; do not preserve its prefix,
+  // and anchor the rewrite to the userinfo span so a first-occurrence replace
+  // cannot corrupt the scheme (mirrors core's redactMatch).
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(match) && match.endsWith("@")) {
+    return match.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^\s/@]+@$/i, "$1***@");
+  }
+  const masked = maskSensitiveToken(token);
+  if (token === match) {
+    return masked;
+  }
+  // Credential patterns capture the secret at the match tail; splice that
+  // position directly so identical bytes earlier in the match are untouched.
+  const tailIndex = match.length - token.length;
+  if (tailIndex > 0 && match.startsWith(token, tailIndex)) {
+    return `${match.slice(0, tailIndex)}${masked}`;
+  }
+  // Replacer function: `masked` keeps token affixes verbatim, and a string
+  // replacement would re-expand `$&`/`$$` sequences from the secret itself.
+  return match.replace(token, () => masked);
+}
+
+/**
+ * Scrub credential-shaped values from free text reaching the log sinks.
+ * Pattern sweep only — secrets-map literal redaction stays in core, which owns
+ * the character configuration.
+ */
+function redactSensitiveLogText(text: string): string {
+  if (!text) {
+    return text;
+  }
+  let next = text;
+  for (const pattern of SENSITIVE_TEXT_REGEXPS) {
+    next = next.replace(pattern, (...args: string[]) =>
+      redactSensitiveLogMatch(args[0], args.slice(1, args.length - 2)),
+    );
+  }
+  return next;
+}
+
 /**
  * Deep-clone a log argument, masking every value under a credential-named key
  * at any depth. The clone is what gets logged, so redaction never mutates the
  * caller's live objects (previously a shallow copy let the redactor overwrite
  * nested credentials in place, corrupting e.g. a provider config mid-use).
+ * String values are pattern-scrubbed for credential shapes at every depth.
  * Cycles and over-depth payloads collapse to a marker instead of recursing
  * forever. Error instances keep their name/message/stack shape (Adze renders
- * it) but their own enumerable properties — axios-style `err.config.headers`
- * and the like — are walked and masked.
+ * it) with message and stack scrubbed — thrown errors routinely interpolate
+ * the offending secret — and their own enumerable properties (axios-style
+ * `err.config.headers`) are walked and masked.
  */
 function redactLogValue(
   value: unknown,
   seen: WeakSet<object>,
   depth: number,
 ): unknown {
+  if (typeof value === "string") return redactSensitiveLogText(value);
   if (value === null || typeof value !== "object") return value;
   if (seen.has(value)) return "[Circular]";
   if (depth >= MAX_REDACT_DEPTH) return REDACTED_VALUE;
   seen.add(value);
 
   if (value instanceof Error) {
-    const clone = new Error(value.message);
+    const clone = new Error(redactSensitiveLogText(value.message));
     clone.name = value.name;
-    if (value.stack) clone.stack = value.stack;
+    if (value.stack) clone.stack = redactSensitiveLogText(value.stack);
     if (value.cause !== undefined) {
       clone.cause = redactLogValue(value.cause, seen, depth + 1);
     }
     const target = clone as unknown as Record<string, unknown>;
-    for (const [key, entry] of Object.entries(value)) {
-      target[key] = isSensitiveLogKey(key)
-        ? REDACTED_VALUE
-        : redactLogValue(entry, seen, depth + 1);
-    }
+    redactOwnPropertiesInto(value, target, seen, depth + 1);
     return clone;
   }
 
@@ -458,21 +617,60 @@ function redactLogValue(
   // ever emits own enumerable properties anyway, and walking them here masks
   // credentials stashed on config/response wrappers (axios-style).
   const result: Record<string, unknown> = {};
-  for (const [key, entry] of Object.entries(value)) {
-    result[key] = isSensitiveLogKey(key)
-      ? REDACTED_VALUE
-      : redactLogValue(entry, seen, depth + 1);
-  }
+  redactOwnPropertiesInto(value, result, seen, depth + 1);
   return result;
 }
 
-/** Redact every object in a trailing-args list; strings pass through. */
+/**
+ * Walk `source`'s own enumerable keys into `target`, masking credential-named
+ * keys and recursing into the rest. Uses Object.keys plus a per-key read
+ * rather than Object.entries so one throwing getter (lazy ORM/REST-client
+ * payloads, Proxies) degrades to a per-key marker instead of throwing the
+ * whole walk — which would fail open and unmask every sibling credential
+ * (W5-028).
+ */
+function redactOwnPropertiesInto(
+  source: object,
+  target: Record<string, unknown>,
+  seen: WeakSet<object>,
+  depth: number,
+): void {
+  for (const key of Object.keys(source)) {
+    if (isSensitiveLogKey(key)) {
+      target[key] = REDACTED_VALUE;
+      continue;
+    }
+    try {
+      target[key] = redactLogValue(
+        (source as Record<string, unknown>)[key],
+        seen,
+        depth,
+      );
+    } catch {
+      // error-policy:J7 logging must never break the runtime; a throwing
+      // getter fails closed on this one key, never emits the raw value.
+      target[key] = REDACTION_FAILED_VALUE;
+    }
+  }
+}
+
+/**
+ * Redact every argument in a trailing-args list: strings are pattern-scrubbed,
+ * objects deep-walked. A walk failure on any argument fails closed to the
+ * redaction-failed marker rather than propagating (or leaking) the raw value.
+ */
 function redactTrailingArgs(args: readonly unknown[]): unknown[] {
-  return args.map((arg) =>
-    arg !== null && typeof arg === "object"
-      ? redactLogValue(arg, new WeakSet<object>(), 0)
-      : arg,
-  );
+  return args.map((arg) => {
+    if (typeof arg === "string") return redactSensitiveLogText(arg);
+    if (arg === null || typeof arg !== "object") return arg;
+    try {
+      return redactLogValue(arg, new WeakSet<object>(), 0);
+    } catch {
+      // error-policy:J7 logging must never break the runtime; fail closed so
+      // an unwalkable payload is marked, never emitted unredacted (W5-028).
+      return REDACTION_FAILED_VALUE;
+    }
+  });
 }
 
 // ============================================================================
@@ -1208,7 +1406,9 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
     };
 
     /**
-     * Safely redact sensitive data from an object (browser version)
+     * Safely redact sensitive data from an object (browser version).
+     * Fails closed: a redactor failure must never emit the caller's original
+     * object — identified secrets would reach the sinks in cleartext (W5-028).
      */
     const safeRedact = (
       obj: Record<string, unknown>,
@@ -1219,10 +1419,9 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
           unknown
         >;
       } catch {
-        // error-policy:J7 logging must never break the runtime; a redactor
-        // failure degrades to the unredacted object, matching the historical
-        // fast-redact fallback behavior.
-        return obj;
+        // error-policy:J7 logging must never break the runtime; the failure
+        // degrades to a marker object, not the unredacted original.
+        return { redactionError: REDACTION_FAILED_VALUE };
       }
     };
 
@@ -1233,19 +1432,24 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
     ): unknown[] => {
       // `msg` is typed string but runtime callers pass objects in that slot;
       // fold it into the trailing args so objects always hit the redactor.
+      const cleanMsg =
+        typeof msg === "string" ? redactSensitiveLogText(msg) : msg;
       if (typeof obj === "string") {
-        const rest = msg !== undefined ? [msg, ...args] : args;
-        return [obj, ...redactTrailingArgs(rest)];
+        const rest = cleanMsg !== undefined ? [cleanMsg, ...args] : args;
+        return [redactSensitiveLogText(obj), ...redactTrailingArgs(rest)];
       }
       if (obj instanceof Error) {
-        const rest = msg !== undefined ? [msg, ...args] : args;
-        return [obj.message, ...redactTrailingArgs(rest)];
+        const rest = cleanMsg !== undefined ? [cleanMsg, ...args] : args;
+        return [
+          redactSensitiveLogText(obj.message),
+          ...redactTrailingArgs(rest),
+        ];
       }
       // Redact sensitive data from objects
       const redactedObj = safeRedact(obj);
-      if (msg !== undefined) {
+      if (cleanMsg !== undefined) {
         // Browser is always pretty mode - format as compact single line
-        const formatted = formatPrettyLog(redactedObj, msg, false);
+        const formatted = formatPrettyLog(redactedObj, cleanMsg, false);
         return [formatted, ...redactTrailingArgs(args)];
       }
       // No message - format context only
@@ -1367,6 +1571,8 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
   /**
    * Safely redact sensitive data from an object.
    * Deep-clones first so redaction never mutates the caller's live objects.
+   * Fails closed: a redactor failure must never emit the caller's original
+   * object — identified secrets would reach the sinks in cleartext (W5-028).
    */
   const safeRedact = (
     obj: Record<string, unknown>,
@@ -1377,10 +1583,9 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
         unknown
       >;
     } catch {
-      // error-policy:J7 logging must never break the runtime; a redactor
-      // failure degrades to the unredacted object, matching the historical
-      // fast-redact fallback behavior.
-      return obj;
+      // error-policy:J7 logging must never break the runtime; the failure
+      // degrades to a marker object, not the unredacted original.
+      return { redactionError: REDACTION_FAILED_VALUE };
     }
   };
 
@@ -1399,29 +1604,36 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
     // String first argument - no context object. `msg` is typed string but
     // runtime callers do pass objects in that slot; fold it into the trailing
     // args so anything object-shaped still goes through the redactor.
+    const cleanMsg =
+      typeof msg === "string" ? redactSensitiveLogText(msg) : msg;
     if (typeof obj === "string") {
-      const rest = msg !== undefined ? [msg, ...args] : args;
-      return [obj, ...redactTrailingArgs(rest)];
+      const rest = cleanMsg !== undefined ? [cleanMsg, ...args] : args;
+      return [redactSensitiveLogText(obj), ...redactTrailingArgs(rest)];
     }
     // Error object - the wrapper must be redacted too: error instances can
-    // carry credentials on enumerable properties (request config, headers).
+    // carry credentials on enumerable properties (request config, headers),
+    // and the headline message itself can interpolate the offending secret.
     if (obj instanceof Error) {
       const errorWrapper = safeRedact({ error: obj });
-      const rest = msg !== undefined ? [msg, ...args] : args;
-      return [obj.message, errorWrapper, ...redactTrailingArgs(rest)];
+      const rest = cleanMsg !== undefined ? [cleanMsg, ...args] : args;
+      return [
+        redactSensitiveLogText(obj.message),
+        errorWrapper,
+        ...redactTrailingArgs(rest),
+      ];
     }
 
     // Object (context) - redact sensitive data
     const redactedObj = safeRedact(obj);
 
-    if (msg !== undefined) {
+    if (cleanMsg !== undefined) {
       // Pretty mode: format as compact single line
       if (!raw) {
-        const formatted = formatPrettyLog(redactedObj, msg, raw);
+        const formatted = formatPrettyLog(redactedObj, cleanMsg, raw);
         return [formatted, ...redactTrailingArgs(args)];
       }
       // JSON mode: keep structured object for machine parsing
-      return [msg, redactedObj, ...redactTrailingArgs(args)];
+      return [cleanMsg, redactedObj, ...redactTrailingArgs(args)];
     }
 
     // No message provided - just context object

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -20,6 +20,12 @@
 export const __loggerTestHooks = {
   clearEnvCacheForTests: () => {},
   stripAnsi: (str: string): string => stripAnsi(str),
+  // Core owns the model/tool redactor while this leaf package owns the log
+  // sink. Expose a copy only to the cross-package contract test so duplicated
+  // credential shapes cannot silently drift between those two boundaries.
+  getSensitiveTextPatternsForTests: (): string[] => [
+    ...SENSITIVE_TEXT_PATTERNS,
+  ],
 };
 
 import adze, {


### PR DESCRIPTION
Wave-6 security remediation for four LOW findings from the wave-5 re-audit. Per-finding summary below; evidence and validation at the bottom.

## Fixes

### W5-025 — `redactSecrets` was a no-op for agents with no character secrets
`AgentRuntime.redactSecrets` early-returned unchanged text when `character.settings.secrets` was empty, so the credential-pattern library never engaged for default/minimal characters — reported errors and provider texts could carry credential-shaped values (API keys, Bearer tokens) into prompts and state verbatim. Systemic: every `redactSecrets` call site was affected (`recent-errors` provider, the `composeState`-wide scrub, etc.).

**Fix** (`packages/core/src/runtime.ts`): dropped the empty-secrets early return — the method now always runs `redactWithSecrets(text, { secrets, applyPatterns: true })`. An empty secrets map is a no-op for the literal pass, and the pattern regexps are compiled once at module load, so the always-on scrub costs one pattern sweep per call.

### W5-026 — agent logger leaked credential-shaped values and key shapes
The logger package's deep-walk redactor missed `webhookUrl`/`webhook_url`, `connectionString`, and separator-free concatenated key shapes (`MASTERKEY`, `SIGNINGKEY`, `SSHKEY`, `ENCRYPTIONKEY`), and string **values** inside logged objects (including Error messages) were never pattern-scanned — nothing downstream scrubs this process's ring buffer, file sinks, or WS stream.

**Fix** (`packages/logger/src/logger.ts`):
- Key policy: added `webhook` / `connectionstring` substrings and a closed normalized-suffix rule `(master|signing|ssh|encryption)key$` — catches the all-caps concatenations without opening `key$` to lookalikes (monkey/turnkey/hotkey stay visible; existing lookalike test still passes).
- Value scanning: every string reaching the sinks (object values at any depth, trailing string args, headline messages, Error message/stack) is scrubbed with the credential-shape pattern library mirrored verbatim from core's `security/redact.ts` (the leaf package cannot import core; the mirror follows the existing "kept in sync by hand" policy). Shapes require an assignment context or known token prefix — no entropy heuristics — to bound false positives. Masking semantics (min-length, keep-affixes, PEM/userinfo anchoring, `$&`-safe splicing) mirror core's.

### W5-028 — log redactor exception failed open
A throwing enumerable getter made `redactLogValue` throw mid-walk, and the `safeRedact` catch returned the caller's **original unredacted object** (by reference) to the sinks.

**Fix** (`packages/logger/src/logger.ts`): fail closed at two levels. The property walk now uses `Object.keys` + per-key reads in a helper (`redactOwnPropertiesInto`), so one throwing getter (lazy ORM/REST-client payloads, Proxies) degrades that single key to a `[REDACTED: redaction failed]` marker while siblings are still masked. A walk that cannot run at all (e.g. throwing `ownKeys`) makes `safeRedact`/`redactTrailingArgs` return the marker instead of the original object. Logging still never breaks the runtime (J7) — it just never emits the unredacted payload.

### W5-032 — three core security modules kept a `Math.random()` fallback
`secret-swap.ts` (session nonce), `pii-pseudonymizer.ts` (session salt), and `pii-pseudonym-map.ts` (corpus salt) each fell back to `Math.random()` when WebCrypto was unavailable — inconsistent with the W1-066 fail-closed house policy.

**Fix**: all three now route through `BufferUtils.randomBytes`, which throws when no CSPRNG is available. Dead code on every pinned target; the change removes the predictable-bytes path on exotic runtimes.

## Tests

New/updated coverage, all green:
- `packages/core/src/providers/recent-errors.test.ts` — new W5-025 case drives a **real** `AgentRuntime` with a no-secrets character through `reportError` → `recentErrorsProvider` and asserts key/token patterns are masked (12/12 pass).
- `packages/logger/src/logger.test.ts` — new W5-026 cases (webhook/connection-string/concatenated keys; credential-shaped string values under neutral keys incl. `postgres://user:pass@host` and embedded JSON; Error-headline scrub; prose false-positive guard) and W5-028 cases (throwing getter → per-key marker, sibling secret still masked, no throw; unwalkable object → marker, no cleartext) — 35/35 pass.
- `secret-swap.test.ts` / `pii-pseudonymizer.test.ts` / `pii-pseudonym-map.test.ts` — new W5-032 cases: with `crypto` stubbed out, session/map construction throws instead of minting predictable bytes.
- Adjacent suites re-run green: `redact`, `secret-swap.redteam`, `secret-swap.fuzz`, `pii-pseudonymizer.fuzz`, `pii-pseudonym-map-store`, `runtime-report-error` (76 tests).

Validation: `bunx biome check` clean on all 10 changed files; `tsc --noEmit` clean for `packages/logger` and `packages/core`.

## Risk notes

- W5-025 widens scrub coverage for no-secrets characters; cost is one precompiled pattern sweep per `redactSecrets` call (same sweep core already runs when any secret is configured).
- W5-026's string scan mirrors the exact pattern set the cloud logger already applies via core's `redactLogArgs`, so agent/cloud/core redaction policy converges instead of drifting. Masking biases toward over-redaction on borderline shapes (deliberate for a security redactor); ordinary prose is covered by a false-positive guard test.
- The logger's public type surface is unchanged; no `dist` rebuild semantics affected.
- No weaponizable detail included here; full evidence is in the wave-5 report (internal artifact).

## Review repair and exact-head validation

- Rebased onto `origin/develop@085558ff6fcfd0d8265e816974f89b4cd6e54cfa`.
- Added a cross-package equality contract so core and logger's 25 credential-pattern expressions cannot silently drift.
- Exact repaired head `c067f22b6ab22557c6de207d44eb24329d6228d4`: logger 35/35 passed; core focused redaction/runtime/CSPRNG suites 110/110 passed; logger typecheck, Biome, and diff checks passed.

## Evidence Gate

<!-- evidence-head:c067f22b6ab22557c6de207d44eb24329d6228d4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - core/logger security behavior only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - core/logger security behavior only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic focused package tests are recorded above; no deployed service changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external integration or persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@085558ff6fcfd0d8265e816974f89b4cd6e54cfa:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@085558ff6fcfd0d8265e816974f89b4cd6e54cfa:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@085558ff6fcfd0d8265e816974f89b4cd6e54cfa:packages/skills/skills/contribute-to-eliza"} -->