### PR TITLE
fix(plugin-telegram): validate per-account appId like the env tier in resolveTelegramAppCredentials

### DIFF
--- a/plugins/plugin-telegram/src/account-setup-routes.test.ts
+++ b/plugins/plugin-telegram/src/account-setup-routes.test.ts
@@ -86,6 +86,30 @@ describe("resolveTelegramAppCredentials", () => {
     expect(creds).toEqual(BUNDLED);
   });
 
+  it("ignores a non-numeric configured appId and falls through to settings", () => {
+    const creds = resolveTelegramAppCredentials(
+      makeRuntime({
+        TELEGRAM_APP_ID: "888",
+        TELEGRAM_APP_HASH: "envHashenvHashenvHashenvHashenv5",
+      }),
+      { appId: "abc", appHash: "cfgHashcfgHashcfgHashcfgHashcfg3" },
+    );
+    expect(creds).toEqual({
+      apiId: 888,
+      apiHash: "envHashenvHashenvHashenvHashenv5",
+    });
+  });
+
+  it("ignores non-positive and fractional configured appIds and falls back to the bundled default", () => {
+    for (const appId of ["-1", 0, 12.5]) {
+      const creds = resolveTelegramAppCredentials(makeRuntime(), {
+        appId,
+        appHash: "cfgHashcfgHashcfgHashcfgHashcfg4",
+      });
+      expect(creds).toEqual(BUNDLED);
+    }
+  });
+
   it("prefers configured creds over deployment settings when both are present", () => {
     const creds = resolveTelegramAppCredentials(
       makeRuntime({

--- a/plugins/plugin-telegram/src/account-setup-routes.ts
+++ b/plugins/plugin-telegram/src/account-setup-routes.ts
@@ -202,14 +202,18 @@ export function resolveTelegramAppCredentials(
   runtime: IAgentRuntime,
   connConfig: Record<string, unknown>,
 ): { apiId: number; apiHash: string } {
+  const parsedAccountId =
+    typeof connConfig.appId === "string" || typeof connConfig.appId === "number"
+      ? Number(connConfig.appId)
+      : Number.NaN;
   if (
-    (typeof connConfig.appId === "string" ||
-      typeof connConfig.appId === "number") &&
+    Number.isInteger(parsedAccountId) &&
+    parsedAccountId > 0 &&
     typeof connConfig.appHash === "string" &&
     connConfig.appHash.trim().length > 0
   ) {
     return {
-      apiId: Number(connConfig.appId),
+      apiId: parsedAccountId,
       apiHash: connConfig.appHash.trim(),
     };
   }


### PR DESCRIPTION
Fixes #21557.

## What

`resolveTelegramAppCredentials` guards the tier-2 env path (`TELEGRAM_APP_ID`) with `Number.isInteger(n) && n > 0`, but the first-priority per-account `connConfig.appId` tier only checked `typeof`. A malformed per-account id — `"abc"` (→ `NaN`), `"-1"`, `12.5` — passed the check and was handed straight to the MTProto login (`POST /api/setup/telegram-account/start` → `TelegramAccountAuthSession.start`), short-circuiting the documented fallback and contradicting the function's "never returns null / invalid creds never reach login" contract.

The same positive-integer guard now applies to tier 1, so malformed per-account ids fall through to deployment settings, then the bundled default.

## Evidence (head `10183e41b`, based on `develop@ba6967748`)

- New regressions in `account-setup-routes.test.ts`: non-numeric per-account `appId` falls through to `TELEGRAM_APP_ID`; `"-1"`, `0`, and `12.5` fall back to the bundled default; both fail on the old code. Focused suite 9/9.
- Full `plugin-telegram` suite: **200/200**.
- Package typecheck and `lint:check` clean.
- N/A UI/visual evidence — server-side credential-resolution guard, no rendered surface; the resolver is pure and fully exercised by the deterministic unit suite.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)