### PR TITLE
fix(deps): reconcile fs-extra lockfile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6073,7 +6073,7 @@
 
     "@types/fluent-ffmpeg": ["@types/fluent-ffmpeg@2.1.28", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ovxsDwBcPfJ+eYs1I/ZpcYCnkce7pvH9AHSvrZllAp1ZPpTRDZAFjF3TRFbukxSgIYTTNYePbS0rKUmaxVbXw=="],
 
-    "@types/fs-extra": ["@types/fs-extra@11.0.4", "", { "dependencies": { "@types/jsonfile": "*", "@types/node": "*" } }, "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ=="],
+    "@types/fs-extra": ["@types/fs-extra@8.1.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ=="],
 
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
@@ -6098,8 +6098,6 @@
     "@types/jsdom": ["@types/jsdom@30.0.0", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^8.0.0", "undici-types": "^8.9.0" } }, "sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
-
-    "@types/jsonfile": ["@types/jsonfile@6.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ=="],
 
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
 
@@ -10024,8 +10022,6 @@
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
-
-    "@ionic/utils-fs/@types/fs-extra": ["@types/fs-extra@8.1.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ=="],
 
     "@ionic/utils-fs/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 


### PR DESCRIPTION
# Relates to

Closes #21643.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated i18n blocker is recorded below.
- [x] A reviewer can confirm the change from the deterministic lockfile diff and frozen-install evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@fec7d2cbb5bb8b1885771fff2eedc02fb589fad5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop` `fec7d2cbb5bb8b1885771fff2eedc02fb589fad5`; zero conflicts.
- [x] `bun run verify` was run post-sync and stops only at the pre-existing repository-wide i18n baseline documented below.

# Risks

Low. This changes only Bun's generated lock metadata after direct `fs-extra` declarations were already removed from a workspace manifest. Package manifests and runtime code are untouched. The retained Ionic dependency still resolves `fs-extra@9.1.0`; other consumers resolve their declared versions.

# Background

## What does this PR do?

Regenerates `bun.lock` with repository-pinned Bun 1.3.14 so `bun install --frozen-lockfile --ignore-scripts` accepts the current workspace manifests again. The six-line diff deduplicates the retained `@types/fs-extra@8.1.5` entry and removes now-unreachable lock metadata.

## What kind of change is this?

Bug fix (non-breaking dependency metadata repair).

# Documentation changes needed?

No project documentation changes are required.

# Testing

## Where should a reviewer start?

Review the complete `bun.lock` diff; it is the only changed file.

## Detailed testing steps

- Before fix: pinned `bun install --frozen-lockfile --ignore-scripts` failed with `lockfile had changes, but lockfile is frozen`.
- Regenerated once with pinned Bun 1.3.14 and lifecycle scripts disabled.
- After fix: pinned `bun install --frozen-lockfile --ignore-scripts` succeeded with 3,597 installs across 3,874 packages and reported `no changes`.
- `bun pm why fs-extra` proved retained `fs-extra@9.1.0` through `@ionic/utils-fs` and `fs-extra@11.4.0` through current direct consumers.
- `bun run fix-deps:check` passed all 144 workspace manifests.
- `bun run audit:workflow-triggers` passed all 52 workflows.
- `bun run audit:scripts` passed.
- `git diff --check` passed.
- `bun run verify` reached the existing repository-wide `check:i18n` baseline and stopped there; this lockfile-only diff touches no locale or UI file.

# Evidence Gate

<!-- evidence-head:593d89ccf5f27f43544b15d62a53934076b237e0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - lockfile-only metadata change has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - lockfile-only metadata change has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive user flow changes.
<!-- evidence-row:backend-logs -->
- [x] [21645-frozen-install.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21645-frozen-install.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request, response, or state change.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [21645-domain-artifact.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21645-domain-artifact.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model behavior changes.

## Backend + frontend logs

Backend evidence is the deterministic pinned Bun output described in testing. Frontend is N/A because no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice behavior change.

## Known gaps / failures

`bun run verify` stops at the existing repository-wide i18n baseline: non-English locale files are missing many current English keys and `en.json` is missing five keys used by unrelated UI files. This PR changes only `bun.lock`; frozen install, workspace dependency checks, workflow audit, script audit, and diff checks pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@fec7d2cbb5bb8b1885771fff2eedc02fb589fad5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-lockfile]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@fec7d2cbb5bb8b1885771fff2eedc02fb589fad5:packages/skills/skills/contribute-to-eliza"} -->



