### PR TITLE
fix(cloud): reject malformed blooio-webhook-secret JSON body

### DIFF
--- a/packages/cloud/api/v1/blooio/webhook-secret/route.json.test.ts
+++ b/packages/cloud/api/v1/blooio/webhook-secret/route.json.test.ts
@@ -1,0 +1,60 @@
+/**
+ * POST /api/v1/blooio/webhook-secret used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+const storeCredentials = mock(async () => undefined);
+const getApiKey = mock(async () => "blooio-key");
+const getFromNumber = mock(async () => "+15555550100");
+const invalidateOAuthState = mock(async () => undefined);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+
+mock.module("@/lib/services/blooio-automation", () => ({
+  blooioAutomationService: {
+    getApiKey,
+    getFromNumber,
+    storeCredentials,
+  },
+}));
+
+mock.module("@/lib/services/oauth/invalidation", () => ({
+  invalidateOAuthState,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: () => undefined, error: () => undefined },
+}));
+
+const { default: app } = await import("./route");
+
+describe("POST /api/v1/blooio/webhook-secret malformed JSON", () => {
+  test("returns 400 instead of 500 and never stores a secret", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(storeCredentials).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still stores a webhook secret", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ webhookSecret: "whsec_testsecret" }),
+    });
+    expect(response.status).toBe(200);
+    expect(storeCredentials).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/blooio/webhook-secret/route.ts
+++ b/packages/cloud/api/v1/blooio/webhook-secret/route.ts
@@ -24,7 +24,15 @@ app.post("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const orgId = user.organization_id;
 
-    const parsed = WebhookSecretBody.safeParse(await c.req.json());
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const parsed = WebhookSecretBody.safeParse(rawBody);
     if (!parsed.success) {
       return c.json({ error: "Webhook secret is required" }, 400);
     }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on blooio webhook-secret POST currently 500s. Not extra-decode / #21472. Not a list-limit / one-flag boolean change. Not tracker #21541 close-bait. Not `/api/a2a` (already J1 400). Not blooio/connect (already 400). Not payment.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still store a Blooio webhook secret. Malformed JSON (`{`, truncated objects) now 400s before `storeCredentials` instead of `failureResponse(SyntaxError)` → 500. Proven on the unfixed head: POST `{` received **500**.

# Background

## What does this PR do?

`POST /api/v1/blooio/webhook-secret` called `WebhookSecretBody.safeParse(await c.req.json())` inside a try whose catch maps unknown errors through `failureResponse` / `inferStatusFromLegacyError`. `safeParse` never sees a thrown `SyntaxError`, so truncated bodies became HTTP 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before credential store.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/blooio/webhook-secret/route.json.test.ts` and the `c.req.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'v1/blooio/webhook-secret/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500** on POST. After the fix: 2 passed on `fc9827262ef0bbc84abb70594729630b4ea945f8`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:fc9827262ef0bbc84abb70594729630b4ea945f8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the blooio webhook-secret HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before store.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that storeCredentials is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches storeCredentials.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on blooio webhook-secret JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500 on POST; after the fix, Bun test asserts 400 and canonical `{ webhookSecret }` still stores.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the blooio webhook-secret HTTP boundary.

## Audio / voice walkthrough

N/A - metadata POST only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `fc9827262e`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
