### PR TITLE
fix(cloud): reject malformed discord gateway heartbeat JSON

### DIFF
--- a/packages/cloud/api/internal/discord/gateway/heartbeat/route.json.test.ts
+++ b/packages/cloud/api/internal/discord/gateway/heartbeat/route.json.test.ts
@@ -1,0 +1,60 @@
+/**
+ * POST /api/internal/discord/gateway/heartbeat used to let c.req.json() throw
+ * into failureResponse, which maps SyntaxError to 500. Malformed JSON is
+ * caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+const updateHeartbeatBatch = mock(async () => 1);
+const updateStats = mock(async () => undefined);
+
+mock.module("../../../_auth", () => ({
+	requireInternalAuth: async () => ({
+		podName: "pod-1",
+		service: "discord-gateway",
+	}),
+}));
+
+mock.module("@/db/repositories/discord-connections", () => ({
+	discordConnectionsRepository: {
+		updateHeartbeatBatch,
+		updateStats,
+	},
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+	logger: { error: () => undefined, info: () => undefined },
+}));
+
+const { default: app } = await import("./route");
+
+const validBody = {
+	pod_name: "pod-1",
+	connection_ids: [],
+	connection_stats: [],
+};
+
+describe("POST /api/internal/discord/gateway/heartbeat malformed JSON", () => {
+	test("returns 400 instead of 500 and never writes a heartbeat", async () => {
+		const response = await app.request("/", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: "{",
+		});
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toMatchObject({
+			error: "Invalid JSON body",
+		});
+		expect(updateHeartbeatBatch).not.toHaveBeenCalled();
+	});
+
+	test("canonical JSON still writes a heartbeat", async () => {
+		const response = await app.request("/", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(validBody),
+		});
+		expect(response.status).toBe(200);
+		expect(updateHeartbeatBatch).toHaveBeenCalled();
+	});
+});

--- a/packages/cloud/api/internal/discord/gateway/heartbeat/route.ts
+++ b/packages/cloud/api/internal/discord/gateway/heartbeat/route.ts
@@ -36,7 +36,15 @@ app.post("/", async (c) => {
     const auth = await requireInternalAuth(c);
     if (auth instanceof Response) return auth;
 
-    const body = heartbeatSchema.parse(await c.req.json());
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const body = heartbeatSchema.parse(rawBody);
     const updated = await discordConnectionsRepository.updateHeartbeatBatch(
       body.pod_name,
       body.connection_ids,


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on `POST /api/internal/discord/gateway/heartbeat` currently 500s. `c.req.json()` throws `SyntaxError` into `failureResponse`, which does not map parse failures to 400. Not path encoding. Not extra-decode after `URLSearchParams.get()` (#21472 / #21482 / #21489). Not list-limit. Not cookies. Not payment. Not #21320 gateway assignments. Not #21385. Proof is `bun:test` of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical heartbeat JSON still updates. Malformed `{` now 400s before repository writes instead of `URI`/`SyntaxError` → `failureResponse` 500. Proven on the unfixed head: POST `{` received **500**.

# Background

## What does this PR do?

`POST /api/internal/discord/gateway/heartbeat` ran `heartbeatSchema.parse(await c.req.json())` inside the route try. Hono's `c.req.json()` throws `SyntaxError` on `{`. `failureResponse` maps that to HTTP 500 / `internal_error`. This PR returns `{ error: "Invalid JSON body" }` with status 400 before schema parse or repository writes.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical heartbeat bodies unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/internal/discord/gateway/heartbeat/route.json.test.ts` and the `c.req.json()` catch in the POST handler.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate ./internal/discord/gateway/heartbeat/route.json.test.ts
```

Unfixed head: `POST /api/internal/discord/gateway/heartbeat` with body `{` returned **500**. After the fix: 2 passed on `88754c0943b0245f5597b35b517e28043431db30`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:88754c0943b0245f5597b35b517e28043431db30 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the gateway heartbeat HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before heartbeat writes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that a canonical heartbeat still writes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches the repository.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on gateway heartbeat JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and a canonical heartbeat still writes.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the gateway heartbeat HTTP boundary.

## Audio / voice walkthrough

N/A - JSON POST only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
