### PR TITLE
fix(cloud): reject malformed billing-settings JSON

### DIFF
--- a/packages/cloud/api/v1/billing/settings/route.json.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.json.test.ts
@@ -1,0 +1,84 @@
+/**
+ * PUT /api/v1/billing/settings used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is
+ * caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+const updateSettings = mock(async () => undefined);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+
+mock.module("@/db/repositories", () => ({
+  organizationsRepository: {
+    findById: async () => ({ id: "org-1", pay_as_you_go_from_earnings: false }),
+    update: async () => undefined,
+  },
+}));
+
+mock.module("@/lib/services/auto-top-up", () => ({
+  AUTO_TOP_UP_LIMITS: {
+    MIN_AMOUNT: 1,
+    MAX_AMOUNT: 1000,
+    MIN_THRESHOLD: 0,
+    MAX_THRESHOLD: 1000,
+  },
+  AutoTopUpSettingsValidationError: class AutoTopUpSettingsValidationError extends Error {},
+  autoTopUpService: {
+    getSettings: async () => ({
+      enabled: false,
+      amount: null,
+      threshold: null,
+      hasPaymentMethod: true,
+    }),
+    updateSettings,
+  },
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: { windowMs: 60_000, maxRequests: 100 } },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: () => undefined,
+    error: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+  },
+}));
+
+const { default: app } = await import("./route");
+
+describe("PUT /api/v1/billing/settings malformed JSON", () => {
+  test("returns 400 instead of 500 and never writes settings", async () => {
+    const response = await app.request("/", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(updateSettings).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still updates settings", async () => {
+    const response = await app.fetch(
+      new Request("http://internal/", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ autoTopUp: { enabled: false } }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(updateSettings).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/billing/settings/route.ts
+++ b/packages/cloud/api/v1/billing/settings/route.ts
@@ -87,7 +87,14 @@ app.put(
     try {
       const user = await requireUserOrApiKeyWithOrg(c);
 
-      const body = await c.req.json();
+      let body: unknown;
+      try {
+        body = await c.req.json();
+      } catch {
+        // error-policy:J3 untrusted request body — malformed JSON is caller
+        // error (400), not failureResponse(SyntaxError) → 500.
+        return c.json({ error: "Invalid JSON body" }, 400);
+      }
       const validation = UpdateSettingsSchema.safeParse(body);
 
       if (!validation.success) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on `PUT /api/v1/billing/settings` currently 500s. `c.req.json()` throws `SyntaxError` into `failureResponse`, which does not map parse failures to 400. Sibling of onboarding coordinator `#21651`. Not generate-image (occupied). Not generate-video (grok backup). Not wallets/provision, x402/requests, or models/status. Not shared-runtime-conversation (throw-not-500). Not advertising. Not path encoding. Not extra-decode after `URLSearchParams.get()` (#21472 / #21482 / #21489). Not list-limit. Not cookies. Not #21385. Proof is `bun:test` of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical billing-settings JSON still updates. Malformed `{` now 400s before settings writes instead of `SyntaxError` → `failureResponse` 500. Proven on the unfixed head: PUT `{` received **500**.

# Background

## What does this PR do?

`PUT /api/v1/billing/settings` ran `await c.req.json()` inside the route try. Hono's `c.req.json()` throws `SyntaxError` on `{`. Zod never sees the body. `failureResponse` maps that to HTTP 500 / `internal_error`. This PR returns `{ error: "Invalid JSON body" }` with status 400 before schema parse or settings writes.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical settings bodies unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/billing/settings/route.json.test.ts` and the `c.req.json()` catch in the PUT handler.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate ./v1/billing/settings/route.json.test.ts
```

Unfixed head: `PUT /api/v1/billing/settings` with body `{` returned **500**. After the fix: 2 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:c17f76ee9386d1615ab92420d274e9da7645111e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the billing-settings HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before settings writes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that a canonical body still updates settings.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches auto-top-up writes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on billing-settings JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and a canonical body still updates settings.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the billing-settings HTTP boundary.

## Audio / voice walkthrough

N/A - leftover-tax is the JSON PUT boundary, not a billing round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
