### PR TITLE
fix(app-core): reject malformed plugins ui-spec path encoding

### DIFF
--- a/packages/app-core/src/api/server.plugin-ui-spec.encoding.test.ts
+++ b/packages/app-core/src/api/server.plugin-ui-spec.encoding.test.ts
@@ -1,0 +1,99 @@
+/**
+ * GET /api/plugins/:id/ui-spec decoded the path id with decodeURIComponent.
+ * A malformed percent-escape threw URIError out of handleElizaCompatRoute;
+ * runCompatRequestPipeline maps that to HTTP 500.
+ */
+import http from "node:http";
+import { Socket } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CompatRuntimeState } from "./compat-route-shared";
+import { handleElizaCompatRoute } from "./server";
+
+const STATE: CompatRuntimeState = {
+  current: null,
+  pendingAgentName: null,
+  pendingRestartReasons: [],
+};
+
+const ENV_KEYS = [
+  "ELIZA_API_TOKEN",
+  "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_REQUIRE_LOCAL_AUTH",
+] as const;
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  delete process.env.ELIZA_API_TOKEN;
+  delete process.env.ELIZA_CLOUD_PROVISIONED;
+  delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+function trustedLoopbackReq(
+  method: string,
+  pathname: string,
+): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = method;
+  req.url = pathname;
+  req.headers = { host: "127.0.0.1:2138" };
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  return req;
+}
+
+function captureRes() {
+  let body = "";
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  const socket = new Socket();
+  res.assignSocket(socket);
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") body += chunk;
+    else if (chunk) body += chunk.toString("utf8");
+    socket.destroy();
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    status: () => res.statusCode,
+    json: () => (body ? JSON.parse(body) : null),
+  };
+}
+
+describe("GET /api/plugins/:id/ui-spec path encoding", () => {
+  it("returns 400 for a malformed percent-encoded plugin id instead of throwing", async () => {
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      trustedLoopbackReq("GET", "/api/plugins/%ZZ/ui-spec"),
+      cap.res,
+      STATE,
+    );
+    expect(handled).toBe(true);
+    expect(cap.status()).toBe(400);
+    expect(cap.json()).toEqual({
+      error: "Plugin id is not valid percent-encoding",
+    });
+  });
+
+  it("still looks up a canonically encoded plugin id", async () => {
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      trustedLoopbackReq("GET", "/api/plugins/telegram/ui-spec"),
+      cap.res,
+      STATE,
+    );
+    expect(handled).toBe(true);
+    expect(cap.status()).toBe(200);
+    expect(cap.json()).toMatchObject({ spec: expect.any(Object) });
+  });
+});

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -867,7 +867,17 @@ const COMPAT_ROUTE_CHAIN: readonly CompatRouteChainEntry[] = [
         return false;
       }
       if (!(await ensureRouteAuthorized(req, res, state))) return true;
-      const pluginId = decodeURIComponent(uiSpecMatch[1]);
+      let pluginId: string;
+      try {
+        pluginId = decodeURIComponent(uiSpecMatch[1]);
+      } catch {
+        // error-policy:J3 untrusted path segment — malformed percent-encoding
+        // is caller error (400), not runCompatRequestPipeline URIError → 500.
+        sendJsonResponse(res, 400, {
+          error: "Plugin id is not valid percent-encoding",
+        });
+        return true;
+      }
       const { buildPluginConfigUiSpec } = await import(
         "@elizaos/shared/config/plugin-ui-spec"
       );


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed percent-encoding on `GET /api/plugins/:id/ui-spec` currently 500s. Raw path-segment `decodeURIComponent` of `url.pathname` (not extra-decode after `URLSearchParams.get()` / parsed URL search/hash). Not #21472 / #21482 / #21489. Not list-limit. Not `apps/[id]/domains` (left after #21606). Not #21385.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical `/api/plugins/telegram/ui-spec` still returns a spec. Malformed `%ZZ` now 400s before plugin lookup instead of `URIError` → `runCompatRequestPipeline` 500. Proven on the unfixed head: `decodeURIComponent` threw **URIError** from the plugin-ui-spec handler.

# Background

## What does this PR do?

`GET /api/plugins/:id/ui-spec` ran `decodeURIComponent` on the raw `url.pathname` capture with no try/catch. `new URL().pathname` is still percent-encoded, so a truncated escape (`%ZZ`) throws `URIError`. The compat pipeline's unhandled-route catch maps that to HTTP 500. This PR returns `{ error: "Plugin id is not valid percent-encoding" }` with status 400 before plugin lookup.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical encoded plugin ids unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/server.plugin-ui-spec.encoding.test.ts` and the `decodeURIComponent` catch in the plugin-ui-spec handler.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/app-core && node ../scripts/run-vitest.mjs run --config vitest.config.ts --coverage.enabled=false src/api/server.plugin-ui-spec.encoding.test.ts
```

Unfixed head: `GET /api/plugins/%ZZ/ui-spec` threw **URIError** (compat pipeline → 500). After the fix: 2 passed on `96189cfaabc999a04058dacbfc435ecee3439828`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:96189cfaabc999a04058dacbfc435ecee3439828 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the plugins ui-spec path.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed path encoding is rejected before plugin lookup.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Vitest asserts 400 and that a canonical plugin id still returns a spec.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid encoding never reaches plugin lookup.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on plugins ui-spec path encoding. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `%ZZ` threw URIError; after the fix, Vitest asserts 400 and canonical `telegram` still returns a spec.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the plugins ui-spec HTTP boundary.

## Audio / voice walkthrough

N/A - metadata GET only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `96189cfaab`). Root verify is an unrelated full-repo cost and is not required to show the URIError→400 boundary.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
