### PR TITLE
fix(cloud): reject malformed elevenlabs voices JSON

### DIFF
--- a/packages/cloud/api/elevenlabs/voices/[id]/route.json.test.ts
+++ b/packages/cloud/api/elevenlabs/voices/[id]/route.json.test.ts
@@ -1,0 +1,64 @@
+/**
+ * PATCH /api/elevenlabs/voices/:id used to let request.json() throw into
+ * nextJsonFromCaughtError / getErrorStatusCode, which maps SyntaxError to 500.
+ * Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const VOICE_ID = "00000000-0000-4000-8000-0000000000aa";
+
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+	user: { id: "user-1", organization_id: "org-1" },
+	apiKey: null,
+}));
+const updateVoice = mock(async () => ({
+	id: VOICE_ID,
+	name: "demo",
+}));
+
+mock.module("@/lib/auth", () => ({
+	requireAuthOrApiKeyWithOrg,
+}));
+mock.module("@/lib/services/voice-cloning", () => ({
+	voiceCloningService: {
+		updateVoice,
+		getVoiceById: async () => ({ id: VOICE_ID }),
+		deleteVoice: async () => undefined,
+	},
+}));
+mock.module("@/lib/utils/logger", () => ({
+	logger: {
+		info: () => undefined,
+		warn: () => undefined,
+		error: () => undefined,
+	},
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id", route);
+
+describe("PATCH /api/elevenlabs/voices/:id malformed JSON", () => {
+	test("returns 400 instead of 500 and never updates the voice", async () => {
+		const response = await app.request(`/${VOICE_ID}`, {
+			method: "PATCH",
+			headers: { "content-type": "application/json" },
+			body: "{",
+		});
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toMatchObject({
+			error: "Invalid JSON body",
+		});
+		expect(updateVoice).not.toHaveBeenCalled();
+	});
+
+	test("canonical JSON still updates the voice", async () => {
+		const response = await app.request(`/${VOICE_ID}`, {
+			method: "PATCH",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ name: "demo" }),
+		});
+		expect(response.status).toBe(200);
+		expect(updateVoice).toHaveBeenCalled();
+	});
+});

--- a/packages/cloud/api/elevenlabs/voices/[id]/route.ts
+++ b/packages/cloud/api/elevenlabs/voices/[id]/route.ts
@@ -196,7 +196,14 @@ async function __hono_PATCH(
     const { user } = await requireAuthOrApiKeyWithOrg(request);
     const params = await context.params;
     const voiceId = params.id;
-    const rawBody = await request.json();
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not nextJsonFromCaughtError(SyntaxError) → 500.
+      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     const parsed = updateVoiceBodySchema.safeParse(rawBody);
     if (!parsed.success) {
       return Response.json(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on `PATCH /api/elevenlabs/voices/:id` currently 500s. `request.json()` throws `SyntaxError` into `nextJsonFromCaughtError` / `getErrorStatusCode`, which does not map parse failures to 400. Not `#21556` (`v1/voice/[id]`). Not path encoding. Not extra-decode after `URLSearchParams.get()` (#21472 / #21482 / #21489). Not list-limit. Not cookies. Not payment. Not #21320. Not #21385. Proof is `bun:test` of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical voice metadata patches still write. Malformed `{` now 400s before voice-cloning updates instead of `SyntaxError` → `nextJsonFromCaughtError` 500. Proven on the unfixed head: PATCH `{` received **500**. GET/DELETE are untouched.

# Background

## What does this PR do?

`PATCH /api/elevenlabs/voices/:id` ran `updateVoiceBodySchema.safeParse(await request.json())` inside the route try. `request.json()` throws `SyntaxError` on `{`. `safeParse` never sees the body. `nextJsonFromCaughtError` / `getErrorStatusCode` map that to HTTP 500 / `internal_error`. This PR returns `{ error: "Invalid JSON body" }` with status 400 before schema parse or voice writes.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical voice patch bodies unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/elevenlabs/voices/[id]/route.json.test.ts` and the `request.json()` catch in the PATCH handler.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate './elevenlabs/voices/[id]/route.json.test.ts'
```

Unfixed head: `PATCH /api/elevenlabs/voices/:id` with body `{` returned **500**. After the fix: 2 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:0c930f3d911f7cd899c9ddc842c69f2cc7e25590 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the elevenlabs voice HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before voice writes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that a canonical patch still updates.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches voice-cloning.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on elevenlabs voice JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and a canonical patch still updates.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the elevenlabs voice HTTP boundary.

## Audio / voice walkthrough

N/A - JSON PATCH only; no TTS / STT / audio round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
