### PR TITLE
fix(cloud): select REST for direct Redis in staging

### DIFF
--- a/packages/cloud/api/__tests__/redis-transport-config.test.ts
+++ b/packages/cloud/api/__tests__/redis-transport-config.test.ts
@@ -1,0 +1,28 @@
+/** Pins staging-only REST selection while production retains its existing automatic policy. */
+
+import { describe, expect, test } from "bun:test";
+
+const wrangler = await Bun.file(
+  new URL("../wrangler.toml", import.meta.url),
+).text();
+
+function environmentVars(name: "staging" | "production"): string {
+  const start = `[env.${name}.vars]`;
+  const startIndex = wrangler.indexOf(start);
+  if (startIndex < 0) throw new Error(`missing ${start}`);
+  const rest = wrangler.slice(startIndex + start.length);
+  const nextEnvironment = rest.search(/\n\[env\.[^.\]]+(?:\.|\])/);
+  return nextEnvironment < 0 ? rest : rest.slice(0, nextEnvironment);
+}
+
+describe("Worker direct Redis transport config", () => {
+  test("staging selects direct REST without changing either environment's cache policy", () => {
+    const staging = environmentVars("staging");
+    const production = environmentVars("production");
+
+    expect(staging).toContain('CACHE_BACKEND = "auto"');
+    expect(staging).toContain('DIRECT_REDIS_BACKEND = "redis-rest"');
+    expect(production).toContain('CACHE_BACKEND = "auto"');
+    expect(production).not.toContain("DIRECT_REDIS_BACKEND");
+  });
+});

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -591,9 +591,11 @@ CRYPTO_DIRECT_SOLANA_RPC_URL = "https://api.mainnet-beta.solana.com"
 CRYPTO_DIRECT_SOLANA_TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 CRYPTO_DIRECT_SOLANA_TOKEN_DECIMALS = "6"
 CACHE_ENABLED = "true"
-# auto: Workers prefer CACHE_KV; non-Worker services use REDIS_URL when set.
-# Explicit "redis" / "redis-rest" overrides remain compatibility options.
+# CacheClient prefers CACHE_KV in Workerd.
 CACHE_BACKEND = "auto"
+# Auth nonces, rate limits, and other direct Redis consumers use the same Redis
+# through its HTTP proxy; raw Railway TCP from Workerd is not reliable.
+DIRECT_REDIS_BACKEND = "redis-rest"
 REDIS_RATE_LIMITING = "true"
 # Enables post-provider billing for cache-only Worker admission. Worker cache
 # misses warm and retry instead of joining an authoritative database fallback.

--- a/packages/cloud/shared/src/lib/cache/__tests__/redis-factory-selection.test.ts
+++ b/packages/cloud/shared/src/lib/cache/__tests__/redis-factory-selection.test.ts
@@ -1,0 +1,170 @@
+/** Verifies direct Redis transport selection without opening network connections. */
+
+import { describe, expect, test } from "bun:test";
+import { Redis as UpstashRedis } from "@upstash/redis";
+import { buildRedisClient, hasRedisConfig } from "../redis-factory";
+import { SocketRedis } from "../socket-redis";
+
+const TCP_URL = "redis://default:test@unreachable.example.test:6379";
+const REST_URL = "https://redis-rest.example.test";
+const REST_TOKEN = "test-token";
+
+describe("direct Redis transport selection", () => {
+  test("missing or blank selection preserves automatic TCP-first behavior", () => {
+    for (const directBackend of [undefined, "", "   "]) {
+      const env = {
+        DIRECT_REDIS_BACKEND: directBackend,
+        REDIS_URL: TCP_URL,
+        KV_REST_API_URL: REST_URL,
+        KV_REST_API_TOKEN: REST_TOKEN,
+      };
+
+      expect(buildRedisClient(env)).toBeInstanceOf(SocketRedis);
+      expect(hasRedisConfig(env)).toBe(true);
+    }
+  });
+
+  test("auto preserves TCP-first selection when both transports are configured", () => {
+    const client = buildRedisClient({
+      DIRECT_REDIS_BACKEND: "auto",
+      REDIS_URL: TCP_URL,
+      KV_REST_API_URL: REST_URL,
+      KV_REST_API_TOKEN: REST_TOKEN,
+    });
+
+    expect(client).toBeInstanceOf(SocketRedis);
+    expect(
+      hasRedisConfig({
+        DIRECT_REDIS_BACKEND: "auto",
+        REDIS_URL: TCP_URL,
+        KV_REST_API_URL: REST_URL,
+        KV_REST_API_TOKEN: REST_TOKEN,
+      }),
+    ).toBe(true);
+  });
+
+  test("explicit redis selects the TCP transport", () => {
+    const client = buildRedisClient({
+      DIRECT_REDIS_BACKEND: "redis",
+      REDIS_URL: TCP_URL,
+      KV_REST_API_URL: REST_URL,
+      KV_REST_API_TOKEN: REST_TOKEN,
+    });
+
+    expect(client).toBeInstanceOf(SocketRedis);
+  });
+
+  test("explicit redis-rest bypasses an unavailable TCP endpoint", () => {
+    const env = {
+      DIRECT_REDIS_BACKEND: "redis-rest",
+      REDIS_URL: TCP_URL,
+      KV_REST_API_URL: REST_URL,
+      KV_REST_API_TOKEN: REST_TOKEN,
+    };
+
+    expect(buildRedisClient(env)).toBeInstanceOf(UpstashRedis);
+    expect(hasRedisConfig(env)).toBe(true);
+  });
+
+  test("explicit selection fails closed when the selected backend is unconfigured", () => {
+    const restSelectedWithoutRest = {
+      DIRECT_REDIS_BACKEND: "redis-rest",
+      REDIS_URL: TCP_URL,
+    };
+    const tcpSelectedWithoutTcp = {
+      DIRECT_REDIS_BACKEND: "redis",
+      KV_REST_API_URL: REST_URL,
+      KV_REST_API_TOKEN: REST_TOKEN,
+    };
+
+    expect(buildRedisClient(restSelectedWithoutRest)).toBeNull();
+    expect(hasRedisConfig(restSelectedWithoutRest)).toBe(false);
+    expect(buildRedisClient(tcpSelectedWithoutTcp)).toBeNull();
+    expect(hasRedisConfig(tcpSelectedWithoutTcp)).toBe(false);
+  });
+
+  test("whitespace-only selected TCP credentials fail closed without throwing", () => {
+    const env = {
+      DIRECT_REDIS_BACKEND: "redis",
+      REDIS_URL: "  \n\t  ",
+    };
+
+    expect(() => buildRedisClient(env)).not.toThrow();
+    expect(buildRedisClient(env)).toBeNull();
+    expect(hasRedisConfig(env)).toBe(false);
+  });
+
+  test("whitespace-only selected REST credentials fail closed without throwing", () => {
+    for (const [url, token] of [
+      ["   ", REST_TOKEN],
+      [REST_URL, " \n "],
+      ["\t", "   "],
+    ]) {
+      const env = {
+        DIRECT_REDIS_BACKEND: "redis-rest",
+        KV_REST_API_URL: url,
+        KV_REST_API_TOKEN: token,
+      };
+
+      expect(() => buildRedisClient(env)).not.toThrow();
+      expect(buildRedisClient(env)).toBeNull();
+      expect(hasRedisConfig(env)).toBe(false);
+    }
+  });
+
+  test("valid selected credentials are trimmed before client construction", () => {
+    const tcpEnv = {
+      DIRECT_REDIS_BACKEND: "redis",
+      REDIS_URL: `  ${TCP_URL} \n`,
+    };
+    const restEnv = {
+      DIRECT_REDIS_BACKEND: "redis-rest",
+      KV_REST_API_URL: `\t${REST_URL}  `,
+      KV_REST_API_TOKEN: `  ${REST_TOKEN}\n`,
+    };
+
+    expect(buildRedisClient(tcpEnv)).toBeInstanceOf(SocketRedis);
+    expect(hasRedisConfig(tcpEnv)).toBe(true);
+    expect(buildRedisClient(restEnv)).toBeInstanceOf(UpstashRedis);
+    expect(hasRedisConfig(restEnv)).toBe(true);
+  });
+
+  test("auto ignores blank TCP credentials and falls through to REST", () => {
+    const env = {
+      REDIS_URL: "   ",
+      KV_REST_API_URL: REST_URL,
+      KV_REST_API_TOKEN: REST_TOKEN,
+    };
+
+    expect(buildRedisClient(env)).toBeInstanceOf(UpstashRedis);
+    expect(hasRedisConfig(env)).toBe(true);
+  });
+
+  test("undocumented aliases and noncanonical variants fail closed", () => {
+    for (const directBackend of [
+      "native-redis",
+      "redis-native",
+      "rest",
+      "upstash",
+      "AUTO",
+      "Redis",
+      "REDIS-REST",
+      " auto",
+      "redis ",
+      " redis-rest ",
+      "redis-rets",
+      "unknown",
+      "redis rest",
+    ]) {
+      const env = {
+        DIRECT_REDIS_BACKEND: directBackend,
+        REDIS_URL: TCP_URL,
+        KV_REST_API_URL: REST_URL,
+        KV_REST_API_TOKEN: REST_TOKEN,
+      };
+
+      expect(buildRedisClient(env)).toBeNull();
+      expect(hasRedisConfig(env)).toBe(false);
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/cache/redis-factory.ts
+++ b/packages/cloud/shared/src/lib/cache/redis-factory.ts
@@ -3,7 +3,7 @@
  * codebase (rate limiters, credit events, agent gateway relay, A2A task
  * store, generic cache).
  *
- * Resolution order:
+ * Resolution order in `auto` mode:
  *   1. `MOCK_REDIS=1` → in-memory `MockSocketRedis` (test/CI only; never
  *      silently shadows real creds).
  *   2. `REDIS_URL` (or per-bindings env)  → `SocketRedis` (RESP2 over
@@ -11,6 +11,11 @@
  *   3. `KV_REST_API_URL` + `KV_REST_API_TOKEN` → `@upstash/redis` REST
  *      client (legacy fallback; kept so existing Upstash deploys still work).
  *   4. null — caller decides what to do.
+ *
+ * `DIRECT_REDIS_BACKEND=redis` and `DIRECT_REDIS_BACKEND=redis-rest` select one
+ * transport explicitly and fail closed when its credentials are incomplete.
+ * The dedicated selector keeps direct consumers (auth nonces, rate limits,
+ * relay state) independent from CacheClient's KV/cache policy.
  */
 
 import { Redis as UpstashRedis } from "@upstash/redis";
@@ -18,13 +23,21 @@ import { MockSocketRedis } from "./mock-redis";
 import { SocketRedis } from "./socket-redis";
 
 interface CompatibleRedisPipeline {
-  zremrangebyscore(key: string, min: number | string, max: number | string): this;
+  zremrangebyscore(
+    key: string,
+    min: number | string,
+    max: number | string,
+  ): this;
   zcard(key: string): this;
   zadd(key: string, member: { score: number; member: string }): this;
   zrem(key: string, ...members: string[]): this;
   expire(key: string, seconds: number): this;
   pexpire(key: string, ms: number): this;
-  set(key: string, value: unknown, options?: { nx?: boolean; ex?: number; px?: number }): this;
+  set(
+    key: string,
+    value: unknown,
+    options?: { nx?: boolean; ex?: number; px?: number },
+  ): this;
   setex(key: string, ttlSeconds: number, value: unknown): this;
   get(key: string): this;
   del(...keys: string[]): this;
@@ -38,12 +51,19 @@ interface CompatibleRedisPipeline {
 // without adding a third overloaded class to the Upstash union. Override the
 // pipeline class itself because its private fields are intentionally nominal.
 export interface EvalCapableRedis {
-  eval(script: string, keys: string[], args: Array<string | number>): Promise<unknown>;
+  eval(
+    script: string,
+    keys: string[],
+    args: Array<string | number>,
+  ): Promise<unknown>;
 }
 
 type CompatibleSocketRedis = Pick<
   SocketRedis,
-  Exclude<Extract<keyof SocketRedis, keyof MockSocketRedis>, "pipeline" | "eval">
+  Exclude<
+    Extract<keyof SocketRedis, keyof MockSocketRedis>,
+    "pipeline" | "eval"
+  >
 > & {
   pipeline(): CompatibleRedisPipeline;
   // The in-memory factory client intentionally has no Lua support. Keeping the
@@ -60,6 +80,7 @@ export function supportsRedisEval(
 }
 
 export interface RedisFactoryEnv {
+  DIRECT_REDIS_BACKEND?: string;
   REDIS_URL?: string;
   KV_REST_API_URL?: string;
   KV_REST_API_TOKEN?: string;
@@ -70,20 +91,63 @@ export interface RedisFactoryEnv {
 
 export type RedisFactoryEnvSource = RedisFactoryEnv | NodeJS.ProcessEnv;
 
-export function buildRedisClient(env?: RedisFactoryEnvSource): CompatibleRedis | null {
+type DirectRedisBackend = "auto" | "redis" | "redis-rest" | "invalid";
+
+function resolveDirectRedisBackend(
+  value: string | undefined,
+): DirectRedisBackend {
+  if (value === undefined || value.trim() === "") {
+    return "auto";
+  }
+  if (value === "auto" || value === "redis" || value === "redis-rest")
+    return value;
+  return "invalid";
+}
+
+function normalizedConfigValue(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function restRedisConfig(
+  env: RedisFactoryEnvSource,
+): { url: string; token: string } | null {
+  const url =
+    normalizedConfigValue(env.KV_REST_API_URL) ??
+    normalizedConfigValue(env.UPSTASH_REDIS_REST_URL);
+  const token =
+    normalizedConfigValue(env.KV_REST_API_TOKEN) ??
+    normalizedConfigValue(env.UPSTASH_REDIS_REST_TOKEN);
+  return url && token ? { url, token } : null;
+}
+
+export function buildRedisClient(
+  env?: RedisFactoryEnvSource,
+): CompatibleRedis | null {
   const e = env ?? process.env;
 
   if (e.MOCK_REDIS === "1") {
     return new MockSocketRedis();
   }
 
-  const url = e.REDIS_URL;
-  if (url) return new SocketRedis({ url });
+  const backend = resolveDirectRedisBackend(e.DIRECT_REDIS_BACKEND);
+  const tcpUrl = normalizedConfigValue(e.REDIS_URL);
+  const rest = restRedisConfig(e);
 
-  const restUrl = e.KV_REST_API_URL || e.UPSTASH_REDIS_REST_URL;
-  const restToken = e.KV_REST_API_TOKEN || e.UPSTASH_REDIS_REST_TOKEN;
-  if (restUrl && restToken) {
-    return new UpstashRedis({ url: restUrl, token: restToken });
+  if (backend === "redis") {
+    return tcpUrl ? new SocketRedis({ url: tcpUrl }) : null;
+  }
+
+  if (backend === "redis-rest") {
+    return rest ? new UpstashRedis(rest) : null;
+  }
+
+  if (backend === "invalid") return null;
+
+  if (tcpUrl) return new SocketRedis({ url: tcpUrl });
+
+  if (rest) {
+    return new UpstashRedis(rest);
   }
 
   return null;
@@ -98,10 +162,13 @@ export function buildRedisClient(env?: RedisFactoryEnvSource): CompatibleRedis |
 export function hasRedisConfig(env?: RedisFactoryEnvSource): boolean {
   const e = env ?? process.env;
   if (e.MOCK_REDIS === "1") return true;
-  if (e.REDIS_URL) return true;
-  const restUrl = e.KV_REST_API_URL || e.UPSTASH_REDIS_REST_URL;
-  const restToken = e.KV_REST_API_TOKEN || e.UPSTASH_REDIS_REST_TOKEN;
-  return !!(restUrl && restToken);
+  const backend = resolveDirectRedisBackend(e.DIRECT_REDIS_BACKEND);
+  if (backend === "redis") return normalizedConfigValue(e.REDIS_URL) !== null;
+  if (backend === "redis-rest") return restRedisConfig(e) !== null;
+  if (backend === "invalid") return false;
+  return (
+    normalizedConfigValue(e.REDIS_URL) !== null || restRedisConfig(e) !== null
+  );
 }
 
 /**

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -475,6 +475,7 @@ export interface Bindings {
   REDIS_RATE_LIMITING?: string;
   CACHE_ENABLED?: string;
   CACHE_BACKEND?: string;
+  DIRECT_REDIS_BACKEND?: string;
   APPS_DEPLOY_ENABLED?: string;
   APPS_DEPLOY_ALLOWED_ORG_IDS?: string;
   // Inference hot path (#9899). The auth+moderation single-read cache is the


### PR DESCRIPTION
# Relates to

Fixes #21641.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] The exact focused transport suite and touched-file Biome check were rerun after the final rebase; package-wide limitations are recorded below.
- [x] A reviewer can confirm the transport policy from the focused tests and production Worker dry-run below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b46c735272bd995a96e7a166fe529df51acba6b1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Exact focused tests and touched-file formatting/lint checks were rerun post-sync; full-workspace limitations are documented below.

# Risks

Low-to-medium. Only staging selects the direct Redis REST transport. Production retains the existing `auto` policy and its dry-run bundle contains no `DIRECT_REDIS_BACKEND` binding. A missing or blank selected credential and any invalid nonempty selector fail closed rather than constructing an unusable client or silently crossing transports.

# Background

## What does this PR do?

Adds a dedicated `DIRECT_REDIS_BACKEND` selector for Redis consumers that bypass `CacheClient`, configures staging Workerd to use its existing Redis REST proxy, and leaves the existing TCP-first `auto` behavior unchanged elsewhere. This lets SIWE nonce storage and other direct Redis consumers use the transport that Workerd can reach without deleting the existing `REDIS_URL` secret.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No external documentation change is needed. The selector and staging rationale are documented next to the factory and Wrangler configuration.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/cache/redis-factory.ts`
- `packages/cloud/shared/src/lib/cache/__tests__/redis-factory-selection.test.ts`
- `packages/cloud/api/__tests__/redis-transport-config.test.ts`

## Detailed testing steps

```text
bun test packages/cloud/shared/src/lib/cache/__tests__/redis-factory-selection.test.ts packages/cloud/shared/src/lib/cache/__tests__/redis-factory-mock.test.ts packages/cloud/api/__tests__/redis-transport-config.test.ts
14 pass, 0 fail, 116 assertions

bun run --cwd packages/cloud/shared typecheck
PASS
bun run --cwd packages/cloud/shared lint
PASS
bun run --cwd packages/cloud/api typecheck
PASS, including wrangler production dry-run
bun run --cwd packages/cloud/api lint
PASS
```

# Evidence Gate

<!-- evidence-head:b46c735272bd995a96e7a166fe529df51acba6b1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend transport/config change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend transport/config change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend transport/config change with no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - live staging deployment is intentionally reserved for maintainer review; focused factory tests exercise selection and fail-closed behavior without credentials or network calls.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, schedule, wallet, generated-file, audio, or other domain artifact is created by this transport-selection change; automated config and factory results are inline in Testing
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

N/A - no live deployment was performed. The focused factory suite constructs each selected client without opening a network connection, and the production Wrangler dry-run passes while omitting the staging-only selector.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` passes the repository preflight and reaches the full Turbo typecheck/lint lane, then the unrelated native gateway SwiftLint task fails because SourceKit cannot load `sourcekitdInProc.framework`. The focused cloud packages and both Worker dry-runs pass independently.
- An earlier `bun run build:core` attempt built 55 of 56 tasks and stopped because the local package build-lock port `127.0.0.1:31343` was already owned by another local development process. The affected cloud packages independently pass typecheck/lint, and the API production Worker bundle dry-run passes.
- No staging deploy or smoke rerun was performed; maintainers can review and deploy this source/config change before an isolated staging credential is minted.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@b46c735272bd995a96e7a166fe529df51acba6b1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shared-smoke-credential]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@b46c735272bd995a96e7a166fe529df51acba6b1:packages/skills/skills/contribute-to-eliza"} -->







