### PR TITLE
refactor(capacitor): keep guarded image helper internal

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/image-url-to-base64.ts
+++ b/plugins/plugin-capacitor-bridge/src/image-url-to-base64.ts
@@ -1,0 +1,34 @@
+/**
+ * Resolves caller-influenced bionic vision image URLs through the canonical
+ * guarded media fetch without widening the bridge package's public exports.
+ */
+import { fetchRemoteMedia } from "@elizaos/core";
+
+// Match the bounds used by the sibling plugin-local-inference vision paths.
+const IMAGE_DESCRIPTION_FETCH_MAX_BYTES = 20 * 1024 * 1024;
+const IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS = 15_000;
+
+/** Resolve a data:/http(s) image URL to base64 image bytes for the host. */
+export async function imageUrlToBase64(url: string): Promise<string> {
+	if (url.startsWith("data:")) {
+		const comma = url.indexOf(",");
+		return comma >= 0 ? url.slice(comma + 1) : url;
+	}
+	try {
+		const media = await fetchRemoteMedia({
+			url,
+			maxBytes: IMAGE_DESCRIPTION_FETCH_MAX_BYTES,
+			timeoutMs: IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS,
+			maxRedirects: 5,
+		});
+		return media.buffer.toString("base64");
+	} catch (err) {
+		// error-policy:J2 context-adding rethrow — preserve guarded-fetch cause
+		throw new Error(
+			`[mobile-device-bridge] IMAGE_DESCRIPTION failed to fetch ${url}: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+			{ cause: err },
+		);
+	}
+}

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.image-fetch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.image-fetch.test.ts
@@ -38,7 +38,7 @@ vi.mock("@elizaos/core", async (importActual) => {
 	};
 });
 
-import { imageUrlToBase64 } from "./mobile-device-bridge-bootstrap";
+import { imageUrlToBase64 } from "./image-url-to-base64";
 
 afterEach(() => {
 	mediaMocks.useRealFetchRemoteMedia = false;

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -32,7 +32,6 @@ import {
 	type AgentRuntime,
 	applyBackgroundInferenceBudget,
 	ElizaError,
-	fetchRemoteMedia,
 	type GenerateTextParams,
 	getInferencePriorityGate,
 	type IAgentRuntime,
@@ -48,6 +47,7 @@ import {
 	ServiceType,
 	type TextEmbeddingParams,
 } from "@elizaos/core";
+import { imageUrlToBase64 } from "./image-url-to-base64.ts";
 import { resolveStoredModelPath } from "./shared/local-inference-stored-path.ts";
 
 const DEVICE_BRIDGE_PATH = "/api/local-inference/device-bridge";
@@ -57,10 +57,6 @@ const DEFAULT_NATIVE_REQUEST_TIMEOUT_MS = 600_000;
 const DEFAULT_CALL_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const DEFAULT_LOAD_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const SERVICE_ENABLED = process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1";
-// Bounds for the bionic IMAGE_DESCRIPTION image fetch — same shape the
-// plugin-local-inference vision handlers apply (VISION_IMAGE_* there).
-const IMAGE_DESCRIPTION_FETCH_MAX_BYTES = 20 * 1024 * 1024;
-const IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS = 15_000;
 
 /**
  * Constant-time pairing-token comparison (W1-011). Callers fail closed when
@@ -2181,34 +2177,6 @@ export async function attachMobileDeviceBridgeToServer(
 	server: HttpServer,
 ): Promise<void> {
 	await mobileDeviceBridge.attachToHttpServer(server);
-}
-
-/** Resolve a data:/http(s) image URL to base64 image bytes for the host. */
-export async function imageUrlToBase64(url: string): Promise<string> {
-	if (url.startsWith("data:")) {
-		const comma = url.indexOf(",");
-		return comma >= 0 ? url.slice(comma + 1) : url;
-	}
-	try {
-		// Caller-influenced image URLs must go through the shared SSRF media
-		// guard; a bare `fetch` would let a bionic-delegated phone describe
-		// internal hosts or pull an unbounded payload into memory.
-		const media = await fetchRemoteMedia({
-			url,
-			maxBytes: IMAGE_DESCRIPTION_FETCH_MAX_BYTES,
-			timeoutMs: IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS,
-			maxRedirects: 5,
-		});
-		return media.buffer.toString("base64");
-	} catch (err) {
-		// error-policy:J2 context-adding rethrow — preserve guarded-fetch cause
-		throw new Error(
-			`[mobile-device-bridge] IMAGE_DESCRIPTION failed to fetch ${url}: ${
-				err instanceof Error ? err.message : String(err)
-			}`,
-			{ cause: err },
-		);
-	}
 }
 
 /**


### PR DESCRIPTION
## Summary

Keep the guarded Capacitor image-fetch helper internal instead of exporting it through a production bridge subpath solely for tests.

- Move `imageUrlToBase64` into an internal module.
- Preserve the merged SSRF guard, redirect/timeout/byte-cap behavior, and error context.
- Point focused tests at the internal module without widening the package surface.

Fixes #21611

## Validation

Exact head `fdd2689b8a45ff0921c195a153fbfb9f05add732`, rebased on `develop@eaf6218ef28b8bf349383446d1538c58309bd1bb`.

- Core SSRF: 24/24 passed.
- Guarded image fetch: 11/11 passed.
- Cloud blob streamed-cap tests: 5/5 passed.
- Capacitor and cloud-shared typechecks passed after required core/shared prerequisites.
- Biome and diff checks passed.

## Evidence Gate

<!-- evidence-head:fdd2689b8a45ff0921c195a153fbfb9f05add732 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - internal module organization only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - internal module organization only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic guard tests are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external integration or persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@eaf6218ef28b8bf349383446d1538c58309bd1bb:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@eaf6218ef28b8bf349383446d1538c58309bd1bb:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@eaf6218ef28b8bf349383446d1538c58309bd1bb:packages/skills/skills/contribute-to-eliza"} -->