### PR TITLE
fix(cloud): reject malformed domains-dns-record JSON

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.json.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.json.test.ts
@@ -1,0 +1,71 @@
+/**
+ * PATCH /api/v1/apps/:id/domains/:domain/dns/:recordId used to let
+ * c.req.json() throw into failureResponse, which maps SyntaxError to 500.
+ * Malformed JSON is caller error.
+ */
+import { Hono } from "hono";
+import { describe, expect, mock, test } from "bun:test";
+
+const updateRecord = mock(async () => ({
+	id: "rec-1",
+	type: "A",
+	content: "1.2.3.4",
+}));
+
+mock.module("../../../guards", () => ({
+	loadCloudflareManagedDomain: async () => ({
+		user: { id: "user-1", organization_id: "org-1" },
+		app: { id: "app-1", organization_id: "org-1" },
+		appId: "app-1",
+		domain: {
+			domain: "example.com",
+			cloudflareZoneId: "zone-1",
+		},
+	}),
+}));
+
+mock.module("@/lib/services/cloudflare-dns", () => ({
+	cloudflareDnsService: {
+		getRecord: async () => ({ id: "rec-1" }),
+		updateRecord,
+		deleteRecord: async () => undefined,
+	},
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+	logger: { error: () => undefined, info: () => undefined },
+}));
+
+mock.module("@/lib/utils/error-handling", () => ({
+	extractErrorMessage: (error: unknown) =>
+		error instanceof Error ? error.message : String(error),
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono();
+app.route("/:recordId", route);
+
+describe("PATCH /api/v1/apps/:id/domains/:domain/dns/:recordId malformed JSON", () => {
+	test("returns 400 instead of 500 and never writes a record", async () => {
+		const response = await app.request("/rec-1", {
+			method: "PATCH",
+			headers: { "content-type": "application/json" },
+			body: "{",
+		});
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toMatchObject({
+			error: "Invalid JSON body",
+		});
+		expect(updateRecord).not.toHaveBeenCalled();
+	});
+
+	test("canonical JSON still updates a DNS record", async () => {
+		const response = await app.request("/rec-1", {
+			method: "PATCH",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ content: "1.2.3.4" }),
+		});
+		expect(response.status).toBe(200);
+		expect(updateRecord).toHaveBeenCalled();
+	});
+});

--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
@@ -64,7 +64,15 @@ app.patch("/", async (c) => {
     if ("error" in ctx)
       return c.json({ success: false, error: ctx.error }, ctx.status);
 
-    const parsed = PatchRecordSchema.safeParse(await c.req.json());
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const parsed = PatchRecordSchema.safeParse(rawBody);
     if (!parsed.success) {
       return c.json(
         {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on `PATCH /api/v1/apps/:id/domains/:domain/dns/:recordId` currently 500s. `c.req.json()` throws `SyntaxError` into `failureResponse`, which does not map parse failures to 400. Sibling of domains-dns create `#21604`. Not path encoding. Not extra-decode after `URLSearchParams.get()` (#21472 / #21482 / #21489). Not list-limit. Not cookies. Not payment (`domains/buy` stays skipped). Not #21320. Not #21385. Proof is `bun:test` of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical DNS record patches still write. Malformed `{` now 400s before Cloudflare updates instead of `SyntaxError` → `failureResponse` 500. Proven on the unfixed head: PATCH `{` received **500**. GET/DELETE are untouched.

# Background

## What does this PR do?

`PATCH /api/v1/apps/:id/domains/:domain/dns/:recordId` ran `PatchRecordSchema.safeParse(await c.req.json())` inside the route try. Hono's `c.req.json()` throws `SyntaxError` on `{`. `safeParse` never sees the body. `failureResponse` maps that to HTTP 500 / `internal_error`. This PR returns `{ error: "Invalid JSON body" }` with status 400 before schema parse or DNS writes.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical DNS patch bodies unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.json.test.ts` and the `c.req.json()` catch in the PATCH handler.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate './v1/apps/[id]/domains/[domain]/dns/[recordId]/route.json.test.ts'
```

Unfixed head: `PATCH …/dns/:recordId` with body `{` returned **500**. After the fix: 2 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:88bc1e54fda1291359f34baa1900f261304319f4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the DNS record HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before Cloudflare writes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that a canonical patch still updates.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches Cloudflare.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on DNS record JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and a canonical patch still updates.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the DNS record HTTP boundary.

## Audio / voice walkthrough

N/A - JSON PATCH only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
