### PR TITLE
fix(security): guard wire-supplied navigation URLs + preserve embed edge CSP (W5-004, W5-034)

### DIFF
--- a/packages/app/functions/_middleware.ts
+++ b/packages/app/functions/_middleware.ts
@@ -183,6 +183,34 @@ export const embedFrameAncestors = (platform: string | null): string =>
     ? EMBED_FRAME_ANCESTORS[platform]
     : EMBED_FRAME_ANCESTORS_DENY;
 
+/**
+ * Replace only the `frame-ancestors` directive inside an existing CSP string,
+ * preserving every other directive. The `/embed` route must relax framing
+ * without dropping the rest of the edge policy (the pinned
+ * `connect-src`/`frame-src`/`img-src` allowlists from `public/_headers`) —
+ * and appending a second CSP header would not work either, because multiple
+ * policies intersect (`'self' ∩ <platform>` denies all framing).
+ */
+export const swapCspFrameAncestors = (
+  csp: string,
+  frameAncestorsDirective: string,
+): string => {
+  const directives = csp
+    .split(";")
+    .map((directive) => directive.trim())
+    .filter((directive) => directive.length > 0);
+  const index = directives.findIndex(
+    (directive) =>
+      directive.split(/\s+/, 1)[0]?.toLowerCase() === "frame-ancestors",
+  );
+  if (index >= 0) {
+    directives[index] = frameAncestorsDirective;
+  } else {
+    directives.push(frameAncestorsDirective);
+  }
+  return directives.join("; ");
+};
+
 const isEmbedPath = (pathname: string): boolean =>
   pathname === "/embed" || pathname.startsWith("/embed/");
 
@@ -215,13 +243,20 @@ export const onRequest = async (
   }
 
   // Serve the same SPA bundle, but override the frame embedding policy so the
-  // page renders inside the matched platform's iframe. The conflicting
-  // `X-Frame-Options` header (which has no allowlist syntax) is dropped so it
-  // cannot veto the CSP `frame-ancestors` directive.
+  // page renders inside the matched platform's iframe. Only the
+  // `frame-ancestors` value inside the inherited `_headers` CSP is swapped —
+  // the rest of the edge policy (connect-src/frame-src/img-src allowlists)
+  // must survive on a surface designed to run inside third-party iframes. The
+  // conflicting `X-Frame-Options` header (which has no allowlist syntax) is
+  // dropped so it cannot veto the CSP `frame-ancestors` directive.
   const headers = new Headers(response.headers);
+  const frameAncestors = embedFrameAncestors(url.searchParams.get("platform"));
+  const inheritedCsp = headers.get("Content-Security-Policy");
   headers.set(
     "Content-Security-Policy",
-    embedFrameAncestors(url.searchParams.get("platform")),
+    inheritedCsp
+      ? swapCspFrameAncestors(inheritedCsp, frameAncestors)
+      : frameAncestors,
   );
   headers.delete("X-Frame-Options");
 

--- a/packages/app/src/__tests__/embed-csp.test.ts
+++ b/packages/app/src/__tests__/embed-csp.test.ts
@@ -1,17 +1,26 @@
 /**
  * Unit tests for the Cloudflare Pages `functions/_middleware` embed CSP policy.
- * Asserts `embedFrameAncestors` and the `/embed` `onRequest` handler emit
- * per-platform `frame-ancestors` (telegram/discord only, stripping
- * X-Frame-Options), deny unknown/missing platforms with `'none'`, and leave
- * non-embed SPA paths and their inherited framing headers untouched. Requests
- * run through the real handler with a stubbed SPA `next()`; no network.
+ * Asserts `embedFrameAncestors` emits per-platform `frame-ancestors`
+ * (telegram/discord only), that the `/embed` `onRequest` handler swaps ONLY the
+ * `frame-ancestors` value inside the inherited `_headers` CSP (preserving the
+ * other edge directives, stripping X-Frame-Options), denies unknown/missing
+ * platforms with `'none'`, and leaves non-embed SPA paths and their inherited
+ * framing headers untouched. Requests run through the real handler with a
+ * stubbed SPA `next()`; no network.
  */
 import { describe, expect, it } from "vitest";
 import {
   type EmbedPlatform,
   embedFrameAncestors,
   onRequest,
+  swapCspFrameAncestors,
 } from "../../functions/_middleware";
+
+// Abbreviated stand-in for the global `public/_headers` policy that the
+// `/embed` route must amend in place: several pinned directives plus the
+// restrictive `frame-ancestors 'self'` that gets swapped per platform.
+const EDGE_CSP =
+  "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; frame-ancestors 'self'; connect-src 'self' https://eliza.app https://*.eliza.app";
 
 // The SPA fall-through response carries the global `public/_headers` framing
 // policy that the `/embed` route must override.
@@ -22,6 +31,7 @@ const spaNext = (): Promise<Response> =>
       statusText: "OK",
       headers: {
         "Content-Type": "text/html; charset=utf-8",
+        "Content-Security-Policy": EDGE_CSP,
         "X-Frame-Options": "SAMEORIGIN",
       },
     }),
@@ -62,48 +72,103 @@ describe("embedFrameAncestors", () => {
   });
 });
 
-describe("onRequest /embed CSP policy", () => {
-  it("allows only telegram framing for ?platform=telegram", async () => {
-    const response = await runRequest("/embed?platform=telegram");
-    const csp = response.headers.get("Content-Security-Policy");
-    expect(csp).toBe(
+describe("swapCspFrameAncestors", () => {
+  it("replaces only the frame-ancestors value, preserving other directives", () => {
+    const swapped = swapCspFrameAncestors(
+      EDGE_CSP,
       "frame-ancestors https://web.telegram.org https://*.telegram.org",
     );
+    expect(swapped).toContain(
+      "frame-ancestors https://web.telegram.org https://*.telegram.org",
+    );
+    expect(swapped).not.toContain("frame-ancestors 'self'");
+    expect(swapped).toContain("default-src 'self'");
+    expect(swapped).toContain("script-src 'self' 'unsafe-inline'");
+    expect(swapped).toContain("img-src 'self' data: blob: https:");
+    expect(swapped).toContain(
+      "connect-src 'self' https://eliza.app https://*.eliza.app",
+    );
+    // One frame-ancestors directive in, exactly one out.
+    expect(swapped.match(/frame-ancestors/g)).toHaveLength(1);
+  });
+
+  it("appends the directive when the policy has no frame-ancestors", () => {
+    const swapped = swapCspFrameAncestors(
+      "default-src 'self'",
+      "frame-ancestors 'none'",
+    );
+    expect(swapped).toBe("default-src 'self'; frame-ancestors 'none'");
+  });
+});
+
+describe("onRequest /embed CSP policy", () => {
+  it("swaps in telegram framing for ?platform=telegram, keeping the edge policy", async () => {
+    const response = await runRequest("/embed?platform=telegram");
+    const csp = response.headers.get("Content-Security-Policy");
+    expect(csp).toContain(
+      "frame-ancestors https://web.telegram.org https://*.telegram.org",
+    );
+    expect(csp).not.toContain("frame-ancestors 'self'");
     expect(csp).not.toContain("discord");
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).toContain(
+      "connect-src 'self' https://eliza.app https://*.eliza.app",
+    );
+    expect(csp?.match(/frame-ancestors/g)).toHaveLength(1);
     expect(response.headers.get("X-Frame-Options")).toBeNull();
     expect(response.status).toBe(200);
   });
 
-  it("allows only discord framing for ?platform=discord", async () => {
+  it("swaps in discord framing for ?platform=discord, keeping the edge policy", async () => {
     const response = await runRequest("/embed?platform=discord");
     const csp = response.headers.get("Content-Security-Policy");
-    expect(csp).toBe(
+    expect(csp).toContain(
       "frame-ancestors https://discord.com https://*.discord.com",
     );
+    expect(csp).not.toContain("frame-ancestors 'self'");
     expect(csp).not.toContain("telegram");
+    expect(csp).toContain("default-src 'self'");
     expect(response.headers.get("X-Frame-Options")).toBeNull();
   });
 
-  it("denies framing for an unknown platform", async () => {
+  it("denies framing for an unknown platform, keeping the edge policy", async () => {
     const response = await runRequest("/embed?platform=evil.example.com");
-    expect(response.headers.get("Content-Security-Policy")).toBe(
-      "frame-ancestors 'none'",
-    );
+    const csp = response.headers.get("Content-Security-Policy");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("default-src 'self'");
     expect(response.headers.get("X-Frame-Options")).toBeNull();
   });
 
   it("denies framing when no platform is supplied", async () => {
     const response = await runRequest("/embed");
-    expect(response.headers.get("Content-Security-Policy")).toBe(
-      "frame-ancestors 'none'",
-    );
+    const csp = response.headers.get("Content-Security-Policy");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("default-src 'self'");
     expect(response.headers.get("X-Frame-Options")).toBeNull();
+  });
+
+  it("falls back to the bare directive when the response has no CSP", async () => {
+    const response = await onRequest({
+      request: new Request("https://cloud.eliza.app/embed?platform=telegram"),
+      env: {},
+      next: () =>
+        Promise.resolve(
+          new Response("<!doctype html>", {
+            status: 200,
+            headers: { "Content-Type": "text/html; charset=utf-8" },
+          }),
+        ),
+    });
+    expect(response.headers.get("Content-Security-Policy")).toBe(
+      "frame-ancestors https://web.telegram.org https://*.telegram.org",
+    );
   });
 
   it("leaves a normal non-/embed SPA path untouched", async () => {
     const response = await runRequest("/cloud");
-    // No CSP injected by the middleware; the global _headers policy stands.
-    expect(response.headers.get("Content-Security-Policy")).toBeNull();
+    // No CSP amended by the middleware; the global _headers policy stands.
+    expect(response.headers.get("Content-Security-Policy")).toBe(EDGE_CSP);
     // X-Frame-Options from the SPA fall-through is preserved.
     expect(response.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
     expect(response.status).toBe(200);
@@ -112,7 +177,7 @@ describe("onRequest /embed CSP policy", () => {
 
   it("does not treat a /embedded-* prefix collision as an embed path", async () => {
     const response = await runRequest("/embedded-viewer");
-    expect(response.headers.get("Content-Security-Policy")).toBeNull();
+    expect(response.headers.get("Content-Security-Policy")).toBe(EDGE_CSP);
     expect(response.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
   });
 });

--- a/packages/ui/src/cloud/billing-console.ts
+++ b/packages/ui/src/cloud/billing-console.ts
@@ -22,6 +22,8 @@ export function cloudBillingConsoleUrl(cloudApiBase?: string): string {
 }
 
 /** Open the billing console on the current platform. */
-export function openCloudBillingConsole(cloudApiBase?: string): Promise<void> {
+export function openCloudBillingConsole(
+  cloudApiBase?: string,
+): Promise<boolean> {
   return openExternalUrl(cloudBillingConsoleUrl(cloudApiBase));
 }

--- a/packages/ui/src/cloud/billing/components/invoice-detail-client.tsx
+++ b/packages/ui/src/cloud/billing/components/invoice-detail-client.tsx
@@ -8,7 +8,9 @@
 import { BrandCard, CornerBrackets } from "@elizaos/ui/cloud-ui";
 import { ArrowLeft, Download, ExternalLink } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
 import { Button } from "../../../components/ui/button";
+import { isSafeNavigationUrl } from "../../lib/navigation-url";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import type { InvoiceDto } from "../types";
 
@@ -27,6 +29,20 @@ const DATE_FORMAT: Intl.DateTimeFormatOptions = {
 export function InvoiceDetailClient({ invoice }: InvoiceDetailClientProps) {
   const t = useCloudT();
   const navigate = useNavigate();
+
+  // Invoice PDF / hosted-invoice URLs are Stripe-relayed wire values — only
+  // absolute http(s) may open, and always with the opener severed.
+  const openInvoiceUrl = (url: string) => {
+    if (!isSafeNavigationUrl(url)) {
+      toast.error(
+        t("cloud.invoiceDetail.invalidInvoiceUrl", {
+          defaultValue: "Invoice link is not a valid URL",
+        }),
+      );
+      return;
+    }
+    window.open(url, "_blank", "noopener,noreferrer");
+  };
 
   const formattedDate = new Date(invoice.created_at).toLocaleDateString(
     "en-US",
@@ -85,8 +101,7 @@ export function InvoiceDetailClient({ invoice }: InvoiceDetailClientProps) {
                   variant="ghost"
                   type="button"
                   onClick={() =>
-                    invoice.invoice_pdf &&
-                    window.open(invoice.invoice_pdf, "_blank")
+                    invoice.invoice_pdf && openInvoiceUrl(invoice.invoice_pdf)
                   }
                   className="flex min-h-touch items-center gap-2 text-base font-mono text-txt-strong underline hover:text-accent transition-colors"
                 >
@@ -102,7 +117,7 @@ export function InvoiceDetailClient({ invoice }: InvoiceDetailClientProps) {
                   type="button"
                   onClick={() =>
                     invoice.hosted_invoice_url &&
-                    window.open(invoice.hosted_invoice_url, "_blank")
+                    openInvoiceUrl(invoice.hosted_invoice_url)
                   }
                   className="flex min-h-touch items-center gap-2 text-base font-mono text-txt-strong underline hover:text-accent transition-colors"
                 >

--- a/packages/ui/src/cloud/lib/navigation-url.test.ts
+++ b/packages/ui/src/cloud/lib/navigation-url.test.ts
@@ -1,62 +1,19 @@
 /**
- * Unit coverage for the top-window navigation scheme allowlist. Wire-supplied
- * URLs (billing checkout, connector OAuth, pairing redirects, onboarding
- * return links) must never reach `location.href` / `href` unvalidated.
+ * Compat coverage for the cloud/lib import path: the navigation scheme
+ * allowlist lives in `utils/navigation-url` (so the platform-level navigation
+ * helpers can enforce it) and this module re-exports it for existing cloud
+ * consumers. The full contract is tested in `utils/navigation-url.test.ts`.
  */
 import { describe, expect, it } from "vitest";
+import { isSafeNavigationUrl as canonical } from "../../utils/navigation-url";
 import { isSafeNavigationUrl } from "./navigation-url";
 
-describe("isSafeNavigationUrl", () => {
-  it("accepts absolute http(s) URLs", () => {
+describe("cloud/lib/navigation-url compat re-export", () => {
+  it("re-exports the canonical guard", () => {
+    expect(isSafeNavigationUrl).toBe(canonical);
     expect(isSafeNavigationUrl("https://checkout.stripe.com/c/pay_123")).toBe(
       true,
     );
-    expect(isSafeNavigationUrl("http://localhost:31337/pair?token=abc")).toBe(
-      true,
-    );
-    expect(isSafeNavigationUrl("http://127.0.0.1:8080/ui")).toBe(true);
-  });
-
-  it("rejects script-capable and file schemes", () => {
     expect(isSafeNavigationUrl("javascript:alert(1)")).toBe(false);
-    expect(isSafeNavigationUrl("JavaScript:alert(1)")).toBe(false);
-    expect(
-      isSafeNavigationUrl("data:text/html,<script>alert(1)</script>"),
-    ).toBe(false);
-    expect(isSafeNavigationUrl("vbscript:msgbox(1)")).toBe(false);
-    expect(isSafeNavigationUrl("file:///etc/passwd")).toBe(false);
-  });
-
-  it("rejects control-char-obfuscated schemes the way the browser parses them", () => {
-    // The WHATWG parser strips tab/newline before resolving the scheme, so
-    // these are `javascript:` URLs and must fail closed.
-    expect(isSafeNavigationUrl("java\tscript:alert(1)")).toBe(false);
-    expect(isSafeNavigationUrl("java\nscript:alert(1)")).toBe(false);
-  });
-
-  it("rejects arbitrary custom schemes by default", () => {
-    expect(isSafeNavigationUrl("customapp://do-thing")).toBe(false);
-    expect(isSafeNavigationUrl("sms:+18087881821")).toBe(false);
-  });
-
-  it("accepts caller-declared extra schemes only", () => {
-    expect(isSafeNavigationUrl("sms:+18087881821", ["sms:"])).toBe(true);
-    expect(isSafeNavigationUrl("tel:+18087881821", ["sms:"])).toBe(false);
-    expect(isSafeNavigationUrl("javascript:alert(1)", ["sms:"])).toBe(false);
-  });
-
-  it("rejects relative, root-relative, scheme-relative, and empty input", () => {
-    expect(isSafeNavigationUrl("/cloud/billing")).toBe(false);
-    expect(isSafeNavigationUrl("//attacker.example/x")).toBe(false);
-    expect(isSafeNavigationUrl("settings/billing")).toBe(false);
-    expect(isSafeNavigationUrl("")).toBe(false);
-    expect(isSafeNavigationUrl("   ")).toBe(false);
-  });
-
-  it("rejects non-string input", () => {
-    expect(isSafeNavigationUrl(undefined)).toBe(false);
-    expect(isSafeNavigationUrl(null)).toBe(false);
-    expect(isSafeNavigationUrl(42)).toBe(false);
-    expect(isSafeNavigationUrl({ href: "https://x.example" })).toBe(false);
   });
 });

--- a/packages/ui/src/cloud/lib/navigation-url.ts
+++ b/packages/ui/src/cloud/lib/navigation-url.ts
@@ -1,44 +1,7 @@
 /**
- * Scheme allowlist for top-window navigations to API- or plugin-supplied URLs.
- *
- * Billing checkout links, connector OAuth `authUrl`s, pairing `redirectUrl`s,
- * and onboarding `returnUrl`s all arrive over the wire and are then assigned to
- * `window.location.href` / `location.assign` or rendered into an `href`. Unlike
- * JSX URL props (which React 19 guards), a `javascript:` value assigned to
- * `location` executes synchronously in the page origin, and other custom
- * schemes can hand off to OS handlers — so every wire-supplied navigation
- * target MUST pass through {@link isSafeNavigationUrl} first, and an invalid
- * target MUST surface the explicit error state the handler already renders
- * instead of navigating.
- *
- * Only absolute `http:`/`https:` URLs pass by default (loopback `http:` stays
- * valid for local dev flows); callers with a documented extra scheme (e.g. the
- * onboarding `sms:` return link) opt in explicitly via `extraSchemes`.
- * `new URL()` normalizes away control-char scheme obfuscation (e.g.
- * `java\tscript:`), so the parsed protocol is the scheme the browser would
- * use.
+ * Compatibility re-export. The scheme allowlist now lives in the shared UI
+ * utils (`utils/navigation-url.ts`) so the platform-level navigation helpers
+ * (`utils/openExternalUrl.ts`) can enforce it without a utils → cloud import;
+ * existing cloud/lib import paths keep working.
  */
-
-/**
- * Returns `true` only for absolute URLs whose scheme is http(s) — or one of
- * the caller-declared `extraSchemes` (protocol strings including the colon,
- * e.g. `["sms:"]`). Everything else (`javascript:`, `data:`, `file:`,
- * `vbscript:`, arbitrary custom schemes, relative/root-relative input,
- * malformed input, non-string input) returns `false`.
- */
-export function isSafeNavigationUrl(
-  url: unknown,
-  extraSchemes: readonly string[] = [],
-): url is string {
-  if (typeof url !== "string" || url.length === 0) return false;
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    // error-policy:J3 untrusted navigation target from an API response —
-    // malformed input fails closed, never navigates.
-    return false;
-  }
-  if (parsed.protocol === "https:" || parsed.protocol === "http:") return true;
-  return extraSchemes.includes(parsed.protocol);
-}
+export { isSafeNavigationUrl } from "../../utils/navigation-url";

--- a/packages/ui/src/components/accounts/AddAccountDialog.component.test.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.component.test.tsx
@@ -56,7 +56,9 @@ vi.mock("../../state/app-store", () => ({
   ) => selector({ t: (_key, vars) => String(vars?.defaultValue ?? _key) }),
 }));
 vi.mock("../../utils", () => ({
-  navigatePreOpenedWindow: vi.fn(),
+  // The helper reports whether the navigation was accepted; the dialog drops
+  // to its error step on `false`.
+  navigatePreOpenedWindow: vi.fn(() => true),
   preOpenWindow: vi.fn(() => ({ close: vi.fn() })),
 }));
 vi.mock("../../utils/clipboard", () => ({ copyTextToClipboard: vi.fn() }));

--- a/packages/ui/src/components/accounts/AddAccountDialog.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.tsx
@@ -464,7 +464,18 @@ export function AddAccountDialog({
         }
         subscribeToFlow(flow.sessionId);
         if (opensWindow) {
-          navigatePreOpenedWindow(win, flow.authUrl);
+          // The authUrl is a wire value navigated into a same-origin
+          // pre-opened popup — a rejected target surfaces the dialog's
+          // visible error state instead of navigating.
+          if (!navigatePreOpenedWindow(win, flow.authUrl)) {
+            setErrorMessage(
+              t("accounts.add.oauth.invalidAuthUrl", {
+                defaultValue:
+                  "The sign-in link returned by the server is not a valid URL.",
+              }),
+            );
+            setStep("error");
+          }
         }
       } catch (err) {
         // error-policy:J4 Enrollment failures remain visible and retryable in the dialog.

--- a/packages/ui/src/components/chat/AppsSection.tsx
+++ b/packages/ui/src/components/chat/AppsSection.tsx
@@ -226,14 +226,25 @@ export function AppsSection({ headerAction }: AppsSectionProps = {}) {
         const targetUrl = result.launchUrl ?? app.launchUrl;
         if (targetUrl) {
           try {
-            await openExternalUrl(targetUrl);
-            setActionNotice(
-              t("appsview.OpenedInNewTab", {
-                name: app.displayName ?? app.name,
-              }),
-              "success",
-              2600,
-            );
+            // launchUrl is a wire value — a rejected target (helper returns
+            // false) shows the same visible failure notice as a blocked popup.
+            if (await openExternalUrl(targetUrl)) {
+              setActionNotice(
+                t("appsview.OpenedInNewTab", {
+                  name: app.displayName ?? app.name,
+                }),
+                "success",
+                2600,
+              );
+            } else {
+              setActionNotice(
+                t("appsview.PopupBlockedOpen", {
+                  name: app.displayName ?? app.name,
+                }),
+                "error",
+                4200,
+              );
+            }
           } catch {
             // error-policy:J4 popup blocked — surfaced as an action notice
             setActionNotice(

--- a/packages/ui/src/components/connectors/ConnectorAccountList.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountList.tsx
@@ -18,6 +18,7 @@ import {
   useConnectorAccounts,
 } from "../../hooks/useConnectorAccounts";
 import { cn } from "../../lib/utils";
+import { isSafeNavigationUrl } from "../../utils/navigation-url";
 import { Button } from "../ui/button";
 import { Spinner } from "../ui/spinner";
 import { ConnectorAccountCard } from "./ConnectorAccountCard";
@@ -95,9 +96,16 @@ function sortConnectorAccounts(
   });
 }
 
-function openConnectorAuthUrl(authUrl: string | undefined): void {
-  if (!authUrl || typeof window === "undefined") return;
+/**
+ * Open a connector OAuth URL in a new tab. The authUrl is a wire value, so it
+ * passes the navigation scheme allowlist first; returns `false` when nothing
+ * was opened (rejected or non-browser environment).
+ */
+function openConnectorAuthUrl(authUrl: string | undefined): boolean {
+  if (!authUrl || typeof window === "undefined") return false;
+  if (!isSafeNavigationUrl(authUrl)) return false;
   window.open(authUrl, "_blank", "noopener,noreferrer");
+  return true;
 }
 
 function defaultTitleForRole(
@@ -148,6 +156,9 @@ export function ConnectorAccountList({
   const [selectedOAuthCapabilities, setSelectedOAuthCapabilities] = useState(
     () => new Set<string>(),
   );
+  // Rejection of a wire-supplied OAuth URL surfaces here — the hook-level
+  // `error` only covers fetch/mutation failures.
+  const [authUrlError, setAuthUrlError] = useState<string | null>(null);
 
   useEffect(() => {
     if (selectedAccountId !== undefined) {
@@ -181,6 +192,7 @@ export function ConnectorAccountList({
   };
 
   const handleAdd = async () => {
+    setAuthUrlError(null);
     if (onAddAccount) {
       const body = await onAddAccount();
       if (!body) return;
@@ -203,7 +215,11 @@ export function ConnectorAccountList({
         privacy: requestedRole === "OWNER" ? "owner_only" : "team_visible",
       },
     });
-    openConnectorAuthUrl(result.authUrl);
+    if (result.authUrl && !openConnectorAuthUrl(result.authUrl)) {
+      setAuthUrlError(
+        "The sign-in link returned by the server is not a valid URL.",
+      );
+    }
   };
 
   const addBusy =
@@ -267,9 +283,9 @@ export function ConnectorAccountList({
         </div>
       ) : null}
 
-      {connectorAccounts.error ? (
+      {connectorAccounts.error || authUrlError ? (
         <div className="rounded-sm border border-border/45 bg-card/30 px-3 py-2 text-xs text-muted">
-          {connectorAccounts.error}
+          {connectorAccounts.error ?? authUrlError}
         </div>
       ) : null}
 

--- a/packages/ui/src/components/pages/ElizaCloudDashboard.tsx
+++ b/packages/ui/src/components/pages/ElizaCloudDashboard.tsx
@@ -389,8 +389,9 @@ export function CloudDashboard() {
       }
 
       const checkoutUrl = resolveCheckoutUrl(response);
-      if (checkoutUrl) {
-        await openExternalUrl(checkoutUrl);
+      // The checkout URL is a wire value — a rejected target (helper returns
+      // false) falls through to the visible checkout-unavailable error below.
+      if (checkoutUrl && (await openExternalUrl(checkoutUrl))) {
         return;
       }
 

--- a/packages/ui/src/components/pages/LauncherSurface.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.tsx
@@ -109,12 +109,22 @@ export const LauncherSurface = React.memo(function LauncherSurface({
           }
           const targetUrl = result.launchUrl ?? entry.launchUrl;
           if (targetUrl) {
-            await openExternalUrl(targetUrl);
-            setActionNotice(
-              t("appsview.OpenedInNewTab", { name: entry.label }),
-              "success",
-              2600,
-            );
+            // launchUrl is a wire value — a rejected target (helper returns
+            // false) surfaces the launch-failed notice instead of a false
+            // "opened" success.
+            if (await openExternalUrl(targetUrl)) {
+              setActionNotice(
+                t("appsview.OpenedInNewTab", { name: entry.label }),
+                "success",
+                2600,
+              );
+            } else {
+              setActionNotice(
+                t("appsview.PopupBlockedOpen", { name: entry.label }),
+                "error",
+                4200,
+              );
+            }
             return;
           }
           if (run) {

--- a/packages/ui/src/components/pages/PluginsView.tsx
+++ b/packages/ui/src/components/pages/PluginsView.tsx
@@ -820,7 +820,11 @@ function PluginListView({
   const handleOpenPluginExternalUrl = useCallback(
     async (url: string) => {
       try {
-        await openExternalUrl(url);
+        // Plugin-declared links are wire values — a rejected target (helper
+        // returns false) surfaces the same error notice as a failed open.
+        if (!(await openExternalUrl(url))) {
+          setActionNotice("Failed to open external link.", "error", 4200);
+        }
       } catch (err) {
         setActionNotice(
           err instanceof Error ? err.message : "Failed to open external link.",

--- a/packages/ui/src/components/settings/SubscriptionStatus.tsx
+++ b/packages/ui/src/components/settings/SubscriptionStatus.tsx
@@ -543,8 +543,10 @@ export function SubscriptionStatus({
     const popup = preOpenWindow();
     try {
       const { authUrl } = await client.startAnthropicLogin();
-      if (authUrl) {
-        navigatePreOpenedWindow(popup, authUrl);
+      // The authUrl is a wire value navigated into a same-origin pre-opened
+      // popup — a rejected target (helper returns false and closes the popup)
+      // falls through to the visible error state below.
+      if (authUrl && navigatePreOpenedWindow(popup, authUrl)) {
         return;
       }
       popup?.close();
@@ -607,8 +609,9 @@ export function SubscriptionStatus({
     setOpenaiOAuthStarted(true);
     try {
       const { authUrl } = await client.startOpenAILogin();
-      if (authUrl) {
-        await openExternalUrl(authUrl);
+      // The authUrl is a wire value — a rejected target (helper returns
+      // false) falls through to the visible error state below.
+      if (authUrl && (await openExternalUrl(authUrl))) {
         return;
       }
       rememberOAuthActive(OPENAI_OAUTH_STORAGE_KEY, false);

--- a/packages/ui/src/components/settings/VoiceProfileSection.tsx
+++ b/packages/ui/src/components/settings/VoiceProfileSection.tsx
@@ -25,6 +25,7 @@ import type {
 } from "../../api/client-voice-profiles";
 import { cn } from "../../lib/utils";
 import { useTranslation } from "../../state/TranslationContext.hooks";
+import { isSafeNavigationUrl } from "../../utils/navigation-url";
 import { Button } from "../ui/button";
 import { Checkbox } from "../ui/checkbox";
 import { Input } from "../ui/input";
@@ -840,8 +841,21 @@ export function VoiceProfileSection({
     setNotice(null);
     try {
       const { downloadUrl } = await profilesClient.exportAll();
-      if (downloadUrl && typeof window !== "undefined") {
-        window.open(downloadUrl, "_blank", "noopener,noreferrer");
+      // The downloadUrl is a wire value — a non-http(s) target fails closed
+      // and surfaces the export error state instead of opening.
+      if (downloadUrl) {
+        if (!isSafeNavigationUrl(downloadUrl)) {
+          setError(
+            t("voiceprofile.error.invalidExportUrl", {
+              defaultValue:
+                "The export link returned by the server is not a valid URL.",
+            }),
+          );
+          return;
+        }
+        if (typeof window !== "undefined") {
+          window.open(downloadUrl, "_blank", "noopener,noreferrer");
+        }
       }
       setNotice(
         t("voiceprofile.notice.exported", {

--- a/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
@@ -33,6 +33,7 @@ import { client } from "../../../api/client";
 import { useTranslation } from "../../../state/TranslationContext.hooks";
 import { resolveApiUrl } from "../../../utils/asset-url";
 import { openEventSource } from "../../../utils/event-source";
+import { isSafeNavigationUrl } from "../../../utils/navigation-url";
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
@@ -622,6 +623,18 @@ export function InstallSheet({
   const start = useCallback(
     async (method: InstallMethod) => {
       if (method.kind === "manual") {
+        // method.url is a wire value from the install/methods endpoint — only
+        // absolute http(s) may open; anything else surfaces the sheet's
+        // visible error state instead of navigating.
+        if (!isSafeNavigationUrl(method.url)) {
+          setError(
+            t("vault.install.invalidMethodUrl", {
+              defaultValue:
+                "The install link returned by the server is not a valid URL.",
+            }),
+          );
+          return;
+        }
         window.open(method.url, "_blank", "noopener,noreferrer");
         return;
       }

--- a/packages/ui/src/components/shell/BugReportModal.tsx
+++ b/packages/ui/src/components/shell/BugReportModal.tsx
@@ -325,7 +325,17 @@ export function BugReportModal() {
           ok = false;
         }
         setCopied(ok);
-        await openExternalUrl(result.fallback);
+        // The fallback URL is a wire value — unlike `result.url` above it is
+        // not pre-normalized, so the central guard applies; a rejected target
+        // surfaces the modal's error state (the report stays on the clipboard).
+        if (!(await openExternalUrl(result.fallback))) {
+          setErrorMsg(
+            t("bugreportmodal.invalidFallbackUrl", {
+              defaultValue:
+                "The report link returned by the server is not a valid URL.",
+            }),
+          );
+        }
       }
     } catch (err) {
       setErrorMsg(

--- a/packages/ui/src/hooks/useConnectorSendAsAccount.ts
+++ b/packages/ui/src/hooks/useConnectorSendAsAccount.ts
@@ -15,7 +15,11 @@ import {
   shouldShowConnectorAccountPicker,
 } from "../components/chat/connector-send-as";
 import type { ActionNoticeFn } from "../state/action-notice";
+import { isSafeNavigationUrl } from "../utils/navigation-url";
 import { useConnectorAccounts } from "./useConnectorAccounts";
+
+const INVALID_AUTH_URL_NOTICE =
+  "The sign-in link returned by the server is not a valid URL.";
 
 export interface UseConnectorSendAsAccountOptions {
   pollMs?: number;
@@ -42,9 +46,16 @@ export interface UseConnectorSendAsAccountResult {
   refresh: () => Promise<void>;
 }
 
-function openAuthUrl(authUrl: string | undefined): void {
-  if (!authUrl || typeof window === "undefined") return;
+/**
+ * Open a connector OAuth URL in a new tab. The authUrl is a wire value, so it
+ * passes the navigation scheme allowlist first; returns `false` when nothing
+ * was opened (rejected or non-browser environment).
+ */
+function openAuthUrl(authUrl: string | undefined): boolean {
+  if (!authUrl || typeof window === "undefined") return false;
+  if (!isSafeNavigationUrl(authUrl)) return false;
   window.open(authUrl, "_blank", "noopener,noreferrer");
+  return true;
 }
 
 export function useConnectorSendAsAccount(
@@ -101,17 +112,21 @@ export function useConnectorSendAsAccount(
         privacy: "owner_only",
       },
     });
-    openAuthUrl(result.authUrl);
+    if (result.authUrl && !openAuthUrl(result.authUrl)) {
+      options.setActionNotice?.(INVALID_AUTH_URL_NOTICE, "error", 4200);
+    }
     return result;
-  }, [startOAuth]);
+  }, [startOAuth, options.setActionNotice]);
 
   const reconnectAccount = useCallback(
     async (accountId: string) => {
       const result = await startOAuth({ accountId });
-      openAuthUrl(result.authUrl);
+      if (result.authUrl && !openAuthUrl(result.authUrl)) {
+        options.setActionNotice?.(INVALID_AUTH_URL_NOTICE, "error", 4200);
+      }
       return result;
     },
-    [startOAuth],
+    [startOAuth, options.setActionNotice],
   );
 
   return {

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -45,6 +45,7 @@ import {
   closeExternalBrowser,
   confirmDesktopAction,
   isCloudStatusAuthenticated,
+  isSafeNavigationUrl,
   navigatePreOpenedWindow,
   openExternalUrl,
   yieldHttpAfterNativeMessageBox,
@@ -920,7 +921,7 @@ export function useCloudState({
         // handlers (e.g. Tails' Tor Browser flatpak when Tor has not
         // bootstrapped, or any environment where xdg-open silently fails)
         // open without crashing but never surface a usable window.
-        if (resp.browserUrl) {
+        if (resp.browserUrl && isSafeNavigationUrl(resp.browserUrl)) {
           setElizaCloudLoginFallbackUrl(resp.browserUrl);
           if (prePoppedWindow) {
             navigatePreOpenedWindow(prePoppedWindow, resp.browserUrl, {
@@ -942,6 +943,20 @@ export function useCloudState({
           }
         } else {
           closePrePoppedWindow();
+          if (resp.browserUrl) {
+            // The login URL is a wire value assigned to a same-origin
+            // pre-opened popup / named window — a non-http(s) target fails
+            // closed and tears the attempt down with a visible error, like a
+            // failed login start.
+            setElizaCloudLoginError(
+              "The login link returned by the server is not a valid URL.",
+            );
+            removeCloudAuthMessageListener();
+            elizaCloudLoginBusyRef.current = false;
+            setElizaCloudLoginBusy(false);
+            completeLogin();
+            return loginCompletion;
+          }
         }
 
         let pollInFlight = false;

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -38,6 +38,7 @@ export * from "./labels";
 export * from "./log-prefix";
 export * from "./name-tokens";
 export * from "./namespace-defaults";
+export * from "./navigation-url";
 export * from "./openExternalUrl";
 export * from "./owner-name";
 export * from "./rate-limiter";

--- a/packages/ui/src/utils/navigation-url.test.ts
+++ b/packages/ui/src/utils/navigation-url.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit coverage for the shared navigation scheme allowlist — the central
+ * guard every wire-supplied navigation target (billing checkout, connector
+ * OAuth, login browserUrl, server-signed download, plugin-declared link) must
+ * pass before reaching `window.open`, `popup.location.href`, `location.href`,
+ * or an `href`. Deterministic; no DOM or network.
+ */
+import { describe, expect, it } from "vitest";
+import { isSafeNavigationUrl } from "./navigation-url";
+
+describe("isSafeNavigationUrl", () => {
+  it("accepts absolute http(s) URLs", () => {
+    expect(isSafeNavigationUrl("https://checkout.stripe.com/c/pay_123")).toBe(
+      true,
+    );
+    expect(isSafeNavigationUrl("http://localhost:31337/pair?token=abc")).toBe(
+      true,
+    );
+    expect(isSafeNavigationUrl("http://127.0.0.1:8080/ui")).toBe(true);
+  });
+
+  it("rejects script-capable and file schemes", () => {
+    expect(isSafeNavigationUrl("javascript:alert(1)")).toBe(false);
+    expect(isSafeNavigationUrl("JavaScript:alert(1)")).toBe(false);
+    expect(
+      isSafeNavigationUrl("data:text/html,<script>alert(1)</script>"),
+    ).toBe(false);
+    expect(isSafeNavigationUrl("vbscript:msgbox(1)")).toBe(false);
+    expect(isSafeNavigationUrl("file:///etc/passwd")).toBe(false);
+  });
+
+  it("rejects control-char-obfuscated schemes the way the browser parses them", () => {
+    // The WHATWG parser strips tab/newline before resolving the scheme, so
+    // these are `javascript:` URLs and must fail closed.
+    expect(isSafeNavigationUrl("java\tscript:alert(1)")).toBe(false);
+    expect(isSafeNavigationUrl("java\nscript:alert(1)")).toBe(false);
+  });
+
+  it("rejects arbitrary custom schemes by default", () => {
+    expect(isSafeNavigationUrl("customapp://do-thing")).toBe(false);
+    expect(isSafeNavigationUrl("sms:+18087881821")).toBe(false);
+  });
+
+  it("accepts caller-declared extra schemes only", () => {
+    expect(isSafeNavigationUrl("sms:+18087881821", ["sms:"])).toBe(true);
+    expect(isSafeNavigationUrl("tel:+18087881821", ["sms:"])).toBe(false);
+    expect(isSafeNavigationUrl("javascript:alert(1)", ["sms:"])).toBe(false);
+  });
+
+  it("rejects relative, root-relative, scheme-relative, and empty input", () => {
+    expect(isSafeNavigationUrl("/cloud/billing")).toBe(false);
+    expect(isSafeNavigationUrl("//attacker.example/x")).toBe(false);
+    expect(isSafeNavigationUrl("settings/billing")).toBe(false);
+    expect(isSafeNavigationUrl("")).toBe(false);
+    expect(isSafeNavigationUrl("   ")).toBe(false);
+  });
+
+  it("rejects non-string input", () => {
+    expect(isSafeNavigationUrl(undefined)).toBe(false);
+    expect(isSafeNavigationUrl(null)).toBe(false);
+    expect(isSafeNavigationUrl(42)).toBe(false);
+    expect(isSafeNavigationUrl({ href: "https://x.example" })).toBe(false);
+  });
+});

--- a/packages/ui/src/utils/navigation-url.ts
+++ b/packages/ui/src/utils/navigation-url.ts
@@ -1,0 +1,48 @@
+/**
+ * Scheme allowlist for browser navigations to API- or plugin-supplied URLs.
+ *
+ * Billing checkout links, connector OAuth `authUrl`s, pairing `redirectUrl`s,
+ * onboarding `returnUrl`s, and server-signed download URLs all arrive over the
+ * wire and are then assigned to `window.location.href` / `location.assign`,
+ * opened via `window.open`, navigated into a pre-opened popup, or rendered
+ * into an `href`. Unlike JSX URL props (which React 19 guards), a
+ * `javascript:` value assigned to `location` executes synchronously in the
+ * page origin — and a pre-opened about:blank popup is guaranteed same-origin,
+ * so `popup.location.href = "javascript:…"` is a straight top-window script
+ * execution. Every wire-supplied navigation target MUST pass through
+ * {@link isSafeNavigationUrl} first, and an invalid target MUST surface the
+ * explicit error state the handler already renders instead of navigating. The
+ * central `openExternalUrl` / `navigatePreOpenedWindow` helpers in
+ * `./openExternalUrl` enforce this for every caller.
+ *
+ * Only absolute `http:`/`https:` URLs pass by default (loopback `http:` stays
+ * valid for local dev flows); callers with a documented extra scheme (e.g. the
+ * onboarding `sms:` return link) opt in explicitly via `extraSchemes`.
+ * `new URL()` normalizes away control-char scheme obfuscation (e.g.
+ * `java\tscript:`), so the parsed protocol is the scheme the browser would
+ * use.
+ */
+
+/**
+ * Returns `true` only for absolute URLs whose scheme is http(s) — or one of
+ * the caller-declared `extraSchemes` (protocol strings including the colon,
+ * e.g. `["sms:"]`). Everything else (`javascript:`, `data:`, `file:`,
+ * `vbscript:`, arbitrary custom schemes, relative/root-relative input,
+ * malformed input, non-string input) returns `false`.
+ */
+export function isSafeNavigationUrl(
+  url: unknown,
+  extraSchemes: readonly string[] = [],
+): url is string {
+  if (typeof url !== "string" || url.length === 0) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // error-policy:J3 untrusted navigation target from an API response —
+    // malformed input fails closed, never navigates.
+    return false;
+  }
+  if (parsed.protocol === "https:" || parsed.protocol === "http:") return true;
+  return extraSchemes.includes(parsed.protocol);
+}

--- a/packages/ui/src/utils/openExternalUrl.test.ts
+++ b/packages/ui/src/utils/openExternalUrl.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit coverage for the central navigation enforcement in `openExternalUrl` /
+ * `navigatePreOpenedWindow`: wire-supplied URLs that fail the
+ * `isSafeNavigationUrl` scheme allowlist must never reach `window.open`, the
+ * desktop bridge, or a same-origin pre-opened popup — the helpers return
+ * `false` so callers surface their visible error state. The Capacitor and
+ * Electrobun bridges are mocked to the plain-web environment; jsdom.
+ */
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { navigatePreOpenedWindow, openExternalUrl } from "./openExternalUrl";
+
+const invokeDesktopBridgeRequestWithTimeout = vi.hoisted(() =>
+  vi.fn<(args: unknown) => Promise<null>>(async () => null),
+);
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false },
+  registerPlugin: vi.fn(),
+}));
+
+vi.mock("../bridge/electrobun-rpc", () => ({
+  getElectrobunRendererRpc: () => undefined,
+  invokeDesktopBridgeRequestWithTimeout,
+}));
+
+type FakePopup = {
+  closed: boolean;
+  opener: unknown;
+  location: { href: string };
+  close: ReturnType<typeof vi.fn>;
+};
+
+const makePopup = (): FakePopup => ({
+  closed: false,
+  opener: {},
+  location: { href: "about:blank" },
+  close: vi.fn(function (this: FakePopup) {
+    this.closed = true;
+  }),
+});
+
+describe("openExternalUrl navigation guard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    invokeDesktopBridgeRequestWithTimeout.mockClear();
+  });
+
+  it("opens an http(s) URL in a new tab with the opener severed", async () => {
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => null as unknown as Window);
+    await expect(
+      openExternalUrl("https://checkout.stripe.com/c/pay_123"),
+    ).resolves.toBe(true);
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://checkout.stripe.com/c/pay_123",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("fails closed on script-capable and custom-scheme wire URLs", async () => {
+    const openSpy = vi.spyOn(window, "open");
+    for (const url of [
+      "javascript:alert(1)",
+      "data:text/html,<script>alert(1)</script>",
+      "vbscript:msgbox(1)",
+      "file:///etc/passwd",
+      "customapp://do-thing",
+      "//attacker.example/x",
+      "not a url",
+      "",
+    ]) {
+      await expect(openExternalUrl(url)).resolves.toBe(false);
+    }
+    // A rejected target never reaches any open channel.
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(invokeDesktopBridgeRequestWithTimeout).not.toHaveBeenCalled();
+  });
+});
+
+describe("navigatePreOpenedWindow navigation guard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    invokeDesktopBridgeRequestWithTimeout.mockClear();
+  });
+
+  it("navigates an open popup to an http(s) URL and severs the opener", () => {
+    const popup = makePopup();
+    const result = navigatePreOpenedWindow(
+      popup as unknown as Window,
+      "https://auth.example/oauth",
+    );
+    expect(result).toBe(true);
+    expect(popup.location.href).toBe("https://auth.example/oauth");
+    expect(popup.opener).toBeNull();
+  });
+
+  it("keeps the opener when preserveOpener is set", () => {
+    const popup = makePopup();
+    const opener = popup.opener;
+    navigatePreOpenedWindow(popup as unknown as Window, "https://x.example", {
+      preserveOpener: true,
+    });
+    expect(popup.opener).toBe(opener);
+  });
+
+  it("closes the popup and refuses a javascript: target", () => {
+    const popup = makePopup();
+    const result = navigatePreOpenedWindow(
+      popup as unknown as Window,
+      "javascript:alert(document.cookie)",
+    );
+    expect(result).toBe(false);
+    expect(popup.close).toHaveBeenCalled();
+    // The popup stays on about:blank — the script URL is never assigned to
+    // the same-origin popup's location.
+    expect(popup.location.href).toBe("about:blank");
+  });
+
+  it("refuses a rejected target even without a popup (no fallback open)", () => {
+    const openSpy = vi.spyOn(window, "open");
+    expect(navigatePreOpenedWindow(null, "javascript:alert(1)")).toBe(false);
+    expect(navigatePreOpenedWindow(null, "data:text/html,x")).toBe(false);
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(invokeDesktopBridgeRequestWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("falls back to openExternalUrl when the popup was blocked", async () => {
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => null as unknown as Window);
+    expect(navigatePreOpenedWindow(null, "https://auth.example/oauth")).toBe(
+      true,
+    );
+    // The fallback awaits the (absent) desktop bridge before window.open.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://auth.example/oauth",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("treats an already-closed popup as blocked and falls back", async () => {
+    const popup = makePopup();
+    popup.closed = true;
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => null as unknown as Window);
+    expect(
+      navigatePreOpenedWindow(
+        popup as unknown as Window,
+        "https://auth.example/oauth",
+      ),
+    ).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(openSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/utils/openExternalUrl.ts
+++ b/packages/ui/src/utils/openExternalUrl.ts
@@ -1,12 +1,20 @@
 /**
  * Opens an external URL on the current platform: desktop bridge, Capacitor
  * in-app browser, or a new tab, so links leave the app shell safely.
+ *
+ * These helpers are the central enforcement point for wire-supplied
+ * navigation targets (billing checkout links, connector OAuth `authUrl`s,
+ * login `browserUrl`s, server-signed download URLs, plugin-declared links):
+ * every URL passes the `isSafeNavigationUrl` scheme allowlist before any
+ * platform handoff, and a rejected URL never reaches `window.open`,
+ * `popup.location.href`, the Electrobun bridge, or the Capacitor browser.
  */
 import { Capacitor, registerPlugin } from "@capacitor/core";
 import {
   getElectrobunRendererRpc,
   invokeDesktopBridgeRequestWithTimeout,
 } from "../bridge/electrobun-rpc";
+import { isSafeNavigationUrl } from "./navigation-url";
 
 interface CapacitorBrowserPlugin {
   open: (options: { url: string; presentationStyle?: string }) => Promise<void>;
@@ -35,14 +43,24 @@ function getCapacitorBrowser(): CapacitorBrowserPlugin | null {
   return registeredCapacitorBrowser;
 }
 
-export async function openExternalUrl(url: string): Promise<void> {
+/**
+ * Open `url` outside the app shell. Returns `true` when a navigation was
+ * initiated, `false` when nothing was opened — either because the URL failed
+ * the navigation scheme allowlist (wire-supplied `javascript:`/`data:`/
+ * custom-scheme targets fail closed here) or because no open channel exists
+ * in this environment. Callers handling wire-supplied URLs should surface
+ * their existing visible error state on `false`.
+ */
+export async function openExternalUrl(url: string): Promise<boolean> {
+  if (!isSafeNavigationUrl(url)) return false;
+
   // Capacitor native (iOS WKWebView / Android WebView): use the Browser
   // plugin. Avoids `window.open` which loses user-gesture context across
   // awaits and is silently dropped by WKWebView.
   const capacitorBrowser = getCapacitorBrowser();
   if (capacitorBrowser) {
     await capacitorBrowser.open({ url });
-    return;
+    return true;
   }
 
   const bridged = await invokeDesktopBridgeRequestWithTimeout<void>({
@@ -52,22 +70,23 @@ export async function openExternalUrl(url: string): Promise<void> {
     timeoutMs: 10_000,
   });
 
-  if (bridged !== null && bridged.status === "ok") return;
+  if (bridged !== null && bridged.status === "ok") return true;
 
   // Inside Electrobun — never fall through to window.open() which spawns an
   // unmanaged BrowserView to an external URL and crashes the shell.
   if (getElectrobunRendererRpc() !== undefined) {
     // desktopOpenExternal RPC returned null — skip window.open fallback to
     // avoid spawning an unmanaged BrowserView inside Electrobun.
-    return;
+    return false;
   }
 
   // Non-desktop (web browser) fallback.
   if (typeof window === "undefined" || typeof window.open !== "function") {
-    return;
+    return false;
   }
 
   window.open(url, "_blank", "noopener,noreferrer");
+  return true;
 }
 
 export async function closeExternalBrowser(): Promise<void> {
@@ -111,12 +130,27 @@ export function preOpenWindow(target = "_blank"): Window | null {
 /**
  * Navigate a pre-opened window to the real URL, or fall back to
  * `openExternalUrl` if the pre-open was blocked / we're on desktop.
+ *
+ * Returns `false` when the URL fails the navigation scheme allowlist — the
+ * pre-opened about:blank popup is same-origin, so an unchecked `javascript:`
+ * assignment would execute in the app origin; on rejection the popup is
+ * closed and the caller surfaces its existing visible error state.
  */
 export function navigatePreOpenedWindow(
   popup: Window | null,
   url: string,
   options?: { preserveOpener?: boolean },
-): void {
+): boolean {
+  if (!isSafeNavigationUrl(url)) {
+    if (popup && !popup.closed) {
+      try {
+        popup.close();
+      } catch {
+        // error-policy:J6 best-effort popup teardown on a rejected target.
+      }
+    }
+    return false;
+  }
   if (popup && !popup.closed) {
     if (!options?.preserveOpener) {
       // Security: sever the opener while the pre-opened about:blank document
@@ -130,8 +164,9 @@ export function navigatePreOpenedWindow(
       }
     }
     popup.location.href = url;
-    return;
+    return true;
   }
   // Fallback — desktop RPC or retry window.open
   void openExternalUrl(url);
+  return true;
 }


### PR DESCRIPTION
## Summary

Wave-6 remediation of two wave-5 re-audit findings. High-level only; evidence notes live in the audit report.

### W5-004 — wire-supplied URLs reaching navigation sinks unguarded (packages/ui)

- **Central enforcement:** `openExternalUrl` / `navigatePreOpenedWindow` (`packages/ui/src/utils/openExternalUrl.ts`) now run every URL through the `isSafeNavigationUrl` scheme allowlist before any platform handoff (new tab, pre-opened popup, desktop bridge, Capacitor browser). Rejected targets fail closed; a rejected pre-opened popup is closed rather than navigated. Both helpers now report whether a navigation was initiated so callers surface their existing visible error state instead of a false success.
- **Guard hoisted:** `isSafeNavigationUrl` moved from `cloud/lib/` to `packages/ui/src/utils/navigation-url.ts` (exported from the utils barrel); `cloud/lib/navigation-url.ts` remains as a compat re-export so existing cloud consumers are untouched.
- **Sinks wired:** invoice PDF / hosted-invoice links (also gained `noopener,noreferrer` + an error toast), cloud login `browserUrl`, `AddAccountDialog` OAuth, `SubscriptionStatus` Anthropic/OpenAI OAuth, the two connector `openAuthUrl` helpers, voice-profile export `downloadUrl`, hosted-checkout fallback in `ElizaCloudDashboard`, bug-report `fallback` URL, and the launcher / apps-section / plugins-view external-link paths.
- `openCloudBillingConsole` passes the new boolean through (all its callers `void` the promise).

### W5-034 — /embed/* middleware replaced the whole edge CSP (packages/app)

- `packages/app/functions/_middleware.ts` now swaps only the `frame-ancestors` value inside the inherited `_headers` CSP string instead of replacing the entire policy with a bare directive. The pinned `connect-src`/`frame-src`/`img-src` allowlists survive on the embed surface; unknown platforms still fail closed with `'none'`, and `X-Frame-Options` is still dropped so it cannot veto the CSP.

## Test evidence

- New: `packages/ui/src/utils/navigation-url.test.ts` (allowlist contract at its canonical home), `packages/ui/src/utils/openExternalUrl.test.ts` (enforcement: rejected schemes never reach `window.open`/bridge/popup; popup teardown; fallback paths) — 15 tests green. `cloud/lib/navigation-url.test.ts` slimmed to a re-export identity check.
- Updated: `packages/app/src/__tests__/embed-csp.test.ts` — 12 tests green, asserting the swap preserves all other directives, emits exactly one `frame-ancestors`, keeps the no-CSP fallback, and leaves non-embed paths untouched.
- Regression runs green: AddAccountDialog (component + unit), LauncherSurface, AutomationsFeed, ConnectorAccountList.oauth, OwnerAgentConnectorSetupPanel, VoiceProfileSection, PluginsView (+reorder), AppsSection.catalog-load-error, subscription-oauth-state, all 8 useCloudState suites, cloud-login-callsite-contract, plugin-view-connectors (+render), BlueBubblesCloudGatewayPanel, ConnectorQrPairingOverlay (127 tests total).
- `biome check` on every touched file: clean (the pre-existing `organizeImports` note in `_middleware.ts` predates this change; `functions/` is outside the package lint lane).
- Typecheck: packages/ui and packages/app show only pre-existing worktree-artifact errors (unbuilt `@elizaos/core/edge` dist, cross-worktree drizzle instance skew), verified identical on the clean tree via stash-and-rerun; the one error this change introduced (`billing-console.ts` return type) is fixed.

## Risk notes

- Behavior change is confined to failure paths: a navigation target outside http(s) (+ explicit per-caller opt-ins like the onboarding `sms:` link) now produces the surface's existing error state instead of opening. All legitimate flows use http(s) URLs, confirmed by the green suites above.
- `packages/app` visual audit (`audit:app`) not run: no rendered markup, styling, or layout changed — the app-side change is an edge middleware header transform, and the UI changes only gate error paths. Flagging per the visual-review contract rather than silently skipping.
- No AGENTS.md/CLAUDE.md files were modified, so the parity check is not applicable.