### PR TITLE
fix(ci): install dedicated smoke dependencies

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -173,6 +173,9 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      - name: Install contract dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
       - name: Validate canary and workflow contracts
         run: |
           bun test \

--- a/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
@@ -158,10 +158,27 @@ describe("managed dedicated live-smoke workflow contract", () => {
     );
     expect(setup.with?.["bun-version"]).toBe("1.3.14");
 
+    const install = namedStep("Install contract dependencies");
+    expect(install.run).toBe("bun install --frozen-lockfile --ignore-scripts");
+    expect(install.uses).toBeUndefined();
+
     const validation = namedStep("Validate canary and workflow contracts").run;
     expect(validation).toContain("bridge-reply-verdict.test.ts");
     expect(validation).toContain("managed-dedicated-canary.test.ts");
     expect(validation).toContain("managed-dedicated-canary-workflow.test.ts");
+
+    const setupIndex = dedicated.steps.indexOf(setup);
+    const installIndex = dedicated.steps.indexOf(install);
+    const validationIndex = dedicated.steps.findIndex(
+      (step) => step.name === "Validate canary and workflow contracts",
+    );
+    expect(installIndex).toBe(setupIndex + 1);
+    expect(validationIndex).toBe(installIndex + 1);
+    expect(
+      dedicated.steps.some(
+        (step) => step.uses === "./.github/actions/setup-bun-workspace",
+      ),
+    ).toBe(false);
   });
 
   test("uploads only canonical privacy-validated evidence", () => {


### PR DESCRIPTION
# Relates to

Closes #21616

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and proportional verification were run after sync; the two unrelated full-gate host/baseline blockers are recorded below.
- [x] A reviewer can confirm the change from the deterministic workflow-contract assertions and test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@08e934c8fd8060af63707fc9f3d45484683bb12d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `ba69677485e3dcde3c1813b966f9a1446e9a4acb`; zero conflicts.
- [ ] `bun run verify` passes post-sync. It reaches two unrelated existing blockers detailed under **Known gaps / failures**; every reachable remainder audit was then run separately and passed.

# Risks

Low. The change adds one dependency-install step to a manually dispatched staging-only job and contract tests its exact flags and ordering. It does not alter canary behavior, credentials, production routing, or cloud resources. The install uses the committed lockfile and disables lifecycle scripts.

# Background

## What does this PR do?

- Installs locked dependencies before the managed-dedicated workflow contract tests, fixing clean-runner resolution of the root `yaml` dependency.
- Uses a direct install instead of the workspace bootstrap composite, avoiding unrelated Python, protoc, native apt dependencies, repository postinstall, and the broad Bun dependency-cache restore.
- Locks the exact `--frozen-lockfile --ignore-scripts` command, its adjacency before validation, and the absence of the heavyweight workspace setup action in the dedicated job.

## What kind of change is this?

Bug fix (non-breaking CI workflow correction).

# Documentation changes needed?

No. This restores the workflow behavior already described by the managed-dedicated canary operator documentation.

# Testing

## Where should a reviewer start?

Review `.github/workflows/live-smoke.yml` around the dedicated job's Bun setup, then `packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts`.

## Detailed testing steps

```text
bun install --frozen-lockfile --ignore-scripts
bun test packages/cloud/scripts/admin/bridge-reply-verdict.test.ts packages/cloud/scripts/admin/managed-dedicated-canary.test.ts packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
# 57 pass, 0 fail, 288 assertions

bunx biome check .github/workflows/live-smoke.yml packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
# clean

node packages/scripts/ci-bun-version-contract.mjs
# passed; canonical Bun 1.3.14, 274 sites scanned

git diff --check origin/develop...HEAD
# clean
```

The remaining repository audit chain after the documented baseline/host blockers also passed: dependency references, plugin test conventions, alias reads, tsconfig resolution, build model, Turbo dependency graph, secret-leak audit, Hetzner routing, workflow triggers, script inventory, test-lane membership, view inventory, and focused-test audit.

# Evidence Gate

<!-- evidence-head:08e934c8fd8060af63707fc9f3d45484683bb12d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or visual interaction changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - the change is deterministic GitHub Actions dependency setup, not a backend runtime path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduler, wallet, media, or cloud resource is changed; the applicable artifact is the 57-test deterministic contract output above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path changes.

## Backend + frontend logs

N/A - this PR changes only workflow dependency bootstrap and its static contract.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice behavior change.

## Known gaps / failures

- `bun run verify` stops first in the current `origin/develop` i18n baseline: `en.json` is missing five unrelated URL-validation keys (`cloud.invoiceDetail.invalidInvoiceUrl`, `accounts.add.oauth.invalidAuthUrl`, `voiceprofile.error.invalidExportUrl`, `vault.install.invalidMethodUrl`, and `bugreportmodal.invalidFallbackUrl`), with pre-existing translation backlog in other locales. This PR touches neither source nor locale files.
- Running the remaining verify chain past i18n reaches an unrelated local SwiftLint host failure in `@elizaos/capacitor-gateway`: SourceKitten cannot load `sourcekitdInProc.framework`. This PR touches neither Swift nor native gateway configuration. All earlier checks and every later repository audit were run separately as listed above.
- No live workflow was dispatched for this PR, by design: the issue was reproduced from the existing exact-SHA failed run, and this contribution was explicitly constrained not to use credentials or mutate staging/cloud resources.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@08e934c8fd8060af63707fc9f3d45484683bb12d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-operator]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@08e934c8fd8060af63707fc9f3d45484683bb12d:packages/skills/skills/contribute-to-eliza"} -->
