### PR TITLE
fix(cloud): reauthenticate headscale router migration

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -1152,7 +1152,11 @@ else
     --tags tag:eliza-proxy --expiration 1h -o json 2>/dev/null | jq -r '.key')
   [ -n "$PREAUTH_KEY" ] || { echo "failed to mint preauth key for cp-router"; exit 1; }
 
+  # This branch already proved the expected router is absent and minted a
+  # fresh, single-use key. Force reauthentication so a daemon still signed in
+  # to the legacy login server can move to the canonical Headscale origin.
   sudo tailscale up \\
+    --force-reauth \\
     --login-server="$LOGIN_SERVER" \\
     --authkey="$PREAUTH_KEY" \\
     --hostname="$CP_ROUTER_HOST" \\

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Locks the protected Headscale self-enrollment and workflow boundaries without
+ * connecting to a host or using live credentials.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { parse } from "yaml";
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+}
+
+interface HeadscaleWorkflow {
+  jobs: {
+    arm: {
+      environment: string;
+      steps: WorkflowStep[];
+    };
+  };
+  on: {
+    workflow_dispatch: {
+      inputs: {
+        environment: { options: string[] };
+        operation: { options: string[] };
+      };
+    };
+  };
+}
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+const scriptPath = resolve(
+  repoRoot,
+  "packages/cloud/scripts/admin/arm-headscale-control-plane.mjs",
+);
+const workflowPath = resolve(
+  repoRoot,
+  ".github/workflows/arm-headscale-control-plane.yml",
+);
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function renderRemoteScript(extraArgs: string[] = []): string {
+  const root = mkdtempSync(join(tmpdir(), "headscale-arm-test-"));
+  tempRoots.push(root);
+  const keyPath = join(root, "deploy-key");
+  const knownHostsPath = join(root, "known-hosts");
+  writeFileSync(keyPath, "test-only-key\n", { mode: 0o600 });
+  writeFileSync(knownHostsPath, "test-only-known-host\n", { mode: 0o600 });
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      scriptPath,
+      "--host",
+      "control-plane.test.invalid",
+      "--ssh-key",
+      keyPath,
+      "--ssh-known-hosts",
+      knownHostsPath,
+      "--headscale-public-url",
+      "https://headscale.eliza.app",
+      "--headscale-legacy-public-url",
+      "https://headscale.elizacloud.ai",
+      "--headscale-api-key",
+      "test-only-api-key",
+      "--skip-nginx-cert",
+      "--dry-run",
+      ...extraArgs,
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe("");
+  return result.stdout;
+}
+
+function namedStep(workflow: HeadscaleWorkflow, name: string): WorkflowStep {
+  const step = workflow.jobs.arm.steps.find(
+    (candidate) => candidate.name === name,
+  );
+  if (!step) throw new Error(`Missing Headscale workflow step: ${name}`);
+  return step;
+}
+
+describe("Headscale control-plane self-enrollment", () => {
+  test("forces reauthentication only after minting a fresh single-use key", () => {
+    const remote = renderRemoteScript();
+    const forceReauth = remote.indexOf("    --force-reauth \\");
+    const mintKey = remote.indexOf(
+      "PREAUTH_KEY=$(sudo headscale preauthkeys create",
+    );
+    const tailscaleUp = remote.indexOf("sudo tailscale up \\");
+    const loginServer = remote.indexOf('    --login-server="$LOGIN_SERVER" \\');
+
+    expect(forceReauth).toBeGreaterThan(mintKey);
+    expect(forceReauth).toBeGreaterThan(tailscaleUp);
+    expect(forceReauth).toBeLessThan(loginServer);
+    expect(remote.match(/--force-reauth/g)).toHaveLength(1);
+    expect(remote).toContain(
+      "already enrolled in headscale; skipping tailscale up",
+    );
+  });
+
+  test("does not emit forced reauthentication when router enrollment is skipped", () => {
+    const remote = renderRemoteScript(["--skip-cp-router"]);
+
+    expect(remote).toContain(
+      "skip-cp-router set: leaving CP tailscale enrollment untouched",
+    );
+    expect(remote).not.toContain("--force-reauth");
+    expect(remote).not.toContain("headscale preauthkeys create");
+  });
+});
+
+describe("Headscale protected workflow contract", () => {
+  const workflow = parse(
+    readFileSync(workflowPath, "utf8"),
+  ) as HeadscaleWorkflow;
+
+  test("keeps production convergence behind the protected environment and main ref", () => {
+    expect(workflow.on.workflow_dispatch.inputs.environment.options).toEqual([
+      "staging",
+      "production",
+    ]);
+    expect(workflow.on.workflow_dispatch.inputs.operation.options).toContain(
+      "converge",
+    );
+    expect(workflow.jobs.arm.environment).toBe(
+      ["$", "{{ inputs.environment }}"].join(""),
+    );
+
+    const sourceGuard = namedStep(
+      workflow,
+      "Validate protected deploy source",
+    ).run;
+    expect(sourceGuard).toContain('production) expected_ref="refs/heads/main"');
+    expect(sourceGuard).toContain('if [ "$GITHUB_REF" != "$expected_ref" ]');
+  });
+
+  test("invokes the reviewed script without exposing a force-reauth input", () => {
+    const converge = namedStep(
+      workflow,
+      "Inspect or converge Headscale control plane",
+    ).run;
+
+    expect(converge).toContain(
+      "node packages/cloud/scripts/admin/arm-headscale-control-plane.mjs",
+    );
+    expect(converge).not.toContain("force-reauth");
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #21620

- [x] Targets `develop` and is rebased onto exact `develop@208a109108404ddc98383845faf72eea165731cb`.
- [x] Independent exact-head source review and focused tests pass.
- [x] Protected convergence remains an operator-owned post-merge action; no live infrastructure was touched.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@4b23a8b6a2d37a1c5bec7aa5e971b3fdd6571d77:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased without conflicts onto exact develop before final review.
- [x] Focused tests, Biome, and diff check pass on final head.

# Risks

Medium operational risk, tightly scoped. `--force-reauth` can interrupt an existing Tailscale session, but it is emitted only in the protected missing-router enrollment branch after minting a fresh one-hour, single-use, pre-tagged Headscale key. Already-enrolled and `--skip-cp-router` paths remain no-ops.

# Background

Adds `--force-reauth` to the canonical Headscale self-enrollment command so a host authenticated to the retired login server can migrate. It does not alter workflow inputs, protected environments, ref guards, or general Tailscale behavior.

# Documentation changes needed?

No external documentation change.

# Testing

Exact head `0d812df7220549a78973000666a34b5b8a67d66a`:

- `bun test packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts` — PASS, 4/4 tests, 19 assertions.
- `bunx @biomejs/biome check packages/cloud/scripts/admin/arm-headscale-control-plane.mjs packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts` — PASS.
- `git diff --check origin/develop...HEAD` — PASS.
- Prior owner evidence: `bun run verify:cloud` — PASS, 81/81 tasks.

# Evidence Gate

<!-- evidence-head:0d812df7220549a78973000666a34b5b8a67d66a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - operator script only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - operator script only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] Deterministic dry-run renders the real protected script and proves branch ordering; live convergence remains post-merge operator evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model/prompt/provider change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - source-only control-plane command; no domain mutation during review.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Known gaps / failures

No live Headscale convergence was dispatched. That protected action can briefly interrupt the control-plane session and remains explicitly operator-owned after merge. The deterministic source boundary and workflow gates are fully covered.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@4b23a8b6a2d37a1c5bec7aa5e971b3fdd6571d77:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nubs-review-cloud]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@4b23a8b6a2d37a1c5bec7aa5e971b3fdd6571d77:packages/skills/skills/contribute-to-eliza"} -->