### PR TITLE
fix(cloud): reject malformed app-auth-connect JSON body

### DIFF
--- a/packages/cloud/api/v1/app-auth/connect/route.json.test.ts
+++ b/packages/cloud/api/v1/app-auth/connect/route.json.test.ts
@@ -1,0 +1,71 @@
+/**
+ * POST /api/v1/app-auth/connect used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+const APP_ID = "00000000-0000-4000-8000-0000000000aa";
+const connectUser = mock(async () => "created");
+const issueAppAuthCode = mock(async () => ({
+  code: "auth-1",
+  expiresAt: "2026-01-01T00:00:00.000Z",
+  expiresIn: 60,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKey: async () => ({ id: "user-1" }),
+}));
+
+mock.module("@/db/repositories/apps", () => ({
+  appsRepository: {
+    findPublicInfoById: async () => ({ id: APP_ID }),
+    connectUser,
+  },
+}));
+
+mock.module("@/lib/services/apps", () => ({
+  appsService: { getAllowedOrigins: async () => [] },
+}));
+
+mock.module("@/lib/services/app-auth-codes", () => ({
+  issueAppAuthCode,
+}));
+
+mock.module("@/lib/security/origin-validation", () => ({
+  isAllowedOrigin: () => true,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    error: () => undefined,
+  },
+}));
+
+const { default: app } = await import("./route");
+
+describe("POST /api/v1/app-auth/connect malformed JSON", () => {
+  test("returns 400 instead of 500 and never connects", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(connectUser).not.toHaveBeenCalled();
+    expect(issueAppAuthCode).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still issues an auth code", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ appId: APP_ID }),
+    });
+    expect(response.status).toBe(200);
+    expect(issueAppAuthCode).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/app-auth/connect/route.ts
+++ b/packages/cloud/api/v1/app-auth/connect/route.ts
@@ -35,7 +35,14 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKey(c);
 
-    const body = await c.req.json();
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
     const parsed = ConnectSchema.safeParse(body);
 
     if (!parsed.success) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on app-auth connect POST currently 500s. Not extra-decode / #21472. Not a list-limit / one-flag boolean change. Not tracker #21541 close-bait. Outside browser-sessions.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still issue an auth code. Malformed JSON (`{`, truncated objects) now 400s before `appsRepository.connectUser` instead of `failureResponse(SyntaxError)` → 500. Proven on the unfixed head: the same test received **500**.

# Background

## What does this PR do?

`POST /api/v1/app-auth/connect` called `await c.req.json()` inside a try whose catch maps unknown errors through `failureResponse` / `inferStatusFromLegacyError`. That helper does not treat `SyntaxError` / "Failed to parse JSON" as caller error, so truncated bodies became HTTP 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before Zod or the connect/issue path.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/app-auth/connect/route.json.test.ts` and the `c.req.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'v1/app-auth/connect/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500**. After the fix: 2 passed on `35b48e6a21bd3c7fb18c8592b05f46cf17a9d854`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:35b48e6a21bd3c7fb18c8592b05f46cf17a9d854 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the app-auth-connect HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before connect.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that `connectUser` / `issueAppAuthCode` are not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches appsRepository.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on app-auth-connect JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and canonical `{ appId }` still issues a code.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the app-auth-connect HTTP boundary.

## Audio / voice walkthrough

N/A - metadata POST only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
