### PR TITLE
fix(scheduling): boot installers wait for the deferred scheduling runner

### DIFF
--- a/plugins/plugin-calendar/src/service/CalendarService.ts
+++ b/plugins/plugin-calendar/src/service/CalendarService.ts
@@ -28,9 +28,10 @@ import {
   GoogleCalendarMutationError,
   GoogleCalendarSyncTokenExpiredError,
 } from "@elizaos/plugin-google-workspace/calendar";
-import type {
-  DispatchResult,
-  ScheduledTaskDispatchRecord,
+import {
+  type DispatchResult,
+  type ScheduledTaskDispatchRecord,
+  waitForScheduledTaskRunnerService,
 } from "@elizaos/plugin-scheduling";
 import type {
   CreateLifeOpsCalendarEventAttendee,
@@ -1188,18 +1189,7 @@ export class CalendarService extends Service {
 
   private async installGoogleWatchMaintenanceOnBoot(): Promise<void> {
     try {
-      await this.runtime.initPromise;
-      // The scheduling runner registers DEFERRED, after initPromise resolves;
-      // installing immediately raced it at every boot and watch maintenance
-      // silently stayed uninstalled (live 2026-08-17). Bounded poll, then
-      // install; if the runner never appears the existing catch reports it.
-      const deadline = Date.now() + 30_000;
-      while (
-        !this.runtime.hasService("lifeops_scheduled_task_runner") &&
-        Date.now() < deadline
-      ) {
-        await new Promise((resolve) => setTimeout(resolve, 250));
-      }
+      await waitForScheduledTaskRunnerService(this.runtime);
       await this.googleWatch.installMaintenanceTask();
     } catch (error) {
       // error-policy:J5 Service.start launches maintenance installation in the

--- a/plugins/plugin-calendar/src/service/CalendarService.ts
+++ b/plugins/plugin-calendar/src/service/CalendarService.ts
@@ -1189,6 +1189,17 @@ export class CalendarService extends Service {
   private async installGoogleWatchMaintenanceOnBoot(): Promise<void> {
     try {
       await this.runtime.initPromise;
+      // The scheduling runner registers DEFERRED, after initPromise resolves;
+      // installing immediately raced it at every boot and watch maintenance
+      // silently stayed uninstalled (live 2026-08-17). Bounded poll, then
+      // install; if the runner never appears the existing catch reports it.
+      const deadline = Date.now() + 30_000;
+      while (
+        !this.runtime.hasService("lifeops_scheduled_task_runner") &&
+        Date.now() < deadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
       await this.googleWatch.installMaintenanceTask();
     } catch (error) {
       // error-policy:J5 Service.start launches maintenance installation in the

--- a/plugins/plugin-calendar/test/google-calendar-watch.pglite.test.ts
+++ b/plugins/plugin-calendar/test/google-calendar-watch.pglite.test.ts
@@ -350,6 +350,7 @@ async function createHarness(
     google?: FakeGoogleCalendar;
     initialize?: boolean;
     webhookEnabled?: boolean;
+    calendarBeforeScheduling?: boolean;
   } = {},
 ): Promise<Harness> {
   const pg = args.pg ?? new PGlite();
@@ -385,6 +386,12 @@ async function createHarness(
       if (name === ScheduledTaskRunnerService.serviceType) return scheduling;
       return null;
     },
+    hasService: (name: string) =>
+      name === ScheduledTaskRunnerService.serviceType && scheduling !== null,
+    getServiceRegistrationStatus: (name: string) =>
+      name === ScheduledTaskRunnerService.serviceType && scheduling !== null
+        ? "registered"
+        : "unknown",
     getServiceLoadPromise: async (name: string) => {
       if (name === "calendar") return calendar;
       if (name === ScheduledTaskRunnerService.serviceType) return scheduling;
@@ -401,8 +408,17 @@ async function createHarness(
     },
   } as unknown as IAgentRuntime;
 
-  scheduling = await ScheduledTaskRunnerService.start(runtime);
-  calendar = await CalendarService.start(runtime);
+  if (args.calendarBeforeScheduling) {
+    calendar = await CalendarService.start(runtime);
+    // Let the detached boot installer observe the missing deferred declaration
+    // before the real runner is made available.
+    await Promise.resolve();
+    await Promise.resolve();
+    scheduling = await ScheduledTaskRunnerService.start(runtime);
+  } else {
+    scheduling = await ScheduledTaskRunnerService.start(runtime);
+    calendar = await CalendarService.start(runtime);
+  }
   const gate: CalendarHostGate = {
     getGoogleConnectorAccounts: async () => [status(grant(ACCOUNT_ID))],
     resolveGuestAvailabilityGrants: async () => {
@@ -489,7 +505,7 @@ async function waitForMaintenanceTask(harness: Harness): Promise<string> {
   const runner = getScheduledTaskRunner(harness.runtime, {
     agentId: AGENT_ID,
   });
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
     const tasks = await runner.list({ kind: "watcher" });
     const maintenance = tasks.find(
       (task) => task.metadata?.calendarGoogleWatchOperation === "maintenance",
@@ -529,6 +545,27 @@ describe("Google Calendar push lifecycle", { timeout: 30_000 }, () => {
       const harness = harnesses.pop();
       if (harness) await harness.close();
     }
+  });
+
+  it("installs one maintenance task when Calendar starts before the deferred runner", async () => {
+    const harness = await createHarness({ calendarBeforeScheduling: true });
+    harnesses.push(harness);
+
+    const maintenanceTaskId = await waitForMaintenanceTask(harness);
+    const tasks = await getScheduledTaskRunner(harness.runtime, {
+      agentId: AGENT_ID,
+    }).list({ kind: "watcher" });
+    const maintenanceTasks = tasks.filter(
+      (task) => task.metadata?.calendarGoogleWatchOperation === "maintenance",
+    );
+
+    expect(maintenanceTasks.map((task) => task.taskId)).toEqual([
+      maintenanceTaskId,
+    ]);
+    expect(harness.reportError).not.toHaveBeenCalledWith(
+      "calendar:google-watch-install",
+      expect.anything(),
+    );
   });
 
   it("does not create or accept push channels when the webhook is disabled", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/family-communications/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/family-communications/service.ts
@@ -13,7 +13,7 @@ import { type IAgentRuntime, Service } from "@elizaos/core";
 import {
   type ScheduledTask,
   type ScheduledTaskRunnerHandle,
-  ScheduledTaskRunnerService,
+  waitForScheduledTaskRunnerService,
 } from "@elizaos/plugin-scheduling";
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 import {
@@ -1088,23 +1088,7 @@ export class FamilyCommunicationsRuntimeService extends Service {
       runtime.getServiceLoadPromise(
         FAMILY_COMMUNICATIONS_SPEAKER_VERIFIER_SERVICE,
       ),
-      // The scheduling plugin registers DEFERRED (its runner appears seconds
-      // after this service starts); both the bare load-promise and the
-      // exported one-microtask waiter reject before it exists, which failed
-      // this service at every boot on the live box. Poll registration for a
-      // bounded window, then take the load promise.
-      (async () => {
-        const deadline = Date.now() + 30_000;
-        while (
-          !runtime.hasService(ScheduledTaskRunnerService.serviceType) &&
-          Date.now() < deadline
-        ) {
-          await new Promise((resolve) => setTimeout(resolve, 250));
-        }
-        return runtime.getServiceLoadPromise(
-          ScheduledTaskRunnerService.serviceType,
-        );
-      })(),
+      waitForScheduledTaskRunnerService(runtime),
     ]);
     const service = new FamilyCommunicationsRuntimeService(runtime);
     await service.family.initialize();

--- a/plugins/plugin-personal-assistant/src/lifeops/family-communications/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/family-communications/service.ts
@@ -1088,7 +1088,23 @@ export class FamilyCommunicationsRuntimeService extends Service {
       runtime.getServiceLoadPromise(
         FAMILY_COMMUNICATIONS_SPEAKER_VERIFIER_SERVICE,
       ),
-      runtime.getServiceLoadPromise(ScheduledTaskRunnerService.serviceType),
+      // The scheduling plugin registers DEFERRED (its runner appears seconds
+      // after this service starts); both the bare load-promise and the
+      // exported one-microtask waiter reject before it exists, which failed
+      // this service at every boot on the live box. Poll registration for a
+      // bounded window, then take the load promise.
+      (async () => {
+        const deadline = Date.now() + 30_000;
+        while (
+          !runtime.hasService(ScheduledTaskRunnerService.serviceType) &&
+          Date.now() < deadline
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+        return runtime.getServiceLoadPromise(
+          ScheduledTaskRunnerService.serviceType,
+        );
+      })(),
     ]);
     const service = new FamilyCommunicationsRuntimeService(runtime);
     await service.family.initialize();

--- a/plugins/plugin-personal-assistant/src/lifeops/household/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/service.ts
@@ -3048,7 +3048,23 @@ export class HouseholdCoordinationRuntimeService extends Service {
   ): Promise<HouseholdCoordinationRuntimeService> {
     await Promise.all([
       runtime.getServiceLoadPromise(KNOWLEDGE_GRAPH_SERVICE),
-      runtime.getServiceLoadPromise(ScheduledTaskRunnerService.serviceType),
+      // The scheduling plugin registers DEFERRED (its runner appears seconds
+      // after this service starts); both the bare load-promise and the
+      // exported one-microtask waiter reject before it exists, which failed
+      // this service at every boot on the live box. Poll registration for a
+      // bounded window, then take the load promise.
+      (async () => {
+        const deadline = Date.now() + 30_000;
+        while (
+          !runtime.hasService(ScheduledTaskRunnerService.serviceType) &&
+          Date.now() < deadline
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+        return runtime.getServiceLoadPromise(
+          ScheduledTaskRunnerService.serviceType,
+        );
+      })(),
     ]);
     const service = new HouseholdCoordinationRuntimeService(runtime);
     await service.coordination.reconcileGrantExpiryWarnings();

--- a/plugins/plugin-personal-assistant/src/lifeops/household/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/service.ts
@@ -15,7 +15,7 @@ import { type IAgentRuntime, Service } from "@elizaos/core";
 import {
   getScheduledTaskRunner,
   type ScheduledTaskRunnerHandle,
-  ScheduledTaskRunnerService,
+  waitForScheduledTaskRunnerService,
 } from "@elizaos/plugin-scheduling";
 import {
   type Entity,
@@ -3048,23 +3048,7 @@ export class HouseholdCoordinationRuntimeService extends Service {
   ): Promise<HouseholdCoordinationRuntimeService> {
     await Promise.all([
       runtime.getServiceLoadPromise(KNOWLEDGE_GRAPH_SERVICE),
-      // The scheduling plugin registers DEFERRED (its runner appears seconds
-      // after this service starts); both the bare load-promise and the
-      // exported one-microtask waiter reject before it exists, which failed
-      // this service at every boot on the live box. Poll registration for a
-      // bounded window, then take the load promise.
-      (async () => {
-        const deadline = Date.now() + 30_000;
-        while (
-          !runtime.hasService(ScheduledTaskRunnerService.serviceType) &&
-          Date.now() < deadline
-        ) {
-          await new Promise((resolve) => setTimeout(resolve, 250));
-        }
-        return runtime.getServiceLoadPromise(
-          ScheduledTaskRunnerService.serviceType,
-        );
-      })(),
+      waitForScheduledTaskRunnerService(runtime),
     ]);
     const service = new HouseholdCoordinationRuntimeService(runtime);
     await service.coordination.reconcileGrantExpiryWarnings();

--- a/plugins/plugin-personal-assistant/src/lifeops/runtime-service-startup.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/runtime-service-startup.pglite.integration.test.ts
@@ -2,6 +2,8 @@
  * Verifies dependency-aware LifeOps service startup through a real AgentRuntime
  * and PGlite while plugin services leave the shared init barrier concurrently.
  */
+
+import { ScheduledTaskRunnerService } from "@elizaos/plugin-scheduling";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createLifeOpsTestRuntime } from "../../test/helpers/runtime.js";
 import {
@@ -31,6 +33,7 @@ describe("LifeOps concurrent runtime-service startup", () => {
   });
 
   it("starts every graph-dependent service once and keeps it registered", async () => {
+    const runnerStart = vi.spyOn(ScheduledTaskRunnerService, "start");
     const householdStart = vi.spyOn(
       HouseholdCoordinationRuntimeService,
       "start",
@@ -46,6 +49,11 @@ describe("LifeOps concurrent runtime-service startup", () => {
     const runtimeResult = await createLifeOpsTestRuntime();
     try {
       const expectations = [
+        {
+          serviceType: ScheduledTaskRunnerService.serviceType,
+          serviceClass: ScheduledTaskRunnerService,
+          start: runnerStart,
+        },
         {
           serviceType: HOUSEHOLD_COORDINATION_SERVICE,
           serviceClass: HouseholdCoordinationRuntimeService,

--- a/plugins/plugin-scheduling/src/plugin.test.ts
+++ b/plugins/plugin-scheduling/src/plugin.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ScheduledTaskRunnerService } from "./scheduled-task/runner-service.js";
 
 const mocks = vi.hoisted(() => ({
@@ -58,6 +58,7 @@ function buildRuntime(overrides: Record<string, unknown> = {}): IAgentRuntime {
     agentId: "agent-1",
     initPromise: Promise.resolve(),
     hasService: () => true,
+    getServiceRegistrationStatus: () => "registered",
     getServiceLoadPromise: vi.fn(async () => ({})),
     getTaskWorker: () => undefined,
     registerTaskWorker: vi.fn(),
@@ -81,28 +82,87 @@ describe("scheduling plugin boot", () => {
     mocks.seedPacks.mockResolvedValue({ seeded: [], skipped: [] });
   });
 
-  it("waits one microtask for the plugin's own service declaration to register", async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits across a delayed deferred declaration before loading the service", async () => {
+    vi.useFakeTimers();
     let registered = false;
     const service = {} as ScheduledTaskRunnerService;
-    const getServiceLoadPromise = vi.fn(async () => {
-      if (!registered) throw new Error("service loaded before registration");
-      return service;
-    });
+    const getServiceLoadPromise = vi.fn(async () => service);
     const runtime = {
       initPromise: Promise.resolve(),
       hasService: () => registered,
+      getServiceRegistrationStatus: () =>
+        registered ? "registered" : "unknown",
       getServiceLoadPromise,
     } as unknown as IAgentRuntime;
 
-    const load = waitForScheduledTaskRunnerService(runtime);
-    await Promise.resolve();
+    const load = waitForScheduledTaskRunnerService(runtime, {
+      registrationTimeoutMs: 1_000,
+      registrationPollMs: 100,
+    });
+    await vi.advanceTimersByTimeAsync(200);
     expect(getServiceLoadPromise).not.toHaveBeenCalled();
 
     registered = true;
+    await vi.advanceTimersByTimeAsync(100);
     await expect(load).resolves.toBe(service);
     expect(getServiceLoadPromise).toHaveBeenCalledWith(
       MockedRunnerService.serviceType,
     );
+  });
+
+  it("fails at the bounded deadline when the declaration never registers", async () => {
+    vi.useFakeTimers();
+    const getServiceLoadPromise = vi.fn();
+    const runtime = {
+      initPromise: Promise.resolve(),
+      hasService: () => false,
+      getServiceRegistrationStatus: () => "unknown",
+      getServiceLoadPromise,
+    } as unknown as IAgentRuntime;
+
+    const load = waitForScheduledTaskRunnerService(runtime, {
+      registrationTimeoutMs: 1_000,
+      registrationPollMs: 100,
+    });
+    const outcome = expect(load).rejects.toMatchObject({
+      code: "SCHEDULED_TASK_RUNNER_REGISTRATION_TIMEOUT",
+      context: expect.objectContaining({ timeoutMs: 1_000 }),
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await outcome;
+    expect(getServiceLoadPromise).not.toHaveBeenCalled();
+  });
+
+  it("fails immediately when the runtime reports failed registration", async () => {
+    vi.useFakeTimers();
+    let status: "unknown" | "failed" = "unknown";
+    const getServiceLoadPromise = vi.fn();
+    const runtime = {
+      initPromise: Promise.resolve(),
+      hasService: () => false,
+      getServiceRegistrationStatus: () => status,
+      getServiceLoadPromise,
+    } as unknown as IAgentRuntime;
+
+    const load = waitForScheduledTaskRunnerService(runtime, {
+      registrationTimeoutMs: 1_000,
+      registrationPollMs: 100,
+    });
+    const outcome = expect(load).rejects.toMatchObject({
+      code: "SCHEDULED_TASK_RUNNER_REGISTRATION_FAILED",
+      context: expect.objectContaining({ status: "failed" }),
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    status = "failed";
+    await vi.advanceTimersByTimeAsync(100);
+
+    await outcome;
+    expect(getServiceLoadPromise).not.toHaveBeenCalled();
   });
 
   it("does not seed at init; seeding waits for the runner boot hook", async () => {

--- a/plugins/plugin-scheduling/src/plugin.ts
+++ b/plugins/plugin-scheduling/src/plugin.ts
@@ -7,7 +7,12 @@
  * runner. Each runtime keeps one runner service, one injected deps set, and one
  * scheduled-task REST route.
  */
-import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
+import {
+  ElizaError,
+  type IAgentRuntime,
+  logger,
+  type Plugin,
+} from "@elizaos/core";
 import { buildSchedulingRoutes } from "./routes/plugin-routes.js";
 import { schedulingDbSchema } from "./scheduled-task/db-schema.js";
 import { buildFallbackDefaultPack } from "./scheduled-task/default-pack.js";
@@ -28,21 +33,91 @@ import {
   registerStandaloneTickWorker,
 } from "./scheduled-task/standalone-tick.js";
 
+export const SCHEDULED_TASK_RUNNER_REGISTRATION_TIMEOUT =
+  "SCHEDULED_TASK_RUNNER_REGISTRATION_TIMEOUT";
+export const SCHEDULED_TASK_RUNNER_REGISTRATION_FAILED =
+  "SCHEDULED_TASK_RUNNER_REGISTRATION_FAILED";
+
+const DEFAULT_RUNNER_REGISTRATION_TIMEOUT_MS = 30_000;
+const DEFAULT_RUNNER_REGISTRATION_POLL_MS = 250;
+
+export interface WaitForScheduledTaskRunnerServiceOptions {
+  registrationTimeoutMs?: number;
+  registrationPollMs?: number;
+}
+
+function requireDuration(
+  value: number | undefined,
+  fallback: number,
+  name: string,
+  allowZero: boolean,
+): number {
+  const duration = value ?? fallback;
+  if (
+    !Number.isFinite(duration) ||
+    !Number.isInteger(duration) ||
+    duration < (allowZero ? 0 : 1)
+  ) {
+    throw new ElizaError(`${name} must be a finite integer in milliseconds`, {
+      code: "SCHEDULED_TASK_RUNNER_WAIT_INVALID",
+      context: { name, value: duration },
+    });
+  }
+  return duration;
+}
+
+/**
+ * Wait for the deferred runner declaration before asking the runtime to load
+ * it. Registration failure is observed immediately; missing registration is
+ * bounded so dependent service startup cannot hang indefinitely.
+ */
 export async function waitForScheduledTaskRunnerService(
   runtime: IAgentRuntime,
+  options: WaitForScheduledTaskRunnerServiceOptions = {},
 ): Promise<ScheduledTaskRunnerService> {
   await runtime.initPromise;
 
-  if (!runtime.hasService(ScheduledTaskRunnerService.serviceType)) {
-    // `registerPlugin` awaits `init()` before recording the same plugin's
-    // service classes. When a plugin is loaded after runtime init, the
-    // already-resolved initPromise can resume this seeder one microtask before
-    // the registerPlugin continuation registers ScheduledTaskRunnerService.
-    await Promise.resolve();
+  const serviceType = ScheduledTaskRunnerService.serviceType;
+  const timeoutMs = requireDuration(
+    options.registrationTimeoutMs,
+    DEFAULT_RUNNER_REGISTRATION_TIMEOUT_MS,
+    "registrationTimeoutMs",
+    true,
+  );
+  const pollMs = requireDuration(
+    options.registrationPollMs,
+    DEFAULT_RUNNER_REGISTRATION_POLL_MS,
+    "registrationPollMs",
+    false,
+  );
+  const deadline = Date.now() + timeoutMs;
+
+  while (!runtime.hasService(serviceType)) {
+    const status = runtime.getServiceRegistrationStatus(serviceType);
+    if (status === "failed") {
+      throw new ElizaError("Scheduled task runner registration failed", {
+        code: SCHEDULED_TASK_RUNNER_REGISTRATION_FAILED,
+        context: { serviceType, status },
+      });
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      throw new ElizaError(
+        "Scheduled task runner was not registered before the startup deadline",
+        {
+          code: SCHEDULED_TASK_RUNNER_REGISTRATION_TIMEOUT,
+          context: { serviceType, status, timeoutMs },
+        },
+      );
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(pollMs, remainingMs)),
+    );
   }
 
   return (await runtime.getServiceLoadPromise(
-    ScheduledTaskRunnerService.serviceType,
+    serviceType,
   )) as ScheduledTaskRunnerService;
 }
 


### PR DESCRIPTION
# Relates to

No linked issue — this repairs the deferred scheduling-runner boot race reported and reviewed on this PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`b4a86483b0416ab882d4c8e229a8ac535fab6338` at repair time).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the changed readiness contract from the exact-head deterministic harness and typecheck evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `b4a86483b0416ab882d4c8e229a8ac535fab6338`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact limitation is documented in **Known gaps / failures** below.

# Risks

Low to medium. The change centralizes startup waiting in plugin-scheduling and affects calendar, household, and family-communications service startup. The wait is bounded (30 seconds by default), observes an explicit failed registration immediately, and preserves each consumer's existing boundary error handling.

# Background

## What does this PR do?

`ScheduledTaskRunnerService` is declared after `runtime.initPromise` resolves. Boot-time consumers could ask the runtime to load it before the declaration existed. The repaired implementation:

- owns one canonical `waitForScheduledTaskRunnerService` helper in plugin-scheduling;
- waits for declaration with a bounded timeout and explicit failed-registration observation;
- uses that helper from calendar, household, and family-communications instead of three duplicated polling loops;
- adds deterministic timeout/failure/delayed-registration coverage and consumer regressions.

## What kind of change is this?

Bug fix (non-breaking) plus test coverage.

# Documentation changes needed?

N/A — no public configuration or user workflow changed; the helper documents its startup contract at the exported API.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-scheduling/src/plugin.ts`, then the three consumers and their exact-head tests.

## Detailed testing steps

Exact repaired head: `d1aedfe7d4f796066a774af316050db73075d93a`.

1. Run `bun run --cwd plugins/plugin-scheduling typecheck`.
2. Run `bun run --cwd plugins/plugin-calendar typecheck`.
3. Run `bun run --cwd plugins/plugin-scheduling test -- src/plugin.test.ts` in a full installed checkout.
4. Run the calendar and personal-assistant focused regression files in a full installed checkout.

Repair-lane results in a network-denied, write-confined disposable sandbox:

```text
PASS direct helper harness: delayed registration, bounded timeout, observable failed registration
$ bun run --cwd plugins/plugin-scheduling typecheck
$ tsc --noEmit -p tsconfig.json
PASS
$ bun run --cwd plugins/plugin-calendar typecheck
$ tsc --noEmit
PASS
$ biome check <7 exact changed files>
Checked 7 files in 118ms. No fixes applied.
$ git diff --check origin/develop...HEAD
PASS
```

# Evidence Gate

<!-- evidence-head:d1aedfe7d4f796066a774af316050db73075d93a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is an internal service-startup contract with no visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - the repair lane used a deterministic service-registration harness, not a deployed backend.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent scheduled item or database schema changed; the exact-head harness result is recorded under Testing.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no deployed backend or frontend evidence was produced in this repair lane. Exact deterministic output is included under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice change.

## Known gaps / failures

- `bun install` and root `bun run verify` were not run: the repair used a sparse disposable clone with read-only dependency artifacts specifically to keep untrusted PR execution network-denied and isolated from the shared checkout. Full-checkout CI/reviewer gates remain required before merge.
- The broad scheduling Vitest file did not reach test collection in the sparse harness because its linked `@elizaos/core/edge` generated/build artifact was absent; both attempts ended with zero tests collected and no assertion failure. The exact helper behavior was instead exercised directly at the repaired head.
- Personal-assistant package typecheck was not usable in that sparse harness because omitted workspace packages/generated artifacts produced unrelated module-resolution and stale-source errors. Scheduling and calendar package typechecks passed.
- No deployment or live restart was performed. The original description's live-boot claim was not independently reproduced by this repair lane.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nubscarson-pr21634-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza"} -->
