### PR TITLE
fix(ci): enforce product ASR proof boundary

### DIFF
--- a/.github/actions/stage-voice-real-assets/action.yml
+++ b/.github/actions/stage-voice-real-assets/action.yml
@@ -1,10 +1,11 @@
-name: Stage real voice assets
+name: Stage voice compatibility assets
 description: >-
-  Self-provision the real-voice asset set on a runner: verify the fused
+  Self-provision the pre-Gemma component-compatibility asset set on a runner: verify the fused
   libelizainference build (downloaded as a workflow artifact) and stage the
   pinned eliza-1-2b voice bundle regions from Hugging Face into the canonical
   $HOME/.eliza/local-inference/models/eliza-1-2b.bundle cache. Every file is
-  sha256-pinned; a present-and-matching file is never re-downloaded, so the
+  sha256-pinned; these assets are not product-runtime ASR evidence. A
+  present-and-matching file is never re-downloaded, so the
   first run per host pays ~2.5 GB once and later runs download nothing. Multiple
   runner slots share one host $HOME, so the whole staging section runs under an
   flock. Exports the ELIZA_* env the real-voice suites consume. Any missing or
@@ -45,7 +46,7 @@ runs:
         echo "fused lib OK: $LIB"
         file "$LIB" || true
 
-    - name: Stage pinned eliza-1-2b voice bundle (sha256-verified, host-cached)
+    - name: Stage pinned pre-Gemma compatibility bundle (sha256-verified, host-cached)
       shell: bash
       run: |
         set -euo pipefail
@@ -90,7 +91,8 @@ runs:
         exec 9>"$LOCK"
         flock 9
 
-        # Fused ASR (decoder head + audio projector — asr-real-smoke contract).
+        # Retired pre-Gemma ASR compatibility pair. The workflow's separate
+        # product-release preflight intentionally rejects these as product proof.
         stage asr/eliza-1-asr.gguf          bundles/e2b/asr/eliza-1-asr.gguf          bca259818b50ca7c4c05e9bdb35a5dc04fa039653a6d6f3f0f331f96f6aa1971
         stage asr/eliza-1-asr-mmproj.gguf   bundles/e2b/asr/eliza-1-asr-mmproj.gguf   41a342b5e4c514e968cb756de6cd1b7be39eff43c44c57a2ef5fc6522e36603d
         # VAD (fused vad_open loads the GGUF; the ggml.bin is the legacy

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -1,16 +1,18 @@
 name: Voice Live E2E
 
 # Provisioned REAL voice lane. The keyless PR lanes stub voice entirely
-# (silent-WAV TTS, shimmed STT transcript), so genuinely-real voice coverage —
-# real speech synthesis + real transcription with real models — lives in this
-# self-hosted model-heavy nightly / workflow_dispatch lane.
+# (silent-WAV TTS, shimmed STT transcript), so live service coverage and native
+# component compatibility evidence live in this model-heavy nightly /
+# workflow_dispatch lane. Product-runtime ASR proof additionally requires the
+# Gemma release-authority job below to pass.
 #
 # What it proves (no mocks at any stage):
 #   - Live Railway voice contract: the free-cloud Kokoro TTS + Whisper STT
 #     services (packages/cloud/services/voice-*) satisfy the exact request shapes
 #     the cloud-api voice routes send, so a dead/drifted service is a red run.
-#   - Real fused ASR: the provisioned libelizainference + ASR bundle
-#     transcribes real speech.
+#   - Pre-Gemma fused ASR compatibility: the provisioned libelizainference +
+#     retired compatibility bundle transcribes real speech at the FFI boundary.
+#     This is explicitly not product-runtime ASR evidence.
 #   - Real fused Kokoro TTS: the provisioned libelizainference loads the
 #     published Kokoro GGUF + voice .bin and synthesizes audible PCM.
 #   - Optional mixed round-trip: when cloud voice/LLM keys are present, real
@@ -111,6 +113,29 @@ env:
   BUN_VERSION: "1.3.14"
   NODE_OPTIONS: "--experimental-sqlite"
 jobs:
+  # Product truth boundary (#17477): the native component smokes below still
+  # exercise retired pre-Gemma assets directly through bun:ffi. They remain
+  # useful ABI compatibility evidence, but the workflow must be red until the
+  # active release publishes an immutable Gemma model/projector pair that the
+  # product runtime can accept. This job never falls back to an older release.
+  voice-product-asr-release:
+    name: Product runtime Gemma ASR release authority
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          show-progress: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Require immutable Gemma ASR model and projector
+        run: bun packages/scripts/verify-voice-product-asr-release.mjs --github-annotations
+
   voice-platform-matrix-index:
     name: Canonical voice matrix index
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
@@ -357,7 +382,7 @@ jobs:
           if-no-files-found: error
 
   voice-roundtrip:
-    name: Real fused ASR + optional mixed round-trip (self-hosted)
+    name: Pre-Gemma ASR compatibility FFI + optional mixed round-trip (self-hosted)
     # Single point of runner config — override with repo var VOICE_LIVE_RUNNER_LABELS.
     runs-on: ${{ fromJSON(vars.VOICE_LIVE_RUNNER_LABELS || '["self-hosted","Linux","X64","eliza"]') }}
     needs: voice-fused-build
@@ -365,8 +390,9 @@ jobs:
     env:
       ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
       CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
-    # Hard live lane: the fused ASR smoke always runs against self-provisioned
-    # assets — a staging or transcription failure is a red job, never a skip.
+    # Hard component lane: the fused ASR smoke always runs against the pinned
+    # pre-Gemma compatibility assets. The independent product-release job keeps
+    # the workflow red until the supported Gemma pair exists.
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -401,12 +427,12 @@ jobs:
           name: voice-fused-lib-linux-x64-cpu
           path: ${{ runner.temp }}/fused-lib
 
-      - name: Stage real voice assets (fused lib + pinned bundle)
+      - name: Stage voice compatibility assets (fused lib + pinned bundle)
         uses: ./.github/actions/stage-voice-real-assets
         with:
           fused-lib-dir: ${{ runner.temp }}/fused-lib
 
-      - name: Real fused ASR smoke (bun:ffi)
+      - name: Pre-Gemma ASR compatibility FFI smoke (bun:ffi)
         run: bun run --cwd plugins/plugin-local-inference test:asr:real
 
       # Designed key-gated step: the mixed round-trip crosses two external
@@ -419,10 +445,10 @@ jobs:
       - name: Note skipped mixed round-trip (keys absent)
         if: env.ELEVENLABS_API_KEY == '' || env.CEREBRAS_API_KEY == ''
         run: |
-          echo "::warning title=Mixed cloud round-trip skipped::ELEVENLABS_API_KEY and/or CEREBRAS_API_KEY are not configured, so the cloud-TTS → local-ASR → cloud-LLM round-trip step did not run. The fused ASR smoke above still ran against real models."
+          echo "::warning title=Mixed cloud round-trip skipped::ELEVENLABS_API_KEY and/or CEREBRAS_API_KEY are not configured, so the cloud-TTS → compatibility-ASR → cloud-LLM round-trip step did not run. The pre-Gemma FFI component smoke above is not product-runtime ASR proof."
 
   voice-acoustic-matrix:
-    name: Real acoustic VAD + diarization + self-voice matrix (self-hosted)
+    name: Real acoustic components + pre-Gemma ASR compatibility matrix (self-hosted)
     # Single point of runner config — override with repo var VOICE_LIVE_RUNNER_LABELS.
     runs-on: ${{ fromJSON(vars.VOICE_LIVE_RUNNER_LABELS || '["self-hosted","Linux","X64","eliza"]') }}
     needs: voice-fused-build
@@ -496,7 +522,7 @@ jobs:
           name: voice-fused-lib-linux-x64-cpu
           path: ${{ runner.temp }}/fused-lib
 
-      - name: Stage real voice assets (fused lib + pinned bundle)
+      - name: Stage voice compatibility assets (fused lib + pinned bundle)
         uses: ./.github/actions/stage-voice-real-assets
         with:
           fused-lib-dir: ${{ runner.temp }}/fused-lib
@@ -548,8 +574,9 @@ jobs:
 
       # bun test, NOT vitest: these suites need bun:ffi, and vitest's node
       # workers make every one of them skip — a green-skip lie this lane bans.
-      # Under `bun test` all 12 tests execute against the staged fused lib.
-      - name: Real fused FFI test lanes (bun:ffi)
+      # Under `bun test` all 12 tests execute against the staged fused lib. The
+      # ASR row is compatibility-only until the product release gate is green.
+      - name: Fused component compatibility FFI test lanes (bun:ffi)
         run: |
           set -euo pipefail
           bun test \
@@ -563,7 +590,7 @@ jobs:
           # a green-skip lie as a full-lane skip, so it fails the same way.
           if grep -Eq "(^| )0 pass" "$VOICE_REAL_MATRIX_OUT/fused-real-bun-test.log" \
             || grep -Eq "(^| )[1-9][0-9]* skip" "$VOICE_REAL_MATRIX_OUT/fused-real-bun-test.log"; then
-            echo "::error title=Fused FFI lanes skipped::one or more real FFI suite cells did not execute — staging or bun:ffi is broken"
+            echo "::error title=Fused FFI lanes skipped::one or more compatibility FFI suite cells did not execute — staging or bun:ffi is broken"
             exit 1
           fi
 

--- a/packages/scripts/__tests__/verify-voice-product-asr-release.test.ts
+++ b/packages/scripts/__tests__/verify-voice-product-asr-release.test.ts
@@ -1,6 +1,7 @@
 /**
  * Verifies the product-ASR publication gate and its Voice Live E2E wiring with
- * deterministic release fixtures; no model download or provider is mocked.
+ * deterministic release fixtures and mocked resolver metadata, without model
+ * downloads.
  */
 
 import { readFileSync } from "node:fs";

--- a/packages/scripts/__tests__/verify-voice-product-asr-release.test.ts
+++ b/packages/scripts/__tests__/verify-voice-product-asr-release.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   latestDeclaredAsrRelease,
   validateProductAsrRelease,
+  verifyProductAsrReleaseAuthority,
 } from "../verify-voice-product-asr-release.mjs";
 
 const SHA_A = "a".repeat(64);
@@ -74,13 +75,79 @@ describe("product ASR release authority", () => {
         expect.stringContaining("immutable 40-character"),
         expect.stringContaining("still declares missing assets"),
         expect.stringContaining("no downloadable GGUF assets"),
-        expect.stringContaining("both a model and an mmproj projector"),
+        expect.stringContaining("Gemma ASR model and its mmproj projector"),
       ]),
     );
   });
 
   it("accepts an immutable, size- and hash-pinned Gemma model/projector pair", () => {
     expect(validateProductAsrRelease([release()]).errors).toEqual([]);
+  });
+
+  it("rejects plausible catalog pins when Hugging Face does not bind them to real assets", async () => {
+    const result = await verifyProductAsrReleaseAuthority([release()], {
+      fetchFn: async () =>
+        new Response(null, {
+          status: 404,
+          headers: { "x-repo-commit": REVISION },
+        }),
+    });
+
+    expect(result.errors).toHaveLength(2);
+    expect(
+      result.errors.every((error) => error.includes("not downloadable")),
+    ).toBe(true);
+  });
+
+  it("requires resolver commit, digest, size, and download-location authority", async () => {
+    const published = release();
+    const assets = published.ggufAssets as Array<{
+      filename: string;
+      sha256: string;
+      sizeBytes: number;
+    }>;
+    const result = await verifyProductAsrReleaseAuthority([published], {
+      fetchFn: async (url: string | URL | Request) => {
+        const asset = assets.find(({ filename }) =>
+          String(url).endsWith(filename),
+        );
+        if (!asset) throw new Error("unexpected asset URL");
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://cdn.example.invalid/immutable-object",
+            "x-linked-etag": `"${asset.sha256}"`,
+            "x-linked-size": String(asset.sizeBytes),
+            "x-repo-commit": REVISION,
+          },
+        });
+      },
+    });
+
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects generic model/projector pairs that are not declared as Gemma ASR", () => {
+    const generic = release({
+      ggufAssets: [
+        {
+          filename: "voice/asr/generic-model.gguf",
+          sha256: SHA_A,
+          sizeBytes: 1_000,
+          quant: "q4_0",
+        },
+        {
+          filename: "voice/asr/generic-mmproj.gguf",
+          sha256: SHA_B,
+          sizeBytes: 200,
+          quant: "f16",
+        },
+      ],
+    });
+
+    expect(validateProductAsrRelease([generic]).errors).toContainEqual(
+      expect.stringContaining("Gemma ASR model"),
+    );
   });
 
   it("keeps Voice Live E2E red while explicitly labeling compatibility evidence", () => {

--- a/packages/scripts/__tests__/verify-voice-product-asr-release.test.ts
+++ b/packages/scripts/__tests__/verify-voice-product-asr-release.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Verifies the product-ASR publication gate and its Voice Live E2E wiring with
+ * deterministic release fixtures; no model download or provider is mocked.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  latestDeclaredAsrRelease,
+  validateProductAsrRelease,
+} from "../verify-voice-product-asr-release.mjs";
+
+const SHA_A = "a".repeat(64);
+const SHA_B = "b".repeat(64);
+const REVISION = "c".repeat(40);
+
+function release(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "asr",
+    version: "1.0.0",
+    publishedToHfAt: "2026-08-17T00:00:00Z",
+    hfRepo: "elizaos/eliza-1",
+    hfRevision: REVISION,
+    ggufAssets: [
+      {
+        filename: "voice/asr/eliza-1-gemma-asr-q4_0.gguf",
+        sha256: SHA_A,
+        sizeBytes: 1_000,
+        quant: "q4_0",
+      },
+      {
+        filename: "voice/asr/eliza-1-gemma-asr-mmproj.gguf",
+        sha256: SHA_B,
+        sizeBytes: 200,
+        quant: "f16",
+      },
+    ],
+    changelogEntry: "Verified Gemma ASR release.",
+    minBundleVersion: "1.0.0",
+    ...overrides,
+  };
+}
+
+describe("product ASR release authority", () => {
+  it("selects the newest declaration instead of falling back to a retired release", () => {
+    const retired = release({ version: "0.2.0" });
+    const pending = release({
+      version: "0.3.0",
+      hfRevision: "pending",
+      ggufAssets: [],
+    });
+    expect(latestDeclaredAsrRelease([retired, pending])).toBe(pending);
+  });
+
+  it("rejects the current pending release and legacy compatibility-only assets", () => {
+    const result = validateProductAsrRelease([
+      release({ version: "0.2.0" }),
+      release({
+        version: "0.3.0",
+        hfRevision: "pending",
+        ggufAssets: [],
+        missingAssets: [
+          {
+            filename: "voice/asr/eliza-1-gemma-asr-q4_0.gguf",
+            reason: "missing-from-hf-repo",
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.release?.version).toBe("0.3.0");
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("immutable 40-character"),
+        expect.stringContaining("still declares missing assets"),
+        expect.stringContaining("no downloadable GGUF assets"),
+        expect.stringContaining("both a model and an mmproj projector"),
+      ]),
+    );
+  });
+
+  it("accepts an immutable, size- and hash-pinned Gemma model/projector pair", () => {
+    expect(validateProductAsrRelease([release()]).errors).toEqual([]);
+  });
+
+  it("keeps Voice Live E2E red while explicitly labeling compatibility evidence", () => {
+    const workflow = readFileSync(
+      new URL("../../../.github/workflows/voice-live-e2e.yml", import.meta.url),
+      "utf8",
+    );
+    const action = readFileSync(
+      new URL(
+        "../../../.github/actions/stage-voice-real-assets/action.yml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(workflow).toContain("voice-product-asr-release:");
+    expect(workflow).toContain(
+      "bun packages/scripts/verify-voice-product-asr-release.mjs --github-annotations",
+    );
+    expect(workflow).toContain("Pre-Gemma ASR compatibility FFI");
+    expect(action).toContain("Stage voice compatibility assets");
+    expect(action).toContain("not product-runtime ASR evidence");
+  });
+});

--- a/packages/scripts/verify-voice-product-asr-release.mjs
+++ b/packages/scripts/verify-voice-product-asr-release.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import {
   compareVoiceModelSemver,
   VOICE_MODEL_VERSIONS,
+  voiceModelAssetUrl,
 } from "../shared/src/local-inference/voice-models.ts";
 
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
@@ -48,15 +49,19 @@ export function validateProductAsrRelease(versions = VOICE_MODEL_VERSIONS) {
     errors.push(`ASR ${release.version} has no downloadable GGUF assets.`);
   }
 
-  const hasModel = release.ggufAssets.some(
+  const gemmaAsrAssets = release.ggufAssets.filter((asset) => {
+    const filename = asset.filename.toLowerCase();
+    return filename.startsWith("voice/asr/") && filename.includes("gemma");
+  });
+  const hasModel = gemmaAsrAssets.some(
     (asset) => !asset.filename.toLowerCase().includes("mmproj"),
   );
-  const hasProjector = release.ggufAssets.some((asset) =>
+  const hasProjector = gemmaAsrAssets.some((asset) =>
     asset.filename.toLowerCase().includes("mmproj"),
   );
   if (!hasModel || !hasProjector) {
     errors.push(
-      `ASR ${release.version} must publish both a model and an mmproj projector.`,
+      `ASR ${release.version} must publish both a Gemma ASR model and its mmproj projector under voice/asr/.`,
     );
   }
 
@@ -72,8 +77,83 @@ export function validateProductAsrRelease(versions = VOICE_MODEL_VERSIONS) {
   return { release, errors };
 }
 
-export function main({ githubAnnotations = false } = {}) {
-  const result = validateProductAsrRelease();
+function unquoteHeader(value) {
+  return value?.trim().replace(/^W\//, "").replace(/^"|"$/g, "") ?? null;
+}
+
+/**
+ * Resolve every catalog asset through Hugging Face without following the LFS
+ * redirect. The resolver response is the publication authority: it binds the
+ * requested revision to the repository commit and exposes the linked object's
+ * digest and byte size without downloading multi-gigabyte model weights.
+ */
+export async function verifyProductAsrReleaseAuthority(
+  versions = VOICE_MODEL_VERSIONS,
+  { fetchFn = fetch, timeoutMs = 30_000 } = {},
+) {
+  const result = validateProductAsrRelease(versions);
+  if (!result.release || result.errors.length > 0) return result;
+
+  const release = result.release;
+  const remoteErrors = [];
+  await Promise.all(
+    release.ggufAssets.map(async (asset) => {
+      const url = voiceModelAssetUrl(release, asset);
+      let response;
+      try {
+        response = await fetchFn(url, {
+          method: "HEAD",
+          redirect: "manual",
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+      } catch (error) {
+        remoteErrors.push(
+          `${asset.filename} could not be resolved at the pinned Hugging Face revision: ${error instanceof Error ? error.message : String(error)}.`,
+        );
+        return;
+      }
+
+      if (response.status < 200 || response.status >= 400) {
+        remoteErrors.push(
+          `${asset.filename} is not downloadable at the pinned Hugging Face revision (HTTP ${response.status}).`,
+        );
+        return;
+      }
+
+      const repositoryCommit = response.headers.get("x-repo-commit");
+      if (repositoryCommit !== release.hfRevision) {
+        remoteErrors.push(
+          `${asset.filename} resolved from revision ${JSON.stringify(repositoryCommit)}, expected ${release.hfRevision}.`,
+        );
+      }
+
+      const linkedDigest = unquoteHeader(response.headers.get("x-linked-etag"));
+      if (linkedDigest !== asset.sha256) {
+        remoteErrors.push(
+          `${asset.filename} resolver sha256 ${JSON.stringify(linkedDigest)} does not match the catalog pin.`,
+        );
+      }
+
+      const linkedSize = Number(response.headers.get("x-linked-size"));
+      if (!Number.isSafeInteger(linkedSize) || linkedSize !== asset.sizeBytes) {
+        remoteErrors.push(
+          `${asset.filename} resolver size ${JSON.stringify(response.headers.get("x-linked-size"))} does not match the catalog pin ${asset.sizeBytes}.`,
+        );
+      }
+
+      if (response.status >= 300 && !response.headers.get("location")) {
+        remoteErrors.push(
+          `${asset.filename} resolver returned HTTP ${response.status} without a download location.`,
+        );
+      }
+    }),
+  );
+
+  return { release, errors: [...result.errors, ...remoteErrors] };
+}
+
+export async function main({ githubAnnotations = false } = {}) {
+  const result = await verifyProductAsrReleaseAuthority();
   if (result.errors.length > 0) {
     for (const message of result.errors) {
       if (githubAnnotations) {
@@ -100,7 +180,7 @@ if (
   process.argv[1] &&
   pathToFileURL(process.argv[1]).href === import.meta.url
 ) {
-  process.exitCode = main({
+  process.exitCode = await main({
     githubAnnotations: process.argv.includes("--github-annotations"),
   });
 }

--- a/packages/scripts/verify-voice-product-asr-release.mjs
+++ b/packages/scripts/verify-voice-product-asr-release.mjs
@@ -96,58 +96,56 @@ export async function verifyProductAsrReleaseAuthority(
 
   const release = result.release;
   const remoteErrors = [];
-  await Promise.all(
-    release.ggufAssets.map(async (asset) => {
-      const url = voiceModelAssetUrl(release, asset);
-      let response;
-      try {
-        response = await fetchFn(url, {
-          method: "HEAD",
-          redirect: "manual",
-          signal: AbortSignal.timeout(timeoutMs),
-        });
-      } catch (error) {
-        remoteErrors.push(
-          `${asset.filename} could not be resolved at the pinned Hugging Face revision: ${error instanceof Error ? error.message : String(error)}.`,
-        );
-        return;
-      }
+  for (const asset of release.ggufAssets) {
+    const url = voiceModelAssetUrl(release, asset);
+    let response;
+    try {
+      response = await fetchFn(url, {
+        method: "HEAD",
+        redirect: "manual",
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      remoteErrors.push(
+        `${asset.filename} could not be resolved at the pinned Hugging Face revision: ${error instanceof Error ? error.message : String(error)}.`,
+      );
+      continue;
+    }
 
-      if (response.status < 200 || response.status >= 400) {
-        remoteErrors.push(
-          `${asset.filename} is not downloadable at the pinned Hugging Face revision (HTTP ${response.status}).`,
-        );
-        return;
-      }
+    if (response.status < 200 || response.status >= 400) {
+      remoteErrors.push(
+        `${asset.filename} is not downloadable at the pinned Hugging Face revision (HTTP ${response.status}).`,
+      );
+      continue;
+    }
 
-      const repositoryCommit = response.headers.get("x-repo-commit");
-      if (repositoryCommit !== release.hfRevision) {
-        remoteErrors.push(
-          `${asset.filename} resolved from revision ${JSON.stringify(repositoryCommit)}, expected ${release.hfRevision}.`,
-        );
-      }
+    const repositoryCommit = response.headers.get("x-repo-commit");
+    if (repositoryCommit !== release.hfRevision) {
+      remoteErrors.push(
+        `${asset.filename} resolved from revision ${JSON.stringify(repositoryCommit)}, expected ${release.hfRevision}.`,
+      );
+    }
 
-      const linkedDigest = unquoteHeader(response.headers.get("x-linked-etag"));
-      if (linkedDigest !== asset.sha256) {
-        remoteErrors.push(
-          `${asset.filename} resolver sha256 ${JSON.stringify(linkedDigest)} does not match the catalog pin.`,
-        );
-      }
+    const linkedDigest = unquoteHeader(response.headers.get("x-linked-etag"));
+    if (linkedDigest !== asset.sha256) {
+      remoteErrors.push(
+        `${asset.filename} resolver sha256 ${JSON.stringify(linkedDigest)} does not match the catalog pin.`,
+      );
+    }
 
-      const linkedSize = Number(response.headers.get("x-linked-size"));
-      if (!Number.isSafeInteger(linkedSize) || linkedSize !== asset.sizeBytes) {
-        remoteErrors.push(
-          `${asset.filename} resolver size ${JSON.stringify(response.headers.get("x-linked-size"))} does not match the catalog pin ${asset.sizeBytes}.`,
-        );
-      }
+    const linkedSize = Number(response.headers.get("x-linked-size"));
+    if (!Number.isSafeInteger(linkedSize) || linkedSize !== asset.sizeBytes) {
+      remoteErrors.push(
+        `${asset.filename} resolver size ${JSON.stringify(response.headers.get("x-linked-size"))} does not match the catalog pin ${asset.sizeBytes}.`,
+      );
+    }
 
-      if (response.status >= 300 && !response.headers.get("location")) {
-        remoteErrors.push(
-          `${asset.filename} resolver returned HTTP ${response.status} without a download location.`,
-        );
-      }
-    }),
-  );
+    if (response.status >= 300 && !response.headers.get("location")) {
+      remoteErrors.push(
+        `${asset.filename} resolver returned HTTP ${response.status} without a download location.`,
+      );
+    }
+  }
 
   return { release, errors: [...result.errors, ...remoteErrors] };
 }

--- a/packages/scripts/verify-voice-product-asr-release.mjs
+++ b/packages/scripts/verify-voice-product-asr-release.mjs
@@ -1,0 +1,106 @@
+/**
+ * Verifies that the active ASR release is an immutable, downloadable Gemma
+ * model/projector pair before native voice CI can count as product evidence.
+ */
+
+import { pathToFileURL } from "node:url";
+import {
+  compareVoiceModelSemver,
+  VOICE_MODEL_VERSIONS,
+} from "../shared/src/local-inference/voice-models.ts";
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const IMMUTABLE_REVISION_PATTERN = /^[0-9a-f]{40}$/;
+
+/** Return the newest declared ASR release without falling back to a retired one. */
+export function latestDeclaredAsrRelease(versions = VOICE_MODEL_VERSIONS) {
+  return versions
+    .filter((release) => release.id === "asr")
+    .toSorted((left, right) =>
+      compareVoiceModelSemver(right.version, left.version),
+    )[0];
+}
+
+/**
+ * Validate the publication facts required for product-runtime ASR proof.
+ * Compatibility assets from an older release never satisfy this boundary.
+ */
+export function validateProductAsrRelease(versions = VOICE_MODEL_VERSIONS) {
+  const release = latestDeclaredAsrRelease(versions);
+  const errors = [];
+  if (!release) {
+    return { release: undefined, errors: ["No ASR release is declared."] };
+  }
+
+  if (!IMMUTABLE_REVISION_PATTERN.test(release.hfRevision)) {
+    errors.push(
+      `ASR ${release.version} has no immutable 40-character Hugging Face revision (found ${JSON.stringify(release.hfRevision)}).`,
+    );
+  }
+  if ((release.missingAssets?.length ?? 0) > 0) {
+    errors.push(
+      `ASR ${release.version} still declares missing assets: ${release.missingAssets
+        .map((asset) => asset.filename)
+        .join(", ")}.`,
+    );
+  }
+  if (release.ggufAssets.length === 0) {
+    errors.push(`ASR ${release.version} has no downloadable GGUF assets.`);
+  }
+
+  const hasModel = release.ggufAssets.some(
+    (asset) => !asset.filename.toLowerCase().includes("mmproj"),
+  );
+  const hasProjector = release.ggufAssets.some((asset) =>
+    asset.filename.toLowerCase().includes("mmproj"),
+  );
+  if (!hasModel || !hasProjector) {
+    errors.push(
+      `ASR ${release.version} must publish both a model and an mmproj projector.`,
+    );
+  }
+
+  for (const asset of release.ggufAssets) {
+    if (!SHA256_PATTERN.test(asset.sha256)) {
+      errors.push(`${asset.filename} has no valid sha256 pin.`);
+    }
+    if (!Number.isSafeInteger(asset.sizeBytes) || asset.sizeBytes <= 0) {
+      errors.push(`${asset.filename} has no positive integer size pin.`);
+    }
+  }
+
+  return { release, errors };
+}
+
+export function main({ githubAnnotations = false } = {}) {
+  const result = validateProductAsrRelease();
+  if (result.errors.length > 0) {
+    for (const message of result.errors) {
+      if (githubAnnotations) {
+        console.error(
+          `::error title=Product ASR release unavailable::${message}`,
+        );
+      } else {
+        console.error(`[voice-product-asr] ${message}`);
+      }
+    }
+    console.error(
+      "[voice-product-asr] Direct pre-Gemma FFI compatibility smokes are not product-runtime ASR evidence.",
+    );
+    return 1;
+  }
+
+  console.log(
+    `[voice-product-asr] verified ASR ${result.release.version} at ${result.release.hfRevision} (${result.release.ggufAssets.length} assets)`,
+  );
+  return 0;
+}
+
+if (
+  process.argv[1] &&
+  pathToFileURL(process.argv[1]).href === import.meta.url
+) {
+  process.exitCode = main({
+    githubAnnotations: process.argv.includes("--github-annotations"),
+  });
+}


### PR DESCRIPTION
# Relates to

Progresses #17477. This is the bounded CI-honesty slice; it does not claim that the unpublished Gemma ASR artifacts or real-device round trips now exist.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated root blocker is recorded below.
- [x] A reviewer can confirm the changed proof boundary from the automated tests and current-catalog negative control.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI / gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@b4a86483b0416ab882d4c8e229a8ac535fab6338:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` at `b4a86483b0416ab882d4c8e229a8ac535fab6338`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated blocker is documented below.

# Risks

Low. This changes CI labels and adds a fail-closed release-authority check. The voice workflow intentionally remains non-green while the catalog's newest ASR release is unpublished; independent compatibility jobs still run and are labeled as pre-Gemma compatibility evidence. The verifier performs one metadata-only Hugging Face `HEAD` request per declared asset once publication metadata exists.

# Background

## What does this PR do?

- Adds a release-authority verifier for the newest non-retired ASR catalog entry.
- Requires an immutable 40-character Hugging Face revision, no declared missing assets, and a Gemma model/projector pair with SHA-256 and size pins.
- Resolves every declared asset through Hugging Face and requires resolver metadata to bind the requested repository commit, LFS digest, byte size, and download location to the catalog declaration without downloading the model weights.
- Runs that verifier as an always-scheduled job in `voice-live-e2e.yml`.
- Relabels the currently staged fixed ASR pair and direct `bun:ffi` smoke as pre-Gemma compatibility evidence so it cannot be mistaken for product-runtime proof.

This makes the current known gap visible and fail-closed: ASR `0.3.0` still says `hfRevision: "pending"`, declares the Gemma GGUF missing, and has no downloadable assets.

## What kind of change is this?

Bug fix: prevents compatibility smoke results or fabricated catalog-shaped metadata from presenting as completion of the product ASR acceptance contract.

# Documentation changes needed?

No user documentation changes are required. The workflow/action descriptions state their narrower evidence contract directly.

# Testing

## Where should a reviewer start?

Start with `packages/scripts/verify-voice-product-asr-release.mjs`, then the `voice-product-asr-release` job in `.github/workflows/voice-live-e2e.yml`.

## Detailed testing steps

```text
$ bun test packages/scripts/__tests__/verify-voice-product-asr-release.test.ts packages/shared/src/local-inference/voice-models.test.ts
22 pass
0 fail
255 expect() calls

$ bunx @biomejs/biome check .github/actions/stage-voice-real-assets/action.yml .github/workflows/voice-live-e2e.yml packages/scripts/verify-voice-product-asr-release.mjs packages/scripts/__tests__/verify-voice-product-asr-release.test.ts
Checked 2 files. No fixes applied. (YAML is outside Biome's handled files.)

$ actionlint .github/workflows/voice-live-e2e.yml
# exit 0, no findings

$ bun run check:agents-claude
[assert-agents-claude-identical] PASS: 155 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.

$ node packages/scripts/verify-voice-product-asr-release.mjs --github-annotations
::error title=Product ASR release unavailable::ASR 0.3.0 has no immutable 40-character Hugging Face revision (found "pending").
::error title=Product ASR release unavailable::ASR 0.3.0 still declares missing assets: voice/asr/eliza-1-gemma-asr-q4_0.gguf.
::error title=Product ASR release unavailable::ASR 0.3.0 has no downloadable GGUF assets.
::error title=Product ASR release unavailable::ASR 0.3.0 must publish both a Gemma ASR model and its mmproj projector under voice/asr/.
# exit 1 is the expected negative control for the current catalog
```

# Evidence Gate

<!-- evidence-head:58832f976060ec344079aa06545dc0abd44b636a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow and verifier only; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow and verifier only; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this slice changes CI proof semantics, not a user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime path changes; verifier output is included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, or state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] The current-catalog negative control and deterministic resolver-authority tests are the applicable artifacts. A live read-only check against Hugging Face confirmed its resolver metadata contract.

  <details><summary>Exact-head domain evidence</summary>

  ```text
  22 focused tests passed with 0 failures and 255 assertions.
  The current ASR 0.3.0 catalog entry failed closed because its revision is pending, its Gemma model is missing, and it has no downloadable GGUF assets.
  Mocked resolver tests require exact x-repo-commit, x-linked-etag, x-linked-size, and redirect-location authority without downloading model weights.
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model behavior changes.

## Backend + frontend logs

N/A - this is a static catalog/workflow authority boundary. The executable verifier transcript is included under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A for this CI-honesty slice. The Gemma model/projector have not been published, so fabricating a product-runtime capture would contradict #17477. Real audio/device artifacts remain required before the parent issue can close.

## Known gaps / failures

- At the reviewed pre-rebase head, `bun run verify` passed i18n, CI Bun/cache, workspace dependency, plugin convention, alias, and tsconfig gates before stopping at the unrelated `@elizaos/plugin-sql#lint:check`: Biome would reformat `plugins/plugin-sql/src/__tests__/integration/electric-sync-end-to-end.test.ts`. That file is outside this four-file PR diff and was present on the live base. Focused Biome, actionlint, guide parity, and all 22 relevant tests pass again at exact head `58832f976060ec344079aa06545dc0abd44b636a` after the final rebase.
- This PR does not publish Gemma ASR artifacts. A release owner still needs to convert/validate the supported model and projector, upload them, and replace the pending catalog metadata with immutable revision/hash/size pins.
- After publication, the staging action must consume the exact catalog pair and the product `AgentRuntime` HTTP path must be exercised on supported CPU/GPU/device tiers with audio, transcript, logs, and latency artifacts.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@b4a86483b0416ab882d4c8e229a8ac535fab6338:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [issue-17477-ci-honesty]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@b4a86483b0416ab882d4c8e229a8ac535fab6338:packages/skills/skills/contribute-to-eliza"} -->
