### PR TITLE
fix(cloud): reject malformed character-update JSON body

### DIFF
--- a/packages/cloud/api/my-agents/characters/[id]/route.json.test.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/route.json.test.ts
@@ -1,0 +1,78 @@
+/**
+ * PUT /api/my-agents/characters/:id used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const CHAR_ID = "00000000-0000-4000-8000-0000000000ff";
+const updated = {
+  id: CHAR_ID,
+  name: "demo",
+  is_public: false,
+};
+
+const updateForUser = mock(async () => updated);
+const toElizaCharacter = mock((row: unknown) => row);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+
+mock.module("@/lib/cache/client", () => ({
+  cache: {
+    del: async () => undefined,
+    delPattern: async () => undefined,
+  },
+}));
+
+mock.module("@/lib/cache/keys", () => ({
+  CacheKeys: {
+    org: { dashboard: () => "dash" },
+    discovery: { pattern: () => "disc*" },
+  },
+}));
+
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: {
+    getByIdForUser: async () => updated,
+    updateForUser,
+    toElizaCharacter,
+    delete: async () => undefined,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: () => undefined, error: () => undefined },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id", route);
+
+describe("PUT /api/my-agents/characters/:id malformed JSON", () => {
+  test("returns 400 instead of 500 and never updates the character", async () => {
+    const response = await app.request(`/${CHAR_ID}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(updateForUser).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still updates the character", async () => {
+    const response = await app.request(`/${CHAR_ID}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "demo" }),
+    });
+    expect(response.status).toBe(200);
+    expect(updateForUser).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/my-agents/characters/[id]/route.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/route.ts
@@ -39,7 +39,15 @@ app.put("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const id = c.req.param("id") ?? "";
-    const elizaCharacter = (await c.req.json()) as ElizaCharacter;
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const elizaCharacter = rawBody as ElizaCharacter;
     // documents/knowledge come verbatim from the unvalidated request body; a
     // non-array value (e.g. `knowledge: {}`) is not iterable and would 500 the
     // update (#13637 class). Non-arrays contribute no document sources — this


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on character-update PUT currently 500s. Not character-create #21586 or character-share #21585. Not extra-decode / #21472. Not a list-limit change. Not tracker #21541 close-bait.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still update a character. Malformed JSON (`{`, truncated objects) now 400s before `updateForUser` instead of `failureResponse(SyntaxError)` → 500. GET/DELETE are untouched. Proven on the unfixed head: PUT `{` received **500**.

# Background

## What does this PR do?

`PUT /api/my-agents/characters/:id` called `await c.req.json()` inside a try whose catch maps unknown errors through `failureResponse` / `inferStatusFromLegacyError`. That helper does not treat `SyntaxError` as caller error, so truncated bodies became HTTP 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before the update.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/my-agents/characters/[id]/route.json.test.ts` and the `c.req.json()` catch in PUT `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'my-agents/characters/[id]/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500** on PUT. After the fix: 2 passed on `ba988f5d6475054254fef48d4714599b920c8edb`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:ba988f5d6475054254fef48d4714599b920c8edb -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the character-update HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before update.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that updateForUser is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches charactersService.updateForUser.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on character-update JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500 on PUT; after the fix, Bun test asserts 400 and canonical `{ name }` still updates.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the character-update HTTP boundary.

## Audio / voice walkthrough

N/A - metadata PUT only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `ba988f5d64`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
