### PR TITLE
fix(cloud): reject malformed api-keys PATCH JSON body

### DIFF
--- a/packages/cloud/api/v1/api-keys/[id]/route.json.test.ts
+++ b/packages/cloud/api/v1/api-keys/[id]/route.json.test.ts
@@ -1,0 +1,81 @@
+/**
+ * PATCH /api/v1/api-keys/:id used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const KEY_ID = "00000000-0000-4000-8000-0000000000bb";
+const existing = {
+  id: KEY_ID,
+  organization_id: "org-1",
+  name: "demo-key",
+  description: null,
+  key_prefix: "eliza_",
+  created_at: "2026-01-01T00:00:00.000Z",
+  rate_limit: 1000,
+  is_active: true,
+  expires_at: null,
+};
+
+const update = mock(async () => existing);
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+
+mock.module("@/api-app/middleware/org-membership", () => ({
+  assertOrgMembership: async () => undefined,
+}));
+
+mock.module("@/api-app/services/audit-dispatcher-singleton", () => ({
+  getAuditDispatcher: () => ({ emit: async () => undefined }),
+}));
+
+mock.module("@/lib/services/api-keys", () => ({
+  apiKeysService: {
+    getById: async () => existing,
+    update,
+    delete: async () => undefined,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: () => undefined, warn: () => undefined, error: () => undefined },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id", route);
+
+describe("PATCH /api/v1/api-keys/:id malformed JSON", () => {
+  test("returns 400 instead of 500 and never updates the key", async () => {
+    const response = await app.request(`/${KEY_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still updates the key", async () => {
+    const response = await app.request(`/${KEY_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "renamed" }),
+    });
+    expect(response.status).toBe(200);
+    expect(update).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/api-keys/[id]/route.ts
+++ b/packages/cloud/api/v1/api-keys/[id]/route.ts
@@ -79,7 +79,14 @@ app.patch("/", async (c) => {
       c,
     });
 
-    const body = await c.req.json();
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
     const { name, description, rate_limit, is_active, expires_at } =
       updateApiKeySchema.parse(body);
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on api-keys PATCH currently 500s. Not a `rate_limit` / list-limit change. Not extra-decode / #21472. Not tracker #21541 close-bait.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still update an API key. Malformed JSON (`{`, truncated objects) now 400s before `apiKeysService.update` instead of `failureResponse(SyntaxError)` → 500. Proven on the unfixed head: PATCH `{` received **500**. Does not change `rate_limit` parsing.

# Background

## What does this PR do?

`PATCH /api/v1/api-keys/:id` called `await c.req.json()` inside a try whose catch maps unknown errors through `failureResponse` / `inferStatusFromLegacyError`. That helper does not treat `SyntaxError` / "Failed to parse JSON" as caller error, so truncated bodies became HTTP 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before Zod or the key update.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/api-keys/[id]/route.json.test.ts` and the `c.req.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'v1/api-keys/[id]/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500** on PATCH. After the fix: 2 passed on `5407b4c128305d3804990b1cb1381851b57d9bb8`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:5407b4c128305d3804990b1cb1381851b57d9bb8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the api-keys PATCH HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before the key update.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that update is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches apiKeysService.update.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on api-keys PATCH JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500 on PATCH; after the fix, Bun test asserts 400 and canonical `{ name }` still updates the key.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the api-keys PATCH HTTP boundary.

## Audio / voice walkthrough

N/A - metadata PATCH only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `5407b4c128`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
