### PR TITLE
fix(core): promoted virtuals execute an explicit declared discriminator instead of refusing

### DIFF
--- a/packages/core/src/actions/__tests__/promote-subactions.test.ts
+++ b/packages/core/src/actions/__tests__/promote-subactions.test.ts
@@ -221,7 +221,33 @@ describe("promoteSubactionsToActions parameter slicing", () => {
 });
 
 describe("promoteSubactionsToActions virtual dispatch consistency", () => {
-	it("rejects a conflicting canonical discriminator without invoking the parent", async () => {
+	it("executes a conflicting DECLARED discriminator via the parent instead of stranding the turn", async () => {
+		// Live regression: the planner called the SPAWN virtual with an explicit
+		// subaction=create, the refusal named a replacement tool that was not on
+		// the turn's surface, and the request died. A declared value is the
+		// model's explicit operation choice — run it.
+		const handler = vi.fn(async () => undefined);
+		const [, ...virtuals] = promoteSubactionsToActions(
+			makeUmbrella({ handler }),
+		);
+		const read = findVirtual(virtuals, "WIDGET_READ");
+
+		await read.handler(
+			{ logger: { info: () => undefined } } as never,
+			{} as never,
+			undefined,
+			{ parameters: { action: "delete", widgetId: "w-1" } },
+		);
+
+		const options = handler.mock.calls[0]?.[3] as HandlerOptions;
+		expect(options.parameters).toMatchObject({
+			action: "delete",
+			subaction: "delete",
+			widgetId: "w-1",
+		});
+	});
+
+	it("still rejects an UNDECLARED conflicting discriminator without invoking the parent", async () => {
 		const handler = vi.fn(async () => undefined);
 		const [, ...virtuals] = promoteSubactionsToActions(
 			makeUmbrella({ handler }),
@@ -229,18 +255,18 @@ describe("promoteSubactionsToActions virtual dispatch consistency", () => {
 		const read = findVirtual(virtuals, "WIDGET_READ");
 
 		const result = await read.handler({} as never, {} as never, undefined, {
-			parameters: { action: "delete" },
+			parameters: { action: "explode" },
 		});
 
 		expect(result).toMatchObject({
 			success: false,
-			text: expect.stringContaining("Call WIDGET_DELETE"),
+			text: expect.stringContaining("Call WIDGET_EXPLODE"),
 		});
 		expect((result as { error?: unknown }).error).toBeInstanceOf(Error);
 		expect(handler).not.toHaveBeenCalled();
 	});
 
-	it("rejects a conflicting declared alias that carries the pinned vocabulary", async () => {
+	it("executes a conflicting declared alias that carries the pinned vocabulary", async () => {
 		const handler = vi.fn(async () => undefined);
 		const umbrella = makeUmbrella({
 			handler,
@@ -256,18 +282,16 @@ describe("promoteSubactionsToActions virtual dispatch consistency", () => {
 		});
 		const [, ...virtuals] = promoteSubactionsToActions(umbrella);
 
-		const result = await findVirtual(virtuals, "WIDGET_READ").handler(
-			{} as never,
+		await findVirtual(virtuals, "WIDGET_READ").handler(
+			{ logger: { info: () => undefined } } as never,
 			{} as never,
 			undefined,
 			{ parameters: { op: "delete" } },
 		);
 
-		expect(result).toMatchObject({
-			success: false,
-			text: expect.stringContaining("'op: delete' contradicts it"),
-		});
-		expect(handler).not.toHaveBeenCalled();
+		// Declared alias value → executes the requested operation (new contract).
+		const options = handler.mock.calls[0]?.[3] as HandlerOptions;
+		expect(options.parameters).toMatchObject({ subaction: "delete" });
 	});
 
 	it("accepts a normalized matching alias and delegates with the virtual pin", async () => {

--- a/packages/core/src/actions/promote-subactions.ts
+++ b/packages/core/src/actions/promote-subactions.ts
@@ -311,6 +311,55 @@ function buildVirtualHandler(parent: Action, subaction: string): Handler {
 					value.trim() !== "" &&
 					normalizeSubaction(value) !== normalizeSubaction(subaction)
 				) {
+					// The explicit discriminator names the operation the model
+					// actually wants; the virtual's pin only records which promoted
+					// NAME the planner picked — often forced by which virtuals the
+					// turn's tool surface happened to carry. When the requested
+					// value is one the parent itself declares, execute it: the
+					// corrective refusal stranded live turns because the named
+					// replacement tool was not on the surface to retry (planner
+					// called TASKS_SPAWN_AGENT with subaction=create, was told to
+					// call TASKS_CREATE, could not, and the request died). This is
+					// not silent rerouting — the parent runs the exact operation
+					// the call spelled out. An UNDECLARED value keeps the refusal:
+					// executing an unknown op on a guess would be the real hazard.
+					const declaredParent = parent.parameters?.find(
+						(p) => p.name === key,
+					);
+					const parentEnum = (
+						declaredParent?.schema as { enum?: unknown } | undefined
+					)?.enum;
+					const parentDeclaresValue =
+						Array.isArray(parentEnum) &&
+						parentEnum.some(
+							(v) =>
+								typeof v === "string" &&
+								normalizeSubaction(v) === normalizeSubaction(value),
+						);
+					if (parentDeclaresValue) {
+						runtime.logger?.info?.(
+							{
+								src: "promote-subactions",
+								pinned: subaction,
+								requested: value,
+								parent: parent.name,
+							},
+							"Virtual pin overridden by explicit declared discriminator; executing the requested operation",
+						);
+						const rerouted = mergeOptionsWithSubaction(
+							parent,
+							options,
+							value.trim(),
+						);
+						return parentHandler(
+							runtime,
+							message,
+							state,
+							rerouted,
+							callback,
+							responses,
+						);
+					}
 					const wanted = `${toUpperSnake(parent.name)}_${toUpperSnake(value.trim())}`;
 					const text = `This tool is pinned to ${subaction}; '${key}: ${value}' contradicts it. Call ${wanted} (or ${toUpperSnake(parent.name)} with ${key}=${value}) instead.`;
 					return {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/create-task.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/create-task.test.ts
@@ -17,7 +17,8 @@ import {
 } from "../../src/test-utils/action-test-utils.js";
 
 describe("TASKS:create", () => {
-  it("rejects a history operation alias on the promoted create tool", async () => {
+  it("executes a declared history alias on the promoted create tool instead of stranding", async () => {
+    // New virtual-pin contract: explicit declared discriminators execute.
     const create = promoteSubactionsToActions(createTaskAction).find(
       (action) => action.name === "TASKS_CREATE",
     );
@@ -32,10 +33,7 @@ describe("TASKS:create", () => {
       callback(),
     );
 
-    expect(result).toMatchObject({
-      success: false,
-      text: expect.stringContaining("Call TASKS_HISTORY"),
-    });
+    expect((result as { success?: boolean }).success).toBe(true);
     expect(svc.spawnSession).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
When the planner calls a promoted virtual (e.g. `TASKS_SPAWN_AGENT`) but supplies the sibling discriminator it actually wants (`subaction: "create"`), the virtual handler answered with a **corrective refusal** telling the model to call the other alias instead. Smaller planner models rarely obey the correction; live turns stranded with an ack and no work (reproduced on a gpt-oss-120b planner, casual phrasing).

## What changed

A DECLARED discriminator value is an unambiguous statement of intent. `buildVirtualHandler` now merges the requested declared value (`mergeOptionsWithSubaction`) and executes through the parent exactly as the correct alias would have — same validation, same parent handler, same receipts. **Undeclared** values still refuse: the refusal remains the guard against invented operations; it stops being a tax on a correctly-stated intent that merely arrived via the sibling tool name.

## Evidence

- promote-subactions suite updated to the new contract: declared cross-alias values execute via the parent (25/25 pass); undeclared values still refuse.
- Orchestrator create-tool alias pin updated to match (`executes a declared history alias … instead of stranding`).
- Live: the exact stranded shape (`TASKS_SPAWN_AGENT` + `subaction:"create"` on a repo ask) executes the create leg and spawns the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
