### PR TITLE
fix(cloud): reject malformed compat-agents JSON body

### DIFF
--- a/packages/cloud/api/compat/agents/route.json.test.ts
+++ b/packages/cloud/api/compat/agents/route.json.test.ts
@@ -1,0 +1,110 @@
+/**
+ * POST /api/compat/agents used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+const createAgent = mock(async () => ({
+  agent: {
+    id: "agent-1",
+    agent_name: "demo",
+    lifecycle_revision: 1,
+    organization_id: "org-1",
+  },
+}));
+
+mock.module("@/lib/auth/service-key-hono-worker", () => ({
+  validateServiceKey: async () => null,
+}));
+
+mock.module("@/lib/auth/waifu-bridge", () => ({
+  authenticateWaifuBridge: async () => null,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate: async () => ({ allowed: true, balance: 100 }),
+}));
+
+mock.module("@/lib/constants/agent-sandbox-quota", () => ({
+  getMaxNonTerminalAgentsForOrg: () => 10,
+}));
+
+mock.module("@/lib/services/eliza-agent-config", () => ({
+  stripReservedElizaConfigKeys: (config: unknown) => config,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  AgentImageNotAllowedError: class AgentImageNotAllowedError extends Error {},
+  AgentQuotaExceededError: class AgentQuotaExceededError extends Error {},
+  elizaSandboxService: { createAgent },
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentProvisionOnce: async () => ({ job: { id: "job-1" } }),
+  },
+}));
+
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth: async () => ({ ok: true }),
+  provisioningWorkerFailureBody: () => ({ error: "unused" }),
+}));
+
+mock.module("@/lib/api/compat-envelope", () => ({
+  envelope: (data: unknown) => ({ success: true, data }),
+  errorEnvelope: (error: string) => ({ success: false, error }),
+  toCompatAgent: (agent: unknown) => agent,
+  toCompatCreateResult: (agent: { id: string }) => ({ id: agent.id }),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  },
+}));
+
+const { default: app } = await import("./route");
+
+const env = { WAIFU_AUTO_PROVISION: "false" };
+
+describe("POST /api/compat/agents malformed JSON", () => {
+  test("returns 400 instead of 500 and never creates an agent", async () => {
+    const response = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{",
+      },
+      env,
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still creates an agent", async () => {
+    const response = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentName: "demo" }),
+      },
+      env,
+    );
+    expect(response.status).toBe(201);
+    expect(createAgent).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/compat/agents/route.ts
+++ b/packages/cloud/api/compat/agents/route.ts
@@ -109,7 +109,14 @@ app.get("/", async (c) => {
 app.post("/", async (c) => {
   try {
     const { user, authMethod } = await requireCompatAuth(c);
-    const body = await c.req.json();
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
 
     const parsed = createAgentSchema.safeParse(body);
     if (!parsed.success) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on compat-agents POST currently 500s. Not extra-decode / #21472. Not a list-limit / one-flag boolean change. Not tracker #21541 close-bait. Not `/api/a2a` (already J1 400). Not discord-gateway max (#21320). Not this climb's owned JSON-500 files.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still create a compat agent. Malformed JSON (`{`, truncated objects) now 400s before `createAgent` instead of `failureResponse(SyntaxError)` → 500. Proven on the unfixed head: POST `{` received **500**.

# Background

## What does this PR do?

`POST /api/compat/agents` called `await c.req.json()` inside a try whose catch maps unknown errors through `failureResponse` / `inferStatusFromLegacyError`. That helper does not treat `SyntaxError` as caller error, so truncated bodies became HTTP 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before credit/quota checks or agent create.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/compat/agents/route.json.test.ts` and the `c.req.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'compat/agents/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500** on POST. After the fix: 2 passed on `a39db260653dfcc9a82ff70d563d3670d010cf4e`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:a39db260653dfcc9a82ff70d563d3670d010cf4e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the compat-agents HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before create.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that createAgent is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches createAgent.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on compat-agents JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500 on POST; after the fix, Bun test asserts 400 and canonical `{ agentName }` still creates.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the compat-agents HTTP boundary.

## Audio / voice walkthrough

N/A - metadata POST only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `a39db26065`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
