### PR TITLE
fix(agent): close media decode-bomb bypasses and GC text-reference gap (wave-5 audit)

### DIFF
--- a/packages/agent/src/api/media-runtime.test.ts
+++ b/packages/agent/src/api/media-runtime.test.ts
@@ -195,6 +195,28 @@ describe("collectReferencedMedia", () => {
     expect(referenced.size).toBe(2);
   });
 
+  it("collects a media URL pasted into message text with no attachment", () => {
+    // Re-share path: the pre-auth capability URL renders inline, so users paste
+    // it into chat bodies. The export capture already treats text URLs as live;
+    // the GC must agree or it unlinks the file under the visible reference.
+    const memories = [
+      {
+        content: {
+          text: `here's that diagram again /api/media/${HASH_A}.png — neat`,
+        },
+      },
+      {
+        content: { text: "no media here, just /api/media/not-a-hash.png" },
+      },
+      { content: { text: 42 } },
+      { content: {} },
+    ] as unknown as Memory[];
+
+    const referenced = collectReferencedMedia(memories);
+
+    expect([...referenced]).toEqual([`${HASH_A}.png`]);
+  });
+
   it("ignores non-media metadata.mediaUrl values", () => {
     const memories = [
       {

--- a/packages/agent/src/api/media-runtime.ts
+++ b/packages/agent/src/api/media-runtime.ts
@@ -20,6 +20,7 @@ import {
   gcUnreferencedMedia,
   handleMediaRouteRequest,
   isStoredMediaUrl,
+  MEDIA_URL_IN_TEXT_RE,
   mediaFileNameFromUrl,
   persistAttachmentUrlIfInline,
   persistMediaBytes,
@@ -258,6 +259,18 @@ export function collectReferencedMedia(
       | undefined;
     addUrl(metadata?.mediaUrl);
     addUrl(metadata?.audioUrl);
+
+    // Re-shared media: a message can reference a stored file by pasting its
+    // `/api/media/<sha256>.<ext>` capability URL into the body text with no
+    // attachment/metadata field pointing at it. The export capture already
+    // treats such text URLs as live references; the GC must agree, or the
+    // sweep unlinks the file and the visible chat reference 404s.
+    const text = (memory.content as { text?: unknown } | undefined)?.text;
+    if (typeof text === "string" && text.includes("/api/media/")) {
+      for (const match of text.matchAll(MEDIA_URL_IN_TEXT_RE)) {
+        addUrl(match[0]);
+      }
+    }
 
     // Transcript rows persist the rich record as JSON in `content.transcript`.
     // Voice captures can retain their WAV solely through the record's `audioUrl`,

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -96,6 +96,14 @@ export function isValidStoredMediaFileName(fileName: string): boolean {
 const MEDIA_URL_PREFIX = "/api/media/";
 
 /**
+ * Matches served media URLs embedded in free text (e.g. a message body that
+ * re-shares an image by pasting its capability URL). Shared by the export
+ * capture and the orphan-media GC so both agree on what counts as a live
+ * text reference; matches are re-validated through `mediaFileNameFromUrl`.
+ */
+export const MEDIA_URL_IN_TEXT_RE = /\/api\/media\/[a-f0-9]{64}\.[a-z0-9]+/gi;
+
+/**
  * MIME types that are safe to render inline in a browser context. Everything
  * else — notably `image/svg+xml`, `application/pdf`, `text/html`, and
  * unknown/active types — is served with `Content-Disposition: attachment` so it

--- a/packages/agent/src/api/media-thumbnail.test.ts
+++ b/packages/agent/src/api/media-thumbnail.test.ts
@@ -2,9 +2,13 @@
  * Verifies generateThumbnailBytes (api/media-thumbnail.ts) downscales oversized
  * images to a ≤512px JPEG, returns null for in-bounds or non-thumbnailable
  * inputs, and rejects declared bomb dimensions from the container header before
- * any decode runs. Uses real PNG/JPEG encode + decode (pngjs / jpeg-js).
+ * any decode runs — including the codec-specific escapes: Adam7-interlaced
+ * PNGs (pngjs inflates those without its dimension-derived output cap) and
+ * multi-SOF JPEGs (jpeg-js allocates every frame's blocks before throwing on
+ * multi-frame input). Uses real PNG/JPEG encode + decode (pngjs / jpeg-js).
  */
 import { Buffer } from "node:buffer";
+import { deflateSync } from "node:zlib";
 import { PNG } from "pngjs";
 import { describe, expect, it } from "vitest";
 import { generateThumbnailBytes } from "./media-thumbnail.ts";
@@ -54,6 +58,128 @@ function makeJpegHeaderOnly(width: number, height: number): Buffer {
   buf.writeUInt16BE(height, 7);
   buf.writeUInt16BE(width, 9);
   return buf;
+}
+
+/** One SOF0 segment (1-component) declaring `width`×`height`. */
+function makeSof0Segment(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(13);
+  buf[0] = 0xff;
+  buf[1] = 0xc0; // SOF0
+  buf.writeUInt16BE(11, 2); // segment length (self-inclusive)
+  buf[4] = 8; // sample precision
+  buf.writeUInt16BE(height, 5);
+  buf.writeUInt16BE(width, 7);
+  buf[9] = 1; // one component: id / sampling / qtable
+  buf[10] = 1;
+  buf[11] = 0x11;
+  buf[12] = 0;
+  return buf;
+}
+
+/**
+ * The wave-5 PoC shape: a small first SOF passes the dimension pre-check, a
+ * second SOF declares bomb geometry — jpeg-js allocates every frame's MCU
+ * blocks at SOF parse and only afterwards throws on multi-frame input.
+ */
+function makeMultiSofJpeg(): Buffer {
+  return Buffer.concat([
+    Buffer.from([0xff, 0xd8]), // SOI
+    makeSof0Segment(64, 64),
+    makeSof0Segment(9999, 9999),
+    Buffer.from([0xff, 0xd9]), // EOI
+  ]);
+}
+
+// ── Minimal valid-PNG construction (signature + CRC'd chunks) ────────────────
+
+const CRC_TABLE = new Int32Array(256);
+for (let n = 0; n < 256; n++) {
+  let c = n;
+  for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+  CRC_TABLE[n] = c;
+}
+
+function crc32(buf: Buffer): number {
+  let c = -1;
+  for (const byte of buf) c = CRC_TABLE[(c ^ byte) & 0xff] ^ (c >>> 8);
+  return (c ^ -1) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const out = Buffer.alloc(12 + data.length);
+  out.writeUInt32BE(data.length, 0);
+  out.write(type, 4, "ascii");
+  data.copy(out, 8);
+  out.writeUInt32BE(
+    crc32(Buffer.concat([Buffer.from(type, "ascii"), data])),
+    8 + data.length,
+  );
+  return out;
+}
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+/** Adam7 pass origins/strides: [x0, y0, dx, dy] for the 7 interlace passes. */
+const ADAM7_PASSES: ReadonlyArray<readonly [number, number, number, number]> = [
+  [0, 0, 8, 8],
+  [4, 0, 8, 8],
+  [0, 4, 4, 8],
+  [2, 0, 4, 4],
+  [0, 2, 2, 4],
+  [1, 0, 2, 2],
+  [0, 1, 1, 2],
+];
+
+/**
+ * A structurally valid Adam7-interlaced RGBA PNG (filter-0 zeroed scanlines,
+ * correct chunk CRCs) — decodable by pngjs, so a header check that ignores the
+ * interlace byte would proceed to decode it.
+ */
+function makeInterlacedPng(width: number, height: number): Buffer {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // color type: RGBA
+  ihdr[10] = 0; // compression
+  ihdr[11] = 0; // filter
+  ihdr[12] = 1; // interlace: Adam7
+  const scanlines: Buffer[] = [];
+  for (const [x0, y0, dx, dy] of ADAM7_PASSES) {
+    const passWidth = width > x0 ? Math.ceil((width - x0) / dx) : 0;
+    const passHeight = height > y0 ? Math.ceil((height - y0) / dy) : 0;
+    for (let row = 0; row < passHeight; row++) {
+      scanlines.push(Buffer.alloc(1 + passWidth * 4));
+    }
+  }
+  return Buffer.concat([
+    PNG_SIGNATURE,
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", deflateSync(Buffer.concat(scanlines))),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+/**
+ * The wave-5 bomb shape, scaled down: a 64×64 IHDR passes the dimension cap,
+ * interlace=1 routes pngjs to its uncapped inflate branch, and the IDAT
+ * carries 4 MiB of deflated zeros — far more than the declared geometry needs.
+ */
+function makeInterlacedBombPng(): Buffer {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(64, 0);
+  ihdr.writeUInt32BE(64, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 6;
+  ihdr[12] = 1;
+  return Buffer.concat([
+    PNG_SIGNATURE,
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", deflateSync(Buffer.alloc(4 * 1024 * 1024))),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
 }
 
 describe("generateThumbnailBytes", () => {
@@ -107,6 +233,31 @@ describe("generateThumbnailBytes decode-dimension bounds", () => {
         makeJpegHeaderOnly(25000, 25000),
         "image/jpeg",
       ),
+    ).toBeNull();
+  });
+
+  it("rejects a multi-SOF JPEG whose later frame declares bomb geometry", async () => {
+    // The first SOF (64×64) passes the dimension pre-check; the second SOF
+    // (9999×9999) would make jpeg-js allocate ~1 GB of MCU blocks before it
+    // throws on multi-frame input. The header walk must fail closed on the
+    // second SOFn instead of returning after the first.
+    expect(
+      await generateThumbnailBytes(makeMultiSofJpeg(), "image/jpeg"),
+    ).toBeNull();
+  });
+
+  it("returns null for an Adam7-interlaced PNG without attempting decode", async () => {
+    // A valid, decodable interlaced PNG above the thumbnail size: pre-fix this
+    // produced a thumbnail; the interlace byte must now fail closed because
+    // pngjs inflates interlaced IDAT with no dimension-derived output cap.
+    const png = makeInterlacedPng(640, 640);
+    expect(png[28]).toBe(1); // sanity: the IHDR interlace byte is set
+    expect(await generateThumbnailBytes(png, "image/png")).toBeNull();
+  });
+
+  it("rejects an interlaced small-IHDR PNG bomb before any inflate runs", async () => {
+    expect(
+      await generateThumbnailBytes(makeInterlacedBombPng(), "image/png"),
     ).toBeNull();
   });
 

--- a/packages/agent/src/api/media-thumbnail.ts
+++ b/packages/agent/src/api/media-thumbnail.ts
@@ -32,30 +32,48 @@ interface ImageDimensions {
   height: number;
 }
 
-/** Dimensions from the PNG signature + IHDR header (BE u32 at bytes 16/20). */
+/**
+ * Dimensions from the PNG signature + IHDR header (BE u32 at bytes 16/20).
+ * Fails closed on Adam7-interlaced inputs (IHDR byte 12, file offset 28):
+ * pngjs bounds its inflate with a dimension-derived `maxLength` only on the
+ * non-interlaced branch — the interlaced branch inflates with no output cap,
+ * so a small IHDR attached to a huge IDAT decompresses unbounded. Skipping
+ * the thumbnail is graceful: callers serve the original bytes instead.
+ */
 function readPngDimensions(source: Buffer): ImageDimensions | null {
-  if (source.length < 24) return null;
+  if (source.length < 29) return null;
   if (source.readUInt32BE(0) !== 0x89504e47) return null;
   if (source.readUInt32BE(4) !== 0x0d0a1a0a) return null;
   if (source.toString("ascii", 12, 16) !== "IHDR") return null;
+  if (source[28] !== 0) return null;
   return { width: source.readUInt32BE(16), height: source.readUInt32BE(20) };
 }
 
 /**
- * Dimensions from the first JPEG SOFn segment. Walks the marker stream from
- * the SOI: every segment is `FF <marker> <u16 length>` except the standalone
- * markers (SOI/RSTn/TEM) that carry no length.
+ * Dimensions from the JPEG SOFn segment. Walks the marker stream from the SOI:
+ * every segment is `FF <marker> <u16 length>` except the standalone markers
+ * (SOI/RSTn/TEM) that carry no length. Fails closed on a second SOFn: jpeg-js
+ * eagerly allocates every declared frame's MCU blocks at SOF parse and only
+ * afterwards throws on multi-frame input, so a small first SOF followed by a
+ * bomb SOF must be rejected here, before decode. Multi-frame streams can never
+ * decode successfully anyway, so no thumbnailable input is lost.
  */
 function readJpegDimensions(source: Buffer): ImageDimensions | null {
   if (source.length < 4 || source[0] !== 0xff || source[1] !== 0xd8) {
     return null;
   }
+  let dimensions: ImageDimensions | null = null;
   let offset = 2;
   while (offset + 4 <= source.length) {
     if (source[offset] !== 0xff) return null;
     const marker = source[offset + 1];
+    // SOS opens entropy-coded scan data, which is not length-delimited — the
+    // header walk ends here (a second SOF after scan data is caught by the
+    // decode-time memory bound instead).
+    if (marker === 0xda) break;
     if (
       marker === 0xd8 ||
+      marker === 0xd9 ||
       marker === 0x01 ||
       (marker >= 0xd0 && marker <= 0xd7)
     ) {
@@ -75,14 +93,15 @@ function readJpegDimensions(source: Buffer): ImageDimensions | null {
       marker !== 0xcc
     ) {
       if (segmentLength < 7) return null;
-      return {
+      if (dimensions !== null) return null;
+      dimensions = {
         height: source.readUInt16BE(offset + 5),
         width: source.readUInt16BE(offset + 7),
       };
     }
     offset += 2 + segmentLength;
   }
-  return null;
+  return dimensions;
 }
 
 /** True when the declared dimensions stay within the decode-time bounds. */
@@ -110,7 +129,12 @@ interface PngStatic {
 interface JpegStatic {
   decode: (
     buf: Buffer,
-    opts?: { useTArray?: boolean; formatAsRGBA?: boolean },
+    opts?: {
+      useTArray?: boolean;
+      formatAsRGBA?: boolean;
+      maxResolutionInMP?: number;
+      maxMemoryUsageInMB?: number;
+    },
   ) => RawImage;
   encode: (img: RawImage, quality?: number) => { data: Buffer };
 }
@@ -208,7 +232,15 @@ export async function generateThumbnailBytes(
     if (!dimensions || !withinDecodeBounds(dimensions)) return null;
     const decoded: RawImage = isPng
       ? loaded.png.sync.read(source)
-      : loaded.jpeg.decode(source, { useTArray: true, formatAsRGBA: true });
+      : // Back the header pre-check with jpeg-js's own per-SOF pixel cap and
+        // cumulative allocation budget (64 MiB matches the RGBA bound above):
+        // a second SOF hiding behind scan data still can't inflate memory.
+        loaded.jpeg.decode(source, {
+          useTArray: true,
+          formatAsRGBA: true,
+          maxResolutionInMP: MAX_DECODE_PIXELS / 1_000_000,
+          maxMemoryUsageInMB: (MAX_DECODE_PIXELS * 4) / (1024 * 1024),
+        });
     const { width, height, data } = decoded;
     const longest = Math.max(width, height);
     if (!longest || longest <= THUMBNAIL_MAX_DIM) return null;

--- a/packages/agent/src/services/agent-export.ts
+++ b/packages/agent/src/services/agent-export.ts
@@ -39,6 +39,7 @@ import { logger } from "@elizaos/core";
 import * as zod from "zod";
 import {
   isStoredMediaUrl,
+  MEDIA_URL_IN_TEXT_RE,
   mediaFileNameFromUrl,
   readStoredMediaBytes,
   storedMediaContentMatchesName,
@@ -401,8 +402,6 @@ function toAgentExportPayload(
 // ---------------------------------------------------------------------------
 // Media (content-addressed store) capture / restore
 // ---------------------------------------------------------------------------
-
-const MEDIA_URL_IN_TEXT_RE = /\/api\/media\/[a-f0-9]{64}\.[a-z0-9]+/gi;
 
 /**
  * The set of `<sha256>.<ext>` media file names referenced by the exported

--- a/packages/core/src/runtime-get-all-memories.test.ts
+++ b/packages/core/src/runtime-get-all-memories.test.ts
@@ -5,8 +5,7 @@
  * depend on this list being complete (#14751: a partition missing here leaves
  * its media references invisible to the sweep) — must paginate each partition
  * to exhaustion rather than truncate at one bounded page (a truncated sweep
- * makes the GC delete still-referenced media), and must skip embedding
- * materialization (the sweep reads content/metadata only).
+ * makes the GC delete still-referenced media).
  */
 
 import { describe, expect, it } from "vitest";
@@ -80,24 +79,5 @@ describe("AgentRuntime.getAllMemories", () => {
 
 		expect(requestedOffsets).toEqual([0, 10000, 20000]);
 		expect(all).toHaveLength(20007);
-	});
-
-	it("asks the adapter to skip embedding materialization during the sweep", async () => {
-		const runtime = new AgentRuntime({
-			character: { name: "get-all-memories-embedding-test" } as Character,
-		});
-		const seenIncludeEmbedding: unknown[] = [];
-		runtime.registerDatabaseAdapter({
-			getMemories: async (params: { includeEmbedding?: boolean }) => {
-				seenIncludeEmbedding.push(params.includeEmbedding);
-				return [];
-			},
-		} as unknown as IDatabaseAdapter);
-
-		await runtime.getAllMemories();
-
-		// One call per partition; every one must opt out of the embedding join.
-		expect(seenIncludeEmbedding).toHaveLength(5);
-		expect(new Set(seenIncludeEmbedding)).toEqual(new Set([false]));
 	});
 });

--- a/packages/core/src/runtime-get-all-memories.test.ts
+++ b/packages/core/src/runtime-get-all-memories.test.ts
@@ -3,9 +3,10 @@
  * recording adapter: the partition sweep must include every platform-owned
  * memory table — the media GC's referenced-set and clearAllAgentMemories both
  * depend on this list being complete (#14751: a partition missing here leaves
- * its media references invisible to the sweep) — and must paginate each
- * partition to exhaustion rather than truncate at one bounded page (a
- * truncated sweep makes the GC delete still-referenced media).
+ * its media references invisible to the sweep) — must paginate each partition
+ * to exhaustion rather than truncate at one bounded page (a truncated sweep
+ * makes the GC delete still-referenced media), and must skip embedding
+ * materialization (the sweep reads content/metadata only).
  */
 
 import { describe, expect, it } from "vitest";
@@ -79,5 +80,24 @@ describe("AgentRuntime.getAllMemories", () => {
 
 		expect(requestedOffsets).toEqual([0, 10000, 20000]);
 		expect(all).toHaveLength(20007);
+	});
+
+	it("asks the adapter to skip embedding materialization during the sweep", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "get-all-memories-embedding-test" } as Character,
+		});
+		const seenIncludeEmbedding: unknown[] = [];
+		runtime.registerDatabaseAdapter({
+			getMemories: async (params: { includeEmbedding?: boolean }) => {
+				seenIncludeEmbedding.push(params.includeEmbedding);
+				return [];
+			},
+		} as unknown as IDatabaseAdapter);
+
+		await runtime.getAllMemories();
+
+		// One call per partition; every one must opt out of the embedding join.
+		expect(seenIncludeEmbedding).toHaveLength(5);
+		expect(new Set(seenIncludeEmbedding)).toEqual(new Set([false]));
 	});
 });

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -11236,12 +11236,26 @@ ${section_end}`;
 			// Paginate until a short page: a single 10k-bounded read silently
 			// truncates a larger partition, and the media GC would then delete
 			// files referenced only by rows past the cap as "orphaned".
+			//
+			// Accepted race (wave-5 audit, W5-022): offset pagination is the only
+			// mechanism the IDatabaseAdapter contract guarantees — it has no
+			// unique-key cursor, and `createdAt` is optional and non-unique, so
+			// keyset pagination cannot be expressed through the interface. A
+			// `deleteMemory` racing the sweep shifts later pages up and can skip
+			// a row; media referenced only by that row is then collected after
+			// the grace window. The window is narrow (a delete must race the
+			// daily task) and the grace window protects fresh media, so this is
+			// documented rather than re-architected.
 			for (let offset = 0; ; offset += GET_ALL_MEMORIES_PAGE_SIZE) {
 				const memories = await this.adapter.getMemories({
 					agentId: this.agentId,
 					tableName,
 					limit: GET_ALL_MEMORIES_PAGE_SIZE,
 					offset,
+					// The sweep reads content/metadata only; skipping the embedding
+					// column avoids materializing a vector per row (both first-party
+					// adapters honor this; others may ignore it per the contract).
+					includeEmbedding: false,
 				});
 				allMemories.push(...memories);
 				if (memories.length < GET_ALL_MEMORIES_PAGE_SIZE) break;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -11252,10 +11252,6 @@ ${section_end}`;
 					tableName,
 					limit: GET_ALL_MEMORIES_PAGE_SIZE,
 					offset,
-					// The sweep reads content/metadata only; skipping the embedding
-					// column avoids materializing a vector per row (both first-party
-					// adapters honor this; others may ignore it per the contract).
-					includeEmbedding: false,
 				});
 				allMemories.push(...memories);
 				if (memories.length < GET_ALL_MEMORIES_PAGE_SIZE) break;


### PR DESCRIPTION
## Summary

Harden media parsing and reference discovery without narrowing the public runtime memory contract.

- Reject Adam7/interlaced PNG input before uncapped inflate work.
- Scan JPEG structure for multiple SOF markers and enforce jpeg-js allocation/dimension limits.
- Keep media URLs pasted into text reachable by the existing content-addressed media GC.
- Retain pagination-race documentation for memory scans.
- Review repair: remove the unrelated `getAllMemories()` change that forced `includeEmbedding: false`; callers of the public runtime method continue receiving full Memory records.

## Exact-head validation

Exact repaired head `2c2a3f1f83d2c5138f7dee2f95a90d0ecab7cae8`, rebased on `develop@416fd65fa4fea1649cb81b520d2af8886c435674`.

- Focused thumbnail/runtime/export/core-memory suite: 45/45 passed on the repaired predecessor; the final review commit only removes the unrelated embedding option and its test.
- Exact repaired changed files pass Biome and diff checks.
- A repeated focused run was stopped after shared Vitest worker contention without failure output.

## Evidence Gate

<!-- evidence-head:2c2a3f1f83d2c5138f7dee2f95a90d0ecab7cae8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server media parsing and GC behavior only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server media parsing and GC behavior only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic focused parser/runtime tests are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - generated thumbnail bytes and GC reference sets are asserted by tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@416fd65fa4fea1649cb81b520d2af8886c435674:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@416fd65fa4fea1649cb81b520d2af8886c435674:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@416fd65fa4fea1649cb81b520d2af8886c435674:packages/skills/skills/contribute-to-eliza"} -->