### PR TITLE
fix(security): wave-6 agent/app-core hardening — pair relay, WS pre-auth bounds, config classifier

### DIFF
--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -122,6 +122,13 @@ State and platform:
 
 Cloud + models:
 - `ELIZAOS_CLOUD_ENABLED`, `ELIZAOS_CLOUD_API_KEY`, `ELIZAOS_CLOUD_BASE_URL`, `ELIZA_CLOUD_PROVISIONED`.
+- `ELIZA_CLOUD_PAIR_DIRECT_RELAY=1` enables the loopback-only `/pair` relay
+  (`api/cloud-pair-route.ts`). Non-loopback peers additionally require
+  `ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS` (comma-separated CIDRs, default
+  empty): local-Docker deployments publish the port on the host loopback, so
+  the in-container peer is the bridge gateway — allow exactly that range, e.g.
+  `172.17.0.0/16`. Each entry widens pairing-token redemption to that LAN/VPC
+  segment; keep the list minimal.
 - Model overrides: `ELIZAOS_CLOUD_{NANO,SMALL,MEDIUM,LARGE,MEGA}_MODEL`, `ELIZAOS_CLOUD_{PLANNER,ACTION_PLANNER,SHOULD_RESPOND,RESPONSE_HANDLER}_MODEL`.
 - Provider keys: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`.
 

--- a/packages/agent/CLAUDE.md
+++ b/packages/agent/CLAUDE.md
@@ -122,6 +122,13 @@ State and platform:
 
 Cloud + models:
 - `ELIZAOS_CLOUD_ENABLED`, `ELIZAOS_CLOUD_API_KEY`, `ELIZAOS_CLOUD_BASE_URL`, `ELIZA_CLOUD_PROVISIONED`.
+- `ELIZA_CLOUD_PAIR_DIRECT_RELAY=1` enables the loopback-only `/pair` relay
+  (`api/cloud-pair-route.ts`). Non-loopback peers additionally require
+  `ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS` (comma-separated CIDRs, default
+  empty): local-Docker deployments publish the port on the host loopback, so
+  the in-container peer is the bridge gateway — allow exactly that range, e.g.
+  `172.17.0.0/16`. Each entry widens pairing-token redemption to that LAN/VPC
+  segment; keep the list minimal.
 - Model overrides: `ELIZAOS_CLOUD_{NANO,SMALL,MEDIUM,LARGE,MEGA}_MODEL`, `ELIZAOS_CLOUD_{PLANNER,ACTION_PLANNER,SHOULD_RESPOND,RESPONSE_HANDLER}_MODEL`.
 - Provider keys: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`.
 

--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -38,6 +38,7 @@ const AGENT_ID = "55555555-5555-4555-8555-555555555555";
 const MANAGED_ENV_KEYS = [
   "ELIZA_CLOUD_PROVISIONED",
   "ELIZA_CLOUD_PAIR_DIRECT_RELAY",
+  "ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS",
   "ELIZA_CLOUD_AGENT_ID",
   "WAIFU_ELIZA_CLOUD_AGENT_ID",
   "ELIZAOS_CLOUD_BASE_URL",
@@ -278,7 +279,7 @@ describe("handleStandaloneCloudPairRoute", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("allows the explicit local-provider relay for loopback and local-Docker peers", async () => {
+  it("allows the explicit local-provider relay for loopback and allowlisted Docker-gateway peers", async () => {
     const fetchMock = vi.fn().mockImplementation(() =>
       Promise.resolve(
         new Response(
@@ -332,11 +333,11 @@ describe("handleStandaloneCloudPairRoute", () => {
       }),
     );
 
-    // Local-Docker deployments publish the port on the host's loopback, so
-    // inside the container the TCP peer is the bridge gateway — a private
-    // address, not 127.0.0.1. That supported flow must keep working.
+    // W5-016: private-range peers are NO LONGER admitted by default. The
+    // local-Docker flow (port published on the host loopback, so the in-container
+    // peer is the bridge gateway) requires the explicit CIDR allowlist.
     fetchMock.mockClear();
-    const dockerHarness = fakeRes();
+    const dockerDefaultHarness = fakeRes();
     await handleStandaloneCloudPairRoute(
       fakeReq({
         pathname: "/pair",
@@ -345,10 +346,62 @@ describe("handleStandaloneCloudPairRoute", () => {
         proto: "http",
         ip: "172.17.0.1",
       }),
-      dockerHarness.res,
+      dockerDefaultHarness.res,
     );
-    expect(dockerHarness.status()).toBe(200);
-    expect(fetchMock).toHaveBeenCalled();
+    expect(dockerDefaultHarness.status()).toBe(421);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS = "172.17.0.0/16";
+    try {
+      fetchMock.mockClear();
+      const dockerHarness = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=pair-token",
+          host: "127.0.0.1:43123",
+          proto: "http",
+          ip: "172.17.0.1",
+        }),
+        dockerHarness.res,
+      );
+      expect(dockerHarness.status()).toBe(200);
+      expect(fetchMock).toHaveBeenCalled();
+
+      // Dual-stack sockets report IPv4 peers in IPv4-mapped spelling.
+      fetchMock.mockClear();
+      const mappedHarness = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=pair-token",
+          host: "127.0.0.1:43123",
+          proto: "http",
+          ip: "::ffff:172.17.0.1",
+        }),
+        mappedHarness.res,
+      );
+      expect(mappedHarness.status()).toBe(200);
+      expect(fetchMock).toHaveBeenCalled();
+
+      // The allowlist admits ONLY its ranges — other LAN/VPC peers stay out.
+      fetchMock.mockClear();
+      const lanHarness = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=pair-token",
+          host: "127.0.0.1:43123",
+          proto: "http",
+          ip: "192.168.1.10",
+        }),
+        lanHarness.res,
+      );
+      expect(lanHarness.status()).toBe(421);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS;
+    }
 
     fetchMock.mockClear();
     const publicHarness = fakeRes();

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -2,11 +2,24 @@
  * Loopback-only `/pair` relay for standalone agent servers.
  * Remote managed pairing terminates at the Cloud edge; explicit local Docker
  * retains this handler so the one-time token resolves before the SPA fallback.
+ *
+ * Peer admission when `ELIZA_CLOUD_PAIR_DIRECT_RELAY=1`: loopback peers only,
+ * plus any ranges in the optional `ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS`
+ * comma-separated CIDR allowlist (default empty). The supported local-Docker
+ * deployment publishes the port on the host's loopback, so inside the
+ * container the TCP peer is the bridge gateway rather than 127.0.0.1 — set
+ * e.g. `ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS=172.17.0.0/16` (default bridge)
+ * to admit exactly that gateway range. Every CIDR entry widens token
+ * redemption to that LAN/VPC segment, so keep the list as narrow as the
+ * deployment allows.
  */
 
 import type http from "node:http";
-import { isPrivateIpAddress, logger } from "@elizaos/core";
-import { isLoopbackRemoteAddress } from "@elizaos/shared";
+import { logger } from "@elizaos/core";
+import {
+  isLoopbackRemoteAddress,
+  isRemoteAddressInCidrList,
+} from "@elizaos/shared";
 import {
   type CloudPairRelaySession,
   parseCloudPairRelaySession,
@@ -63,12 +76,19 @@ function canUseManagedDirectRelay(req: http.IncomingMessage): boolean {
   // The local-only gate must key on the TCP peer, never on request headers:
   // Host and X-Forwarded-Host are client-controlled, so a remote caller
   // could previously spoof a loopback origin and redeem a held pairing token
-  // through this relay (W1-037). Private-range peers are accepted because
-  // the supported local-Docker deployment publishes the port on the host's
-  // loopback, so inside the container the peer is the bridge gateway rather
-  // than 127.0.0.1.
+  // through this relay (W1-037). Non-loopback peers are admitted only through
+  // the explicit ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS allowlist (W5-016) —
+  // a broad private-range admission would let any LAN/VPC host redeem a
+  // leaked token, far beyond the local-Docker bridge gateway the relay
+  // exists for.
   const peer = req.socket?.remoteAddress;
-  return isLoopbackRemoteAddress(peer) || isPrivateIpAddress(peer ?? "");
+  return (
+    isLoopbackRemoteAddress(peer) ||
+    isRemoteAddressInCidrList(
+      peer,
+      process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS,
+    )
+  );
 }
 
 function escapeHtml(value: string): string {

--- a/packages/agent/src/api/server-auth-boundary.test.ts
+++ b/packages/agent/src/api/server-auth-boundary.test.ts
@@ -8,6 +8,10 @@
  *    boot phase) for callers that fail the trusted-local check.
  *  - W1-011: the device-bridge WS path fails closed (HTTP 404) when the
  *    bridge cannot be attached, instead of skipping WS auth unconditionally.
+ *  - W5-015: unauthenticated /ws sockets are bounded — a per-peer cap on
+ *    concurrent pre-auth upgrades and a post-open auth grace period that
+ *    closes sockets which never authenticate — while the post-open token
+ *    flow keeps working.
  * Boots the real `startApiServer` on an ephemeral loopback port with an
  * explicit API token; a remote caller is simulated with a non-loopback
  * X-Forwarded-For, which the trusted-local classifier treats as untrusted.
@@ -17,8 +21,15 @@ import { mkdtemp, rm } from "node:fs/promises";
 import net from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
 import { startApiServer } from "./server.ts";
+import {
+  __resetPendingWebSocketsForTests,
+  MAX_PENDING_WEBSOCKETS_PER_PEER,
+  pendingWebSocketCount,
+  WS_AUTH_GRACE_TIMEOUT_MS,
+} from "./server-helpers-auth.ts";
 
 // The gate contract under test lives in server.ts. The cloud plugin's own
 // handler is NOT exercised here: under the source-alias test environment the
@@ -214,4 +225,114 @@ describe("device-bridge WS upgrade gate (W1-011)", () => {
     );
     expect(raw.startsWith("HTTP/1.1 404 Not Found")).toBe(true);
   }, 120_000);
+});
+
+describe("unauthenticated /ws bounds (W5-015)", () => {
+  beforeEach(() => {
+    __resetPendingWebSocketsForTests();
+  });
+
+  function openUnauthenticatedWs(port: number): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      ws.once("open", () => resolve(ws));
+      ws.once("error", reject);
+    });
+  }
+
+  function waitForClose(ws: WebSocket, timeoutMs: number): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("timed out waiting for the server close")),
+        timeoutMs,
+      );
+      ws.once("close", (code: number) => {
+        clearTimeout(timer);
+        resolve(code);
+      });
+    });
+  }
+
+  /** Waits for a specific frame type, ignoring the interleaved status/replay. */
+  function waitForFrame(ws: WebSocket, type: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`timed out waiting for ${type}`)),
+        5_000,
+      );
+      ws.on("message", (data: unknown) => {
+        const msg = JSON.parse(String(data)) as { type?: string };
+        if (msg.type === type) {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+  }
+
+  it("closes a socket that never authenticates after the grace period", async () => {
+    const baseUrl = await bootServer();
+    const port = Number(new URL(baseUrl).port);
+    const ws = await openUnauthenticatedWs(port);
+    expect(pendingWebSocketCount("127.0.0.1")).toBe(1);
+
+    const code = await waitForClose(ws, WS_AUTH_GRACE_TIMEOUT_MS + 8_000);
+    expect(code).toBe(1008);
+    // The pre-auth slot is released once the closed socket is reaped.
+    await vi.waitFor(() => {
+      expect(pendingWebSocketCount("127.0.0.1")).toBe(0);
+    });
+  }, 30_000);
+
+  it("keeps the post-open token auth flow working past the grace period", async () => {
+    const baseUrl = await bootServer();
+    const port = Number(new URL(baseUrl).port);
+    const ws = await openUnauthenticatedWs(port);
+
+    const authOk = waitForFrame(ws, "auth-ok");
+    ws.send(JSON.stringify({ type: "auth", token: API_TOKEN }));
+    await authOk;
+    // Authentication released the pre-auth slot.
+    expect(pendingWebSocketCount("127.0.0.1")).toBe(0);
+
+    // Wait out the grace period: an authenticated socket must survive it.
+    await new Promise((resolve) =>
+      setTimeout(resolve, WS_AUTH_GRACE_TIMEOUT_MS + 1_500),
+    );
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+
+    const pong = waitForFrame(ws, "pong");
+    ws.send(JSON.stringify({ type: "ping" }));
+    await pong;
+    ws.close();
+    await vi.waitFor(() => {
+      expect(pendingWebSocketCount("127.0.0.1")).toBe(0);
+    });
+  }, 30_000);
+
+  it("caps concurrent unauthenticated upgrades per peer", async () => {
+    const baseUrl = await bootServer();
+    const port = Number(new URL(baseUrl).port);
+    const sockets: WebSocket[] = [];
+    try {
+      for (let i = 0; i < MAX_PENDING_WEBSOCKETS_PER_PEER; i++) {
+        sockets.push(await openUnauthenticatedWs(port));
+      }
+      expect(pendingWebSocketCount("127.0.0.1")).toBe(
+        MAX_PENDING_WEBSOCKETS_PER_PEER,
+      );
+
+      // The next credential-less upgrade from the same peer is refused at the
+      // handshake instead of pinning another file descriptor forever.
+      await expect(openUnauthenticatedWs(port)).rejects.toThrow(/401/);
+      expect(pendingWebSocketCount("127.0.0.1")).toBe(
+        MAX_PENDING_WEBSOCKETS_PER_PEER,
+      );
+    } finally {
+      for (const ws of sockets) ws.close();
+    }
+    await vi.waitFor(() => {
+      expect(pendingWebSocketCount("127.0.0.1")).toBe(0);
+    });
+  }, 30_000);
 });

--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -733,6 +733,59 @@ export function resolveWebSocketUpgradeRejection(
   return null;
 }
 
+// ---------------------------------------------------------------------------
+// Unauthenticated WebSocket bounds (W5-015)
+// ---------------------------------------------------------------------------
+
+/**
+ * Credential-less upgrades are allowed so browser clients can authenticate
+ * post-open with `{type:"auth"}` — browsers cannot set Authorization on
+ * `new WebSocket(url)`. An unbounded accept was a remote FD-exhaustion DoS:
+ * every completed handshake pinned a file descriptor forever. Two bounds now
+ * apply: this per-peer cap on concurrent pre-auth sockets, and a post-open
+ * auth grace period (enforced in server.ts, cleared on `auth-ok`) after which
+ * the server closes a socket that never authenticated.
+ */
+export const WS_AUTH_GRACE_TIMEOUT_MS = 10_000;
+export const MAX_PENDING_WEBSOCKETS_PER_PEER = 16;
+
+const pendingWebSocketsByPeer = new Map<string, number>();
+
+/**
+ * Reserve a pre-auth slot for the peer; false when the peer is at the cap.
+ * Every true return must be paired with {@link releasePendingWebSocket} once
+ * the socket authenticates or closes.
+ */
+export function tryAcquirePendingWebSocket(
+  remoteAddress: string | null | undefined,
+): boolean {
+  const key = remoteAddress || "unknown";
+  const current = pendingWebSocketsByPeer.get(key) ?? 0;
+  if (current >= MAX_PENDING_WEBSOCKETS_PER_PEER) return false;
+  pendingWebSocketsByPeer.set(key, current + 1);
+  return true;
+}
+
+export function releasePendingWebSocket(
+  remoteAddress: string | null | undefined,
+): void {
+  const key = remoteAddress || "unknown";
+  const current = pendingWebSocketsByPeer.get(key) ?? 0;
+  if (current <= 1) pendingWebSocketsByPeer.delete(key);
+  else pendingWebSocketsByPeer.set(key, current - 1);
+}
+
+export function __resetPendingWebSocketsForTests(): void {
+  pendingWebSocketsByPeer.clear();
+}
+
+/** Current pre-auth socket count for the peer — test/diagnostic visibility. */
+export function pendingWebSocketCount(
+  remoteAddress: string | null | undefined,
+): number {
+  return pendingWebSocketsByPeer.get(remoteAddress || "unknown") ?? 0;
+}
+
 export function rejectWebSocketUpgrade(
   socket: import("node:stream").Duplex,
   statusCode: number,

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -1320,10 +1320,13 @@ import {
   pairingEnabled as _pairingEnabled,
   rateLimitPairing as _rateLimitPairing,
   rejectWebSocketUpgrade as _rejectWebSocketUpgrade,
+  releasePendingWebSocket as _releasePendingWebSocket,
   resolveBoundaryRole as _resolveBoundaryRole,
   resolveTerminalRunClientId as _resolveTerminalRunClientId,
   resolveTerminalRunRejection as _resolveTerminalRunRejection,
   resolveWebSocketUpgradeRejection as _resolveWebSocketUpgradeRejection,
+  tryAcquirePendingWebSocket as _tryAcquirePendingWebSocket,
+  WS_AUTH_GRACE_TIMEOUT_MS,
 } from "./server-helpers-auth.ts";
 
 // Importing the artifact share-viewer scheme self-registers its resolver with
@@ -1365,6 +1368,8 @@ const resolveTerminalRunRejection = _resolveTerminalRunRejection;
 const resolveWebSocketUpgradeRejection = _resolveWebSocketUpgradeRejection;
 const rejectWebSocketUpgrade = _rejectWebSocketUpgrade;
 const isWebSocketAuthorized = _isWebSocketAuthorized;
+const tryAcquirePendingWebSocket = _tryAcquirePendingWebSocket;
+const releasePendingWebSocket = _releasePendingWebSocket;
 const getConfiguredApiToken = _getConfiguredApiToken;
 const pairingEnabled = _pairingEnabled;
 
@@ -4131,18 +4136,45 @@ export async function startApiServer(opts?: {
         rejectWebSocketUpgrade(socket, rejection.status, rejection.reason);
         return;
       }
-      wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
-        // Attach an 'error' listener IMMEDIATELY — before emit('connection')
-        // runs the (long) connection handler that only attaches its own error
-        // listener near the end. A client that RSTs in that window otherwise
-        // emits an unhandled 'error' on the ws and crashes the process.
-        ws.on("error", (err: unknown) => {
-          logger.warn(
-            `[eliza-api] WebSocket error: ${err instanceof Error ? err.message : err}`,
+      // W5-015: an upgrade without handshake credentials is allowed so the
+      // client can authenticate post-open, but concurrent pre-auth sockets
+      // are capped per peer — an unbounded accept was a remote FD-exhaustion
+      // DoS. The slot releases when the socket authenticates or closes (see
+      // the connection handler), or in the catch below if the upgrade fails.
+      let pendingWsPeer: string | null | undefined;
+      if (!isWebSocketAuthorized(request, wsUrl)) {
+        const peer = request.socket.remoteAddress ?? null;
+        if (!tryAcquirePendingWebSocket(peer)) {
+          rejectWebSocketUpgrade(
+            socket,
+            401,
+            "Too many unauthenticated WebSocket connections",
           );
+          return;
+        }
+        pendingWsPeer = peer;
+      }
+      try {
+        wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
+          // Attach an 'error' listener IMMEDIATELY — before emit('connection')
+          // runs the (long) connection handler that only attaches its own error
+          // listener near the end. A client that RSTs in that window otherwise
+          // emits an unhandled 'error' on the ws and crashes the process.
+          ws.on("error", (err: unknown) => {
+            logger.warn(
+              `[eliza-api] WebSocket error: ${err instanceof Error ? err.message : err}`,
+            );
+          });
+          wss.emit("connection", ws, request);
         });
-        wss.emit("connection", ws, request);
-      });
+      } catch (upgradeErr) {
+        // error-policy:J2 release the reserved pre-auth slot, then rethrow
+        // unchanged into the outer boundary handler.
+        if (pendingWsPeer !== undefined) {
+          releasePendingWebSocket(pendingWsPeer);
+        }
+        throw upgradeErr;
+      }
     } catch (err) {
       logger.error(
         `[eliza-api] WebSocket upgrade error: ${err instanceof Error ? err.message : err}`,
@@ -4171,6 +4203,38 @@ export async function startApiServer(opts?: {
     }
 
     let isAuthenticated = isWebSocketAuthorized(request, wsUrl);
+
+    // W5-015: the upgrade handler reserved a pre-auth slot for this socket's
+    // peer. It releases on post-open authentication or on close — whichever
+    // comes first — and a socket that never authenticates is closed when the
+    // grace period expires, so a silent peer can no longer pin a file
+    // descriptor indefinitely. The peer is captured now so the release keys
+    // on the same bucket even if the socket is already torn down.
+    const pendingWsPeer = request.socket?.remoteAddress ?? null;
+    let pendingSlotHeld = !isAuthenticated;
+    const releasePendingSlot = () => {
+      if (!pendingSlotHeld) return;
+      pendingSlotHeld = false;
+      releasePendingWebSocket(pendingWsPeer);
+    };
+    let authGraceTimer: NodeJS.Timeout | null = null;
+    const clearAuthGraceTimer = () => {
+      if (authGraceTimer) {
+        clearTimeout(authGraceTimer);
+        authGraceTimer = null;
+      }
+    };
+    if (!isAuthenticated) {
+      authGraceTimer = setTimeout(() => {
+        authGraceTimer = null;
+        logger.warn(
+          "[eliza-api] closing WebSocket that did not authenticate within the grace period",
+        );
+        ws.close(1008, "Unauthorized");
+      }, WS_AUTH_GRACE_TIMEOUT_MS);
+      // A stuck pre-auth socket must not hold the process open on shutdown.
+      authGraceTimer.unref?.();
+    }
 
     // Optional reconnect cursor: a client that tracks the highest buffered
     // event sequence it has applied can pass it back as `?lastEventId=` so the
@@ -4300,6 +4364,8 @@ export async function startApiServer(opts?: {
             tokenMatches(expected, msg.token.trim())
           ) {
             isAuthenticated = true;
+            clearAuthGraceTimer();
+            releasePendingSlot();
             ws.send(JSON.stringify({ type: "auth-ok" }));
             activateAuthenticatedConnection();
           } else {
@@ -4474,6 +4540,8 @@ export async function startApiServer(opts?: {
     });
 
     ws.on("close", () => {
+      clearAuthGraceTimer();
+      releasePendingSlot();
       wsClients.delete(ws);
       wsActiveConversations.delete(ws);
       // Clean up any PTY output subscriptions for this client
@@ -4493,6 +4561,8 @@ export async function startApiServer(opts?: {
       logger.error(
         `[eliza-api] WebSocket error: ${err instanceof Error ? err.message : err}`,
       );
+      clearAuthGraceTimer();
+      releasePendingSlot();
       wsClients.delete(ws);
       wsActiveConversations.delete(ws);
       // Clean up PTY subscriptions on error too

--- a/packages/agent/src/config/sensitive-keys.test.ts
+++ b/packages/agent/src/config/sensitive-keys.test.ts
@@ -161,3 +161,35 @@ describe("URL-shaped and misc secret keys (W1-021)", () => {
     expect(redacted.env.LOG_LEVEL).toBe("info");
   });
 });
+
+/**
+ * W5-027: the classifier must cover the `passwd`/`passphrase` credential
+ * names that the logger and core policies already treat as secret — a stored
+ * `WALLET_PASSPHRASE` must never be served back in cleartext by /api/config.
+ */
+describe("passwd/passphrase credential names (W5-027)", () => {
+  it("classifies passwd and passphrase names as sensitive", () => {
+    for (const key of [
+      "passwd",
+      "PASSWD",
+      "db.passwd",
+      "passphrase",
+      "PASSPHRASE",
+      "WALLET_PASSPHRASE",
+      "walletPassphrase",
+    ]) {
+      expect(isSensitiveConfigKey(key), key).toBe(true);
+    }
+  });
+
+  it("redacts a stored WALLET_PASSPHRASE through GET /api/config", () => {
+    const redacted = redactConfigSecrets({
+      env: {
+        WALLET_PASSPHRASE: "correct horse battery staple",
+        LOG_LEVEL: "info",
+      },
+    }) as { env: Record<string, unknown> };
+    expect(redacted.env.WALLET_PASSPHRASE).toBe("[REDACTED]");
+    expect(redacted.env.LOG_LEVEL).toBe("info");
+  });
+});

--- a/packages/agent/src/config/sensitive-keys.ts
+++ b/packages/agent/src/config/sensitive-keys.ts
@@ -6,7 +6,7 @@
  * sensitivity hints for arbitrary config paths.
  */
 const SENSITIVE_CONFIG_KEY_RE =
-  /password|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|tokens?$|(?:^|[._-])pat$|(?:^|[._-])webhook[a-z]*$|(?:^|[._-])(?:dsn|url|uri|jwt|bearer|cookie|mnemonic)$|(?:^|[._-])key$/i;
+  /password|passwd|passphrase|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|tokens?$|(?:^|[._-])pat$|(?:^|[._-])webhook[a-z]*$|(?:^|[._-])(?:dsn|url|uri|jwt|bearer|cookie|mnemonic)$|(?:^|[._-])key$/i;
 
 /**
  * camelCase companions for the separator-anchored names above, so

--- a/packages/agent/src/providers/media-provider.test.ts
+++ b/packages/agent/src/providers/media-provider.test.ts
@@ -6,9 +6,23 @@
  * vision) with the right URL, headers, and request-body shape; input is
  * validated before any network call; and no direct Eliza Cloud fetch provider is
  * exposed. Deterministic: `fetch` is stubbed with a fake that records calls and
- * replays canned responses — no live models or network.
+ * replays canned responses — no live models or network. The Ollama vision
+ * suite additionally stubs core's `fetchRemoteMedia` to prove image URLs go
+ * through the SSRF-guarded, byte-capped fetcher (W5-020).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchRemoteMediaMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return {
+    ...actual,
+    fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMediaMock(...args),
+  };
+});
+
+import { VISION_IMAGE_MAX_BYTES } from "@elizaos/core";
 import { ElizaSchema } from "../config/zod-schema";
 import {
   type AudioGenerationProvider,
@@ -480,5 +494,101 @@ describe("media vision provider input validation", () => {
         },
       ],
     });
+  });
+});
+
+/**
+ * W5-020: the Ollama vision provider must resolve `imageUrl` through core's
+ * SSRF-guarded `fetchRemoteMedia` under a hard byte cap — never a raw,
+ * unbounded fetch.
+ */
+describe("Ollama vision image fetching (W5-020)", () => {
+  beforeEach(() => {
+    fetchRemoteMediaMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubOllamaFetch(calls: FetchCall[]): void {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push({
+          url: href,
+          init,
+          body:
+            typeof init?.body === "string"
+              ? (JSON.parse(init.body) as Record<string, unknown>)
+              : {},
+        });
+        if (href.endsWith("/api/tags")) {
+          return Response.json({ models: [{ name: "llava" }] });
+        }
+        if (href.endsWith("/api/chat")) {
+          return Response.json({ message: { content: "a cat" } });
+        }
+        throw new Error(`unexpected fetch: ${href}`);
+      }),
+    );
+  }
+
+  it("fetches imageUrl through the guarded fetcher with the vision byte cap", async () => {
+    const calls: FetchCall[] = [];
+    stubOllamaFetch(calls);
+    fetchRemoteMediaMock.mockResolvedValue({
+      buffer: Buffer.from([1, 2, 3]),
+      contentType: "image/jpeg",
+      fileName: "cat.jpg",
+    });
+
+    const provider = createVisionProvider(
+      { mode: "own-key", provider: "ollama", ollama: {} },
+      { cloudMediaDisabled: true },
+    );
+
+    const result = await provider.analyze({
+      imageUrl: "https://example.com/cat.jpg",
+      prompt: "describe",
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { description: "a cat" },
+    });
+    expect(fetchRemoteMediaMock).toHaveBeenCalledTimes(1);
+    const options = fetchRemoteMediaMock.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(options.url).toBe("https://example.com/cat.jpg");
+    expect(options.maxBytes).toBe(VISION_IMAGE_MAX_BYTES);
+    // The fetched bytes reach Ollama as base64 image input.
+    const chatCall = calls.find((call) => call.url.endsWith("/api/chat"));
+    expect(chatCall?.body.messages).toMatchObject([{ images: ["AQID"] }]);
+  });
+
+  it("fails closed when the guarded fetch rejects, before calling Ollama", async () => {
+    const calls: FetchCall[] = [];
+    stubOllamaFetch(calls);
+    fetchRemoteMediaMock.mockRejectedValue(new Error("SSRF blocked"));
+
+    const provider = createVisionProvider(
+      { mode: "own-key", provider: "ollama", ollama: {} },
+      { cloudMediaDisabled: true },
+    );
+
+    const result = await provider.analyze({
+      imageUrl: "http://192.168.1.1/internal.jpg",
+      prompt: "describe",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to fetch image");
+    expect(
+      calls.find((call) => call.url.endsWith("/api/chat")),
+    ).toBeUndefined();
   });
 });

--- a/packages/agent/src/providers/media-provider.ts
+++ b/packages/agent/src/providers/media-provider.ts
@@ -12,7 +12,13 @@
  * - "own-key" mode uses the user's own API keys
  */
 
-import { logger } from "@elizaos/core";
+import {
+  fetchRemoteMedia,
+  logger,
+  nodeLookupFn,
+  nodePinnedFetch,
+  VISION_IMAGE_MAX_BYTES,
+} from "@elizaos/core";
 import type {
   AudioGenConfig,
   AudioGenProvider,
@@ -1164,22 +1170,20 @@ class OllamaVisionProvider implements VisionAnalysisProvider {
     // Ollama uses a different format for vision - images must be base64
     let imageData = options.imageBase64;
     if (!imageData && options.imageUrl) {
-      // Fetch the image and convert to base64
+      // Fetch the image through the SSRF-guarded fetcher (DNS-pinned, private
+      // ranges blocked) with a hard byte cap, then convert to base64 (W5-020).
       try {
-        const imageResponse = await fetchWithTimeout(
-          options.imageUrl,
-          {},
-          120_000,
-        );
-        if (!imageResponse.ok) {
-          return {
-            success: false,
-            error: `Failed to fetch image: ${imageResponse.statusText}`,
-          };
-        }
-        const buffer = await imageResponse.arrayBuffer();
-        imageData = Buffer.from(buffer).toString("base64");
+        const { buffer } = await fetchRemoteMedia({
+          url: options.imageUrl,
+          maxBytes: VISION_IMAGE_MAX_BYTES,
+          timeoutMs: 120_000,
+          lookupFn: nodeLookupFn,
+          pinnedFetchImpl: nodePinnedFetch,
+        });
+        imageData = buffer.toString("base64");
       } catch (err) {
+        // error-policy:J1 the provider boundary returns a structured failure
+        // result instead of throwing.
         return {
           success: false,
           error: `Failed to fetch image: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/agent/test/api/server-helpers-auth.test.ts
+++ b/packages/agent/test/api/server-helpers-auth.test.ts
@@ -3,10 +3,15 @@ import * as http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  __resetPendingWebSocketsForTests,
   applyCors,
   CORS_ALLOWED_HEADERS,
   isAuthorized,
   isServerTokenAuthorized,
+  MAX_PENDING_WEBSOCKETS_PER_PEER,
+  pendingWebSocketCount,
+  releasePendingWebSocket,
+  tryAcquirePendingWebSocket,
 } from "../../src/api/server-helpers-auth";
 
 class HeaderCapture extends http.ServerResponse {
@@ -308,5 +313,51 @@ describe("SSE query-token auth (?token= for EventSource)", () => {
       { Accept: "text/event-stream", Authorization: `Bearer ${API_TOKEN}` },
     );
     expect(isAuthorized(req)).toBe(true);
+  });
+});
+
+describe("unauthenticated WebSocket pending-socket bounds (W5-015)", () => {
+  afterEach(() => {
+    __resetPendingWebSocketsForTests();
+  });
+
+  it("admits pre-auth sockets up to the per-peer cap, then refuses", () => {
+    for (let i = 0; i < MAX_PENDING_WEBSOCKETS_PER_PEER; i++) {
+      expect(tryAcquirePendingWebSocket("203.0.113.10")).toBe(true);
+    }
+    expect(pendingWebSocketCount("203.0.113.10")).toBe(
+      MAX_PENDING_WEBSOCKETS_PER_PEER,
+    );
+    expect(tryAcquirePendingWebSocket("203.0.113.10")).toBe(false);
+    expect(pendingWebSocketCount("203.0.113.10")).toBe(
+      MAX_PENDING_WEBSOCKETS_PER_PEER,
+    );
+  });
+
+  it("tracks caps independently per peer", () => {
+    for (let i = 0; i < MAX_PENDING_WEBSOCKETS_PER_PEER; i++) {
+      expect(tryAcquirePendingWebSocket("203.0.113.10")).toBe(true);
+    }
+    expect(tryAcquirePendingWebSocket("198.51.100.7")).toBe(true);
+  });
+
+  it("releases slots back down to zero and tolerates over-release", () => {
+    expect(tryAcquirePendingWebSocket("203.0.113.10")).toBe(true);
+    expect(tryAcquirePendingWebSocket("203.0.113.10")).toBe(true);
+    releasePendingWebSocket("203.0.113.10");
+    expect(pendingWebSocketCount("203.0.113.10")).toBe(1);
+    releasePendingWebSocket("203.0.113.10");
+    expect(pendingWebSocketCount("203.0.113.10")).toBe(0);
+    // Releasing a peer with no held slots is a no-op, not a negative count.
+    releasePendingWebSocket("203.0.113.10");
+    expect(pendingWebSocketCount("203.0.113.10")).toBe(0);
+    expect(tryAcquirePendingWebSocket("203.0.113.10")).toBe(true);
+  });
+
+  it("buckets a missing peer address under the shared unknown key", () => {
+    expect(tryAcquirePendingWebSocket(undefined)).toBe(true);
+    expect(pendingWebSocketCount(null)).toBe(1);
+    releasePendingWebSocket(undefined);
+    expect(pendingWebSocketCount(undefined)).toBe(0);
   });
 });

--- a/packages/app-core/src/api/cloud-pair-route.test.ts
+++ b/packages/app-core/src/api/cloud-pair-route.test.ts
@@ -40,6 +40,7 @@ const AGENT_ID = "55555555-5555-4555-8555-555555555555";
 const MANAGED_ENV_KEYS = [
   "ELIZA_CLOUD_PROVISIONED",
   "ELIZA_CLOUD_PAIR_DIRECT_RELAY",
+  "ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS",
   "ELIZA_CLOUD_AGENT_ID",
   "WAIFU_ELIZA_CLOUD_AGENT_ID",
   "ELIZAOS_CLOUD_BASE_URL",
@@ -149,7 +150,7 @@ function fakeReq(opts: {
     ...(opts.proto ? { "x-forwarded-proto": opts.proto } : {}),
   };
   Object.defineProperty(req.socket, "remoteAddress", {
-    value: opts.ip ?? "203.0.113.50",
+    value: opts.ip ?? "127.0.0.1",
     configurable: true,
   });
   return req;
@@ -329,6 +330,7 @@ describe("handleCloudPairRoute", () => {
       search: "?token=abc",
       host: "eliza-staging-1.elizacloud.ai",
       proto: "https",
+      ip: "203.0.113.10",
     });
     req.headers["x-forwarded-host"] = "attacker.example";
     const harness = fakeRes();
@@ -339,15 +341,42 @@ describe("handleCloudPairRoute", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("allows the explicit local-provider relay only for a loopback origin", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          apiKey: "agent_secret_value",
-          agentId: AGENT_ID,
-          agentName: "Local",
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
+  it("never exchanges for a remote peer spoofing a loopback forwarded host (W5-014)", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    // Before the fix, X-Forwarded-Host/Host were trusted for the loopback
+    // gate, so this exact request passed it: a remote peer presenting a
+    // loopback-looking origin could redeem a held pairing token through the
+    // relay and receive the minted agent apiKey in the handoff HTML.
+    const req = fakeReq({
+      pathname: "/pair",
+      search: "?token=abc",
+      host: "localhost:43123",
+      ip: "203.0.113.10",
+    });
+    req.headers["x-forwarded-host"] = "localhost";
+    req.headers["x-forwarded-proto"] = "http";
+    const harness = fakeRes();
+    await handleCloudPairRoute(req, harness.res);
+
+    expect(harness.status()).toBe(421);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("allows the explicit local-provider relay only for loopback or allowlisted peers", async () => {
+    // Each invocation gets a fresh Response — a single shared Response body
+    // would be consumed on the first .json() and later calls would 502.
+    const fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            apiKey: "agent_secret_value",
+            agentId: AGENT_ID,
+            agentName: "Local",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
       ),
     );
     globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
@@ -373,6 +402,29 @@ describe("handleCloudPairRoute", () => {
       }),
     );
 
+    // The exchange origin is built from direct request metadata only:
+    // forwarded headers must not rewrite it (W5-014).
+    fetchMock.mockClear();
+    const forwardedHarness = fakeRes();
+    const forwardedReq = fakeReq({
+      pathname: "/pair",
+      search: "?token=abc",
+      host: "127.0.0.1:43123",
+      proto: "http",
+    });
+    forwardedReq.headers["x-forwarded-host"] = "attacker.example";
+    await handleCloudPairRoute(forwardedReq, forwardedHarness.res);
+    expect(forwardedHarness.status()).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.eliza.app/api/auth/pair",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          origin: "http://127.0.0.1:43123",
+        }),
+      }),
+    );
+
+    // A public peer is rejected no matter what origin metadata it presents.
     fetchMock.mockClear();
     const publicHarness = fakeRes();
     await handleCloudPairRoute(
@@ -381,11 +433,64 @@ describe("handleCloudPairRoute", () => {
         search: "?token=abc",
         host: "agent.example",
         proto: "https",
+        ip: "203.0.113.10",
       }),
       publicHarness.res,
     );
     expect(publicHarness.status()).toBe(421);
     expect(fetchMock).not.toHaveBeenCalled();
+
+    // W5-016: the local-Docker bridge gateway is admitted only through the
+    // explicit CIDR allowlist; other private-range peers stay rejected.
+    fetchMock.mockClear();
+    const dockerDefaultHarness = fakeRes();
+    await handleCloudPairRoute(
+      fakeReq({
+        pathname: "/pair",
+        search: "?token=abc",
+        host: "127.0.0.1:43123",
+        proto: "http",
+        ip: "172.17.0.1",
+      }),
+      dockerDefaultHarness.res,
+    );
+    expect(dockerDefaultHarness.status()).toBe(421);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS = "172.17.0.0/16";
+    try {
+      fetchMock.mockClear();
+      const dockerHarness = fakeRes();
+      await handleCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=abc",
+          host: "127.0.0.1:43123",
+          proto: "http",
+          ip: "172.17.0.1",
+        }),
+        dockerHarness.res,
+      );
+      expect(dockerHarness.status()).toBe(200);
+      expect(fetchMock).toHaveBeenCalled();
+
+      fetchMock.mockClear();
+      const lanHarness = fakeRes();
+      await handleCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=abc",
+          host: "127.0.0.1:43123",
+          proto: "http",
+          ip: "192.168.1.10",
+        }),
+        lanHarness.res,
+      );
+      expect(lanHarness.status()).toBe(421);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS;
+    }
   });
 
   it("fails before exchange when the local platform identity is missing", async () => {
@@ -546,13 +651,14 @@ describe("handleCloudPairRoute", () => {
     ) as unknown as typeof globalThis.fetch;
 
     // Bucket size is 5/min from sensitive-rate-limit.ts. Hit it 5 times +
-    // assert the 6th call returns 429.
+    // assert the 6th call returns 429. A loopback peer is required now that
+    // the relay gate keys on the TCP peer (W5-014).
     for (let i = 0; i < 5; i++) {
       const h = fakeRes();
       const r = fakeReq({
         pathname: "/pair",
         search: "?token=abc",
-        ip: "9.9.9.9",
+        ip: "127.0.0.2",
       });
       await handleCloudPairRoute(r, h.res);
       expect(h.status()).toBe(200);
@@ -561,7 +667,7 @@ describe("handleCloudPairRoute", () => {
     const r6 = fakeReq({
       pathname: "/pair",
       search: "?token=abc",
-      ip: "9.9.9.9",
+      ip: "127.0.0.2",
     });
     await handleCloudPairRoute(r6, h6.res);
     expect(h6.status()).toBe(429);

--- a/packages/app-core/src/api/cloud-pair-route.ts
+++ b/packages/app-core/src/api/cloud-pair-route.ts
@@ -5,10 +5,24 @@
  * local-Docker mode exchanges its one-time token server-side, validates the
  * returned owner, installs the scoped browser handoff, and fails visibly when
  * storage or the Cloud dependency is unavailable.
+ *
+ * Peer admission when `ELIZA_CLOUD_PAIR_DIRECT_RELAY=1` keys on the TCP peer,
+ * never on request headers: loopback peers only, plus any ranges in the
+ * optional `ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS` comma-separated CIDR
+ * allowlist (default empty). The supported local-Docker deployment publishes
+ * the port on the host's loopback, so inside the container the TCP peer is
+ * the bridge gateway rather than 127.0.0.1 — set e.g.
+ * `ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS=172.17.0.0/16` to admit exactly that
+ * gateway range. Every CIDR entry widens token redemption to that LAN/VPC
+ * segment, so keep the list as narrow as the deployment allows.
  */
 
 import type http from "node:http";
 import { logger } from "@elizaos/core";
+import {
+  isLoopbackRemoteAddress,
+  isRemoteAddressInCidrList,
+} from "@elizaos/shared";
 import {
   type CloudPairRelaySession,
   parseCloudPairRelaySession,
@@ -40,39 +54,33 @@ function resolveCloudAuthRoot(): string {
   return base.replace(/\/api\/v1\/?$/, "");
 }
 
-function resolveRequestOrigin(req: http.IncomingMessage): string {
-  // Self-hosted and explicit local relays need their proxy-aware request
-  // origin. Remote managed pairing terminates at the Cloud edge instead.
+function resolveDirectRequestOrigin(req: http.IncomingMessage): string {
+  // The origin forwarded to the Cloud exchange is built from direct request
+  // metadata only — X-Forwarded-Host/X-Forwarded-Proto are client-controlled
+  // and must not rewrite the origin the exchange is bound to (W5-014).
   const proto =
-    (req.headers["x-forwarded-proto"] as string | undefined) ||
-    (req.socket && "encrypted" in req.socket && req.socket.encrypted
+    req.socket && "encrypted" in req.socket && req.socket.encrypted
       ? "https"
-      : "http");
-  const host =
-    (req.headers["x-forwarded-host"] as string | undefined) || req.headers.host;
+      : "http";
+  const host = req.headers.host?.split(",", 1)[0]?.trim();
   return host ? `${proto}://${host}` : "";
 }
 
-function isLoopbackOrigin(origin: string): boolean {
-  try {
-    const hostname = new URL(origin).hostname
-      .toLowerCase()
-      .replace(/^\[|\]$/g, "");
-    return (
-      hostname === "localhost" ||
-      hostname === "::1" ||
-      /^127(?:\.\d{1,3}){3}$/.test(hostname)
-    );
-  } catch {
-    // error-policy:J3 malformed request origins are never trusted as loopback.
-    return false;
-  }
-}
-
 function canUseManagedDirectRelay(req: http.IncomingMessage): boolean {
+  if (process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY !== "1") return false;
+  // The local-only gate must key on the TCP peer, never on request headers:
+  // Host and X-Forwarded-Host are client-controlled, so a remote caller
+  // could previously spoof a loopback origin and redeem a held pairing token
+  // through this relay (W5-014). Non-loopback peers are admitted only through
+  // the explicit ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS allowlist (W5-016) —
+  // see the file header for the local-Docker gateway flow.
+  const peer = req.socket?.remoteAddress;
   return (
-    process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY === "1" &&
-    isLoopbackOrigin(resolveRequestOrigin(req))
+    isLoopbackRemoteAddress(peer) ||
+    isRemoteAddressInCidrList(
+      peer,
+      process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS,
+    )
   );
 }
 
@@ -219,7 +227,7 @@ export async function handleCloudPairRoute(
     return true;
   }
 
-  const origin = resolveRequestOrigin(req);
+  const origin = resolveDirectRequestOrigin(req);
   if (!origin) {
     sendHtml(
       res,

--- a/packages/shared/src/loopback-trust.test.ts
+++ b/packages/shared/src/loopback-trust.test.ts
@@ -156,6 +156,16 @@ describe("isRemoteAddressInCidrList", () => {
     expect(isRemoteAddressInCidrList("172.17.0.1", "172.17.0.0/-1")).toBe(
       false,
     );
+    // A trailing slash must not parse as prefix 0 — that would silently
+    // widen the malformed entry into a /0 admit-all for the whole family.
+    expect(isRemoteAddressInCidrList("172.17.0.1", "172.17.0.0/")).toBe(false);
+    expect(isRemoteAddressInCidrList("203.0.113.9", "172.17.0.0/")).toBe(false);
+    expect(isRemoteAddressInCidrList("172.17.0.1", "172.17.0.0/0x10")).toBe(
+      false,
+    );
+    expect(isRemoteAddressInCidrList("172.17.0.1", "172.17.0.0/+16")).toBe(
+      false,
+    );
     expect(
       isRemoteAddressInCidrList("172.17.0.1", "nonsense,172.17.0.0/16"),
     ).toBe(true);

--- a/packages/shared/src/loopback-trust.test.ts
+++ b/packages/shared/src/loopback-trust.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBootConfig, setBootConfig } from "./config/boot-config.js";
 import {
   isLoopbackRemoteAddress,
+  isRemoteAddressInCidrList,
   isTrustedLocalRequest,
   type LoopbackTrustOptions,
   proxyClientHeaderBlocksLocalTrust,
@@ -83,6 +84,82 @@ describe("isLoopbackRemoteAddress", () => {
       expect(isLoopbackRemoteAddress(addr)).toBe(false);
     },
   );
+});
+
+describe("isRemoteAddressInCidrList", () => {
+  it("matches IPv4 peers inside a listed subnet", () => {
+    expect(isRemoteAddressInCidrList("172.17.0.1", "172.17.0.0/16")).toBe(true);
+    expect(isRemoteAddressInCidrList("172.17.255.254", "172.17.0.0/16")).toBe(
+      true,
+    );
+    expect(isRemoteAddressInCidrList("192.168.65.2", "192.168.65.0/24")).toBe(
+      true,
+    );
+  });
+
+  it("rejects IPv4 peers outside every listed subnet", () => {
+    expect(isRemoteAddressInCidrList("172.18.0.1", "172.17.0.0/16")).toBe(
+      false,
+    );
+    expect(isRemoteAddressInCidrList("10.0.0.8", "172.17.0.0/16")).toBe(false);
+    expect(isRemoteAddressInCidrList("192.168.1.1", "172.17.0.0/16")).toBe(
+      false,
+    );
+    expect(isRemoteAddressInCidrList("203.0.113.9", "172.17.0.0/16")).toBe(
+      false,
+    );
+  });
+
+  it("matches a bare IP entry only for that exact host", () => {
+    expect(isRemoteAddressInCidrList("172.17.0.1", "172.17.0.1")).toBe(true);
+    expect(isRemoteAddressInCidrList("172.17.0.2", "172.17.0.1")).toBe(false);
+  });
+
+  it("matches IPv4-mapped IPv6 peer spellings against IPv4 entries", () => {
+    expect(
+      isRemoteAddressInCidrList("::ffff:172.17.0.1", "172.17.0.0/16"),
+    ).toBe(true);
+    expect(
+      isRemoteAddressInCidrList("::ffff:0:172.17.0.1", "172.17.0.0/16"),
+    ).toBe(true);
+    expect(isRemoteAddressInCidrList("::ffff:10.0.0.8", "172.17.0.0/16")).toBe(
+      false,
+    );
+  });
+
+  it("matches IPv6 peers against IPv6 entries", () => {
+    expect(isRemoteAddressInCidrList("fd00::1", "fd00::/8")).toBe(true);
+    expect(isRemoteAddressInCidrList("fd00:0:0:1::1", "fd00::/64")).toBe(false);
+    expect(isRemoteAddressInCidrList("::1", "fd00::/8")).toBe(false);
+  });
+
+  it("honours comma-separated lists with surrounding whitespace", () => {
+    expect(
+      isRemoteAddressInCidrList("10.1.2.3", " 172.17.0.0/16 , 10.0.0.0/8 "),
+    ).toBe(true);
+  });
+
+  it("fails closed on empty, missing, or malformed input", () => {
+    expect(isRemoteAddressInCidrList("172.17.0.1", "")).toBe(false);
+    expect(isRemoteAddressInCidrList("172.17.0.1", null)).toBe(false);
+    expect(isRemoteAddressInCidrList("172.17.0.1", undefined)).toBe(false);
+    expect(isRemoteAddressInCidrList("172.17.0.1", "  ")).toBe(false);
+    expect(isRemoteAddressInCidrList("", "172.17.0.0/16")).toBe(false);
+    expect(isRemoteAddressInCidrList(null, "172.17.0.0/16")).toBe(false);
+    expect(isRemoteAddressInCidrList("not-an-ip", "172.17.0.0/16")).toBe(false);
+    // Malformed entries are skipped — they never widen the gate, and a list
+    // of only malformed entries admits nothing.
+    expect(isRemoteAddressInCidrList("172.17.0.1", "nonsense")).toBe(false);
+    expect(isRemoteAddressInCidrList("172.17.0.1", "172.17.0.0/33")).toBe(
+      false,
+    );
+    expect(isRemoteAddressInCidrList("172.17.0.1", "172.17.0.0/-1")).toBe(
+      false,
+    );
+    expect(
+      isRemoteAddressInCidrList("172.17.0.1", "nonsense,172.17.0.0/16"),
+    ).toBe(true);
+  });
 });
 
 describe("proxyClientHeaderBlocksLocalTrust", () => {

--- a/packages/shared/src/loopback-trust.ts
+++ b/packages/shared/src/loopback-trust.ts
@@ -262,11 +262,15 @@ export function isRemoteAddressInCidrList(
       added += 1;
       continue;
     }
-    const prefix = Number(entry.slice(slash + 1));
+    // Require a plain decimal prefix: Number("") parses a trailing slash as
+    // 0, which would turn a malformed entry into a /0 admit-all, and Number
+    // also accepts spellings like "0x10" or "+16" that operators did not
+    // mean. Malformed entries must admit nothing.
+    const prefixText = entry.slice(slash + 1);
+    if (!/^\d+$/.test(prefixText)) continue;
+    const prefix = Number(prefixText);
     const maxPrefix = family === 4 ? 32 : 128;
-    if (!Number.isInteger(prefix) || prefix < 0 || prefix > maxPrefix) {
-      continue;
-    }
+    if (prefix > maxPrefix) continue;
     try {
       blockList.addSubnet(ip, prefix, type);
       added += 1;

--- a/packages/shared/src/loopback-trust.ts
+++ b/packages/shared/src/loopback-trust.ts
@@ -27,7 +27,7 @@
  */
 
 import type http from "node:http";
-import { isIP } from "node:net";
+import { BlockList, isIP } from "node:net";
 import { isCloudProvisionedContainer } from "./elizacloud/cloud-provisioning.js";
 import { isLoopbackBindHost } from "./runtime-env.js";
 import { readAliasedEnv } from "./utils/env.js";
@@ -224,6 +224,77 @@ export function isLoopbackRemoteAddress(
     normalized.startsWith("::ffff:127.") ||
     normalized.startsWith("::ffff:0:127.")
   );
+}
+
+/**
+ * True when the TCP peer address falls inside an operator-supplied CIDR
+ * allowlist: a comma-separated list of `ip[/prefix]` entries (IPv4 or IPv6; a
+ * bare IP means an exact host match). The Cloud-pair relay uses this to admit
+ * the local-Docker bridge gateway without opening the gate to every
+ * private-range LAN/VPC peer (W5-016). Fail-closed by construction: empty
+ * lists, unparseable peers, and malformed entries admit nothing. IPv4-mapped
+ * IPv6 peer spellings (`::ffff:a.b.c.d`, as dual-stack sockets report them)
+ * are matched against the IPv4 entries.
+ */
+export function isRemoteAddressInCidrList(
+  remoteAddress: string | null | undefined,
+  cidrList: string | null | undefined,
+): boolean {
+  if (!remoteAddress || !cidrList) return false;
+  const entries = cidrList
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (entries.length === 0) return false;
+
+  const blockList = new BlockList();
+  let added = 0;
+  for (const entry of entries) {
+    const slash = entry.lastIndexOf("/");
+    const ip = slash === -1 ? entry : entry.slice(0, slash);
+    const family = isIP(ip);
+    if (family === 0) continue;
+    const type = family === 4 ? "ipv4" : "ipv6";
+    if (slash === -1) {
+      // Bare IP = exact host. Expressed as a full-prefix subnet because not
+      // every runtime's BlockList implements `add`.
+      blockList.addSubnet(ip, family === 4 ? 32 : 128, type);
+      added += 1;
+      continue;
+    }
+    const prefix = Number(entry.slice(slash + 1));
+    const maxPrefix = family === 4 ? 32 : 128;
+    if (!Number.isInteger(prefix) || prefix < 0 || prefix > maxPrefix) {
+      continue;
+    }
+    try {
+      blockList.addSubnet(ip, prefix, type);
+      added += 1;
+    } catch {
+      // error-policy:J3 malformed operator CIDR entries admit nothing.
+    }
+  }
+  if (added === 0) return false;
+
+  let peer = remoteAddress.trim().toLowerCase();
+  if (isIP(peer) === 6) {
+    for (const mappedPrefix of ["::ffff:", "::ffff:0:"]) {
+      const mapped = peer.slice(mappedPrefix.length);
+      if (peer.startsWith(mappedPrefix) && isIP(mapped) === 4) {
+        peer = mapped;
+        break;
+      }
+    }
+  }
+  const peerFamily = isIP(peer);
+  if (peerFamily === 0) return false;
+  try {
+    return blockList.check(peer, peerFamily === 4 ? "ipv4" : "ipv6");
+  } catch {
+    // error-policy:J3 an exotic-but-unmatchable peer spelling (e.g. a zoned
+    // link-local address on a runtime that rejects it) admits nothing.
+    return false;
+  }
 }
 
 const LOCAL_APP_PROTOCOLS = new Set([


### PR DESCRIPTION
## Summary

Wave-6 security remediation for five wave-5 re-audit findings (all LOW severity). Each fix maps to a W5-ID from the wave-5 report.

### W5-014 — app-core `/pair` relay trusted `X-Forwarded-Host` (W1-037 twin)
`packages/app-core/src/api/cloud-pair-route.ts` now ports the agent-side fix: the direct-relay gate evaluates the TCP peer (`req.socket.remoteAddress`) instead of client-controlled headers, and the origin forwarded to the Cloud exchange is reconstructed from direct request metadata only. This also covers the agent binary's pre-auth dispatch, which serves the app-core handler via the host bridge.

### W5-016 — pair-relay private-range admission too broad
Both `cloud-pair-route.ts` twins (agent + app-core) no longer admit every RFC1918/ULA peer. Admission is now loopback-only by default, plus an explicit operator allowlist `ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS` (comma-separated CIDRs, default empty) backed by a new fail-closed `isRemoteAddressInCidrList` helper in `@elizaos/shared` (the module that already unified the loopback-trust boundary after an earlier twin-drift incident). The local-Docker gateway flow is documented in both file headers and in `packages/agent/AGENTS.md`/`CLAUDE.md`: publish the port on host loopback and allowlist exactly the bridge range (e.g. `172.17.0.0/16`).

### W5-015 — unauthenticated `/ws` upgrades accepted forever (FD exhaustion)
Credential-less upgrades are still allowed so browser clients can authenticate post-open, but they are now bounded (`server-helpers-auth.ts` + `server.ts`):
- per-peer cap (16) on concurrent pre-auth sockets, enforced at the upgrade handshake;
- a 10 s post-open auth grace period — a socket that never authenticates is closed with 1008;
- slots release on auth, close, error, or failed upgrade; grace timers are unref'd so they can't hold the process open.

### W5-020 — `OllamaVisionProvider.analyze` raw-fetched `imageUrl` (latent)
Now routes through core's SSRF-guarded `fetchRemoteMedia` with `VISION_IMAGE_MAX_BYTES` (20 MB) instead of an unguarded, unbounded fetch. The factory remains unwired in-repo; fixed before a caller appears.

### W5-027 — `/api/config` classifier missed `passwd`/`passphrase`
`SENSITIVE_CONFIG_KEY_RE` now covers `passwd` and `passphrase`, matching the logger and core policies, so user-stored keys like `WALLET_PASSPHRASE` are redacted from config API responses.

## Test evidence
All focused suites pass in the worktree (Vitest):
- `packages/shared`: `loopback-trust.test.ts` — 79 passed (incl. new CIDR-helper cases: v4/v6 subnets, bare hosts, v4-mapped v6 peers, malformed entries fail closed)
- `packages/agent`: `cloud-pair-route.test.ts` 22, `sensitive-keys.test.ts` 12, `media-provider.test.ts` 16, `server-helpers-auth.test.ts` 21, `server-auth-boundary.test.ts` 9 (real `startApiServer`: silent socket closed at the grace deadline, post-open token auth survives past it, 17th concurrent pre-auth upgrade refused), plus WS-adjacent suites (`server-skip-listen`, `health-routes.canRespond-ws`, trust/wildcard/isAllowedHost, `self-api-auth-contract`, `host-bridge`) — all green
- `packages/app-core`: `cloud-pair-route.test.ts` 17 (incl. forwarded-host spoof regression and allowlisted-gateway cases), `server-compat-route-chain.guard.test.ts` + `install-agent-host-bridge.test.ts` green
- `tsc --noEmit` clean for `packages/agent`, `packages/app-core`, `packages/shared`; Biome clean on all changed files; `check:agents-claude` passes (155 pairs byte-identical)

## Risk notes
- **Behavioral change (intended):** with `ELIZA_CLOUD_PAIR_DIRECT_RELAY=1`, non-loopback peers (including LAN hosts and the Docker bridge gateway) are now rejected unless allowlisted via `ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS`. Operators using the local-Docker pairing flow must set it, e.g. `ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS=172.17.0.0/16`. Loopback pairing is unaffected.
- **WS clients:** browsers that authenticate post-open within 10 s are unaffected (the SPA sends its auth frame immediately on open). A client that connects and stays silent is now closed after 10 s and limited to 16 concurrent pre-auth sockets per peer.
- The Ollama vision provider has no in-repo callers (latent code); the change is preventive and covered by a mocked-boundary unit test.
- The config classifier change only widens redaction (fail-safe direction); lookalike keys are unaffected.