### PR TITLE
fix(cloud): reject malformed domains-status JSON body

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/domains/status/route.json.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/status/route.json.test.ts
@@ -1,0 +1,74 @@
+/**
+ * POST /api/v1/apps/:id/domains/status used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+const getOwnDomainRow = mock(async () => ({
+  id: "md-1",
+  appId: "app-1",
+  domain: "example.com",
+  registrar: "external",
+  status: "pending",
+  verified: false,
+  sslStatus: null,
+  expiresAt: null,
+}));
+
+mock.module("../guards", () => ({
+  loadOwnedApp: async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    app: { id: "app-1", organization_id: "org-1" },
+    appId: "app-1",
+  }),
+}));
+
+mock.module("@/lib/services/managed-domains", () => ({
+  managedDomainsService: { getOwnDomainRow },
+}));
+
+mock.module("@/lib/services/cloudflare-registrar", () => ({
+  cloudflareRegistrarService: {
+    getRegistrationStatus: async () => ({
+      status: "active",
+      completedAt: null,
+      failureReason: null,
+    }),
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn: () => undefined, info: () => undefined },
+}));
+
+mock.module("@/lib/utils/error-handling", () => ({
+  extractErrorMessage: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+}));
+
+const { default: app } = await import("./route");
+
+describe("POST /api/v1/apps/:id/domains/status malformed JSON", () => {
+  test("returns 400 instead of 500 and never loads a domain row", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(getOwnDomainRow).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still returns stored status", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ domain: "example.com" }),
+    });
+    expect(response.status).toBe(200);
+    expect(getOwnDomainRow).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
@@ -24,7 +24,15 @@ app.post("/", async (c) => {
       return c.json({ success: false, error: ctx.error }, ctx.status);
     const { user, appId } = ctx;
 
-    const parsed = StatusSchema.safeParse(await c.req.json());
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const parsed = StatusSchema.safeParse(rawBody);
     if (!parsed.success) {
       return c.json(
         {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on apps domains-status POST currently 500s. Not extra-decode / #21472. Not a list-limit / one-flag boolean change. Not `domains/search` (list-limit). Not `domains/buy` (payment). Not advertising (#21540). Not this climb's owned JSON-500 files.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical JSON bodies still return stored domain status. Malformed JSON (`{`, truncated objects) now 400s before `getOwnDomainRow` instead of `failureResponse(SyntaxError)` → 500. Proven on the unfixed head: POST `{` received **500**.

# Background

## What does this PR do?

`POST /api/v1/apps/:id/domains/status` called `StatusSchema.safeParse(await c.req.json())` inside a try whose catch maps unknown errors through `failureResponse` / `inferStatusFromLegacyError`. `safeParse` never sees a thrown `SyntaxError`, so truncated bodies became HTTP 500. This PR catches JSON parse errors and returns `{ error: "Invalid JSON body" }` with status 400 before domain lookup.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical JSON callers unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/apps/[id]/domains/status/route.json.test.ts` and the `c.req.json()` catch in `route.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate 'v1/apps/[id]/domains/status/route.json.test.ts'
```

Unfixed head: malformed `{` returned **500** on POST. After the fix: 2 passed on `6c4e1525cc7f5e4b10d709c5a2513e9a799317bf`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:6c4e1525cc7f5e4b10d709c5a2513e9a799317bf -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the domains-status HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before status lookup.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that getOwnDomainRow is not called.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches getOwnDomainRow.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on domains-status JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500 on POST; after the fix, Bun test asserts 400 and canonical `{ domain }` still returns status.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the domains-status HTTP boundary.

## Audio / voice walkthrough

N/A - metadata POST only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `6c4e1525cc`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
