### PR TITLE
fix(core): stage-1 shell and coding candidate inventions resolve to their real umbrellas

### DIFF
--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -801,12 +801,10 @@ describe("action catalogue and retrieval", () => {
 		}
 	});
 
-	// Coding/repo-shaped invented names route to the TASKS coding umbrella —
-	// both the explicit spellings stage-1 emits live (tj-79876bf0f950e8) and
-	// the heuristic git-surface family, which must win before the view
-	// heuristic (CODE_PR_CREATE's CREATE token otherwise reads as a generated
-	// view capability and repo work misroutes to VIEWS).
-	it("routes coding candidates to TASKS ahead of the view heuristic", () => {
+	// Observed coding/repo inventions route to the TASKS coding umbrella. Keep
+	// this mapping explicit: generic CODE, PR, COMMIT, and BRANCH tokens are
+	// ambiguous and must not admit the coding surface on their own.
+	it("routes observed coding candidates to TASKS without broad token guessing", () => {
 		for (const candidate of [
 			"CODE_EDIT",
 			"CODE_PR_CREATE",
@@ -820,10 +818,17 @@ describe("action catalogue and retrieval", () => {
 		]) {
 			expect(parentAliasesForCandidateAction(candidate)).toEqual(["TASKS"]);
 		}
-		// QR guard: scan/generate-a-code names are not repo work.
-		expect(parentAliasesForCandidateAction("SCAN_QR_CODE")).not.toEqual([
-			"TASKS",
-		]);
+		for (const unrelatedCandidate of [
+			"SCAN_QR_CODE",
+			"READ_ERROR_CODE",
+			"BANK_BRANCH",
+			"PUBLIC_RELATIONS_PR",
+			"COMMITMENT_STATUS",
+		]) {
+			expect(parentAliasesForCandidateAction(unrelatedCandidate)).not.toContain(
+				"TASKS",
+			);
+		}
 	});
 
 	// Habit/reminder-shaped invented names must hint the owner-life umbrella AND

--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -801,6 +801,31 @@ describe("action catalogue and retrieval", () => {
 		}
 	});
 
+	// Coding/repo-shaped invented names route to the TASKS coding umbrella —
+	// both the explicit spellings stage-1 emits live (tj-79876bf0f950e8) and
+	// the heuristic git-surface family, which must win before the view
+	// heuristic (CODE_PR_CREATE's CREATE token otherwise reads as a generated
+	// view capability and repo work misroutes to VIEWS).
+	it("routes coding candidates to TASKS ahead of the view heuristic", () => {
+		for (const candidate of [
+			"CODE_EDIT",
+			"CODE_PR_CREATE",
+			"CREATE_PR",
+			"OPEN_PULL_REQUEST",
+			"FIX_BUG",
+			"UPDATE_REPO_README",
+			"GITHUB_ISSUE_FIX",
+			"COMMIT_CHANGES",
+			"CREATE_BRANCH",
+		]) {
+			expect(parentAliasesForCandidateAction(candidate)).toEqual(["TASKS"]);
+		}
+		// QR guard: scan/generate-a-code names are not repo work.
+		expect(parentAliasesForCandidateAction("SCAN_QR_CODE")).not.toEqual([
+			"TASKS",
+		]);
+	});
+
 	// Habit/reminder-shaped invented names must hint the owner-life umbrella AND
 	// the TRIGGER scheduler, so deployments without plugin-personal-assistant
 	// keep the only real scheduled-work capability on the planner surface.

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -280,6 +280,10 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	CREATE_PULL_REQUEST: ["TASKS"],
 	OPEN_PULL_REQUEST: ["TASKS"],
 	GITHUB_PR: ["TASKS"],
+	UPDATE_REPO_README: ["TASKS"],
+	GITHUB_ISSUE_FIX: ["TASKS"],
+	COMMIT_CHANGES: ["TASKS"],
+	CREATE_BRANCH: ["TASKS"],
 	// Finance-shaped candidates: OWNER_FINANCES declares only one simile
 	// ("FINANCES"), so the common Stage-1 inventions need explicit hints.
 	FINANCE: ["OWNER_FINANCES"],
@@ -1146,13 +1150,6 @@ export function parentAliasesForCandidateAction(actionName: string): string[] {
 	if (looksLikeSettingsPermissionCandidateAction(normalized)) {
 		return ["SETTINGS"];
 	}
-	// Coding/repo-shaped names route to the TASKS umbrella before the view
-	// heuristics get a chance to claim them: git-surface tokens plus a view
-	// operation (CODE_PR_CREATE, UPDATE_REPO_README) otherwise read as a
-	// "generated capability" and misroute repo work to the views catalog.
-	if (looksLikeCodingCandidateAction(normalized)) {
-		return ["TASKS"];
-	}
 	const aliases: string[] = [];
 	if (looksLikeViewCandidateAction(normalized)) {
 		aliases.push("VIEWS");
@@ -1258,30 +1255,6 @@ function looksLikeSettingsPermissionCandidateAction(
 		tokens.has("ACCESS") &&
 		hasAnyToken(tokens, SETTINGS_PERMISSION_NAMESPACE_TOKENS);
 	return namesAPermission || namesAScopedAccess;
-}
-
-// Git-surface vocabulary. CODE is included but guarded against QR_CODE-style
-// names; generic verbs (PULL, MERGE, CREATE) are deliberately absent — bare
-// verbs collide with contact/view inventions (MERGE_CONTACTS) and only the
-// surface nouns are unambiguous.
-const CODING_SURFACE_TOKENS = new Set([
-	"CODE",
-	"CODING",
-	"REPO",
-	"REPOSITORY",
-	"GITHUB",
-	"PR",
-	"COMMIT",
-	"BRANCH",
-]);
-
-function looksLikeCodingCandidateAction(
-	normalizedActionName: string,
-): boolean {
-	if (!normalizedActionName) return false;
-	const tokens = new Set(normalizedActionName.split(/_+/).filter(Boolean));
-	if (tokens.has("QR")) return false;
-	return hasAnyToken(tokens, CODING_SURFACE_TOKENS);
 }
 
 function looksLikeViewCandidateAction(normalizedActionName: string): boolean {

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -195,6 +195,15 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	TERMINAL_COMMAND: ["SHELL", "TERMINAL_SHELL"],
 	TERMINAL: ["SHELL", "TERMINAL_SHELL"],
 	RUN_COMMAND: ["SHELL", "TERMINAL_SHELL"],
+	// "write X and run it" asks: stage-1 invents EXEC/EXECUTE spellings the
+	// simile table does not carry; unresolved, the planner ran toolless and
+	// answered with unexecuted code (live 2026-08-17: a "run this python
+	// one-liner" ask returned the code, never the output).
+	EXEC_COMMAND: ["SHELL", "TERMINAL_SHELL"],
+	EXECUTE_COMMAND: ["SHELL", "TERMINAL_SHELL"],
+	EXEC: ["SHELL", "TERMINAL_SHELL"],
+	RUN_SCRIPT: ["SHELL", "TERMINAL_SHELL"],
+	RUN_PYTHON: ["SHELL", "TERMINAL_SHELL"],
 	// Todo-shaped candidates hint BOTH todo owners: the personal-assistant
 	// umbrella and plugin-todos' TODO parent. Deployments load one or the
 	// other; the resolver keeps whichever is registered. Without these the
@@ -245,6 +254,32 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	CREATE_ALARM: ["OWNER_ALARMS", "TRIGGER"],
 	ALARM_CREATE: ["OWNER_ALARMS", "TRIGGER"],
 	WAKE_ME_UP: ["OWNER_ALARMS", "TRIGGER"],
+	// Coding/repo-shaped candidates bind to the TASKS coding umbrella. Stage-1
+	// invents CODE_*/PR spellings for repo asks ("add a one-line description to
+	// the readme and put up a pr" → CODE_EDIT + CODE_PR_CREATE, live
+	// tj-79876bf0f950e8): CODE_EDIT resolved to nothing while CODE_PR_CREATE's
+	// CREATE token tripped the view heuristic into VIEWS, so the planner surface
+	// carried no coding tool and the turn ended on a bare re-ack — the promised
+	// PR never started. TASKS owns repo work end-to-end (clone, commits, push,
+	// PR), so the intent hint routes there; admission still passes through
+	// appendIfAllowed's role/context gates.
+	CODE_EDIT: ["TASKS"],
+	CODE_CHANGE: ["TASKS"],
+	CODE_WRITE: ["TASKS"],
+	EDIT_CODE: ["TASKS"],
+	WRITE_CODE: ["TASKS"],
+	CODE_FIX: ["TASKS"],
+	FIX_CODE: ["TASKS"],
+	FIX_BUG: ["TASKS"],
+	CODE_PR_CREATE: ["TASKS"],
+	CREATE_PR: ["TASKS"],
+	OPEN_PR: ["TASKS"],
+	SUBMIT_PR: ["TASKS"],
+	PR_CREATE: ["TASKS"],
+	PULL_REQUEST: ["TASKS"],
+	CREATE_PULL_REQUEST: ["TASKS"],
+	OPEN_PULL_REQUEST: ["TASKS"],
+	GITHUB_PR: ["TASKS"],
 	// Finance-shaped candidates: OWNER_FINANCES declares only one simile
 	// ("FINANCES"), so the common Stage-1 inventions need explicit hints.
 	FINANCE: ["OWNER_FINANCES"],
@@ -1111,6 +1146,13 @@ export function parentAliasesForCandidateAction(actionName: string): string[] {
 	if (looksLikeSettingsPermissionCandidateAction(normalized)) {
 		return ["SETTINGS"];
 	}
+	// Coding/repo-shaped names route to the TASKS umbrella before the view
+	// heuristics get a chance to claim them: git-surface tokens plus a view
+	// operation (CODE_PR_CREATE, UPDATE_REPO_README) otherwise read as a
+	// "generated capability" and misroute repo work to the views catalog.
+	if (looksLikeCodingCandidateAction(normalized)) {
+		return ["TASKS"];
+	}
 	const aliases: string[] = [];
 	if (looksLikeViewCandidateAction(normalized)) {
 		aliases.push("VIEWS");
@@ -1216,6 +1258,30 @@ function looksLikeSettingsPermissionCandidateAction(
 		tokens.has("ACCESS") &&
 		hasAnyToken(tokens, SETTINGS_PERMISSION_NAMESPACE_TOKENS);
 	return namesAPermission || namesAScopedAccess;
+}
+
+// Git-surface vocabulary. CODE is included but guarded against QR_CODE-style
+// names; generic verbs (PULL, MERGE, CREATE) are deliberately absent — bare
+// verbs collide with contact/view inventions (MERGE_CONTACTS) and only the
+// surface nouns are unambiguous.
+const CODING_SURFACE_TOKENS = new Set([
+	"CODE",
+	"CODING",
+	"REPO",
+	"REPOSITORY",
+	"GITHUB",
+	"PR",
+	"COMMIT",
+	"BRANCH",
+]);
+
+function looksLikeCodingCandidateAction(
+	normalizedActionName: string,
+): boolean {
+	if (!normalizedActionName) return false;
+	const tokens = new Set(normalizedActionName.split(/_+/).filter(Boolean));
+	if (tokens.has("QR")) return false;
+	return hasAnyToken(tokens, CODING_SURFACE_TOKENS);
 }
 
 function looksLikeViewCandidateAction(normalizedActionName: string): boolean {


### PR DESCRIPTION
# Relates to

Addresses the Stage-1 candidate-routing failures documented by live trajectory `tj-79876bf0f950e8`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` at the evidence head.
- [x] The focused routing suites were rerun on the exact head in a credential-free, network-denied sandbox.
- [x] Broad token guessing was removed after review; only observed, explicit aliases can admit the TASKS coding surface.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `a844083690bb729f43fdca30602a991880b8d5c4` with zero conflicts.

# Risks

Low. Candidate aliases only affect catalogue retrieval; the normal role, context, and action-admission gates still apply. The reviewed rewrite removes the generic CODE/PR/COMMIT/BRANCH token heuristic because those words have common non-coding meanings.

# Background

Stage 1 emitted shell and repository-oriented action names that were not present in the runtime catalogue. Some resolved to no action; `CODE_PR_CREATE` could instead be claimed by the generated-view heuristic. This PR maps the observed inventions to their existing SHELL or TASKS umbrella without broadening the tool surface based on ambiguous vocabulary.

# Testing

```text
bun test packages/core/src/runtime/__tests__/action-retrieval.test.ts packages/core/src/runtime/__tests__/action-tiering.test.ts
86 pass, 0 fail, 268 assertions

bun x biome check packages/core/src/runtime/action-retrieval.ts packages/core/src/runtime/__tests__/action-retrieval.test.ts
Checked 2 files. No fixes applied.
```

The tests ran with Bun 1.3.14 in a clean environment with network access denied and credential paths denied. Regression coverage includes `READ_ERROR_CODE`, `BANK_BRANCH`, `PUBLIC_RELATIONS_PR`, and `COMMITMENT_STATUS`, none of which may resolve to TASKS.

# Evidence Gate

<!-- evidence-head:a5e3c5f9dab6eff02613766f8a4a0042f0679d96 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - runtime routing change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - runtime routing change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual flow.
<!-- evidence-row:backend-logs -->
- [x] Focused exact-head test output is recorded above; the original failure is identified by live trajectory `tj-79876bf0f950e8`.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] Original live failing trajectory: `tj-79876bf0f950e8`; no new live-model replay was performed during the review rewrite.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, schedule, wallet, or generated artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

# Known gaps

- Root `bun run verify` was not rerun in the sparse isolated audit clone. The directly affected core routing suites and Biome gate pass on the exact head.
- A post-fix live-model trajectory remains desirable before deployment, but the source-level capability widening identified in review is removed and the focused contract is deterministic.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nubscarson-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza"} -->
