### PR TITLE
fix(security): scheme-gate app-authorize redirects and mask logger binary payloads

### DIFF
--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -639,6 +639,61 @@ describe("secret redaction", () => {
 });
 
 /**
+ * Binary-payload redaction contract: a Buffer/TypedArray/DataView logged under
+ * a neutral key must collapse to a size-only marker in both the node and
+ * browser log paths — JSON would otherwise serialize the raw bytes verbatim
+ * (`{"type":"Buffer","data":[...]}`) into the ring buffer and every sink.
+ */
+describe("binary payload redaction", () => {
+  afterEach(() => {
+    createLogger({ level: "info" }).clear();
+    vi.restoreAllMocks();
+  });
+
+  it("masks a Buffer under a neutral key in the node path", () => {
+    const logger = createLogger({ level: "trace" });
+    logger.info({ payload: Buffer.from("topsecret-bytes") }, "ctx");
+    const logs = recentLogs();
+    expect(logs).toContain("[BUFFER REDACTED 15 bytes]");
+    expect(logs).not.toContain('"type":"Buffer"');
+    expect(logs).not.toContain("116,111,112");
+  });
+
+  it("masks TypedArray, DataView, and ArrayBuffer values", () => {
+    const logger = createLogger({ level: "trace" });
+    logger.info(
+      {
+        u8: new Uint8Array([1, 2, 3]),
+        view: new DataView(new ArrayBuffer(7)),
+        buf: new ArrayBuffer(9),
+      },
+      "ctx",
+    );
+    const logs = recentLogs();
+    expect(logs).toContain("[BUFFER REDACTED 3 bytes]");
+    expect(logs).toContain("[BUFFER REDACTED 7 bytes]");
+    expect(logs).toContain("[BUFFER REDACTED 9 bytes]");
+  });
+
+  it("masks a Buffer passed as a trailing arg", () => {
+    const logger = createLogger({ level: "trace" });
+    logger.info("plain message", { file: Buffer.from("trailing-secret") });
+    const logs = recentLogs();
+    expect(logs).toContain("[BUFFER REDACTED 15 bytes]");
+    expect(logs).not.toContain('"type":"Buffer"');
+  });
+
+  it("masks a Buffer in the browser logger path", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const logger = createLogger({ level: "trace", __forceType: "browser" });
+    logger.info({ payload: Buffer.from("browser-secret") }, "ctx");
+    const out = infoSpy.mock.calls.flat().join(" ");
+    expect(out).toContain("[BUFFER REDACTED 14 bytes]");
+    expect(out).not.toContain('"type":"Buffer"');
+  });
+});
+
+/**
  * File-sink permission contract (W1-059): output.log/prompts.log/chat.log
  * must be created 0600, and files left world-readable by older builds must be
  * healed on first open. Needs a fresh module instance per case because the

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -5,7 +5,9 @@
  * `success`/`progress` levels. Redacts sensitive fields with a deep-walk
  * redactor that deep-clones log context objects (callers keep their live
  * objects unmutated) and masks every value under a credential-named key at any
- * nesting depth, matched case-insensitively. String values — object properties,
+ * nesting depth, matched case-insensitively. Binary payloads (Buffer, typed
+ * arrays, DataView, ArrayBuffer) collapse to a size-only marker so raw bytes
+ * never reach a sink under a neutral key. String values — object properties,
  * headline messages, and Error message/stack — are additionally scrubbed for
  * credential shapes (API keys, Bearer tokens, URI userinfo, PEM blocks) with
  * the pattern library mirrored from `@elizaos/core`'s security/redact.ts,
@@ -571,7 +573,10 @@ function redactSensitiveLogText(text: string): string {
  * nested credentials in place, corrupting e.g. a provider config mid-use).
  * String values are pattern-scrubbed for credential shapes at every depth.
  * Cycles and over-depth payloads collapse to a marker instead of recursing
- * forever. Error instances keep their name/message/stack shape (Adze renders
+ * forever. Buffer/TypedArray/DataView/ArrayBuffer values collapse to a
+ * size-only marker — JSON would otherwise serialize the raw bytes verbatim
+ * (`{"type":"Buffer","data":[...]}`) under an innocent-looking key. Error
+ * instances keep their name/message/stack shape (Adze renders
  * it) with message and stack scrubbed — thrown errors routinely interpolate
  * the offending secret — and their own enumerable properties (axios-style
  * `err.config.headers`) are walked and masked.
@@ -603,6 +608,14 @@ function redactLogValue(
     return value.map((item) => redactLogValue(item, seen, depth + 1));
   }
 
+  // Binary payloads carry raw bytes that JSON serializes verbatim
+  // ({"type":"Buffer","data":[...]}); under a neutral key that silently leaks
+  // secret material into every sink, so mask with a size-only marker. Both
+  // the node and browser log paths funnel through this walker.
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+    return `[BUFFER REDACTED ${value.byteLength} bytes]`;
+  }
+
   // Opaque built-ins have no enumerable credential keys to mask and are never
   // mutated by the walker, so returning them by reference is safe.
   if (
@@ -612,9 +625,7 @@ function redactLogValue(
     value instanceof Set ||
     value instanceof WeakMap ||
     value instanceof WeakSet ||
-    value instanceof Promise ||
-    ArrayBuffer.isView(value) ||
-    value instanceof ArrayBuffer
+    value instanceof Promise
   ) {
     return value;
   }

--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx
@@ -186,6 +186,38 @@ describe("AuthorizeContent", () => {
     );
   });
 
+  it("refuses a scriptable redirect_uri scheme and never navigates", async () => {
+    searchParamsRef.current = new URLSearchParams(
+      "app_id=app-1&redirect_uri=javascript%3Aalert(1)&state=state-1",
+    );
+
+    render(<AuthorizeContent />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Invalid redirect_uri format.")).toBeTruthy(),
+    );
+    expect(locationAssignMock).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: "Authorize Demo App" }),
+    ).toBeNull();
+  });
+
+  it("hands off to native-app custom scheme redirect URIs", async () => {
+    const user = userEvent.setup();
+    searchParamsRef.current = new URLSearchParams(
+      "app_id=app-1&redirect_uri=myapp%3A%2F%2Foauth%2Fcallback&state=state-1",
+    );
+
+    render(<AuthorizeContent />);
+
+    await waitFor(() => expect(screen.getByText("Demo App")).toBeTruthy());
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(locationAssignMock).toHaveBeenCalledWith(
+      "myapp://oauth/callback?error=access_denied&error_description=User+denied+authorization&state=state-1",
+    );
+  });
+
   it("keeps the signed-out state to sign-in controls plus one cancel affordance", async () => {
     authRef.current = {
       ...authRef.current,

--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
@@ -19,6 +19,7 @@ import { BrandButton, BrandCard, CornerBrackets } from "../primitives";
 import {
   buildAppAuthorizeCancelRedirect,
   buildAppAuthorizeCompletionRedirect,
+  isSafeAppAuthorizeRedirectUri,
   storeCurrentAppAuthorizeReturnTo,
 } from "./authorize-return";
 
@@ -231,12 +232,7 @@ function AuthorizeFlow({
     let cancelled = false;
 
     async function validateApp() {
-      try {
-        const uri = new URL(redirectUri);
-        if (uri.protocol !== "http:" && uri.protocol !== "https:") {
-          throw new Error("Invalid protocol");
-        }
-      } catch {
+      if (!isSafeAppAuthorizeRedirectUri(redirectUri)) {
         setError("Invalid redirect_uri format.");
         setStatus("error");
         return;
@@ -326,6 +322,12 @@ function AuthorizeFlow({
         );
       }
 
+      // The mount-time gate already ran, but the navigation sink re-checks
+      // the hand-off scheme so no future refactor can route around it.
+      if (!isSafeAppAuthorizeRedirectUri(redirectUri)) {
+        throw new Error("Invalid redirect_uri format.");
+      }
+
       window.location.assign(
         buildAppAuthorizeCompletionRedirect({
           code,
@@ -344,7 +346,9 @@ function AuthorizeFlow({
   }, [appId, redirectUri, state, appInfo?.name, getToken, signOut]);
 
   const handleCancel = useCallback(() => {
-    if (!redirectUri) {
+    // Fail closed on an untrusted hand-off target: stay on our own origin
+    // rather than navigating to a scriptable or slash-less scheme.
+    if (!redirectUri || !isSafeAppAuthorizeRedirectUri(redirectUri)) {
       router.push("/");
       return;
     }

--- a/packages/ui/src/cloud-ui/components/auth/authorize-return.test.ts
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-return.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for the app-authorize hand-off scheme gate
+ * (`isSafeAppAuthorizeRedirectUri`): the fail-closed check every authorize
+ * navigation target must pass. Pure function, deterministic, no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import { isSafeAppAuthorizeRedirectUri } from "./authorize-return";
+
+describe("isSafeAppAuthorizeRedirectUri", () => {
+  it.each([
+    "https://app.example/callback",
+    "http://localhost:2138/callback",
+    "myapp://oauth/callback",
+    "myapp:/oauth/callback",
+    "eliza-app://auth?next=%2Fhome",
+  ])("allows %s", (value) => {
+    expect(isSafeAppAuthorizeRedirectUri(value)).toBe(true);
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "JaVaScRiPt:alert(1)",
+    "javascript:/alert(1)",
+    "javascript://alert(1)",
+    "data:text/html;base64,PHNjcmlwdD4=",
+    "vbscript:msgbox(1)",
+    "file:///etc/passwd",
+    "about:blank",
+    "blob:https://app.example/1234",
+    "mailto:user@example.com",
+    "not a url",
+    "",
+    "//example.com/protocol-relative",
+  ])("rejects %s", (value) => {
+    expect(isSafeAppAuthorizeRedirectUri(value)).toBe(false);
+  });
+});

--- a/packages/ui/src/cloud-ui/components/auth/authorize-return.ts
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-return.ts
@@ -1,5 +1,6 @@
 /**
- * Return-to plumbing for the app-authorize flow: the path and the persisted return target.
+ * Return-to plumbing for the app-authorize flow: the path, the persisted
+ * return target, and the fail-closed scheme gate for hand-off navigations.
  */
 import { shellLocalStorage } from "../../../surface-realm-channel";
 export const APP_AUTHORIZE_PATH = "/app-auth/authorize";
@@ -47,6 +48,40 @@ export function buildAppAuthorizeCancelRedirect(input: {
   url.searchParams.set("error_description", "User denied authorization");
   if (input.state != null) url.searchParams.set("state", input.state);
   return url.toString();
+}
+
+/**
+ * Protocols that must never become a navigation target from the authorize
+ * hand-off, even though `new URL()` parses them without complaint.
+ */
+const BLOCKED_REDIRECT_PROTOCOLS: ReadonlySet<string> = new Set([
+  "javascript:",
+  "data:",
+  "vbscript:",
+  "file:",
+]);
+
+/**
+ * Fail-closed scheme gate for the authorize hand-off navigation. Allows
+ * http(s) URLs and native-app custom schemes shaped like real navigation
+ * targets (`myapp://callback` or `myapp:/callback`); everything else —
+ * scriptable protocols, slash-less `scheme:payload` forms, unparseable
+ * input — is rejected. Passing here is necessary, not sufficient: the server
+ * separately requires the URI's origin to be registered for the app.
+ */
+export function isSafeAppAuthorizeRedirectUri(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    // error-policy:J3 unparseable hand-off target is rejected (fail closed).
+    return false;
+  }
+  const protocol = url.protocol.toLowerCase();
+  if (protocol === "http:" || protocol === "https:") return true;
+  if (BLOCKED_REDIRECT_PROTOCOLS.has(protocol)) return false;
+  if (!/^[a-z][a-z0-9+.-]*:$/.test(protocol)) return false;
+  return /^[a-z][a-z0-9+.-]*:\/\/?/i.test(value);
 }
 
 export function storeCurrentAppAuthorizeReturnTo(): void {


### PR DESCRIPTION
## Summary

Two small wave-8 residual hardening fixes:

1. **App-authorize redirect sinks (`packages/ui`)** — the consent screen navigated to the query-string `redirect_uri` via `window.location.assign(...)` in both the completion and cancel paths. A single fail-closed scheme gate (`isSafeAppAuthorizeRedirectUri`, in `authorize-return.ts`) now runs at mount validation and again at both navigation sinks: http(s) URLs and native-app custom schemes (`scheme://` or `scheme:/` forms) pass; scriptable or non-navigational schemes are rejected — the authorize path fails to a visible error state, the cancel path falls back to a safe local route instead of navigating.

   **Server-side note:** the backend already validates `redirect_uri` — `GET /api/v1/apps/[id]/public` and `POST /api/v1/app-auth/connect` both reject any URI whose origin is not registered for the app (`isAllowedOrigin` against `appsService.getAllowedOrigins`), and non-http(s) candidates normalize to `null` and are refused. No server change was required; this PR adds the client-side defense-in-depth at the sinks themselves.

2. **Logger binary payload redaction (`packages/logger`)** — the deep-walk redactor passed `Buffer`/TypedArray/DataView/ArrayBuffer values through by reference, so a binary payload logged under a neutral key serialized its raw bytes into every sink (ring buffer, file logs, WS stream). The walker now collapses them to a `[BUFFER REDACTED <n> bytes]` size-only marker. Both the node and the browser log paths funnel through this walker, so the one change covers both.

## Test evidence

- `bun run --cwd packages/logger test` — 39/39 pass, including 4 new binary-redaction cases (node path, trailing args, TypedArray/DataView/ArrayBuffer sizes, browser path via `__forceType: "browser"`).
- `bun run --cwd packages/ui test -- src/cloud-ui/components/auth/authorize-content.test.tsx src/cloud-ui/components/auth/authorize-return.test.ts` — 26/26 pass, including new cases: a scriptable `redirect_uri` scheme renders the invalid-format error and never navigates; a native custom scheme still reaches the consent screen and completes the cancel hand-off; an 18-case allow/reject table for the scheme gate.
- `bun run --cwd packages/logger typecheck` — clean.
- `bun run --cwd packages/ui typecheck` — clean.
- `biome check` on all six changed files — clean.

No rendered-output/styling change (navigation-guard logic only), so the app visual audit was not applicable.