### PR TITLE
fix(security): serialize pairing admission and preserve iMessage compatibility

### DIFF
--- a/packages/core/src/services/pairing.test.ts
+++ b/packages/core/src/services/pairing.test.ts
@@ -407,6 +407,36 @@ describe("PairingService pending-queue cap", () => {
 		expect(result.request?.senderId).toBe(existing.senderId);
 		expect(updatePairingRequest).toHaveBeenCalledTimes(1);
 	});
+
+	it("serializes concurrent admissions so the pending queue cannot overrun its cap", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-10T00:00:00.000Z"));
+		const pending: PairingRequest[] = [];
+		const { runtime, createPairingRequest } = cappedQueueRuntime(pending);
+		createPairingRequest.mockImplementation(async (created: PairingRequest) => {
+			// Yield once to make an unguarded read-check-create race deterministic.
+			await Promise.resolve();
+			pending.push(created);
+		});
+		const service = new PairingService(runtime, {
+			maxPendingRequests: 3,
+			requestTtlMs: Number.MAX_SAFE_INTEGER,
+		});
+
+		const results = await Promise.all(
+			Array.from({ length: 12 }, (_, index) =>
+				service.upsertRequest({
+					channel: "discord",
+					senderId: `concurrent-sender-${index}`,
+				}),
+			),
+		);
+
+		expect(results.filter((result) => result.created)).toHaveLength(3);
+		expect(results.filter((result) => !result.code)).toHaveLength(9);
+		expect(pending).toHaveLength(3);
+		expect(createPairingRequest).toHaveBeenCalledTimes(3);
+	});
 });
 
 describe("PairingService pairing reply claims", () => {

--- a/packages/core/src/services/pairing.ts
+++ b/packages/core/src/services/pairing.ts
@@ -70,6 +70,13 @@ export class PairingService extends Service {
 	 */
 	private readonly pairingReplyClaims = new Map<string, number>();
 
+	/**
+	 * Serializes the read-check-create portion of request admission in this
+	 * runtime. Without this queue, concurrent first messages can all observe a
+	 * free slot and overrun `maxPendingRequests` before any create is visible.
+	 */
+	private pairingRequestAdmissionTail: Promise<void> = Promise.resolve();
+
 	/** Bound on retained reply claims before expired entries are swept. */
 	private static readonly MAX_PAIRING_REPLY_CLAIMS = 4096;
 
@@ -341,6 +348,21 @@ export class PairingService extends Service {
 	 * If too many pending requests exist, returns empty code.
 	 */
 	async upsertRequest(
+		params: UpsertPairingRequestParams,
+	): Promise<UpsertPairingRequestResult> {
+		const admitted = this.pairingRequestAdmissionTail.then(() =>
+			this.upsertRequestSerial(params),
+		);
+		// Keep the queue usable after a persistence or CSPRNG failure; the caller
+		// still observes the original rejection through `admitted`.
+		this.pairingRequestAdmissionTail = admitted.then(
+			() => undefined,
+			() => undefined,
+		);
+		return admitted;
+	}
+
+	private async upsertRequestSerial(
 		params: UpsertPairingRequestParams,
 	): Promise<UpsertPairingRequestResult> {
 		const { channel, senderId, metadata } = params;

--- a/plugins/plugin-imessage/src/accounts.test.ts
+++ b/plugins/plugin-imessage/src/accounts.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Static iMessage account policy compatibility tests; stateful pairing is
+ * intentionally excluded because the live service owns that handshake.
+ */
+import { describe, expect, it } from "vitest";
+import { isIMessageUserAllowed } from "./accounts";
+
+describe("isIMessageUserAllowed", () => {
+  it("fails closed for the stateful pairing policy", () => {
+    expect(
+      isIMessageUserAllowed({
+        identifier: "+14155550123",
+        accountConfig: { dmPolicy: "pairing" },
+        isGroup: false,
+      })
+    ).toBe(false);
+  });
+
+  it("preserves static open and allowlist evaluation", () => {
+    expect(
+      isIMessageUserAllowed({
+        identifier: "+14155550123",
+        accountConfig: { dmPolicy: "open" },
+        isGroup: false,
+      })
+    ).toBe(true);
+    expect(
+      isIMessageUserAllowed({
+        identifier: "+14155550123",
+        accountConfig: {
+          dmPolicy: "allowlist",
+          allowFrom: ["+14155550123"],
+        },
+        isGroup: false,
+      })
+    ).toBe(true);
+  });
+});

--- a/plugins/plugin-imessage/src/accounts.ts
+++ b/plugins/plugin-imessage/src/accounts.ts
@@ -4,9 +4,9 @@
  * mention-policy check (`isIMessageMentionRequired`) that decides whether a
  * group inbound message is handled. DM access is gated live by
  * `IMessageService.checkDmAccess`, which routes the `pairing` policy through
- * the core PairingService — there is intentionally no exported DM allow
- * helper, because a synchronous policy check cannot honor the pairing
- * handshake and would mislead importers into default-open behavior.
+ * the core PairingService. The deprecated synchronous DM helper remains for
+ * source compatibility but fails closed for `pairing`, because it cannot
+ * perform that stateful handshake.
  * Config is read from `character.settings.imessage`. In practice one macOS host
  * runs a single Messages account (`DEFAULT_ACCOUNT_ID`); these helpers still model
  * the general inventory so the connector-account provider and service share one
@@ -300,6 +300,42 @@ export function resolveIMessageGroupConfig(
 
   // Fall back to base-level groups
   return multiConfig.groups?.[groupId];
+}
+
+/**
+ * Synchronous compatibility helper for legacy callers that only need static
+ * allowlist/group-policy evaluation.
+ *
+ * @deprecated Pairing is stateful; use `IMessageService.checkDmAccess` for
+ * inbound authorization. This helper deliberately fails closed for the
+ * `pairing` policy instead of pretending an unknown sender is authorized.
+ */
+export function isIMessageUserAllowed(params: {
+  identifier: string;
+  accountConfig: IMessageAccountConfig;
+  isGroup: boolean;
+  groupId?: string;
+  groupConfig?: IMessageGroupConfig;
+}): boolean {
+  const { identifier, accountConfig, isGroup, groupConfig } = params;
+
+  if (isGroup) {
+    const policy = accountConfig.groupPolicy ?? "allowlist";
+    if (policy === "disabled") return false;
+    if (policy === "open") return true;
+    if (groupConfig?.allowFrom?.length) {
+      return groupConfig.allowFrom.some((allowed) => String(allowed) === identifier);
+    }
+    if (accountConfig.groupAllowFrom?.length) {
+      return accountConfig.groupAllowFrom.some((allowed) => String(allowed) === identifier);
+    }
+    return false;
+  }
+
+  const policy = accountConfig.dmPolicy ?? "pairing";
+  if (policy === "disabled" || policy === "pairing") return false;
+  if (policy === "open") return true;
+  return Boolean(accountConfig.allowFrom?.some((allowed) => String(allowed) === identifier));
 }
 
 /**

--- a/plugins/plugin-imessage/src/index.ts
+++ b/plugins/plugin-imessage/src/index.ts
@@ -29,6 +29,7 @@ export {
   type IMessageGroupConfig,
   type IMessageMultiAccountConfig,
   isIMessageMentionRequired,
+  isIMessageUserAllowed,
   isMultiAccountEnabled,
   listEnabledIMessageAccounts,
   listIMessageAccountIds,


### PR DESCRIPTION
## Summary

Follow up merged PR #21572 with two review repairs:

- Serialize the full PairingService admission path so concurrent first messages cannot all observe a free slot and exceed `maxPendingRequests`.
- Preserve the public `isIMessageUserAllowed` export for source compatibility, mark it deprecated, and make stateful `pairing` fail closed rather than deleting the API.

Fixes #21609

## Validation

Exact head `fcc2654209710ec103dcacc439626d756b5d0b3b`, rebased on `develop@cf6d90cb3fdb4a312683751cbc21e8b5c95b44cc`.

- Core pairing/integration: 23/23 passed, including deterministic 12-way concurrent admission (3 admitted, 9 rejected).
- Telegram DM/standalone: 27/27 passed.
- New iMessage compatibility cases: 2/2 passed; the broader focused set passed 8/8 before the final base refresh.
- Biome, guide parity, and diff checks passed.

## Evidence Gate

<!-- evidence-head:fcc2654209710ec103dcacc439626d756b5d0b3b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - runtime messaging admission behavior only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - runtime messaging admission behavior only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic concurrency and connector tests are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external integration or persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@cf6d90cb3fdb4a312683751cbc21e8b5c95b44cc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@cf6d90cb3fdb4a312683751cbc21e8b5c95b44cc:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@cf6d90cb3fdb4a312683751cbc21e8b5c95b44cc:packages/skills/skills/contribute-to-eliza"} -->