### PR TITLE
fix(plugin-sql): reject non-positive POSTGRES_POOL_MAX instead of letting pg-pool silently coerce 0 to 10

### DIFF
--- a/plugins/plugin-sql/src/__tests__/pg-manager.test.ts
+++ b/plugins/plugin-sql/src/__tests__/pg-manager.test.ts
@@ -81,6 +81,22 @@ describe("PostgresConnectionManager", () => {
     expect(pool.config.application_name).toBe("0123456789abcdef");
   });
 
+  it("rejects non-positive POSTGRES_POOL_MAX (falls back to the documented 20, not pg-pool's silent 10) but keeps 0 valid for min", () => {
+    process.env.POSTGRES_POOL_MAX = "0";
+    process.env.POSTGRES_POOL_MIN = "0";
+    new PostgresConnectionManager(CONN);
+    let pool = lastPool();
+
+    expect(pool.config.max).toBe(20);
+    expect(pool.config.min).toBe(0);
+
+    process.env.POSTGRES_POOL_MAX = "-3";
+    new PostgresConnectionManager(CONN);
+    pool = lastPool();
+
+    expect(pool.config.max).toBe(20);
+  });
+
   it("sets hnsw.iterative_scan = strict_order on every new connection", async () => {
     new PostgresConnectionManager(CONN);
     const pool = lastPool();

--- a/plugins/plugin-sql/src/pg/manager.ts
+++ b/plugins/plugin-sql/src/pg/manager.ts
@@ -24,15 +24,19 @@ export class PostgresConnectionManager {
     // exhaust the server's max_connections. Defaults preserve the original
     // single-agent behavior (max 20 / min 2). Set POSTGRES_POOL_MIN=0 so idle
     // agents release every connection; a small POSTGRES_POOL_MAX caps bursts.
-    const envInt = (key: string, fallback: number): number => {
+    const envInt = (key: string, fallback: number, min = 0): number => {
       const raw = process.env[key];
       if (raw === undefined || raw === "") return fallback;
       const n = Number(raw);
-      return Number.isFinite(n) && n >= 0 ? n : fallback;
+      return Number.isFinite(n) && n >= min ? n : fallback;
     };
     const poolConfig: PoolConfig = {
       connectionString: normalizePgSslMode(connectionString),
-      max: envInt("POSTGRES_POOL_MAX", 20),
+      // max must stay >= 1: pg-pool's constructor coerces a falsy max via
+      // `max || poolSize || 10`, so a configured 0 silently becomes pg-pool's
+      // own default (10) instead of this plugin's documented default (20).
+      // Rejecting non-positive input keeps the fallback explicit and ours.
+      max: envInt("POSTGRES_POOL_MAX", 20, 1),
       min: envInt("POSTGRES_POOL_MIN", 2),
       idleTimeoutMillis: envInt("POSTGRES_POOL_IDLE_TIMEOUT_MS", 30000),
       connectionTimeoutMillis: 5000,


### PR DESCRIPTION
Fixes #21542 (re-scoped per review — see below).

## What

`PostgresConnectionManager`'s `envInt` validated every `POSTGRES_POOL_*` var with the same `Number.isFinite(n) && n >= 0` guard. Zero is legitimate for `POSTGRES_POOL_MIN` and `POSTGRES_POOL_IDLE_TIMEOUT_MS` (#8695 sets `POSTGRES_POOL_MIN=0` for managed cloud agents), but `POSTGRES_POOL_MAX=0` passed through to `pg`.

**Re-scoped after review:** the original issue claimed `max: 0` deadlocks every query via pg-pool's `_isFull()`. That premise is wrong against the pinned dependency — `pg-pool@3.14.0`'s constructor coerces falsy `max` via `this.options.max = this.options.max || this.options.poolSize || 10` (index.js:89) before `_isFull` is ever consulted. I verified empirically: `new Pool({max: 0})` → `options.max === 10`, `_isFull() === false`. Credit to the reviewer for catching this.

The real defect is quieter: a configured `POSTGRES_POOL_MAX=0` silently becomes **pg-pool's default of 10** instead of this plugin's **documented default of 20** — a misconfiguration is masked with a third value nobody chose. `envInt` now takes a per-key minimum; `POSTGRES_POOL_MAX` requires `>= 1` and falls back to the documented default (20) explicitly, exactly as negative and non-numeric input already did. `POOL_MIN` and `IDLE_TIMEOUT_MS` keep accepting `0` unchanged.

## Evidence (head `d089f9b45`, rebased on `develop@57ff39210`)

- Regression in `pg-manager.test.ts`: `POSTGRES_POOL_MAX=0` and `-3` fall back to `max: 20` while `POSTGRES_POOL_MIN=0` in the same construction stays honored — fails on the old guard for the `=0` case, passes now. Focused suite 7/7.
- Pinned-dependency verification: `pg-pool@3.14.0` `index.js:89` coercion confirmed by reading the installed tree and constructing `new Pool({max:0})` directly.
- `plugins/plugin-sql` typecheck and `lint:check` clean.
- N/A UI/visual evidence — backend config-validation change with no rendered surface.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)