### PR TITLE
fix(plugin-local-inference): reject malformed download id encoding

### DIFF
--- a/plugins/plugin-local-inference/src/local-inference-routes.encoding.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.encoding.test.ts
@@ -1,0 +1,71 @@
+/**
+ * DELETE /api/local-inference/downloads/:id decoded the raw URL.pathname
+ * segment with decodeURIComponent. A malformed percent-escape threw URIError
+ * into the agent route kernel, which maps unknown errors to HTTP 500.
+ */
+import { EventEmitter } from "node:events";
+import type http from "node:http";
+import { describe, expect, test } from "bun:test";
+import { handleLocalInferenceRoutes } from "./local-inference-routes.ts";
+
+function makeReq(method: string, url: string): http.IncomingMessage {
+	const req = new EventEmitter() as EventEmitter & {
+		method: string;
+		url: string;
+		headers: Record<string, string>;
+	};
+	req.method = method;
+	req.url = url;
+	req.headers = {};
+	return req as unknown as http.IncomingMessage;
+}
+
+function makeRes(): http.ServerResponse & {
+	json: () => unknown;
+} {
+	let body = "";
+	const res = {
+		statusCode: 200,
+		setHeader() {},
+		writeHead(statusCode: number) {
+			this.statusCode = statusCode;
+			return this;
+		},
+		end(chunk?: unknown) {
+			if (chunk !== undefined) body += String(chunk);
+			return this;
+		},
+		json() {
+			return JSON.parse(body);
+		},
+	};
+	return res as unknown as http.ServerResponse & { json: () => unknown };
+}
+
+describe("local-inference download path encoding", () => {
+	test("returns 400 instead of 500 for a malformed download id", async () => {
+		const res = makeRes();
+		await expect(
+			handleLocalInferenceRoutes(
+				makeReq("DELETE", "/api/local-inference/downloads/%ZZ"),
+				res,
+			),
+		).resolves.toBe(true);
+		expect(res.statusCode).toBe(400);
+		expect(res.json()).toEqual({
+			error: "Invalid model id: malformed URL encoding",
+		});
+	});
+
+	test("canonical download id still cancels", async () => {
+		const res = makeRes();
+		await expect(
+			handleLocalInferenceRoutes(
+				makeReq("DELETE", "/api/local-inference/downloads/demo-model"),
+				res,
+			),
+		).resolves.toBe(true);
+		expect(res.statusCode).toBe(200);
+		expect(res.json()).toEqual({ cancelled: true });
+	});
+});

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -1517,6 +1517,25 @@ function writeSse(res: http.ServerResponse, payload: unknown): void {
 	res.write(`data: ${JSON.stringify(payload)}\n\n`);
 }
 
+function decodeLocalInferencePathId(
+	raw: string,
+	res: http.ServerResponse,
+	fieldName: string,
+): string | null {
+	try {
+		return decodeURIComponent(raw);
+	} catch {
+		// error-policy:J3 untrusted-input sanitizing — malformed percent-encoding
+		// is invalid client input, not a route/server failure.
+		sendJsonError(
+			res,
+			`Invalid ${fieldName}: malformed URL encoding`,
+			400,
+		);
+		return null;
+	}
+}
+
 export async function handleLocalInferenceRoutes(
 	req: http.IncomingMessage,
 	res: http.ServerResponse,
@@ -1820,7 +1839,12 @@ export async function handleLocalInferenceRoutes(
 		pathname,
 	);
 	if (method === "DELETE" && downloadMatch) {
-		const modelId = decodeURIComponent(downloadMatch[1] ?? "");
+		const modelId = decodeLocalInferencePathId(
+			downloadMatch[1] ?? "",
+			res,
+			"model id",
+		);
+		if (modelId === null) return true;
 		activeDownloads.get(modelId)?.abortController.abort();
 		activeDownloads.delete(modelId);
 		sendJson(res, { cancelled: true });
@@ -1944,7 +1968,12 @@ export async function handleLocalInferenceRoutes(
 	const verifyMatch =
 		/^\/api\/local-inference\/installed\/([^/]+)\/verify$/.exec(pathname);
 	if (method === "POST" && verifyMatch) {
-		const id = decodeURIComponent(verifyMatch[1] ?? "");
+		const id = decodeLocalInferencePathId(
+			verifyMatch[1] ?? "",
+			res,
+			"model id",
+		);
+		if (id === null) return true;
 		const installed = (await installedSnapshot()).find(
 			(model) => model.id === id,
 		);
@@ -1965,7 +1994,12 @@ export async function handleLocalInferenceRoutes(
 		pathname,
 	);
 	if (method === "DELETE" && installedMatch) {
-		const id = decodeURIComponent(installedMatch[1] ?? "");
+		const id = decodeLocalInferencePathId(
+			installedMatch[1] ?? "",
+			res,
+			"model id",
+		);
+		if (id === null) return true;
 		sendJson(res, { removed: await removeInstalledModel(id) });
 		return true;
 	}


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed percent-encoding on `DELETE /api/local-inference/downloads/:id` currently 500s. Raw path-segment `decodeURIComponent` of `new URL().pathname` (not extra-decode after `URLSearchParams.get()` / parsed URL search/hash). Not #21472 / #21482 / #21489. Not list-limit. Not cookies (#21406/#21460/#21459). Not workflow-routes (#20839). Not `apps/[id]/domains`. Not #21385. Not #21380. Not ios-local-agent-kernel. Proof is `bun:test` of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical download ids still cancel. Malformed `%ZZ` now 400s before abort lookup instead of `URIError` → agent route-kernel 500. Proven on the unfixed head: DELETE `%ZZ` received **500**.

# Background

## What does this PR do?

`handleLocalInferenceRoutes` ran `decodeURIComponent` on the raw `url.pathname` download/verify/installed id capture with no try/catch. `new URL().pathname` is still percent-encoded, so a truncated escape (`%ZZ`) throws `URIError`. The agent `createRouteKernel` `translateFailure` maps unknown errors to HTTP 500. This PR returns 400 with `Invalid model id: malformed URL encoding` before cancel/verify/remove.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical encoded model ids unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/src/local-inference-routes.encoding.test.ts` and the `decodeLocalInferencePathId` helper.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-local-inference && bun test --isolate src/local-inference-routes.encoding.test.ts
```

Unfixed head: `DELETE /api/local-inference/downloads/%ZZ` threw `URIError` and the agent route kernel wrote **500**. After the fix: 2 passed on `4b919491dbcbba31d48d1ce72a8024584e8e99e8`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:4b919491dbcbba31d48d1ce72a8024584e8e99e8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the local-inference download HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed path encoding is rejected before cancel/verify/remove.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that a canonical download id still cancels.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid encoding never reaches activeDownloads.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on local-inference download path encoding. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `%ZZ` was 500; after the fix, Bun test asserts 400 and a canonical download id still cancels.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the local-inference download HTTP boundary.

## Audio / voice walkthrough

N/A - metadata DELETE only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
