### PR TITLE
fix(cloud): reject malformed character-share JSON body

### DIFF
--- a/packages/cloud/api/my-agents/characters/[id]/share/route.json.test.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/share/route.json.test.ts
@@ -1,0 +1,83 @@
+/**
+ * PUT /api/my-agents/characters/:id/share used to let c.req.json() throw
+ * into the outer catch, which returns 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const CHAR_ID = "00000000-0000-4000-8000-0000000000dd";
+const existing = {
+  id: CHAR_ID,
+  name: "demo",
+  is_public: false,
+  organization_id: "org-1",
+};
+
+const update = mock(async () => ({
+  ...existing,
+  is_public: true,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+
+mock.module("@/lib/cache/client", () => ({
+  cache: {
+    del: async () => undefined,
+    delPattern: async () => undefined,
+  },
+}));
+
+mock.module("@/lib/cache/keys", () => ({
+  CacheKeys: {
+    org: { dashboard: () => "dash" },
+    discovery: { pattern: () => "disc*" },
+  },
+}));
+
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: {
+    getByIdForUser: async () => existing,
+    update,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: () => undefined, error: () => undefined },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id", route);
+
+describe("PUT /api/my-agents/characters/:id/share malformed JSON", () => {
+  test("returns 400 instead of 500 and never updates the character", async () => {
+    const response = await app.request(`/${CHAR_ID}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still toggles share", async () => {
+    const response = await app.request(
+      `/${CHAR_ID}`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ isPublic: true }),
+      },
+      {},
+    );
+    expect(response.status).toBe(200);
+    expect(update).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/my-agents/characters/[id]/share/route.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/share/route.ts
@@ -69,7 +69,14 @@ app.put("/", async (c) => {
       );
     }
 
-    const body = await c.req.json();
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not the outer catch → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
     const validation = ShareSchema.safeParse(body);
     if (!validation.success) {
       return c.json(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on character-share PUT currently 500s. Not extra-decode / #21472. Not a list-limit / one-flag boolean change. Not tracker #21541 close-bait.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still toggle `is_public`. Malformed JSON (`{`, truncated objects) now 400s before `charactersService.update` instead of the outer catch → 500. Proven on the unfixed head: PUT `{` received **500**.

# Background

## What does this PR do?

`PUT /api/my-agents/characters/:id/share` called `await c.req.json()` inside a try whose catch returns HTTP 500 with `error.message`. Truncated bodies throw `SyntaxError` and became 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before Zod or the share update.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/my-agents/characters/[id]/share/route.json.test.ts` and the `c.req.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'my-agents/characters/[id]/share/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500** on PUT. After the fix: 2 passed on `8eea47a5342404da9818f3094a84c4a60f83a3b2`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:8eea47a5342404da9818f3094a84c4a60f83a3b2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the character-share HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before the share update.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that update is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches charactersService.update.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on character-share JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500 on PUT; after the fix, Bun test asserts 400 and canonical `{ isPublic }` still toggles share.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the character-share HTTP boundary.

## Audio / voice walkthrough

N/A - metadata PUT only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `8eea47a534`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
