### PR TITLE
fix(ci): build core before cloud live smoke

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -69,6 +69,13 @@ jobs:
         if: inputs.suite == 'all' || inputs.suite == 'scenarios'
         run: bun run --cwd packages/scenario-runner test:live:e2e
 
+      # Cloud API e2e loads the compiled Workerd export from
+      # @elizaos/core/edge. The lean install above skips lifecycle scripts, so
+      # this artifact must be built explicitly on a clean runner.
+      - name: Build core runtime contract
+        if: inputs.suite == 'all' || inputs.suite == 'cloud'
+        run: bun run build:core
+
       - name: Cloud end-to-end
         if: inputs.suite == 'all' || inputs.suite == 'cloud'
         run: bun run test:cloud:e2e

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -35,6 +35,8 @@ const smokeLanesE2eCommand =
 const zeroKeyCondition = "needs.changes.outputs.zero_key == 'true'";
 const smokeLanesCoreBuildCondition =
   "needs.changes.outputs.cloud == 'true' || needs.changes.outputs.zero_key == 'true'";
+const liveSmokeCloudCondition =
+  "inputs.suite == 'all' || inputs.suite == 'cloud'";
 
 function assertJobBrowserBootstrap(
   steps: WorkflowStep[],
@@ -103,6 +105,44 @@ function assertSmokeLanesCoreBootstrap(source: string): void {
   }
   if (e2eIndex < 0 || buildIndex >= e2eIndex) {
     throw new Error("Smoke lanes must build the core contract before E2E");
+  }
+}
+
+function assertLiveSmokeCloudCoreBootstrap(source: string): void {
+  const workflow = Bun.YAML.parse(source) as {
+    jobs?: { smoke?: { steps?: WorkflowStep[] } };
+  };
+  const steps = workflow.jobs?.smoke?.steps ?? [];
+  const setupIndex = steps.findIndex(
+    (step) => step.uses === "./.github/actions/setup-bun-workspace",
+  );
+  const buildIndex = steps.findIndex(
+    (step) =>
+      step.name === "Build core runtime contract" &&
+      step.run === "bun run build:core",
+  );
+  const e2eIndex = steps.findIndex(
+    (step) =>
+      step.name === "Cloud end-to-end" && step.run === "bun run test:cloud:e2e",
+  );
+
+  if (setupIndex < 0 || buildIndex < 0 || e2eIndex < 0) {
+    throw new Error(
+      "Live Smoke must retain workspace setup, core build, and Cloud e2e steps",
+    );
+  }
+  if (
+    steps[buildIndex]?.if !== liveSmokeCloudCondition ||
+    steps[e2eIndex]?.if !== liveSmokeCloudCondition
+  ) {
+    throw new Error(
+      "Live Smoke core build and Cloud e2e must share the cloud-suite condition",
+    );
+  }
+  if (!(setupIndex < buildIndex && buildIndex < e2eIndex)) {
+    throw new Error(
+      "Live Smoke must build the core edge contract before Cloud e2e",
+    );
   }
 }
 
@@ -329,6 +369,43 @@ describe("GitHub action supply-chain references", () => {
       ),
     ).toThrow(
       "Smoke lanes must build the core contract for cloud and zero-key work",
+    );
+  });
+
+  test("builds the compiled core edge contract before Live Smoke cloud E2E", () => {
+    const source = readFileSync(
+      join(githubRoot, "workflows", "live-smoke.yml"),
+      "utf8",
+    );
+
+    expect(() => assertLiveSmokeCloudCoreBootstrap(source)).not.toThrow();
+    expect(() =>
+      assertLiveSmokeCloudCoreBootstrap(
+        source.replace(
+          "run: bun run build:core",
+          "run: echo core-build-removed",
+        ),
+      ),
+    ).toThrow(
+      "Live Smoke must retain workspace setup, core build, and Cloud e2e steps",
+    );
+
+    const buildStep = `      # Cloud API e2e loads the compiled Workerd export from
+      # @elizaos/core/edge. The lean install above skips lifecycle scripts, so
+      # this artifact must be built explicitly on a clean runner.
+      - name: Build core runtime contract
+        if: ${liveSmokeCloudCondition}
+        run: bun run build:core
+
+`;
+    const afterE2e = source
+      .replace(buildStep, "")
+      .replace(
+        "        run: bun run test:cloud:e2e\n",
+        (command) => `${command}\n${buildStep}`,
+      );
+    expect(() => assertLiveSmokeCloudCoreBootstrap(afterE2e)).toThrow(
+      "Live Smoke must build the core edge contract before Cloud e2e",
     );
   });
 


### PR DESCRIPTION
# Relates to

Closes #21621.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` was attempted after sync; current `develop` has unrelated frozen-lockfile drift documented below. The requested build and exact Cloud API e2e proof pass.
- [x] A reviewer can confirm the repair from the workflow-order contract test, clean-build artifact proof, and exact Cloud API e2e result below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ba69677485d83f1fed2b358505e317aa47538530:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `fec7d2cbb5bb8b1885771fff2eedc02fb589fad5`; zero conflicts.
- [x] Focused validation passes post-sync; the unrelated full-verify baseline is recorded below.

# Risks

Low. The change adds the repository's canonical `bun run build:core` prerequisite only for `suite=cloud` and `suite=all`. It adds CI duration but does not change product code, credentials, permissions, or deployment behavior.

# Background

## What does this PR do?

Builds the compiled core runtime contract after the lean dependency install and before the Live Smoke Cloud API e2e step. The Cloud API Worker imports `@elizaos/core/edge`, whose package export deliberately points to `packages/core/dist/edge/index.edge.js`; `--ignore-scripts` leaves that artifact absent on a clean runner.

The regression test parses the real workflow and enforces all three invariants:

1. workspace setup precedes the build;
2. core build precedes Cloud API e2e;
3. build and e2e share the exact `all || cloud` suite condition.

## What kind of change is this?

Bug fix (non-breaking CI workflow repair).

# Documentation changes needed?

No product documentation change is needed; the workflow comment records why the compiled edge build is required.

# Testing

## Where should a reviewer start?

Review `.github/workflows/live-smoke.yml`, then the new contract in `packages/scripts/__tests__/github-action-pinning.test.ts`.

## Detailed testing steps

- `bun install --frozen-lockfile --ignore-scripts` on the fresh worktree: passed; `packages/core/dist/edge/index.edge.js` was absent.
- `bun run build:core`: passed; the compiled edge artifact was present and non-empty afterward.
- `CI=true bun run test:cloud:e2e`: passed end to end; Wrangler reached `GET /api/health 200`, and every executed Cloud API e2e batch passed.
- `bun test packages/scripts/__tests__/github-action-pinning.test.ts`: 15 passed, 0 failed, including positive, missing-build, and misordered-build cases.
- `bunx @biomejs/biome check packages/scripts/__tests__/github-action-pinning.test.ts`: passed.
- `bun run audit:workflow-triggers`: passed, 52 workflows verified.
- `bun run audit:scripts`: passed.

# Evidence Gate

<!-- evidence-head:78cfdde4cddc46d5ed99df389581505c58bfa497 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - workflow-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - workflow-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - workflow-only change with no interactive user flow
<!-- evidence-row:backend-logs -->
- [x] [21625-cloud-api-e2e-latest.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21625-cloud-api-e2e-latest.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser request path changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the compiled edge output is a transient CI build artifact verified by the exact build and Cloud API e2e commands documented above
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual surface changed

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

The pre-fix GitHub Actions job is linked in the backend evidence row. Post-fix validation ran the exact workflow command locally after a clean canonical core build; the Worker reached health and the suite exited successfully. Frontend logs are N/A because no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - workflow-only change with no rendered surface.

## Audio / voice walkthrough

N/A - no voice behavior changed.

## Known gaps / failures

After the refresh, `bun install --frozen-lockfile` stops because current `origin/develop` would modify `bun.lock`; the PR does not touch the manifest or lockfile. The prior `bun run verify` also stopped in the pre-existing `check:i18n` baseline: multiple non-English locale files are already missing over 900 English keys, and `en.json` is already missing five keys used by unrelated UI source files. This PR changes only the Live Smoke workflow and its workflow-contract test; focused formatting, workflow policy, script audit, clean core build, and the exact Cloud API e2e command pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@ba69677485d83f1fed2b358505e317aa47538530:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-smoke-build-fix]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@ba69677485d83f1fed2b358505e317aa47538530:packages/skills/skills/contribute-to-eliza"} -->






