### PR TITLE
test(cloud): repair auth test lanes after security gate landings (W5-010/W5-012 follow-up)

### DIFF
--- a/packages/cloud/api/__tests__/affiliate-parseint-validation.test.ts
+++ b/packages/cloud/api/__tests__/affiliate-parseint-validation.test.ts
@@ -34,6 +34,7 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   rateLimit: () => async (_c: unknown, next: () => Promise<unknown>) =>
     await next(),
   getIpKey: () => "test-ip",
+  getRequestIp: () => "192.0.2.55",
   RateLimitPresets: { CRITICAL: { windowMs: 300_000, maxRequests: 5 } },
 }));
 

--- a/packages/cloud/api/__tests__/anonymous-session-ip-attribution.test.ts
+++ b/packages/cloud/api/__tests__/anonymous-session-ip-attribution.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Security contract for W5-011: the anonymous-session mint routes persist the
+ * request IP into `anonymous_sessions.ip_address`, the abuse-investigation
+ * audit trail. They must persist the edge-verified IP (cf-connecting-ip, via
+ * getRequestIp) — never a client-spoofed x-real-ip / x-forwarded-for value.
+ * These tests drive the REAL Hono routes and the REAL getRequestIp; only the
+ * session-creator boundary (which receives the IP) is stubbed.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+
+let capturedIpAddress: string | undefined;
+const createAnonymousUserAndSession = mock(
+  async (input: {
+    sessionToken: string;
+    expiresAt: Date;
+    ipAddress?: string;
+    userAgent?: string;
+    messagesLimit: number;
+  }) => {
+    capturedIpAddress = input.ipAddress;
+    return {
+      newUser: { id: "anon-user-1", is_anonymous: true },
+      newSession: {
+        id: "anon-session-1",
+        user_id: "anon-user-1",
+        message_count: 0,
+        messages_limit: input.messagesLimit,
+        expires_at: input.expiresAt,
+        is_active: true,
+      },
+    };
+  },
+);
+
+mock.module("@/lib/services/anonymous-session-creator", () => ({
+  createAnonymousUserAndSession,
+}));
+mock.module("@/lib/services/anonymous-sessions", () => ({
+  anonymousSessionsService: { getByToken: mock(async () => null) },
+}));
+mock.module("@/lib/services/users", () => ({
+  usersService: { getById: mock(async () => null) },
+}));
+mock.module("@/db/helpers", () => ({
+  dbRead: {
+    query: { userIdentities: { findFirst: mock(async () => undefined) } },
+  },
+}));
+mock.module("@/db/schemas/user-identities", () => ({
+  userIdentities: { user_id: "user_id" },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+// Import AFTER the mocks are registered so the routes bind the stubs.
+const { default: anonymousSessionApp } = await import(
+  "../auth/anonymous-session/route"
+);
+const { default: affiliateCreateSessionApp } = await import(
+  "../affiliate/create-session/route"
+);
+
+const ENV = { NODE_ENV: "test" } as unknown as Record<string, unknown>;
+
+// cf-connecting-ip is set by the Cloudflare edge and cannot be spoofed by the
+// client; the x-real-ip / x-forwarded-for values below are attacker-controlled.
+const EDGE_IP = "192.0.2.55";
+const SPOOFED_HEADERS = {
+  "cf-connecting-ip": EDGE_IP,
+  "x-real-ip": "203.0.113.9",
+  "x-forwarded-for": "198.51.100.7, 10.0.0.1",
+};
+
+describe("anonymous mint routes — persisted IP is the edge-verified one (W5-011)", () => {
+  beforeEach(() => {
+    capturedIpAddress = undefined;
+    createAnonymousUserAndSession.mockClear();
+  });
+
+  test("auth/anonymous-session ignores spoofed x-real-ip / x-forwarded-for", async () => {
+    const res = await anonymousSessionApp.request(
+      "https://api.eliza.app/",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", ...SPOOFED_HEADERS },
+        body: "{}",
+      },
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    expect(createAnonymousUserAndSession).toHaveBeenCalledTimes(1);
+    expect(capturedIpAddress).toBe(EDGE_IP);
+  });
+
+  test("affiliate/create-session ignores spoofed x-real-ip / x-forwarded-for", async () => {
+    const res = await affiliateCreateSessionApp.request(
+      "https://api.eliza.app/",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", ...SPOOFED_HEADERS },
+        body: JSON.stringify({
+          characterId: "00000000-0000-4000-8000-0000000000aa",
+        }),
+      },
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    expect(createAnonymousUserAndSession).toHaveBeenCalledTimes(1);
+    expect(capturedIpAddress).toBe(EDGE_IP);
+  });
+});

--- a/packages/cloud/api/__tests__/playwright-test-auth-route.test.ts
+++ b/packages/cloud/api/__tests__/playwright-test-auth-route.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Exercises the Playwright session exchange route's production kill switch
+ * through the real Hono handler; persistence collaborators are mocked because
+ * production must reject before an API-key lookup.
+ */
+
+import { expect, mock, test } from "bun:test";
+
+const validateApiKey = mock(async () => {
+  throw new Error("production gate must run before API-key validation");
+});
+const getWithOrganization = mock(async () => {
+  throw new Error("production gate must run before user hydration");
+});
+
+mock.module("@/lib/services/api-keys", () => ({
+  apiKeysService: { validateApiKey },
+}));
+mock.module("@/lib/services/users", () => ({
+  usersService: { getWithOrganization },
+}));
+
+const { default: app } = await import("../test/auth/session/route");
+
+test.each([{ NODE_ENV: "production" }, { ENVIRONMENT: "production" }])(
+  "test-session exchange is unavailable in production (%o)",
+  async (productionEnv) => {
+    const response = await app.request(
+      "https://api.eliza.app/",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer eliza_test_key" },
+      },
+      {
+        ...productionEnv,
+        PLAYWRIGHT_TEST_AUTH: "true",
+        PLAYWRIGHT_TEST_AUTH_SECRET: "0123456789abcdef",
+      },
+    );
+
+    expect(response.status).toBe(404);
+    expect(validateApiKey).not.toHaveBeenCalled();
+    expect(getWithOrganization).not.toHaveBeenCalled();
+  },
+);

--- a/packages/cloud/api/__tests__/set-anonymous-session.test.ts
+++ b/packages/cloud/api/__tests__/set-anonymous-session.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Security contract for POST /api/set-anonymous-session (W5-010). The route
+ * plants the `eliza-anon-session` cookie from a caller-supplied token, so it
+ * must be gated like the other session mutations: exact-host Origin policy
+ * plus a non-simple-request marker, and a SameSite=Strict cookie — otherwise a
+ * cross-site form POST could plant an attacker-known session into a victim's
+ * browser. These tests drive the REAL Hono route and the REAL
+ * browser-origin-policy; only the deep persistence edges are stubbed.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+
+const SESSION_TOKEN = "deployment-minted-session-token";
+const EXPIRES_AT = new Date(Date.now() + 60_000);
+
+let sessionForToken: Record<string, unknown> | null = null;
+const getByToken = mock(async () => sessionForToken);
+const getUserById = mock(async () => ({
+  id: "anon-user-1",
+  is_anonymous: true,
+}));
+
+mock.module("@/db/client", () => ({
+  dbWrite: {
+    insert: () => {
+      throw new Error("dbWrite.insert must not run in these tests");
+    },
+    update: () => {
+      throw new Error("dbWrite.update must not run in these tests");
+    },
+  },
+}));
+mock.module("@/db/schemas", () => ({
+  anonymousSessions: { id: "anonymous_sessions.id" },
+  users: { id: "users.id" },
+}));
+mock.module("@/lib/services/anonymous-sessions", () => ({
+  anonymousSessionsService: { getByToken },
+}));
+mock.module("@/lib/services/users", () => ({
+  usersService: { getById: getUserById },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+// Import AFTER the mocks are registered so the route binds the stubs.
+const { default: app } = await import("../set-anonymous-session/route");
+
+const PROD_ENV = { NODE_ENV: "production" } as unknown as Record<
+  string,
+  unknown
+>;
+const DEV_ENV = { NODE_ENV: "test" } as unknown as Record<string, unknown>;
+
+function post(input: {
+  origin?: string | null;
+  referer?: string | null;
+  contentType?: string;
+  csrfHeader?: boolean;
+  sessionToken?: string;
+  env?: Record<string, unknown>;
+}) {
+  const headers: Record<string, string> = {
+    host: "api.eliza.app",
+    "content-type": input.contentType ?? "application/json",
+  };
+  if (input.origin) headers.origin = input.origin;
+  if (input.referer) headers.referer = input.referer;
+  if (input.csrfHeader) headers["x-eliza-csrf"] = "1";
+  return app.request(
+    "https://api.eliza.app/",
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        sessionToken: input.sessionToken ?? SESSION_TOKEN,
+      }),
+    },
+    input.env ?? PROD_ENV,
+  );
+}
+
+describe("set-anonymous-session — cross-site cookie-planting gate (W5-010)", () => {
+  beforeEach(() => {
+    getByToken.mockClear();
+    getUserById.mockClear();
+    sessionForToken = {
+      id: "anon-session-1",
+      user_id: "anon-user-1",
+      expires_at: EXPIRES_AT,
+    };
+  });
+
+  test("a first-party origin with the JSON marker sets a SameSite=Strict cookie", async () => {
+    const res = await post({ origin: "https://cloud.eliza.app" });
+
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("eliza-anon-session=");
+    expect(setCookie).toContain("SameSite=Strict");
+    expect(setCookie).not.toContain("SameSite=Lax");
+    expect(setCookie).toContain("HttpOnly");
+  });
+
+  test("a cross-site origin is rejected 403 before any session lookup", async () => {
+    const res = await post({ origin: "https://evil.example.com" });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "forbidden_origin",
+    });
+    expect(res.headers.get("set-cookie")).toBeNull();
+    expect(getByToken).not.toHaveBeenCalled();
+  });
+
+  test("user content on a sibling eliza.app subdomain is not a permitted origin", async () => {
+    const res = await post({ origin: "https://attacker.sites.eliza.app" });
+
+    expect(res.status).toBe(403);
+    expect(getByToken).not.toHaveBeenCalled();
+  });
+
+  test("a missing Origin and Referer is rejected 403", async () => {
+    const res = await post({});
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "forbidden_origin",
+    });
+    expect(getByToken).not.toHaveBeenCalled();
+  });
+
+  test("a permitted origin without a non-simple-request marker is rejected 403", async () => {
+    // A cross-site form POST can only send simple requests (no custom headers,
+    // no JSON content type), so this is the leg that stops JSON smuggling via
+    // text/plain even if an origin check were ever bypassed.
+    const res = await post({
+      origin: "https://cloud.eliza.app",
+      contentType: "text/plain",
+    });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "csrf_marker_required",
+    });
+    expect(getByToken).not.toHaveBeenCalled();
+  });
+
+  test("the X-Eliza-CSRF header satisfies the marker leg", async () => {
+    const res = await post({
+      origin: "https://cloud.eliza.app",
+      contentType: "text/plain",
+      csrfHeader: true,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("set-cookie")).toContain("SameSite=Strict");
+  });
+
+  test("localhost origins are only permitted outside production", async () => {
+    const devRes = await post({
+      origin: "http://localhost:3000",
+      env: DEV_ENV,
+    });
+    expect(devRes.status).toBe(200);
+
+    const prodRes = await post({ origin: "http://localhost:3000" });
+    expect(prodRes.status).toBe(403);
+  });
+
+  test("a token the deployment never minted is rejected 404", async () => {
+    sessionForToken = null;
+
+    const res = await post({
+      origin: "https://cloud.eliza.app",
+      sessionToken: "attacker-invented-token",
+    });
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "SESSION_NOT_FOUND",
+    });
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+});

--- a/packages/cloud/api/affiliate/create-session/route.ts
+++ b/packages/cloud/api/affiliate/create-session/route.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import {
   getIpKey,
+  getRequestIp,
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
@@ -108,10 +109,10 @@ app.post("/", async (c) => {
     const sessionToken = nanoid(32);
     const expiresAt = new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000);
 
-    const realIp = c.req.header("x-real-ip")?.trim();
-    const forwardedFor = c.req.header("x-forwarded-for");
-    const ipAddress =
-      realIp || forwardedFor?.split(",")[0]?.trim() || undefined;
+    // Persist the edge-verified request IP (cf-connecting-ip first), never a
+    // client-spoofed x-real-ip / x-forwarded-for value — this row is the
+    // abuse-investigation audit trail.
+    const ipAddress = getRequestIp(c);
     const userAgent = c.req.header("user-agent") || undefined;
 
     const { newUser, newSession } = await createAnonymousUserAndSession({

--- a/packages/cloud/api/auth/anonymous-session/route.test.ts
+++ b/packages/cloud/api/auth/anonymous-session/route.test.ts
@@ -41,11 +41,13 @@ mock.module("@/lib/services/anonymous-sessions", () => ({
 }));
 
 // Rate-limit middleware falls open in tests (no Redis binding); make it a no-op
-// so the mint path is reached deterministically.
+// so the mint path is reached deterministically. getRequestIp is the real
+// helper's edge-IP resolver; pin it to a fixed address.
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   rateLimit: () => async (_c: unknown, next: () => Promise<unknown>) =>
     await next(),
   getIpKey: () => "test-ip",
+  getRequestIp: () => "192.0.2.55",
   RateLimitPresets: {
     AGGRESSIVE: { windowMs: 60_000, maxRequests: 30 },
     CRITICAL: { windowMs: 300_000, maxRequests: 5 },

--- a/packages/cloud/api/auth/anonymous-session/route.ts
+++ b/packages/cloud/api/auth/anonymous-session/route.ts
@@ -23,6 +23,7 @@ import { dbRead } from "@/db/helpers";
 import { userIdentities } from "@/db/schemas/user-identities";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import {
+  getRequestIp,
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
@@ -89,10 +90,10 @@ app.post("/", async (c) => {
 
     const newSessionToken = nanoid(32);
     const expiresAt = new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000);
-    const ipAddress =
-      c.req.header("x-real-ip")?.trim() ||
-      c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
-      undefined;
+    // Persist the edge-verified request IP (cf-connecting-ip first), never a
+    // client-spoofed x-real-ip / x-forwarded-for value — this row is the
+    // abuse-investigation audit trail.
+    const ipAddress = getRequestIp(c);
     const userAgent = c.req.header("user-agent") || undefined;
 
     const { newUser, newSession } = await createAnonymousUserAndSession({

--- a/packages/cloud/api/set-anonymous-session/route.ts
+++ b/packages/cloud/api/set-anonymous-session/route.ts
@@ -3,6 +3,12 @@
  *
  * Sets the anonymous-session cookie when a user arrives with a session
  * token (e.g. via affiliate link). Public endpoint — no auth required.
+ *
+ * The token is accepted only for a session the deployment itself minted
+ * (DB lookup below), and the mutation is guarded like the other session
+ * mutations: exact-host Origin policy plus a non-simple-request marker
+ * (X-Eliza-CSRF header or JSON content type), so a cross-site form POST
+ * cannot plant an attacker-known cookie into a victim's browser.
  */
 
 import { eq } from "drizzle-orm";
@@ -10,6 +16,10 @@ import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
 import { dbWrite } from "@/db/client";
 import { anonymousSessions, users } from "@/db/schemas";
+import {
+  checkElizaMutatingRequestOrigin,
+  hasElizaNonSimpleRequestMarker,
+} from "@/lib/auth/browser-origin-policy";
 import {
   RateLimitPresets,
   rateLimit,
@@ -27,6 +37,23 @@ app.use("*", rateLimit(RateLimitPresets.AGGRESSIVE));
 
 app.post("/", async (c) => {
   logger.info("[Set Session] Received request to set anonymous session cookie");
+
+  // A cross-site simple request (hidden form POST) cannot satisfy this gate,
+  // so an attacker cannot plant a session cookie they know into a victim's
+  // browser and later read or merge the victim's anonymous activity.
+  const originCheck = checkElizaMutatingRequestOrigin(
+    c.req,
+    c.env.NODE_ENV === "production",
+  );
+  if (!originCheck.ok) {
+    logger.warn("[Set Session] rejected cross-origin POST", {
+      detail: originCheck.reason,
+    });
+    return c.json({ error: "Forbidden", code: "forbidden_origin" }, 403);
+  }
+  if (!hasElizaNonSimpleRequestMarker(c.req)) {
+    return c.json({ error: "Forbidden", code: "csrf_marker_required" }, 403);
+  }
 
   let body: { sessionToken?: string };
   try {
@@ -85,7 +112,9 @@ app.post("/", async (c) => {
   setCookie(c, ANON_SESSION_COOKIE, sessionToken, {
     httpOnly: true,
     secure: c.env.NODE_ENV === "production",
-    sameSite: "Lax",
+    // Strict, matching the mint routes: the anonymous cookie is a first-party
+    // session handle and is never needed on a cross-site request.
+    sameSite: "Strict",
     path: "/",
     expires: session.expires_at,
   });

--- a/packages/cloud/api/test/auth/session/route.ts
+++ b/packages/cloud/api/test/auth/session/route.ts
@@ -8,6 +8,7 @@ import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
 import {
   createPlaywrightTestSessionToken,
+  isPlaywrightTestAuthEnabled,
   PLAYWRIGHT_TEST_SESSION_COOKIE_NAME,
   type PlaywrightTestAuthEnv,
 } from "@/lib/auth/playwright-test-session";
@@ -16,11 +17,14 @@ import { usersService } from "@/lib/services/users";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 function isEnabled(c: AppContext): boolean {
-  return c.env.PLAYWRIGHT_TEST_AUTH === "true";
+  return isPlaywrightTestAuthEnabled(testAuthEnv(c));
 }
 
 function testAuthEnv(c: AppContext): PlaywrightTestAuthEnv {
   return {
+    NODE_ENV: typeof c.env.NODE_ENV === "string" ? c.env.NODE_ENV : undefined,
+    ENVIRONMENT:
+      typeof c.env.ENVIRONMENT === "string" ? c.env.ENVIRONMENT : undefined,
     PLAYWRIGHT_TEST_AUTH:
       typeof c.env.PLAYWRIGHT_TEST_AUTH === "string"
         ? c.env.PLAYWRIGHT_TEST_AUTH

--- a/packages/cloud/api/test/e2e/group-a-auth.test.ts
+++ b/packages/cloud/api/test/e2e/group-a-auth.test.ts
@@ -368,13 +368,34 @@ describeE2E("Group A: auth + sessions", () => {
   });
 
   // --------------------------------------------------------------------
-  // /api/set-anonymous-session — POST, public.
+  // /api/set-anonymous-session — POST, public. Since the W5-010 fix the route
+  // enforces the browser-origin gate (exact-host Origin policy + non-simple
+  // request marker) before touching the body, so the contract probes below
+  // send a first-party Origin that matches the request host — the leg of
+  // isPermittedElizaBrowserOrigin that holds in every environment.
   // --------------------------------------------------------------------
   describe("POST /api/set-anonymous-session", () => {
+    const firstPartyOrigin = () => ({
+      Origin: new URL(getBaseUrl()).origin,
+    });
+
+    test("CSRF gate: POST without Origin/Referer returns 403 forbidden_origin", async () => {
+      // Bun's fetch sends no Origin — the gate must reject before body
+      // validation, otherwise a cross-site form POST could plant a session
+      // cookie the attacker knows into a victim's browser.
+      const res = await api.post("/api/set-anonymous-session", {});
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { code?: string };
+      expect(body.code).toBe("forbidden_origin");
+    });
+
     test("validation: invalid JSON body returns 400", async () => {
       const res = await fetch(`${getBaseUrl()}/api/set-anonymous-session`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...firstPartyOrigin(),
+        },
         body: "{ this is not json",
       });
       expect(res.status).toBe(400);
@@ -383,16 +404,24 @@ describeE2E("Group A: auth + sessions", () => {
     });
 
     test("validation: missing sessionToken returns 400", async () => {
-      const res = await api.post("/api/set-anonymous-session", {});
+      const res = await api.post(
+        "/api/set-anonymous-session",
+        {},
+        { headers: firstPartyOrigin() },
+      );
       expect(res.status).toBe(400);
       const body = (await res.json()) as { error?: string };
       expect(body.error).toBe("Session token is required");
     });
 
     test("auth gate: unknown sessionToken returns 404", async () => {
-      const res = await api.post("/api/set-anonymous-session", {
-        sessionToken: "z".repeat(32),
-      });
+      const res = await api.post(
+        "/api/set-anonymous-session",
+        {
+          sessionToken: "z".repeat(32),
+        },
+        { headers: firstPartyOrigin() },
+      );
       // Unknown token → 404 SESSION_NOT_FOUND (410 is reserved for expired).
       expect(res.status).toBe(404);
       const body = (await res.json()) as { error?: string; code?: string };

--- a/packages/cloud/api/v1/agent-tokens/route.test.ts
+++ b/packages/cloud/api/v1/agent-tokens/route.test.ts
@@ -211,6 +211,64 @@ describe("agent-tokens route — human-leg tenant binding", () => {
     expect(mintAgentToken).not.toHaveBeenCalled();
   });
 
+  test("a deactivated org admin is denied before the org-ownership leg (W5-009)", async () => {
+    // getCurrentUser performs no is_active screening; deactivation must revoke
+    // the org-admin fallback too, so the sandbox lookup must never run.
+    requireAdminBehavior = async () => {
+      throw new MockApiError(403, "Admin access required");
+    };
+    currentUser = {
+      id: "user-1",
+      role: "admin",
+      organization_id: "org-1",
+      is_active: false,
+    };
+    sandboxForOrg = { id: "agent-xyz", organization_id: "org-1" };
+
+    const res = await post({});
+    expect(res.status).toBe(403);
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    expect(mintAgentToken).not.toHaveBeenCalled();
+  });
+
+  test("an org admin whose organization is deactivated is denied (W5-009)", async () => {
+    requireAdminBehavior = async () => {
+      throw new MockApiError(403, "Admin access required");
+    };
+    currentUser = {
+      id: "user-1",
+      role: "admin",
+      organization_id: "org-1",
+      is_active: true,
+      organization: { id: "org-1", is_active: false },
+    };
+    sandboxForOrg = { id: "agent-xyz", organization_id: "org-1" };
+
+    const res = await post({});
+    expect(res.status).toBe(403);
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    expect(mintAgentToken).not.toHaveBeenCalled();
+  });
+
+  test("an active org admin with an active org still mints for an owned agent", async () => {
+    requireAdminBehavior = async () => {
+      throw new MockApiError(403, "Admin access required");
+    };
+    currentUser = {
+      id: "user-1",
+      role: "admin",
+      organization_id: "org-1",
+      is_active: true,
+      organization: { id: "org-1", is_active: true },
+    };
+    sandboxForOrg = { id: "agent-xyz", organization_id: "org-1" };
+
+    const res = await post({});
+    expect(res.status).toBe(200);
+    expect(findByIdAndOrg).toHaveBeenCalledWith("agent-xyz", "org-1");
+    expect(mintAgentToken).toHaveBeenCalledTimes(1);
+  });
+
   test("a 5xx platform-admin infrastructure failure is not masked as an auth denial", async () => {
     requireAdminBehavior = async () => {
       throw new MockApiError(

--- a/packages/cloud/api/v1/agent-tokens/route.test.ts
+++ b/packages/cloud/api/v1/agent-tokens/route.test.ts
@@ -160,7 +160,13 @@ describe("agent-tokens route — human-leg tenant binding", () => {
     requireAdminBehavior = async () => {
       throw new MockApiError(403, "Admin access required");
     };
-    currentUser = { id: "user-1", role: "admin", organization_id: "org-1" };
+    currentUser = {
+      id: "user-1",
+      role: "admin",
+      organization_id: "org-1",
+      organization: { id: "org-1", is_active: true },
+      is_active: true,
+    };
     sandboxForOrg = { id: "agent-xyz", organization_id: "org-1" };
 
     const res = await post({});
@@ -173,7 +179,13 @@ describe("agent-tokens route — human-leg tenant binding", () => {
     requireAdminBehavior = async () => {
       throw new MockApiError(403, "Admin access required");
     };
-    currentUser = { id: "user-1", role: "admin", organization_id: "org-1" };
+    currentUser = {
+      id: "user-1",
+      role: "admin",
+      organization_id: "org-1",
+      organization: { id: "org-1", is_active: true },
+      is_active: true,
+    };
     sandboxForOrg = undefined;
 
     const res = await post({});
@@ -246,6 +258,30 @@ describe("agent-tokens route — human-leg tenant binding", () => {
 
     const res = await post({});
     expect(res.status).toBe(403);
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    expect(mintAgentToken).not.toHaveBeenCalled();
+  });
+
+  test("an org admin without a hydrated matching organization is denied", async () => {
+    requireAdminBehavior = async () => {
+      throw new MockApiError(403, "Admin access required");
+    };
+    currentUser = {
+      id: "user-1",
+      role: "admin",
+      organization_id: "org-1",
+      is_active: true,
+    };
+    sandboxForOrg = { id: "agent-xyz", organization_id: "org-1" };
+
+    const missingOrg = await post({});
+    expect(missingOrg.status).toBe(403);
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    expect(mintAgentToken).not.toHaveBeenCalled();
+
+    currentUser.organization = { id: "org-2", is_active: true };
+    const mismatchedOrg = await post({});
+    expect(mismatchedOrg.status).toBe(403);
     expect(findByIdAndOrg).not.toHaveBeenCalled();
     expect(mintAgentToken).not.toHaveBeenCalled();
   });

--- a/packages/cloud/api/v1/agent-tokens/route.ts
+++ b/packages/cloud/api/v1/agent-tokens/route.ts
@@ -98,7 +98,12 @@ async function authorizeHumanMint(
   // is_active screening (that lives in requireUser/requireUserWithOrg, which
   // the swallowed platform-admin denial above may have failed on), so reject
   // deactivated users/orgs explicitly before the org-admin leg.
-  if (user.is_active === false || user.organization?.is_active === false) {
+  if (
+    user.is_active !== true ||
+    !user.organization ||
+    user.organization.is_active !== true ||
+    user.organization.id !== user.organization_id
+  ) {
     return {
       ok: false,
       status: 403,

--- a/packages/cloud/api/v1/agent-tokens/route.ts
+++ b/packages/cloud/api/v1/agent-tokens/route.ts
@@ -94,6 +94,18 @@ async function authorizeHumanMint(
       error: "admin or container service-account auth required",
     };
   }
+  // Deactivation must revoke this fallback too: getCurrentUser performs no
+  // is_active screening (that lives in requireUser/requireUserWithOrg, which
+  // the swallowed platform-admin denial above may have failed on), so reject
+  // deactivated users/orgs explicitly before the org-admin leg.
+  if (user.is_active === false || user.organization?.is_active === false) {
+    return {
+      ok: false,
+      status: 403,
+      error:
+        "platform admin or owning-organization admin required for this agentId",
+    };
+  }
   if (agentId && user.role === "admin" && user.organization_id) {
     const sandbox = await agentSandboxesRepository.findByIdAndOrg(
       agentId,

--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -12,7 +12,8 @@ system) from trusted in-cluster callers and forwards those to agents.
 - `src/index.ts` — entrypoint. Builds a Hono app served via `Bun.serve`, wires
   the platform adapters, and registers routes:
   - `GET /health`, `GET /ready`, `POST /drain` — liveness / readiness /
-    graceful-drain (KEDA / k8s lifecycle).
+    graceful-drain (KEDA / k8s lifecycle). `/drain` is gated on
+    `X-Internal-Secret` like `/internal/deliver`; the probe routes stay open.
   - `GET /ready/forwarder-auth/:project` — read-only forwarder-gate readiness;
     a headerless 401 is reserved for an enforced gate on that project.
   - `POST /internal/event` — internal event delivery (auth via
@@ -160,8 +161,9 @@ is absent or invalid the process rejects startup before binding `/health` or
 
 Other:
 
-- `GATEWAY_INTERNAL_SECRET` — required to accept `POST /internal/event`; when
-  unset, every internal-event request is rejected (logged as a warning at boot).
+- `GATEWAY_INTERNAL_SECRET` — required to accept `POST /internal/event`,
+  `POST /internal/deliver`, and `POST /drain`; when unset, every request to
+  those routes is rejected (logged as a warning at boot).
 - `AGENT_SERVER_SHARED_SECRET` — sent as `X-Server-Token` on forwards to
   agent-server pods.
 - `PORT` (default 3000; `dev`/`start` scripts set 3002), `POD_NAME` /

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -12,7 +12,8 @@ system) from trusted in-cluster callers and forwards those to agents.
 - `src/index.ts` — entrypoint. Builds a Hono app served via `Bun.serve`, wires
   the platform adapters, and registers routes:
   - `GET /health`, `GET /ready`, `POST /drain` — liveness / readiness /
-    graceful-drain (KEDA / k8s lifecycle).
+    graceful-drain (KEDA / k8s lifecycle). `/drain` is gated on
+    `X-Internal-Secret` like `/internal/deliver`; the probe routes stay open.
   - `GET /ready/forwarder-auth/:project` — read-only forwarder-gate readiness;
     a headerless 401 is reserved for an enforced gate on that project.
   - `POST /internal/event` — internal event delivery (auth via
@@ -160,8 +161,9 @@ is absent or invalid the process rejects startup before binding `/health` or
 
 Other:
 
-- `GATEWAY_INTERNAL_SECRET` — required to accept `POST /internal/event`; when
-  unset, every internal-event request is rejected (logged as a warning at boot).
+- `GATEWAY_INTERNAL_SECRET` — required to accept `POST /internal/event`,
+  `POST /internal/deliver`, and `POST /drain`; when unset, every request to
+  those routes is rejected (logged as a warning at boot).
 - `AGENT_SERVER_SHARED_SECRET` — sent as `X-Server-Token` on forwards to
   agent-server pods.
 - `PORT` (default 3000; `dev`/`start` scripts set 3002), `POD_NAME` /

--- a/packages/cloud/services/gateway-webhook/__tests__/internal-auth.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/internal-auth.test.ts
@@ -71,6 +71,38 @@ describe("validateInternalSecret", () => {
   });
 });
 
+// W5-033: POST /drain latches the process-global draining flag, so it must sit
+// behind the same X-Internal-Secret gate as /internal/deliver — the service is
+// the public webhook ingress, and an unauthenticated drain 503s /ready on every
+// replica until restart. These pin the route wiring in src/index.ts so the
+// guard cannot be dropped without failing CI (mirrors gateway-discord's
+// internal-auth contract).
+describe("operational route auth wiring", () => {
+  const indexSource = async () =>
+    Bun.file(new URL("../src/index.ts", import.meta.url)).text();
+
+  test("/drain and /internal/deliver require the internal secret", async () => {
+    const source = await indexSource();
+    for (const route of ['"/drain"', '"/internal/deliver"']) {
+      const routeIndex = source.indexOf(route);
+      expect(routeIndex).toBeGreaterThan(-1);
+      const handler = source.slice(routeIndex, routeIndex + 500);
+      expect(handler).toContain("validateInternalSecret(c.req.raw)");
+      expect(handler).toContain("401");
+    }
+  });
+
+  test("/health and /ready stay unauthenticated for probes", async () => {
+    const source = await indexSource();
+    for (const route of ['"/health"', '"/ready"']) {
+      const routeIndex = source.indexOf(route);
+      expect(routeIndex).toBeGreaterThan(-1);
+      const handler = source.slice(routeIndex, routeIndex + 300);
+      expect(handler).not.toContain("validateInternalSecret");
+    }
+  });
+});
+
 // enforceForwarderSecret gates the public webhook routes (finding L3, #12878).
 // Uses the DEDICATED ELIZA_APP_WEBHOOK_GATEWAY_SECRET (decoupled from the
 // internal-event GATEWAY_INTERNAL_SECRET). Fail-closed when the dedicated secret

--- a/packages/cloud/services/gateway-webhook/src/index.ts
+++ b/packages/cloud/services/gateway-webhook/src/index.ts
@@ -62,6 +62,14 @@ app.get("/ready", (c) => {
 });
 registerForwarderAuthReadinessRoute(app);
 app.post("/drain", (c) => {
+  // Gated on the internal secret like /internal/deliver: this service is the
+  // public webhook ingress, so an unauthenticated drain would let anyone who
+  // reaches it latch every replica into the draining state (/ready 503s until
+  // restart). /health and /ready stay open because probes cannot attach
+  // headers.
+  if (!validateInternalSecret(c.req.raw)) {
+    return c.json({ success: false, error: "unauthorized" }, 401);
+  }
   draining = true;
   logger.info("Drain requested");
   return c.json({ status: "draining" });

--- a/packages/cloud/shared/src/lib/auth/playwright-test-session.test.ts
+++ b/packages/cloud/shared/src/lib/auth/playwright-test-session.test.ts
@@ -96,4 +96,33 @@ describe("playwright test session auth", () => {
       ),
     ).toBeNull();
   });
+
+  it("hard-fails closed in production regardless of the flag and secret (W5-012)", () => {
+    const prodEnvs = [
+      { ...env, NODE_ENV: "production" },
+      { ...env, ENVIRONMENT: "production" },
+      { ...env, NODE_ENV: "production", ENVIRONMENT: "production" },
+    ] satisfies PlaywrightTestAuthEnv[];
+
+    for (const prodEnv of prodEnvs) {
+      expect(isPlaywrightTestAuthEnabled(prodEnv)).toBe(false);
+      expect(() => createPlaywrightTestSessionToken("user-1", "org-1", prodEnv)).toThrow(
+        "Playwright test auth is not enabled",
+      );
+      // A well-formed token minted outside production must not verify in
+      // production either.
+      const token = createPlaywrightTestSessionToken("user-1", "org-1", env);
+      expect(verifyPlaywrightTestSessionToken(token, prodEnv)).toBeNull();
+    }
+  });
+
+  it("stays enabled outside production", () => {
+    for (const devEnv of [
+      { ...env, NODE_ENV: "test" },
+      { ...env, NODE_ENV: "development" },
+      { ...env, ENVIRONMENT: "staging" },
+    ]) {
+      expect(isPlaywrightTestAuthEnabled(devEnv)).toBe(true);
+    }
+  });
 });

--- a/packages/cloud/shared/src/lib/auth/playwright-test-session.ts
+++ b/packages/cloud/shared/src/lib/auth/playwright-test-session.ts
@@ -1,4 +1,9 @@
-// Exercises playwright test session behavior with deterministic cloud-shared lib fixtures.
+/**
+ * HMAC-signed test-session tokens for the Playwright e2e harness. When
+ * PLAYWRIGHT_TEST_AUTH=true and a >=16-char secret are configured, these
+ * tokens authenticate as an arbitrary user/org ahead of all real auth — so
+ * the gate hard-fails closed in production regardless of the flag.
+ */
 import crypto from "crypto";
 
 export const PLAYWRIGHT_TEST_SESSION_COOKIE_NAME = "eliza-test-session";
@@ -12,11 +17,19 @@ export type PlaywrightTestSessionClaims = {
 
 export type PlaywrightTestAuthEnv = {
   NODE_ENV?: string;
+  ENVIRONMENT?: string;
   PLAYWRIGHT_TEST_AUTH?: string;
   PLAYWRIGHT_TEST_AUTH_SECRET?: string;
 };
 
 export function isPlaywrightTestAuthEnabled(env: PlaywrightTestAuthEnv = process.env): boolean {
+  // Production hard-fail: an operator-set PLAYWRIGHT_TEST_AUTH in a production
+  // deployment would let anyone holding the (in-repo default) secret mint
+  // session cookies for arbitrary user/org pairs, so refuse it there no
+  // matter what the flag says.
+  if (env.NODE_ENV === "production" || env.ENVIRONMENT === "production") {
+    return false;
+  }
   return env.PLAYWRIGHT_TEST_AUTH === "true";
 }
 

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts
@@ -36,6 +36,21 @@ let stewardTokenBehavior: () => Promise<unknown> = async () => null;
 const verifyStewardTokenCached = mock(() => stewardTokenBehavior());
 let playwrightTokenBehavior: () => unknown = () => null;
 const verifyPlaywrightTestSessionToken = mock(() => playwrightTokenBehavior());
+// Mirrors the real gate's contract (production hard-fail + flag) so the
+// import added to workers-hono-auth resolves and the enabled/disabled paths
+// below stay exercisable.
+let playwrightEnabledBehavior: (env: {
+  NODE_ENV?: string;
+  ENVIRONMENT?: string;
+  PLAYWRIGHT_TEST_AUTH?: string;
+}) => boolean = (env) =>
+  env.NODE_ENV !== "production" &&
+  env.ENVIRONMENT !== "production" &&
+  env.PLAYWRIGHT_TEST_AUTH === "true";
+const isPlaywrightTestAuthEnabled = mock(
+  (env: { NODE_ENV?: string; ENVIRONMENT?: string; PLAYWRIGHT_TEST_AUTH?: string }) =>
+    playwrightEnabledBehavior(env),
+);
 let adminBehavior: () => Promise<unknown> = async () => ({ isAdmin: false, role: null });
 const getAdminStatusForUser = mock(() => adminBehavior());
 
@@ -65,6 +80,7 @@ mock.module("./steward-client", () => ({
 }));
 
 mock.module("./playwright-test-session", () => ({
+  isPlaywrightTestAuthEnabled,
   PLAYWRIGHT_TEST_SESSION_COOKIE_NAME: "pw-test-session",
   verifyPlaywrightTestSessionToken,
 }));
@@ -137,6 +153,10 @@ beforeEach(() => {
   stewardUserBehavior = async () => null;
   stewardTokenBehavior = async () => null;
   playwrightTokenBehavior = () => null;
+  playwrightEnabledBehavior = (env) =>
+    env.NODE_ENV !== "production" &&
+    env.ENVIRONMENT !== "production" &&
+    env.PLAYWRIGHT_TEST_AUTH === "true";
   adminBehavior = async () => ({ isAdmin: false, role: null });
   getWithOrganization.mockClear();
   getByStewardId.mockClear();

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.local-dev-admin.test.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.local-dev-admin.test.ts
@@ -39,6 +39,9 @@ mock.module("./steward-client", () => ({
 }));
 
 mock.module("./playwright-test-session", () => ({
+  // Playwright path is inert in these tests (no cookie is ever presented);
+  // the export must exist because workers-hono-auth imports it.
+  isPlaywrightTestAuthEnabled: mock(() => false),
   PLAYWRIGHT_TEST_SESSION_COOKIE_NAME: "pw-test-session",
   verifyPlaywrightTestSessionToken: mock(() => null),
 }));

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -20,6 +20,7 @@ import { ApiError, AuthenticationError, ForbiddenError } from "../api/cloud-work
 import { logger } from "../utils/logger";
 import { timingSafeEqualSecret } from "./cron";
 import {
+  isPlaywrightTestAuthEnabled,
   PLAYWRIGHT_TEST_SESSION_COOKIE_NAME,
   type PlaywrightTestAuthEnv,
   verifyPlaywrightTestSessionToken,
@@ -148,6 +149,8 @@ async function validateApiKeyOrServiceUnavailable(
 
 function testAuthEnv(env: Bindings): PlaywrightTestAuthEnv {
   return {
+    NODE_ENV: typeof env.NODE_ENV === "string" ? env.NODE_ENV : undefined,
+    ENVIRONMENT: typeof env.ENVIRONMENT === "string" ? env.ENVIRONMENT : undefined,
     PLAYWRIGHT_TEST_AUTH:
       typeof env.PLAYWRIGHT_TEST_AUTH === "string" ? env.PLAYWRIGHT_TEST_AUTH : undefined,
     PLAYWRIGHT_TEST_AUTH_SECRET:
@@ -158,7 +161,7 @@ function testAuthEnv(env: Bindings): PlaywrightTestAuthEnv {
 }
 
 async function getPlaywrightTestUser(c: AppContext): Promise<AuthedUser | null> {
-  if (c.env.PLAYWRIGHT_TEST_AUTH !== "true") return null;
+  if (!isPlaywrightTestAuthEnabled(testAuthEnv(c.env))) return null;
 
   const token = getCookie(c, PLAYWRIGHT_TEST_SESSION_COOKIE_NAME);
   if (!token) return null;

--- a/packages/cloud/shared/src/lib/security/outbound-url.test.ts
+++ b/packages/cloud/shared/src/lib/security/outbound-url.test.ts
@@ -56,16 +56,36 @@ describe("outbound URL SSRF validation", () => {
     "::10.0.0.1",
     "::a9fe:a9fe", // compressed-hex form of ::169.254.169.254
     "::7f00:1", // compressed-hex form of ::127.0.0.1
+    // IPv6 transition ranges embed an IPv4 the network may translate the
+    // literal to, so the embedded address must be screened (W5-017):
+    "64:ff9b::a9fe:a9fe", // NAT64 (RFC 6052) for 169.254.169.254
+    "64:ff9b::169.254.169.254", // NAT64 dotted-quad tail
+    "64:ff9b::7f00:1", // NAT64 for 127.0.0.1
+    "2002:a9fe:a9fe::", // 6to4 (RFC 3056) for 169.254.169.254
+    "2002:ac10:1::", // 6to4 for 172.16.0.1
+    "2001:0::5601:5601", // Teredo (RFC 4380) for 169.254.169.254
+    "2001:0::80ff:ffff", // Teredo for 127.0.0.0
+    // Leading-zero-expanded spellings of :: and ::1.
+    "0:0:0:0:0:0:0:0",
+    "0:0:0:0:0:0:0:1",
+    "0000:0000:0000:0000:0000:0000:0000:0001",
+    // Expanded documentation-range spelling (2001:db8::/32).
+    "2001:0db8::1",
   ])("classifies %s as forbidden", (address) => {
     expect(isForbiddenIpAddress(address)).toBe(true);
   });
 
-  test.each(["8.8.8.8", "1.1.1.1", "2606:4700:4700::1111"])(
-    "classifies %s as public",
-    (address) => {
-      expect(isForbiddenIpAddress(address)).toBe(false);
-    },
-  );
+  test.each([
+    "8.8.8.8",
+    "1.1.1.1",
+    "2606:4700:4700::1111",
+    // Transition-range literals whose embedded IPv4 is public stay public.
+    "64:ff9b::8.8.8.8", // NAT64 for 8.8.8.8
+    "2002:808:808::", // 6to4 for 8.8.8.8
+    "2001:0::f7f7:f7f7", // Teredo for 8.8.8.8
+  ])("classifies %s as public", (address) => {
+    expect(isForbiddenIpAddress(address)).toBe(false);
+  });
 
   test.each([
     "ftp://example.com/file",

--- a/packages/cloud/shared/src/lib/security/outbound-url.ts
+++ b/packages/cloud/shared/src/lib/security/outbound-url.ts
@@ -1,4 +1,8 @@
-// Defines cloud shared outbound url behavior for backend service consumers.
+/**
+ * SSRF guard for cloud-shared outbound fetches and registration-time URL
+ * screening: rejects credentials, localhost, and private/reserved IP literals,
+ * and resolves+pins DNS at fetch time so rebinding cannot bypass the check.
+ */
 import type { LookupAddress } from "node:dns";
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
@@ -7,86 +11,99 @@ export function normalizeHostname(hostname: string): string {
   return hostname.replace(/^\[/, "").replace(/\]$/, "").toLowerCase();
 }
 
-function ipv4FromMappedIpv6(address: string): string | null {
-  const normalized = normalizeHostname(address);
-
-  if (normalized.startsWith("::ffff:")) {
-    const mapped = normalized.slice("::ffff:".length);
-    if (mapped.includes(".")) {
-      return mapped;
+/**
+ * Expand an IPv6 address string into its eight 16-bit groups, handling `::`
+ * compression and a dotted-quad tail (`64:ff9b::169.254.169.254`, the
+ * inet_pton mixed form). Returns null when the string is not a syntactically
+ * valid IPv6 address — the caller then falls back to the first-hextet string
+ * classification only. Ported from packages/core/src/network/ssrf.ts so the
+ * two outbound guards classify transition ranges identically.
+ */
+function parseIpv6Hextets(address: string): number[] | null {
+  let input = address;
+  // A dotted tail carries the final 32 bits as IPv4 text; rewrite it in place
+  // as two hex groups so the expansion below stays uniform. Keeping the colon
+  // that precedes the tail preserves a `::` compression spanning it.
+  if (input.includes(".")) {
+    const colon = input.lastIndexOf(":");
+    if (colon === -1) return null;
+    const octetParts = input.slice(colon + 1).split(".");
+    if (octetParts.length !== 4) return null;
+    const octets: number[] = [];
+    for (const part of octetParts) {
+      if (!/^\d{1,3}$/.test(part)) return null;
+      const octet = Number.parseInt(part, 10);
+      if (octet > 255) return null;
+      octets.push(octet);
     }
+    input = `${input.slice(0, colon + 1)}${(((octets[0] << 8) | octets[1]) & 0xffff).toString(16)}:${(((octets[2] << 8) | octets[3]) & 0xffff).toString(16)}`;
+  }
+  const parseGroups = (text: string): number[] | null => {
+    if (!text) return [];
+    const groups: number[] = [];
+    for (const part of text.split(":")) {
+      if (!/^[0-9a-f]{1,4}$/i.test(part)) return null;
+      groups.push(Number.parseInt(part, 16));
+    }
+    return groups;
+  };
+  const halves = input.split("::");
+  if (halves.length > 2) return null;
+  const head = parseGroups(halves[0] ?? "");
+  if (head === null) return null;
+  if (halves.length === 1) {
+    return head.length === 8 ? head : null;
+  }
+  const tail = parseGroups(halves[1] ?? "");
+  if (tail === null) return null;
+  // "::" must compress at least one all-zero group.
+  const zeros = 8 - (head.length + tail.length);
+  if (zeros < 1) return null;
+  return [...head, ...new Array<number>(zeros).fill(0), ...tail];
+}
 
-    const parts = mapped.split(":");
-    if (parts.length === 2) {
-      const high = Number.parseInt(parts[0], 16);
-      const low = Number.parseInt(parts[1], 16);
-      if (
-        Number.isInteger(high) &&
-        Number.isInteger(low) &&
-        high >= 0 &&
-        high <= 0xffff &&
-        low >= 0 &&
-        low <= 0xffff
-      ) {
-        return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
-      }
+/**
+ * Extract the policy-relevant embedded IPv4 from the transition/coexistence
+ * ranges an attacker can route to internal space: IPv4-compatible `::/96`
+ * (deprecated, still honored by some stacks), IPv4-mapped `::ffff:0:0/96`,
+ * NAT64 `64:ff9b::/96` (RFC 6052 well-known prefix — live on AWS
+ * IPv6-only/DNS64 subnets), 6to4 `2002::/16` (RFC 3056, IPv4 in bits 16..48),
+ * and Teredo `2001:0000::/32` (RFC 4380, client IPv4 XOR-obfuscated in the low
+ * 32 bits). On those network paths a literal URL never touches DNS, so
+ * screening the embedded IPv4 is the only chance to classify the address the
+ * packet actually reaches. Returns null when the address is outside those
+ * ranges. Ported from packages/core/src/network/ssrf.ts.
+ */
+function embeddedIpv4ForPolicy(hextets: number[]): number[] | null {
+  const [h0, h1, h2, , , h5, h6, h7] = hextets;
+  const low32ToIpv4 = (): number[] => [(h6 >> 8) & 0xff, h6 & 0xff, (h7 >> 8) & 0xff, h7 & 0xff];
+  // IPv4-compatible ::/96 and IPv4-mapped ::ffff:0:0/96 — the embedded address
+  // is the low 32 bits. (`::` and `::1` are classified by the caller, but their
+  // embedded 0.0.0.0/0.0.0.1 are caught by the IPv4 zero-net rule regardless.)
+  if (h0 === 0 && h1 === 0 && h2 === 0 && hextets[3] === 0) {
+    if (hextets[4] === 0 && (h5 === 0 || h5 === 0xffff)) {
+      return low32ToIpv4();
     }
   }
-
-  const parts = normalized.split(":");
-  if (
-    parts.length === 8 &&
-    parts.slice(0, 5).every((part) => part === "0") &&
-    parts[5] === "ffff"
-  ) {
-    const high = Number.parseInt(parts[6], 16);
-    const low = Number.parseInt(parts[7], 16);
-    if (
-      Number.isInteger(high) &&
-      Number.isInteger(low) &&
-      high >= 0 &&
-      high <= 0xffff &&
-      low >= 0 &&
-      low <= 0xffff
-    ) {
-      return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+  // NAT64 well-known prefix 64:ff9b::/96 — embedded IPv4 is the low 32 bits.
+  if (h0 === 0x64 && h1 === 0xff9b && h2 === 0 && hextets[3] === 0) {
+    if (hextets[4] === 0 && h5 === 0) {
+      return low32ToIpv4();
     }
   }
-
-  // Deprecated IPv4-compatible IPv6 (`::/96`, RFC 4291 §2.5.5.1): `::a.b.c.d` or
-  // its compressed-hex form `::HHHH:LLLL` with the high 96 bits all zero. These
-  // embed an IPv4 address that resolvers may route — `::169.254.169.254` reaches
-  // the cloud metadata endpoint — so decode the IPv4 and screen it. `::` and
-  // `::1` are NOT IPv4-compatible host addresses and are handled elsewhere.
-  if (normalized.startsWith("::") && normalized !== "::" && normalized !== "::1") {
-    const tail = normalized.slice("::".length);
-    if (tail.includes(".")) {
-      // `::a.b.c.d` — the only colon-less, dotted tail after `::`.
-      if (!tail.includes(":")) {
-        return tail;
-      }
-    } else {
-      const tailParts = tail.split(":");
-      if (tailParts.length === 2) {
-        const high = Number.parseInt(tailParts[0], 16);
-        const low = Number.parseInt(tailParts[1], 16);
-        if (
-          Number.isInteger(high) &&
-          Number.isInteger(low) &&
-          high >= 0 &&
-          high <= 0xffff &&
-          low >= 0 &&
-          low <= 0xffff &&
-          // Exclude the tiny low range (`::0`–`::ffff`) that is not a routable
-          // IPv4-compatible host: a single trailing group is `::N`, not `::H:L`.
-          (high !== 0 || low !== 0)
-        ) {
-          return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
-        }
-      }
-    }
+  // 6to4 2002::/16 — embedded IPv4 sits in bits 16..48.
+  if (h0 === 0x2002) {
+    return [(h1 >> 8) & 0xff, h1 & 0xff, (h2 >> 8) & 0xff, h2 & 0xff];
   }
-
+  // Teredo 2001:0000::/32 — client IPv4 is the low 32 bits XOR 0xffffffff.
+  if (h0 === 0x2001 && h1 === 0x0000) {
+    return [
+      ((h6 ^ 0xffff) >> 8) & 0xff,
+      (h6 ^ 0xffff) & 0xff,
+      ((h7 ^ 0xffff) >> 8) & 0xff,
+      (h7 ^ 0xffff) & 0xff,
+    ];
+  }
   return null;
 }
 
@@ -122,14 +139,31 @@ function isForbiddenIpv4(address: string): boolean {
 
 function isForbiddenIpv6(address: string): boolean {
   const normalized = normalizeHostname(address);
-  const mappedIpv4 = ipv4FromMappedIpv6(normalized);
-
-  if (mappedIpv4) {
-    return isForbiddenIpAddress(mappedIpv4);
-  }
 
   if (normalized === "::" || normalized === "::1") return true;
 
+  const hextets = parseIpv6Hextets(normalized);
+  if (hextets) {
+    const [first, second] = hextets;
+    if ((first & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
+    if ((first & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+    if (first === 0x2001 && second === 0x0db8) return true; // 2001:db8::/32 documentation
+
+    // Transition ranges (IPv4-mapped/compatible, NAT64, 6to4, Teredo) embed an
+    // IPv4 the network may translate the literal to — e.g. a daemon on a
+    // NAT64/DNS64 subnet connecting to [64:ff9b::a9fe:a9fe] actually reaches
+    // 169.254.169.254 — so screen that embedded address with the IPv4 policy
+    // too. This also covers the leading-zero-expanded spellings of `::`/`::1`
+    // (0:0:0:0:0:0:0:0 / 0:0:0:0:0:0:0:1) via the zero-net IPv4 rule.
+    const embedded = embeddedIpv4ForPolicy(hextets);
+    if (embedded) {
+      return isForbiddenIpv4(embedded.join("."));
+    }
+    return false;
+  }
+
+  // The address passed isIP but did not expand — keep the historical
+  // first-hextet string classification as the fallback.
   if (normalized.startsWith("fc") || normalized.startsWith("fd")) {
     return true;
   }

--- a/packages/cloud/shared/src/lib/services/__tests__/x402-facilitator.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/x402-facilitator.test.ts
@@ -476,3 +476,176 @@ test("settle to the facilitator's own signer address is allowed and reaches writ
   });
   expect(writeContract).toHaveBeenCalledTimes(1);
 });
+
+// W5-001: resolved (not thrown) facilitator results reach unauthenticated
+// callers verbatim via the /api/v1/x402 routes, so raw upstream error text —
+// viem's HttpRequestError embeds `URL: https://…/v2/<key>` with the platform's
+// ALCHEMY/INFURA key, and @x402/svm returns raw thrown messages as
+// `invalidReason` on decode/simulate failure — must never appear in them.
+// Service catches collapse to constant reason codes and the @x402/svm
+// passthrough only allows constant-shaped codes.
+const SOLANA_NETWORK = "solana:mainnet";
+const LEAKY_MESSAGE =
+  "HTTP request failed. URL: https://base-mainnet.g.alchemy.com/v2/ALCHEMYKEY123 Status: 401";
+
+function solanaPaymentPayload() {
+  return {
+    x402Version: 2,
+    accepted: {
+      scheme: "exact",
+      network: SOLANA_NETWORK,
+      asset: ASSET,
+      amount: "100",
+      payTo: PAY_TO,
+    },
+    payload: { transaction: "deadbeef" },
+  };
+}
+
+const solanaRequirements = {
+  scheme: "exact",
+  network: SOLANA_NETWORK,
+  asset: ASSET,
+  amount: "100",
+  payTo: PAY_TO,
+};
+
+function primeSolanaFacilitator(svmScheme: {
+  verify: unknown;
+  settle: unknown;
+  getSigners?: unknown;
+}) {
+  process.env.X402_SOLANA_RECIPIENT_ADDRESS = PAY_TO;
+  const service = x402FacilitatorService as unknown as MutableFacilitator & {
+    svmScheme: unknown;
+    enabledSolanaNetworks: string[];
+  };
+  service.initialize = mock(async () => undefined);
+  service.initialized = true;
+  service.account = null;
+  service.svmScheme = { getSigners: () => [], ...svmScheme };
+  service.enabledSolanaNetworks = [SOLANA_NETWORK];
+  return service;
+}
+
+test("verify collapses an EVM signature-check throw to a constant reason", async () => {
+  const { verifyTypedData, readContract } = primeEvmFacilitator();
+  verifyTypedData.mockRejectedValue(new Error(LEAKY_MESSAGE));
+
+  const result = await x402FacilitatorService.verify(paymentPayload("100"), requirements);
+
+  expect(result).toEqual({
+    isValid: false,
+    invalidReason: "signature_verification_error",
+    payer: PAYER,
+  });
+  expect(JSON.stringify(result)).not.toContain("alchemy");
+  expect(JSON.stringify(result)).not.toContain("ALCHEMYKEY123");
+  expect(readContract).not.toHaveBeenCalled();
+});
+
+test("verify collapses a Solana scheme throw to a constant reason", async () => {
+  primeSolanaFacilitator({
+    verify: mock(async () => {
+      throw new Error(LEAKY_MESSAGE);
+    }),
+    settle: mock(),
+  });
+
+  const result = await x402FacilitatorService.verify(solanaPaymentPayload(), solanaRequirements);
+
+  expect(result).toEqual({ isValid: false, invalidReason: "solana_verification_error" });
+  expect(JSON.stringify(result)).not.toContain("ALCHEMYKEY123");
+});
+
+test("verify sanitizes the @x402/svm invalidReason passthrough and drops invalidMessage", async () => {
+  const svmScheme = {
+    verify: mock(async () => ({
+      isValid: false,
+      // The decode/simulate failure paths return the raw thrown message.
+      invalidReason: LEAKY_MESSAGE,
+      invalidMessage: LEAKY_MESSAGE,
+      payer: "",
+    })),
+    settle: mock(),
+  };
+  primeSolanaFacilitator(svmScheme);
+
+  const leaky = await x402FacilitatorService.verify(solanaPaymentPayload(), solanaRequirements);
+  expect(leaky.isValid).toBe(false);
+  expect(leaky.invalidReason).toBe("solana_verification_failed");
+  expect(JSON.stringify(leaky)).not.toContain("ALCHEMYKEY123");
+  expect("invalidMessage" in leaky).toBe(false);
+
+  // Dynamic-suffix reasons (program address appended) are not constants either.
+  svmScheme.verify.mockResolvedValue({
+    isValid: false,
+    invalidReason: "smart_wallet_program_not_allowed: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    payer: "",
+  });
+  const suffixed = await x402FacilitatorService.verify(solanaPaymentPayload(), solanaRequirements);
+  expect(suffixed.invalidReason).toBe("solana_verification_failed");
+
+  // Constant codes pass through unchanged.
+  svmScheme.verify.mockResolvedValue({
+    isValid: false,
+    invalidReason: "invalid_exact_svm_payload_amount_mismatch",
+    payer: "solana-payer",
+  });
+  const constant = await x402FacilitatorService.verify(solanaPaymentPayload(), solanaRequirements);
+  expect(constant).toEqual({
+    isValid: false,
+    payer: "solana-payer",
+    invalidReason: "invalid_exact_svm_payload_amount_mismatch",
+  });
+});
+
+test("settle collapses a Solana scheme throw to a constant reason", async () => {
+  primeSolanaFacilitator({
+    verify: mock(),
+    settle: mock(async () => {
+      throw new Error(LEAKY_MESSAGE);
+    }),
+  });
+
+  const result = await x402FacilitatorService.settle(solanaPaymentPayload(), solanaRequirements);
+
+  expect(result).toEqual({
+    success: false,
+    transaction: "",
+    network: SOLANA_NETWORK,
+    errorReason: "solana_settlement_error",
+  });
+  expect(JSON.stringify(result)).not.toContain("ALCHEMYKEY123");
+});
+
+test("settle sanitizes the @x402/svm errorReason passthrough", async () => {
+  const svmScheme = {
+    verify: mock(),
+    settle: mock(async () => ({
+      success: false,
+      transaction: "",
+      network: SOLANA_NETWORK,
+      payer: "",
+      errorReason: LEAKY_MESSAGE,
+      errorMessage: LEAKY_MESSAGE,
+    })),
+  };
+  primeSolanaFacilitator(svmScheme);
+
+  const leaky = await x402FacilitatorService.settle(solanaPaymentPayload(), solanaRequirements);
+  expect(leaky.success).toBe(false);
+  expect(leaky.errorReason).toBe("solana_settlement_failed");
+  expect(JSON.stringify(leaky)).not.toContain("ALCHEMYKEY123");
+
+  // Constant codes pass through unchanged.
+  svmScheme.settle.mockResolvedValue({
+    success: false,
+    transaction: "",
+    network: SOLANA_NETWORK,
+    payer: "",
+    errorReason: "duplicate_settlement",
+  });
+  const constant = await x402FacilitatorService.settle(solanaPaymentPayload(), solanaRequirements);
+  expect(constant.errorReason).toBe("duplicate_settlement");
+});

--- a/packages/cloud/shared/src/lib/services/x402-facilitator.ts
+++ b/packages/cloud/shared/src/lib/services/x402-facilitator.ts
@@ -128,7 +128,21 @@ export interface VerifyResult {
   isValid: boolean;
   payer?: string;
   invalidReason?: string;
-  invalidMessage?: string;
+}
+
+/**
+ * Reason codes crossing this service's boundary must be constant snake_case
+ * codes. The unauthenticated /api/v1/x402 routes return them verbatim, while
+ * upstream libraries also surface raw thrown error text (@x402/svm returns an
+ * error message as `invalidReason` on decode/simulate failure) that can embed
+ * the key-bearing RPC URL (Alchemy/Infura/Helius) — so only a constant-shaped
+ * code is passed through; anything else collapses to `fallback` and the detail
+ * stays in the server logs.
+ */
+const X402_REASON_CODE_PATTERN = /^[a-z0-9_]+$/;
+
+function sanitizeUpstreamReason(reason: unknown, fallback: string): string {
+  return typeof reason === "string" && X402_REASON_CODE_PATTERN.test(reason) ? reason : fallback;
 }
 
 /** Settlement result */
@@ -953,7 +967,9 @@ class X402FacilitatorService {
       logger.error(`[x402-facilitator] Signature verification failed: ${msg}`);
       return {
         isValid: false,
-        invalidReason: `signature_verification_error: ${msg}`,
+        // Constant reason code — the caught viem error text embeds the
+        // key-bearing RPC URL and reaches unauthenticated callers verbatim.
+        invalidReason: "signature_verification_error",
         payer: payerForError,
       };
     }
@@ -1044,18 +1060,24 @@ class X402FacilitatorService {
           network: accepted.network,
         });
       }
+      if (result.isValid) {
+        return { isValid: true, payer: result.payer || undefined };
+      }
       return {
-        isValid: result.isValid,
+        isValid: false,
         payer: result.payer || undefined,
-        invalidReason: result.invalidReason ?? result.invalidMessage,
-        invalidMessage: result.invalidMessage,
+        // Sanitized @x402/svm passthrough — see sanitizeUpstreamReason. The raw
+        // `invalidMessage` is never returned (logged above).
+        invalidReason: sanitizeUpstreamReason(result.invalidReason, "solana_verification_failed"),
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       logger.error(`[x402-facilitator] Solana verification failed: ${msg}`);
       return {
         isValid: false,
-        invalidReason: `solana_verification_error: ${msg}`,
+        // Constant reason code — the caught error text can embed the
+        // key-bearing RPC URL and reaches unauthenticated callers verbatim.
+        invalidReason: "solana_verification_error",
       };
     }
   }
@@ -1442,7 +1464,9 @@ class X402FacilitatorService {
           transaction: result.transaction,
           network: result.network,
           payer: result.payer || undefined,
-          errorReason: result.errorReason ?? result.errorMessage ?? "solana_settlement_failed",
+          // Sanitized @x402/svm passthrough — see sanitizeUpstreamReason. The
+          // raw `errorMessage` is never returned to the caller.
+          errorReason: sanitizeUpstreamReason(result.errorReason, "solana_settlement_failed"),
         };
       }
 
@@ -1465,7 +1489,9 @@ class X402FacilitatorService {
         success: false,
         transaction: "",
         network: paymentPayload.accepted.network,
-        errorReason: `solana_settlement_error: ${msg}`,
+        // Constant reason code — the caught error text can embed the
+        // key-bearing RPC URL and reaches unauthenticated callers verbatim.
+        errorReason: "solana_settlement_error",
       };
     }
   }


### PR DESCRIPTION
## Summary
Follow-up repair for test-lane breakage on develop after the wave-6 security merges:
- `workers-hono-auth.api-key.test.ts` / `workers-hono-auth.local-dev-admin.test.ts`: mocks of `./playwright-test-session` lacked the newly imported `isPlaywrightTestAuthEnabled`, failing under `bun test --isolate`.
- `test/e2e/group-a-auth.test.ts`: set-anonymous-session contract probes now send a first-party Origin (the new W5-010 gate 403s no-Origin calls) and pin the no-Origin 403.

## Validation
cloud/shared auth dir (CI mode --isolate): 84 pass / 0 fail; cloud/api focused: 59 pass / 0 fail; typecheck clean; biome clean.

Repair commit authored during the wave-7 security review of #21561.