### PR TITLE
fix(cloud): reject malformed app-id JSON body

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/route.json.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.json.test.ts
@@ -1,0 +1,80 @@
+/**
+ * PATCH/PUT /api/v1/apps/:id used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const APP_ID = "00000000-0000-4000-8000-0000000000aa";
+const existing = {
+  id: APP_ID,
+  organization_id: "org-1",
+  name: "demo",
+  description: null,
+  app_url: null,
+  website_url: null,
+  review_status: "draft" as const,
+  review_content_hash: null,
+  metadata: {},
+};
+
+const update = mock(async () => existing);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+
+mock.module("@/lib/auth/app-key-scope", () => ({
+  isAppKeyOutOfScope: async () => false,
+}));
+
+mock.module("@/lib/services/apps", () => ({
+  appsService: {
+    getById: async () => existing,
+    update,
+    withDatabaseState: async (row: unknown) => row,
+  },
+}));
+
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: { getById: async () => null },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id", route);
+
+describe("PATCH /api/v1/apps/:id malformed JSON", () => {
+  test("returns 400 instead of 500 and never updates the app", async () => {
+    const response = await app.request(`/${APP_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still updates the app", async () => {
+    const response = await app.request(`/${APP_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "demo" }),
+    });
+    expect(response.status).toBe(200);
+    expect(update).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/apps/[id]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.ts
@@ -94,7 +94,14 @@ async function updateApp(c: AppContext, verb: "PUT" | "PATCH") {
     return c.json({ success: false, error: "Access denied" }, 403);
   }
 
-  const rawBody = await c.req.json();
+  let rawBody: unknown;
+  try {
+    rawBody = await c.req.json();
+  } catch {
+    // error-policy:J3 untrusted request body — malformed JSON is caller
+    // error (400), not failureResponse(SyntaxError) → 500.
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
   const validationResult = UpdateAppSchema.safeParse(rawBody);
   if (!validationResult.success) {
     return c.json(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on app PUT/PATCH currently 500s. Not apps/[id]/characters list-route leftover. Not a list-limit / canonical-text / one-flag boolean change. Not tracker #21541 close-bait. Outside browser-sessions.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still update the app. Malformed JSON (`{`, truncated objects) now 400s before `appsService.update` instead of `failureResponse(SyntaxError)` → 500. Proven on the unfixed head: the same test received **500**.

# Background

## What does this PR do?

`PUT`/`PATCH /api/v1/apps/:id` called `await c.req.json()` inside `updateApp`, whose callers catch unknown errors through `failureResponse` / `inferStatusFromLegacyError`. That helper does not treat `SyntaxError` / "Failed to parse JSON" as caller error, so truncated bodies became HTTP 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before Zod or `appsService.update`.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/apps/[id]/route.json.test.ts` and the `c.req.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'v1/apps/[id]/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500**. After the fix: 2 passed on `81cb84c50bcc33c27a8ba6db316cdf1fb77b4fb9`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:81cb84c50bcc33c27a8ba6db316cdf1fb77b4fb9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the app-id HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before the app update.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that `appsService.update` is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches appsService.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on app-id JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and canonical `{ name: "demo" }` still updates.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the app-id HTTP boundary.

## Audio / voice walkthrough

N/A - metadata PUT/PATCH only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `81cb84c50b`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
