### PR TITLE
fix(cloud): reject malformed org-credentials JSON body

### DIFF
--- a/packages/cloud/api/organizations/credentials/[credentialId]/route.json.test.ts
+++ b/packages/cloud/api/organizations/credentials/[credentialId]/route.json.test.ts
@@ -1,0 +1,71 @@
+/**
+ * PATCH /api/organizations/credentials/:credentialId used to let c.req.json()
+ * throw into failureResponse, which maps SyntaxError to 500.
+ * Malformed JSON is caller error.
+ */
+import { Hono } from "hono";
+import { describe, expect, mock, test } from "bun:test";
+
+const updatePooledCredential = mock(async () => ({
+  id: "cred-1",
+  enabled: true,
+}));
+const getPooledCredential = mock(async () => ({
+  id: "cred-1",
+  organization_id: "org-1",
+  contributed_by: "user-1",
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+    role: "owner",
+  }),
+}));
+
+mock.module("@/lib/services/team-credential-pool/service", () => ({
+  TeamCredentialPoolError: class TeamCredentialPoolError extends Error {
+    status = 400;
+  },
+  getPooledCredential,
+  removePooledCredential: async () => undefined,
+  updatePooledCredential,
+}));
+
+mock.module("../../../src/middleware/org-membership", () => ({
+  assertOrgMembership: async () => undefined,
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:credentialId", route);
+
+describe("PATCH /api/organizations/credentials/:credentialId malformed JSON", () => {
+  test("returns 400 instead of 500 and never updates a credential", async () => {
+    const response = await app.request("/cred-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(updatePooledCredential).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still updates a credential", async () => {
+    const response = await app.request("/cred-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ enabled: true }),
+    });
+    expect(response.status).toBe(200);
+    expect(updatePooledCredential).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/organizations/credentials/[credentialId]/route.ts
+++ b/packages/cloud/api/organizations/credentials/[credentialId]/route.ts
@@ -73,7 +73,15 @@ app.patch("/", async (c) => {
       );
     }
 
-    const validated = updateSchema.parse(await c.req.json());
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const validated = updateSchema.parse(rawBody);
     const credential = await updatePooledCredential({
       credentialId,
       organizationId: user.organization_id,


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on organization credentials PATCH currently 500s. Not extra-decode / #21472. Not a list-limit / one-flag boolean change. Not tracker #21541 close-bait. Not `/api/a2a` (already J1 400). Not payment. Not this climb's owned JSON-500 files.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still update a pooled credential. Malformed JSON (`{`, truncated objects) now 400s before `updatePooledCredential` instead of `failureResponse(SyntaxError)` → 500. Proven on the unfixed head: PATCH `{` received **500**.

# Background

## What does this PR do?

`PATCH /api/organizations/credentials/:credentialId` called `updateSchema.parse(await c.req.json())` inside a try whose catch maps unknown errors through `failureResponse` / `inferStatusFromLegacyError`. Zod validation errors were already 400, but `SyntaxError` from a truncated body was not. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before credential update.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/organizations/credentials/[credentialId]/route.json.test.ts` and the `c.req.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'organizations/credentials/[credentialId]/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500** on PATCH. After the fix: 2 passed on `7a04bc552c49759e361272bc73c63d218594d9df`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:7a04bc552c49759e361272bc73c63d218594d9df -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the org-credentials HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before update.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that updatePooledCredential is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches updatePooledCredential.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on org-credentials JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500 on PATCH; after the fix, Bun test asserts 400 and canonical `{ enabled }` still updates.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the org-credentials HTTP boundary.

## Audio / voice walkthrough

N/A - metadata PATCH only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `7a04bc552c`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
