### PR TITLE
fix(cloud): reject malformed apps-create JSON body

### DIFF
--- a/packages/cloud/api/v1/apps/route.json.test.ts
+++ b/packages/cloud/api/v1/apps/route.json.test.ts
@@ -1,0 +1,81 @@
+/**
+ * POST /api/v1/apps used to let c.req.json() throw into failureResponse,
+ * which maps SyntaxError to 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+const APP_ID = "00000000-0000-4000-8000-0000000000aa";
+const created = {
+  id: APP_ID,
+  name: "demo",
+  organization_id: "org-1",
+};
+
+const createApp = mock(async () => ({
+  app: created,
+  apiKey: { id: "key-1", key: "eliza_test" },
+  githubRepo: null,
+  githubRepoCreated: false,
+  errors: [],
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+
+mock.module("@/lib/services/app-credits", () => ({
+  appCreditsService: {
+    updateMonetizationSettings: async () => undefined,
+  },
+}));
+
+mock.module("@/lib/services/app-factory", () => ({
+  appFactoryService: { createApp },
+}));
+
+mock.module("@/lib/services/apps", () => ({
+  AppCreationLimitError: class AppCreationLimitError extends Error {},
+  AppNameConflictError: class AppNameConflictError extends Error {},
+  appsService: {
+    getById: async () => created,
+    withDatabaseState: async (row: unknown) => row,
+    listByOrganizationWithDatabaseState: async () => [],
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: () => undefined, warn: () => undefined, error: () => undefined },
+}));
+
+const { default: app } = await import("./route");
+
+describe("POST /api/v1/apps malformed JSON", () => {
+  test("returns 400 instead of 500 and never creates an app", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(createApp).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still creates an app", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "demo",
+        app_url: "https://app.example.test",
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(createApp).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/apps/route.ts
+++ b/packages/cloud/api/v1/apps/route.ts
@@ -76,7 +76,14 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    const rawBody = await c.req.json();
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
     const validationResult = CreateAppSchema.safeParse(rawBody);
     if (!validationResult.success) {
       return c.json(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on apps POST create currently 500s. Not apps/[id] (already shipped #21563). Not extra-decode / #21472. Not a list-limit / one-flag boolean change. Not tracker #21541 close-bait.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still create an app. Malformed JSON (`{`, truncated objects) now 400s before `appFactoryService.createApp` instead of `failureResponse(SyntaxError)` → 500. Proven on the unfixed head: POST `{` received **500**.

# Background

## What does this PR do?

`POST /api/v1/apps` called `await c.req.json()` inside a try whose catch maps unknown errors through `failureResponse` / `inferStatusFromLegacyError`. That helper does not treat `SyntaxError` / "Failed to parse JSON" as caller error, so truncated bodies became HTTP 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before Zod or app creation.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/apps/route.json.test.ts` and the `c.req.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'v1/apps/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500** on POST. After the fix: 2 passed on `dcc1dc80086abd4eec0954474b89dedf13cb717e`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:dcc1dc80086abd4eec0954474b89dedf13cb717e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the apps-create HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before app creation.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that createApp is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches appFactoryService.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on apps-create JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500 on POST; after the fix, Bun test asserts 400 and canonical `{ name, app_url }` still creates an app.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the apps-create HTTP boundary.

## Audio / voice walkthrough

N/A - metadata POST only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `dcc1dc8008`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
