### PR TITLE
style(wallet): format the dexscreener fetch call

### DIFF
--- a/plugins/plugin-wallet/src/analytics/dexscreener/service.ts
+++ b/plugins/plugin-wallet/src/analytics/dexscreener/service.ts
@@ -100,7 +100,10 @@ export class DexScreenerService extends Service {
     if (params && Object.keys(params).length > 0) {
       url += `?${new URLSearchParams(params).toString()}`;
     }
-    const response = await fetch(url, { headers: this.defaultHeaders, signal: AbortSignal.timeout(10_000) });
+    const response = await fetch(url, {
+      headers: this.defaultHeaders,
+      signal: AbortSignal.timeout(10_000),
+    });
     if (!response.ok) {
       const errData = await response.json().catch(() => ({}));
       throw Object.assign(


### PR DESCRIPTION
An unformatted fetch call in dexscreener/service.ts failed plugin-wallet lint:check inside the release candidate's verify gate (run 32083533363 — the only red). Package biome check now clean (287 files).