### PR TITLE
fix(cloud): reject malformed internal-auth-token JSON body

### DIFF
--- a/packages/cloud/api/internal/auth/token/route.json.test.ts
+++ b/packages/cloud/api/internal/auth/token/route.json.test.ts
@@ -1,0 +1,65 @@
+/**
+ * POST /api/internal/auth/token used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+const signInternalToken = mock(async () => ({
+  token: "jwt-1",
+  expiresIn: 60,
+}));
+
+mock.module("@/lib/auth/jwks", () => ({
+  isJWKSConfigured: () => true,
+}));
+
+mock.module("@/lib/auth/jwt-internal", () => ({
+  internalTokenLifetimeForService: () => 60,
+  isShortLivedGatewayService: (service: string | undefined) =>
+    service === "discord-gateway",
+  signInternalToken,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: () => undefined, info: () => undefined },
+}));
+
+const { default: app } = await import("./route");
+
+const env = { GATEWAY_BOOTSTRAP_SECRET: "gateway-secret" };
+const headers = {
+  "content-type": "application/json",
+  "X-Gateway-Secret": "gateway-secret",
+};
+
+describe("POST /api/internal/auth/token malformed JSON", () => {
+  test("returns 400 instead of 500 and never signs a token", async () => {
+    const response = await app.request(
+      "/",
+      { method: "POST", headers, body: "{" },
+      env,
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(signInternalToken).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still signs a token", async () => {
+    const response = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          pod_name: "pod-1",
+          service: "discord-gateway",
+        }),
+      },
+      env,
+    );
+    expect(response.status).toBe(200);
+    expect(signInternalToken).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/internal/auth/token/route.ts
+++ b/packages/cloud/api/internal/auth/token/route.ts
@@ -40,10 +40,17 @@ app.post("/*", async (c) => {
       return c.json({ error: "Unauthorized" }, 401);
     }
 
-    const body = (await c.req.json()) as {
-      pod_name?: string;
-      service?: string;
-    };
+    let body: { pod_name?: string; service?: string };
+    try {
+      body = (await c.req.json()) as {
+        pod_name?: string;
+        service?: string;
+      };
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
     const subject =
       typeof body.pod_name === "string" ? body.pod_name.trim() : "";
     if (!subject) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on internal auth-token POST currently 500s. Not extra-decode / #21472. Not a list-limit / one-flag boolean change. Not tracker #21541 close-bait. Not `/api/a2a` (already J1 400). Not discord-gateway max (#21320). Not this climb's owned JSON-500 files.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still mint a short-lived gateway token. Malformed JSON (`{`, truncated objects) now 400s before `signInternalToken` instead of `failureResponse(SyntaxError)` → 500. Proven on the unfixed head: POST `{` received **500**.

# Background

## What does this PR do?

`POST /api/internal/auth/token` called `await c.req.json()` inside a try whose catch maps unknown errors through `failureResponse` / `inferStatusFromLegacyError`. That helper does not treat `SyntaxError` as caller error, so truncated bodies became HTTP 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before token sign.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/internal/auth/token/route.json.test.ts` and the `c.req.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'internal/auth/token/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500** on POST. After the fix: 2 passed on `35da8dedf249ce9fb433eb384828af31e26636e3`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:35da8dedf249ce9fb433eb384828af31e26636e3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the internal-auth-token HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before sign.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that signInternalToken is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches signInternalToken.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on internal-auth-token JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500 on POST; after the fix, Bun test asserts 400 and canonical `{ pod_name, service }` still signs.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the internal-auth-token HTTP boundary.

## Audio / voice walkthrough

N/A - metadata POST only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `35da8dedf2`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
