### PR TITLE
fix(security): close SSRF gaps in guarded media fetch paths and IPv4 classifier

### DIFF
--- a/packages/cloud/shared/src/lib/blob.test.ts
+++ b/packages/cloud/shared/src/lib/blob.test.ts
@@ -1,0 +1,135 @@
+// Exercises uploadFromUrl's SSRF-guarded fetch and streamed byte cap with a
+// mocked safeFetch and an in-memory R2 binding. Deterministic, no network.
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const safeFetchMock = vi.fn();
+
+vi.mock("./security/safe-fetch", () => ({
+  safeFetch: (...args: unknown[]) => safeFetchMock(...args),
+}));
+
+const { uploadFromUrl } = await import("./blob");
+const { setRuntimeR2Bucket } = await import("./storage/r2-runtime-binding");
+
+const MAX_BYTES = 25 * 1024 * 1024;
+
+const puts: Array<{ key: string; bytes: Uint8Array; contentType?: string }> = [];
+
+function streamResponse(
+  chunks: Uint8Array[],
+  init: { headers?: Record<string, string> } = {},
+): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    statusText: "OK",
+    headers: init.headers,
+  });
+}
+
+describe("uploadFromUrl", () => {
+  beforeEach(() => {
+    puts.length = 0;
+    safeFetchMock.mockReset();
+    setRuntimeR2Bucket({
+      get: async () => null,
+      put: async (
+        key: string,
+        value: unknown,
+        options?: { httpMetadata?: { contentType?: string } },
+      ) => {
+        puts.push({
+          key,
+          bytes: new Uint8Array(value as ArrayBuffer),
+          contentType: options?.httpMetadata?.contentType,
+        });
+      },
+      delete: async () => undefined,
+    });
+  });
+
+  afterEach(() => {
+    setRuntimeR2Bucket(null);
+  });
+
+  test("uploads a capped payload with the response content type", async () => {
+    const payload = new TextEncoder().encode("affiliate image bytes");
+    safeFetchMock.mockResolvedValue(
+      streamResponse([payload], { headers: { "content-type": "image/png" } }),
+    );
+
+    const result = await uploadFromUrl("https://images.example/avatar.png", {
+      filename: "avatar.png",
+      folder: "affiliate/char-1",
+    });
+
+    expect(puts).toHaveLength(1);
+    expect(puts[0].key).toMatch(/^affiliate\/char-1\/\d+-avatar\.png$/);
+    expect(Buffer.from(puts[0].bytes).toString()).toBe("affiliate image bytes");
+    expect(puts[0].contentType).toBe("image/png");
+    expect(result.size).toBe(payload.length);
+  });
+
+  test("propagates the outbound guard rejection without touching R2", async () => {
+    safeFetchMock.mockRejectedValue(new Error("Private or reserved IP addresses are not allowed"));
+
+    await expect(
+      uploadFromUrl("http://169.254.169.254/latest/meta-data", { filename: "x.png" }),
+    ).rejects.toThrow("Private or reserved IP addresses are not allowed");
+    expect(puts).toHaveLength(0);
+  });
+
+  test("rejects a non-OK response without reading the body", async () => {
+    safeFetchMock.mockResolvedValue(new Response("nope", { status: 404, statusText: "Not Found" }));
+
+    await expect(
+      uploadFromUrl("https://images.example/missing.png", { filename: "x.png" }),
+    ).rejects.toThrow("Failed to fetch URL: Not Found");
+    expect(puts).toHaveLength(0);
+  });
+
+  test("rejects a declared Content-Length above the cap before reading", async () => {
+    safeFetchMock.mockResolvedValue(
+      streamResponse([], {
+        headers: { "content-length": String(MAX_BYTES + 1) },
+      }),
+    );
+
+    await expect(
+      uploadFromUrl("https://images.example/huge.png", { filename: "x.png" }),
+    ).rejects.toThrow(`exceeds the ${MAX_BYTES}-byte cap`);
+    expect(puts).toHaveLength(0);
+  });
+
+  test("stops reading the stream once the running total crosses the cap", async () => {
+    // 2MB chunks: the 13th chunk (26MB) crosses the 25MB cap. If the reader
+    // bailed at the crossing instead of draining the body, the source can have
+    // produced at most a high-water-mark prefetch past it — never all 16.
+    let sent = 0;
+    const chunk = new Uint8Array(2 * 1024 * 1024).fill(1);
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (sent >= 16) {
+          controller.close();
+          return;
+        }
+        sent += 1;
+        controller.enqueue(chunk);
+      },
+    });
+    safeFetchMock.mockResolvedValue(new Response(stream, { status: 200, statusText: "OK" }));
+
+    await expect(
+      uploadFromUrl("https://images.example/lying.png", { filename: "x.png" }),
+    ).rejects.toThrow(`exceeds the ${MAX_BYTES}-byte cap`);
+    expect(sent).toBeLessThan(16);
+    expect(puts).toHaveLength(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/blob.ts
+++ b/packages/cloud/shared/src/lib/blob.ts
@@ -1,4 +1,5 @@
 // Defines cloud shared blob behavior for backend service consumers.
+import { safeFetch } from "./security/safe-fetch";
 import { getRuntimeR2Bucket, runtimeR2BucketConfigured } from "./storage/r2-runtime-binding";
 
 const DEFAULT_R2_PUBLIC_HOST = "blob.eliza.app";
@@ -158,23 +159,113 @@ export async function uploadBase64Image(
 }
 
 /**
+ * Upper bound on the bytes uploadFromUrl pulls through a caller-controlled
+ * URL. The body is streamed and cancelled as soon as the running total
+ * exceeds the cap, so a missing or lying Content-Length cannot force an
+ * unbounded allocation before the payload lands on the public blob host.
+ */
+const UPLOAD_FROM_URL_MAX_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Reads a response body under a hard byte cap, cancelling the stream as soon
+ * as the running total exceeds maxBytes instead of materializing the payload
+ * first. A declared Content-Length above the cap is rejected before any byte
+ * is read. Falls back to a post-read check only when the response exposes no
+ * stream.
+ */
+async function readResponseBodyWithCap(
+  response: Response,
+  maxBytes: number,
+  sourceUrl: string,
+): Promise<Buffer> {
+  const contentLength = response.headers.get("content-length");
+  const declaredLength = contentLength === null ? null : Number(contentLength);
+  if (declaredLength !== null && Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    try {
+      await response.body?.cancel();
+    } catch {
+      // error-policy:J6 Cancellation is best-effort teardown after the
+      // byte-limit failure has already been established.
+    }
+    throw new Error(
+      `Failed to fetch URL: content length ${declaredLength} exceeds the ${maxBytes}-byte cap (${sourceUrl})`,
+    );
+  }
+
+  const body = response.body;
+  if (!body) {
+    const fallback = Buffer.from(await response.arrayBuffer());
+    if (fallback.length > maxBytes) {
+      throw new Error(
+        `Failed to fetch URL: payload exceeds the ${maxBytes}-byte cap (${sourceUrl})`,
+      );
+    }
+    return fallback;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value.length) {
+        total += value.length;
+        if (total > maxBytes) {
+          try {
+            await reader.cancel();
+          } catch {
+            // error-policy:J6 Cancellation is best-effort teardown after the
+            // byte-limit failure has already been established.
+          }
+          throw new Error(
+            `Failed to fetch URL: payload exceeds the ${maxBytes}-byte cap (${sourceUrl})`,
+          );
+        }
+        chunks.push(value);
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // error-policy:J6 Stream lock release is best-effort teardown.
+    }
+  }
+
+  return Buffer.concat(
+    chunks.map((chunk) => Buffer.from(chunk)),
+    total,
+  );
+}
+
+/**
  * Downloads content from a URL and uploads it to R2 storage.
+ *
+ * The fetch goes through the SSRF-hardened safeFetch — every redirect hop is
+ * re-validated against the outbound guard and, on Node, pinned to the
+ * validated IP — and the body streams under UPLOAD_FROM_URL_MAX_BYTES, so a
+ * caller-controlled URL can neither read internal-network targets nor exhaust
+ * memory on its way onto the public blob host.
  *
  * @param sourceUrl - URL to download content from.
  * @param options - Upload options for the downloaded content.
  * @returns Upload result with URL and metadata.
- * @throws Error if the URL cannot be fetched.
+ * @throws Error if the outbound guard rejects the URL, the fetch fails, or the payload exceeds the byte cap.
  */
 export async function uploadFromUrl(
   sourceUrl: string,
   options: BlobUploadOptions,
 ): Promise<BlobUploadResult> {
-  const response = await fetch(sourceUrl);
+  const response = await safeFetch(sourceUrl);
   if (!response.ok) {
     throw new Error(`Failed to fetch URL: ${response.statusText}`);
   }
 
-  const buffer = Buffer.from(await response.arrayBuffer());
+  const buffer = await readResponseBodyWithCap(response, UPLOAD_FROM_URL_MAX_BYTES, sourceUrl);
   const contentType = options.contentType || response.headers.get("content-type") || undefined;
 
   return uploadToBlob(buffer, {

--- a/packages/core/src/network/ssrf.test.ts
+++ b/packages/core/src/network/ssrf.test.ts
@@ -120,6 +120,25 @@ describe("SSRF policy enforcement", () => {
 		expect(isPrivateIpAddress("2001:4860:4860::8888")).toBe(false);
 	});
 
+	it("classifies the special-purpose parity ranges the cloud guard blocks", () => {
+		// 198.18.0.0/15 (benchmarking) is internally routable on carrier/lab
+		// networks; 192.0.0.0/24 holds IETF protocol assignments; 224/4 is
+		// multicast and 240/4 is reserved (including 255.255.255.255).
+		expect(isPrivateIpAddress("198.18.0.1")).toBe(true);
+		expect(isPrivateIpAddress("198.19.255.254")).toBe(true);
+		expect(isPrivateIpAddress("192.0.0.1")).toBe(true);
+		expect(isPrivateIpAddress("192.0.0.170")).toBe(true);
+		expect(isPrivateIpAddress("224.0.0.1")).toBe(true);
+		expect(isPrivateIpAddress("239.255.255.255")).toBe(true);
+		expect(isPrivateIpAddress("240.0.0.1")).toBe(true);
+		expect(isPrivateIpAddress("255.255.255.255")).toBe(true);
+		// Just outside each added range stays public.
+		expect(isPrivateIpAddress("198.17.255.255")).toBe(false);
+		expect(isPrivateIpAddress("198.20.0.1")).toBe(false);
+		expect(isPrivateIpAddress("192.0.1.1")).toBe(false);
+		expect(isPrivateIpAddress("223.255.255.255")).toBe(false);
+	});
+
 	it("blocks localhost and internal hostnames after normalization", () => {
 		expect(isBlockedHostname("LOCALHOST.")).toBe(true);
 		expect(isBlockedHostname("metadata.google.internal")).toBe(true);

--- a/packages/core/src/network/ssrf.ts
+++ b/packages/core/src/network/ssrf.ts
@@ -190,7 +190,7 @@ function parseIpv4FromMappedIpv6(mapped: string): number[] | null {
 }
 
 function isPrivateIpv4(parts: number[]): boolean {
-	const [octet1, octet2] = parts;
+	const [octet1, octet2, octet3] = parts;
 	if (octet1 === 0) {
 		return true;
 	}
@@ -210,6 +210,17 @@ function isPrivateIpv4(parts: number[]): boolean {
 		return true;
 	}
 	if (octet1 === 100 && octet2 >= 64 && octet2 <= 127) {
+		return true;
+	}
+	// Special-purpose ranges kept in parity with the cloud outbound guard:
+	// not globally routable, but internally reachable on carrier/lab networks.
+	if (octet1 === 192 && octet2 === 0 && octet3 === 0) {
+		return true;
+	}
+	if (octet1 === 198 && (octet2 === 18 || octet2 === 19)) {
+		return true;
+	}
+	if (octet1 >= 224) {
 		return true;
 	}
 	return false;

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.image-fetch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.image-fetch.test.ts
@@ -1,0 +1,123 @@
+/**
+ * SSRF coverage for the bionic IMAGE_DESCRIPTION image fetch (W5-018).
+ *
+ * `imageUrlToBase64` resolves caller-influenced image URLs for the on-device
+ * vision describe loop on a bionic-delegated phone. URL-kind images must load
+ * through the shared `fetchRemoteMedia` guard (DNS pinning, byte cap, timeout)
+ * so the phone cannot be turned into an internal-network fetch oracle or an
+ * unbounded memory sink. Deterministic — `fetchRemoteMedia` is mocked except
+ * in the real-guard block, which asserts blocked literals never reach fetch.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mediaMocks = vi.hoisted(() => ({
+	fetchRemoteMedia: vi.fn(),
+	useRealFetchRemoteMedia: false,
+	realFetchRemoteMedia: null as
+		| null
+		| ((...args: unknown[]) => Promise<unknown>),
+}));
+
+vi.mock("@elizaos/core", async (importActual) => {
+	const actual = await importActual<typeof import("@elizaos/core")>();
+	mediaMocks.realFetchRemoteMedia = actual.fetchRemoteMedia as (
+		...args: unknown[]
+	) => Promise<unknown>;
+	return {
+		...actual,
+		fetchRemoteMedia: (...args: unknown[]) => {
+			if (
+				mediaMocks.useRealFetchRemoteMedia &&
+				mediaMocks.realFetchRemoteMedia
+			) {
+				return mediaMocks.realFetchRemoteMedia(...args);
+			}
+			return mediaMocks.fetchRemoteMedia(...args);
+		},
+	};
+});
+
+import { imageUrlToBase64 } from "./mobile-device-bridge-bootstrap";
+
+afterEach(() => {
+	mediaMocks.useRealFetchRemoteMedia = false;
+	vi.restoreAllMocks();
+	vi.clearAllMocks();
+});
+
+describe("imageUrlToBase64", () => {
+	it("returns the base64 payload of a data URL without fetching", async () => {
+		const payload = Buffer.from("hello bionic").toString("base64");
+		await expect(
+			imageUrlToBase64(`data:image/png;base64,${payload}`),
+		).resolves.toBe(payload);
+		expect(mediaMocks.fetchRemoteMedia).not.toHaveBeenCalled();
+	});
+
+	it("loads http(s) URLs through fetchRemoteMedia with the vision bounds", async () => {
+		const bytes = Buffer.from([9, 8, 7, 6]);
+		mediaMocks.fetchRemoteMedia.mockResolvedValue({
+			buffer: bytes,
+			contentType: "image/png",
+			fileName: "i.png",
+		});
+
+		await expect(imageUrlToBase64("https://example.test/i.png")).resolves.toBe(
+			bytes.toString("base64"),
+		);
+		expect(mediaMocks.fetchRemoteMedia).toHaveBeenCalledWith({
+			url: "https://example.test/i.png",
+			maxBytes: 20 * 1024 * 1024,
+			timeoutMs: 15_000,
+			maxRedirects: 5,
+		});
+	});
+
+	it("wraps a guarded-fetch failure with handler context and preserves the cause", async () => {
+		const cause = new Error("SSRF blocked");
+		mediaMocks.fetchRemoteMedia.mockRejectedValue(cause);
+
+		const err = await imageUrlToBase64(
+			"http://169.254.169.254/latest/meta-data",
+		).then(
+			() => {
+				throw new Error("expected imageUrlToBase64 to reject");
+			},
+			(caught: unknown) => caught,
+		);
+
+		expect(err).toBeInstanceOf(Error);
+		expect((err as Error).message).toContain(
+			"[mobile-device-bridge] IMAGE_DESCRIPTION failed to fetch http://169.254.169.254/latest/meta-data: SSRF blocked",
+		);
+		expect((err as Error).cause).toBe(cause);
+	});
+});
+
+describe("imageUrlToBase64 SSRF policy (real fetchRemoteMedia)", () => {
+	it.each([
+		"http://127.0.0.1/secret.png",
+		"http://[::1]/secret.png",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://localhost/internal.png",
+		"http://10.0.0.5/intranet.png",
+		"http://192.168.1.1/router.png",
+		"http://198.18.0.1/benchmark.png",
+		"file:///etc/passwd",
+	])(
+		"fails closed for blocked image URL %s without calling global fetch",
+		async (url) => {
+			mediaMocks.useRealFetchRemoteMedia = true;
+			const fetchMock = vi.fn();
+			vi.spyOn(globalThis, "fetch").mockImplementation(
+				fetchMock as typeof fetch,
+			);
+
+			await expect(imageUrlToBase64(url)).rejects.toThrow(
+				/Failed to fetch media|not allowed|blocked|private|loopback|link-local|Invalid URL|SSRF/i,
+			);
+			expect(fetchMock).not.toHaveBeenCalled();
+		},
+	);
+});

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -32,6 +32,7 @@ import {
 	type AgentRuntime,
 	applyBackgroundInferenceBudget,
 	ElizaError,
+	fetchRemoteMedia,
 	type GenerateTextParams,
 	getInferencePriorityGate,
 	type IAgentRuntime,
@@ -56,6 +57,10 @@ const DEFAULT_NATIVE_REQUEST_TIMEOUT_MS = 600_000;
 const DEFAULT_CALL_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const DEFAULT_LOAD_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const SERVICE_ENABLED = process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1";
+// Bounds for the bionic IMAGE_DESCRIPTION image fetch — same shape the
+// plugin-local-inference vision handlers apply (VISION_IMAGE_* there).
+const IMAGE_DESCRIPTION_FETCH_MAX_BYTES = 20 * 1024 * 1024;
+const IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS = 15_000;
 
 /**
  * Constant-time pairing-token comparison (W1-011). Callers fail closed when
@@ -2178,19 +2183,32 @@ export async function attachMobileDeviceBridgeToServer(
 	await mobileDeviceBridge.attachToHttpServer(server);
 }
 
-/** Resolve a data:/http(s)/file image URL to base64 image bytes for the host. */
-async function imageUrlToBase64(url: string): Promise<string> {
+/** Resolve a data:/http(s) image URL to base64 image bytes for the host. */
+export async function imageUrlToBase64(url: string): Promise<string> {
 	if (url.startsWith("data:")) {
 		const comma = url.indexOf(",");
 		return comma >= 0 ? url.slice(comma + 1) : url;
 	}
-	const resp = await fetch(url);
-	if (!resp.ok) {
+	try {
+		// Caller-influenced image URLs must go through the shared SSRF media
+		// guard; a bare `fetch` would let a bionic-delegated phone describe
+		// internal hosts or pull an unbounded payload into memory.
+		const media = await fetchRemoteMedia({
+			url,
+			maxBytes: IMAGE_DESCRIPTION_FETCH_MAX_BYTES,
+			timeoutMs: IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS,
+			maxRedirects: 5,
+		});
+		return media.buffer.toString("base64");
+	} catch (err) {
+		// error-policy:J2 context-adding rethrow — preserve guarded-fetch cause
 		throw new Error(
-			`[mobile-device-bridge] IMAGE_DESCRIPTION failed to fetch ${url}: ${resp.status}`,
+			`[mobile-device-bridge] IMAGE_DESCRIPTION failed to fetch ${url}: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+			{ cause: err },
 		);
 	}
-	return Buffer.from(await resp.arrayBuffer()).toString("base64");
 }
 
 /**


### PR DESCRIPTION
## Summary

Wave-6 security remediation for three SSRF findings from the wave-5 re-audit. Each fix reuses the repository's existing guard primitives and ships with focused tests.

### W5-018 — plugin-capacitor-bridge: guard the bionic IMAGE_DESCRIPTION fetch

- `imageUrlToBase64` (`plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts`) resolved caller-influenced image URLs with a bare `fetch` + unbounded `arrayBuffer()`; the parallel local-inference vision paths were already guarded and this one was missed.
- Now routes through the shared `fetchRemoteMedia` guard (SSRF screening with DNS pinning, 20 MB byte cap, 15 s timeout, 5 re-validated redirect hops) — the same bounds the plugin-local-inference vision handlers apply (`VISION_IMAGE_MAX_BYTES` / `VISION_IMAGE_FETCH_TIMEOUT_MS`).
- Failures keep the `[mobile-device-bridge] IMAGE_DESCRIPTION failed to fetch …` context with the guarded-fetch error preserved as `cause` (`error-policy:J2`).
- New `mobile-device-bridge-bootstrap.image-fetch.test.ts` (11 tests): data-URL passthrough without fetch, exact guard bounds, error wrapping with cause, and real-guard fail-closed coverage for loopback / link-local / private / benchmarking-range / `file://` URLs without touching the network.

### W5-019 — cloud-shared: rebuild `uploadFromUrl` on safeFetch + streamed byte cap

- `uploadFromUrl` (`packages/cloud/shared/src/lib/blob.ts`) raw-fetched arbitrary URLs and buffered the full response into memory before uploading to R2. Latent today (sole consumer `processAffiliateImages` has no in-repo callers); fixed before a caller appears.
- The download now goes through `safeFetch` (per-hop outbound-URL validation, IP-pinned connections on Node) and streams through a new 25 MB cap (`readResponseBodyWithCap`): an over-cap declared `Content-Length` is rejected before any byte is read, and the running stream total is enforced as chunks arrive so a missing or lying length cannot force an unbounded allocation.
- New `blob.test.ts` (5 tests, deterministic — mocked `safeFetch`, in-memory R2 binding): success path with content-type propagation, guard rejection without R2 write, non-OK response, declared-length rejection, and early stream termination once the cap is crossed.

### W5-038 — core: IPv4 classifier parity with the cloud outbound guard

- `isPrivateIpv4` (`packages/core/src/network/ssrf.ts`) now also classifies `192.0.0.0/24`, `198.18.0.0/15`, `224/4` (multicast), and `240/4` (reserved, incl. 255.255.255.255) as non-public, matching the cloud outbound guard in `packages/cloud/shared/src/lib/security/outbound-url.ts`.
- `ssrf.test.ts` extended with boundary coverage: inside each new range blocked, just outside stays public.

## Validation

- `packages/core`: `vitest run src/network/` — 59/59 pass (incl. extended `ssrf.test.ts`, 24/24); `tsc --noEmit` clean; multi-target build green.
- `plugins/plugin-capacitor-bridge`: full `vitest run` — 23 files, 141 passed / 2 skipped; `tsc --noEmit -p tsconfig.build.json` clean.
- `packages/cloud/shared`: `bun test --isolate src/lib/security/ src/lib/blob.test.ts` — 82/82 pass; `tsc --noEmit` clean. Full `src/lib/` sweep (704 files) shows only load-flake timeouts in timing-sensitive storage/backup/oauth suites unrelated to this change — each flaked file passes standalone (22/22 and 24/24).
- `biome check` clean on every touched file.

## Risk notes

- `imageUrlToBase64` no longer attempts `file:` URLs; the previous bare `fetch` could not resolve them on this stack either, so no working path was removed. The function is newly exported for the test only and is not added to the package barrel.
- `uploadFromUrl` keeps its signature; the 25 MB ceiling is a new behavioral bound on a currently-unreachable path, aligned in shape with the sibling `uploadBase64Image` size guard.
- The widened core classifier blocks four additional special-purpose IPv4 ranges on every core-guarded fetch path; no first-party code fetches from those ranges, and the cloud guard already blocks them.
