### PR TITLE
fix(core): carry a worldId in the document echo-test harness

### DIFF
--- a/packages/core/src/features/documents/__tests__/actions-echo.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-echo.test.ts
@@ -50,6 +50,10 @@ function makeMessage(text: string, source?: string): Memory {
 		entityId: USER_ID,
 		agentId: AGENT_ID,
 		roomId: ROOM_ID,
+		// The canonical tenant-scope path resolves worldId before any file
+		// existence check; the harness message carries one so scope
+		// resolution cannot mask the behavior under test.
+		worldId: "00000000-0000-0000-0000-0000000000bb" as UUID,
 		content: { text, ...(source ? { source } : {}) },
 		createdAt: Date.now(),
 	} as Memory;


### PR DESCRIPTION
The canonical tenant-scope enforcement (e35c0b433fdc, merged today) resolves worldId before the import_file existence check; the echo harness message had no worldId and no room world, so the blob-path test failed on scope resolution instead of exercising the neutral not-found copy (release candidate run 32078252604 — the only remaining red in the full test lane). The harness message now carries a worldId. Suite 8/8; Biome clean.