### PR TITLE
feat(cloud): epoch-fenced sealed memory promotion per #21090 review

### DIFF
--- a/packages/agent/src/api/memory-import-staged.test.ts
+++ b/packages/agent/src/api/memory-import-staged.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Deterministic tests for the staged sealed importer: seal trust, batch
+ * geometry, staging completeness, digest binding to the ORIGINAL seal,
+ * dimension negotiation, id-conflict semantics, and the atomic publish
+ * ordering (verify → scaffold → publish → drain, all inside one
+ * transaction). The database is a scripted double that records every
+ * statement; real SQL behavior is covered by the pglite suites.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  computeSharedMemoryTransferDigest,
+  type SealedMemoryExportRow,
+  signSeal,
+} from "@elizaos/shared/contracts/shared-memory-transfer";
+import {
+  finalizeSealedImport,
+  MEMORY_IMPORT_BATCH_INVALID,
+  MEMORY_IMPORT_DIGEST_MISMATCH,
+  MEMORY_IMPORT_DIMENSION_UNSUPPORTED,
+  MEMORY_IMPORT_ID_CONFLICT,
+  MEMORY_IMPORT_SEAL_INVALID,
+  MEMORY_IMPORT_STAGING_INCOMPLETE,
+  stageSealedBatch,
+} from "./memory-import-staged.ts";
+
+const KEY = "test-seal-key";
+const AGENT = "77000000-0000-4000-8000-000000000001";
+
+function row(
+  i: number,
+  overrides: Partial<SealedMemoryExportRow> = {},
+): SealedMemoryExportRow {
+  return {
+    id: `66000000-0000-4000-8000-${String(i).padStart(12, "0")}`,
+    type: "messages",
+    created_at: new Date(1700000000000 + i * 1000).toISOString(),
+    content: { text: `memory ${i}` },
+    entity_id: null,
+    agent_id: AGENT,
+    room_id: "55000000-0000-4000-8000-000000000001",
+    world_id: "44000000-0000-4000-8000-000000000001",
+    unique: false,
+    metadata: {},
+    embedding: Array.from({ length: 384 }, (_, k) => ((i + k) % 7) / 7),
+    ...overrides,
+  };
+}
+
+async function sealFor(
+  rows: SealedMemoryExportRow[],
+  dimension: number | null = 384,
+) {
+  const digest = await computeSharedMemoryTransferDigest(rows);
+  const body = {
+    version: 3 as const,
+    epoch: 1,
+    source_agent_id: AGENT,
+    scope: "org:user:agent",
+    row_count: rows.length,
+    digest,
+    vector_dimension: dimension,
+    exported_at: new Date(1700000000000).toISOString(),
+  };
+  return { ...body, signature: await signSeal(body, KEY) };
+}
+
+interface ScriptedDb {
+  statements: string[];
+  transactions: number;
+  stagedRows: SealedMemoryExportRow[];
+  existing: Array<{ id: string; content: unknown }>;
+}
+
+function scriptedRuntime(script: Partial<ScriptedDb> = {}) {
+  const state: ScriptedDb = {
+    statements: [],
+    transactions: 0,
+    stagedRows: script.stagedRows ?? [],
+    existing: script.existing ?? [],
+    ...script,
+  };
+  const exec = async (q: unknown) => {
+    const text = JSON.stringify(q);
+    state.statements.push(text);
+    if (text.includes("SELECT payload FROM memory_import_staging")) {
+      return { rows: state.stagedRows.map((payload) => ({ payload })) };
+    }
+    if (text.includes("FROM memories")) {
+      return { rows: state.existing };
+    }
+    if (text.includes("count(*)")) {
+      return { rows: [{ n: state.stagedRows.length }] };
+    }
+    return { rows: [] };
+  };
+  const db = {
+    execute: exec,
+    transaction: async <T>(
+      fn: (tx: { execute: typeof exec }) => Promise<T>,
+    ) => {
+      state.transactions += 1;
+      return fn({ execute: exec });
+    },
+  };
+  const runtime = {
+    agentId: AGENT,
+    db,
+    getSetting: (name: string) =>
+      name === "ELIZA_MEMORY_TRANSFER_SEAL_KEY" ? KEY : undefined,
+  } as never;
+  return { runtime, state };
+}
+
+async function expectCode(promise: Promise<unknown>, code: string) {
+  try {
+    await promise;
+    throw new Error(`expected ${code}`);
+  } catch (error) {
+    expect((error as { code?: string }).code).toBe(code);
+  }
+}
+
+describe("stageSealedBatch", () => {
+  test("rejects a seal signed with a different key", async () => {
+    const rows = [row(1)];
+    const seal = { ...(await sealFor(rows)), signature: "0".repeat(64) };
+    const { runtime } = scriptedRuntime();
+    await expectCode(
+      stageSealedBatch(runtime, { seal, batch_index: 0, batch_count: 1, rows }),
+      MEMORY_IMPORT_SEAL_INVALID,
+    );
+  });
+
+  test("rejects batch geometry that does not match the seal", async () => {
+    const rows = [row(1)];
+    const seal = await sealFor(rows);
+    const { runtime } = scriptedRuntime();
+    await expectCode(
+      stageSealedBatch(runtime, { seal, batch_index: 0, batch_count: 4, rows }),
+      MEMORY_IMPORT_BATCH_INVALID,
+    );
+  });
+
+  test("stages rows idempotently and reports totals", async () => {
+    const rows = [row(1), row(2)];
+    const seal = await sealFor(rows);
+    const { runtime, state } = scriptedRuntime({ stagedRows: rows });
+    const out = await stageSealedBatch(runtime, {
+      seal,
+      batch_index: 0,
+      batch_count: 1,
+      rows,
+    });
+    expect(out).toEqual({ staged: 2, total_staged: 2 });
+    expect(
+      state.statements.filter((s) =>
+        s.includes("ON CONFLICT (seal_digest, row_id) DO NOTHING"),
+      ),
+    ).toHaveLength(2);
+  });
+});
+
+describe("finalizeSealedImport", () => {
+  test("refuses an unsupported vector dimension before touching the db", async () => {
+    const rows = [row(1)];
+    const seal = await sealFor(rows, 999);
+    const { runtime, state } = scriptedRuntime({ stagedRows: rows });
+    await expectCode(
+      finalizeSealedImport(runtime, { seal }),
+      MEMORY_IMPORT_DIMENSION_UNSUPPORTED,
+    );
+    expect(state.transactions).toBe(0);
+  });
+
+  test("fails closed when staging does not cover the seal", async () => {
+    const rows = [row(1), row(2)];
+    const seal = await sealFor(rows, 384);
+    const { runtime } = scriptedRuntime({ stagedRows: rows.slice(0, 1) });
+    await expectCode(
+      finalizeSealedImport(runtime, { seal }),
+      MEMORY_IMPORT_STAGING_INCOMPLETE,
+    );
+  });
+
+  test("binds finalization to the ORIGINAL digest — tampered rows fail", async () => {
+    const rows = [row(1)];
+    const seal = await sealFor(rows, 384);
+    const tampered = [row(1, { content: { text: "swapped" } })];
+    const { runtime } = scriptedRuntime({ stagedRows: tampered });
+    await expectCode(
+      finalizeSealedImport(runtime, { seal }),
+      MEMORY_IMPORT_DIGEST_MISMATCH,
+    );
+  });
+
+  test("conflicting existing id fails the whole finalize", async () => {
+    const rows = [row(1)];
+    const seal = await sealFor(rows, 384);
+    const { runtime } = scriptedRuntime({
+      stagedRows: rows,
+      existing: [{ id: row(1).id, content: { text: "different" } }],
+    });
+    await expectCode(
+      finalizeSealedImport(runtime, { seal }),
+      MEMORY_IMPORT_ID_CONFLICT,
+    );
+  });
+
+  test("publishes atomically: scaffold, rows, vectors, drain in one transaction", async () => {
+    const rows = [row(1), row(2)];
+    const seal = await sealFor(rows, 384);
+    const { runtime, state } = scriptedRuntime({ stagedRows: rows });
+    const out = await finalizeSealedImport(runtime, { seal });
+    expect(out).toEqual({ published: 2, skipped_existing: 0 });
+    expect(state.transactions).toBe(1);
+    const joined = state.statements.join("\n");
+    expect(joined).toContain("INSERT INTO worlds");
+    expect(joined).toContain("INSERT INTO rooms");
+    expect(joined).toContain("INSERT INTO memories");
+    expect(joined).toContain("dim_384");
+    expect(joined).toContain("DELETE FROM memory_import_staging");
+    const memInserts = state.statements.filter((s) =>
+      s.includes("INSERT INTO memories"),
+    );
+    expect(memInserts).toHaveLength(2);
+  });
+
+  test("hash-identical existing rows are skipped, not conflicts", async () => {
+    const rows = [row(1), row(2)];
+    const seal = await sealFor(rows, 384);
+    const { runtime, state } = scriptedRuntime({
+      stagedRows: rows,
+      existing: [{ id: row(1).id, content: row(1).content }],
+    });
+    const out = await finalizeSealedImport(runtime, { seal });
+    expect(out).toEqual({ published: 1, skipped_existing: 1 });
+    expect(
+      state.statements.filter((s) => s.includes("INSERT INTO memories")),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/agent/src/api/memory-import-staged.ts
+++ b/packages/agent/src/api/memory-import-staged.ts
@@ -1,0 +1,271 @@
+/**
+ * Staged Shared→Dedicated memory import with one atomic finalization
+ * (round 3, #21090 review).
+ *
+ * Batches land in a dedicated staging table keyed by the seal digest; nothing
+ * is visible to the runtime until `finalizeSealedImport` republishes the whole
+ * set in ONE transaction that (1) re-verifies the ORIGINAL seal — signature
+ * and order-sensitive digest recomputed from the staged rows themselves,
+ * (2) negotiates the vector dimension against the core embeddings columns,
+ * (3) creates missing room/world/entity scaffolding, inserts memories and
+ * embeddings, and (4) drains the staging rows — so a failed finalize leaves
+ * zero visible rows and a repeated finalize is a typed conflict, not a
+ * duplicate publish.
+ */
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
+import {
+  computeSharedMemoryTransferDigest,
+  type SealedExportSeal,
+  SealedMemoryFinalizeRequestSchema,
+  type SealedMemoryStageRequest,
+  SealedMemoryStageRequestSchema,
+  type SealedMemoryExportRow,
+  verifySealSignature,
+} from "@elizaos/shared/contracts/shared-memory-transfer";
+import { sql } from "drizzle-orm";
+
+export const MEMORY_IMPORT_SEAL_INVALID = "MEMORY_IMPORT_SEAL_INVALID";
+export const MEMORY_IMPORT_BATCH_INVALID = "MEMORY_IMPORT_BATCH_INVALID";
+export const MEMORY_IMPORT_STAGING_INCOMPLETE = "MEMORY_IMPORT_STAGING_INCOMPLETE";
+export const MEMORY_IMPORT_DIGEST_MISMATCH = "MEMORY_IMPORT_DIGEST_MISMATCH";
+export const MEMORY_IMPORT_DIMENSION_UNSUPPORTED = "MEMORY_IMPORT_DIMENSION_UNSUPPORTED";
+export const MEMORY_IMPORT_ID_CONFLICT = "MEMORY_IMPORT_ID_CONFLICT";
+export const MEMORY_IMPORT_DB_UNAVAILABLE = "MEMORY_IMPORT_DB_UNAVAILABLE";
+
+/** Core embeddings columns by dimension (schemas/embedding.ts). */
+const SUPPORTED_DIMENSION_COLUMNS: Record<number, string> = {
+  384: "dim_384",
+  512: "dim_512",
+  768: "dim_768",
+  1024: "dim_1024",
+  1536: "dim_1536",
+  3072: "dim_3072",
+};
+
+type Db = { transaction: <T>(fn: (tx: DbTx) => Promise<T>) => Promise<T> } & DbTx;
+type DbTx = { execute: (q: unknown) => Promise<{ rows?: unknown[] } | unknown[]> };
+
+function requireDb(runtime: IAgentRuntime): Db {
+  const db = (runtime as { db?: unknown }).db;
+  if (!db || typeof (db as Db).transaction !== "function") {
+    throw new ElizaError("Runtime database is unavailable for memory import", {
+      code: MEMORY_IMPORT_DB_UNAVAILABLE,
+    });
+  }
+  return db as Db;
+}
+
+function rowsOf(result: { rows?: unknown[] } | unknown[]): unknown[] {
+  return Array.isArray(result) ? result : (result.rows ?? []);
+}
+
+async function ensureStagingTable(db: DbTx): Promise<void> {
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS memory_import_staging (
+      seal_digest text NOT NULL,
+      row_id uuid NOT NULL,
+      row_index integer NOT NULL,
+      payload jsonb NOT NULL,
+      staged_at timestamp NOT NULL DEFAULT now(),
+      PRIMARY KEY (seal_digest, row_id)
+    )
+  `);
+}
+
+function sealKeyFromEnv(runtime: IAgentRuntime): string {
+  const key = runtime.getSetting("ELIZA_MEMORY_TRANSFER_SEAL_KEY");
+  if (typeof key !== "string" || key.length === 0) {
+    throw new ElizaError("Memory transfer seal key is not configured", {
+      code: MEMORY_IMPORT_SEAL_INVALID,
+    });
+  }
+  return key;
+}
+
+async function assertSealTrusted(
+  runtime: IAgentRuntime,
+  seal: SealedExportSeal,
+): Promise<void> {
+  const ok = await verifySealSignature(seal, sealKeyFromEnv(runtime));
+  if (!ok) {
+    throw new ElizaError("Whole-export seal signature is invalid", {
+      code: MEMORY_IMPORT_SEAL_INVALID,
+    });
+  }
+}
+
+/** Stage one batch. Rows become visible to nothing; replays are idempotent. */
+export async function stageSealedBatch(
+  runtime: IAgentRuntime,
+  request: unknown,
+): Promise<{ staged: number; total_staged: number }> {
+  const parsed: SealedMemoryStageRequest = SealedMemoryStageRequestSchema.parse(request);
+  await assertSealTrusted(runtime, parsed.seal);
+  const expectedBatches = Math.max(1, Math.ceil(parsed.seal.row_count / 500));
+  if (parsed.batch_count !== expectedBatches || parsed.batch_index >= parsed.batch_count) {
+    throw new ElizaError("Stage request batch geometry does not match the seal", {
+      code: MEMORY_IMPORT_BATCH_INVALID,
+      context: { batch_index: parsed.batch_index, batch_count: parsed.batch_count, expectedBatches },
+    });
+  }
+  const db = requireDb(runtime);
+  await ensureStagingTable(db);
+  const base = parsed.batch_index * 500;
+  for (const [i, row] of parsed.rows.entries()) {
+    await db.execute(sql`
+      INSERT INTO memory_import_staging (seal_digest, row_id, row_index, payload)
+      VALUES (${parsed.seal.digest}, ${row.id}, ${base + i}, ${JSON.stringify(row)}::jsonb)
+      ON CONFLICT (seal_digest, row_id) DO NOTHING
+    `);
+  }
+  const counted = rowsOf(
+    await db.execute(
+      sql`SELECT count(*)::int AS n FROM memory_import_staging WHERE seal_digest = ${parsed.seal.digest}`,
+    ),
+  ) as Array<{ n: number }>;
+  return { staged: parsed.rows.length, total_staged: counted[0]?.n ?? 0 };
+}
+
+/**
+ * The ONE atomic publish/finalization step. Everything happens inside a
+ * single transaction against the runtime database: seal re-verification from
+ * the staged rows, dimension negotiation, scaffolding, row+vector publish,
+ * and staging drain. Any thrown error rolls the whole step back.
+ */
+export async function finalizeSealedImport(
+  runtime: IAgentRuntime,
+  request: unknown,
+): Promise<{ published: number; skipped_existing: number }> {
+  const { seal } = SealedMemoryFinalizeRequestSchema.parse(request);
+  await assertSealTrusted(runtime, seal);
+
+  const dimensionColumn =
+    seal.vector_dimension === null
+      ? null
+      : (SUPPORTED_DIMENSION_COLUMNS[seal.vector_dimension] ?? undefined);
+  if (dimensionColumn === undefined) {
+    throw new ElizaError("Export vector dimension has no destination column", {
+      code: MEMORY_IMPORT_DIMENSION_UNSUPPORTED,
+      context: { dimension: seal.vector_dimension },
+    });
+  }
+
+  const db = requireDb(runtime);
+  await ensureStagingTable(db);
+
+  return db.transaction(async (tx) => {
+    const staged = rowsOf(
+      await tx.execute(sql`
+        SELECT payload FROM memory_import_staging
+        WHERE seal_digest = ${seal.digest}
+        ORDER BY row_index ASC
+        FOR UPDATE
+      `),
+    ) as Array<{ payload: SealedMemoryExportRow | string }>;
+    const rows: SealedMemoryExportRow[] = staged.map((r) =>
+      typeof r.payload === "string" ? JSON.parse(r.payload) : r.payload,
+    );
+
+    if (rows.length !== seal.row_count) {
+      throw new ElizaError("Staged rows do not cover the sealed export", {
+        code: MEMORY_IMPORT_STAGING_INCOMPLETE,
+        context: { staged: rows.length, sealed: seal.row_count },
+      });
+    }
+    const digest = await computeSharedMemoryTransferDigest(rows);
+    if (digest !== seal.digest) {
+      throw new ElizaError("Recomputed digest does not match the original seal", {
+        code: MEMORY_IMPORT_DIGEST_MISMATCH,
+      });
+    }
+
+    // Conflict pre-check inside the same transaction: identical ids are
+    // skipped, any differing row fails the WHOLE finalize.
+    const ids = rows.map((r) => r.id);
+    const existing =
+      ids.length === 0
+        ? []
+        : (rowsOf(
+            await tx.execute(sql`
+              SELECT id::text AS id, content FROM memories
+              WHERE id IN (SELECT jsonb_array_elements_text(${JSON.stringify(ids)}::jsonb)::uuid)
+            `),
+          ) as Array<{ id: string; content: unknown }>);
+    const existingById = new Map(existing.map((r) => [r.id, r]));
+    let skipped = 0;
+    const toPublish: SealedMemoryExportRow[] = [];
+    for (const row of rows) {
+      const found = existingById.get(row.id);
+      if (!found) {
+        toPublish.push(row);
+        continue;
+      }
+      const same =
+        JSON.stringify(found.content) === JSON.stringify(row.content);
+      if (!same) {
+        throw new ElizaError("A staged row conflicts with an existing memory", {
+          code: MEMORY_IMPORT_ID_CONFLICT,
+          context: { id: row.id },
+        });
+      }
+      skipped += 1;
+    }
+
+    // Scaffolding: create-if-absent only, never overwrite target-native rows.
+    const agentId = runtime.agentId;
+    const worldIds = [...new Set(toPublish.map((r) => r.world_id).filter(Boolean))] as string[];
+    for (const worldId of worldIds) {
+      await tx.execute(sql`
+        INSERT INTO worlds (id, agent_id, name, server_id)
+        VALUES (${worldId}, ${agentId}, 'Shared transfer', 'shared-transfer')
+        ON CONFLICT (id) DO NOTHING
+      `);
+    }
+    const roomPairs = [
+      ...new Map(
+        toPublish.filter((r) => r.room_id).map((r) => [r.room_id as string, r.world_id]),
+      ).entries(),
+    ];
+    for (const [roomId, worldId] of roomPairs) {
+      await tx.execute(sql`
+        INSERT INTO rooms (id, agent_id, world_id, source, type)
+        VALUES (${roomId}, ${agentId}, ${worldId}, 'shared-transfer', 'DM')
+        ON CONFLICT (id) DO NOTHING
+      `);
+    }
+    const entityIds = [...new Set(toPublish.map((r) => r.entity_id).filter(Boolean))] as string[];
+    for (const entityId of entityIds) {
+      await tx.execute(sql`
+        INSERT INTO entities (id, agent_id, names)
+        VALUES (${entityId}, ${agentId}, ARRAY['shared-transfer'])
+        ON CONFLICT (id) DO NOTHING
+      `);
+    }
+
+    for (const row of toPublish) {
+      await tx.execute(sql`
+        INSERT INTO memories (id, type, created_at, content, entity_id, agent_id, room_id, world_id, "unique", metadata)
+        VALUES (
+          ${row.id}, ${row.type}, ${row.created_at}::timestamptz,
+          ${JSON.stringify(row.content)}::jsonb, ${row.entity_id},
+          ${agentId}, ${row.room_id}, ${row.world_id}, ${row.unique},
+          ${JSON.stringify({ ...row.metadata, source: "shared-runtime-transfer", transfer_epoch: seal.epoch })}::jsonb
+        )
+      `);
+      if (row.embedding && dimensionColumn) {
+        // pgvector literal: '[x,y,...]'::vector(D) (embeddings columns are
+        // typed vector(D), not real[] — plugin-sql schema/embedding.ts).
+        const vectorLiteral = `[${row.embedding.join(",")}]`;
+        await tx.execute(sql`
+          INSERT INTO embeddings (id, memory_id, created_at, ${sql.raw(`"${dimensionColumn}"`)})
+          VALUES (gen_random_uuid(), ${row.id}, now(), ${vectorLiteral}::vector)
+        `);
+      }
+    }
+
+    await tx.execute(
+      sql`DELETE FROM memory_import_staging WHERE seal_digest = ${seal.digest}`,
+    );
+    return { published: toPublish.length, skipped_existing: skipped };
+  });
+}

--- a/packages/agent/src/api/memory-import-staged.ts
+++ b/packages/agent/src/api/memory-import-staged.ts
@@ -16,19 +16,21 @@ import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import {
   computeSharedMemoryTransferDigest,
   type SealedExportSeal,
+  type SealedMemoryExportRow,
   SealedMemoryFinalizeRequestSchema,
   type SealedMemoryStageRequest,
   SealedMemoryStageRequestSchema,
-  type SealedMemoryExportRow,
   verifySealSignature,
 } from "@elizaos/shared/contracts/shared-memory-transfer";
 import { sql } from "drizzle-orm";
 
 export const MEMORY_IMPORT_SEAL_INVALID = "MEMORY_IMPORT_SEAL_INVALID";
 export const MEMORY_IMPORT_BATCH_INVALID = "MEMORY_IMPORT_BATCH_INVALID";
-export const MEMORY_IMPORT_STAGING_INCOMPLETE = "MEMORY_IMPORT_STAGING_INCOMPLETE";
+export const MEMORY_IMPORT_STAGING_INCOMPLETE =
+  "MEMORY_IMPORT_STAGING_INCOMPLETE";
 export const MEMORY_IMPORT_DIGEST_MISMATCH = "MEMORY_IMPORT_DIGEST_MISMATCH";
-export const MEMORY_IMPORT_DIMENSION_UNSUPPORTED = "MEMORY_IMPORT_DIMENSION_UNSUPPORTED";
+export const MEMORY_IMPORT_DIMENSION_UNSUPPORTED =
+  "MEMORY_IMPORT_DIMENSION_UNSUPPORTED";
 export const MEMORY_IMPORT_ID_CONFLICT = "MEMORY_IMPORT_ID_CONFLICT";
 export const MEMORY_IMPORT_DB_UNAVAILABLE = "MEMORY_IMPORT_DB_UNAVAILABLE";
 
@@ -42,8 +44,12 @@ const SUPPORTED_DIMENSION_COLUMNS: Record<number, string> = {
   3072: "dim_3072",
 };
 
-type Db = { transaction: <T>(fn: (tx: DbTx) => Promise<T>) => Promise<T> } & DbTx;
-type DbTx = { execute: (q: unknown) => Promise<{ rows?: unknown[] } | unknown[]> };
+type Db = {
+  transaction: <T>(fn: (tx: DbTx) => Promise<T>) => Promise<T>;
+} & DbTx;
+type DbTx = {
+  execute: (q: unknown) => Promise<{ rows?: unknown[] } | unknown[]>;
+};
 
 function requireDb(runtime: IAgentRuntime): Db {
   const db = (runtime as { db?: unknown }).db;
@@ -99,14 +105,25 @@ export async function stageSealedBatch(
   runtime: IAgentRuntime,
   request: unknown,
 ): Promise<{ staged: number; total_staged: number }> {
-  const parsed: SealedMemoryStageRequest = SealedMemoryStageRequestSchema.parse(request);
+  const parsed: SealedMemoryStageRequest =
+    SealedMemoryStageRequestSchema.parse(request);
   await assertSealTrusted(runtime, parsed.seal);
   const expectedBatches = Math.max(1, Math.ceil(parsed.seal.row_count / 500));
-  if (parsed.batch_count !== expectedBatches || parsed.batch_index >= parsed.batch_count) {
-    throw new ElizaError("Stage request batch geometry does not match the seal", {
-      code: MEMORY_IMPORT_BATCH_INVALID,
-      context: { batch_index: parsed.batch_index, batch_count: parsed.batch_count, expectedBatches },
-    });
+  if (
+    parsed.batch_count !== expectedBatches ||
+    parsed.batch_index >= parsed.batch_count
+  ) {
+    throw new ElizaError(
+      "Stage request batch geometry does not match the seal",
+      {
+        code: MEMORY_IMPORT_BATCH_INVALID,
+        context: {
+          batch_index: parsed.batch_index,
+          batch_count: parsed.batch_count,
+          expectedBatches,
+        },
+      },
+    );
   }
   const db = requireDb(runtime);
   await ensureStagingTable(db);
@@ -174,9 +191,12 @@ export async function finalizeSealedImport(
     }
     const digest = await computeSharedMemoryTransferDigest(rows);
     if (digest !== seal.digest) {
-      throw new ElizaError("Recomputed digest does not match the original seal", {
-        code: MEMORY_IMPORT_DIGEST_MISMATCH,
-      });
+      throw new ElizaError(
+        "Recomputed digest does not match the original seal",
+        {
+          code: MEMORY_IMPORT_DIGEST_MISMATCH,
+        },
+      );
     }
 
     // Conflict pre-check inside the same transaction: identical ids are
@@ -213,7 +233,9 @@ export async function finalizeSealedImport(
 
     // Scaffolding: create-if-absent only, never overwrite target-native rows.
     const agentId = runtime.agentId;
-    const worldIds = [...new Set(toPublish.map((r) => r.world_id).filter(Boolean))] as string[];
+    const worldIds = [
+      ...new Set(toPublish.map((r) => r.world_id).filter(Boolean)),
+    ] as string[];
     for (const worldId of worldIds) {
       await tx.execute(sql`
         INSERT INTO worlds (id, agent_id, name, server_id)
@@ -223,7 +245,9 @@ export async function finalizeSealedImport(
     }
     const roomPairs = [
       ...new Map(
-        toPublish.filter((r) => r.room_id).map((r) => [r.room_id as string, r.world_id]),
+        toPublish
+          .filter((r) => r.room_id)
+          .map((r) => [r.room_id as string, r.world_id]),
       ).entries(),
     ];
     for (const [roomId, worldId] of roomPairs) {
@@ -233,7 +257,9 @@ export async function finalizeSealedImport(
         ON CONFLICT (id) DO NOTHING
       `);
     }
-    const entityIds = [...new Set(toPublish.map((r) => r.entity_id).filter(Boolean))] as string[];
+    const entityIds = [
+      ...new Set(toPublish.map((r) => r.entity_id).filter(Boolean)),
+    ] as string[];
     for (const entityId of entityIds) {
       await tx.execute(sql`
         INSERT INTO entities (id, agent_id, names)

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -36,6 +36,11 @@ import {
   getDocumentsService,
 } from "./documents-service-loader.ts";
 import { decodePathComponent } from "./server-helpers.ts";
+import {
+  finalizeSealedImport,
+  MEMORY_IMPORT_ID_CONFLICT,
+  stageSealedBatch,
+} from "./memory-import-staged.ts";
 
 export const HASH_MEMORY_SOURCE = "hash_memory";
 const UUID_REGEX =
@@ -421,6 +426,26 @@ export function parseMemoryTableFilter(
   };
 }
 
+const SEALED_TRANSFER_CONFLICTS = new Set([
+  MEMORY_IMPORT_ID_CONFLICT,
+]);
+
+/** 409 for conflicts, 400 for everything typed, 500 only for the unknown. */
+function respondSealedTransferError(
+  error: MemoryRouteContext["error"],
+  res: MemoryRouteContext["res"],
+  err: unknown,
+): void {
+  const code =
+    err && typeof err === "object" && "code" in err
+      ? String((err as { code: unknown }).code)
+      : undefined;
+  const message = err instanceof Error ? err.message : "sealed transfer failed";
+  if (code && SEALED_TRANSFER_CONFLICTS.has(code)) return error(res, message, 409);
+  if (code) return error(res, message, 400);
+  return error(res, message, 500);
+}
+
 export async function handleMemoryRoutes(
   ctx: MemoryRouteContext,
 ): Promise<boolean> {
@@ -451,6 +476,31 @@ export async function handleMemoryRoutes(
   }
 
   const resolvedAgentName = resolveAgentName(runtime, agentName);
+
+  // Round-3 sealed transfer endpoints run BEFORE ensureMemoryConnection: they
+  // must not create the agent's default DM scaffolding — the finalize step
+  // creates exactly the transferred scaffolding inside its own transaction.
+  if (method === "POST" && pathname === "/api/memory/transfer/stage") {
+    const rawStage = await readJsonBody<Record<string, unknown>>(req, res);
+    if (rawStage === null) return true;
+    try {
+      json(res, { ok: true, ...(await stageSealedBatch(runtime, rawStage)) });
+    } catch (err) {
+      respondSealedTransferError(error, res, err);
+    }
+    return true;
+  }
+  if (method === "POST" && pathname === "/api/memory/transfer/finalize") {
+    const rawFin = await readJsonBody<Record<string, unknown>>(req, res);
+    if (rawFin === null) return true;
+    try {
+      json(res, { ok: true, ...(await finalizeSealedImport(runtime, rawFin)) });
+    } catch (err) {
+      respondSealedTransferError(error, res, err);
+    }
+    return true;
+  }
+
   const { roomId, entityId } = await ensureMemoryConnection(
     runtime,
     resolvedAgentName,

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -35,12 +35,12 @@ import {
   type DocumentsServiceResult,
   getDocumentsService,
 } from "./documents-service-loader.ts";
-import { decodePathComponent } from "./server-helpers.ts";
 import {
   finalizeSealedImport,
   MEMORY_IMPORT_ID_CONFLICT,
   stageSealedBatch,
 } from "./memory-import-staged.ts";
+import { decodePathComponent } from "./server-helpers.ts";
 
 export const HASH_MEMORY_SOURCE = "hash_memory";
 const UUID_REGEX =
@@ -426,9 +426,7 @@ export function parseMemoryTableFilter(
   };
 }
 
-const SEALED_TRANSFER_CONFLICTS = new Set([
-  MEMORY_IMPORT_ID_CONFLICT,
-]);
+const SEALED_TRANSFER_CONFLICTS = new Set([MEMORY_IMPORT_ID_CONFLICT]);
 
 /** 409 for conflicts, 400 for everything typed, 500 only for the unknown. */
 function respondSealedTransferError(
@@ -441,9 +439,15 @@ function respondSealedTransferError(
       ? String((err as { code: unknown }).code)
       : undefined;
   const message = err instanceof Error ? err.message : "sealed transfer failed";
-  if (code && SEALED_TRANSFER_CONFLICTS.has(code)) return error(res, message, 409);
-  if (code) return error(res, message, 400);
-  return error(res, message, 500);
+  if (code && SEALED_TRANSFER_CONFLICTS.has(code)) {
+    error(res, message, 409);
+    return;
+  }
+  if (code) {
+    error(res, message, 400);
+    return;
+  }
+  error(res, message, 500);
 }
 
 export async function handleMemoryRoutes(

--- a/packages/cloud/shared/src/db/migrations/0236_shared_transfer_epochs.sql
+++ b/packages/cloud/shared/src/db/migrations/0236_shared_transfer_epochs.sql
@@ -1,0 +1,21 @@
+-- Promotion epochs for Shared→Dedicated memory transfer (round 3).
+-- Write fence + atomic-promotion state machine per transfer scope.
+CREATE TABLE IF NOT EXISTS "shared_transfer_epochs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"agent_id" uuid NOT NULL,
+	"epoch" integer NOT NULL,
+	"state" text NOT NULL,
+	"seal_digest" text,
+	"fenced_at" timestamp,
+	"resolved_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+ALTER TABLE "shared_transfer_epochs" ADD CONSTRAINT "shared_transfer_epochs_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "shared_transfer_epochs" ADD CONSTRAINT "shared_transfer_epochs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_shared_transfer_epochs_scope_epoch" ON "shared_transfer_epochs" ("organization_id","user_id","agent_id","epoch");
+CREATE INDEX IF NOT EXISTS "idx_shared_transfer_epochs_scope_state" ON "shared_transfer_epochs" ("organization_id","user_id","agent_id","state");
+-- Only one non-terminal epoch per scope: the fence check and promotion flip
+-- race-safely on this partial unique index.
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_shared_transfer_epochs_scope_active" ON "shared_transfer_epochs" ("organization_id","user_id","agent_id") WHERE "state" IN ('open','fenced');

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1646,6 +1646,13 @@
       "when": 1789416000000,
       "tag": "0235_agent_backup_rpo_scheduler",
       "breakpoints": true
+    },
+    {
+      "idx": 235,
+      "version": "7",
+      "when": 1789416060000,
+      "tag": "0236_shared_transfer_epochs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/shared-transfer-epochs.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-transfer-epochs.pglite.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Exercises the promotion-epoch state machine, the write fence, and the
+ * fenced sealed export against real PGlite: concurrent opens racing on the
+ * partial unique index, invalid transitions, double-promotion, fence
+ * enforcement ahead of any store write, keyset pagination across equal
+ * timestamps, and seal signature verification — the exact-head concurrency
+ * evidence for the round-3 transfer (#21090 review).
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const TIMEOUT = 60_000;
+const ORG = "51000000-0000-4000-8000-000000000001";
+const USER = "52000000-0000-4000-8000-000000000001";
+const AGENT = "53000000-0000-4000-8000-000000000001";
+const SCOPE = { organizationId: ORG, userId: USER, agentId: AGENT };
+const KEY = "pglite-test-seal-key";
+
+let epochs: typeof import("./shared-transfer-epochs");
+let sealedExport: typeof import("../../lib/services/shared-runtime/shared-memory-sealed-export");
+let contract: typeof import("@elizaos/shared/contracts/shared-memory-transfer");
+let dbWrite: typeof import("../client").dbWrite;
+let closeForTests: typeof import("../client").closeDatabaseConnectionsForTests | undefined;
+
+beforeAll(async () => {
+  const client = await import("../client");
+  dbWrite = client.dbWrite;
+  closeForTests = client.closeDatabaseConnectionsForTests;
+  epochs = await import("./shared-transfer-epochs");
+  sealedExport = await import("../../lib/services/shared-runtime/shared-memory-sealed-export");
+  contract = await import("@elizaos/shared/contracts/shared-memory-transfer");
+  await client.getPgliteClientForTests().exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE shared_transfer_epochs (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+      user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      agent_id uuid NOT NULL,
+      epoch integer NOT NULL,
+      state text NOT NULL,
+      seal_digest text,
+      fenced_at timestamp,
+      resolved_at timestamp,
+      created_at timestamp NOT NULL DEFAULT now()
+    );
+    CREATE UNIQUE INDEX uq_shared_transfer_epochs_scope_epoch
+      ON shared_transfer_epochs (organization_id, user_id, agent_id, epoch);
+    CREATE UNIQUE INDEX uq_shared_transfer_epochs_scope_active
+      ON shared_transfer_epochs (organization_id, user_id, agent_id)
+      WHERE state IN ('open','fenced');
+    CREATE TABLE shared_agent_memories (
+      id uuid PRIMARY KEY,
+      organization_id uuid NOT NULL,
+      user_id uuid NOT NULL,
+      agent_id uuid NOT NULL,
+      entity_id uuid,
+      room_id uuid,
+      world_id uuid,
+      type text NOT NULL,
+      content jsonb NOT NULL,
+      embedding real[],
+      embedding_model text,
+      created_at timestamp NOT NULL DEFAULT now()
+    );
+    INSERT INTO organizations (id) VALUES ('${ORG}');
+    INSERT INTO users (id) VALUES ('${USER}');
+  `);
+}, TIMEOUT);
+
+afterAll(async () => {
+  await closeForTests?.();
+});
+
+async function resetEpochs() {
+  await dbWrite.execute(sql`DELETE FROM shared_transfer_epochs`);
+}
+
+async function insertMemoryRow(i: number, createdAt: string) {
+  const id = `61000000-0000-4000-8000-${String(i).padStart(12, "0")}`;
+  await dbWrite.execute(sql`
+    INSERT INTO shared_agent_memories
+      (id, organization_id, user_id, agent_id, type, content, embedding, created_at)
+    VALUES (${id}, ${ORG}, ${USER}, ${AGENT}, 'messages',
+      ${JSON.stringify({ text: `m${i}` })}::jsonb,
+      ${`{0.1,0.2}`}::real[], ${createdAt}::timestamp)
+  `);
+  return id;
+}
+
+describe("epoch state machine (pglite)", () => {
+  test(
+    "open → fence → promote records digest and is terminal",
+    async () => {
+      await resetEpochs();
+      const opened = await epochs.openEpoch(SCOPE);
+      expect(opened.state).toBe("open");
+      const fenced = await epochs.fenceEpoch(SCOPE, opened.epoch);
+      expect(fenced.state).toBe("fenced");
+      const promoted = await epochs.promoteEpoch(SCOPE, opened.epoch, "a".repeat(64));
+      expect(promoted.state).toBe("promoted");
+      expect(promoted.seal_digest).toBe("a".repeat(64));
+      await expect(epochs.promoteEpoch(SCOPE, opened.epoch, "b".repeat(64))).rejects.toMatchObject({
+        code: epochs.SHARED_TRANSFER_EPOCH_INVALID_STATE,
+      });
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "concurrent opens race at the partial unique index — exactly one wins",
+    async () => {
+      await resetEpochs();
+      const results = await Promise.allSettled([
+        epochs.openEpoch(SCOPE),
+        epochs.openEpoch(SCOPE),
+        epochs.openEpoch(SCOPE),
+      ]);
+      const wins = results.filter((r) => r.status === "fulfilled");
+      expect(wins).toHaveLength(1);
+      for (const loss of results.filter((r) => r.status === "rejected")) {
+        expect((loss as PromiseRejectedResult).reason?.code).toBe(
+          epochs.SHARED_TRANSFER_EPOCH_CONFLICT,
+        );
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "promote requires fenced; fence requires open",
+    async () => {
+      await resetEpochs();
+      const opened = await epochs.openEpoch(SCOPE);
+      await expect(epochs.promoteEpoch(SCOPE, opened.epoch, "c".repeat(64))).rejects.toMatchObject({
+        code: epochs.SHARED_TRANSFER_EPOCH_INVALID_STATE,
+      });
+      await epochs.fenceEpoch(SCOPE, opened.epoch);
+      await expect(epochs.fenceEpoch(SCOPE, opened.epoch)).rejects.toMatchObject({
+        code: epochs.SHARED_TRANSFER_EPOCH_INVALID_STATE,
+      });
+      await epochs.abortEpoch(SCOPE, opened.epoch);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "write fence: open does not block, fenced does, abort lifts it",
+    async () => {
+      await resetEpochs();
+      await epochs.assertScopeWritable(SCOPE);
+      const opened = await epochs.openEpoch(SCOPE);
+      await epochs.assertScopeWritable(SCOPE);
+      await epochs.fenceEpoch(SCOPE, opened.epoch);
+      await expect(epochs.assertScopeWritable(SCOPE)).rejects.toMatchObject({
+        code: epochs.SHARED_TRANSFER_SCOPE_FENCED,
+      });
+      await epochs.abortEpoch(SCOPE, opened.epoch);
+      await epochs.assertScopeWritable(SCOPE);
+    },
+    TIMEOUT,
+  );
+});
+
+describe("fenced sealed export (pglite)", () => {
+  test(
+    "export refuses an unfenced scope",
+    async () => {
+      await resetEpochs();
+      await expect(sealedExport.exportSealedSharedMemories(SCOPE, KEY)).rejects.toMatchObject({
+        code: sealedExport.SHARED_MEMORY_EXPORT_NOT_FENCED,
+      });
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "export paginates across equal timestamps without loss and seals verifiably",
+    async () => {
+      await resetEpochs();
+      await dbWrite.execute(sql`DELETE FROM shared_agent_memories`);
+      // 503 rows forces two keyset pages; a shared timestamp across the
+      // boundary exercises the tuple-compare cursor.
+      const SHARED_TS = "2026-08-17T12:00:00.000Z";
+      for (let i = 0; i < 503; i++) {
+        const ts =
+          i < 490 ? new Date(Date.parse(SHARED_TS) - (503 - i) * 1000).toISOString() : SHARED_TS;
+        await insertMemoryRow(i, ts);
+      }
+      const opened = await epochs.openEpoch(SCOPE);
+      await epochs.fenceEpoch(SCOPE, opened.epoch);
+      const out = await sealedExport.exportSealedSharedMemories(SCOPE, KEY);
+      expect(out.rows).toHaveLength(503);
+      expect(new Set(out.rows.map((r) => r.id)).size).toBe(503);
+      expect(out.seal.row_count).toBe(503);
+      expect(out.seal.epoch).toBe(opened.epoch);
+      expect(out.seal.vector_dimension).toBe(2);
+      expect(await contract.verifySealSignature(out.seal, KEY)).toBe(true);
+      expect(await contract.verifySealSignature(out.seal, "wrong")).toBe(false);
+      expect(await contract.computeSharedMemoryTransferDigest(out.rows)).toBe(out.seal.digest);
+      await epochs.promoteEpoch(SCOPE, opened.epoch, out.seal.digest);
+    },
+    TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/db/repositories/shared-transfer-epochs.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-transfer-epochs.ts
@@ -44,9 +44,7 @@ export async function getActiveEpoch(
   const rows = await dbRead
     .select()
     .from(sharedTransferEpochs)
-    .where(
-      and(scopePredicate(scope), inArray(sharedTransferEpochs.state, [...ACTIVE_STATES])),
-    )
+    .where(and(scopePredicate(scope), inArray(sharedTransferEpochs.state, [...ACTIVE_STATES])))
     .limit(1);
   return rows[0] ?? null;
 }
@@ -56,9 +54,7 @@ export async function getActiveEpoch(
  * max(existing)+1. Fails with SHARED_TRANSFER_EPOCH_CONFLICT if an active
  * epoch already exists (unique-index race included).
  */
-export async function openEpoch(
-  scope: SharedAgentMemoryScope,
-): Promise<SharedTransferEpochRow> {
+export async function openEpoch(scope: SharedAgentMemoryScope): Promise<SharedTransferEpochRow> {
   const existing = await dbRead
     .select({ epoch: sharedTransferEpochs.epoch })
     .from(sharedTransferEpochs)
@@ -117,11 +113,7 @@ export function fenceEpoch(scope: SharedAgentMemoryScope, epoch: number) {
 }
 
 /** fenced → promoted: terminal; records the whole-export seal digest. */
-export function promoteEpoch(
-  scope: SharedAgentMemoryScope,
-  epoch: number,
-  sealDigest: string,
-) {
+export function promoteEpoch(scope: SharedAgentMemoryScope, epoch: number, sealDigest: string) {
   return transition(scope, epoch, ["fenced"], "promoted", {
     seal_digest: sealDigest,
     resolved_at: new Date(),
@@ -140,9 +132,7 @@ export function abortEpoch(scope: SharedAgentMemoryScope, epoch: number) {
  * SHARED_TRANSFER_SCOPE_FENCED while the scope's active epoch is fenced.
  * One indexed point read on the scope-state index; open epochs do not block.
  */
-export async function assertScopeWritable(
-  scope: SharedAgentMemoryScope,
-): Promise<void> {
+export async function assertScopeWritable(scope: SharedAgentMemoryScope): Promise<void> {
   const active = await getActiveEpoch(scope);
   if (active?.state === "fenced") {
     throw new ElizaError("Memory writes are fenced during Shared→Dedicated promotion", {

--- a/packages/cloud/shared/src/db/repositories/shared-transfer-epochs.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-transfer-epochs.ts
@@ -1,0 +1,153 @@
+/**
+ * State machine over `shared_transfer_epochs` — the server-bound write fence
+ * for Shared→Dedicated memory promotion (round 3, #21090 review).
+ *
+ * Transitions: (none|terminal) --open--> open --fence--> fenced
+ *   fenced --promote--> promoted        (records the seal digest, terminal)
+ *   open|fenced --abort--> aborted      (terminal)
+ *
+ * The single-active-epoch invariant is enforced by the partial unique index
+ * `uq_shared_transfer_epochs_scope_active` (state IN open,fenced), so two
+ * concurrent opens race at the database, not in this module. Every predicate
+ * pins organization AND user, matching the tenant discipline of
+ * `shared-agent-memories`.
+ */
+import { ElizaError } from "@elizaos/core";
+import { and, eq, inArray } from "drizzle-orm";
+import { dbRead, dbWrite } from "../client";
+import {
+  type SharedTransferEpochRow,
+  sharedTransferEpochs,
+} from "../schemas/shared-transfer-epochs";
+import type { SharedAgentMemoryScope } from "./shared-agent-memories";
+
+export const SHARED_TRANSFER_EPOCH_CONFLICT = "SHARED_TRANSFER_EPOCH_CONFLICT";
+export const SHARED_TRANSFER_EPOCH_NOT_FOUND = "SHARED_TRANSFER_EPOCH_NOT_FOUND";
+export const SHARED_TRANSFER_EPOCH_INVALID_STATE = "SHARED_TRANSFER_EPOCH_INVALID_STATE";
+/** Writes refused while the scope is fenced (memory-commit path). */
+export const SHARED_TRANSFER_SCOPE_FENCED = "SHARED_TRANSFER_SCOPE_FENCED";
+
+const ACTIVE_STATES = ["open", "fenced"] as const;
+
+function scopePredicate(scope: SharedAgentMemoryScope) {
+  return and(
+    eq(sharedTransferEpochs.organization_id, scope.organizationId),
+    eq(sharedTransferEpochs.user_id, scope.userId),
+    eq(sharedTransferEpochs.agent_id, scope.agentId),
+  );
+}
+
+/** The scope's single active (open|fenced) epoch row, if any. */
+export async function getActiveEpoch(
+  scope: SharedAgentMemoryScope,
+): Promise<SharedTransferEpochRow | null> {
+  const rows = await dbRead
+    .select()
+    .from(sharedTransferEpochs)
+    .where(
+      and(scopePredicate(scope), inArray(sharedTransferEpochs.state, [...ACTIVE_STATES])),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Open the next epoch for the scope. Epoch numbers are strictly increasing:
+ * max(existing)+1. Fails with SHARED_TRANSFER_EPOCH_CONFLICT if an active
+ * epoch already exists (unique-index race included).
+ */
+export async function openEpoch(
+  scope: SharedAgentMemoryScope,
+): Promise<SharedTransferEpochRow> {
+  const existing = await dbRead
+    .select({ epoch: sharedTransferEpochs.epoch })
+    .from(sharedTransferEpochs)
+    .where(scopePredicate(scope));
+  const next = existing.reduce((m, r) => Math.max(m, r.epoch), 0) + 1;
+  try {
+    const inserted = await dbWrite
+      .insert(sharedTransferEpochs)
+      .values({
+        organization_id: scope.organizationId,
+        user_id: scope.userId,
+        agent_id: scope.agentId,
+        epoch: next,
+        state: "open",
+      })
+      .returning();
+    return inserted[0]!;
+  } catch (error) {
+    throw new ElizaError("An active transfer epoch already exists for this scope", {
+      code: SHARED_TRANSFER_EPOCH_CONFLICT,
+      cause: error,
+    });
+  }
+}
+
+async function transition(
+  scope: SharedAgentMemoryScope,
+  epoch: number,
+  from: readonly string[],
+  to: "fenced" | "promoted" | "aborted",
+  patch: Partial<typeof sharedTransferEpochs.$inferInsert> = {},
+): Promise<SharedTransferEpochRow> {
+  const updated = await dbWrite
+    .update(sharedTransferEpochs)
+    .set({ state: to, ...patch })
+    .where(
+      and(
+        scopePredicate(scope),
+        eq(sharedTransferEpochs.epoch, epoch),
+        inArray(sharedTransferEpochs.state, [...from]),
+      ),
+    )
+    .returning();
+  if (!updated[0]) {
+    throw new ElizaError("Transfer epoch is not in a valid state for this transition", {
+      code: SHARED_TRANSFER_EPOCH_INVALID_STATE,
+      context: { epoch, expected: [...from], to },
+    });
+  }
+  return updated[0];
+}
+
+/** open → fenced: from this moment scope writes are refused. */
+export function fenceEpoch(scope: SharedAgentMemoryScope, epoch: number) {
+  return transition(scope, epoch, ["open"], "fenced", { fenced_at: new Date() });
+}
+
+/** fenced → promoted: terminal; records the whole-export seal digest. */
+export function promoteEpoch(
+  scope: SharedAgentMemoryScope,
+  epoch: number,
+  sealDigest: string,
+) {
+  return transition(scope, epoch, ["fenced"], "promoted", {
+    seal_digest: sealDigest,
+    resolved_at: new Date(),
+  });
+}
+
+/** open|fenced → aborted: terminal; lifts the fence without promotion. */
+export function abortEpoch(scope: SharedAgentMemoryScope, epoch: number) {
+  return transition(scope, epoch, [...ACTIVE_STATES], "aborted", {
+    resolved_at: new Date(),
+  });
+}
+
+/**
+ * Write-fence check for the shared-runtime memory-commit path: throws
+ * SHARED_TRANSFER_SCOPE_FENCED while the scope's active epoch is fenced.
+ * One indexed point read on the scope-state index; open epochs do not block.
+ */
+export async function assertScopeWritable(
+  scope: SharedAgentMemoryScope,
+): Promise<void> {
+  const active = await getActiveEpoch(scope);
+  if (active?.state === "fenced") {
+    throw new ElizaError("Memory writes are fenced during Shared→Dedicated promotion", {
+      code: SHARED_TRANSFER_SCOPE_FENCED,
+      context: { epoch: active.epoch },
+    });
+  }
+}

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -96,6 +96,7 @@ export * from "./secrets";
 export * from "./seo";
 export * from "./service-pricing";
 export * from "./shared-agent-memories";
+export * from "./shared-transfer-epochs";
 export * from "./shared-runtime-history";
 export * from "./shared-turn-traces";
 export * from "./sso-bridge";

--- a/packages/cloud/shared/src/db/schemas/shared-transfer-epochs.ts
+++ b/packages/cloud/shared/src/db/schemas/shared-transfer-epochs.ts
@@ -7,8 +7,9 @@
  * an epoch number — finalizing twice, or importing a stale epoch's seal,
  * fails closed on this state machine rather than on caller discipline.
  */
-import { index, integer, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { index, integer, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
 import { organizations } from "./organizations";
 import { users } from "./users";
 

--- a/packages/cloud/shared/src/db/schemas/shared-transfer-epochs.ts
+++ b/packages/cloud/shared/src/db/schemas/shared-transfer-epochs.ts
@@ -1,0 +1,50 @@
+/**
+ * Server-bound promotion epochs for Shared→Dedicated memory transfer
+ * (round 3, #21090 architecture review). One row per (organization, user,
+ * agent) transfer scope. The epoch is the write fence: while `state` is
+ * `fenced`, the shared-runtime memory commit path refuses writes for the
+ * scope, so a sealed export cannot race a writer. `promoted` is terminal for
+ * an epoch number — finalizing twice, or importing a stale epoch's seal,
+ * fails closed on this state machine rather than on caller discipline.
+ */
+import { index, integer, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { organizations } from "./organizations";
+import { users } from "./users";
+
+export const sharedTransferEpochs = pgTable(
+  "shared_transfer_epochs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    user_id: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    agent_id: uuid("agent_id").notNull(),
+    epoch: integer("epoch").notNull(),
+    state: text("state").notNull(), // open | fenced | promoted | aborted
+    seal_digest: text("seal_digest"),
+    fenced_at: timestamp("fenced_at"),
+    resolved_at: timestamp("resolved_at"),
+    created_at: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    scopeEpochUnique: uniqueIndex("uq_shared_transfer_epochs_scope_epoch").on(
+      table.organization_id,
+      table.user_id,
+      table.agent_id,
+      table.epoch,
+    ),
+    scopeStateIdx: index("idx_shared_transfer_epochs_scope_state").on(
+      table.organization_id,
+      table.user_id,
+      table.agent_id,
+      table.state,
+    ),
+  }),
+);
+
+export type SharedTransferEpochRow = InferSelectModel<typeof sharedTransferEpochs>;
+export type SharedTransferEpochInsert = InferInsertModel<typeof sharedTransferEpochs>;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-sealed-export.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-sealed-export.ts
@@ -1,0 +1,131 @@
+/**
+ * Fenced sealed export — the source leg of Shared→Dedicated memory promotion
+ * (round 3, #21090 review).
+ *
+ * Preconditions are structural, not conventional: the scope's active epoch
+ * must already be `fenced` (writers are refused at the store), so the keyset
+ * scan cannot race a commit. The whole read still runs in one REPEATABLE READ
+ * transaction as defense in depth. The result is the full row set plus a
+ * SIGNED whole-export seal binding {epoch, scope, count, order-sensitive
+ * digest, vector dimension}; the destination re-derives everything and binds
+ * finalization to this exact seal.
+ */
+import {
+  computeSharedMemoryTransferDigest,
+  type SealedExportSeal,
+  type SealedMemoryExportRow,
+  signSeal,
+} from "@elizaos/shared/contracts/shared-memory-transfer";
+import { ElizaError } from "@elizaos/core";
+import { and, asc, eq, gt, or } from "drizzle-orm";
+import { dbRead } from "../../../db/client";
+import {
+  type SharedAgentMemoryScope,
+} from "../../../db/repositories/shared-agent-memories";
+import { getActiveEpoch } from "../../../db/repositories/shared-transfer-epochs";
+import { sharedAgentMemories } from "../../../db/schemas/shared-agent-memories";
+
+export const SHARED_MEMORY_EXPORT_NOT_FENCED = "SHARED_MEMORY_EXPORT_NOT_FENCED";
+export const SHARED_MEMORY_EXPORT_MIXED_DIMENSIONS = "SHARED_MEMORY_EXPORT_MIXED_DIMENSIONS";
+
+const PAGE_SIZE = 500;
+
+export interface SealedSharedMemoryExport {
+  seal: SealedExportSeal;
+  rows: SealedMemoryExportRow[];
+}
+
+/** Env var NAME for the seal HMAC key; the value never enters logs or seals. */
+export const SEAL_KEY_ENV = "ELIZA_MEMORY_TRANSFER_SEAL_KEY";
+
+export async function exportSealedSharedMemories(
+  scope: SharedAgentMemoryScope,
+  sealKey: string,
+): Promise<SealedSharedMemoryExport> {
+  const active = await getActiveEpoch(scope);
+  if (!active || active.state !== "fenced") {
+    throw new ElizaError("Sealed export requires a fenced promotion epoch", {
+      code: SHARED_MEMORY_EXPORT_NOT_FENCED,
+      context: { state: active?.state ?? "none" },
+    });
+  }
+
+  const rows: SealedMemoryExportRow[] = [];
+  let dimension: number | null = null;
+
+  await dbRead.transaction(
+    async (tx) => {
+      let cursor: { created_at: Date; id: string } | null = null;
+      for (;;) {
+        const where = and(
+          eq(sharedAgentMemories.organization_id, scope.organizationId),
+          eq(sharedAgentMemories.user_id, scope.userId),
+          eq(sharedAgentMemories.agent_id, scope.agentId),
+          // Keyset over the stable (created_at, id) order; tuple-compare
+          // emulated so equal timestamps across a page boundary are not
+          // skipped: (created_at > c) OR (created_at = c AND id > last_id).
+          ...(cursor
+            ? [
+                or(
+                  gt(sharedAgentMemories.created_at, cursor.created_at),
+                  and(
+                    eq(sharedAgentMemories.created_at, cursor.created_at),
+                    gt(sharedAgentMemories.id, cursor.id),
+                  ),
+                ),
+              ]
+            : []),
+        );
+        const page = await tx
+          .select()
+          .from(sharedAgentMemories)
+          .where(where)
+          .orderBy(asc(sharedAgentMemories.created_at), asc(sharedAgentMemories.id))
+          .limit(PAGE_SIZE);
+        for (const row of page) {
+          const vector = row.embedding ?? null;
+          if (vector) {
+            if (dimension === null) dimension = vector.length;
+            else if (dimension !== vector.length) {
+              throw new ElizaError("Export found mixed embedding dimensions", {
+                code: SHARED_MEMORY_EXPORT_MIXED_DIMENSIONS,
+                context: { expected: dimension, found: vector.length, id: row.id },
+              });
+            }
+          }
+          rows.push({
+            id: row.id,
+            type: row.type,
+            created_at: row.created_at.toISOString(),
+            content: row.content,
+            entity_id: row.entity_id,
+            agent_id: row.agent_id,
+            room_id: row.room_id,
+            world_id: row.world_id,
+            unique: false,
+            metadata: {},
+            embedding: vector,
+          });
+        }
+        if (page.length < PAGE_SIZE) break;
+        const last = page[page.length - 1]!;
+        cursor = { created_at: last.created_at, id: last.id };
+      }
+    },
+    { isolationLevel: "repeatable read" },
+  );
+
+  const digest = await computeSharedMemoryTransferDigest(rows);
+  const body = {
+    version: 3 as const,
+    epoch: active.epoch,
+    source_agent_id: scope.agentId,
+    scope: `${scope.organizationId}:${scope.userId}:${scope.agentId}`,
+    row_count: rows.length,
+    digest,
+    vector_dimension: dimension,
+    exported_at: new Date().toISOString(),
+  };
+  const signature = await signSeal(body, sealKey);
+  return { seal: { ...body, signature }, rows };
+}

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-sealed-export.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-sealed-export.ts
@@ -10,18 +10,17 @@
  * digest, vector dimension}; the destination re-derives everything and binds
  * finalization to this exact seal.
  */
+
+import { ElizaError } from "@elizaos/core";
 import {
   computeSharedMemoryTransferDigest,
   type SealedExportSeal,
   type SealedMemoryExportRow,
   signSeal,
 } from "@elizaos/shared/contracts/shared-memory-transfer";
-import { ElizaError } from "@elizaos/core";
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { dbRead } from "../../../db/client";
-import {
-  type SharedAgentMemoryScope,
-} from "../../../db/repositories/shared-agent-memories";
+import { type SharedAgentMemoryScope } from "../../../db/repositories/shared-agent-memories";
 import { getActiveEpoch } from "../../../db/repositories/shared-transfer-epochs";
 import { sharedAgentMemories } from "../../../db/schemas/shared-agent-memories";
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.test.ts
@@ -26,6 +26,7 @@ import {
 const ORG = "5a5c62c4-51b6-4e94-8c4e-a41d62b85e2f";
 const USER = "9a3d9f2e-97ab-46be-a687-3a4f2f6bfa53";
 const AGENT_KEY = "agent-shared-42";
+const NOOP_FENCE = async () => {};
 
 function scriptedWriter(behavior?: { failOn?: number }): {
   writer: SharedAgentMemoriesWriter;
@@ -88,6 +89,9 @@ describe("SharedMemoryStore.recordTurnPair", () => {
     const store = new SharedMemoryStore(
       { organizationId: ORG, userId: USER, agentKey: AGENT_KEY, storage },
       writer,
+      undefined,
+      undefined,
+      NOOP_FENCE,
     );
     const messageIds = {
       user: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
@@ -134,6 +138,9 @@ describe("SharedMemoryStore.recordTurnPair", () => {
     const store = new SharedMemoryStore(
       { organizationId: ORG, userId: USER, agentKey: AGENT_KEY },
       writer,
+      undefined,
+      undefined,
+      NOOP_FENCE,
     );
     await store.recordTurnPair({
       userMessage: "hello",
@@ -155,6 +162,9 @@ describe("SharedMemoryStore.recordTurnPair", () => {
     const store = new SharedMemoryStore(
       { organizationId: ORG, userId: USER, agentKey: AGENT_KEY },
       interrupted.writer,
+      undefined,
+      undefined,
+      NOOP_FENCE,
     );
     await store.recordTurnPair({
       userMessage: "tell me slowly",
@@ -172,6 +182,9 @@ describe("SharedMemoryStore.recordTurnPair", () => {
     const emptyStore = new SharedMemoryStore(
       { organizationId: ORG, userId: USER, agentKey: AGENT_KEY },
       empty.writer,
+      undefined,
+      undefined,
+      NOOP_FENCE,
     );
     await emptyStore.recordTurnPair({
       userMessage: "cancelled before output",
@@ -187,6 +200,9 @@ describe("SharedMemoryStore.recordTurnPair", () => {
     const store = new SharedMemoryStore(
       { organizationId: ORG, userId: USER, agentKey: AGENT_KEY },
       unkeyed.writer,
+      undefined,
+      undefined,
+      NOOP_FENCE,
     );
     await store.recordTurnPair({ userMessage: "no ids", assistantReply: "still lands" });
     expect(unkeyed.inserts[0]?.id).toBeUndefined();
@@ -196,11 +212,36 @@ describe("SharedMemoryStore.recordTurnPair", () => {
     const failingStore = new SharedMemoryStore(
       { organizationId: ORG, userId: USER, agentKey: AGENT_KEY },
       failing.writer,
+      undefined,
+      undefined,
+      NOOP_FENCE,
     );
     await expect(
       failingStore.recordTurnPair({ userMessage: "user landed", assistantReply: "lost" }),
     ).rejects.toThrow("scripted storage failure");
     // Sequential writes: the user row landed before the failure surfaced.
     expect(failing.inserts).toHaveLength(2);
+  });
+});
+
+describe("SharedMemoryStore write fence", () => {
+  test("a fenced scope rejects the turn pair before any writer insert", async () => {
+    const { writer, inserts } = scriptedWriter();
+    const fencedError = Object.assign(new Error("fenced"), {
+      code: "SHARED_TRANSFER_SCOPE_FENCED",
+    });
+    const store = new SharedMemoryStore(
+      { organizationId: ORG, userId: USER, agentKey: AGENT_KEY },
+      writer,
+      undefined,
+      undefined,
+      async () => {
+        throw fencedError;
+      },
+    );
+    await expect(store.recordTurnPair({ userMessage: "hi", assistantReply: "yo" })).rejects.toBe(
+      fencedError,
+    );
+    expect(inserts).toHaveLength(0);
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
@@ -76,6 +76,10 @@ export class SharedMemoryStore {
     private readonly writer: SharedAgentMemoriesWriter = sharedAgentMemoriesWriter,
     private readonly reader: SharedAgentMemoriesReader = sharedAgentMemoriesReader,
     private readonly embed?: SharedMemoryEmbedConfig,
+    /** Injectable for deterministic tests; production uses the real fence. */
+    private readonly fence: (
+      scope: Parameters<typeof assertScopeWritable>[0],
+    ) => Promise<void> = assertScopeWritable,
   ) {}
 
   /**
@@ -117,7 +121,7 @@ export class SharedMemoryStore {
     // Round-3 transfer fence: while this scope's promotion epoch is fenced,
     // the turn commit fails closed instead of racing the sealed export
     // (#21090 review). One indexed point read; open epochs do not block.
-    await assertScopeWritable(scope);
+    await this.fence(scope);
     const landedAt = Date.now();
     // One batched sidecar round-trip for both texts; an embedding failure
     // degrades to vector-less rows (recall coverage shrinks) but never loses

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
@@ -17,6 +17,7 @@ import {
   sharedAgentMemoriesReader,
   sharedAgentMemoriesWriter,
 } from "../../../db/repositories/shared-agent-memories";
+import { assertScopeWritable } from "../../../db/repositories/shared-transfer-epochs";
 import { logger } from "../../utils/logger";
 import {
   type SharedTodoStorageScope,
@@ -113,6 +114,10 @@ export class SharedMemoryStore {
       userId: this.scope.userId,
       agentId,
     };
+    // Round-3 transfer fence: while this scope's promotion epoch is fenced,
+    // the turn commit fails closed instead of racing the sealed export
+    // (#21090 review). One indexed point read; open epochs do not block.
+    await assertScopeWritable(scope);
     const landedAt = Date.now();
     // One batched sidecar round-trip for both texts; an embedding failure
     // degrades to vector-less rows (recall coverage shrinks) but never loses

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,550 +1,560 @@
 {
-  "name": "@elizaos/shared",
-  "version": "2.0.3-beta.7",
-  "description": "Shared code for Eliza agent and app-core.",
-  "type": "module",
-  "sideEffects": false,
-  "main": "./dist/index.js",
-  "license": "MIT",
-  "homepage": "https://github.com/elizaOS/eliza",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/elizaOS/eliza.git",
-    "directory": "packages/shared"
-  },
-  "keywords": [
-    "elizaos",
-    "shared",
-    "contracts",
-    "i18n"
-  ],
-  "files": [
-    "dist",
-    "assets",
-    "assets-classic"
-  ],
-  "engines": {
-    "node": ">=24.0.0"
-  },
-  "scripts": {
-    "clean": "node ../scripts/rm-path-recursive.mjs dist",
-    "prepublishOnly": "bun run build",
-    "build": "bun run build:i18n && bun run build:dist",
-    "build:i18n": "node scripts/generate-keywords.mjs",
-    "typecheck": "bun run build:i18n && tsc --noEmit -p tsconfig.json",
-    "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
-    "lint": "bunx @biomejs/biome check --write src",
-    "lint:check": "bunx @biomejs/biome check src",
-    "format": "bunx @biomejs/biome format --write src",
-    "format:check": "bunx @biomejs/biome format src",
-    "build:dist": "node ../scripts/rm-path-recursive.mjs dist && tsc6 --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/shared && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/shared && node ../scripts/copy-package-assets.mjs packages/shared src/brand/brand.css src/brand-classic/brand.css",
-    "pack:dry-run": "cd dist && npm pack --dry-run",
-    "sync": "node scripts/sync-to-public.mjs"
-  },
-  "exports": {
-    "./package.json": "./package.json",
-    "./todo-cutover": {
-      "types": "./dist/todo-cutover.d.ts",
-      "eliza-source": {
-        "types": "./src/todo-cutover.ts",
-        "import": "./src/todo-cutover.ts",
-        "default": "./src/todo-cutover.ts"
-      },
-      "import": "./dist/todo-cutover.js",
-      "default": "./dist/todo-cutover.js"
-    },
-    ".": {
-      "types": "./dist/index.d.ts",
-      "eliza-source": {
-        "types": "./src/index.ts",
-        "import": "./src/index.ts",
-        "default": "./src/index.ts"
-      },
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "./automation-node-contributors": {
-      "types": "./dist/automation-node-contributors.d.ts",
-      "eliza-source": {
-        "types": "./src/automation-node-contributors.ts",
-        "import": "./src/automation-node-contributors.ts",
-        "default": "./src/automation-node-contributors.ts"
-      },
-      "import": "./dist/automation-node-contributors.js",
-      "default": "./dist/automation-node-contributors.js"
-    },
-    "./connector-account-catalog": {
-      "types": "./dist/connector-account-catalog.d.ts",
-      "eliza-source": {
-        "types": "./src/connector-account-catalog.ts",
-        "import": "./src/connector-account-catalog.ts",
-        "default": "./src/connector-account-catalog.ts"
-      },
-      "import": "./dist/connector-account-catalog.js",
-      "default": "./dist/connector-account-catalog.js"
-    },
-    "./discord-dm-policy": {
-      "types": "./dist/discord-dm-policy.d.ts",
-      "eliza-source": {
-        "types": "./src/discord-dm-policy.ts",
-        "import": "./src/discord-dm-policy.ts",
-        "default": "./src/discord-dm-policy.ts"
-      },
-      "import": "./dist/discord-dm-policy.js",
-      "default": "./dist/discord-dm-policy.js"
-    },
-    "./types": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/types/index.js",
-      "default": "./dist/types/index.js"
-    },
-    "./elizacloud": {
-      "types": "./dist/elizacloud/index.d.ts",
-      "eliza-source": {
-        "types": "./src/elizacloud/index.ts",
-        "import": "./src/elizacloud/index.ts",
-        "default": "./src/elizacloud/index.ts"
-      },
-      "import": "./dist/elizacloud/index.js",
-      "default": "./dist/elizacloud/index.js"
-    },
-    "./elizacloud/domain-contract": {
-      "types": "./dist/elizacloud/domain-contract.d.ts",
-      "eliza-source": {
-        "types": "./src/elizacloud/domain-contract.ts",
-        "import": "./src/elizacloud/domain-contract.ts",
-        "default": "./src/elizacloud/domain-contract.ts"
-      },
-      "import": "./dist/elizacloud/domain-contract.js",
-      "default": "./dist/elizacloud/domain-contract.js"
-    },
-    "./config/allowed-hosts": {
-      "types": "./dist/config/allowed-hosts.d.ts",
-      "import": "./dist/config/allowed-hosts.js",
-      "default": "./dist/config/allowed-hosts.js"
-    },
-    "./config/brand-env-aliases": {
-      "types": "./dist/config/brand-env-aliases.d.ts",
-      "eliza-source": {
-        "types": "./src/config/brand-env-aliases.ts",
-        "import": "./src/config/brand-env-aliases.ts",
-        "default": "./src/config/brand-env-aliases.ts"
-      },
-      "import": "./dist/config/brand-env-aliases.js",
-      "default": "./dist/config/brand-env-aliases.js"
-    },
-    "./config/boot-config": {
-      "types": "./dist/config/boot-config.d.ts",
-      "eliza-source": {
-        "types": "./src/config/boot-config.ts",
-        "import": "./src/config/boot-config.ts",
-        "default": "./src/config/boot-config.ts"
-      },
-      "import": "./dist/config/boot-config.js",
-      "default": "./dist/config/boot-config.js"
-    },
-    "./config/boot-config-store": {
-      "types": "./dist/config/boot-config-store.d.ts",
-      "eliza-source": {
-        "types": "./src/config/boot-config-store.ts",
-        "import": "./src/config/boot-config-store.ts",
-        "default": "./src/config/boot-config-store.ts"
-      },
-      "import": "./dist/config/boot-config-store.js",
-      "default": "./dist/config/boot-config-store.js"
-    },
-    "./dev-settings-banner-style": {
-      "types": "./dist/dev-settings-banner-style.d.ts",
-      "import": "./dist/dev-settings-banner-style.js",
-      "default": "./dist/dev-settings-banner-style.js"
-    },
-    "./dev-settings-figlet-heading": {
-      "types": "./dist/dev-settings-figlet-heading.d.ts",
-      "import": "./dist/dev-settings-figlet-heading.js",
-      "default": "./dist/dev-settings-figlet-heading.js"
-    },
-    "./dev-settings-table": {
-      "types": "./dist/dev-settings-table.d.ts",
-      "import": "./dist/dev-settings-table.js",
-      "default": "./dist/dev-settings-table.js"
-    },
-    "./local-inference": {
-      "types": "./dist/local-inference/index.d.ts",
-      "import": "./dist/local-inference/index.js",
-      "default": "./dist/local-inference/index.js"
-    },
-    "./local-inference/routing-preferences": {
-      "types": "./dist/local-inference/routing-preferences.d.ts",
-      "import": "./dist/local-inference/routing-preferences.js",
-      "default": "./dist/local-inference/routing-preferences.js"
-    },
-    "./local-inference/verify": {
-      "types": "./dist/local-inference/verify.d.ts",
-      "import": "./dist/local-inference/verify.js",
-      "default": "./dist/local-inference/verify.js"
-    },
-    "./platform/native-library-policy": {
-      "types": "./dist/platform/native-library-policy.d.ts",
-      "eliza-source": {
-        "types": "./src/platform/native-library-policy.ts",
-        "import": "./src/platform/native-library-policy.ts",
-        "default": "./src/platform/native-library-policy.ts"
-      },
-      "import": "./dist/platform/native-library-policy.js",
-      "default": "./dist/platform/native-library-policy.js"
-    },
-    "./character-presets": {
-      "types": "./dist/character-presets.d.ts",
-      "eliza-source": {
-        "types": "./src/character-presets.ts",
-        "import": "./src/character-presets.ts",
-        "default": "./src/character-presets.ts"
-      },
-      "import": "./dist/character-presets.js",
-      "default": "./dist/character-presets.js"
-    },
-    "./runtime-env": {
-      "types": "./dist/runtime-env.d.ts",
-      "eliza-source": {
-        "types": "./src/runtime-env.ts",
-        "import": "./src/runtime-env.ts",
-        "default": "./src/runtime-env.ts"
-      },
-      "import": "./dist/runtime-env.js",
-      "default": "./dist/runtime-env.js"
-    },
-    "./restart": {
-      "types": "./dist/restart.d.ts",
-      "eliza-source": {
-        "types": "./src/restart.ts",
-        "import": "./src/restart.ts",
-        "default": "./src/restart.ts"
-      },
-      "import": "./dist/restart.js",
-      "default": "./dist/restart.js"
-    },
-    "./host-execution-env": {
-      "types": "./dist/host-execution-env.d.ts",
-      "eliza-source": {
-        "types": "./src/host-execution-env.ts",
-        "import": "./src/host-execution-env.ts",
-        "default": "./src/host-execution-env.ts"
-      },
-      "import": "./dist/host-execution-env.js",
-      "default": "./dist/host-execution-env.js"
-    },
-    "./sandbox-registry": {
-      "types": "./dist/sandbox-registry.d.ts",
-      "eliza-source": {
-        "types": "./src/sandbox-registry.ts",
-        "import": "./src/sandbox-registry.ts",
-        "default": "./src/sandbox-registry.ts"
-      },
-      "import": "./dist/sandbox-registry.js",
-      "default": "./dist/sandbox-registry.js"
-    },
-    "./brand": {
-      "types": "./dist/brand/index.d.ts",
-      "eliza-source": {
-        "types": "./src/brand/index.ts",
-        "import": "./src/brand/index.ts",
-        "default": "./src/brand/index.ts"
-      },
-      "import": "./dist/brand/index.js",
-      "default": "./dist/brand/index.js"
-    },
-    "./brand-classic": {
-      "types": "./dist/brand-classic/index.d.ts",
-      "import": "./dist/brand-classic/index.js",
-      "default": "./dist/brand-classic/index.js"
-    },
-    "./steward-session-client": {
-      "types": "./dist/steward-session-client/index.d.ts",
-      "import": "./dist/steward-session-client/index.js",
-      "default": "./dist/steward-session-client/index.js"
-    },
-    "./events": {
-      "types": "./dist/events/index.d.ts",
-      "eliza-source": {
-        "types": "./src/events/index.ts",
-        "import": "./src/events/index.ts",
-        "default": "./src/events/index.ts"
-      },
-      "import": "./dist/events/index.js",
-      "default": "./dist/events/index.js"
-    },
-    "./backgrounds/catalog-index": {
-      "types": "./dist/backgrounds/catalog-index.d.ts",
-      "eliza-source": {
-        "types": "./src/backgrounds/catalog-index.ts",
-        "import": "./src/backgrounds/catalog-index.ts",
-        "default": "./src/backgrounds/catalog-index.ts"
-      },
-      "import": "./dist/backgrounds/catalog-index.js",
-      "default": "./dist/backgrounds/catalog-index.js"
-    },
-    "./contracts": {
-      "types": "./dist/contracts/index.d.ts",
-      "eliza-source": {
-        "types": "./src/contracts/index.ts",
-        "import": "./src/contracts/index.ts",
-        "default": "./src/contracts/index.ts"
-      },
-      "import": "./dist/contracts/index.js",
-      "default": "./dist/contracts/index.js"
-    },
-    "./contracts/pendant-session-sync": {
-      "types": "./dist/contracts/pendant-session-sync.d.ts",
-      "eliza-source": {
-        "types": "./src/contracts/pendant-session-sync.ts",
-        "import": "./src/contracts/pendant-session-sync.ts",
-        "default": "./src/contracts/pendant-session-sync.ts"
-      },
-      "import": "./dist/contracts/pendant-session-sync.js",
-      "default": "./dist/contracts/pendant-session-sync.js"
-    },
-    "./contracts/scheduled-task-execution": {
-      "types": "./dist/contracts/scheduled-task-execution.d.ts",
-      "eliza-source": {
-        "types": "./src/contracts/scheduled-task-execution.ts",
-        "import": "./src/contracts/scheduled-task-execution.ts",
-        "default": "./src/contracts/scheduled-task-execution.ts"
-      },
-      "import": "./dist/contracts/scheduled-task-execution.js",
-      "default": "./dist/contracts/scheduled-task-execution.js"
-    },
-    "./utils/asset-url": {
-      "types": "./dist/utils/asset-url.d.ts",
-      "eliza-source": {
-        "types": "./src/utils/asset-url.ts",
-        "import": "./src/utils/asset-url.ts",
-        "default": "./src/utils/asset-url.ts"
-      },
-      "import": "./dist/utils/asset-url.js",
-      "default": "./dist/utils/asset-url.js"
-    },
-    "./utils/permission-deep-links": {
-      "types": "./dist/utils/permission-deep-links.d.ts",
-      "eliza-source": {
-        "types": "./src/utils/permission-deep-links.ts",
-        "import": "./src/utils/permission-deep-links.ts",
-        "default": "./src/utils/permission-deep-links.ts"
-      },
-      "import": "./dist/utils/permission-deep-links.js",
-      "default": "./dist/utils/permission-deep-links.js"
-    },
-    "./utils/format": {
-      "types": "./dist/utils/format.d.ts",
-      "eliza-source": {
-        "types": "./src/utils/format.ts",
-        "import": "./src/utils/format.ts",
-        "default": "./src/utils/format.ts"
-      },
-      "import": "./dist/utils/format.js",
-      "default": "./dist/utils/format.js"
-    },
-    "./utils/number-parsing": {
-      "types": "./dist/utils/number-parsing.d.ts",
-      "eliza-source": {
-        "types": "./src/utils/number-parsing.ts",
-        "import": "./src/utils/number-parsing.ts",
-        "default": "./src/utils/number-parsing.ts"
-      },
-      "import": "./dist/utils/number-parsing.js",
-      "default": "./dist/utils/number-parsing.js"
-    },
-    "./config/config-catalog": {
-      "types": "./dist/config/config-catalog.d.ts",
-      "eliza-source": {
-        "types": "./src/config/config-catalog.ts",
-        "import": "./src/config/config-catalog.ts",
-        "default": "./src/config/config-catalog.ts"
-      },
-      "import": "./dist/config/config-catalog.js",
-      "default": "./dist/config/config-catalog.js"
-    },
-    "./contracts/apps": {
-      "types": "./dist/contracts/apps.d.ts",
-      "eliza-source": {
-        "types": "./src/contracts/apps.ts",
-        "import": "./src/contracts/apps.ts",
-        "default": "./src/contracts/apps.ts"
-      },
-      "import": "./dist/contracts/apps.js",
-      "default": "./dist/contracts/apps.js"
-    },
-    "./views/view-interact-protocol": {
-      "types": "./dist/views/view-interact-protocol.d.ts",
-      "eliza-source": {
-        "types": "./src/views/view-interact-protocol.ts",
-        "import": "./src/views/view-interact-protocol.ts",
-        "default": "./src/views/view-interact-protocol.ts"
-      },
-      "import": "./dist/views/view-interact-protocol.js",
-      "default": "./dist/views/view-interact-protocol.js"
-    },
-    "./views/view-command-matcher": {
-      "types": "./dist/views/view-command-matcher.d.ts",
-      "eliza-source": {
-        "types": "./src/views/view-command-matcher.ts",
-        "import": "./src/views/view-command-matcher.ts",
-        "default": "./src/views/view-command-matcher.ts"
-      },
-      "import": "./dist/views/view-command-matcher.js",
-      "default": "./dist/views/view-command-matcher.js"
-    },
-    "./views/shared-nav-targets": {
-      "types": "./dist/views/shared-nav-targets.d.ts",
-      "eliza-source": {
-        "types": "./src/views/shared-nav-targets.ts",
-        "import": "./src/views/shared-nav-targets.ts",
-        "default": "./src/views/shared-nav-targets.ts"
-      },
-      "import": "./dist/views/shared-nav-targets.js",
-      "default": "./dist/views/shared-nav-targets.js"
-    },
-    "./voice-wer": {
-      "types": "./dist/voice-wer.d.ts",
-      "eliza-source": {
-        "types": "./src/voice-wer.ts",
-        "import": "./src/voice-wer.ts",
-        "default": "./src/voice-wer.ts"
-      },
-      "import": "./dist/voice-wer.js",
-      "default": "./dist/voice-wer.js"
-    },
-    "./voice-eot": {
-      "types": "./dist/voice-eot.d.ts",
-      "eliza-source": {
-        "types": "./src/voice-eot.ts",
-        "import": "./src/voice-eot.ts",
-        "default": "./src/voice-eot.ts"
-      },
-      "import": "./dist/voice-eot.js",
-      "default": "./dist/voice-eot.js"
-    },
-    "./voice/respond-gate": {
-      "types": "./dist/voice/respond-gate.d.ts",
-      "eliza-source": {
-        "types": "./src/voice/respond-gate.ts",
-        "import": "./src/voice/respond-gate.ts",
-        "default": "./src/voice/respond-gate.ts"
-      },
-      "import": "./dist/voice/respond-gate.js",
-      "default": "./dist/voice/respond-gate.js"
-    },
-    "./voice/first-sentence-snip": {
-      "types": "./dist/voice/first-sentence-snip.d.ts",
-      "eliza-source": {
-        "types": "./src/voice/first-sentence-snip.ts",
-        "import": "./src/voice/first-sentence-snip.ts",
-        "default": "./src/voice/first-sentence-snip.ts"
-      },
-      "import": "./dist/voice/first-sentence-snip.js",
-      "default": "./dist/voice/first-sentence-snip.js"
-    },
-    "./voice/owner-inference": {
-      "types": "./dist/voice/owner-inference.d.ts",
-      "eliza-source": {
-        "types": "./src/voice/owner-inference.ts",
-        "import": "./src/voice/owner-inference.ts",
-        "default": "./src/voice/owner-inference.ts"
-      },
-      "import": "./dist/voice/owner-inference.js",
-      "default": "./dist/voice/owner-inference.js"
-    },
-    "./voice/aec": {
-      "types": "./dist/voice/aec/index.d.ts",
-      "eliza-source": {
-        "types": "./src/voice/aec/index.ts",
-        "import": "./src/voice/aec/index.ts",
-        "default": "./src/voice/aec/index.ts"
-      },
-      "import": "./dist/voice/aec/index.js",
-      "default": "./dist/voice/aec/index.js"
-    },
-    "./transcripts": {
-      "types": "./dist/transcripts.d.ts",
-      "eliza-source": {
-        "types": "./src/transcripts.ts",
-        "import": "./src/transcripts.ts",
-        "default": "./src/transcripts.ts"
-      },
-      "import": "./dist/transcripts.js",
-      "default": "./dist/transcripts.js"
-    },
-    "./audio-redaction": {
-      "types": "./dist/audio-redaction.d.ts",
-      "eliza-source": {
-        "types": "./src/audio-redaction.ts",
-        "import": "./src/audio-redaction.ts",
-        "default": "./src/audio-redaction.ts"
-      },
-      "import": "./dist/audio-redaction.js",
-      "default": "./dist/audio-redaction.js"
-    },
-    "./audio-redaction-verify": {
-      "types": "./dist/audio-redaction-verify.d.ts",
-      "eliza-source": {
-        "types": "./src/audio-redaction-verify.ts",
-        "import": "./src/audio-redaction-verify.ts",
-        "default": "./src/audio-redaction-verify.ts"
-      },
-      "import": "./dist/audio-redaction-verify.js",
-      "default": "./dist/audio-redaction-verify.js"
-    },
-    "./terminal/palette": {
-      "types": "./dist/terminal/palette.d.ts",
-      "eliza-source": {
-        "types": "./src/terminal/palette.ts",
-        "import": "./src/terminal/palette.ts",
-        "default": "./src/terminal/palette.ts"
-      },
-      "import": "./dist/terminal/palette.js",
-      "default": "./dist/terminal/palette.js"
-    },
-    "./*.css": "./dist/*.css",
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "import": "./dist/*.js",
-      "default": "./dist/*.js"
-    },
-    "./brand.css": "./dist/brand/brand.css",
-    "./brand-classic.css": "./dist/brand-classic/brand.css",
-    "./assets/*": "./assets/*"
-  },
-  "publishConfig": {
-    "access": "public",
-    "directory": "dist"
-  },
-  "dependencies": {
-    "@elizaos/core": "workspace:*",
-    "@elizaos/registry": "workspace:*",
-    "chalk": "^6.0.0",
-    "drizzle-orm": "0.45.2",
-    "phonemizer": "^1.2.1",
-    "react": "^19.0.0",
-    "yaml": "^2.8.2",
-    "zod": "^4.4.3"
-  },
-  "optionalDependencies": {
-    "figlet": "^1.11.0"
-  },
-  "devDependencies": {
-    "@types/figlet": "^1.7.0",
-    "bun-types": "^1.3.12",
-    "@typescript/native": "npm:typescript@^7.0.2",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.0",
-    "vitest": "^4.0.17"
-  },
-  "types": "./dist/index.d.ts",
-  "elizaos": {
-    "scripts": {
-      "coreBuild": true,
-      "testLanes": [
-        "server"
-      ]
-    }
-  }
+	"name": "@elizaos/shared",
+	"version": "2.0.3-beta.7",
+	"description": "Shared code for Eliza agent and app-core.",
+	"type": "module",
+	"sideEffects": false,
+	"main": "./dist/index.js",
+	"license": "MIT",
+	"homepage": "https://github.com/elizaOS/eliza",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/elizaOS/eliza.git",
+		"directory": "packages/shared"
+	},
+	"keywords": [
+		"elizaos",
+		"shared",
+		"contracts",
+		"i18n"
+	],
+	"files": [
+		"dist",
+		"assets",
+		"assets-classic"
+	],
+	"engines": {
+		"node": ">=24.0.0"
+	},
+	"scripts": {
+		"clean": "node ../scripts/rm-path-recursive.mjs dist",
+		"prepublishOnly": "bun run build",
+		"build": "bun run build:i18n && bun run build:dist",
+		"build:i18n": "node scripts/generate-keywords.mjs",
+		"typecheck": "bun run build:i18n && tsc --noEmit -p tsconfig.json",
+		"test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
+		"lint": "bunx @biomejs/biome check --write src",
+		"lint:check": "bunx @biomejs/biome check src",
+		"format": "bunx @biomejs/biome format --write src",
+		"format:check": "bunx @biomejs/biome format src",
+		"build:dist": "node ../scripts/rm-path-recursive.mjs dist && tsc6 --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/shared && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/shared && node ../scripts/copy-package-assets.mjs packages/shared src/brand/brand.css src/brand-classic/brand.css",
+		"pack:dry-run": "cd dist && npm pack --dry-run",
+		"sync": "node scripts/sync-to-public.mjs"
+	},
+	"exports": {
+		"./package.json": "./package.json",
+		"./todo-cutover": {
+			"types": "./dist/todo-cutover.d.ts",
+			"eliza-source": {
+				"types": "./src/todo-cutover.ts",
+				"import": "./src/todo-cutover.ts",
+				"default": "./src/todo-cutover.ts"
+			},
+			"import": "./dist/todo-cutover.js",
+			"default": "./dist/todo-cutover.js"
+		},
+		".": {
+			"types": "./dist/index.d.ts",
+			"eliza-source": {
+				"types": "./src/index.ts",
+				"import": "./src/index.ts",
+				"default": "./src/index.ts"
+			},
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		},
+		"./automation-node-contributors": {
+			"types": "./dist/automation-node-contributors.d.ts",
+			"eliza-source": {
+				"types": "./src/automation-node-contributors.ts",
+				"import": "./src/automation-node-contributors.ts",
+				"default": "./src/automation-node-contributors.ts"
+			},
+			"import": "./dist/automation-node-contributors.js",
+			"default": "./dist/automation-node-contributors.js"
+		},
+		"./connector-account-catalog": {
+			"types": "./dist/connector-account-catalog.d.ts",
+			"eliza-source": {
+				"types": "./src/connector-account-catalog.ts",
+				"import": "./src/connector-account-catalog.ts",
+				"default": "./src/connector-account-catalog.ts"
+			},
+			"import": "./dist/connector-account-catalog.js",
+			"default": "./dist/connector-account-catalog.js"
+		},
+		"./discord-dm-policy": {
+			"types": "./dist/discord-dm-policy.d.ts",
+			"eliza-source": {
+				"types": "./src/discord-dm-policy.ts",
+				"import": "./src/discord-dm-policy.ts",
+				"default": "./src/discord-dm-policy.ts"
+			},
+			"import": "./dist/discord-dm-policy.js",
+			"default": "./dist/discord-dm-policy.js"
+		},
+		"./types": {
+			"types": "./dist/types/index.d.ts",
+			"import": "./dist/types/index.js",
+			"default": "./dist/types/index.js"
+		},
+		"./elizacloud": {
+			"types": "./dist/elizacloud/index.d.ts",
+			"eliza-source": {
+				"types": "./src/elizacloud/index.ts",
+				"import": "./src/elizacloud/index.ts",
+				"default": "./src/elizacloud/index.ts"
+			},
+			"import": "./dist/elizacloud/index.js",
+			"default": "./dist/elizacloud/index.js"
+		},
+		"./elizacloud/domain-contract": {
+			"types": "./dist/elizacloud/domain-contract.d.ts",
+			"eliza-source": {
+				"types": "./src/elizacloud/domain-contract.ts",
+				"import": "./src/elizacloud/domain-contract.ts",
+				"default": "./src/elizacloud/domain-contract.ts"
+			},
+			"import": "./dist/elizacloud/domain-contract.js",
+			"default": "./dist/elizacloud/domain-contract.js"
+		},
+		"./config/allowed-hosts": {
+			"types": "./dist/config/allowed-hosts.d.ts",
+			"import": "./dist/config/allowed-hosts.js",
+			"default": "./dist/config/allowed-hosts.js"
+		},
+		"./config/brand-env-aliases": {
+			"types": "./dist/config/brand-env-aliases.d.ts",
+			"eliza-source": {
+				"types": "./src/config/brand-env-aliases.ts",
+				"import": "./src/config/brand-env-aliases.ts",
+				"default": "./src/config/brand-env-aliases.ts"
+			},
+			"import": "./dist/config/brand-env-aliases.js",
+			"default": "./dist/config/brand-env-aliases.js"
+		},
+		"./config/boot-config": {
+			"types": "./dist/config/boot-config.d.ts",
+			"eliza-source": {
+				"types": "./src/config/boot-config.ts",
+				"import": "./src/config/boot-config.ts",
+				"default": "./src/config/boot-config.ts"
+			},
+			"import": "./dist/config/boot-config.js",
+			"default": "./dist/config/boot-config.js"
+		},
+		"./config/boot-config-store": {
+			"types": "./dist/config/boot-config-store.d.ts",
+			"eliza-source": {
+				"types": "./src/config/boot-config-store.ts",
+				"import": "./src/config/boot-config-store.ts",
+				"default": "./src/config/boot-config-store.ts"
+			},
+			"import": "./dist/config/boot-config-store.js",
+			"default": "./dist/config/boot-config-store.js"
+		},
+		"./dev-settings-banner-style": {
+			"types": "./dist/dev-settings-banner-style.d.ts",
+			"import": "./dist/dev-settings-banner-style.js",
+			"default": "./dist/dev-settings-banner-style.js"
+		},
+		"./dev-settings-figlet-heading": {
+			"types": "./dist/dev-settings-figlet-heading.d.ts",
+			"import": "./dist/dev-settings-figlet-heading.js",
+			"default": "./dist/dev-settings-figlet-heading.js"
+		},
+		"./dev-settings-table": {
+			"types": "./dist/dev-settings-table.d.ts",
+			"import": "./dist/dev-settings-table.js",
+			"default": "./dist/dev-settings-table.js"
+		},
+		"./local-inference": {
+			"types": "./dist/local-inference/index.d.ts",
+			"import": "./dist/local-inference/index.js",
+			"default": "./dist/local-inference/index.js"
+		},
+		"./local-inference/routing-preferences": {
+			"types": "./dist/local-inference/routing-preferences.d.ts",
+			"import": "./dist/local-inference/routing-preferences.js",
+			"default": "./dist/local-inference/routing-preferences.js"
+		},
+		"./local-inference/verify": {
+			"types": "./dist/local-inference/verify.d.ts",
+			"import": "./dist/local-inference/verify.js",
+			"default": "./dist/local-inference/verify.js"
+		},
+		"./platform/native-library-policy": {
+			"types": "./dist/platform/native-library-policy.d.ts",
+			"eliza-source": {
+				"types": "./src/platform/native-library-policy.ts",
+				"import": "./src/platform/native-library-policy.ts",
+				"default": "./src/platform/native-library-policy.ts"
+			},
+			"import": "./dist/platform/native-library-policy.js",
+			"default": "./dist/platform/native-library-policy.js"
+		},
+		"./character-presets": {
+			"types": "./dist/character-presets.d.ts",
+			"eliza-source": {
+				"types": "./src/character-presets.ts",
+				"import": "./src/character-presets.ts",
+				"default": "./src/character-presets.ts"
+			},
+			"import": "./dist/character-presets.js",
+			"default": "./dist/character-presets.js"
+		},
+		"./runtime-env": {
+			"types": "./dist/runtime-env.d.ts",
+			"eliza-source": {
+				"types": "./src/runtime-env.ts",
+				"import": "./src/runtime-env.ts",
+				"default": "./src/runtime-env.ts"
+			},
+			"import": "./dist/runtime-env.js",
+			"default": "./dist/runtime-env.js"
+		},
+		"./restart": {
+			"types": "./dist/restart.d.ts",
+			"eliza-source": {
+				"types": "./src/restart.ts",
+				"import": "./src/restart.ts",
+				"default": "./src/restart.ts"
+			},
+			"import": "./dist/restart.js",
+			"default": "./dist/restart.js"
+		},
+		"./host-execution-env": {
+			"types": "./dist/host-execution-env.d.ts",
+			"eliza-source": {
+				"types": "./src/host-execution-env.ts",
+				"import": "./src/host-execution-env.ts",
+				"default": "./src/host-execution-env.ts"
+			},
+			"import": "./dist/host-execution-env.js",
+			"default": "./dist/host-execution-env.js"
+		},
+		"./sandbox-registry": {
+			"types": "./dist/sandbox-registry.d.ts",
+			"eliza-source": {
+				"types": "./src/sandbox-registry.ts",
+				"import": "./src/sandbox-registry.ts",
+				"default": "./src/sandbox-registry.ts"
+			},
+			"import": "./dist/sandbox-registry.js",
+			"default": "./dist/sandbox-registry.js"
+		},
+		"./brand": {
+			"types": "./dist/brand/index.d.ts",
+			"eliza-source": {
+				"types": "./src/brand/index.ts",
+				"import": "./src/brand/index.ts",
+				"default": "./src/brand/index.ts"
+			},
+			"import": "./dist/brand/index.js",
+			"default": "./dist/brand/index.js"
+		},
+		"./brand-classic": {
+			"types": "./dist/brand-classic/index.d.ts",
+			"import": "./dist/brand-classic/index.js",
+			"default": "./dist/brand-classic/index.js"
+		},
+		"./steward-session-client": {
+			"types": "./dist/steward-session-client/index.d.ts",
+			"import": "./dist/steward-session-client/index.js",
+			"default": "./dist/steward-session-client/index.js"
+		},
+		"./events": {
+			"types": "./dist/events/index.d.ts",
+			"eliza-source": {
+				"types": "./src/events/index.ts",
+				"import": "./src/events/index.ts",
+				"default": "./src/events/index.ts"
+			},
+			"import": "./dist/events/index.js",
+			"default": "./dist/events/index.js"
+		},
+		"./backgrounds/catalog-index": {
+			"types": "./dist/backgrounds/catalog-index.d.ts",
+			"eliza-source": {
+				"types": "./src/backgrounds/catalog-index.ts",
+				"import": "./src/backgrounds/catalog-index.ts",
+				"default": "./src/backgrounds/catalog-index.ts"
+			},
+			"import": "./dist/backgrounds/catalog-index.js",
+			"default": "./dist/backgrounds/catalog-index.js"
+		},
+		"./contracts": {
+			"types": "./dist/contracts/index.d.ts",
+			"eliza-source": {
+				"types": "./src/contracts/index.ts",
+				"import": "./src/contracts/index.ts",
+				"default": "./src/contracts/index.ts"
+			},
+			"import": "./dist/contracts/index.js",
+			"default": "./dist/contracts/index.js"
+		},
+		"./contracts/pendant-session-sync": {
+			"types": "./dist/contracts/pendant-session-sync.d.ts",
+			"eliza-source": {
+				"types": "./src/contracts/pendant-session-sync.ts",
+				"import": "./src/contracts/pendant-session-sync.ts",
+				"default": "./src/contracts/pendant-session-sync.ts"
+			},
+			"import": "./dist/contracts/pendant-session-sync.js",
+			"default": "./dist/contracts/pendant-session-sync.js"
+		},
+		"./contracts/scheduled-task-execution": {
+			"types": "./dist/contracts/scheduled-task-execution.d.ts",
+			"eliza-source": {
+				"types": "./src/contracts/scheduled-task-execution.ts",
+				"import": "./src/contracts/scheduled-task-execution.ts",
+				"default": "./src/contracts/scheduled-task-execution.ts"
+			},
+			"import": "./dist/contracts/scheduled-task-execution.js",
+			"default": "./dist/contracts/scheduled-task-execution.js"
+		},
+		"./utils/asset-url": {
+			"types": "./dist/utils/asset-url.d.ts",
+			"eliza-source": {
+				"types": "./src/utils/asset-url.ts",
+				"import": "./src/utils/asset-url.ts",
+				"default": "./src/utils/asset-url.ts"
+			},
+			"import": "./dist/utils/asset-url.js",
+			"default": "./dist/utils/asset-url.js"
+		},
+		"./utils/permission-deep-links": {
+			"types": "./dist/utils/permission-deep-links.d.ts",
+			"eliza-source": {
+				"types": "./src/utils/permission-deep-links.ts",
+				"import": "./src/utils/permission-deep-links.ts",
+				"default": "./src/utils/permission-deep-links.ts"
+			},
+			"import": "./dist/utils/permission-deep-links.js",
+			"default": "./dist/utils/permission-deep-links.js"
+		},
+		"./utils/format": {
+			"types": "./dist/utils/format.d.ts",
+			"eliza-source": {
+				"types": "./src/utils/format.ts",
+				"import": "./src/utils/format.ts",
+				"default": "./src/utils/format.ts"
+			},
+			"import": "./dist/utils/format.js",
+			"default": "./dist/utils/format.js"
+		},
+		"./utils/number-parsing": {
+			"types": "./dist/utils/number-parsing.d.ts",
+			"eliza-source": {
+				"types": "./src/utils/number-parsing.ts",
+				"import": "./src/utils/number-parsing.ts",
+				"default": "./src/utils/number-parsing.ts"
+			},
+			"import": "./dist/utils/number-parsing.js",
+			"default": "./dist/utils/number-parsing.js"
+		},
+		"./config/config-catalog": {
+			"types": "./dist/config/config-catalog.d.ts",
+			"eliza-source": {
+				"types": "./src/config/config-catalog.ts",
+				"import": "./src/config/config-catalog.ts",
+				"default": "./src/config/config-catalog.ts"
+			},
+			"import": "./dist/config/config-catalog.js",
+			"default": "./dist/config/config-catalog.js"
+		},
+		"./contracts/apps": {
+			"types": "./dist/contracts/apps.d.ts",
+			"eliza-source": {
+				"types": "./src/contracts/apps.ts",
+				"import": "./src/contracts/apps.ts",
+				"default": "./src/contracts/apps.ts"
+			},
+			"import": "./dist/contracts/apps.js",
+			"default": "./dist/contracts/apps.js"
+		},
+		"./views/view-interact-protocol": {
+			"types": "./dist/views/view-interact-protocol.d.ts",
+			"eliza-source": {
+				"types": "./src/views/view-interact-protocol.ts",
+				"import": "./src/views/view-interact-protocol.ts",
+				"default": "./src/views/view-interact-protocol.ts"
+			},
+			"import": "./dist/views/view-interact-protocol.js",
+			"default": "./dist/views/view-interact-protocol.js"
+		},
+		"./views/view-command-matcher": {
+			"types": "./dist/views/view-command-matcher.d.ts",
+			"eliza-source": {
+				"types": "./src/views/view-command-matcher.ts",
+				"import": "./src/views/view-command-matcher.ts",
+				"default": "./src/views/view-command-matcher.ts"
+			},
+			"import": "./dist/views/view-command-matcher.js",
+			"default": "./dist/views/view-command-matcher.js"
+		},
+		"./views/shared-nav-targets": {
+			"types": "./dist/views/shared-nav-targets.d.ts",
+			"eliza-source": {
+				"types": "./src/views/shared-nav-targets.ts",
+				"import": "./src/views/shared-nav-targets.ts",
+				"default": "./src/views/shared-nav-targets.ts"
+			},
+			"import": "./dist/views/shared-nav-targets.js",
+			"default": "./dist/views/shared-nav-targets.js"
+		},
+		"./voice-wer": {
+			"types": "./dist/voice-wer.d.ts",
+			"eliza-source": {
+				"types": "./src/voice-wer.ts",
+				"import": "./src/voice-wer.ts",
+				"default": "./src/voice-wer.ts"
+			},
+			"import": "./dist/voice-wer.js",
+			"default": "./dist/voice-wer.js"
+		},
+		"./voice-eot": {
+			"types": "./dist/voice-eot.d.ts",
+			"eliza-source": {
+				"types": "./src/voice-eot.ts",
+				"import": "./src/voice-eot.ts",
+				"default": "./src/voice-eot.ts"
+			},
+			"import": "./dist/voice-eot.js",
+			"default": "./dist/voice-eot.js"
+		},
+		"./voice/respond-gate": {
+			"types": "./dist/voice/respond-gate.d.ts",
+			"eliza-source": {
+				"types": "./src/voice/respond-gate.ts",
+				"import": "./src/voice/respond-gate.ts",
+				"default": "./src/voice/respond-gate.ts"
+			},
+			"import": "./dist/voice/respond-gate.js",
+			"default": "./dist/voice/respond-gate.js"
+		},
+		"./voice/first-sentence-snip": {
+			"types": "./dist/voice/first-sentence-snip.d.ts",
+			"eliza-source": {
+				"types": "./src/voice/first-sentence-snip.ts",
+				"import": "./src/voice/first-sentence-snip.ts",
+				"default": "./src/voice/first-sentence-snip.ts"
+			},
+			"import": "./dist/voice/first-sentence-snip.js",
+			"default": "./dist/voice/first-sentence-snip.js"
+		},
+		"./voice/owner-inference": {
+			"types": "./dist/voice/owner-inference.d.ts",
+			"eliza-source": {
+				"types": "./src/voice/owner-inference.ts",
+				"import": "./src/voice/owner-inference.ts",
+				"default": "./src/voice/owner-inference.ts"
+			},
+			"import": "./dist/voice/owner-inference.js",
+			"default": "./dist/voice/owner-inference.js"
+		},
+		"./voice/aec": {
+			"types": "./dist/voice/aec/index.d.ts",
+			"eliza-source": {
+				"types": "./src/voice/aec/index.ts",
+				"import": "./src/voice/aec/index.ts",
+				"default": "./src/voice/aec/index.ts"
+			},
+			"import": "./dist/voice/aec/index.js",
+			"default": "./dist/voice/aec/index.js"
+		},
+		"./transcripts": {
+			"types": "./dist/transcripts.d.ts",
+			"eliza-source": {
+				"types": "./src/transcripts.ts",
+				"import": "./src/transcripts.ts",
+				"default": "./src/transcripts.ts"
+			},
+			"import": "./dist/transcripts.js",
+			"default": "./dist/transcripts.js"
+		},
+		"./audio-redaction": {
+			"types": "./dist/audio-redaction.d.ts",
+			"eliza-source": {
+				"types": "./src/audio-redaction.ts",
+				"import": "./src/audio-redaction.ts",
+				"default": "./src/audio-redaction.ts"
+			},
+			"import": "./dist/audio-redaction.js",
+			"default": "./dist/audio-redaction.js"
+		},
+		"./audio-redaction-verify": {
+			"types": "./dist/audio-redaction-verify.d.ts",
+			"eliza-source": {
+				"types": "./src/audio-redaction-verify.ts",
+				"import": "./src/audio-redaction-verify.ts",
+				"default": "./src/audio-redaction-verify.ts"
+			},
+			"import": "./dist/audio-redaction-verify.js",
+			"default": "./dist/audio-redaction-verify.js"
+		},
+		"./terminal/palette": {
+			"types": "./dist/terminal/palette.d.ts",
+			"eliza-source": {
+				"types": "./src/terminal/palette.ts",
+				"import": "./src/terminal/palette.ts",
+				"default": "./src/terminal/palette.ts"
+			},
+			"import": "./dist/terminal/palette.js",
+			"default": "./dist/terminal/palette.js"
+		},
+		"./*.css": "./dist/*.css",
+		"./*": {
+			"types": "./dist/*.d.ts",
+			"import": "./dist/*.js",
+			"default": "./dist/*.js"
+		},
+		"./brand.css": "./dist/brand/brand.css",
+		"./brand-classic.css": "./dist/brand-classic/brand.css",
+		"./assets/*": "./assets/*",
+		"./contracts/shared-memory-transfer": {
+			"types": "./dist/contracts/shared-memory-transfer.d.ts",
+			"eliza-source": {
+				"types": "./src/contracts/shared-memory-transfer.ts",
+				"import": "./src/contracts/shared-memory-transfer.ts",
+				"default": "./src/contracts/shared-memory-transfer.ts"
+			},
+			"import": "./dist/contracts/shared-memory-transfer.js",
+			"default": "./dist/contracts/shared-memory-transfer.js"
+		}
+	},
+	"publishConfig": {
+		"access": "public",
+		"directory": "dist"
+	},
+	"dependencies": {
+		"@elizaos/core": "workspace:*",
+		"@elizaos/registry": "workspace:*",
+		"chalk": "^6.0.0",
+		"drizzle-orm": "0.45.2",
+		"phonemizer": "^1.2.1",
+		"react": "^19.0.0",
+		"yaml": "^2.8.2",
+		"zod": "^4.4.3"
+	},
+	"optionalDependencies": {
+		"figlet": "^1.11.0"
+	},
+	"devDependencies": {
+		"@types/figlet": "^1.7.0",
+		"bun-types": "^1.3.12",
+		"@typescript/native": "npm:typescript@^7.0.2",
+		"typescript": "^6.0.3",
+		"vite": "^8.0.0",
+		"vitest": "^4.0.17"
+	},
+	"types": "./dist/index.d.ts",
+	"elizaos": {
+		"scripts": {
+			"coreBuild": true,
+			"testLanes": [
+				"server"
+			]
+		}
+	}
 }

--- a/packages/shared/src/contracts/shared-memory-transfer.ts
+++ b/packages/shared/src/contracts/shared-memory-transfer.ts
@@ -1,0 +1,199 @@
+/**
+ * Shared→Dedicated memory transfer wire contract, round 3 (#20923 spec,
+ * #21090 architecture review).
+ *
+ * The transfer is a fenced, epoch-bound promotion rather than a best-effort
+ * copy:
+ *
+ * 1. The SOURCE (Shared runtime) opens a promotion epoch for the scope. The
+ *    epoch is server-bound: while it is `fenced`, the Shared runtime refuses
+ *    memory writes for that scope, so the snapshot cannot race a writer.
+ * 2. The export runs inside the fence and produces a SIGNED whole-export seal
+ *    binding {epoch, scope, row count, order-sensitive digest, vector
+ *    dimension}. The signature key never travels with the payload.
+ * 3. The DESTINATION stages batches without making them visible, verifying
+ *    each batch chains to the seal it references.
+ * 4. Finalization is ONE atomic step: the staged set is re-verified against
+ *    the ORIGINAL whole-export seal (signature included), scaffolding and row
+ *    visibility are published in the same transaction, and the epoch is
+ *    marked promoted. A failed finalize leaves nothing visible.
+ * 5. Vector dimensions are negotiated explicitly: the seal declares the
+ *    dimension; a destination without a matching column refuses with a typed
+ *    error instead of re-embedding or silently dropping.
+ */
+
+import { z } from "zod";
+
+export const SHARED_MEMORY_TRANSFER_MAX_ROWS = 500;
+
+/** Epoch lifecycle: open → fenced → promoted | aborted. */
+export const PromotionEpochStateSchema = z.enum([
+  "open",
+  "fenced",
+  "promoted",
+  "aborted",
+]);
+export type PromotionEpochState = z.infer<typeof PromotionEpochStateSchema>;
+
+export const SealedMemoryExportRowSchema = z.object({
+  id: z.string().uuid(),
+  type: z.string().min(1),
+  created_at: z.string().datetime(),
+  content: z.record(z.string(), z.unknown()),
+  entity_id: z.string().uuid().nullable(),
+  agent_id: z.string().uuid(),
+  room_id: z.string().uuid().nullable(),
+  world_id: z.string().uuid().nullable(),
+  unique: z.boolean(),
+  metadata: z.record(z.string(), z.unknown()),
+  embedding: z.array(z.number()).nullable(),
+});
+export type SealedMemoryExportRow = z.infer<typeof SealedMemoryExportRowSchema>;
+
+/**
+ * Whole-export seal. `signature` is HMAC-SHA256 over the canonical seal body
+ * (every field except `signature` itself, in the exact key order of
+ * `sealSigningPayload`) with the key named by
+ * `ELIZA_MEMORY_TRANSFER_SEAL_KEY`. The destination re-derives it from the
+ * ORIGINAL seal on finalize; batches cannot substitute a weaker seal.
+ */
+export const SealedExportSealSchema = z.object({
+  version: z.literal(3),
+  epoch: z.number().int().positive(),
+  source_agent_id: z.string().uuid(),
+  scope: z.string().min(1),
+  row_count: z.number().int().nonnegative(),
+  digest: z.string().regex(/^[0-9a-f]{64}$/),
+  vector_dimension: z.number().int().positive().nullable(),
+  exported_at: z.string().datetime(),
+  signature: z.string().regex(/^[0-9a-f]{64}$/),
+});
+export type SealedExportSeal = z.infer<typeof SealedExportSealSchema>;
+
+/** One staged batch: rows plus the seal they claim membership of. */
+export const SealedMemoryStageRequestSchema = z.object({
+  seal: SealedExportSealSchema,
+  batch_index: z.number().int().nonnegative(),
+  batch_count: z.number().int().positive(),
+  rows: z.array(SealedMemoryExportRowSchema).max(SHARED_MEMORY_TRANSFER_MAX_ROWS),
+});
+export type SealedMemoryStageRequest = z.infer<
+  typeof SealedMemoryStageRequestSchema
+>;
+
+/** Finalize: no rows travel here — only the ORIGINAL seal to bind against. */
+export const SealedMemoryFinalizeRequestSchema = z.object({
+  seal: SealedExportSealSchema,
+});
+export type SealedMemoryFinalizeRequest = z.infer<
+  typeof SealedMemoryFinalizeRequestSchema
+>;
+
+export const SealedMemoryTransferErrorCode = z.enum([
+  "EPOCH_NOT_FENCED",
+  "EPOCH_ALREADY_PROMOTED",
+  "SEAL_SIGNATURE_INVALID",
+  "SEAL_DIGEST_MISMATCH",
+  "BATCH_OUT_OF_ORDER",
+  "DIMENSION_UNSUPPORTED",
+  "IMPORT_ID_CONFLICT",
+  "STAGING_INCOMPLETE",
+]);
+export type SealedMemoryTransferError = z.infer<
+  typeof SealedMemoryTransferErrorCode
+>;
+
+/* ------------------------------------------------------------------ */
+/* Canonical hashing / signing (WebCrypto: workerd + node + bun)      */
+/* ------------------------------------------------------------------ */
+
+const encoder = new TextEncoder();
+
+function toHex(bytes: ArrayBuffer): string {
+  return [...new Uint8Array(bytes)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Stable per-row line: identity + content hash inputs, order-sensitive. */
+export function sharedMemoryRowLine(row: SealedMemoryExportRow): string {
+  return [
+    row.id,
+    row.created_at,
+    row.type,
+    row.entity_id ?? "",
+    row.room_id ?? "",
+    row.world_id ?? "",
+    JSON.stringify(row.content),
+    row.embedding ? JSON.stringify(row.embedding) : "",
+  ].join("|");
+}
+
+/**
+ * Order-sensitive whole-export digest: sha256 over the newline-joined row
+ * lines followed by the row count. Both sides recompute it from raw rows —
+ * the digest is derived, never trusted from the wire.
+ */
+export async function computeSharedMemoryTransferDigest(
+  rows: readonly SealedMemoryExportRow[],
+): Promise<string> {
+  const body = rows.map(sharedMemoryRowLine).join("\n") + `\ncount:${rows.length}`;
+  return toHex(await crypto.subtle.digest("SHA-256", encoder.encode(body)));
+}
+
+/** Canonical signing payload — every seal field except the signature. */
+export function sealSigningPayload(
+  seal: Omit<SealedExportSeal, "signature">,
+): string {
+  return [
+    `v:${seal.version}`,
+    `epoch:${seal.epoch}`,
+    `agent:${seal.source_agent_id}`,
+    `scope:${seal.scope}`,
+    `count:${seal.row_count}`,
+    `digest:${seal.digest}`,
+    `dim:${seal.vector_dimension ?? "none"}`,
+    `at:${seal.exported_at}`,
+  ].join("|");
+}
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+export async function signSeal(
+  seal: Omit<SealedExportSeal, "signature">,
+  secret: string,
+): Promise<string> {
+  const key = await hmacKey(secret);
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(sealSigningPayload(seal)),
+  );
+  return toHex(sig);
+}
+
+/** Constant-time verification via WebCrypto's own verify. */
+export async function verifySealSignature(
+  seal: SealedExportSeal,
+  secret: string,
+): Promise<boolean> {
+  const { signature, ...body } = seal;
+  const key = await hmacKey(secret);
+  const sigBytes = new Uint8Array(
+    (signature.match(/.{2}/g) ?? []).map((h) => parseInt(h, 16)),
+  );
+  return crypto.subtle.verify(
+    "HMAC",
+    key,
+    sigBytes,
+    encoder.encode(sealSigningPayload(body)),
+  );
+}

--- a/packages/shared/src/contracts/shared-memory-transfer.ts
+++ b/packages/shared/src/contracts/shared-memory-transfer.ts
@@ -75,7 +75,9 @@ export const SealedMemoryStageRequestSchema = z.object({
   seal: SealedExportSealSchema,
   batch_index: z.number().int().nonnegative(),
   batch_count: z.number().int().positive(),
-  rows: z.array(SealedMemoryExportRowSchema).max(SHARED_MEMORY_TRANSFER_MAX_ROWS),
+  rows: z
+    .array(SealedMemoryExportRowSchema)
+    .max(SHARED_MEMORY_TRANSFER_MAX_ROWS),
 });
 export type SealedMemoryStageRequest = z.infer<
   typeof SealedMemoryStageRequestSchema
@@ -137,7 +139,7 @@ export function sharedMemoryRowLine(row: SealedMemoryExportRow): string {
 export async function computeSharedMemoryTransferDigest(
   rows: readonly SealedMemoryExportRow[],
 ): Promise<string> {
-  const body = rows.map(sharedMemoryRowLine).join("\n") + `\ncount:${rows.length}`;
+  const body = `${rows.map(sharedMemoryRowLine).join("\n")}\ncount:${rows.length}`;
   return toHex(await crypto.subtle.digest("SHA-256", encoder.encode(body)));
 }
 


### PR DESCRIPTION
# Relates to

#20923 (P2.5 replacement spec) — round 3 rebuilt to the #21090 exact-head architecture review.

# What changed

Shared→Dedicated memory transfer as a **fenced, epoch-bound promotion**, replacing the closed round-2 copy design. Each of the four review findings maps to a structural mechanism:

- **Write fence / promotion epoch** — new `shared_transfer_epochs` table with an `open → fenced → promoted|aborted` state machine. A **partial unique index** permits only one non-terminal epoch per (org, user, agent) scope, so concurrent opens race at the database; `SharedMemoryStore.recordTurnPair` calls the fence before any insert, so a fenced scope fails the turn commit closed instead of racing the snapshot.
- **Destination binds the ORIGINAL seal** — the export emits an HMAC-SHA256-signed whole-export seal (`{version, epoch, scope, row_count, order-sensitive digest, vector_dimension, exported_at}`; key via `ELIZA_MEMORY_TRANSFER_SEAL_KEY`, WebCrypto so the same module runs in workerd/node/bun). Finalize re-verifies the signature AND recomputes the digest **from the staged rows themselves** — a substituted or tampered seal/row set cannot pass.
- **Atomic publish/finalization** — batches land in `memory_import_staging` (invisible to the runtime; idempotent replays). `POST /api/memory/transfer/finalize` runs ONE transaction: staged rows locked `FOR UPDATE` → count+digest+signature verification → id-conflict pre-check (hash-identical skipped, differing id fails the whole request) → create-if-absent scaffolding → memories+embeddings publish → staging drain. A failed finalize leaves zero visible rows.
- **Dimension negotiation** — the seal declares the vector dimension; the destination refuses non-matching core `vector(D)` columns with typed `DIMENSION_UNSUPPORTED` (no silent re-embed/drop). pgvector literals used for the embedding columns (they are `vector(D)`, not `real[]`).

Export runs only against an already-fenced epoch, inside a REPEATABLE READ transaction, with tuple-emulated keyset pagination (`(created_at, id)`), so equal timestamps across page boundaries cannot drop rows.

# Evidence

- `shared-transfer-epochs.pglite.test.ts` (real PGlite, 6 tests): concurrent `openEpoch` ×3 → exactly one winner, losers typed conflicts; promote-before-fence and double-fence/promote rejected; fence blocks writes and abort lifts it; unfenced export refused; **503-row export across a shared-timestamp page boundary** → zero loss, digest matches recompute, signature verifies with the right key and fails with the wrong one.
- `shared-memory-store.test.ts` (+1): a fenced scope rejects `recordTurnPair` with **zero writer inserts** — fence ordering proven at the store layer.
- `memory-import-staged.test.ts` (9 tests): seal-signature trust, batch geometry, staging completeness, ORIGINAL-digest binding (tampered rows fail), dimension refusal before any DB work, id-conflict vs hash-identical-skip semantics, and the atomic ordering (scaffold/rows/vectors/drain in exactly one transaction).
- Typecheck clean in `packages/shared`, `packages/cloud/shared`, `packages/agent`; biome clean on all touched files.

# Review

Round-2 surface (#21090) was shaw's close with this spec — requesting @lalalune review; seal/HMAC surface also flagged for gauss. **Not for self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
