### PR TITLE
fix(cloud): reject malformed onboarding coordinator JSON

### DIFF
--- a/packages/cloud/api/src/onboarding-session-coordinator.json.test.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.json.test.ts
@@ -1,0 +1,77 @@
+/**
+ * POST /turn used to let request.json() throw SyntaxError into
+ * onboardingCoordinatorErrorResponse, which maps every non-ElizaError to 500.
+ * Malformed JSON is caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../../shared/src/lib/cache/client", () => ({
+  cache: {
+    get: mock(async () => null),
+    set: mock(async () => undefined),
+  },
+}));
+
+mock.module("../../shared/src/lib/services/eliza-app/user-service", () => ({
+  elizaAppUserService: {
+    findOrCreateByPhone: mock(async () => ({ success: true })),
+    linkPhoneToUser: mock(async () => ({ success: true })),
+    linkDiscordToUser: mock(async () => ({ success: true })),
+  },
+}));
+
+mock.module("../../shared/src/lib/services/eliza-app/provisioning", () => ({
+  ensureElizaAppProvisioning: mock(async () => ({
+    status: "none",
+    agentId: null,
+    bridgeUrl: null,
+    sandbox: null,
+  })),
+  getElizaAppProvisioningStatus: mock(async () => ({
+    status: "none",
+    agentId: null,
+    bridgeUrl: null,
+    sandbox: null,
+  })),
+}));
+
+const { OnboardingSessionCoordinator } = await import(
+  "./onboarding-session-coordinator"
+);
+
+function coordinator(): InstanceType<typeof OnboardingSessionCoordinator> {
+  return new OnboardingSessionCoordinator(
+    { storage: {} } as unknown as DurableObjectState,
+    {} as never,
+  );
+}
+
+describe("onboarding session coordinator malformed JSON", () => {
+  test("returns 400 instead of 500 on truncated JSON", async () => {
+    const response = await coordinator().fetch(
+      new Request("https://onboarding.test/turn", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{",
+      }),
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+  });
+
+  test("canonical JSON is still parsed and rejected as an invalid turn", async () => {
+    const response = await coordinator().fetch(
+      new Request("https://onboarding.test/turn", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionId: "platform:discord:user-1" }),
+      }),
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid coordinator request",
+    });
+  });
+});

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -972,6 +972,11 @@ export class OnboardingSessionCoordinator {
         );
         return Response.json(result);
       } catch (error) {
+        if (error instanceof SyntaxError) {
+          // error-policy:J3 untrusted request body — malformed JSON is caller
+          // error (400), not onboardingCoordinatorErrorResponse(SyntaxError) → 500.
+          return Response.json({ error: "Invalid JSON body" }, 400);
+        }
         // error-policy:J1 Durable Object transport boundary; inner onboarding
         // failures remain observable as a failed request and are never replaced
         // with an empty or successful-looking result.


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on the onboarding session Durable Object currently 500s. `request.json()` throws `SyntaxError` into `onboardingCoordinatorErrorResponse`, which maps every non-ElizaError to HTTP 500. Sibling of generate-sfx `#21650`. Not generate-image (occupied). Not generate-video (grok backup). Not wallets/provision, x402/requests, or models/status. Not advertising. Not path encoding. Not extra-decode after `URLSearchParams.get()` (#21472 / #21482 / #21489). Not list-limit. Not cookies. Not payment. Proof is `bun:test` of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Parsed JSON still goes through `isCoordinatorRequest`. Malformed `{` now 400s instead of `onboardingCoordinatorErrorResponse(SyntaxError)` 500. Proven on the unfixed head: POST `{` received **500** `{"error":"Failed to parse JSON"}`.

# Background

## What does this PR do?

The onboarding session Durable Object `fetch` ran `await request.json()` inside one try. Truncated `{` throws `SyntaxError`. The catch forwarded that to `onboardingCoordinatorErrorResponse`, which always returns HTTP 500 for non-ElizaError. This PR returns `{ error: "Invalid JSON body" }` with status 400 for `SyntaxError` before that mapper.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Valid JSON bodies unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/src/onboarding-session-coordinator.json.test.ts` and the `SyntaxError` branch in `fetch`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate ./src/onboarding-session-coordinator.json.test.ts
```

Unfixed head: POST `/turn` with body `{` returned **500**. After the fix: 2 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:654aa26dec625c23dc0c83b1afc1dd5e23d50c17 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the onboarding Durable Object HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before a turn runs.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that parsed JSON still reaches request validation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches the onboarding turn machine.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on onboarding JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and a canonical body is still parsed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the onboarding Durable Object HTTP boundary.

## Audio / voice walkthrough

N/A - leftover-tax is the JSON POST boundary, not an onboarding conversation.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
