### PR TITLE
fix(agent): reject malformed capability-asset path encoding

### DIFF
--- a/packages/agent/src/services/remote-capability-router.encoding.test.ts
+++ b/packages/agent/src/services/remote-capability-router.encoding.test.ts
@@ -1,0 +1,42 @@
+/**
+ * GET /v1/capabilities/assets/:moduleId/... decoded moduleId with
+ * decodeURIComponent. A malformed percent-escape threw URIError into the
+ * fetch-handler catch, which maps unknown errors to HTTP 500.
+ */
+import { describe, expect, test } from "bun:test";
+import { UnavailableCapabilityRouter } from "@elizaos/core";
+import { createRemoteCapabilityFetchHandler } from "./remote-capability-router.ts";
+
+describe("remote capability asset path encoding", () => {
+  test("returns 400 instead of 500 for a malformed module id", async () => {
+    const handler = createRemoteCapabilityFetchHandler(
+      new UnavailableCapabilityRouter("server"),
+    );
+    const response = await handler(
+      new Request(
+        "https://device.test/v1/capabilities/assets/%ZZ/views/demo.js",
+      ),
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "CAPABILITY_DECODE_FAILED",
+      },
+    });
+  });
+
+  test("canonical encoded module id still reaches getAsset", async () => {
+    const handler = createRemoteCapabilityFetchHandler(
+      new UnavailableCapabilityRouter("server"),
+    );
+    const response = await handler(
+      new Request(
+        "https://device.test/v1/capabilities/assets/demo-plugin/views/demo.js",
+      ),
+    );
+    // Unavailable router rejects the asset call as a capability error (not 400).
+    expect(response.status).not.toBe(400);
+    expect([200, 404, 500]).toContain(response.status);
+  });
+});

--- a/packages/agent/src/services/remote-capability-router.ts
+++ b/packages/agent/src/services/remote-capability-router.ts
@@ -502,7 +502,20 @@ async function serveRemotePluginAsset(
       },
     });
   }
-  const moduleId = decodeURIComponent(remainder.slice(0, slashIndex));
+  let moduleId: string;
+  try {
+    moduleId = decodeURIComponent(remainder.slice(0, slashIndex));
+  } catch {
+    // error-policy:J3 untrusted path segment — malformed percent-encoding is
+    // caller error (400), not URIError → CAPABILITY_REQUEST_FAILED 500.
+    return jsonResponse(400, {
+      ok: false,
+      error: {
+        code: "CAPABILITY_DECODE_FAILED",
+        message: "Capability asset module id is not valid percent-encoding",
+      },
+    });
+  }
   const assetPath = `/${remainder.slice(slashIndex + 1)}`;
   const asset = await router.plugin.getAsset({
     moduleId,


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed percent-encoding on `GET /v1/capabilities/assets/:moduleId/...` currently 500s. Raw path-segment `decodeURIComponent` of `url.pathname` (not extra-decode after `URLSearchParams.get()` / parsed URL search/hash). Not #21472 / #21482 / #21489. Not list-limit. Not cookies (#21406/#21460/#21459). Not workflow-routes (#20839). Not `apps/[id]/domains`. Not #21385. Proof is `bun:test` of this file only — does not load `packages/agent/vitest.config.ts` (`@octokit/rest`) and does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical asset paths still reach `getAsset`. Malformed `%ZZ` now 400s before asset lookup instead of `URIError` → fetch-handler 500. Proven on the unfixed head: GET `%ZZ` received **500**.

# Background

## What does this PR do?

`serveRemotePluginAsset` ran `decodeURIComponent` on the raw `url.pathname` module-id capture with no try/catch. `new URL().pathname` is still percent-encoded, so a truncated escape (`%ZZ`) throws `URIError`. The fetch handler's catch maps unknown errors to HTTP 500 / `CAPABILITY_REQUEST_FAILED`. This PR returns `{ ok: false, error: { code: "CAPABILITY_DECODE_FAILED" } }` with status 400 before `getAsset`.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical encoded module ids unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/remote-capability-router.encoding.test.ts` and the `decodeURIComponent` catch in `serveRemotePluginAsset`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/agent && bun test --isolate src/services/remote-capability-router.encoding.test.ts
```

Unfixed head: `GET /v1/capabilities/assets/%ZZ/views/demo.js` returned **500**. After the fix: 2 passed on `fd30e804216d1c835ba28c8080e4f19bff3ce935`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:fd30e804216d1c835ba28c8080e4f19bff3ce935 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the capability-asset HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed path encoding is rejected before getAsset.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that a canonical module id still reaches getAsset.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid encoding never reaches getAsset.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on capability-asset path encoding. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `%ZZ` was 500; after the fix, Bun test asserts 400 and a canonical module id still reaches getAsset.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the capability-asset HTTP boundary.

## Audio / voice walkthrough

N/A - metadata GET only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass` at `fd30e80421`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary. Agent `vitest.config.ts` was not loaded.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
