### PR TITLE
fix(cloud): reject malformed wallet-path JSON

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.json.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.json.test.ts
@@ -1,0 +1,110 @@
+/**
+ * POST steward-approve-tx used to let JSON.parse throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is
+ * caller error.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@elizaos/plugin-todos/edge", () => ({
+  convergeTodoScopesInTransaction: async () => undefined,
+}));
+
+const dbLimit = mock(async () => []);
+const dbWhere = mock(() => ({ limit: dbLimit }));
+const dbFrom = mock(() => ({ where: dbWhere }));
+const dbSelect = mock(() => ({ from: dbFrom }));
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+const getAgent = mock(async () => ({ id: "sandbox-agent-1" }));
+const approveTransaction = mock(async () => ({ ok: true, txId: "tx-1" }));
+const createStewardClient = mock(async () => ({
+  getAddresses: async () => ({ addresses: [] }),
+  getAgent: async () => ({ walletAddress: "0x1", walletAddresses: {} }),
+  getBalance: async () => ({
+    balances: { native: "0", chainId: 56, symbol: "BNB" },
+  }),
+  getPolicies: async () => [],
+  setPolicies: async () => undefined,
+  getAgentDashboard: async () => ({
+    pendingApprovals: 0,
+    recentTransactions: [],
+  }),
+  listPendingApprovals: async () => [],
+  listApprovals: async () => [],
+  approveTransaction,
+  denyTransaction: async () => ({}),
+}));
+
+mock.module("@/db/helpers", () => ({
+  dbWrite: { select: dbSelect },
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+  readSessionCredential: () => undefined,
+}));
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: { getAgent },
+}));
+mock.module("@/lib/services/steward-client", () => ({
+  createStewardClient,
+}));
+mock.module("@/lib/services/proxy/cors", () => ({
+  applyCorsHeaders: (response: Response) => response,
+  handleCorsOptions: () => new Response(null, { status: 204 }),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+const { handleDirectWalletRequest } = await import("./route");
+
+function context(bodyText: string) {
+  return {
+    req: {
+      url: "http://test.local/api/wallet/steward-approve-tx",
+      header: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json" : undefined,
+      text: async () => bodyText,
+    },
+    json: (body: unknown, status?: number) =>
+      Response.json(body, { status: status ?? 200 }),
+  } as never;
+}
+
+describe("wallet-path malformed JSON", () => {
+  test("returns 400 instead of 500 and never approves", async () => {
+    const response = await handleDirectWalletRequest(
+      context("{"),
+      Promise.resolve({
+        agentId: "sandbox-agent-1",
+        path: ["steward-approve-tx"],
+      }),
+      "POST",
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(approveTransaction).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still approves the transaction", async () => {
+    const response = await handleDirectWalletRequest(
+      context(JSON.stringify({ txId: "tx-1" })),
+      Promise.resolve({
+        agentId: "sandbox-agent-1",
+        path: ["steward-approve-tx"],
+      }),
+      "POST",
+    );
+    expect(response.status).toBe(200);
+    expect(approveTransaction).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
@@ -295,7 +295,11 @@ function normalizePolicy(value: JsonValue): StewardPolicyRule | null {
   };
 }
 
-async function readJsonBody(c: Context<AppEnv>): Promise<JsonObject | null> {
+const INVALID_JSON_BODY = Symbol("invalid-json-body");
+
+async function readJsonBody(
+  c: Context<AppEnv>,
+): Promise<JsonObject | null | typeof INVALID_JSON_BODY> {
   const contentType = c.req.header("content-type");
   if (!contentType?.includes("application/json")) {
     return null;
@@ -305,7 +309,14 @@ async function readJsonBody(c: Context<AppEnv>): Promise<JsonObject | null> {
     throw new Error("Request body too large");
   }
   if (!text.trim()) return {};
-  const parsed = JSON.parse(text) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch {
+    // error-policy:J3 untrusted request body — malformed JSON is caller
+    // error (400), not failureResponse(SyntaxError) → 500.
+    return INVALID_JSON_BODY;
+  }
   return isJsonObject(parsed) ? parsed : null;
 }
 
@@ -447,6 +458,9 @@ export async function handleDirectWalletRequest(
 
   if (method === "PUT" && walletPath === "steward-policies") {
     const body = await readJsonBody(c);
+    if (body === INVALID_JSON_BODY) {
+      return json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     const policies = body?.policies;
     if (!Array.isArray(policies)) {
       return json({ error: "policies must be an array" }, { status: 400 });
@@ -520,6 +534,9 @@ export async function handleDirectWalletRequest(
 
   if (method === "POST" && walletPath === "steward-approve-tx") {
     const body = await readJsonBody(c);
+    if (body === INVALID_JSON_BODY) {
+      return json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     const txId = typeof body?.txId === "string" ? body.txId : "";
     if (!txId) return json({ error: "txId is required" }, { status: 400 });
     return json(await client.approveTransaction(txId, { approvedBy: user.id }));
@@ -527,6 +544,9 @@ export async function handleDirectWalletRequest(
 
   if (method === "POST" && walletPath === "steward-deny-tx") {
     const body = await readJsonBody(c);
+    if (body === INVALID_JSON_BODY) {
+      return json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     const txId = typeof body?.txId === "string" ? body.txId : "";
     const reason =
       typeof body?.reason === "string"
@@ -553,6 +573,9 @@ honoRouter.get("/", async (c) => {
       "GET",
     );
   } catch (error) {
+    if (error instanceof SyntaxError) {
+      return json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     return failureResponse(c, error);
   }
 });
@@ -564,6 +587,9 @@ honoRouter.post("/", async (c) => {
       "POST",
     );
   } catch (error) {
+    if (error instanceof SyntaxError) {
+      return json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     return failureResponse(c, error);
   }
 });
@@ -575,6 +601,9 @@ honoRouter.put("/", async (c) => {
       "PUT",
     );
   } catch (error) {
+    if (error instanceof SyntaxError) {
+      return json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     return failureResponse(c, error);
   }
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on the agent wallet-path proxy currently 500s. `readJsonBody` runs bare `JSON.parse` and the Hono wrappers map `SyntaxError` through `failureResponse` to 500. Sibling of billing-settings `#21653`. Not wallets/provision (grok). Not x402/requests or models/status. Not generate-video (grok backup). Not generate-image / generateMedia (Nubs `#21431`). Not shared-runtime-conversation (Nubs Fleet HQ `#18309` exclusive; throw-not-500). Not `#21385`. Not advertising. Not path encoding. Not extra-decode after `URLSearchParams.get()`. Not list-limit. Not cookies. Proof is `bun:test` of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical steward-approve-tx JSON still approves. Malformed `{` now 400s before approve/deny/policy writes instead of `SyntaxError` → `failureResponse` 500. Proven on the unfixed head: POST `{` received **500**.

# Background

## What does this PR do?

`POST .../wallet/steward-approve-tx` (and deny / PUT steward-policies) ran bare `JSON.parse` in `readJsonBody`. Truncated `{` threw `SyntaxError`. The Hono GET/POST/PUT wrappers catch that into `failureResponse`, which maps it to HTTP 500 / `internal_error`. This PR returns `{ error: "Invalid JSON body" }` with status 400 before steward writes.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical approve bodies unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.json.test.ts` and the `readJsonBody` parse in that route.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate './v1/eliza/agents/[agentId]/api/wallet/[...path]/route.json.test.ts'
```

Unfixed head: POST steward-approve-tx with body `{` returned **500**. After the fix: 2 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the wallet-path HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before steward writes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that a canonical body still approves.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches approve/deny.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on wallet-path JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and a canonical body still approves.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the wallet-path HTTP boundary.

## Audio / voice walkthrough

N/A - leftover-tax is the JSON POST/PUT boundary, not a wallet round-trip.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary. No `bun install`.

<!-- evidence-head:e49a3a6b3cac66c5fa3f5dde3f29dcddfe204ea4 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
