### PR TITLE
fix(security): fail-closed Telegram DM policy and pairing churn hardening (W5-005, W5-023, W5-024)

### DIFF
--- a/packages/core/src/services/pairing-integration.test.ts
+++ b/packages/core/src/services/pairing-integration.test.ts
@@ -1,11 +1,21 @@
 /**
  * Pairing integration tests for channel connectors that gate DMs behind
  * `dmPolicy="pairing"`. The missing-service path must fail closed so a host
- * wiring mistake cannot silently turn pairing-gated DMs into open DMs.
+ * wiring mistake cannot silently turn pairing-gated DMs into open DMs, and
+ * the reply path must stay decoupled from request-row existence: churning
+ * sender identities at the pending-queue cap may not re-arm the unsolicited
+ * pairing-code reply. The PairingService is real; only storage is faked.
  */
-import { describe, expect, it, vi } from "vitest";
-import type { IAgentRuntime } from "../types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMockRuntime } from "../testing/mock-runtime";
+import type {
+	IAgentRuntime,
+	PairingAllowlistEntry,
+	PairingRequest,
+	UUID,
+} from "../types";
 import { ServiceType } from "../types/service";
+import { PairingService } from "./pairing";
 import { checkPairingAllowed } from "./pairing-integration";
 
 describe("checkPairingAllowed", () => {
@@ -31,5 +41,182 @@ describe("checkPairingAllowed", () => {
 		// Systemic misconfiguration must reach the agent/owner, not just a log.
 		expect(reportError).toHaveBeenCalledTimes(1);
 		expect(reportError.mock.calls[0][0]).toBe("pairing-integration");
+	});
+});
+
+describe("checkPairingAllowed reply suppression", () => {
+	const noop = () => undefined;
+
+	/**
+	 * Stateful in-memory adapter double behind a real PairingService, so the
+	 * queue-cap and reply-claim behavior is exercised end to end.
+	 */
+	function makeHarness() {
+		const requests: PairingRequest[] = [];
+		const allowlist: PairingAllowlistEntry[] = [];
+		const runtime = createMockRuntime({
+			getPairingRequests: (async (queries) =>
+				queries.map((query) => ({
+					channel: query.channel,
+					agentId: query.agentId,
+					requests: requests.filter(
+						(r) => r.channel === query.channel && r.agentId === query.agentId,
+					),
+				}))) as IAgentRuntime["getPairingRequests"],
+			createPairingRequest: (async (request: PairingRequest) => {
+				requests.push(request);
+				return request.id;
+			}) as IAgentRuntime["createPairingRequest"],
+			updatePairingRequest: (async (updated: PairingRequest) => {
+				const index = requests.findIndex((r) => r.id === updated.id);
+				if (index >= 0) {
+					requests[index] = updated;
+				}
+			}) as IAgentRuntime["updatePairingRequest"],
+			deletePairingRequest: (async (id: UUID) => {
+				const index = requests.findIndex((r) => r.id === id);
+				if (index >= 0) {
+					requests.splice(index, 1);
+				}
+			}) as IAgentRuntime["deletePairingRequest"],
+			getPairingAllowlists: (async (queries) =>
+				queries.map((query) => ({
+					channel: query.channel,
+					agentId: query.agentId,
+					entries: allowlist.filter(
+						(e) => e.channel === query.channel && e.agentId === query.agentId,
+					),
+				}))) as IAgentRuntime["getPairingAllowlists"],
+			createPairingAllowlistEntry: (async (entry: PairingAllowlistEntry) => {
+				allowlist.push(entry);
+				return entry.id;
+			}) as IAgentRuntime["createPairingAllowlistEntry"],
+			logger: {
+				debug: noop,
+				info: noop,
+				warn: noop,
+				error: noop,
+			} as unknown as IAgentRuntime["logger"],
+		});
+		let service: PairingService;
+		runtime.getService = (() =>
+			service) as unknown as IAgentRuntime["getService"];
+		service = new PairingService(runtime);
+		return { runtime, service, requests, allowlist };
+	}
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("replies once per sender, holds repeats, and re-arms after the TTL", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-10T00:00:00.000Z"));
+		const { runtime } = makeHarness();
+
+		const first = await checkPairingAllowed(runtime, {
+			channel: "discord",
+			senderId: "sender-a",
+		});
+		expect(first.allowed).toBe(false);
+		expect(first.newRequest).toBe(true);
+		expect(first.replyMessage).toContain(`Pairing code: ${first.pairingCode}`);
+
+		// A repeat message from the same sender returns the existing request
+		// without re-sending the unsolicited reply.
+		const repeat = await checkPairingAllowed(runtime, {
+			channel: "discord",
+			senderId: "sender-a",
+		});
+		expect(repeat).toMatchObject({
+			allowed: false,
+			newRequest: false,
+			pairingCode: first.pairingCode,
+		});
+		expect(repeat.replyMessage).toBeUndefined();
+
+		// Once the request has expired, the sender is re-notified with a fresh code.
+		vi.setSystemTime(new Date("2026-01-10T01:00:01.000Z"));
+		const afterExpiry = await checkPairingAllowed(runtime, {
+			channel: "discord",
+			senderId: "sender-a",
+		});
+		expect(afterExpiry.newRequest).toBe(true);
+		expect(afterExpiry.replyMessage).toContain(
+			`Pairing code: ${afterExpiry.pairingCode}`,
+		);
+	});
+
+	it("survives identity churn at the queue cap without re-replies or eviction", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-10T00:00:00.000Z"));
+		const { runtime, requests } = makeHarness();
+
+		// Fill the queue (maxPendingRequests defaults to 3).
+		for (const senderId of ["sender-a", "sender-b", "sender-c"]) {
+			const result = await checkPairingAllowed(runtime, {
+				channel: "discord",
+				senderId,
+			});
+			expect(result.replyMessage).toBeDefined();
+		}
+		expect(requests).toHaveLength(3);
+
+		// A fourth cycling identity is held at the cap: no new request, no
+		// reply, and the legitimate pending requests are not evicted.
+		const overflow = await checkPairingAllowed(runtime, {
+			channel: "discord",
+			senderId: "sender-d",
+		});
+		expect(overflow).toMatchObject({ allowed: false, idLabel: "userId" });
+		expect(overflow.pairingCode).toBeUndefined();
+		expect(overflow.replyMessage).toBeUndefined();
+		expect(requests.map((r) => r.senderId)).toEqual([
+			"sender-a",
+			"sender-b",
+			"sender-c",
+		]);
+
+		// Repeat messages from senders already holding a request stay silent.
+		for (const senderId of ["sender-a", "sender-b", "sender-c", "sender-d"]) {
+			const result = await checkPairingAllowed(runtime, {
+				channel: "discord",
+				senderId,
+			});
+			expect(result.replyMessage).toBeUndefined();
+		}
+		expect(requests).toHaveLength(3);
+	});
+
+	it("keeps the legitimate approve-and-admit flow working", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-10T00:00:00.000Z"));
+		const { runtime, service } = makeHarness();
+
+		const pending = await checkPairingAllowed(runtime, {
+			channel: "discord",
+			senderId: "sender-legit",
+		});
+		expect(pending.replyMessage).toBeDefined();
+
+		const approved = await service.approveCode({
+			channel: "discord",
+			code: pending.pairingCode ?? "",
+		});
+		expect(approved?.senderId).toBe("sender-legit");
+
+		const admitted = await checkPairingAllowed(runtime, {
+			channel: "discord",
+			senderId: "sender-legit",
+		});
+		expect(admitted).toEqual({ allowed: true });
+
+		// Approving freed the pending slot, so a new sender can pair again.
+		const next = await checkPairingAllowed(runtime, {
+			channel: "discord",
+			senderId: "sender-next",
+		});
+		expect(next.newRequest).toBe(true);
+		expect(next.replyMessage).toBeDefined();
 	});
 });

--- a/packages/core/src/services/pairing-integration.ts
+++ b/packages/core/src/services/pairing-integration.ts
@@ -121,20 +121,34 @@ export async function checkPairingAllowed(
 		metadata,
 	});
 
-	// Build the reply message
 	const idLabel = getPairingIdLabel(channel);
-	const replyMessage = buildPairingReplyMessage({
-		channel,
-		senderId,
-		code,
-		idLabel,
-	});
+
+	// The pending queue is at its cap — hold the sender silently. No "busy"
+	// notice is sent: it would be an unsolicited-message vector of its own,
+	// and the sender can complete pairing once a slot frees.
+	if (!code) {
+		return { allowed: false, idLabel };
+	}
+
+	// Reply at most once per request TTL per sender. Suppression rides on the
+	// PairingService reply claim rather than request-row existence, so
+	// deleting and recreating the request (expiry sweep, churn, moderation)
+	// cannot re-arm the unsolicited reply.
+	const replyMessage =
+		created && pairingService.claimPairingReply(channel, senderId)
+			? buildPairingReplyMessage({
+					channel,
+					senderId,
+					code,
+					idLabel,
+				})
+			: undefined;
 
 	return {
 		allowed: false,
 		pairingCode: code,
 		newRequest: created,
-		replyMessage: created ? replyMessage : undefined,
+		replyMessage,
 		idLabel,
 	};
 }

--- a/packages/core/src/services/pairing.test.ts
+++ b/packages/core/src/services/pairing.test.ts
@@ -1,9 +1,10 @@
 /**
  * Public PairingService contract tests: bounded pagination reads (the legacy
  * array APIs stay source-compatible while bounded pages carry validated
- * options into storage) and the pairing-code entropy source (CSPRNG-only,
- * fail-closed when no CSPRNG exists). The storage adapter is mocked; the
- * service under test is real.
+ * options into storage), the pairing-code entropy source (CSPRNG-only,
+ * fail-closed when no CSPRNG exists), the pending-queue cap (reject-at-max,
+ * never evict), and the per-sender pairing-reply claim window. The storage
+ * adapter is mocked; the service under test is real.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMockRuntime, MOCK_AGENT_ID } from "../testing/mock-runtime";
@@ -331,5 +332,106 @@ describe("PairingService pairing-code entropy", () => {
 		} finally {
 			vi.unstubAllGlobals();
 		}
+	});
+});
+
+describe("PairingService pending-queue cap", () => {
+	const noop = () => undefined;
+
+	function cappedQueueRuntime(pending: PairingRequest[]) {
+		const deletePairingRequest = vi.fn(async () => undefined);
+		const createPairingRequest = vi.fn(async () => undefined);
+		const updatePairingRequest = vi.fn(async () => undefined);
+		const runtime = createMockRuntime({
+			getPairingRequests: vi.fn(async () => [
+				{ channel: "discord", agentId: MOCK_AGENT_ID, requests: pending },
+			]),
+			createPairingRequest,
+			updatePairingRequest,
+			deletePairingRequest,
+			logger: {
+				debug: noop,
+				info: noop,
+				warn: noop,
+				error: noop,
+			} as unknown as IAgentRuntime["logger"],
+		});
+		return {
+			runtime,
+			deletePairingRequest,
+			createPairingRequest,
+			updatePairingRequest,
+		};
+	}
+
+	it("rejects a new sender at the cap instead of evicting the oldest pending request", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-10T00:00:00.000Z"));
+		const pending = [
+			request(1, new Date("2026-01-10T00:00:00.000Z")),
+			request(2, new Date("2026-01-10T00:00:01.000Z")),
+			request(3, new Date("2026-01-10T00:00:02.000Z")),
+		];
+		const { runtime, deletePairingRequest, createPairingRequest } =
+			cappedQueueRuntime(pending);
+
+		const result = await new PairingService(runtime, {
+			maxPendingRequests: 3,
+			requestTtlMs: Number.MAX_SAFE_INTEGER,
+		}).upsertRequest({ channel: "discord", senderId: "sender-new" });
+
+		expect(result).toEqual({ code: "", created: false, request: undefined });
+		expect(createPairingRequest).not.toHaveBeenCalled();
+		// The legitimate pending requests must survive a flood of new identities.
+		expect(deletePairingRequest).not.toHaveBeenCalled();
+	});
+
+	it("still refreshes an existing sender's request when the queue is full", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-10T00:00:00.000Z"));
+		const existing = request(1, new Date("2026-01-10T00:00:00.000Z"));
+		const pending = [
+			existing,
+			request(2, new Date("2026-01-10T00:00:01.000Z")),
+			request(3, new Date("2026-01-10T00:00:02.000Z")),
+		];
+		const { runtime, updatePairingRequest } = cappedQueueRuntime(pending);
+
+		const result = await new PairingService(runtime, {
+			maxPendingRequests: 3,
+			requestTtlMs: Number.MAX_SAFE_INTEGER,
+		}).upsertRequest({ channel: "discord", senderId: existing.senderId });
+
+		expect(result.created).toBe(false);
+		expect(result.code).toBe(existing.code);
+		expect(result.request?.senderId).toBe(existing.senderId);
+		expect(updatePairingRequest).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("PairingService pairing reply claims", () => {
+	function claimRuntime(): IAgentRuntime {
+		return createMockRuntime({
+			getPairingRequests: vi.fn(async () => [
+				{ channel: "discord", agentId: MOCK_AGENT_ID, requests: [] },
+			]),
+		});
+	}
+
+	it("claims at most one reply per sender per request TTL", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-10T00:00:00.000Z"));
+		const service = new PairingService(claimRuntime(), {
+			requestTtlMs: 60_000,
+		});
+
+		expect(service.claimPairingReply("discord", "sender-1")).toBe(true);
+		expect(service.claimPairingReply("discord", "sender-1")).toBe(false);
+		// Other senders and other channels are independent claims.
+		expect(service.claimPairingReply("discord", "sender-2")).toBe(true);
+		expect(service.claimPairingReply("telegram", "sender-1")).toBe(true);
+
+		vi.setSystemTime(new Date("2026-01-10T00:01:01.000Z"));
+		expect(service.claimPairingReply("discord", "sender-1")).toBe(true);
 	});
 });

--- a/packages/core/src/services/pairing.ts
+++ b/packages/core/src/services/pairing.ts
@@ -61,6 +61,18 @@ export class PairingService extends Service {
 
 	private pairingConfig: Required<PairingConfig>;
 
+	/**
+	 * Last-issued pairing-reply timestamps keyed `${channel}:${senderId}`.
+	 * Reply suppression is deliberately decoupled from request-row existence:
+	 * eviction, expiry cleanup, or manual deletion of the requests table must
+	 * not re-arm an unsolicited pairing reply for a sender who was already
+	 * answered within the TTL.
+	 */
+	private readonly pairingReplyClaims = new Map<string, number>();
+
+	/** Bound on retained reply claims before expired entries are swept. */
+	private static readonly MAX_PAIRING_REPLY_CLAIMS = 4096;
+
 	constructor(runtime: IAgentRuntime, config?: PairingConfig) {
 		super(runtime);
 		this.pairingConfig = {
@@ -280,6 +292,50 @@ export class PairingService extends Service {
 	}
 
 	/**
+	 * Claim the one pairing reply available to a sender per request TTL.
+	 *
+	 * Returns true at most once per `requestTtlMs` window per
+	 * (channel, senderId), no matter how often the sender's request row is
+	 * deleted and recreated in between. This keeps an attacker cycling
+	 * identities on one channel from turning request churn into a sustained
+	 * stream of unsolicited pairing replies from the operator's account.
+	 */
+	claimPairingReply(channel: PairingChannel, senderId: string): boolean {
+		const now = Date.now();
+		const key = `${channel}:${senderId}`;
+		const claimedAt = this.pairingReplyClaims.get(key);
+		if (
+			claimedAt !== undefined &&
+			now - claimedAt < this.pairingConfig.requestTtlMs
+		) {
+			return false;
+		}
+
+		if (
+			this.pairingReplyClaims.size >= PairingService.MAX_PAIRING_REPLY_CLAIMS
+		) {
+			// Lazy bound: drop expired claims first, then the oldest survivors
+			// (Map iteration is insertion-ordered). A claim evicted here simply
+			// re-arms one reply for that sender after a flood — never more.
+			for (const [claimKey, claimedAtMs] of this.pairingReplyClaims) {
+				if (now - claimedAtMs >= this.pairingConfig.requestTtlMs) {
+					this.pairingReplyClaims.delete(claimKey);
+				}
+			}
+			while (
+				this.pairingReplyClaims.size >= PairingService.MAX_PAIRING_REPLY_CLAIMS
+			) {
+				const oldest = this.pairingReplyClaims.keys().next().value;
+				if (oldest === undefined) break;
+				this.pairingReplyClaims.delete(oldest);
+			}
+		}
+
+		this.pairingReplyClaims.set(key, now);
+		return true;
+	}
+
+	/**
 	 * Create or update a pairing request for a sender.
 	 * If the sender already has a pending request, returns the existing code.
 	 * If too many pending requests exist, returns empty code.
@@ -314,13 +370,22 @@ export class PairingService extends Service {
 			};
 		}
 
-		// Check if we've hit the max pending requests limit
+		// Reject new senders once the pending queue is full. Pruning the oldest
+		// request to make room let an attacker cycling a handful of identities
+		// continuously evict legitimate senders' pending requests and re-arm a
+		// fresh pairing reply on every repeat message; reject-at-cap keeps the
+		// queue stable until requests expire or are approved.
 		if (existingRequests.length >= this.pairingConfig.maxPendingRequests) {
-			// Prune oldest request to make room
-			const oldest = existingRequests[0];
-			if (oldest) {
-				await this.runtime.deletePairingRequest(oldest.id);
-			}
+			this.runtime.logger.warn(
+				{
+					src: "service:pairing",
+					channel,
+					senderId,
+					maxPendingRequests: this.pairingConfig.maxPendingRequests,
+				},
+				"Rejecting pairing request: pending queue is full",
+			);
+			return { code: "", created: false, request: undefined };
 		}
 
 		// Generate a new unique code

--- a/packages/core/src/types/pairing.ts
+++ b/packages/core/src/types/pairing.ts
@@ -141,12 +141,16 @@ export function normalizePairingPageOptions(
  * Result of upserting a pairing request
  */
 export interface UpsertPairingRequestResult {
-	/** The pairing code (existing or newly generated) */
+	/**
+	 * The pairing code (existing or newly generated). Empty when the request
+	 * was rejected because the channel's pending queue is at
+	 * `maxPendingRequests` — pending requests are never evicted to make room.
+	 */
 	code: string;
 	/** Whether a new request was created (vs updating existing) */
 	created: boolean;
-	/** The full request object */
-	request: PairingRequest;
+	/** The full request object; absent when the request was rejected at the pending-queue cap */
+	request?: PairingRequest;
 }
 
 /**
@@ -197,7 +201,11 @@ export interface ChannelPairingAdapter {
  * Pairing configuration for DM access control
  */
 export interface PairingConfig {
-	/** Maximum pending requests per channel (default: 3) */
+	/**
+	 * Maximum pending requests per channel (default: 3). New senders are
+	 * rejected at the cap; pending requests are never pruned to make room, so
+	 * a flood of fresh identities cannot evict a legitimate sender's request.
+	 */
 	maxPendingRequests?: number;
 	/** Request expiration time in milliseconds (default: 1 hour) */
 	requestTtlMs?: number;

--- a/plugins/plugin-bluebubbles/__tests__/inbound-policy.test.ts
+++ b/plugins/plugin-bluebubbles/__tests__/inbound-policy.test.ts
@@ -29,6 +29,7 @@ function makeRuntime(
 			code: "PAIRCODE1",
 			created: options.pairingRequestCreated ?? true,
 		})),
+		claimPairingReply: vi.fn(() => true),
 	};
 	const handleMessage = vi.fn(async () => undefined);
 	const createMemory = vi.fn(async () => undefined);

--- a/plugins/plugin-imessage/__tests__/dm-policy.test.ts
+++ b/plugins/plugin-imessage/__tests__/dm-policy.test.ts
@@ -44,6 +44,7 @@ function makeService(
   const pairingService = {
     isAllowed: vi.fn(async () => options.pairingAllowed ?? false),
     upsertRequest: vi.fn(async () => ({ code: "PAIRCODE1", created: true })),
+    claimPairingReply: vi.fn(() => true),
   };
   const runtime = {
     agentId: "agent-1" as UUID,

--- a/plugins/plugin-imessage/src/accounts.ts
+++ b/plugins/plugin-imessage/src/accounts.ts
@@ -1,8 +1,12 @@
 /**
  * Multi-account configuration model for the iMessage connector: config shapes,
  * the merge order (env defaults < base config < per-account overrides), and the
- * DM/group policy + allowlist checks (`isIMessageUserAllowed`,
- * `isIMessageMentionRequired`) that decide whether an inbound message is handled.
+ * mention-policy check (`isIMessageMentionRequired`) that decides whether a
+ * group inbound message is handled. DM access is gated live by
+ * `IMessageService.checkDmAccess`, which routes the `pairing` policy through
+ * the core PairingService — there is intentionally no exported DM allow
+ * helper, because a synchronous policy check cannot honor the pairing
+ * handshake and would mislead importers into default-open behavior.
  * Config is read from `character.settings.imessage`. In practice one macOS host
  * runs a single Messages account (`DEFAULT_ACCOUNT_ID`); these helpers still model
  * the general inventory so the connector-account provider and service share one
@@ -296,63 +300,6 @@ export function resolveIMessageGroupConfig(
 
   // Fall back to base-level groups
   return multiConfig.groups?.[groupId];
-}
-
-/**
- * Checks if a user is allowed based on policy and allowlist
- */
-export function isIMessageUserAllowed(params: {
-  identifier: string;
-  accountConfig: IMessageAccountConfig;
-  isGroup: boolean;
-  groupId?: string;
-  groupConfig?: IMessageGroupConfig;
-}): boolean {
-  const { identifier, accountConfig, isGroup, groupConfig } = params;
-
-  if (isGroup) {
-    const policy = accountConfig.groupPolicy ?? "allowlist";
-    if (policy === "disabled") {
-      return false;
-    }
-
-    if (policy === "open") {
-      return true;
-    }
-
-    // Check group-specific allowlist first
-    if (groupConfig?.allowFrom?.length) {
-      return groupConfig.allowFrom.some((allowed) => String(allowed) === identifier);
-    }
-
-    // Check account-level group allowlist
-    if (accountConfig.groupAllowFrom?.length) {
-      return accountConfig.groupAllowFrom.some((allowed) => String(allowed) === identifier);
-    }
-
-    return policy !== "allowlist";
-  }
-
-  // DM handling
-  const policy = accountConfig.dmPolicy ?? "pairing";
-  if (policy === "disabled") {
-    return false;
-  }
-
-  if (policy === "open") {
-    return true;
-  }
-
-  if (policy === "pairing") {
-    return true;
-  }
-
-  // Allowlist policy
-  if (accountConfig.allowFrom?.length) {
-    return accountConfig.allowFrom.some((allowed) => String(allowed) === identifier);
-  }
-
-  return false;
 }
 
 /**

--- a/plugins/plugin-imessage/src/index.ts
+++ b/plugins/plugin-imessage/src/index.ts
@@ -29,7 +29,6 @@ export {
   type IMessageGroupConfig,
   type IMessageMultiAccountConfig,
   isIMessageMentionRequired,
-  isIMessageUserAllowed,
   isMultiAccountEnabled,
   listEnabledIMessageAccounts,
   listIMessageAccountIds,

--- a/plugins/plugin-telegram/AGENTS.md
+++ b/plugins/plugin-telegram/AGENTS.md
@@ -49,6 +49,7 @@ src/
   account-auth-service.ts     TelegramAccountAuthSession — GramJS MTProto auth state machine
   accounts.ts                 Multi-account config resolution (resolveTelegramAccount, listEnabledTelegramAccounts)
   connector-account-provider.ts  ConnectorAccountManager bridge (CRUD, no OAuth)
+  dm-policy.ts                TELEGRAM_DM_POLICY resolution + the private-chat gate shared by the full service and the standalone poller (fail-closed pairing default)
   interactions.ts             renderTelegramInteractions — inline keyboard / interaction rendering
   command-registration.ts     buildTelegramCommandDescriptors, registerTelegramCommandHandlers, applyTelegramSetMyCommands
   local-client.ts             TELEGRAM_LOCAL_MOCK_SESSION_PREFIX — mock session helpers
@@ -65,6 +66,7 @@ src/
   messageConnector.test.ts    Unit tests for connector registration and send routing (vitest, mocked runtime)
   command-registration.test.ts  Unit tests for command registration helpers
   connector-account-provider.test.ts  Unit tests for ConnectorAccountProvider
+  dm-policy.test.ts           Unit tests for the DM policy gate (fail-closed default, pairing delegation, middleware wiring)
   interactions-roundtrip.test.ts  Round-trip tests for interaction rendering
   interactions.test.ts        Unit tests for interaction rendering
 ```
@@ -90,7 +92,8 @@ bun run --cwd plugins/plugin-telegram clean          # rm dist .turbo
 |---|---|---|
 | `TELEGRAM_BOT_TOKEN` | Yes (default account) | Bot token from @BotFather; format `<id>:<alphanum>`. Read via `runtime.getSetting()` then `process.env`. |
 | `TELEGRAM_API_ROOT` | No | Override Telegram Bot API base URL (default `https://api.telegram.org`). Allows local Bot API server. |
-| `TELEGRAM_ALLOWED_CHATS` | No | JSON array of chat ID strings that the bot will respond to. If absent, all chats are allowed. Read via `runtime.getSetting()`. |
+| `TELEGRAM_ALLOWED_CHATS` | No | JSON array of chat ID strings that the bot will respond to; authoritative for every chat type when set. Read via `runtime.getSetting()`. |
+| `TELEGRAM_DM_POLICY` | No | `open` / `pairing` / `allowlist` / `disabled` — gates private chats when no allowlist is configured. Default `pairing` routes unknown senders through the core `checkPairingAllowed` handshake (fail closed); group chats are unaffected. |
 | `TELEGRAM_TEST_CHAT_ID` | No | Chat ID used by `TelegramTestSuite` for live smoke tests. |
 | `ELIZA_TELEGRAM_STANDALONE_BOT` | No | `1`/`true`/`yes` switches on the standalone long-poll mode (`TelegramStandaloneService`) — only honored when LifeOps passive connectors are disabled; otherwise the passive connector owns the long-poll. |
 
@@ -134,6 +137,7 @@ Account resolution order (for the `default` account): `character.settings.telegr
 - **GramJS (user-account)**: `account-auth-service.ts` uses the `telegram` npm package (GramJS/MTProto) for user-account login, distinct from the bot-API `telegraf` package used for bot accounts.
 - **ConnectorAccountManager**: registered in `init()`. Telegram bot accounts use long-lived bot tokens rather than OAuth, so start/complete OAuth flows are unsupported by design. Single-account env configs are surfaced as a synthetic `"default"` account.
 - **Sensitive request adapter**: `registerTelegramDmSensitiveRequestAdapter` (called in `init()`) wires Telegram DM delivery for secret / OAuth link-out requests, mirroring the Discord DM adapter.
+- **DM access fails closed by default.** With no `TELEGRAM_ALLOWED_CHATS` allowlist, private chats are gated by `TELEGRAM_DM_POLICY` (default `pairing` through the core PairingService; the code reply is issued at most once per sender per request TTL, and pending requests are rejected — never evicted — at the queue cap). `TELEGRAM_DM_POLICY=open` restores the legacy default-open behavior; non-private chats are unaffected because a bot only sees groups it was invited to. The standalone poller applies the same gate via `src/dm-policy.ts`.
 - See repo root `CLAUDE.md` for architecture rules, logging standards, and git workflow.
 
 ## Verification

--- a/plugins/plugin-telegram/CLAUDE.md
+++ b/plugins/plugin-telegram/CLAUDE.md
@@ -49,6 +49,7 @@ src/
   account-auth-service.ts     TelegramAccountAuthSession — GramJS MTProto auth state machine
   accounts.ts                 Multi-account config resolution (resolveTelegramAccount, listEnabledTelegramAccounts)
   connector-account-provider.ts  ConnectorAccountManager bridge (CRUD, no OAuth)
+  dm-policy.ts                TELEGRAM_DM_POLICY resolution + the private-chat gate shared by the full service and the standalone poller (fail-closed pairing default)
   interactions.ts             renderTelegramInteractions — inline keyboard / interaction rendering
   command-registration.ts     buildTelegramCommandDescriptors, registerTelegramCommandHandlers, applyTelegramSetMyCommands
   local-client.ts             TELEGRAM_LOCAL_MOCK_SESSION_PREFIX — mock session helpers
@@ -65,6 +66,7 @@ src/
   messageConnector.test.ts    Unit tests for connector registration and send routing (vitest, mocked runtime)
   command-registration.test.ts  Unit tests for command registration helpers
   connector-account-provider.test.ts  Unit tests for ConnectorAccountProvider
+  dm-policy.test.ts           Unit tests for the DM policy gate (fail-closed default, pairing delegation, middleware wiring)
   interactions-roundtrip.test.ts  Round-trip tests for interaction rendering
   interactions.test.ts        Unit tests for interaction rendering
 ```
@@ -90,7 +92,8 @@ bun run --cwd plugins/plugin-telegram clean          # rm dist .turbo
 |---|---|---|
 | `TELEGRAM_BOT_TOKEN` | Yes (default account) | Bot token from @BotFather; format `<id>:<alphanum>`. Read via `runtime.getSetting()` then `process.env`. |
 | `TELEGRAM_API_ROOT` | No | Override Telegram Bot API base URL (default `https://api.telegram.org`). Allows local Bot API server. |
-| `TELEGRAM_ALLOWED_CHATS` | No | JSON array of chat ID strings that the bot will respond to. If absent, all chats are allowed. Read via `runtime.getSetting()`. |
+| `TELEGRAM_ALLOWED_CHATS` | No | JSON array of chat ID strings that the bot will respond to; authoritative for every chat type when set. Read via `runtime.getSetting()`. |
+| `TELEGRAM_DM_POLICY` | No | `open` / `pairing` / `allowlist` / `disabled` — gates private chats when no allowlist is configured. Default `pairing` routes unknown senders through the core `checkPairingAllowed` handshake (fail closed); group chats are unaffected. |
 | `TELEGRAM_TEST_CHAT_ID` | No | Chat ID used by `TelegramTestSuite` for live smoke tests. |
 | `ELIZA_TELEGRAM_STANDALONE_BOT` | No | `1`/`true`/`yes` switches on the standalone long-poll mode (`TelegramStandaloneService`) — only honored when LifeOps passive connectors are disabled; otherwise the passive connector owns the long-poll. |
 
@@ -134,6 +137,7 @@ Account resolution order (for the `default` account): `character.settings.telegr
 - **GramJS (user-account)**: `account-auth-service.ts` uses the `telegram` npm package (GramJS/MTProto) for user-account login, distinct from the bot-API `telegraf` package used for bot accounts.
 - **ConnectorAccountManager**: registered in `init()`. Telegram bot accounts use long-lived bot tokens rather than OAuth, so start/complete OAuth flows are unsupported by design. Single-account env configs are surfaced as a synthetic `"default"` account.
 - **Sensitive request adapter**: `registerTelegramDmSensitiveRequestAdapter` (called in `init()`) wires Telegram DM delivery for secret / OAuth link-out requests, mirroring the Discord DM adapter.
+- **DM access fails closed by default.** With no `TELEGRAM_ALLOWED_CHATS` allowlist, private chats are gated by `TELEGRAM_DM_POLICY` (default `pairing` through the core PairingService; the code reply is issued at most once per sender per request TTL, and pending requests are rejected — never evicted — at the queue cap). `TELEGRAM_DM_POLICY=open` restores the legacy default-open behavior; non-private chats are unaffected because a bot only sees groups it was invited to. The standalone poller applies the same gate via `src/dm-policy.ts`.
 - See repo root `CLAUDE.md` for architecture rules, logging standards, and git workflow.
 
 ## Verification

--- a/plugins/plugin-telegram/README.md
+++ b/plugins/plugin-telegram/README.md
@@ -61,7 +61,8 @@ The plugin reads the token from the runtime setting `TELEGRAM_BOT_TOKEN` or `pro
 |---|---|---|
 | `TELEGRAM_BOT_TOKEN` | Yes (default account) | Bot token from @BotFather |
 | `TELEGRAM_API_ROOT` | No | Override Bot API base URL (e.g. local Bot API server). Default: `https://api.telegram.org` |
-| `TELEGRAM_ALLOWED_CHATS` | No | JSON array of chat ID strings the bot will respond to. If absent, all chats are allowed. Example: `["-100123456789"]` |
+| `TELEGRAM_ALLOWED_CHATS` | No | JSON array of chat ID strings the bot will respond to; authoritative for every chat type when set. Example: `["-100123456789"]` |
+| `TELEGRAM_DM_POLICY` | No | `open` / `pairing` / `allowlist` / `disabled` — gates private chats when no allowlist is configured. Default `pairing`: unknown senders get a one-time pairing code (core PairingService handshake) instead of full bot access, so an unconfigured bot is never default-open. Group chats are unaffected; a bot only sees groups it was invited to. |
 | `TELEGRAM_TEST_CHAT_ID` | No | Chat ID used by the live smoke-test suite |
 
 ## Enabling the plugin

--- a/plugins/plugin-telegram/__tests__/core-test-mock.ts
+++ b/plugins/plugin-telegram/__tests__/core-test-mock.ts
@@ -34,6 +34,14 @@ vi.mock("@elizaos/core", async () => {
   );
   const { ElizaError } = await import("../../../packages/core/src/errors");
 
+  // The pairing integration is a pure service lookup plus reply formatting
+  // over a duck-typed PairingService; the DM-policy suites exercise its real
+  // fail-closed behavior (missing service, queue cap, reply claims), so it is
+  // delegated rather than re-stubbed.
+  const { checkPairingAllowed } = await import(
+    "../../../packages/core/src/services/pairing-integration"
+  );
+
   const logger = {
     debug: vi.fn(),
     error: vi.fn(),
@@ -129,6 +137,7 @@ vi.mock("@elizaos/core", async () => {
     CommandRegistryService,
     ElizaError,
     EventType,
+    checkPairingAllowed,
     getConfiguredOwnerEntityIds: () => [],
     getDefaultTriageService,
     ModelType,

--- a/plugins/plugin-telegram/src/dm-policy.test.ts
+++ b/plugins/plugin-telegram/src/dm-policy.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for the Telegram DM access gate: `TELEGRAM_DM_POLICY` resolution
+ * (fail-closed default), the pairing handshake delegation shared by the full
+ * bot service and the standalone poller, and the `TelegramService`
+ * authorization middleware wiring. The PairingService is a duck-typed double;
+ * the core `checkPairingAllowed` integration runs for real.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  checkTelegramDmAccess,
+  DEFAULT_TELEGRAM_DM_POLICY,
+  resolveTelegramDmPolicy,
+} from "./dm-policy";
+import { TelegramService } from "./service";
+
+function makePairingRuntime(
+  options: {
+    pairingAllowed?: boolean;
+    pairingService?: boolean;
+    created?: boolean;
+    code?: string;
+    claim?: boolean;
+  } = {},
+) {
+  const pairingService = {
+    isAllowed: vi.fn(async () => options.pairingAllowed ?? false),
+    upsertRequest: vi.fn(async () => ({
+      code: options.code ?? "PAIRCODE1",
+      created: options.created ?? true,
+    })),
+    claimPairingReply: vi.fn(() => options.claim ?? true),
+  };
+  const runtime = {
+    agentId: "agent-1",
+    getSetting: vi.fn(() => undefined),
+    getService: vi.fn(() =>
+      options.pairingService === false ? null : pairingService,
+    ),
+    reportError: vi.fn(),
+    logger: { warn: vi.fn() },
+  } as unknown as IAgentRuntime;
+  return { runtime, pairingService };
+}
+
+describe("resolveTelegramDmPolicy", () => {
+  it("fails closed to pairing when the setting is absent or blank", () => {
+    expect(DEFAULT_TELEGRAM_DM_POLICY).toBe("pairing");
+    expect(resolveTelegramDmPolicy(undefined)).toBe("pairing");
+    expect(resolveTelegramDmPolicy(null)).toBe("pairing");
+    expect(resolveTelegramDmPolicy("")).toBe("pairing");
+    expect(resolveTelegramDmPolicy("   ")).toBe("pairing");
+  });
+
+  it("accepts the documented policies case-insensitively", () => {
+    expect(resolveTelegramDmPolicy("open")).toBe("open");
+    expect(resolveTelegramDmPolicy(" OPEN ")).toBe("open");
+    expect(resolveTelegramDmPolicy("Pairing")).toBe("pairing");
+    expect(resolveTelegramDmPolicy("ALLOWLIST")).toBe("allowlist");
+    expect(resolveTelegramDmPolicy("disabled")).toBe("disabled");
+  });
+
+  it("fails closed to the default on unrecognized values", () => {
+    expect(resolveTelegramDmPolicy("bogus")).toBe("pairing");
+    expect(resolveTelegramDmPolicy("open;drop")).toBe("pairing");
+  });
+});
+
+describe("checkTelegramDmAccess", () => {
+  it("allows everyone under the explicit open policy", async () => {
+    const { runtime, pairingService } = makePairingRuntime();
+
+    const access = await checkTelegramDmAccess(runtime, {
+      policy: "open",
+      senderId: "42",
+    });
+
+    expect(access).toEqual({ allowed: true });
+    expect(pairingService.isAllowed).not.toHaveBeenCalled();
+  });
+
+  it("denies silently under disabled and allowlist policies", async () => {
+    const { runtime, pairingService } = makePairingRuntime();
+
+    for (const policy of ["disabled", "allowlist"] as const) {
+      const access = await checkTelegramDmAccess(runtime, {
+        policy,
+        senderId: "42",
+      });
+      expect(access).toEqual({ allowed: false });
+    }
+    expect(pairingService.isAllowed).not.toHaveBeenCalled();
+  });
+
+  it("admits a pairing-approved sender without a reply", async () => {
+    const { runtime, pairingService } = makePairingRuntime({
+      pairingAllowed: true,
+    });
+
+    const access = await checkTelegramDmAccess(runtime, {
+      policy: "pairing",
+      senderId: "42",
+    });
+
+    expect(access).toEqual({ allowed: true });
+    expect(pairingService.isAllowed).toHaveBeenCalledWith("telegram", "42");
+    expect(pairingService.upsertRequest).not.toHaveBeenCalled();
+  });
+
+  it("holds an unknown sender and returns the one-time pairing reply", async () => {
+    const { runtime, pairingService } = makePairingRuntime();
+
+    const access = await checkTelegramDmAccess(runtime, {
+      policy: "pairing",
+      senderId: "42",
+      username: "ada",
+    });
+
+    expect(access.allowed).toBe(false);
+    expect(access.replyMessage).toContain("Pairing code: PAIRCODE1");
+    expect(pairingService.upsertRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        senderId: "42",
+        metadata: { username: "ada" },
+      }),
+    );
+  });
+
+  it("suppresses the reply when the sender was already answered", async () => {
+    const { runtime } = makePairingRuntime({ claim: false });
+
+    const access = await checkTelegramDmAccess(runtime, {
+      policy: "pairing",
+      senderId: "42",
+    });
+
+    expect(access).toEqual({ allowed: false });
+  });
+
+  it("holds the sender silently when the pending queue is full", async () => {
+    const { runtime } = makePairingRuntime({ code: "", created: false });
+
+    const access = await checkTelegramDmAccess(runtime, {
+      policy: "pairing",
+      senderId: "42",
+    });
+
+    expect(access).toEqual({ allowed: false });
+  });
+
+  it("fails closed when the PairingService is not registered", async () => {
+    const { runtime } = makePairingRuntime({ pairingService: false });
+
+    const access = await checkTelegramDmAccess(runtime, {
+      policy: "pairing",
+      senderId: "42",
+    });
+
+    expect(access.allowed).toBe(false);
+    expect(access.replyMessage).toBe(
+      "Access pairing is temporarily unavailable.",
+    );
+    expect(runtime.reportError).toHaveBeenCalled();
+  });
+});
+
+describe("TelegramService authorization middleware DM gate", () => {
+  type Middleware = (
+    ctx: unknown,
+    next: () => Promise<void>,
+    accountId?: string,
+  ) => Promise<void>;
+
+  function makeService(
+    settings: Record<string, unknown>,
+    options: Parameters<typeof makePairingRuntime>[0] = {},
+  ) {
+    const { runtime, pairingService } = makePairingRuntime(options);
+    runtime.getSetting = vi.fn(
+      (key: string) => settings[key],
+    ) as IAgentRuntime["getSetting"];
+    const service = Object.assign(
+      Object.create(TelegramService.prototype) as TelegramService,
+      { runtime, defaultAccountId: "default" },
+    );
+    const middleware = (
+      service as unknown as { authorizationMiddleware: Middleware }
+    ).authorizationMiddleware.bind(service);
+    return { middleware, pairingService };
+  }
+
+  function dmContext(reply = vi.fn(async () => ({}))) {
+    return {
+      chat: { id: 111, type: "private" },
+      from: { id: 42, username: "ada" },
+      reply,
+    };
+  }
+
+  it("denies an unconfigured DM by default and replies with the pairing code", async () => {
+    const { middleware } = makeService({});
+    const reply = vi.fn(async () => ({}));
+    const next = vi.fn(async () => undefined);
+
+    await middleware(dmContext(reply), next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledTimes(1);
+    expect(reply.mock.calls[0][0]).toContain("Pairing code: PAIRCODE1");
+  });
+
+  it("admits a configured DM chat from the allowlist without pairing", async () => {
+    const { middleware, pairingService } = makeService({
+      TELEGRAM_ALLOWED_CHATS: '["111"]',
+    });
+    const reply = vi.fn(async () => ({}));
+    const next = vi.fn(async () => undefined);
+
+    await middleware(dmContext(reply), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(reply).not.toHaveBeenCalled();
+    expect(pairingService.isAllowed).not.toHaveBeenCalled();
+  });
+
+  it("denies a DM chat missing from the allowlist without a pairing reply", async () => {
+    const { middleware } = makeService({
+      TELEGRAM_ALLOWED_CHATS: '["-100999"]',
+    });
+    const reply = vi.fn(async () => ({}));
+    const next = vi.fn(async () => undefined);
+
+    await middleware(dmContext(reply), next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it("keeps group chats open when nothing is configured", async () => {
+    const { middleware } = makeService({});
+    const next = vi.fn(async () => undefined);
+    const ctx = {
+      chat: { id: -100999, type: "supergroup" },
+      from: { id: 42, username: "ada" },
+      reply: vi.fn(async () => ({})),
+    };
+
+    await middleware(ctx, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores the legacy default-open DM behavior only under the explicit open policy", async () => {
+    const { middleware } = makeService({ TELEGRAM_DM_POLICY: "open" });
+    const next = vi.fn(async () => undefined);
+
+    await middleware(dmContext(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("denies a private chat with no stable sender id", async () => {
+    const { middleware } = makeService({});
+    const reply = vi.fn(async () => ({}));
+    const next = vi.fn(async () => undefined);
+    const ctx = { chat: { id: 111, type: "private" }, reply };
+
+    await middleware(ctx, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(reply).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-telegram/src/dm-policy.ts
+++ b/plugins/plugin-telegram/src/dm-policy.ts
@@ -1,0 +1,90 @@
+/**
+ * Telegram private-chat access policy shared by the full bot service and the
+ * standalone poller. `TELEGRAM_DM_POLICY` decides how a DM from an arbitrary
+ * Telegram user is gated when no `TELEGRAM_ALLOWED_CHATS` allowlist is
+ * configured; the default `pairing` delegates to the core PairingService code
+ * handshake so an unconfigured bot is never default-open to strangers.
+ */
+import { checkPairingAllowed, type IAgentRuntime, logger } from "@elizaos/core";
+
+/** DM gating modes accepted by `TELEGRAM_DM_POLICY`. */
+export type TelegramDmPolicy = "open" | "pairing" | "allowlist" | "disabled";
+
+/**
+ * Unset or unparsable policy values fail closed to `pairing`: unknown senders
+ * are held for owner approval instead of silently getting full bot access.
+ */
+export const DEFAULT_TELEGRAM_DM_POLICY: TelegramDmPolicy = "pairing";
+
+const TELEGRAM_DM_POLICIES: readonly TelegramDmPolicy[] = [
+  "open",
+  "pairing",
+  "allowlist",
+  "disabled",
+];
+
+/**
+ * Parse a raw `TELEGRAM_DM_POLICY` setting. Blank or absent input yields the
+ * default; unrecognized values are warned about and fail closed to the
+ * default rather than being treated as `open`.
+ */
+export function resolveTelegramDmPolicy(raw: unknown): TelegramDmPolicy {
+  if (raw === undefined || raw === null) {
+    return DEFAULT_TELEGRAM_DM_POLICY;
+  }
+  const normalized = String(raw).trim().toLowerCase();
+  if (!normalized) {
+    return DEFAULT_TELEGRAM_DM_POLICY;
+  }
+  if ((TELEGRAM_DM_POLICIES as readonly string[]).includes(normalized)) {
+    return normalized as TelegramDmPolicy;
+  }
+  logger.warn(
+    { src: "plugin:telegram", policy: normalized },
+    "Unrecognized TELEGRAM_DM_POLICY value; failing closed to the default pairing policy",
+  );
+  return DEFAULT_TELEGRAM_DM_POLICY;
+}
+
+/** Outcome of gating one inbound private chat against the DM policy. */
+export interface TelegramDmAccessDecision {
+  allowed: boolean;
+  /** Pairing-code reply to deliver to the sender, when one was issued. */
+  replyMessage?: string;
+}
+
+/**
+ * Evaluate one private-chat sender against the resolved DM policy. Only the
+ * `pairing` branch is stateful: it delegates to the core PairingService,
+ * which replies with a one-time code at most once per request TTL per sender.
+ * `allowlist` denies here because callers only reach this gate when no
+ * allowlist is configured; a configured allowlist decides before this runs.
+ */
+export async function checkTelegramDmAccess(
+  runtime: IAgentRuntime,
+  params: {
+    policy: TelegramDmPolicy;
+    senderId: string;
+    username?: string;
+  },
+): Promise<TelegramDmAccessDecision> {
+  const { policy, senderId, username } = params;
+
+  if (policy === "open") {
+    return { allowed: true };
+  }
+
+  if (policy === "disabled" || policy === "allowlist") {
+    return { allowed: false };
+  }
+
+  const pairing = await checkPairingAllowed(runtime, {
+    channel: "telegram",
+    senderId,
+    metadata: username ? { username } : undefined,
+  });
+  return {
+    allowed: pairing.allowed,
+    ...(pairing.replyMessage ? { replyMessage: pairing.replyMessage } : {}),
+  };
+}

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -57,6 +57,7 @@ import {
   registerTelegramCommandHandlers,
 } from "./command-registration";
 import { TELEGRAM_SERVICE_NAME } from "./constants";
+import { checkTelegramDmAccess, resolveTelegramDmPolicy } from "./dm-policy";
 import { resolveTelegramRuntimeEntityId } from "./identity";
 import { MessageManager } from "./messageManager";
 import {
@@ -1076,8 +1077,10 @@ export class TelegramService extends Service {
   }
 
   /**
-   * Authorization middleware - checks if chat is allowed to interact with the bot
-   * based on the TELEGRAM_ALLOWED_CHATS configuration.
+   * Authorization middleware - checks if chat is allowed to interact with the
+   * bot based on the TELEGRAM_ALLOWED_CHATS configuration and, for private
+   * chats without an allowlist, the TELEGRAM_DM_POLICY gate. A denied sender
+   * who was issued a pairing code receives it as a one-time reply.
    *
    * @param {Context} ctx - The context of the incoming update
    * @param {Function} next - The function to call to proceed to the next middleware
@@ -1089,7 +1092,8 @@ export class TelegramService extends Service {
     next: MiddlewareNext,
     accountId = this.defaultAccountId,
   ): Promise<void> {
-    if (!(await this.isGroupAuthorized(ctx, accountId))) {
+    const access = await this.checkChatAccess(ctx, accountId);
+    if (!access.allowed) {
       // Skip further processing if chat is not authorized
       logger.debug(
         {
@@ -1100,6 +1104,25 @@ export class TelegramService extends Service {
         },
         "Chat not authorized, skipping",
       );
+      if (access.pairingReplyMessage) {
+        try {
+          await ctx.reply(access.pairingReplyMessage);
+        } catch (error) {
+          // error-policy:J1 The middleware is the transport boundary: a failed
+          // pairing reply is logged with context and the update stays blocked;
+          // the sender can retry on their next message.
+          logger.warn(
+            {
+              src: "plugin:telegram",
+              agentId: this.runtime.agentId,
+              accountId,
+              chatId: ctx.chat?.id,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            "Failed to deliver pairing reply",
+          );
+        }
+      }
       return;
     }
     await next();
@@ -1263,61 +1286,101 @@ export class TelegramService extends Service {
   }
 
   /**
-   * Checks if a group is authorized, based on the TELEGRAM_ALLOWED_CHATS setting.
+   * Checks if a chat is authorized to interact with the bot.
+   *
+   * A configured allowlist (per-account `allowedChats`, else the
+   * TELEGRAM_ALLOWED_CHATS JSON array) is authoritative for every chat type.
+   * With no allowlist configured, non-private chats stay open — a bot only
+   * sees groups it was invited to — while private DMs fall to the
+   * TELEGRAM_DM_POLICY gate, which fails closed to the core pairing handshake
+   * by default so an unconfigured bot is never default-open to strangers.
+   *
    * @param {Context} ctx - The context of the incoming update.
-   * @returns {Promise<boolean>} A Promise that resolves with a boolean indicating if the group is authorized.
+   * @returns {Promise<{allowed: boolean, pairingReplyMessage?: string}>} The
+   *   access decision, plus the pairing-code reply to deliver when the DM
+   *   policy issued one.
    */
-  private async isGroupAuthorized(
+  private async checkChatAccess(
     ctx: Context,
     accountId = this.defaultAccountId,
-  ): Promise<boolean> {
+  ): Promise<{ allowed: boolean; pairingReplyMessage?: string }> {
     const chatId = ctx.chat?.id.toString();
     if (!chatId) {
-      return false;
+      return { allowed: false };
     }
 
     const accountAllowedChats =
       this.getAccountState(accountId)?.account.config.allowedChats;
     if (accountAllowedChats?.length) {
-      return accountAllowedChats.includes(chatId);
+      return { allowed: accountAllowedChats.includes(chatId) };
     }
 
     const allowedChats = this.runtime.getSetting("TELEGRAM_ALLOWED_CHATS");
-    if (!allowedChats) {
-      return true;
-    }
-    if (typeof allowedChats !== "string") {
-      logger.warn(
-        { src: "plugin:telegram", agentId: this.runtime.agentId, accountId },
-        "TELEGRAM_ALLOWED_CHATS must be a JSON array of chat-id strings; blocking all chats until fixed",
-      );
-      return false;
-    }
-
-    try {
-      const parsed = JSON.parse(allowedChats);
-      if (!Array.isArray(parsed)) {
-        // A bare JSON string (e.g. "-1001234567") would make `.includes` a
-        // substring match and silently over-authorize — fail closed instead.
+    if (allowedChats) {
+      if (typeof allowedChats !== "string") {
         logger.warn(
           { src: "plugin:telegram", agentId: this.runtime.agentId, accountId },
           "TELEGRAM_ALLOWED_CHATS must be a JSON array of chat-id strings; blocking all chats until fixed",
         );
-        return false;
+        return { allowed: false };
       }
-      return parsed.map((entry) => String(entry)).includes(chatId);
-    } catch (error) {
-      logger.error(
-        {
-          src: "plugin:telegram",
-          agentId: this.runtime.agentId,
-          accountId,
-          error: error instanceof Error ? error.message : String(error),
-        },
-        "Error parsing TELEGRAM_ALLOWED_CHATS",
-      );
-      return false;
+
+      try {
+        const parsed = JSON.parse(allowedChats);
+        if (!Array.isArray(parsed)) {
+          // A bare JSON string (e.g. "-1001234567") would make `.includes` a
+          // substring match and silently over-authorize — fail closed instead.
+          logger.warn(
+            {
+              src: "plugin:telegram",
+              agentId: this.runtime.agentId,
+              accountId,
+            },
+            "TELEGRAM_ALLOWED_CHATS must be a JSON array of chat-id strings; blocking all chats until fixed",
+          );
+          return { allowed: false };
+        }
+        return {
+          allowed: parsed.map((entry) => String(entry)).includes(chatId),
+        };
+      } catch (error) {
+        logger.error(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            accountId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Error parsing TELEGRAM_ALLOWED_CHATS",
+        );
+        return { allowed: false };
+      }
     }
+
+    if (ctx.chat?.type !== "private") {
+      return { allowed: true };
+    }
+
+    const senderId = ctx.from?.id?.toString();
+    if (!senderId) {
+      // A private chat without a stable sender id cannot complete the pairing
+      // handshake — fail closed rather than skipping the DM policy.
+      return { allowed: false };
+    }
+    const policy = resolveTelegramDmPolicy(
+      this.runtime.getSetting("TELEGRAM_DM_POLICY"),
+    );
+    const access = await checkTelegramDmAccess(this.runtime, {
+      policy,
+      senderId,
+      username: ctx.from?.username,
+    });
+    return {
+      allowed: access.allowed,
+      ...(access.replyMessage
+        ? { pairingReplyMessage: access.replyMessage }
+        : {}),
+    };
   }
 
   /**

--- a/plugins/plugin-telegram/src/standalone/handler.test.ts
+++ b/plugins/plugin-telegram/src/standalone/handler.test.ts
@@ -7,13 +7,35 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveTelegramRuntimeEntityId } from "../identity";
 import { handleTelegramStandaloneMessage } from "./handler";
 
-function makeRuntime() {
+function makeRuntime(
+  options: {
+    settings?: Record<string, unknown>;
+    pairingAllowed?: boolean;
+    pairingService?: boolean;
+  } = {},
+) {
   const cache = new Map<string, unknown>();
   const createMemory = vi.fn(async () => undefined);
   const handleMessage = vi.fn(async () => undefined);
+  const pairingService = {
+    isAllowed: vi.fn(async () => options.pairingAllowed ?? false),
+    upsertRequest: vi.fn(async () => ({ code: "PAIRCODE1", created: true })),
+    claimPairingReply: vi.fn(() => true),
+  };
   const runtime = {
     agentId: "agent-1",
-    getSetting: vi.fn(() => undefined),
+    // These tests exercise identity and redelivery, not the DM gate, so the
+    // policy defaults to the explicit open opt-in unless a case overrides it
+    // (a key present with an undefined value simulates an unset setting).
+    getSetting: vi.fn((key: string) => {
+      if (options.settings && key in options.settings) {
+        return options.settings[key];
+      }
+      return key === "TELEGRAM_DM_POLICY" ? "open" : undefined;
+    }),
+    getService: vi.fn(() =>
+      options.pairingService === false ? null : pairingService,
+    ),
     getCache: vi.fn(async (key: string) => cache.get(key)),
     setCache: vi.fn(async (key: string, value: unknown) => {
       cache.set(key, value);
@@ -24,7 +46,7 @@ function makeRuntime() {
     messageService: { handleMessage },
     reportError: vi.fn(),
   } as unknown as IAgentRuntime;
-  return { runtime, cache, createMemory, handleMessage };
+  return { runtime, cache, createMemory, handleMessage, pairingService };
 }
 
 function context(chatId: number, messageId = 7) {
@@ -134,5 +156,80 @@ describe("standalone Telegram durable identity", () => {
     expect(logged).not.toContain("hunter2");
     expect(logged).not.toContain("passphrase");
     infoSpy.mockRestore();
+  });
+});
+
+describe("standalone Telegram DM policy gate", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("holds an unconfigured private chat by default and replies with the pairing code", async () => {
+    const { runtime, handleMessage } = makeRuntime({
+      settings: { TELEGRAM_DM_POLICY: undefined },
+    });
+    const update = context(111);
+
+    await handleTelegramStandaloneMessage(runtime, update as never);
+
+    expect(handleMessage).not.toHaveBeenCalled();
+    expect(update.reply).toHaveBeenCalledTimes(1);
+    expect(update.reply.mock.calls[0][0]).toContain("Pairing code: PAIRCODE1");
+  });
+
+  it("fails closed when the PairingService is unavailable", async () => {
+    const { runtime, handleMessage } = makeRuntime({
+      settings: { TELEGRAM_DM_POLICY: undefined },
+      pairingService: false,
+    });
+    const update = context(111);
+
+    await handleTelegramStandaloneMessage(runtime, update as never);
+
+    expect(handleMessage).not.toHaveBeenCalled();
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "pairing-integration",
+      expect.any(Error),
+      expect.objectContaining({ channel: "telegram", senderId: "42" }),
+    );
+  });
+
+  it("admits a pairing-approved sender", async () => {
+    const { runtime, handleMessage } = makeRuntime({
+      settings: { TELEGRAM_DM_POLICY: undefined },
+      pairingAllowed: true,
+    });
+
+    await handleTelegramStandaloneMessage(runtime, context(111) as never);
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps group chats open when nothing is configured", async () => {
+    const { runtime, handleMessage } = makeRuntime({
+      settings: { TELEGRAM_DM_POLICY: undefined },
+    });
+    const update = context(111) as {
+      chat: { type: string };
+      message: { chat: { type: string } };
+    };
+    update.chat.type = "supergroup";
+    update.message.chat.type = "supergroup";
+
+    await handleTelegramStandaloneMessage(runtime, update as never);
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("still honors the allowlist before the DM policy", async () => {
+    const { runtime, handleMessage, pairingService } = makeRuntime({
+      settings: {
+        TELEGRAM_DM_POLICY: undefined,
+        TELEGRAM_ALLOWED_CHATS: '["111"]',
+      },
+    });
+
+    await handleTelegramStandaloneMessage(runtime, context(111) as never);
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(pairingService.isAllowed).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-telegram/src/standalone/handler.ts
+++ b/plugins/plugin-telegram/src/standalone/handler.ts
@@ -13,6 +13,7 @@ import {
   type Memory,
   type UUID,
 } from "@elizaos/core";
+import { checkTelegramDmAccess, resolveTelegramDmPolicy } from "../dm-policy";
 import { resolveTelegramRuntimeEntityId } from "../identity";
 
 function formatError(err: unknown): string {
@@ -158,6 +159,28 @@ export async function handleTelegramStandaloneMessage(
     );
     if (allowedChats && !allowedChats.has(chatId)) {
       return;
+    }
+
+    // With no allowlist configured, private DMs fall to the TELEGRAM_DM_POLICY
+    // gate — fail-closed pairing by default, so an unconfigured standalone bot
+    // is never default-open to arbitrary Telegram users. Non-private chats
+    // stay open; the bot only sees groups it was invited to.
+    if (!allowedChats && chat.type === "private") {
+      const policy = resolveTelegramDmPolicy(
+        runtime.getSetting("TELEGRAM_DM_POLICY") ??
+          process.env.TELEGRAM_DM_POLICY,
+      );
+      const access = await checkTelegramDmAccess(runtime, {
+        policy,
+        senderId: telegramUserId,
+        username: from?.username,
+      });
+      if (!access.allowed) {
+        if (access.replyMessage) {
+          await ctx.reply(access.replyMessage);
+        }
+        return;
+      }
     }
 
     logger.info(


### PR DESCRIPTION
## Summary

Wave-6 security remediation for the messaging surface, from the wave-5 re-audit (`artifacts/security-audit/wave5-report.md`).

### W5-005 (MEDIUM) — Telegram bot default-open when `TELEGRAM_ALLOWED_CHATS` is unset
- Added `TELEGRAM_DM_POLICY` (`open` / `pairing` / `allowlist` / `disabled`, default `pairing`), wired through the core `checkPairingAllowed` handshake exactly like the bluebubbles/imessage/whatsapp connectors. Unset or unparsable values fail closed to `pairing`.
- New shared gate `plugins/plugin-telegram/src/dm-policy.ts`, consumed by both the full `TelegramService` authorization middleware (`service.ts`, `isGroupAuthorized` → `checkChatAccess`) and the standalone poller (`standalone/handler.ts`).
- A denied sender who was issued a pairing request receives the one-time pairing-code reply; everything else is held silently.
- **Semantics preserved:** a configured allowlist (account-level or env) stays authoritative for every chat type; non-private chats remain open with no allowlist (a bot only sees groups it was invited to). `TELEGRAM_DM_POLICY=open` restores the legacy default-open behavior explicitly.

### W5-023 (LOW) — PairingService prune-oldest churn
- `upsertRequest` no longer evicts the oldest pending request at `maxPendingRequests`; it rejects the new sender with the documented empty-code result (`UpsertPairingRequestResult.request` is now optional for that case; the only in-repo caller destructures `code`/`created`).
- Reply suppression is decoupled from request-row existence: `PairingService.claimPairingReply(channel, senderId)` permits at most one pairing reply per request TTL per sender (bounded in-memory map, expired entries swept lazily), so deleting/recreating a request can no longer re-arm the unsolicited reply.
- Legitimate flow unchanged: ≤3 concurrent pending senders pair exactly as before, approvals free slots, existing senders refresh their request even when the queue is full.

### W5-024 (LOW, informational) — iMessage dead helper with fake-pairing semantics
- Deleted the exported `isIMessageUserAllowed` (pairing branch returned `true`). Zero in-repo callers (definition + barrel export only); `IMessageService.checkDmAccess` remains the live path.

## Test evidence
- New: `plugins/plugin-telegram/src/dm-policy.test.ts` (16 tests: policy resolution fail-closed matrix, pairing delegation, middleware wiring incl. allowlist precedence + group pass-through), `packages/core` pairing-integration churn tests (reply-once-per-sender, reject-at-cap without eviction, approve-and-admit), `PairingService` cap + reply-claim tests; standalone handler DM-gate tests.
- `plugins/plugin-telegram`: 22 files / 198 tests pass. `packages/core` pairing suites: 22 tests pass. `plugin-imessage` 153, `plugin-bluebubbles` 60, `plugin-slack` 128, `plugin-whatsapp` 66 (incl. PGLite real-runtime), `plugin-discord` dm-access/dm-policy 7 — all pass.
- Typecheck clean for `packages/core`, `plugin-telegram`, `plugin-imessage`, `plugin-bluebubbles`; biome clean on all changed files; `bun run check:agents-claude` passes (telegram AGENTS.md/CLAUDE.md pair updated byte-identically); plugin builds succeed.
- Note: two suite failures observed before fixes (`plugin-imessage` resolution of `@elizaos/core`, `plugin-whatsapp` pglite resolution of `@elizaos/plugin-sql`) were pre-existing worktree build gaps, proven by stash-and-rerun; resolved by building those packages in the worktree, after which the suites pass.

## Risk notes
- **Behavior change:** Telegram bots without an allowlist no longer answer stranger DMs by default; unknown senders get a pairing code (owner approves via `pairing approve telegram <code>`), and `TELEGRAM_DM_POLICY=open` opts back into the old behavior. This is the intended remediation, matching every other DM connector's default.
- Senders beyond the pending-queue cap now get silence instead of a code until a slot frees (≤ request TTL, default 1 h) — the trade the audit recommended over evicting legitimate requests.
- `UpsertPairingRequestResult.request` became optional and `isIMessageUserAllowed` was removed from the iMessage plugin's public surface — both grep-verified zero in-repo consumers; flagged for any third-party importer.
- The reply-claim window is process-local (consistent with the pre-existing in-memory suppression semantics); a restart can re-issue at most one reply per sender.