### PR TITLE
fix(cloud): reject malformed voice-id JSON body

### DIFF
--- a/packages/cloud/api/v1/voice/[id]/route.json.test.ts
+++ b/packages/cloud/api/v1/voice/[id]/route.json.test.ts
@@ -1,0 +1,64 @@
+/**
+ * PATCH /api/v1/voice/:id used to let request.json() throw into
+ * nextJsonFromCaughtError / getErrorStatusCode, which maps SyntaxError to 500.
+ * Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const VOICE_ID = "00000000-0000-4000-8000-0000000000aa";
+
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+  user: { id: "user-1", organization_id: "org-1" },
+  apiKey: null,
+}));
+const updateVoice = mock(async () => ({
+  id: VOICE_ID,
+  name: "demo",
+}));
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg,
+}));
+mock.module("@/lib/services/voice-cloning", () => ({
+  voiceCloningService: {
+    updateVoice,
+    getVoiceById: async () => ({ id: VOICE_ID }),
+    deleteVoice: async () => undefined,
+  },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id", route);
+
+describe("PATCH /api/v1/voice/:id malformed JSON", () => {
+  test("returns 400 instead of 500 and never updates the voice", async () => {
+    const response = await app.request(`/${VOICE_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(updateVoice).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still updates the voice", async () => {
+    const response = await app.request(`/${VOICE_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "demo" }),
+    });
+    expect(response.status).toBe(200);
+    expect(updateVoice).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/voice/[id]/route.ts
+++ b/packages/cloud/api/v1/voice/[id]/route.ts
@@ -228,7 +228,14 @@ async function __hono_PATCH(
       return invalidVoiceIdResponse;
     }
 
-    const rawBody = await request.json();
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not nextJsonFromCaughtError(SyntaxError) → 500.
+      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     const parsed = VoiceUpdateBody.safeParse(rawBody);
     if (!parsed.success) {
       return Response.json(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on voice PATCH currently 500s. Not elevenlabs voices/user list-limit (HARD_SKIP / #21297). Not a list-limit / canonical-text / one-flag boolean change. Not tracker #21541 close-bait. Outside browser-sessions.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still update voice metadata. Malformed JSON (`{`, truncated objects) now 400s before `updateVoice` instead of `nextJsonFromCaughtError(SyntaxError)` → 500. Proven on the unfixed head: the same test received **500**.

# Background

## What does this PR do?

`PATCH /api/v1/voice/:id` called `await request.json()` inside a try whose catch maps unknown errors through `nextJsonFromCaughtError` / `getErrorStatusCode`. That helper does not treat `SyntaxError` / "Failed to parse JSON" as caller error, so truncated bodies became HTTP 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before Zod or `voiceCloningService.updateVoice`.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/voice/[id]/route.json.test.ts` and the `request.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'v1/voice/[id]/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500**. After the fix: 2 passed on `e6be5e3a696c71181d37ddc750bb760ea0c0d82a`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:e6be5e3a696c71181d37ddc750bb760ea0c0d82a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the voice-id HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before the voice update.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that `updateVoice` is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches voice cloning.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on voice-id JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and canonical `{ name: "demo" }` still updates.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the voice-id HTTP boundary.

## Audio / voice walkthrough

N/A - metadata PATCH only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `e6be5e3a69`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
