### PR TITLE
fix(core): honest replies when the planner dies or recovers mid-turn

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
@@ -441,6 +441,131 @@ describe("planner-loop failed-operation correlation", () => {
 		expect(result.finalMessage).not.toContain("Project B tests passed");
 	});
 
+	it("resolves a failed SHELL command re-run verbatim inside a corrective retry (fail git commit -> succeed git config && git commit)", async () => {
+		const failedCommand = 'git add README.md && git commit -m "Add description"';
+		const retryCommand = `git config user.email "e@x" && ${failedCommand}`;
+		const replyText = "Added the description and committed the change.";
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce(
+					plannerToolCall("shell-fail", "SHELL", {
+						command: failedCommand,
+						cwd: "/workspace/repo",
+					}),
+				)
+				.mockResolvedValueOnce(
+					plannerToolCall("shell-retry", "SHELL", {
+						command: retryCommand,
+						cwd: "/workspace/repo",
+					}),
+				)
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{ id: "reply", name: "REPLY", arguments: { text: replyText } },
+					],
+				}),
+		};
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall: vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: false,
+					error: "command exited with code 128",
+					text: "command exited with code 128",
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "[exit 0]",
+					userFacingText: "[exit 0]",
+				}),
+			evaluate: vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: false,
+					decision: "CONTINUE",
+					thought: "Retry with git identity configured.",
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					decision: "FINISH",
+					thought: "Committed.",
+					messageToUser: replyText,
+				}),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(replyText);
+		expect(result.finalMessage).not.toContain("runtime step failed");
+	});
+
+	it("does not resolve a failed SHELL command from a word-substring match in a later command", async () => {
+		const shellFailure = "git is not installed.";
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce(
+					plannerToolCall("shell-fail", "SHELL", {
+						command: "git",
+						cwd: "/workspace/repo",
+					}),
+				)
+				.mockResolvedValueOnce(
+					plannerToolCall("shell-other", "SHELL", {
+						command: "github-audit run",
+						cwd: "/workspace/repo",
+					}),
+				)
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "reply",
+							name: "REPLY",
+							arguments: { text: "All done." },
+						},
+					],
+				}),
+		};
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall: vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: false,
+					error: "missing-git",
+					text: shellFailure,
+					userFacingText: shellFailure,
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "audit ok",
+					userFacingText: "audit ok",
+				}),
+			evaluate: vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: false,
+					decision: "CONTINUE",
+					thought: "Try the audit tool.",
+				})
+				.mockResolvedValueOnce({
+					success: false,
+					decision: "CONTINUE",
+					thought: "Invalid evaluator envelope.",
+					protocolFailure: true,
+				}),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(shellFailure);
+		expect(result.finalMessage).not.toContain("All done");
+	});
+
 	it("keeps a failed VIEWS operation authoritative over an unrelated evaluator FINISH", async () => {
 		const runtime = {
 			useModel: vi

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -182,9 +182,9 @@ function isCodingFullSurfaceMode(): boolean {
  * a real single-file app (the reference `tetris.html` is ~4.6k tokens once
  * escaped) blows straight past the chat default of {@link DEFAULT_PLANNER_MAX_TOKENS}
  * (1024), which truncates the tool-call argument mid-stream so the model either
- * narrates without ever completing the call or the provider 400s. opencode on
- * the same Cerebras `zai-glm-4.7` builds the same app reliably precisely because
- * it does not clamp the file-emitting completion to a chat-sized budget.
+ * narrates without ever completing the call or the provider 400s. Coding CLIs
+ * on the same Cerebras `zai-glm-4.7` build the same app reliably precisely
+ * because they do not clamp the file-emitting completion to a chat-sized budget.
  * Overridable via `ELIZA_CODING_PLANNER_MAX_TOKENS`. See issue #10132.
  */
 const DEFAULT_CODING_PLANNER_MAX_TOKENS = 16384;
@@ -3614,9 +3614,78 @@ function latestUnresolvedFailedNonTerminalToolStep(
 			unresolvedByOperation.set(operationKey, step);
 		} else if (step.result.success === true) {
 			unresolvedByOperation.delete(operationKey);
+			resolveShellFailuresSubsumedBy(step, unresolvedByOperation);
 		}
 	}
 	return [...unresolvedByOperation.values()].at(-1);
+}
+
+/**
+ * A successful SHELL run also resolves an earlier failed run whose exact
+ * command it re-executes with a corrective prefix. The operation key includes
+ * the command payload, so the canonical shell recovery shape — fail on
+ * `git commit …`, retry as `git config … && git commit …` — never matches by
+ * key, the recovered failure stayed "unresolved", and failure authority
+ * replaced the model's truthful terminal REPLY with the generic failed-step
+ * sentence (live 2026-08-18: the sub-agent committed its README change and
+ * the user was told the runtime step failed). Verbatim containment of the
+ * failed command at a token boundary, in the same cwd, is evidence the same
+ * operation re-ran and succeeded; unrelated sibling work still cannot
+ * launder a failure it did not re-execute.
+ */
+function resolveShellFailuresSubsumedBy(
+	step: PlannerStep,
+	unresolvedByOperation: Map<string, PlannerStep>,
+): void {
+	const call = step.toolCall;
+	if (!call || call.name.toUpperCase() !== "SHELL") return;
+	const command = shellCommandParam(call);
+	if (!command) return;
+	const cwd = shellCwdParam(call);
+	for (const [key, failed] of [...unresolvedByOperation.entries()]) {
+		const failedCall = failed.toolCall;
+		if (!failedCall || failedCall.name.toUpperCase() !== "SHELL") continue;
+		const failedCommand = shellCommandParam(failedCall);
+		if (!failedCommand || shellCwdParam(failedCall) !== cwd) continue;
+		if (containsCommandVerbatim(command, failedCommand)) {
+			unresolvedByOperation.delete(key);
+		}
+	}
+}
+
+function shellCommandParam(call: PlannerToolCall): string {
+	const value = (call.params as Record<string, unknown> | undefined)?.command;
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function shellCwdParam(call: PlannerToolCall): string {
+	const value = (call.params as Record<string, unknown> | undefined)?.cwd;
+	return typeof value === "string" ? value.trim() : "";
+}
+
+/** True when `needle` appears in `haystack` verbatim on shell token
+ *  boundaries (start/end, whitespace, or a control operator), so a failed
+ *  `git` cannot be "resolved" by an unrelated command that merely contains
+ *  those letters inside a longer word. */
+function containsCommandVerbatim(haystack: string, needle: string): boolean {
+	if (haystack === needle) return true;
+	const BOUNDARY = new Set([" ", "\t", "\n", ";", "&", "|", "(", ")"]);
+	let from = 0;
+	for (;;) {
+		const at = haystack.indexOf(needle, from);
+		if (at === -1) return false;
+		const before = at === 0 ? undefined : haystack[at - 1];
+		const afterIndex = at + needle.length;
+		const after =
+			afterIndex >= haystack.length ? undefined : haystack[afterIndex];
+		if (
+			(before === undefined || BOUNDARY.has(before)) &&
+			(after === undefined || BOUNDARY.has(after))
+		) {
+			return true;
+		}
+		from = at + 1;
+	}
 }
 
 /**

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -10702,14 +10702,30 @@ function looksLikeDelegationExcludedAsk(text: string): boolean {
 
 const LEGACY_CODING_WORK_VERB_PATTERN =
 	/\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|update|verify)\b/giu;
+// Add-family verbs are everyday mutation words ("add a reminder", "delete the
+// weather app"), so they pair ONLY with strong code artifacts — never the
+// legacy artifact set whose app/site/page tokens belong to view and app
+// management asks. Live gap 2026-08-18: "yo can u add a lil one-line
+// description to the readme in my <name> repo and put up a pr" carried
+// repo+pr artifacts but no legacy verb; no deterministic coding candidate
+// fired and Stage-1 answered ["simple"] from stale room history, fabricating
+// "a PR is up".
+const ADD_FAMILY_CODING_VERB_PATTERN =
+	/\b(?:add|append|insert|rename|remove|delete)\b/giu;
 const LEGACY_CODING_ARTIFACT_PATTERN =
 	/\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|feature|bug|url)\b/giu;
 const CODING_OPERATION_VERB_PATTERN =
 	/\b(?:refactor|debug|deploy|patch|optimize|migrate|profile)\b/giu;
+// Repo-submission verbs pair ONLY with the strong code artifacts: "put up a
+// pr", "push a branch", "open a pull request". "open" lives here and NOT in
+// the legacy verb set because anchored to pr/repo/branch it is unambiguous,
+// while "open the app/page" is view navigation.
+const REPO_SUBMIT_VERB_PATTERN =
+	/\b(?:put\s+up|open|submit|push|raise|file)\b/giu;
 const REVIEW_WORK_VERB_PATTERN =
 	/\b(?:review|audit|investigate|analyze|inspect|test|trace|diagnose)\b/giu;
 const STRONG_CODE_ARTIFACT_PATTERN =
-	/\b(?:code|cli|script|backend|frontend|repo|repository|bug|pr|pull request|commit|branch|stack trace|pipeline|ci)\b/giu;
+	/\b(?:code|cli|script|backend|frontend|repo|repository|bug|pr|pull request|commit|branch|stack trace|pipeline|ci|readme|changelog)\b/giu;
 const EXPANDED_WORK_ARTIFACT_PATTERN =
 	/\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|repository|feature|bug|url|pr|pull request|issue|commit|branch|build|test|error|stack trace|failure|log|docs|documentation|run|pipeline|ci)\b/giu;
 const HTTP_URL_PATTERN = /\bhttps?:\/\/[^\s<>()]+/iu;
@@ -10777,6 +10793,22 @@ function looksLikeCodingWorkRequest(text: string): boolean {
 		hasNearbyTerms(
 			normalized,
 			REVIEW_WORK_VERB_PATTERN,
+			STRONG_CODE_ARTIFACT_PATTERN,
+			160,
+		) ||
+		// Submission verbs anchored to strong code artifacts: "put up a pr",
+		// "push the branch", "open a pull request".
+		hasNearbyTerms(
+			normalized,
+			REPO_SUBMIT_VERB_PATTERN,
+			STRONG_CODE_ARTIFACT_PATTERN,
+			160,
+		) ||
+		// Add-family mutations anchored to strong code artifacts: "add a line
+		// to the readme", "rename the branch", "delete the stale commit".
+		hasNearbyTerms(
+			normalized,
+			ADD_FAMILY_CODING_VERB_PATTERN,
 			STRONG_CODE_ARTIFACT_PATTERN,
 			160,
 		) ||

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9761,17 +9761,36 @@ export async function runV5MessageRuntimeStage1(args: {
 		// visible-TEXT set, and deliberate silence (suppressPlannerReply
 		// terminals, ambient IGNORE after tool work) is a contract this
 		// invariant must honor, not a failure for it to "fix" into filler.
+		// An early ack ("on it.") is a PROMISE of work. When the planner then
+		// dies toolless with nothing else delivered, leaving only the ack turns
+		// the promise into a lie by omission — the recovery below must still
+		// fire and own up (live 2026-08-17: "on it." then silence on a repo
+		// ask). Tool-ful turns keep the stricter early-reply exclusion: their
+		// ack was followed by real result delivery paths.
+		const earlyAckBrokenPromise =
+			earlyReplySent && actionResults.length === 0 && !ambientTurn;
 		if (
 			!shouldSendPlannedText &&
-			!earlyReplySent &&
+			(!earlyReplySent || earlyAckBrokenPromise) &&
 			!suppressesPlannerReply &&
-			deliveredVisibleTexts.size === 0 &&
+			(deliveredVisibleTexts.size === 0 || earlyAckBrokenPromise) &&
 			deliveredMediaUrls.length === 0 &&
-			actionResults.length > 0
+			// Toolless planner deaths on an ADDRESSED turn are the same
+			// recoverable silence: the planner exhausted its retries with no
+			// tool call and no usable terminal text, every fallback above
+			// rejected the ack-shaped Stage-1 reply, and the user saw nothing
+			// (live 2026-08-17: casual-phrased coding asks after the
+			// gpt-oss-120b cutover ended [messageHandler, toolSearch, planner]
+			// with zero deliveries). Ambient turns keep their silence contract.
+			(actionResults.length > 0 || !ambientTurn)
 		) {
+			// On a toolless recovery the Stage-1 ack is a false promise of work
+			// that never happened ("On it." then nothing) — skip straight to
+			// the honest line instead.
+			const recoverableAck = actionResults.length > 0 ? stageOneAck : "";
 			const recoveredText =
 				effectiveDeliveredReplyText ||
-				stageOneAck ||
+				recoverableAck ||
 				actionResults
 					.map((result) =>
 						typeof result.userFacingText === "string"
@@ -10659,7 +10678,7 @@ function looksLikeDelegationExcludedAsk(text: string): boolean {
 		return false;
 	}
 	if (
-		/\b(?:do not|don't|dont|without)\s+(?:spawn|delegate|use|start)\s+(?:a\s+)?(?:sub[- ]?agent|task[- ]?agent|coding agent|opencode|codex|claude)\b/iu.test(
+		/\b(?:do not|don't|dont|without)\s+(?:spawn|delegate|use|start)\s+(?:a\s+)?(?:sub[- ]?agent|task[- ]?agent|coding agent|eliza[- ]?code|opencode|codex|claude)\b/iu.test(
 			normalized,
 		)
 	) {
@@ -10778,10 +10797,10 @@ function looksLikeCodingWorkRequest(text: string): boolean {
 function looksLikeExplicitDelegationRequest(text: string): boolean {
 	const normalized = text.toLowerCase();
 	return (
-		/\b(?:spawn|delegate|use|start|ask|have)\b[\s\S]{0,80}\b(?:sub[- ]?agent|task[- ]?agent|coding agent|opencode|codex|claude)\b/iu.test(
+		/\b(?:spawn|delegate|use|start|ask|have)\b[\s\S]{0,80}\b(?:sub[- ]?agent|task[- ]?agent|coding agent|eliza[- ]?code|opencode|codex|claude)\b/iu.test(
 			normalized,
 		) ||
-		/\b(?:sub[- ]?agent|task[- ]?agent|coding agent|opencode|codex|claude)\b[\s\S]{0,80}\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|verify)\b/iu.test(
+		/\b(?:sub[- ]?agent|task[- ]?agent|coding agent|eliza[- ]?code|opencode|codex|claude)\b[\s\S]{0,80}\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|verify)\b/iu.test(
 			normalized,
 		)
 	);


### PR DESCRIPTION
Three truthfulness holes around planner failure/recovery, all reproduced live on a gpt-oss-120b planner with casual phrasing:

1. **Toolless planner deaths were silent.** On an addressed turn the planner exhausted its retries with no tool call and no usable terminal text; the zero-deliveries recovery floor required `actionResults.length > 0`, so the user saw nothing at all.
2. **A broken early-ack promise stayed broken.** Stage-1 sent "on it." and the planner then died toolless; the floor's `earlyReplySent` exclusion treated the ack as a delivery and skipped recovery — the promise became a lie by omission.
3. **A recovered SHELL failure kept failure authority.** The child failed `git commit` (exit 128, no identity), retried as `git config … && git commit …` (success), and replied truthfully — but the failed step's operation key includes the full command payload, so the corrective-prefix retry never resolved it, and `terminalMessageWithFailureAuthority` replaced the truthful reply with "the runtime step failed before it produced a usable result" (live: sub-agent committed its README change; user and orchestrator were told the step failed).

## What changed

- The recovery floor fires for addressed turns even with zero action results, and treats an early-ack-then-toolless-death as recoverable silence; on that path it skips the ack-shaped text and ships an honest "that didn't go through" line. Ambient turns keep their silence contract.
- A successful SHELL run resolves earlier failed SHELL runs whose exact command it re-executes at a shell token boundary in the same cwd (`resolveShellFailuresSubsumedBy`). Different cwd, different command, or word-substring overlap do not resolve — the sibling-mutation laundering guard is preserved.
- Also teaches the delegation matchers the `eliza-code` spelling alongside codex/claude.

## Evidence

- 2 new failure-correlation pins: corrective-prefix retry resolves (final message = the model's truthful reply), word-substring does not (failure text keeps authority). Suite 18/18; adjacent planner-loop suites 144/144; message-service suites green.
- Live: the exact repro (one-shot coding child, commit → exit 128 → config+commit → clean reply) previously shipped the failure sentence; with the fix the truthful completion ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Follow-up commit in this branch: add-family and submission verbs (add/append/insert/rename/remove/delete; put up/open/submit/push/raise) anchored to STRONG code artifacts (repo/pr/branch/commit/readme/…) now count as coding work, so the deterministic coding candidate fires for casual phrasings like "add a lil one-line description to the readme in my … repo and put up a pr" — previously Stage-1 answered ["simple"] from stale room history and fabricated "a PR is up". Weak artifacts (app/site/page) are deliberately excluded so "delete the weather app" stays an app-management ask.