### PR TITLE
fix(cloud): reject malformed character-create JSON body

### DIFF
--- a/packages/cloud/api/my-agents/characters/route.json.test.ts
+++ b/packages/cloud/api/my-agents/characters/route.json.test.ts
@@ -1,0 +1,74 @@
+/**
+ * POST /api/my-agents/characters used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+const created = {
+  id: "00000000-0000-4000-8000-0000000000ee",
+  name: "demo",
+};
+
+const create = mock(async () => created);
+const toElizaCharacter = mock((row: unknown) => row);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+    email: "u@example.com",
+    organization: { name: "org" },
+  }),
+}));
+
+mock.module("@/db/repositories/characters", () => ({
+  userCharactersRepository: {
+    count: async () => 0,
+    search: async () => [],
+  },
+}));
+
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: { create, toElizaCharacter },
+}));
+
+mock.module("@/lib/services/discord", () => ({
+  discordService: {
+    logCharacterCreated: async () => undefined,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: () => undefined,
+    info: () => undefined,
+    error: () => undefined,
+  },
+}));
+
+const { default: app } = await import("./route");
+
+describe("POST /api/my-agents/characters malformed JSON", () => {
+  test("returns 400 instead of 500 and never creates a character", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still creates a character", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "demo" }),
+    });
+    expect(response.status).toBe(200);
+    expect(create).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/my-agents/characters/route.ts
+++ b/packages/cloud/api/my-agents/characters/route.ts
@@ -137,7 +137,15 @@ app.get("/", async (c) => {
 app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    const elizaCharacter = (await c.req.json()) as ElizaCharacter;
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const elizaCharacter = rawBody as ElizaCharacter;
     // documents/knowledge come verbatim from the unvalidated request body; a
     // non-array value (e.g. `knowledge: {}`) is not iterable and would 500 the
     // create (#13637 class). Non-arrays contribute no document sources — this


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on character-create POST currently 500s. Not the GET list/limit on the same file. Not extra-decode / #21472. Not tracker #21541 close-bait.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still create a character. Malformed JSON (`{`, truncated objects) now 400s before `charactersService.create` instead of `failureResponse(SyntaxError)` → 500. GET pagination is untouched. Proven on the unfixed head: POST `{` received **500**.

# Background

## What does this PR do?

`POST /api/my-agents/characters` called `await c.req.json()` inside a try whose catch maps unknown errors through `failureResponse` / `inferStatusFromLegacyError`. That helper does not treat `SyntaxError` as caller error, so truncated bodies became HTTP 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before character create. The GET list/limit path is not changed.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/my-agents/characters/route.json.test.ts` and the `c.req.json()` catch in `route.ts` POST.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'my-agents/characters/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500** on POST. After the fix: 2 passed on `397fc2e7c73bc85f0f7d2b5d0e7c3ce8460b9887`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:397fc2e7c73bc85f0f7d2b5d0e7c3ce8460b9887 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the character-create HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before create.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that create is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches charactersService.create.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on character-create JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500 on POST; after the fix, Bun test asserts 400 and canonical `{ name }` still creates a character.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the character-create HTTP boundary.

## Audio / voice walkthrough

N/A - metadata POST only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `397fc2e7c7`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
