### PR TITLE
fix(cloud): reject malformed voice TTS JSON

### DIFF
--- a/packages/cloud/api/v1/voice/tts/route.json.test.ts
+++ b/packages/cloud/api/v1/voice/tts/route.json.test.ts
@@ -1,0 +1,157 @@
+/**
+ * POST /api/v1/voice/tts used to let request.json() throw into the route
+ * catch, which maps SyntaxError to 500 "Failed to generate speech".
+ * Malformed JSON is caller error.
+ */
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+const assertSafeForPublicUse = mock(async () => undefined);
+const markProviderDispatched = mock(async () => undefined);
+const realFetch = globalThis.fetch;
+const fetchMock = mock(async (...args: Parameters<typeof fetch>): Promise<Response> => {
+  const url = String(args[0]);
+  if (url === "https://api.cartesia.ai/tts/bytes") {
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([73, 68, 51, 4]));
+          controller.close();
+        },
+      }),
+      { headers: { "Content-Type": "audio/mpeg; codec=mp3" } },
+    );
+  }
+  throw new Error(`unexpected fetch ${url}`);
+});
+globalThis.fetch = fetchMock as typeof fetch;
+
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  requireGenerativeRouteCaller: async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: null,
+    admissionSnapshot: null,
+  }),
+  admitFlatGenerativeOperation: async () => ({
+    reservation: undefined,
+    settleUnknown: undefined,
+    markProviderDispatched,
+  }),
+  asGenerativeCacheApiError: () => null,
+  getGenerativeExecutionContext: () => undefined,
+	getGenerativePricingCacheOptions: () => ({}),
+}));
+
+mock.module("@elizaos/shared/voice/first-sentence-snip", () => ({
+  FIRST_SENTENCE_SNIP_VERSION: "1",
+  firstSentenceSnip: (text: string) => ({
+    raw: text,
+    normalized: text,
+    endOffset: text.length,
+    wordCount: 1,
+  }),
+}));
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  ApiError: class ApiError extends Error {
+    status = 500;
+  },
+}));
+
+mock.module("@/lib/services/content-safety", () => ({
+  contentSafetyService: { assertSafeForPublicUse },
+}));
+
+mock.module("@/lib/services/ai-billing", () => ({
+  billFlatUsage: async () => ({ totalCost: 0 }),
+  reserveFlatUsageCredits: async () => undefined,
+}));
+
+mock.module("@/lib/services/ai-pricing", () => ({
+  calculateTTSCostFromCatalog: async () => ({
+    totalCost: 0.001,
+    baseTotalCost: 0.001,
+    platformMarkup: 0,
+  }),
+}));
+
+mock.module("@/lib/services/credits", () => ({
+  InsufficientCreditsError: class InsufficientCreditsError extends Error {},
+}));
+
+mock.module("@/lib/services/elevenlabs", () => ({
+  getElevenLabsService: () => ({
+    textToSpeech: async () => {
+      throw new Error("elevenlabs must not run in leftover-tax test");
+    },
+  }),
+}));
+
+mock.module("@/lib/services/tts-custom-voice-usage", () => ({
+  recordCustomVoiceUsage: async () => undefined,
+}));
+
+mock.module("@/lib/services/tts-first-line-cache", () => ({
+  fingerprintCloudVoiceSettings: () => "fp",
+  getCloudFirstLineCacheService: () => ({
+    get: async () => null,
+    has: async () => false,
+    put: async () => true,
+  }),
+  shouldBypassCloudFirstLineCache: () => true,
+}));
+
+mock.module("@/lib/services/usage", () => ({
+  usageService: { create: async () => undefined },
+}));
+
+mock.module("@/lib/pricing-constants", () => ({
+  CUSTOM_VOICE_TTS_MARKUP: 1.2,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+const { default: app } = await import("./route");
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("POST /api/v1/voice/tts malformed JSON", () => {
+  test("returns 400 instead of 500 and never admits synthesis", async () => {
+    const response = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{",
+      },
+      { CARTESIA_API_KEY: "cartesia-key" },
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(assertSafeForPublicUse).not.toHaveBeenCalled();
+    expect(markProviderDispatched).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still synthesizes speech", async () => {
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: "Hello from leftover-tax." }),
+      }),
+      { CARTESIA_API_KEY: "cartesia-key" },
+    );
+    expect(response.status).toBe(200);
+    expect(markProviderDispatched).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -186,7 +186,14 @@ async function __hono_POST(c: AppContext) {
     timings.authMs = Date.now() - requestStart;
     const admissionStart = Date.now();
 
-    const rawBody = await request.json();
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not the POST catch's generic 500 "Failed to generate speech".
+      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     const parsed = TtsBody.safeParse(rawBody);
     if (!parsed.success) {
       return Response.json(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on `POST /api/v1/voice/tts` currently 500s. `request.json()` throws `SyntaxError` into the POST catch, which returns 500 "Failed to generate speech". Not `#21556` (`v1/voice/[id]`). Not `#21642` (elevenlabs voices). Not path encoding. Not extra-decode after `URLSearchParams.get()` (#21472 / #21482 / #21489). Not list-limit. Not cookies. Not payment. Not advertising. Not #21320. Not #21385. Proof is `bun:test` of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical TTS JSON still synthesizes. Malformed `{` now 400s before content-safety or admission instead of the POST catch's 500. Proven on the unfixed head: POST `{` received **500**.

# Background

## What does this PR do?

`POST /api/v1/voice/tts` ran `TtsBody.safeParse(await request.json())` inside the route try. `request.json()` throws `SyntaxError` on `{`. `safeParse` never sees the body. The POST catch maps that to HTTP 500 / "Failed to generate speech". This PR returns `{ error: "Invalid JSON body" }` with status 400 before schema parse, safety checks, or synthesis.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical TTS bodies unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/voice/tts/route.json.test.ts` and the `request.json()` catch in the POST handler.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate ./v1/voice/tts/route.json.test.ts
```

Unfixed head: `POST /api/v1/voice/tts` with body `{` returned **500**. After the fix: 2 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:794cbfd212c4da5d9ab28da30ac8570091cf03d9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the voice TTS HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before synthesis.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that a canonical body still synthesizes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches TTS admission.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on voice TTS JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and a canonical body still synthesizes.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the voice TTS HTTP boundary.

## Audio / voice walkthrough

N/A - leftover-tax is the JSON POST boundary, not a TTS/STT round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
