### PR TITLE
fix(plugin-agent-skills): reject Windows-canonicalized names in skill zip entries

### DIFF
--- a/plugins/plugin-agent-skills/src/storage.test.ts
+++ b/plugins/plugin-agent-skills/src/storage.test.ts
@@ -1,10 +1,12 @@
 /**
  * Tests for skill zip extraction hardening — the sinks for W5-007 (zip-slip:
  * backslash, absolute, and `..` entry names escaping the skill directory on
- * extraction) and W5-031 (zip-bomb: uncompressed expansion previously bounded
- * only by the 10 MB compressed download cap). Uses real fflate-produced
- * archives, a real tmpdir-backed FileSystemSkillStore, and forged
- * central-directory sizes. No mocks beyond the shared @elizaos/core double.
+ * extraction), its Windows residual (segments Win32 canonicalizes at write
+ * time — trailing dots/spaces per component, colons, reserved device names),
+ * and W5-031 (zip-bomb: uncompressed expansion previously bounded only by the
+ * 10 MB compressed download cap). Uses real fflate-produced archives, a real
+ * tmpdir-backed FileSystemSkillStore, and forged central-directory sizes. No
+ * mocks beyond the shared @elizaos/core double.
  */
 
 import fs from "node:fs";
@@ -72,6 +74,31 @@ const traversalEntries: Array<[label: string, entryName: string]> = [
 	["backslash-only parent", "..\\escape.txt"],
 ];
 
+// Win32 canonicalizes every path component at write time: trailing dots and
+// spaces are stripped (`.. ` becomes `..`, `...` collapses to nothing), a
+// colon addresses an NTFS alternate data stream, and reserved device stems
+// resolve to devices rather than files. Each of these passes an exact-`..`
+// check, so every class must be rejected by name validation.
+const windowsCanonicalizationEntries: Array<[label: string, entryName: string]> =
+	[
+		["trailing-space parent segment", ".. /escape.txt"],
+		["trailing-space parent segment mid-path", "sub/.. /escape.txt"],
+		["parent segment with mixed trailing dots and spaces", "sub/.. ./escape.txt"],
+		["parent segment with multiple trailing spaces", "sub/..  /escape.txt"],
+		["dots-only segment", ".../escape.txt"],
+		["dots-and-spaces-only segment", "sub/ . /escape.txt"],
+		["space-only segment", "sub/ /escape.txt"],
+		["trailing-dot file name", "escape.txt."],
+		["trailing-space directory segment", "sub /escape.txt"],
+		["NTFS alternate data stream", "escape.txt:payload"],
+		["NTFS stream type on nested entry", "sub/escape.txt:$DATA"],
+		["reserved device name CON", "CON"],
+		["reserved device name with extension", "NUL.txt"],
+		["lowercase reserved device stem", "nul.md"],
+		["reserved device name as directory segment", "com1/escape.txt"],
+		["reserved device name LPT", "lpt9/escape.txt"],
+	];
+
 describe("zip entry path validation", () => {
 	let basePath: string;
 	let fsStore: FileSystemSkillStore;
@@ -99,7 +126,10 @@ describe("zip entry path validation", () => {
 		},
 	];
 
-	for (const [label, entryName] of traversalEntries) {
+	for (const [label, entryName] of [
+		...traversalEntries,
+		...windowsCanonicalizationEntries,
+	]) {
 		it(`rejects ${label} entries in both stores`, async () => {
 			const zip = makeZip({ "SKILL.md": "# demo", [entryName]: "payload" });
 			for (const store of stores()) {
@@ -155,6 +185,33 @@ describe("zip entry path validation", () => {
 		expect(
 			fs.existsSync(path.join(basePath, "demo", "scripts", "run.sh")),
 		).toBe(true);
+	});
+
+	it("keeps skipping conventional no-op segments", async () => {
+		const zip = makeZip({ "./SKILL.md": "# demo" });
+		await fsStore.saveFromZip("demo", zip);
+		expect(await fsStore.loadSkillContent("demo")).toBe("# demo");
+	});
+
+	it("accepts names with leading dots and internal spaces or dots", async () => {
+		const zip = makeZip({
+			"SKILL.md": "# demo",
+			".gitignore": "node_modules",
+			"my notes/v1.2 draft.md": "docs",
+		});
+		await fsStore.saveFromZip("demo", zip);
+		expect(fs.existsSync(path.join(basePath, "demo", ".gitignore"))).toBe(true);
+		expect(
+			fs.readFileSync(
+				path.join(basePath, "demo", "my notes", "v1.2 draft.md"),
+				"utf-8",
+			),
+		).toBe("docs");
+
+		await memStore.loadFromZip("demo", zip);
+		expect(await memStore.loadFile("demo", "my notes/v1.2 draft.md")).toBe(
+			"docs",
+		);
 	});
 });
 

--- a/plugins/plugin-agent-skills/src/storage.ts
+++ b/plugins/plugin-agent-skills/src/storage.ts
@@ -8,10 +8,12 @@
  * Both implement the same interface for seamless switching.
  *
  * Zip packages are untrusted input (registry downloads). Extraction rejects
- * entries with backslashes, absolute paths, or `..` segments, refuses archives
- * whose central directory declares an uncompressed total over
- * MAX_ZIP_UNCOMPRESSED_SIZE, and asserts every filesystem write and delete
- * resolves inside the target skill directory.
+ * entries with backslashes, absolute paths, `..` segments, or names Windows
+ * would canonicalize at write time (trailing dots/spaces per component,
+ * colons, reserved device names), refuses archives whose central directory
+ * declares an uncompressed total over MAX_ZIP_UNCOMPRESSED_SIZE, and asserts
+ * every filesystem write and delete resolves inside the target skill
+ * directory.
  */
 
 import { ElizaError } from "@elizaos/core";
@@ -540,19 +542,37 @@ function assertZipUncompressedSizeWithinLimit(zipBuffer: Uint8Array): void {
 }
 
 /**
+ * Reserved Windows device name stems. Win32 resolves these as the stem of any
+ * path component — with or without an extension (`NUL`, `nul.txt`) — to a
+ * device rather than a regular file, so a skill entry using one would never
+ * land where the validated relative path says it should.
+ */
+const WINDOWS_RESERVED_STEMS = new Set([
+	"CON",
+	"PRN",
+	"AUX",
+	"NUL",
+	...Array.from({ length: 10 }, (_, i) => `COM${i}`),
+	...Array.from({ length: 10 }, (_, i) => `LPT${i}`),
+]);
+
+/**
  * Normalize a zip entry name to a safe relative path, or return null for
  * entries that carry no file (e.g. bare `.` segments). Throws on any entry
- * that could escape the skill directory: backslashes (path separators on
- * Windows, invisible to a `/`-split filter), absolute paths (POSIX root or
- * drive letter), and `..` segments. Rejecting the whole archive rather than
- * silently filtering keeps a malicious package from installing in a
- * half-sanitized shape.
+ * whose name could resolve to a different file than the one validated here:
+ * backslashes (path separators on Windows, invisible to a `/`-split filter),
+ * absolute paths, colons (drive designators and NTFS alternate-data-stream
+ * separators), `..` segments, segments ending in a dot or space (Win32
+ * strips those per component, so `.. ` becomes `..` and `...` collapses to
+ * nothing at write time), and reserved Windows device names. Rejecting the
+ * whole archive rather than silently filtering keeps a malicious package
+ * from installing in a half-sanitized shape.
  */
 function sanitizeZipEntryPath(fileName: string): string | null {
 	if (
 		fileName.includes("\\") ||
 		fileName.startsWith("/") ||
-		/^[A-Za-z]:/.test(fileName)
+		fileName.includes(":")
 	) {
 		throw new ElizaError("Skill zip entry has an unsafe path", {
 			code: "SKILL_ZIP_ENTRY_UNSAFE",
@@ -560,16 +580,42 @@ function sanitizeZipEntryPath(fileName: string): string | null {
 		});
 	}
 
-	const parts = fileName.split("/");
-	if (parts.some((p) => p === "..")) {
+	const kept: string[] = [];
+	for (const part of fileName.split("/")) {
+		// Conventional no-op segments (`a//b`, `a/./b`) stay silently skipped.
+		if (part === "" || part === ".") continue;
+		assertSafeZipEntrySegment(part, fileName);
+		kept.push(part);
+	}
+	return kept.length === 0 ? null : kept.join("/");
+}
+
+/**
+ * Validate one zip entry path segment against Windows canonicalization
+ * tricks. Win32 strips trailing dots and spaces from every component before
+ * writing, so `.. ` becomes a parent traversal, `...` collapses to nothing,
+ * and `dir ` silently renames to `dir`; reserved stems resolve to devices
+ * rather than files. Rejecting the whole class guarantees the name validated
+ * here is the name the filesystem actually writes, on every platform.
+ */
+function assertSafeZipEntrySegment(segment: string, entryName: string): void {
+	const reject = (reason: string): never => {
 		throw new ElizaError("Skill zip entry has an unsafe path", {
 			code: "SKILL_ZIP_ENTRY_UNSAFE",
-			context: { entry: fileName },
+			context: { entry: entryName, reason },
 		});
-	}
+	};
 
-	const kept = parts.filter((p) => p && p !== ".");
-	return kept.length === 0 ? null : kept.join("/");
+	if (segment === "..") {
+		reject("parent traversal segment");
+	}
+	if (/[. ]$/.test(segment)) {
+		reject("segment ends with a dot or space, which Windows strips");
+	}
+	const stem = segment.split(".", 1)[0].toUpperCase();
+	if (WINDOWS_RESERVED_STEMS.has(stem)) {
+		reject("reserved Windows device name");
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to the wave-7 security review of #21526 (skill zip extraction hardening). The merged fix validates zip entry names with an exact parent-segment check, but Windows rewrites certain path components at write time, so a name that passes validation can resolve to a different location than the one that was checked. Entry-name validation in `plugins/plugin-agent-skills/src/storage.ts` now rejects the full class of names Windows would canonicalize — components with trailing dots or spaces, colons (drive designators / NTFS alternate data streams), and reserved device name stems (CON, PRN, AUX, NUL, COM0–9, LPT0–9, case-insensitive, with or without extension) — in addition to the existing backslash, absolute-path, and parent-segment rejection. As before, the entire archive is rejected before any write, in both the filesystem and in-memory skill stores, so a malicious package cannot install in a half-sanitized shape.

Conventional no-op segments (`a//b`, `a/./b`) remain silently skipped, and ordinary portable names (leading-dot files, internal spaces/dots) remain accepted.

## Test evidence

- `src/storage.test.ts` adds 16 adversarial entry names covering each canonicalization class, run against both stores with real fflate-produced archives and a real tmpdir-backed store, asserting rejection and that nothing is written; plus positive boundary tests for the still-accepted names.
- `bunx vitest run src/storage.test.ts` — 36/36 passed.
- `bun run --cwd plugins/plugin-agent-skills test` — 19 files, 130/130 passed.
- `bun run --cwd plugins/plugin-agent-skills typecheck` — clean.
- `biome check` on both changed files — clean.