### PR TITLE
fix(app): stop pinning Android E2E host port

### DIFF
--- a/packages/app-core/scripts/serve-real-local-agent.ts
+++ b/packages/app-core/scripts/serve-real-local-agent.ts
@@ -5,12 +5,15 @@
  * real AgentRuntime + real app-core HTTP API with a deterministic model plugin,
  * then stays alive until the surrounding workflow sends SIGTERM. Android
  * WebView tests reach it through adb reverse as a "remote" first-run target.
+ * When the parent requests an ephemeral port, this process advertises the
+ * already-bound listener through the shared atomic port-file handshake.
  */
 
 import { readFile } from "node:fs/promises";
 import { ModelType, type Plugin, type Route } from "@elizaos/core";
 import { createDeterministicModelPlugin } from "@elizaos/core/testing";
 import { backgroundUploadImageRoute } from "../../agent/src/api/background-routes.ts";
+import { advertisePort } from "../../scripts/e2e-ports.mjs";
 import { startApiServer } from "../src/api/server.ts";
 import { useIsolatedConfigEnv } from "../test/helpers/isolated-config.ts";
 import { createRealTestRuntime } from "../test/helpers/real-runtime.ts";
@@ -147,9 +150,15 @@ async function installGeneratedRegistryFixture(): Promise<() => void> {
 
 function resolvePort(): number {
   const raw = process.env.ELIZA_API_PORT ?? process.env.ELIZA_PORT ?? "31337";
-  const port = Number.parseInt(raw, 10);
-  if (!Number.isFinite(port) || port <= 0) {
+  const port = /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN;
+  const allowsEphemeral = Boolean(process.env.ELIZA_E2E_PORT_FILE?.trim());
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
     throw new Error(`Invalid ELIZA_API_PORT/ELIZA_PORT: ${raw}`);
+  }
+  if (port === 0 && !allowsEphemeral) {
+    throw new Error(
+      "ELIZA_API_PORT=0 requires ELIZA_E2E_PORT_FILE so the parent can discover the bound port.",
+    );
   }
   return port;
 }
@@ -256,6 +265,9 @@ async function main(): Promise<void> {
     runtime: runtimeResult.runtime,
     skipDeferredStartupWork: true,
   });
+
+  const portFile = process.env.ELIZA_E2E_PORT_FILE?.trim();
+  if (portFile) advertisePort(portFile, server.port);
 
   console.log(
     `[device-e2e-host-agent] real API up on :${server.port} in ${Date.now() - t0}ms`,

--- a/packages/app/scripts/android-e2e-port-contract.test.mjs
+++ b/packages/app/scripts/android-e2e-port-contract.test.mjs
@@ -11,6 +11,10 @@ const source = readFileSync(
   join(import.meta.dirname, "android-e2e.mjs"),
   "utf8",
 );
+const globalSetupSource = readFileSync(
+  join(import.meta.dirname, "../test/android/global-setup.ts"),
+  "utf8",
+);
 
 describe("Android E2E host-agent port contract (#18359)", () => {
   it("delegates default allocation and accepts only explicit port overrides", () => {
@@ -18,5 +22,17 @@ describe("Android E2E host-agent port contract (#18359)", () => {
       'requestedPort: val(\n            "--host-agent-port",\n            process.env.ELIZA_ANDROID_HOST_AGENT_PORT,\n          )',
     );
     expect(source).not.toMatch(/requestedPort:\s*\d{4,5}\b/);
+  });
+
+  it("routes the canonical device port to the selected host port", () => {
+    expect(globalSetupSource).toContain(
+      "adbReverse(adb, serial, AGENT_API_PORT, HOST_AGENT_PORT)",
+    );
+    expect(globalSetupSource).toContain(
+      "process.env.ELIZA_ANDROID_HOST_AGENT_PORT ?? AGENT_API_PORT",
+    );
+    expect(globalSetupSource).not.toContain(
+      "adbReverse(adb, serial, AGENT_API_PORT, AGENT_API_PORT)",
+    );
   });
 });

--- a/packages/app/scripts/android-e2e-port-contract.test.mjs
+++ b/packages/app/scripts/android-e2e-port-contract.test.mjs
@@ -1,0 +1,22 @@
+/**
+ * Guards the Android E2E host-agent launch against reintroducing a fixed host
+ * port while preserving the explicit CLI and environment override contract.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  join(import.meta.dirname, "android-e2e.mjs"),
+  "utf8",
+);
+
+describe("Android E2E host-agent port contract (#18359)", () => {
+  it("delegates default allocation and accepts only explicit port overrides", () => {
+    expect(source).toContain(
+      'requestedPort: val(\n            "--host-agent-port",\n            process.env.ELIZA_ANDROID_HOST_AGENT_PORT,\n          )',
+    );
+    expect(source).not.toMatch(/requestedPort:\s*\d{4,5}\b/);
+  });
+});

--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -7,7 +7,7 @@
  *
  * Flags: --serial <s>, --skip-local-chat, --skip-route-coverage, --cloud,
  * --launcher-loop, --start-host-agent, --host-emulator-probes,
- * --arm64-local-probes, --force-build/--build, --skip-build,
+ * --arm64-local-probes, --host-agent-port <port>, --force-build/--build, --skip-build,
  * --no-emulator-boot, and --no-wait.
  */
 import { execFileSync, spawnSync } from "node:child_process";
@@ -533,7 +533,10 @@ async function main() {
         hostAgent = await startDeviceE2eHostAgent({
           repoRoot: elizaRoot,
           artifactDir: bundle.logsDir,
-          requestedPort: 31337,
+          requestedPort: val(
+            "--host-agent-port",
+            process.env.ELIZA_ANDROID_HOST_AGENT_PORT,
+          ),
           log,
         });
         process.env.ELIZA_ANDROID_HOST_AGENT_PORT = String(hostAgent.port);

--- a/packages/app/scripts/ios-attachment-smoke.mjs
+++ b/packages/app/scripts/ios-attachment-smoke.mjs
@@ -10,10 +10,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  DEFAULT_HOST_AGENT_PORT,
-  startDeviceE2eHostAgent,
-} from "./lib/host-agent.mjs";
+import { startDeviceE2eHostAgent } from "./lib/host-agent.mjs";
 import {
   captureIosSimulatorScreenshot,
   startIosSimulatorVideo,
@@ -33,7 +30,6 @@ const ONBOARDING_REQUEST_KEY = "eliza:ios-onboarding-smoke:request";
 const ONBOARDING_RESULT_KEY = "eliza:ios-onboarding-smoke:result";
 const ATTACHMENT_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
 const ATTACHMENT_RESULT_KEY = "eliza:ios-attachment-smoke:result";
-const DEFAULT_HOST_AGENT_PORT_STRING = String(DEFAULT_HOST_AGENT_PORT);
 const PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
@@ -408,10 +404,8 @@ async function main() {
     : await startDeviceE2eHostAgent({
         repoRoot,
         artifactDir: resultDir,
-        requestedPort: val("--host-agent-port"),
-        preferredPort:
-          process.env.ELIZA_IOS_HOST_AGENT_PORT ??
-          DEFAULT_HOST_AGENT_PORT_STRING,
+        requestedPort:
+          val("--host-agent-port") ?? process.env.ELIZA_IOS_HOST_AGENT_PORT,
         log,
       });
   apiBase = apiBase ?? hostAgent.apiBase;

--- a/packages/app/scripts/ios-onboarding-smoke.mjs
+++ b/packages/app/scripts/ios-onboarding-smoke.mjs
@@ -16,10 +16,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertLiveReply } from "../test/liveness-contract.mjs";
-import {
-  DEFAULT_HOST_AGENT_PORT,
-  startDeviceE2eHostAgent,
-} from "./lib/host-agent.mjs";
+import { startDeviceE2eHostAgent } from "./lib/host-agent.mjs";
 import { assertIosMixedContentSmokeResult } from "./lib/ios-mixed-content-smoke-contract.mjs";
 import {
   assertCandidateIosAppRendererFresh,
@@ -48,7 +45,6 @@ const MIXED_CONTENT_REQUEST_KEY = "eliza:ios-mixed-content-smoke:request";
 const MIXED_CONTENT_RESULT_KEY = "eliza:ios-mixed-content-smoke:result";
 const ATTACHMENT_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
 const ATTACHMENT_RESULT_KEY = "eliza:ios-attachment-smoke:result";
-const DEFAULT_HOST_AGENT_PORT_STRING = String(DEFAULT_HOST_AGENT_PORT);
 
 const has = (flag) => process.argv.includes(flag);
 const val = (flag, fallback = null) => {
@@ -481,10 +477,8 @@ async function main() {
     : await startDeviceE2eHostAgent({
         repoRoot,
         artifactDir: resultDir,
-        requestedPort: val("--host-agent-port"),
-        preferredPort:
-          process.env.ELIZA_IOS_HOST_AGENT_PORT ??
-          DEFAULT_HOST_AGENT_PORT_STRING,
+        requestedPort:
+          val("--host-agent-port") ?? process.env.ELIZA_IOS_HOST_AGENT_PORT,
         log,
       });
   apiBase = apiBase ?? hostAgent.apiBase;

--- a/packages/app/scripts/ios-voice-selftest-smoke.mjs
+++ b/packages/app/scripts/ios-voice-selftest-smoke.mjs
@@ -28,10 +28,7 @@ import {
   evaluateVoiceSelfTestReport,
   resolveVoiceSelfTestPollPolicy,
 } from "./ios-voice-selftest-lib.mjs";
-import {
-  DEFAULT_HOST_AGENT_PORT,
-  startDeviceE2eHostAgent,
-} from "./lib/host-agent.mjs";
+import { startDeviceE2eHostAgent } from "./lib/host-agent.mjs";
 import {
   captureIosSimulatorScreenshot,
   startIosSimulatorVideo,
@@ -51,7 +48,6 @@ const ONBOARDING_REQUEST_KEY = "eliza:ios-onboarding-smoke:request";
 const ONBOARDING_RESULT_KEY = "eliza:ios-onboarding-smoke:result";
 const VOICE_REQUEST_KEY = "eliza:ios-voice-selftest:request";
 const VOICE_RESULT_KEY = "eliza:ios-voice-selftest:result";
-const DEFAULT_HOST_AGENT_PORT_STRING = String(DEFAULT_HOST_AGENT_PORT);
 
 const has = (flag) => process.argv.includes(flag);
 const val = (flag, fallback = null) => {
@@ -426,10 +422,8 @@ async function main() {
     : await startDeviceE2eHostAgent({
         repoRoot,
         artifactDir: resultDir,
-        requestedPort: val("--host-agent-port"),
-        preferredPort:
-          process.env.ELIZA_IOS_HOST_AGENT_PORT ??
-          DEFAULT_HOST_AGENT_PORT_STRING,
+        requestedPort:
+          val("--host-agent-port") ?? process.env.ELIZA_IOS_HOST_AGENT_PORT,
         log,
       });
   apiBase = apiBase ?? hostAgent.apiBase;

--- a/packages/app/scripts/lib/host-agent.mjs
+++ b/packages/app/scripts/lib/host-agent.mjs
@@ -1,14 +1,14 @@
 /**
- * Local device-e2e host-agent process helper. Chooses an exclusive API port,
- * spawns the real local agent (or a caller-supplied command), waits for health,
- * and returns a stop handle used by iOS/Android device lanes.
+ * Local device-e2e host-agent process helper. The child binds port 0 and
+ * atomically advertises the live socket, avoiding probe-then-release races;
+ * explicit caller ports remain strict. The helper waits for health and returns
+ * the stop handle used by iOS/Android device lanes.
  */
 import { spawn } from "node:child_process";
 import fs from "node:fs";
-import net from "node:net";
 import path from "node:path";
+import { waitForAdvertisedPort } from "../../../scripts/e2e-ports.mjs";
 
-export const DEFAULT_HOST_AGENT_PORT = 31338;
 export const DEFAULT_HOST_AGENT_HOST = "127.0.0.1";
 export const DEFAULT_HOST_AGENT_HEALTH_PATH = "/api/health";
 export const DEFAULT_READY_ATTEMPTS = 90;
@@ -121,48 +121,6 @@ export function hostAgentApiBase(port, host = DEFAULT_HOST_AGENT_HOST) {
   return `http://${host}:${port}`;
 }
 
-export async function isPortAvailable(port, host = DEFAULT_HOST_AGENT_HOST) {
-  return new Promise((resolve) => {
-    const server = net.createServer();
-    server.once("error", () => resolve(false));
-    server.once("listening", () => {
-      server.close(() => resolve(true));
-    });
-    server.listen(port, host);
-  });
-}
-
-export async function chooseHostAgentPort({
-  preferredPort = DEFAULT_HOST_AGENT_PORT,
-  requestedPort = null,
-  host = DEFAULT_HOST_AGENT_HOST,
-} = {}) {
-  if (requestedPort !== null && requestedPort !== undefined) {
-    const port = parsePort(requestedPort, "host-agent port");
-    if (!(await isPortAvailable(port, host))) {
-      throw new Error(`Requested host-agent port ${port} is already in use.`);
-    }
-    return port;
-  }
-
-  const preferred = parsePort(preferredPort, "host-agent preferred port");
-  if (await isPortAvailable(preferred, host)) return preferred;
-
-  return new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.once("error", reject);
-    server.once("listening", () => {
-      const address = server.address();
-      const port = typeof address === "object" && address ? address.port : null;
-      server.close(() => {
-        if (typeof port === "number") resolve(port);
-        else reject(new Error("Unable to allocate a free host-agent port."));
-      });
-    });
-    server.listen(0, host);
-  });
-}
-
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -243,8 +201,6 @@ export async function startDeviceE2eHostAgent({
   repoRoot,
   artifactDir,
   requestedPort = null,
-  preferredPort = process.env.ELIZA_IOS_HOST_AGENT_PORT ??
-    DEFAULT_HOST_AGENT_PORT,
   host = DEFAULT_HOST_AGENT_HOST,
   readyAttempts,
   readyDelayMs,
@@ -271,20 +227,25 @@ export async function startDeviceE2eHostAgent({
     env: process.env,
   });
 
-  const port = await chooseHostAgentPort({
-    preferredPort,
-    requestedPort,
-    host,
-  });
-  const apiBase = hostAgentApiBase(port, host);
+  const explicitPort =
+    requestedPort === null || requestedPort === undefined
+      ? null
+      : parsePort(requestedPort, "host-agent port");
   fs.mkdirSync(artifactDir, { recursive: true });
   const logPath = path.join(artifactDir, "host-agent.log");
+  const portFile = path.join(
+    artifactDir,
+    `.host-agent-port-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  fs.rmSync(portFile, { force: true });
   const logFd = fs.openSync(logPath, "w");
   const child = spawn(command, args, {
     cwd: repoRoot,
     env: {
       ...env,
-      ELIZA_API_PORT: String(port),
+      ELIZA_API_PORT: String(explicitPort ?? 0),
+      ELIZA_API_STRICT_PORT: "1",
+      ELIZA_E2E_PORT_FILE: portFile,
       ELIZA_PAIRING_DISABLED: "1",
     },
     stdio: ["ignore", logFd, logFd],
@@ -310,6 +271,7 @@ export async function startDeviceE2eHostAgent({
         } catch {
           // error-policy:J6 log fd may already be closed by the platform
         }
+        fs.rmSync(portFile, { force: true });
         resolve();
       };
 
@@ -350,8 +312,25 @@ export async function startDeviceE2eHostAgent({
     signalHandlers.set(signal, handler);
     process.once(signal, handler);
   }
+  const removeSignalHandlers = () => {
+    for (const [signal, handler] of signalHandlers) {
+      process.off(signal, handler);
+    }
+  };
 
   try {
+    const port = await Promise.race([
+      waitForAdvertisedPort(portFile, { child }),
+      new Promise((_, reject) => {
+        child.once("error", reject);
+      }),
+    ]);
+    if (explicitPort !== null && port !== explicitPort) {
+      throw new Error(
+        `Host agent advertised port ${port}, expected explicit port ${explicitPort}.`,
+      );
+    }
+    const apiBase = hostAgentApiBase(port, host);
     log?.(`starting host agent at ${apiBase} (log: ${logPath})`);
     await waitForHealth({
       apiBase,
@@ -362,23 +341,21 @@ export async function startDeviceE2eHostAgent({
       delayMs: resolvedReady.readyDelayMs,
       log,
     });
+    return {
+      apiBase,
+      port,
+      logPath,
+      pid: child.pid,
+      async stop() {
+        removeSignalHandlers();
+        await stop();
+        log?.(`stopped host agent at ${apiBase}`);
+      },
+    };
   } catch (error) {
     // error-policy:J2 stop child then rethrow readiness/spawn failure
+    removeSignalHandlers();
     await stop();
     throw error;
   }
-
-  return {
-    apiBase,
-    port,
-    logPath,
-    pid: child.pid,
-    async stop() {
-      for (const [signal, handler] of signalHandlers) {
-        process.off(signal, handler);
-      }
-      await stop();
-      log?.(`stopped host agent at ${apiBase}`);
-    },
-  };
 }

--- a/packages/app/scripts/lib/host-agent.test.mjs
+++ b/packages/app/scripts/lib/host-agent.test.mjs
@@ -10,12 +10,9 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  chooseHostAgentPort,
-  DEFAULT_HOST_AGENT_PORT,
   DEFAULT_READY_ATTEMPTS,
   DEFAULT_READY_DELAY_MS,
   hostAgentApiBase,
-  isPortAvailable,
   MAX_TIMER_DELAY_MS,
   parseNonNegativeSafeInteger,
   parsePort,
@@ -75,6 +72,7 @@ function makeTmpDir() {
 
 function fakeHostAgentScript() {
   return `
+    const fs = require("node:fs");
     const http = require("node:http");
     const port = Number.parseInt(process.env.ELIZA_API_PORT, 10);
     const server = http.createServer((req, res) => {
@@ -87,6 +85,13 @@ function fakeHostAgentScript() {
       res.end("not found");
     });
     server.listen(port, "127.0.0.1", () => {
+      const portFile = process.env.ELIZA_E2E_PORT_FILE;
+      if (portFile) {
+        const actualPort = server.address().port;
+        const tmp = portFile + "." + process.pid + ".tmp";
+        fs.writeFileSync(tmp, actualPort + "\\n", "utf8");
+        fs.renameSync(tmp, portFile);
+      }
       console.log("fake host agent up on :" + port);
     });
     const stop = () => server.close(() => process.exit(0));
@@ -112,7 +117,7 @@ afterEach(() => {
 
 describe("host-agent helper", () => {
   it("validates ports without coercing malformed values", () => {
-    expect(parsePort("31338")).toBe(DEFAULT_HOST_AGENT_PORT);
+    expect(parsePort("31338")).toBe(31338);
     for (const value of ["", "0", "-1", "123abc", "70000"]) {
       expect(() => parsePort(value)).toThrow(/Invalid/);
     }
@@ -214,7 +219,7 @@ describe("host-agent helper", () => {
       startDeviceE2eHostAgent({
         repoRoot: process.cwd(),
         artifactDir,
-        requestedPort: await chooseHostAgentPort(),
+        requestedPort: 31338,
         readyAttempts: "10abc",
         readyDelayMs: 20,
         command: process.execPath,
@@ -231,7 +236,7 @@ describe("host-agent helper", () => {
       startDeviceE2eHostAgent({
         repoRoot: process.cwd(),
         artifactDir,
-        requestedPort: await chooseHostAgentPort(),
+        requestedPort: 31338,
         readyAttempts: 2,
         readyDelayMs: MAX_TIMER_DELAY_MS + 1,
         command: process.execPath,
@@ -278,42 +283,42 @@ describe("host-agent helper", () => {
     expect(fs.existsSync(path.join(artifactDir, "host-agent.log"))).toBe(false);
   });
 
-  it("keeps explicit requested ports exclusive", async () => {
+  it("keeps explicit requested ports strict when already occupied", async () => {
     const server = await listen();
+    const signalCounts = new Map(
+      ["SIGINT", "SIGTERM", "SIGHUP"].map((signal) => [
+        signal,
+        process.listenerCount(signal),
+      ]),
+    );
     try {
       const address = server.address();
       const port = typeof address === "object" && address ? address.port : 0;
       await expect(
-        chooseHostAgentPort({ requestedPort: port }),
-      ).rejects.toThrow(`Requested host-agent port ${port} is already in use.`);
+        startDeviceE2eHostAgent({
+          repoRoot: process.cwd(),
+          artifactDir: makeTmpDir(),
+          requestedPort: port,
+          readyAttempts: 5,
+          readyDelayMs: 10,
+          command: process.execPath,
+          args: ["-e", fakeHostAgentScript()],
+          env: {},
+        }),
+      ).rejects.toThrow(/exited|EADDRINUSE|health/i);
+      for (const [signal, count] of signalCounts) {
+        expect(process.listenerCount(signal)).toBe(count);
+      }
     } finally {
       await new Promise((resolve) => server.close(resolve));
     }
   });
 
-  it("falls back to a free port when the preferred default is occupied", async () => {
-    const server = await listen();
-    try {
-      const address = server.address();
-      const occupiedPort =
-        typeof address === "object" && address ? address.port : 0;
-      const selected = await chooseHostAgentPort({
-        preferredPort: occupiedPort,
-      });
-      expect(selected).not.toBe(occupiedPort);
-      expect(await isPortAvailable(selected)).toBe(true);
-    } finally {
-      await new Promise((resolve) => server.close(resolve));
-    }
-  });
-
-  it("starts a child host agent, waits for health, writes logs, and stops it", async () => {
+  it("lets the child bind a kernel-assigned port, then waits for health and stops it", async () => {
     const artifactDir = makeTmpDir();
-    const requestedPort = await chooseHostAgentPort();
     const agent = await startDeviceE2eHostAgent({
       repoRoot: process.cwd(),
       artifactDir,
-      requestedPort,
       readyAttempts: 50,
       readyDelayMs: 20,
       command: process.execPath,
@@ -321,7 +326,8 @@ describe("host-agent helper", () => {
       env: {},
     });
 
-    expect(agent.apiBase).toBe(hostAgentApiBase(requestedPort));
+    expect(agent.apiBase).toBe(hostAgentApiBase(agent.port));
+    expect(agent.port).toBeGreaterThan(0);
     const response = await fetch(`${agent.apiBase}/api/health`);
     expect(response.ok).toBe(true);
     expect(await response.json()).toEqual({
@@ -331,7 +337,7 @@ describe("host-agent helper", () => {
 
     await agent.stop();
     expect(fs.readFileSync(agent.logPath, "utf8")).toContain(
-      `fake host agent up on :${requestedPort}`,
+      "fake host agent up on :0",
     );
 
     const probe = spawnSync(process.execPath, [
@@ -345,13 +351,37 @@ describe("host-agent helper", () => {
     expect(probe.status).toBe(0);
   });
 
+  it("starts concurrent children on distinct bound ports without probe races", async () => {
+    const agents = await Promise.all(
+      Array.from({ length: 12 }, (_, index) =>
+        startDeviceE2eHostAgent({
+          repoRoot: process.cwd(),
+          artifactDir: path.join(makeTmpDir(), String(index)),
+          readyAttempts: 50,
+          readyDelayMs: 10,
+          command: process.execPath,
+          args: ["-e", fakeHostAgentScript()],
+          env: {},
+        }),
+      ),
+    );
+    try {
+      expect(new Set(agents.map((agent) => agent.port)).size).toBe(12);
+      const responses = await Promise.all(
+        agents.map((agent) => fetch(`${agent.apiBase}/api/health`)),
+      );
+      expect(responses.every((response) => response.ok)).toBe(true);
+    } finally {
+      await Promise.all(agents.map((agent) => agent.stop()));
+    }
+  });
+
   it("fails fast and closes the log fd when the child cannot spawn", async () => {
     const artifactDir = makeTmpDir();
     await expect(
       startDeviceE2eHostAgent({
         repoRoot: process.cwd(),
         artifactDir,
-        requestedPort: await chooseHostAgentPort(),
         readyAttempts: 2,
         readyDelayMs: 20,
         command: path.join(artifactDir, "missing-node"),

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -381,7 +381,7 @@ Options:
   --live                           Exercise the app-core local-agent HTTP API on Android
   --api-base URL                   Exercise an already-reachable app-core HTTP API
   --start-host-agent               Start the deterministic host app-core API when --api-base is omitted
-  --host-agent-port PORT           Port for --start-host-agent (default: 31338, or a free port if busy)
+  --host-agent-port PORT           Explicit port for --start-host-agent (default: kernel-assigned)
   --auth-token TOKEN               Bearer token for protected app-core API routes
   --ios-select-local               Pre-seed iOS first-run/runtime state for Local mode before launch
   --ios-full-bun-smoke             Run a WebView-executed full Bun backend smoke in the iOS app

--- a/packages/app/test/android/README.md
+++ b/packages/app/test/android/README.md
@@ -125,12 +125,12 @@ bun run --cwd packages/app test:e2e:android:routes
 The scheduled and `ci:device`-label-gated Android job in
 `.github/workflows/device-e2e.yml` is a load-bearing x86_64 host-emulator lane:
 
-1. Start `packages/app-core/scripts/serve-real-local-agent.ts` on host
-   `127.0.0.1:31337` with pairing disabled and deterministic model handlers.
+1. Start `packages/app-core/scripts/serve-real-local-agent.ts` on a
+   kernel-assigned host port with pairing disabled and deterministic model handlers.
 2. Boot/install the WebView-debuggable APK on the Android emulator.
 3. Run `test/android/onboarding-to-home.android.spec.ts` with
    `ELIZA_ANDROID_BACKEND=host`, so global setup wires `adb reverse
-   tcp:31337 -> host:31337`.
+   device `tcp:31337` to the selected host port.
 4. Hard-gate the explicit host-safe set: remote onboarding, route rendering,
    and the native `ElizaSystem` plugin bridge. A newly added Android spec does
    not enter this set implicitly.

--- a/packages/app/test/android/global-setup.ts
+++ b/packages/app/test/android/global-setup.ts
@@ -19,6 +19,7 @@ import {
   resolveApk,
   resolveSerial,
 } from "../../scripts/lib/android-device.mjs";
+import { parsePort } from "../../scripts/lib/host-agent.mjs";
 
 const HEALTH_POLL_MS = Number(
   process.env.ELIZA_ANDROID_HEALTH_TIMEOUT_MS ?? 180_000,
@@ -26,6 +27,13 @@ const HEALTH_POLL_MS = Number(
 const REQUIRE_AGENT = process.env.ELIZA_ANDROID_REQUIRE_AGENT !== "0";
 const BACKEND = (process.env.ELIZA_ANDROID_BACKEND ?? "local").toLowerCase();
 const CLEAR_APP_DATA = process.env.ELIZA_ANDROID_CLEAR_APP_DATA === "1";
+const HOST_AGENT_PORT =
+  BACKEND === "host"
+    ? parsePort(
+        process.env.ELIZA_ANDROID_HOST_AGENT_PORT ?? AGENT_API_PORT,
+        "ELIZA_ANDROID_HOST_AGENT_PORT",
+      )
+    : AGENT_API_PORT;
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -91,12 +99,13 @@ export default async function globalSetup() {
     adbTry(adb, ["-s", serial, "shell", "pm", "grant", APP_ID, perm]);
   }
 
-  // host backend: route the device's loopback :31337 to the host agent.
+  // Host backend: preserve the device's canonical loopback API while routing
+  // it to the exact kernel-assigned host-agent port selected by the parent.
   if (BACKEND === "host") {
     adbTry(adb, ["-s", serial, "shell", "am", "force-stop", APP_ID]);
-    adbReverse(adb, serial, AGENT_API_PORT, AGENT_API_PORT);
+    adbReverse(adb, serial, AGENT_API_PORT, HOST_AGENT_PORT);
     console.log(
-      `[android-e2e] host backend: adb reverse tcp:${AGENT_API_PORT} -> host:${AGENT_API_PORT}`,
+      `[android-e2e] host backend: adb reverse tcp:${AGENT_API_PORT} -> host:${HOST_AGENT_PORT}`,
     );
   }
 
@@ -119,7 +128,7 @@ export default async function globalSetup() {
   // and poll that — avoids colliding with anything already bound to host :31337.
   const pollPort =
     BACKEND === "host"
-      ? AGENT_API_PORT
+      ? HOST_AGENT_PORT
       : Number(
           adbTry(adb, [
             "-s",
@@ -143,7 +152,7 @@ export default async function globalSetup() {
     throw new Error(
       `[android-e2e] ${where} never became healthy within ${HEALTH_POLL_MS}ms — the ${BACKEND} runtime failed to start. ` +
         (BACKEND === "host"
-          ? "Start a host agent on :31337 (bun run dev) first. "
+          ? `Start a host agent on :${HOST_AGENT_PORT} first. `
           : "Run the local bring-up first (bun run --cwd packages/app test:sim:local-chat:android:live) ") +
         `or set ELIZA_ANDROID_REQUIRE_AGENT=0. ` +
         `Logcat: ${logPath}. Last health: ${JSON.stringify((health as { last?: unknown }).last)}`,

--- a/packages/app/test/android/onboarding-to-home.android.spec.ts
+++ b/packages/app/test/android/onboarding-to-home.android.spec.ts
@@ -11,9 +11,9 @@
 // (the original `choice-remote` / `first-run-remote-address` / `choice-connect`
 // flow). Replaces the lane quarantined in #10322.
 //
-// The deterministic host agent listens on host port 31337 and is exposed on a
-// non-reserved device loopback port through `adb reverse`; loopback needs no
-// confirm prompt.
+// The deterministic host agent binds a kernel-assigned host port and is
+// exposed on a non-reserved device loopback port through `adb reverse`;
+// loopback needs no confirm prompt.
 //
 // Liveness contract (#14359): this lane is STUB-BACKED by default — the host
 // agent is the deterministic ui-smoke stub, so a "real model" reply cannot be
@@ -28,6 +28,7 @@ import {
   adbReverse,
   resolveAdb,
 } from "../../scripts/lib/android-device.mjs";
+import { parsePort } from "../../scripts/lib/host-agent.mjs";
 import {
   assertOnboardingLiveness,
   sendChatAndReadReply,
@@ -39,8 +40,9 @@ import { expect, ORIGIN, test } from "./android-harness";
 // the deterministic stub.
 const LIVENESS_ENABLED = process.env.ELIZA_ONBOARDING_LIVENESS === "1";
 
-const HOST_AGENT_PORT = Number(
+const HOST_AGENT_PORT = parsePort(
   process.env.ELIZA_ANDROID_HOST_AGENT_PORT ?? "31337",
+  "ELIZA_ANDROID_HOST_AGENT_PORT",
 );
 // Android reserves loopback:31337 for the bundled local agent. Expose the host
 // on a distinct device port so remote adoption exercises HTTP through adb

--- a/packages/scripts/__tests__/e2e-ports.test.ts
+++ b/packages/scripts/__tests__/e2e-ports.test.ts
@@ -54,6 +54,14 @@ describe("advertisePort / waitForAdvertisedPort", () => {
     );
   });
 
+  it("rejects partial numeric content instead of truncating it", async () => {
+    const portFile = path.join(dir, "partial.port");
+    writeFileSync(portFile, "31338junk\n", "utf8");
+    await expect(waitForAdvertisedPort(portFile)).rejects.toThrow(
+      /does not contain a port/,
+    );
+  });
+
   it("rejects on timeout when nothing advertises", async () => {
     const portFile = path.join(dir, "never.port");
     await expect(

--- a/packages/scripts/e2e-ports.mjs
+++ b/packages/scripts/e2e-ports.mjs
@@ -52,9 +52,13 @@ export async function waitForAdvertisedPort(
 ) {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
-    if (child && child.exitCode !== null) {
+    if (child && (child.exitCode !== null || child.signalCode !== null)) {
       throw new Error(
-        `waitForAdvertisedPort: child exited with code ${child.exitCode} before advertising a port (${portFile})`,
+        `waitForAdvertisedPort: child exited with ${
+          child.exitCode !== null
+            ? `code ${child.exitCode}`
+            : `signal ${child.signalCode}`
+        } before advertising a port (${portFile})`,
       );
     }
     let raw = null;
@@ -66,7 +70,8 @@ export async function waitForAdvertisedPort(
       // treated as a result, and timeout/child-exit surface as errors.
     }
     if (raw !== null) {
-      const port = Number.parseInt(raw.trim(), 10);
+      const value = raw.trim();
+      const port = /^\d+$/.test(value) ? Number.parseInt(value, 10) : NaN;
       if (!Number.isInteger(port) || port <= 0 || port > 65535) {
         throw new Error(
           `waitForAdvertisedPort: ${portFile} does not contain a port: ${JSON.stringify(raw)}`,


### PR DESCRIPTION
Closes #18359

## Summary

- remove the reintroduced literal Android host-agent port while preserving explicit CLI/environment overrides
- replace probe-then-release allocation with a child bind to port `0` and an atomic advertisement of the already-bound socket
- keep explicit requested ports strict; route Android's canonical device port to the exact selected host port
- share the contract across Android, iOS, and mobile smoke callers
- fail closed on malformed/partial advertisement, child exit/signal, unbound values, explicit-port mismatch, timeout, and spawn failure

Independent review widened the original two-file repair after finding the shared allocator still had a TOCTOU window. The final series fixes both the call site and lifecycle contract.

## Evidence (exact head `10917c7d0ebc93b873664468e11300ecc5e01c82`)

- Rebased on develop `06e46d4b2383efad98a05fb55d5d11f16687f64c`; both commits are patch-equivalent by range-diff.
- `bun install --frozen-lockfile`: PASS, no diff.
- Focused port/host-agent contracts: PASS, 27/27 tests, 115 assertions.
- Real allocation: PASS; a real child advertises its kernel-bound port and concurrent children bind distinct ports without probe races.
- `packages/app-core` typecheck: PASS.
- `packages/app` typecheck: PASS after building its six declared native workspace prerequisites.
- Scoped Biome across all changed source/test paths: PASS.
- Diff integrity: PASS.
- Screenshots/video/device run: N/A; command-line E2E harness plumbing only, with no rendered or installed-device state change.
- Model trajectory: N/A; no model/prompt/provider behavior changes.

## Contribution provenance

- Contributor: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Skill: `contribute-to-eliza`
- Lane: `[nubs-gap-cloud]` plus independent review
