### PR TITLE
fix(code): the one-shot eliza-code entry captures the host execution baseline

### DIFF
--- a/packages/examples/code/src/host-baseline.test.ts
+++ b/packages/examples/code/src/host-baseline.test.ts
@@ -1,24 +1,34 @@
 /**
- * Pins the ACP child's executable-search authority contract: importing the
- * entry's first module captures a real PATH baseline, and acp.ts keeps
- * host-baseline as its FIRST import so no runtime module body can beat it.
- * Deterministic; no live runtime.
+ * Pins the executable-search authority contract shared by the ACP, one-shot,
+ * and TUI entrypoints. Importing the capture module produces a real PATH
+ * baseline, and both executable entries keep that module as their first import
+ * so no runtime module body can beat it. Deterministic; no live runtime.
  */
 import { readFileSync } from "node:fs";
-import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+import {
+  getHostExecutionBaseline,
+  resolveHostExecutable,
+} from "@elizaos/shared/host-execution-env";
 import { describe, expect, it } from "vitest";
 
-describe("acp host execution baseline", () => {
+describe("eliza-code host execution baseline", () => {
   it("captures a non-empty PATH baseline via the side-effect module", async () => {
     await import("./host-baseline.js");
     const baseline = getHostExecutionBaseline();
     expect(baseline.path).toBeDefined();
     expect(baseline.path).toContain("/");
+    expect(resolveHostExecutable(process.execPath)).toBe(process.execPath);
   });
 
-  it("keeps host-baseline as the FIRST import of the acp entry", () => {
-    const source = readFileSync(new URL("./acp.ts", import.meta.url), "utf8");
-    const firstImport = source.match(/^import .*$/m)?.[0] ?? "";
-    expect(firstImport).toBe('import "./host-baseline.js";');
-  });
+  it.each(["acp.ts", "index.ts"])(
+    "keeps host-baseline as the FIRST import of %s",
+    (entry) => {
+      const source = readFileSync(
+        new URL(`./${entry}`, import.meta.url),
+        "utf8",
+      );
+      const firstImport = source.match(/^import .*$/m)?.[0] ?? "";
+      expect(firstImport).toBe('import "./host-baseline.js";');
+    },
+  );
 });

--- a/packages/examples/code/src/index.ts
+++ b/packages/examples/code/src/index.ts
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+/**
+ * Boots the interactive and one-shot eliza-code entrypoints after capturing
+ * the host executable-search baseline needed by shell-backed coding tools.
+ */
+
 // Suppress elizaOS logs before any imports
 process.env.LOG_LEVEL = "fatal";
 

--- a/packages/examples/code/src/index.ts
+++ b/packages/examples/code/src/index.ts
@@ -2,6 +2,13 @@
 // Suppress elizaOS logs before any imports
 process.env.LOG_LEVEL = "fatal";
 
+// FIRST import: capture the executable-search authority before any runtime
+// module (or loadEnv) can mutate process.env — same contract as the acp
+// entry. Without it the one-shot/TUI child resolves git/rg/bun against an
+// empty baseline and every SHELL dispatch dies "not available in PATH"
+// (live 2026-08-18: repo tasks completed with no commits).
+import "./host-baseline.js";
+
 import type { AgentRuntime } from "@elizaos/core";
 import { main as cliMain } from "./cli.js";
 import { loadEnv } from "./lib/load-env.js";


### PR DESCRIPTION
# Relates to

Follow-up to #20737: the ACP entry already captured the child process's host executable-search baseline, but the one-shot/TUI entry did not.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto current `origin/develop` (`13484a619d82412a54af92669a58e66d1d43ce15`) with zero conflicts.
- [ ] `bun install` and full `bun run verify` were not run; scoped package gates and the exact isolation constraint are recorded below.
- [x] The deterministic evidence below exercises the entrypoint ordering, executable resolution, package suite, build, and built one-shot boot.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` was not run in the sparse disposable review clone; the owning package's test, typecheck, lint, and build gates pass on the exact head.

# Risks

Low. The change adds the same first-import capture contract already used by `acp.ts` to the one-shot/TUI entry. A regression could leave shell-backed tools unable to resolve executables; the expanded deterministic test now pins both executable entries and resolves the running Bun executable through the captured authority.

# Background

## What does this PR do?

`packages/examples/code/src/index.ts` now imports `./host-baseline.js` before any runtime-bearing import. This captures the process's boot PATH authority before runtime or dotenv initialization can mutate environment state. The entrypoint also receives the repository-required prose header.

`host-baseline.test.ts` now proves:

- importing the capture module records a non-empty baseline;
- the captured authority resolves the currently running Bun executable;
- both `acp.ts` and `index.ts` keep `host-baseline` as their first import.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No public documentation change is required; this aligns the one-shot/TUI entry with the already documented ACP boot contract.

# Testing

## Where should a reviewer start?

Review `packages/examples/code/src/index.ts` and `packages/examples/code/src/host-baseline.test.ts`.

## Detailed testing steps

All commands below ran on exact head `9e053e15a1a8b268462114cfb452eb018a8146d1` in a fresh sparse clone under a macOS process sandbox with network denied and writes confined to that temporary clone.

```text
bun test --conditions=eliza-source packages/examples/code/src/host-baseline.test.ts
3 pass, 0 fail, 5 expect() calls

bun run --cwd packages/examples/code test
84 pass, 0 fail, 441 expect() calls

bun run --cwd packages/examples/code typecheck
exit 0

bun run --cwd packages/examples/code lint:check
Checked 66 files. No fixes applied.

bun run --cwd packages/examples/code build
Bundled index.js and acp.js; exit 0.

bun packages/examples/code/dist/index.js --help
Printed the Eliza Code one-shot CLI usage; exit 0.

git diff --check
exit 0
```

# Evidence Gate

<!-- evidence-head:9e053e15a1a8b268462114cfb452eb018a8146d1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI or visual layout changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI or visual layout changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI flow changed; the built one-shot CLI boot is captured as text output above.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server or backend request path changed; package and built-entry output is included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console, or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action contract changed; this entrypoint initialization fix is exercised deterministically without provider credentials.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain state is produced; executable resolution, bundle output, and built-entry boot results are recorded in **Testing**.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this repair changes process initialization ordering, not model behavior. No provider credential was introduced into the disposable test sandbox.

## Backend + frontend logs

N/A - no backend or frontend transport path changed. Exact command summaries are in **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - no UI pixels changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- Full repository `bun run verify` was not run: the repair used a sparse disposable clone and scoped verification proportional to the two-file example-package change.
- `bun install` was not run. The sandbox used read-only dependencies from the existing repository-pinned Bun workspace; no lifecycle scripts or network access were allowed.
- No live provider/model shell trajectory was captured. The exact-head deterministic proof covers the failing authority boundary directly by resolving the active Bun executable after capture, plus the complete example-package suite, build, and built one-shot boot.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [core-safety-refresh]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza"} -->
