### PR TITLE
fix(cloud): require staging Blooio config on current develop

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -642,6 +642,33 @@ jobs:
             require_exact RELAY_ORIGIN "$RELAY_ORIGIN" "https://relay-staging.eliza.app"
           fi
 
+      - name: Validate protected staging Blooio configuration
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
+        env:
+          DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
+          ELIZA_APP_BLOOIO_API_KEY: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_API_KEY || '' }}
+          ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER || '' }}
+          ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET || '' }}
+        run: |
+          set -euo pipefail
+          required_names=(
+            ELIZA_APP_BLOOIO_API_KEY
+            ELIZA_APP_BLOOIO_PHONE_NUMBER
+            ELIZA_APP_BLOOIO_WEBHOOK_SECRET
+          )
+          missing=()
+          for name in "${required_names[@]}"; do
+            value="${!name:-}"
+            if [ -z "${value//[[:space:]]/}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required protected staging Blooio secret name(s): ${missing[*]}"
+            exit 1
+          fi
+          echo "Verified ${#required_names[@]} protected staging Blooio secret names; values were not printed."
+
       - name: Disable staging session exchange before cutover
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api
@@ -781,6 +808,13 @@ jobs:
           # activation is a separate protected, live-proven rollout.
           ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
           ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
+          # Personal Shared Blooio is a staging acceptance surface. These
+          # protected values are mandatory in staging and are committed with
+          # the exact Worker source through the atomic secrets file below.
+          # Production keeps its existing bindings and never queues this source.
+          ELIZA_APP_BLOOIO_API_KEY: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_API_KEY || '' }}
+          ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER || '' }}
+          ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET || '' }}
           # Personal Shared APNs stays dormant unless the complete protected
           # environment config is present. Topic/environment are explicit so a
           # signed development build cannot silently receive production pushes.
@@ -1117,6 +1151,20 @@ jobs:
             queue_secret "$name" || exit 1
           done
 
+          if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then
+            for name in \
+              ELIZA_APP_BLOOIO_API_KEY \
+              ELIZA_APP_BLOOIO_PHONE_NUMBER \
+              ELIZA_APP_BLOOIO_WEBHOOK_SECRET
+            do
+              if ! has_nonblank_value "${!name:-}"; then
+                echo "::error::Required protected staging Blooio secret is absent or blank: $name"
+                exit 1
+              fi
+              queue_secret "$name" || exit 1
+            done
+          fi
+
           for name in \
             OPENROUTER_API_KEY \
             OPENAI_API_KEY \
@@ -1325,6 +1373,11 @@ jobs:
             ];
             if (process.env.DEPLOY_ENVIRONMENT === "staging") {
               required.push("LOCAL_EMBEDDINGS_API_KEY");
+              required.push(
+                "ELIZA_APP_BLOOIO_API_KEY",
+                "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+                "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+              );
             }
             if (
               process.env.DEPLOY_ENVIRONMENT === "production" &&

--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -212,6 +212,14 @@ jobs:
               AGENT_ROUTER_ORIGIN_HOST: .AGENT_ROUTER_ORIGIN_HOST,
               ELIZA_CLOUD_AGENT_BASE_DOMAIN: .ELIZA_CLOUD_AGENT_BASE_DOMAIN
             },
+            staging_blooio_nonblank_names: [
+              to_entries[] |
+              select(.key == "ELIZA_APP_BLOOIO_API_KEY" or
+                     .key == "ELIZA_APP_BLOOIO_PHONE_NUMBER" or
+                     .key == "ELIZA_APP_BLOOIO_WEBHOOK_SECRET") |
+              select((.value | type) == "string" and (.value | test("\\S"))) |
+              .key
+            ],
             nonblank_sensitive_names: [
               to_entries[] |
               select(.value | type == "string" and length > 0) |
@@ -238,6 +246,15 @@ jobs:
               exit 1
             fi
           }
+          require_staging_blooio_name() {
+            local name="$1"
+            if ! jq -e --arg name "$name" \
+              '.staging_blooio_nonblank_names | index($name) != null' \
+              "$variables_path" >/dev/null; then
+              echo "::error::Required sensitive Railway variable name is absent or blank: $name"
+              exit 1
+            fi
+          }
 
           require_exact_variable ELIZA_CLOUD_URL "$EXPECTED_CLOUD_URL"
           require_exact_variable AGENT_ROUTER_ORIGIN_HOST "$EXPECTED_ROUTER_ORIGIN"
@@ -249,6 +266,14 @@ jobs:
             ELIZA_APP_WEBHOOK_GATEWAY_SECRET; do
             require_sensitive_name "$name"
           done
+          if [ "$TARGET_ENVIRONMENT" = "staging" ]; then
+            for name in \
+              ELIZA_APP_BLOOIO_API_KEY \
+              ELIZA_APP_BLOOIO_PHONE_NUMBER \
+              ELIZA_APP_BLOOIO_WEBHOOK_SECRET; do
+              require_staging_blooio_name "$name"
+            done
+          fi
           if ! jq -e '.nonblank_sensitive_names as $names |
             (($names | index("REDIS_URL")) != null or
              ((($names | index("KV_REST_API_URL")) != null) and

--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -116,9 +116,17 @@ The workflow validates the existing Railway variable names and canonical
 non-secret values without printing or rewriting sensitive values. Keep runtime
 secrets in Railway; do not copy their values into workflow YAML or logs. The
 names-only inventory requires `ELIZA_APP_WEBHOOK_GATEWAY_SECRET`, which keeps
-the cloud BFF forwarding trust gate enabled. Staging is branch/configuration
-gated but currently has no required reviewer; production retains reviewer
-approval.
+the cloud BFF forwarding trust gate enabled. Staging additionally requires the
+complete `ELIZA_APP_BLOOIO_API_KEY`, `ELIZA_APP_BLOOIO_PHONE_NUMBER`, and
+`ELIZA_APP_BLOOIO_WEBHOOK_SECRET` set before a deployment can start; production
+keeps its existing contract. Provision staging values out of band through
+`railway variable set --stdin --skip-deploys` so an incomplete update cannot
+trigger a release, then use the protected dispatcher once all three names are
+present. Restore or remove only those staged names before dispatch if setup
+fails. The webhook secret must match the Worker protected-environment source;
+the workflows verify names without reading or comparing values. Staging is
+branch/configuration gated but currently has no required reviewer; production
+retains reviewer approval.
 
 `__tests__/dockerfile-workspace-context.test.ts` guards the workspace build
 context. The repository-level

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -116,9 +116,17 @@ The workflow validates the existing Railway variable names and canonical
 non-secret values without printing or rewriting sensitive values. Keep runtime
 secrets in Railway; do not copy their values into workflow YAML or logs. The
 names-only inventory requires `ELIZA_APP_WEBHOOK_GATEWAY_SECRET`, which keeps
-the cloud BFF forwarding trust gate enabled. Staging is branch/configuration
-gated but currently has no required reviewer; production retains reviewer
-approval.
+the cloud BFF forwarding trust gate enabled. Staging additionally requires the
+complete `ELIZA_APP_BLOOIO_API_KEY`, `ELIZA_APP_BLOOIO_PHONE_NUMBER`, and
+`ELIZA_APP_BLOOIO_WEBHOOK_SECRET` set before a deployment can start; production
+keeps its existing contract. Provision staging values out of band through
+`railway variable set --stdin --skip-deploys` so an incomplete update cannot
+trigger a release, then use the protected dispatcher once all three names are
+present. Restore or remove only those staged names before dispatch if setup
+fails. The webhook secret must match the Worker protected-environment source;
+the workflows verify names without reading or comparing values. Staging is
+branch/configuration gated but currently has no required reviewer; production
+retains reviewer approval.
 
 `__tests__/dockerfile-workspace-context.test.ts` guards the workspace build
 context. The repository-level

--- a/packages/scripts/__tests__/cloud-cf-blooio-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-blooio-deploy-workflow.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Guards staging-only Blooio secret sourcing, atomic Worker publication, and
+ * names-only post-deploy verification in the protected Cloud release.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const source = readFileSync(
+  new URL(".github/workflows/cloud-cf-release.yml", repoRoot),
+  "utf8",
+);
+
+interface WorkflowStep {
+  env?: Record<string, string>;
+  id?: string;
+  if?: string;
+  name?: string;
+  run?: string;
+}
+
+interface Workflow {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+const workflow = Bun.YAML.parse(source) as Workflow;
+const steps = workflow.jobs?.["deploy-api"]?.steps ?? [];
+const blooioNames = [
+  "ELIZA_APP_BLOOIO_API_KEY",
+  "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+  "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+] as const;
+const stagingValues: Record<(typeof blooioNames)[number], string> = {
+  ELIZA_APP_BLOOIO_API_KEY: "api-key-private-canary",
+  ELIZA_APP_BLOOIO_PHONE_NUMBER: "+15555550199",
+  ELIZA_APP_BLOOIO_WEBHOOK_SECRET: "webhook-secret-private-canary",
+};
+
+function step(name: string): WorkflowStep {
+  const found = steps.find((candidate) => candidate.name === name);
+  if (!found?.run) throw new Error(`Missing executable workflow step: ${name}`);
+  return found;
+}
+
+function index(name: string): number {
+  return steps.findIndex((candidate) => candidate.name === name);
+}
+
+function githubExpression(body: string): string {
+  return ["$", "{{ ", body, " }}"].join("");
+}
+
+function runValidation(
+  overrides: Partial<typeof stagingValues> = {},
+): ReturnType<typeof Bun.spawnSync> {
+  const validation = step("Validate protected staging Blooio configuration");
+  return Bun.spawnSync(["bash", "-c", validation.run ?? ""], {
+    env: {
+      ...process.env,
+      DEPLOY_ENVIRONMENT: "staging",
+      ...stagingValues,
+      ...overrides,
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+}
+
+describe("protected Cloud staging Blooio configuration", () => {
+  test("fails closed before Worker mutation without exposing protected values", () => {
+    const validation = step("Validate protected staging Blooio configuration");
+    expect(validation.if).toContain(
+      "steps.env.outputs.deploy_environment == 'staging'",
+    );
+    expect(index("Validate canonical routing contract")).toBeLessThan(
+      index("Validate protected staging Blooio configuration"),
+    );
+    expect(
+      index("Validate protected staging Blooio configuration"),
+    ).toBeLessThan(index("Disable staging session exchange before cutover"));
+
+    const complete = runValidation();
+    expect(complete.exitCode).toBe(0);
+    expect(complete.stdout.toString()).toContain(
+      "Verified 3 protected staging Blooio secret names",
+    );
+    const completeOutput = `${complete.stdout.toString()}${complete.stderr.toString()}`;
+    for (const value of Object.values(stagingValues)) {
+      expect(completeOutput).not.toContain(value);
+    }
+
+    for (const name of blooioNames) {
+      for (const missingValue of ["", " \t "]) {
+        const missing = runValidation({ [name]: missingValue });
+        expect(missing.exitCode).toBe(1);
+        const output = `${missing.stdout.toString()}${missing.stderr.toString()}`;
+        expect(output).toContain(name);
+        for (const value of Object.values(stagingValues)) {
+          expect(output).not.toContain(value);
+        }
+      }
+    }
+  });
+
+  test("sources only protected staging values and commits them atomically", () => {
+    const validation = step("Validate protected staging Blooio configuration");
+    const prepare = step("Prepare Worker secrets for atomic deploy");
+    const deploy = step("Deploy to Cloudflare Workers");
+    const cleanup = step("Remove atomic Worker secrets file");
+
+    for (const name of blooioNames) {
+      const expected = githubExpression(
+        `steps.env.outputs.deploy_environment == 'staging' && secrets.${name} || ''`,
+      );
+      expect(validation.env?.[name]).toBe(expected);
+      expect(prepare.env?.[name]).toBe(expected);
+      expect(prepare.run).toContain(`\n    ${name}`);
+    }
+    expect(prepare.run).toContain('if [ "$DEPLOY_ENVIRONMENT" = "staging" ]');
+    expect(prepare.run).toContain('queue_secret "$name" || exit 1');
+    expect(prepare.run).toContain("worker-secrets-file.mjs");
+    expect(prepare.run).toContain('create "$RUNNER_TEMP"');
+    expect(prepare.run).not.toMatch(/^\s*bunx wrangler secret put/m);
+    expect(deploy.run).toContain('--secrets-file "$WORKER_SECRETS_FILE"');
+    expect(cleanup.if).toContain("always()");
+    expect(cleanup.run).toContain('remove-all "$RUNNER_TEMP"');
+  });
+
+  test("verifies staging names after deploy while leaving production isolated", () => {
+    const verify = step("Verify required Worker secret binding names");
+    expect(verify.run).toContain(
+      'process.env.DEPLOY_ENVIRONMENT === "staging"',
+    );
+    for (const name of blooioNames) {
+      expect(verify.run).toContain(`"${name}"`);
+    }
+    expect(verify.run).toContain("values were not read");
+
+    const validation = step("Validate protected staging Blooio configuration");
+    expect(validation.if).not.toContain("production");
+    for (const name of blooioNames) {
+      expect(validation.env?.[name]).not.toContain(
+        `deploy_environment == 'production' && secrets.${name}`,
+      );
+      expect(
+        step("Prepare Worker secrets for atomic deploy").env?.[name],
+      ).not.toContain(`deploy_environment == 'production' && secrets.${name}`);
+    }
+  });
+});

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -465,7 +465,7 @@ describe("protected gateway-webhook deployment workflow", () => {
     expect(production.stdout.toString()).toContain(
       "required sensitive variable names are present",
     );
-  });
+  }, 15_000);
 
   test("binds the exact root source and manifest to its new deployment id", () => {
     const exactSource = step("Deploy exact gateway-webhook source");

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -27,6 +28,16 @@ const workflowReadme = readFileSync(
   new URL(".github/workflows/README.md", repoRoot),
   "utf8",
 );
+const blooioNames = [
+  "ELIZA_APP_BLOOIO_API_KEY",
+  "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+  "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+] as const;
+const blooioValues: Record<(typeof blooioNames)[number], string> = {
+  ELIZA_APP_BLOOIO_API_KEY: "railway-api-key-private-canary",
+  ELIZA_APP_BLOOIO_PHONE_NUMBER: "+15555550200",
+  ELIZA_APP_BLOOIO_WEBHOOK_SECRET: "railway-webhook-private-canary",
+};
 interface WorkflowStep {
   env?: Record<string, string>;
   id?: string;
@@ -127,6 +138,86 @@ function railwayUpPathArgument(run: string): string | undefined {
   return firstArgument && !firstArgument.startsWith("-")
     ? firstArgument
     : undefined;
+}
+
+function verifyRailwayVariableInventory(
+  target: "staging" | "production",
+  overrides: Record<string, string | undefined> = {},
+): ReturnType<typeof Bun.spawnSync> {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "gateway-webhook-vars-"));
+  const binRoot = join(fixtureRoot, "bin");
+  mkdirSync(binRoot, { recursive: true });
+  const canonical =
+    target === "staging"
+      ? {
+          ELIZA_CLOUD_URL: "https://api-staging.eliza.app",
+          AGENT_ROUTER_ORIGIN_HOST: "eliza-staging-1.eliza.app",
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud-staging.eliza.app",
+        }
+      : {
+          ELIZA_CLOUD_URL: "https://api.eliza.app",
+          AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.eliza.app",
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+        };
+  const variables: Record<string, string | undefined> = {
+    ...canonical,
+    GATEWAY_BOOTSTRAP_SECRET: "bootstrap-private-canary",
+    GATEWAY_INTERNAL_SECRET: "internal-private-canary",
+    AGENT_SERVER_SHARED_SECRET: "server-private-canary",
+    ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "forwarder-private-canary",
+    REDIS_URL: "redis-private-canary",
+    ...(target === "staging" ? blooioValues : {}),
+    ...overrides,
+  };
+  writeFileSync(
+    join(binRoot, "railway"),
+    `#!/bin/sh
+set -eu
+if [ "$1" = "variable" ] && [ "$2" = "list" ]; then
+  printf '%s' "$RAILWAY_VARIABLES_FIXTURE"
+  exit 0
+fi
+exit 97
+`,
+  );
+  writeFileSync(
+    join(binRoot, "shred"),
+    `#!/bin/sh
+set -eu
+if [ "$1" = "-u" ]; then
+  rm -f "$2"
+  exit 0
+fi
+exit 98
+`,
+  );
+  chmodSync(join(binRoot, "railway"), 0o755);
+  chmodSync(join(binRoot, "shred"), 0o755);
+
+  try {
+    const verification = step(
+      "Verify canonical Railway variables and sensitive names",
+    );
+    return Bun.spawnSync(["bash", "-c", verification.run ?? ""], {
+      env: {
+        ...process.env,
+        EXPECTED_AGENT_BASE_DOMAIN: canonical.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
+        EXPECTED_CLOUD_URL: canonical.ELIZA_CLOUD_URL,
+        EXPECTED_ROUTER_ORIGIN: canonical.AGENT_ROUTER_ORIGIN_HOST,
+        PATH: `${binRoot}:${process.env.PATH ?? ""}`,
+        RAILWAY_ENVIRONMENT_ID: "22222222-2222-4222-8222-222222222222",
+        RAILWAY_PROJECT_ID: "11111111-1111-4111-8111-111111111111",
+        RAILWAY_SERVICE_ID: "33333333-3333-4333-8333-333333333333",
+        RAILWAY_VARIABLES_FIXTURE: JSON.stringify(variables),
+        RUNNER_TEMP: fixtureRoot,
+        TARGET_ENVIRONMENT: target,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
 }
 
 /**
@@ -334,9 +425,46 @@ describe("protected gateway-webhook deployment workflow", () => {
     expect(variables.run).toContain("KV_REST_API_TOKEN");
     expect(variables.run).toContain("AGENT_ROUTER_ORIGIN_HOST");
     expect(variables.run).toContain("ELIZA_CLOUD_AGENT_BASE_DOMAIN");
+    expect(variables.run).toContain("staging_blooio_nonblank_names");
+    expect(variables.run).toContain('if [ "$TARGET_ENVIRONMENT" = "staging" ]');
+    for (const name of blooioNames) {
+      expect(variables.run).toContain(name);
+    }
     expect(source).not.toContain("railway variable set");
     expect(source).not.toContain('cat "$variables_path"');
     expect(source).not.toContain('echo "$RAILWAY_TOKEN"');
+  });
+
+  test("requires the complete staging Blooio set without changing production", () => {
+    const complete = verifyRailwayVariableInventory("staging");
+    expect(complete.exitCode).toBe(0);
+    expect(complete.stdout.toString()).toContain(
+      "required sensitive variable names are present",
+    );
+    const completeOutput = `${complete.stdout.toString()}${complete.stderr.toString()}`;
+    for (const value of Object.values(blooioValues)) {
+      expect(completeOutput).not.toContain(value);
+    }
+
+    for (const name of blooioNames) {
+      for (const missingValue of [undefined, "", " \t "]) {
+        const missing = verifyRailwayVariableInventory("staging", {
+          [name]: missingValue,
+        });
+        expect(missing.exitCode).toBe(1);
+        const output = `${missing.stdout.toString()}${missing.stderr.toString()}`;
+        expect(output).toContain(name);
+        for (const value of Object.values(blooioValues)) {
+          expect(output).not.toContain(value);
+        }
+      }
+    }
+
+    const production = verifyRailwayVariableInventory("production");
+    expect(production.exitCode).toBe(0);
+    expect(production.stdout.toString()).toContain(
+      "required sensitive variable names are present",
+    );
   });
 
   test("binds the exact root source and manifest to its new deployment id", () => {


### PR DESCRIPTION
Closes #21426

Current-`develop` replacement for stale-source draft #21432. The original remote branch remains preserved in Git history.

## Scope

- Six paths only: protected Cloud and gateway deployment workflows, gateway owner guidance, and their exact contract tests.
- Staging fails closed unless the full Blooio key, phone, and webhook-secret name set is nonblank.
- Protected Cloud values are staged through the existing mode-0600 atomic Wrangler secrets file and never printed.
- Railway inspects a private, names-only inventory and never writes variables.
- Production behavior and configuration remain unchanged.
- No environment, provider, deployment, secret, production, or channel-traffic mutation is included.

## Exact pin

- base: `5bc247fc11c860d46b2967a6a482aa69b35714bf`
- evidence-head: `67d906ff6dd79672b73970c598ffd80928f1d75c`
- tree: `125dffc7d7c3d2ba96d4628a44baeb5f62968248`
- The two rebased commits retain exact stable patch IDs from the reviewed source: `f6b0b367f3dd9c8220d2457ac3a8f0d9d00a446f` and `1ede35ec5e206d1f1985f5a295af57c9808e723d`.

## Exact-head evidence

- Focused executable workflow contracts: **10 pass, 0 fail, 270 assertions**.
- Gateway service suite: **168 pass, 0 fail, 470 assertions**.
- Gateway typecheck, read-only lint, and build: **PASS**.
- Repository-pinned actionlint on both changed workflows: **PASS**.
- Cloud API production Wrangler dry bundle after the required core build: **PASS** (26.3 MiB upload / 6.39 MiB gzip; dry-run only).
- Exact-file Biome: **PASS with two unchanged pre-existing workflow-expression warnings outside this patch**.
- `CLAUDE.md` / `AGENTS.md` parity and `git diff --check`: **PASS**.
- Root `bun run verify`: **BASELINE BLOCKED** in `packages/cloud/shared/src/lib/cache/redis-factory.ts`, which is unchanged from the exact base and outside this PR; the current base fails its read-only formatter check.
- Cloud API typecheck: **BASELINE BLOCKED** by six existing backup-catalog test errors under `packages/cloud/shared`; no changed path contributes to those errors. The production Worker bundle itself passes.

## Release hold

Keep this PR draft and unmerged until an authorized operator attaches the protected staging lifecycle/configuration receipt required by the independent review: the Phase A rollback floor serving on protected staging, the complete protected GitHub and Railway staging name sets, and the cross-surface webhook-secret agreement. This source review did not mutate credentials, protected environments, deployments, provider state, production, or channel traffic.

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex Desktop / multi-agent
- Contribution skill revision: `elizaOS/eliza@67d906ff6dd79672b73970c598ffd80928f1d75c:packages/skills/skills/contribute-to-eliza`
- Attribution status: self-reported

— [codex-root/pr-21605]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"elizaOS/eliza@67d906ff6dd79672b73970c598ffd80928f1d75c:packages/skills/skills/contribute-to-eliza"} -->
