### PR TITLE
fix(agent-skills): contain filesystem storage paths

### DIFF
--- a/plugins/plugin-agent-skills/src/storage.test.ts
+++ b/plugins/plugin-agent-skills/src/storage.test.ts
@@ -97,6 +97,8 @@ const windowsCanonicalizationEntries: Array<[label: string, entryName: string]> 
 		["lowercase reserved device stem", "nul.md"],
 		["reserved device name as directory segment", "com1/escape.txt"],
 		["reserved device name LPT", "lpt9/escape.txt"],
+		["reserved device name COM with superscript digit", "COM¹.txt"],
+		["reserved device name LPT with superscript digit", "lpt³/escape.txt"],
 	];
 
 describe("zip entry path validation", () => {
@@ -172,6 +174,42 @@ describe("zip entry path validation", () => {
 		await memStore.loadFromZip("demo", zip);
 		expect(await memStore.loadSkillContent("demo")).toBe("# demo skill");
 		expect(await memStore.loadFile("demo", "scripts/run.sh")).toBe("echo hi");
+	});
+
+	it("keeps an existing installation intact when a replacement package is unsafe", async () => {
+		await fsStore.saveFromZip(
+			"demo",
+			makeZip({ "SKILL.md": "# original", "original.txt": "keep" }),
+		);
+
+		await expect(
+			fsStore.saveFromZip(
+				"demo",
+				makeZip({ "SKILL.md": "# replacement", "COM².txt": "unsafe" }),
+			),
+		).rejects.toMatchObject({ code: "SKILL_ZIP_ENTRY_UNSAFE" });
+
+		expect(await fsStore.loadSkillContent("demo")).toBe("# original");
+		expect(fs.readFileSync(path.join(basePath, "demo", "original.txt"), "utf-8")).toBe(
+			"keep",
+		);
+	});
+
+	it("atomically replaces the complete installed package", async () => {
+		await fsStore.saveFromZip(
+			"demo",
+			makeZip({ "SKILL.md": "# original", "obsolete.txt": "old" }),
+		);
+		await fsStore.saveFromZip(
+			"demo",
+			makeZip({ "SKILL.md": "# replacement", "current.txt": "new" }),
+		);
+
+		expect(await fsStore.loadSkillContent("demo")).toBe("# replacement");
+		expect(fs.existsSync(path.join(basePath, "demo", "obsolete.txt"))).toBe(false);
+		expect(fs.readFileSync(path.join(basePath, "demo", "current.txt"), "utf-8")).toBe(
+			"new",
+		);
 	});
 
 	it("skips directory entries without rejecting the archive", async () => {
@@ -416,7 +454,7 @@ describe("filesystem path containment", () => {
 	);
 
 	it.runIf(process.platform !== "win32")(
-		"does not create directories through a symlink stored inside a skill",
+		"replaces a skill without following a stored child symlink",
 		async () => {
 			const outside = path.join(outerDir, "outside");
 			const skillDir = path.join(basePath, "demo");
@@ -424,22 +462,23 @@ describe("filesystem path containment", () => {
 			fs.mkdirSync(skillDir);
 			fs.symlinkSync(outside, path.join(skillDir, "linked"), "dir");
 
-			await expect(
-				store.saveSkill({
-					slug: "demo",
-					files: new Map([
-						[
-							"linked/nested/file.txt",
-							{
-								path: "linked/nested/file.txt",
-								content: "payload",
-								isText: true,
-							},
-						],
-					]),
-				}),
-			).rejects.toMatchObject({ code: "SKILL_PATH_TRAVERSAL" });
+			await store.saveSkill({
+				slug: "demo",
+				files: new Map([
+					[
+						"linked/nested/file.txt",
+						{
+							path: "linked/nested/file.txt",
+							content: "payload",
+							isText: true,
+						},
+					],
+				]),
+			});
 			expect(fs.existsSync(path.join(outside, "nested"))).toBe(false);
+			expect(
+				fs.readFileSync(path.join(skillDir, "linked", "nested", "file.txt"), "utf8"),
+			).toBe("payload");
 		},
 	);
 

--- a/plugins/plugin-agent-skills/src/storage.test.ts
+++ b/plugins/plugin-agent-skills/src/storage.test.ts
@@ -306,6 +306,25 @@ describe("filesystem path containment", () => {
 		expect(fs.existsSync(path.join(basePath, "escape.txt"))).toBe(false);
 	});
 
+	it("validates every package path before creating a partial skill", async () => {
+		await expect(
+			store.saveSkill({
+				slug: "demo",
+				files: new Map([
+					[
+						"SKILL.md",
+						{ path: "SKILL.md", content: "# demo", isText: true },
+					],
+					[
+						"../../escape.txt",
+						{ path: "../../escape.txt", content: "payload", isText: true },
+					],
+				]),
+			}),
+		).rejects.toMatchObject({ code: "SKILL_PATH_TRAVERSAL" });
+		expect(fs.existsSync(path.join(basePath, "demo"))).toBe(false);
+	});
+
 	it("refuses to save a package whose slug escapes the base directory", async () => {
 		await expect(
 			store.saveSkill({
@@ -331,6 +350,98 @@ describe("filesystem path containment", () => {
 		// The store itself is untouched by the rejected deletes.
 		expect(fs.existsSync(basePath)).toBe(true);
 	});
+
+	it("refuses traversal through every public filesystem read/list path", async () => {
+		const secretDir = path.join(outerDir, "secret-skill");
+		fs.mkdirSync(secretDir);
+		fs.writeFileSync(path.join(secretDir, "SKILL.md"), "outside");
+		fs.writeFileSync(path.join(outerDir, "secret.txt"), "TOPSECRET");
+		fs.mkdirSync(path.join(basePath, "demo"));
+
+		await expect(store.hasSkill("../secret-skill")).rejects.toMatchObject({
+			code: "SKILL_PATH_TRAVERSAL",
+		});
+		await expect(
+			store.loadSkillContent("../secret-skill"),
+		).rejects.toMatchObject({ code: "SKILL_PATH_TRAVERSAL" });
+		await expect(
+			store.loadFile("demo", "../../secret.txt"),
+		).rejects.toMatchObject({ code: "SKILL_PATH_TRAVERSAL" });
+		await expect(store.listFiles("demo", "../..")).rejects.toMatchObject({
+			code: "SKILL_PATH_TRAVERSAL",
+		});
+		expect(() => store.getSkillPath("../secret-skill")).toThrow(
+			/escapes the skill directory/,
+		);
+	});
+
+	it.runIf(process.platform !== "win32")(
+		"rejects reads, writes, lists, and deletes through a child symlink",
+		async () => {
+			const outside = path.join(outerDir, "outside");
+			fs.mkdirSync(outside);
+			fs.writeFileSync(path.join(outside, "SKILL.md"), "outside");
+			fs.symlinkSync(outside, path.join(basePath, "linked"), "dir");
+
+			await expect(store.hasSkill("linked")).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			await expect(store.loadSkillContent("linked")).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			await expect(store.loadFile("linked", "SKILL.md")).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			await expect(store.listFiles("linked")).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			await expect(
+				store.saveSkill({
+					slug: "linked",
+					files: new Map([
+						[
+							"SKILL.md",
+							{ path: "SKILL.md", content: "changed", isText: true },
+						],
+					]),
+				}),
+			).rejects.toMatchObject({ code: "SKILL_PATH_TRAVERSAL" });
+			await expect(store.deleteSkill("linked")).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			expect(fs.readFileSync(path.join(outside, "SKILL.md"), "utf8")).toBe(
+				"outside",
+			);
+		},
+	);
+
+	it.runIf(process.platform !== "win32")(
+		"does not create directories through a symlink stored inside a skill",
+		async () => {
+			const outside = path.join(outerDir, "outside");
+			const skillDir = path.join(basePath, "demo");
+			fs.mkdirSync(outside);
+			fs.mkdirSync(skillDir);
+			fs.symlinkSync(outside, path.join(skillDir, "linked"), "dir");
+
+			await expect(
+				store.saveSkill({
+					slug: "demo",
+					files: new Map([
+						[
+							"linked/nested/file.txt",
+							{
+								path: "linked/nested/file.txt",
+								content: "payload",
+								isText: true,
+							},
+						],
+					]),
+				}),
+			).rejects.toMatchObject({ code: "SKILL_PATH_TRAVERSAL" });
+			expect(fs.existsSync(path.join(outside, "nested"))).toBe(false);
+		},
+	);
 
 	it("still deletes a real skill directory", async () => {
 		await store.saveSkill({

--- a/plugins/plugin-agent-skills/src/storage.test.ts
+++ b/plugins/plugin-agent-skills/src/storage.test.ts
@@ -413,6 +413,51 @@ describe("filesystem path containment", () => {
 		);
 	});
 
+	it.each(["NUL", "com1.txt", "LPT²", "demo.", "demo ", "name:stream"])(
+		"rejects the non-portable storage slug %s across public operations",
+		async (slug) => {
+			expect(() => store.getSkillPath(slug)).toThrow(/escapes the skill directory/);
+			await expect(store.hasSkill(slug)).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			await expect(store.loadSkillContent(slug)).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			await expect(store.listFiles(slug)).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			await expect(store.deleteSkill(slug)).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			await expect(
+				store.saveSkill({
+					slug,
+					files: new Map([
+						["SKILL.md", { path: "SKILL.md", content: "# x", isText: true }],
+					]),
+				}),
+			).rejects.toMatchObject({ code: "SKILL_PATH_TRAVERSAL" });
+		},
+	);
+
+	it.runIf(process.platform !== "win32")(
+		"omits pre-existing non-portable directory aliases from listings",
+		async () => {
+			for (const slug of ["NUL", "com1.txt", "demo.", "demo ", "name:stream"]) {
+				const dir = path.join(basePath, slug);
+				fs.mkdirSync(dir);
+				fs.writeFileSync(path.join(dir, "SKILL.md"), "# unsafe alias");
+			}
+			fs.mkdirSync(path.join(basePath, "portable-skill"));
+			fs.writeFileSync(
+				path.join(basePath, "portable-skill", "SKILL.md"),
+				"# portable",
+			);
+
+			expect(await store.listSkills()).toEqual(["portable-skill"]);
+		},
+	);
+
 	it.runIf(process.platform !== "win32")(
 		"rejects reads, writes, lists, and deletes through a child symlink",
 		async () => {
@@ -450,6 +495,38 @@ describe("filesystem path containment", () => {
 			expect(fs.readFileSync(path.join(outside, "SKILL.md"), "utf8")).toBe(
 				"outside",
 			);
+		},
+	);
+
+	it.runIf(process.platform !== "win32")(
+		"rejects symlinks that cross into a sibling skill inside the storage root",
+		async () => {
+			const firstDir = path.join(basePath, "first");
+			const secondDir = path.join(basePath, "second");
+			fs.mkdirSync(firstDir);
+			fs.mkdirSync(secondDir);
+			fs.writeFileSync(path.join(secondDir, "SKILL.md"), "sibling secret");
+			fs.writeFileSync(path.join(secondDir, "secret.txt"), "TOPSECRET");
+			fs.symlinkSync(
+				path.join(secondDir, "SKILL.md"),
+				path.join(firstDir, "SKILL.md"),
+				"file",
+			);
+			fs.symlinkSync(secondDir, path.join(firstDir, "linked"), "dir");
+
+			await expect(store.loadSkillContent("first")).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			await expect(store.hasSkill("first")).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			await expect(store.loadFile("first", "linked/secret.txt")).rejects.toMatchObject(
+				{ code: "SKILL_PATH_TRAVERSAL" },
+			);
+			await expect(store.listFiles("first", "linked")).rejects.toMatchObject({
+				code: "SKILL_PATH_TRAVERSAL",
+			});
+			expect(await store.listSkills()).toEqual(["second"]);
 		},
 	);
 
@@ -497,4 +574,5 @@ describe("filesystem path containment", () => {
 		expect(fs.existsSync(path.join(basePath, "demo"))).toBe(false);
 		expect(await store.deleteSkill("demo")).toBe(false);
 	});
+
 });

--- a/plugins/plugin-agent-skills/src/storage.ts
+++ b/plugins/plugin-agent-skills/src/storage.ts
@@ -16,7 +16,7 @@
  * directory.
  */
 
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { unzipSync } from "fflate";
 import { parseFrontmatter, validateFrontmatter } from "./parser";
 import type { Skill } from "./types";
@@ -329,15 +329,42 @@ export class FileSystemSkillStore implements ISkillStorage {
 	async listSkills(): Promise<string[]> {
 		if (!this.fs || !this.path) await this.initialize();
 		const { fs, path } = this.requireNodeModules();
+		const resolvedBase = path.resolve(this.basePath);
 		const entries = fs.readdirSync(this.basePath, {
 			withFileTypes: true,
 		});
-		return entries
-			.filter((e) => e.isDirectory() && !e.name.startsWith("."))
-			.filter((e) =>
-				fs.existsSync(path.join(this.basePath, e.name, "SKILL.md")),
-			)
-			.map((e) => e.name);
+		const slugs: string[] = [];
+		for (const entry of entries) {
+			if (
+				!entry.isDirectory() ||
+				entry.name.startsWith(".") ||
+				!isPortableSkillStorageSlug(entry.name)
+			) {
+				continue;
+			}
+			const skillDir = resolveSkillDirectory(path, resolvedBase, entry.name);
+			const skillPath = path.join(skillDir, "SKILL.md");
+			if (!fs.existsSync(skillPath)) continue;
+			try {
+				assertSkillTargetRealPathContained(
+					fs,
+					path,
+					resolvedBase,
+					skillDir,
+					skillPath,
+					entry.name,
+				);
+			} catch (error) {
+				// error-policy:J3 A stored entry that crosses its skill boundary is
+				// explicitly invalid and omitted; unrelated valid skills remain usable.
+				if (error instanceof ElizaError && error.code === "SKILL_PATH_TRAVERSAL") {
+					continue;
+				}
+				throw error;
+			}
+			slugs.push(entry.name);
+		}
+		return slugs;
 	}
 
 	async hasSkill(slug: string): Promise<boolean> {
@@ -351,7 +378,14 @@ export class FileSystemSkillStore implements ISkillStorage {
 			path.join(skillDir, "SKILL.md"),
 			"SKILL.md",
 		);
-		assertExistingRealPathContained(fs, path, resolvedBase, skillPath, slug);
+		assertSkillTargetRealPathContained(
+			fs,
+			path,
+			resolvedBase,
+			skillDir,
+			skillPath,
+			slug,
+		);
 		return fs.existsSync(skillPath);
 	}
 
@@ -367,7 +401,14 @@ export class FileSystemSkillStore implements ISkillStorage {
 			"SKILL.md",
 		);
 		if (!fs.existsSync(skillPath)) return null;
-		assertExistingRealPathContained(fs, path, resolvedBase, skillPath, slug);
+		assertSkillTargetRealPathContained(
+			fs,
+			path,
+			resolvedBase,
+			skillDir,
+			skillPath,
+			slug,
+		);
 
 		return fs.readFileSync(skillPath, "utf-8");
 	}
@@ -389,10 +430,11 @@ export class FileSystemSkillStore implements ISkillStorage {
 		);
 
 		if (!fs.existsSync(fullPath)) return null;
-		assertExistingRealPathContained(
+		assertSkillTargetRealPathContained(
 			fs,
 			path,
 			resolvedBase,
+			skillDir,
 			fullPath,
 			relativePath,
 		);
@@ -420,7 +462,14 @@ export class FileSystemSkillStore implements ISkillStorage {
 			: skillDir;
 
 		if (!fs.existsSync(dirPath)) return [];
-		assertExistingRealPathContained(fs, path, resolvedBase, dirPath, subdir ?? slug);
+		assertSkillTargetRealPathContained(
+			fs,
+			path,
+			resolvedBase,
+			skillDir,
+			dirPath,
+			subdir ?? slug,
+		);
 
 		return fs.readdirSync(dirPath).filter((f) => !f.startsWith("."));
 	}
@@ -479,16 +528,46 @@ export class FileSystemSkillStore implements ISkillStorage {
 			fs.renameSync(stagingDir, skillDir);
 			installed = true;
 			if (movedExisting) {
-				fs.rmSync(backupDir, { recursive: true, force: true });
+				try {
+					fs.rmSync(backupDir, { recursive: true, force: true });
+				} catch (cause) {
+					// error-policy:J6 The validated replacement is already live. Old
+					// backup cleanup is best-effort and must not report installation failure.
+					logger.warn(
+						`[FileSystemSkillStore] Failed to remove replaced skill backup: ${cause instanceof Error ? cause.message : String(cause)}`,
+					);
+				}
 			}
 		} catch (error) {
+			// error-policy:J2 A rollback failure is wrapped with both causes; after a
+			// successful rollback, the authoritative staging/swap failure propagates.
 			if (movedExisting && !installed && !fs.existsSync(skillDir)) {
-				fs.renameSync(backupDir, skillDir);
+				try {
+					fs.renameSync(backupDir, skillDir);
+				} catch (rollbackCause) {
+					throw new ElizaError("Failed to restore skill after replacement failure", {
+						code: "SKILL_STORAGE_ROLLBACK_FAILED",
+						context: { slug: pkg.slug },
+						severity: "fatal",
+						cause: new AggregateError(
+							[error, rollbackCause],
+							"Skill replacement and rollback both failed",
+						),
+					});
+				}
 			}
 			throw error;
 		} finally {
 			if (!installed) {
-				fs.rmSync(stagingDir, { recursive: true, force: true });
+				try {
+					fs.rmSync(stagingDir, { recursive: true, force: true });
+				} catch (cause) {
+					// error-policy:J6 A failed install is already being propagated; staging
+					// cleanup is best-effort and must not mask the authoritative failure.
+					logger.warn(
+						`[FileSystemSkillStore] Failed to remove skill staging directory: ${cause instanceof Error ? cause.message : String(cause)}`,
+					);
+				}
 			}
 		}
 	}
@@ -755,20 +834,31 @@ function resolveContainedPath(
 /**
  * Keep the storage key to one portable directory component. Domain-level
  * skill-name validation is intentionally stricter and remains owned by the
- * service boundary; this lower-level guard only prevents filesystem escape.
+ * service boundary; this lower-level guard prevents escape and cross-platform
+ * aliases such as reserved Win32 device stems.
  */
 function assertSkillStorageSlug(slug: string): void {
+	if (!isPortableSkillStorageSlug(slug)) {
+		throwSkillPathTraversal(slug);
+	}
+}
+
+/** Whether a storage key names the same single directory on every platform. */
+function isPortableSkillStorageSlug(slug: string): boolean {
 	if (
 		!slug ||
 		slug === "." ||
 		slug === ".." ||
 		slug.includes("/") ||
 		slug.includes("\\") ||
+		slug.includes(":") ||
 		slug.includes("\0") ||
-		/^[A-Za-z]:/.test(slug)
+		/[. ]$/.test(slug)
 	) {
-		throwSkillPathTraversal(slug);
+		return false;
 	}
+	const stem = slug.split(".", 1)[0].toUpperCase();
+	return !WINDOWS_RESERVED_STEMS.has(stem);
 }
 
 /** Resolve a portable skill slug beneath the configured storage root. */
@@ -785,7 +875,9 @@ function resolveSkillDirectory(
  * Reject an existing target whose real path escapes through a symlink. Lexical
  * containment alone is insufficient for public read/write helpers because an
  * otherwise safe child directory can be replaced with a link to arbitrary
- * host files.
+ * host files. This rejects stored links at operation time; it cannot close the
+ * check/use race against a same-host actor who can mutate the storage root, so
+ * filesystem ownership remains the trust boundary for that stronger threat.
  */
 function assertExistingRealPathContained(
 	fs: typeof import("fs"),
@@ -800,6 +892,19 @@ function assertExistingRealPathContained(
 	if (realTarget !== realBase && !realTarget.startsWith(realBase + path.sep)) {
 		throwSkillPathTraversal(label);
 	}
+}
+
+/** Enforce both the storage-root boundary and the selected skill boundary. */
+function assertSkillTargetRealPathContained(
+	fs: typeof import("fs"),
+	path: typeof import("path"),
+	resolvedBase: string,
+	skillDir: string,
+	target: string,
+	label: string,
+): void {
+	assertExistingRealPathContained(fs, path, resolvedBase, skillDir, label);
+	assertExistingRealPathContained(fs, path, skillDir, target, label);
 }
 
 function throwSkillPathTraversal(label: string): never {

--- a/plugins/plugin-agent-skills/src/storage.ts
+++ b/plugins/plugin-agent-skills/src/storage.ts
@@ -437,42 +437,58 @@ export class FileSystemSkillStore implements ISkillStorage {
 		// malicious later entry must not leave a partially installed skill behind.
 		const validatedFiles = [...pkg.files].map(([relativePath, file]) => ({
 			file,
-			fullPath: resolveContainedPath(
+			relativePath: validateSkillPackagePath(
 				path,
 				resolvedSkillDir,
-				path.join(resolvedSkillDir, relativePath),
 				relativePath,
 			),
-			relativePath,
 		}));
 
-		// Create skill directory
-		if (!fs.existsSync(skillDir)) {
-			fs.mkdirSync(skillDir);
+		if (fs.existsSync(skillDir)) {
+			assertExistingRealPathContained(fs, path, resolvedBase, skillDir, pkg.slug);
 		}
-		assertExistingRealPathContained(fs, path, resolvedBase, skillDir, pkg.slug);
 
-		// Write all files
-		for (const { file, fullPath, relativePath } of validatedFiles) {
-			const dir = path.dirname(fullPath);
+		// Materialize the entire validated package beside the live skill. The
+		// replacement becomes visible only after every file has been written, and
+		// an unsafe or failed replacement leaves the previous installation intact.
+		const stagingDir = fs.mkdtempSync(path.join(resolvedBase, ".skill-install-"));
+		const backupDir = `${stagingDir}.previous`;
+		let movedExisting = false;
+		let installed = false;
 
-			// Ensure directory exists
-			ensureContainedDirectory(
-				fs,
-				path,
-				resolvedSkillDir,
-				dir,
-				relativePath,
-			);
-			if (fs.existsSync(fullPath) && fs.lstatSync(fullPath).isSymbolicLink()) {
-				throwSkillPathTraversal(relativePath);
+		try {
+			for (const { file, relativePath } of validatedFiles) {
+				const fullPath = resolveContainedPath(
+					path,
+					stagingDir,
+					path.join(stagingDir, relativePath),
+					relativePath,
+				);
+				fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+				if (file.isText) {
+					fs.writeFileSync(fullPath, file.content as string, "utf-8");
+				} else {
+					fs.writeFileSync(fullPath, file.content as Uint8Array);
+				}
 			}
 
-			// Write file
-			if (file.isText) {
-				fs.writeFileSync(fullPath, file.content as string, "utf-8");
-			} else {
-				fs.writeFileSync(fullPath, file.content as Uint8Array);
+			if (fs.existsSync(skillDir)) {
+				fs.renameSync(skillDir, backupDir);
+				movedExisting = true;
+			}
+			fs.renameSync(stagingDir, skillDir);
+			installed = true;
+			if (movedExisting) {
+				fs.rmSync(backupDir, { recursive: true, force: true });
+			}
+		} catch (error) {
+			if (movedExisting && !installed && !fs.existsSync(skillDir)) {
+				fs.renameSync(backupDir, skillDir);
+			}
+			throw error;
+		} finally {
+			if (!installed) {
+				fs.rmSync(stagingDir, { recursive: true, force: true });
 			}
 		}
 	}
@@ -610,6 +626,12 @@ const WINDOWS_RESERVED_STEMS = new Set([
 	"NUL",
 	...Array.from({ length: 10 }, (_, i) => `COM${i}`),
 	...Array.from({ length: 10 }, (_, i) => `LPT${i}`),
+	"COM¹",
+	"COM²",
+	"COM³",
+	"LPT¹",
+	"LPT²",
+	"LPT³",
 ]);
 
 /**
@@ -644,6 +666,28 @@ function sanitizeZipEntryPath(fileName: string): string | null {
 		kept.push(part);
 	}
 	return kept.length === 0 ? null : kept.join("/");
+}
+
+/** Validate a direct storage package path against lexical and portable rules. */
+function validateSkillPackagePath(
+	path: typeof import("path"),
+	resolvedSkillDir: string,
+	relativePath: string,
+): string {
+	resolveContainedPath(
+		path,
+		resolvedSkillDir,
+		path.join(resolvedSkillDir, relativePath),
+		relativePath,
+	);
+	const normalized = sanitizeZipEntryPath(relativePath);
+	if (normalized === null || normalized !== relativePath) {
+		throw new ElizaError("Skill file has an unsafe path", {
+			code: "SKILL_ZIP_ENTRY_UNSAFE",
+			context: { entry: relativePath },
+		});
+	}
+	return normalized;
 }
 
 /**
@@ -755,36 +799,6 @@ function assertExistingRealPathContained(
 	const realTarget = fs.realpathSync(target);
 	if (realTarget !== realBase && !realTarget.startsWith(realBase + path.sep)) {
 		throwSkillPathTraversal(label);
-	}
-}
-
-/**
- * Create each missing directory only after its existing parent has passed the
- * real-path containment check. A recursive mkdir could otherwise traverse a
- * stored symlink and mutate outside the skill root before the final check.
- */
-function ensureContainedDirectory(
-	fs: typeof import("fs"),
-	path: typeof import("path"),
-	base: string,
-	target: string,
-	label: string,
-): void {
-	const resolvedBase = path.resolve(base);
-	const resolvedTarget = path.resolve(target);
-	if (resolvedTarget !== resolvedBase) {
-		assertContainedPath(path, resolvedBase, resolvedTarget, label);
-	}
-	assertExistingRealPathContained(fs, path, resolvedBase, resolvedBase, label);
-
-	const relative = path.relative(resolvedBase, resolvedTarget);
-	let current = resolvedBase;
-	for (const component of relative.split(path.sep).filter(Boolean)) {
-		current = path.join(current, component);
-		if (!fs.existsSync(current)) {
-			fs.mkdirSync(current);
-		}
-		assertExistingRealPathContained(fs, path, resolvedBase, current, label);
 	}
 }
 

--- a/plugins/plugin-agent-skills/src/storage.ts
+++ b/plugins/plugin-agent-skills/src/storage.ts
@@ -343,15 +343,31 @@ export class FileSystemSkillStore implements ISkillStorage {
 	async hasSkill(slug: string): Promise<boolean> {
 		if (!this.fs || !this.path) await this.initialize();
 		const { fs, path } = this.requireNodeModules();
-		const skillPath = path.join(this.basePath, slug, "SKILL.md");
+		const resolvedBase = path.resolve(this.basePath);
+		const skillDir = resolveSkillDirectory(path, resolvedBase, slug);
+		const skillPath = resolveContainedPath(
+			path,
+			skillDir,
+			path.join(skillDir, "SKILL.md"),
+			"SKILL.md",
+		);
+		assertExistingRealPathContained(fs, path, resolvedBase, skillPath, slug);
 		return fs.existsSync(skillPath);
 	}
 
 	async loadSkillContent(slug: string): Promise<string | null> {
 		if (!this.fs || !this.path) await this.initialize();
 		const { fs, path } = this.requireNodeModules();
-		const skillPath = path.join(this.basePath, slug, "SKILL.md");
+		const resolvedBase = path.resolve(this.basePath);
+		const skillDir = resolveSkillDirectory(path, resolvedBase, slug);
+		const skillPath = resolveContainedPath(
+			path,
+			skillDir,
+			path.join(skillDir, "SKILL.md"),
+			"SKILL.md",
+		);
 		if (!fs.existsSync(skillPath)) return null;
+		assertExistingRealPathContained(fs, path, resolvedBase, skillPath, slug);
 
 		return fs.readFileSync(skillPath, "utf-8");
 	}
@@ -363,12 +379,23 @@ export class FileSystemSkillStore implements ISkillStorage {
 		if (!this.fs || !this.path) await this.initialize();
 		const { fs, path } = this.requireNodeModules();
 
-		// Sanitize path to prevent directory traversal
-		const safePath = path.basename(relativePath);
-		const subdir = path.dirname(relativePath);
-		const fullPath = path.join(this.basePath, slug, subdir, safePath);
+		const resolvedBase = path.resolve(this.basePath);
+		const skillDir = resolveSkillDirectory(path, resolvedBase, slug);
+		const fullPath = resolveContainedPath(
+			path,
+			skillDir,
+			path.join(skillDir, relativePath),
+			relativePath,
+		);
 
 		if (!fs.existsSync(fullPath)) return null;
+		assertExistingRealPathContained(
+			fs,
+			path,
+			resolvedBase,
+			fullPath,
+			relativePath,
+		);
 
 		if (isTextFile(relativePath)) {
 			return fs.readFileSync(fullPath, "utf-8");
@@ -381,11 +408,19 @@ export class FileSystemSkillStore implements ISkillStorage {
 		if (!this.fs || !this.path) await this.initialize();
 		const { fs, path } = this.requireNodeModules();
 
+		const resolvedBase = path.resolve(this.basePath);
+		const skillDir = resolveSkillDirectory(path, resolvedBase, slug);
 		const dirPath = subdir
-			? path.join(this.basePath, slug, subdir)
-			: path.join(this.basePath, slug);
+			? resolveContainedPath(
+					path,
+					skillDir,
+					path.join(skillDir, subdir),
+					subdir,
+				)
+			: skillDir;
 
 		if (!fs.existsSync(dirPath)) return [];
+		assertExistingRealPathContained(fs, path, resolvedBase, dirPath, subdir ?? slug);
 
 		return fs.readdirSync(dirPath).filter((f) => !f.startsWith("."));
 	}
@@ -394,24 +429,43 @@ export class FileSystemSkillStore implements ISkillStorage {
 		if (!this.fs || !this.path) await this.initialize();
 		const { fs, path } = this.requireNodeModules();
 
-		const skillDir = path.join(this.basePath, pkg.slug);
-		assertContainedPath(path, path.resolve(this.basePath), skillDir, pkg.slug);
+		const resolvedBase = path.resolve(this.basePath);
+		const skillDir = resolveSkillDirectory(path, resolvedBase, pkg.slug);
 		const resolvedSkillDir = path.resolve(skillDir);
+
+		// Validate the complete package before creating or changing anything. A
+		// malicious later entry must not leave a partially installed skill behind.
+		const validatedFiles = [...pkg.files].map(([relativePath, file]) => ({
+			file,
+			fullPath: resolveContainedPath(
+				path,
+				resolvedSkillDir,
+				path.join(resolvedSkillDir, relativePath),
+				relativePath,
+			),
+			relativePath,
+		}));
 
 		// Create skill directory
 		if (!fs.existsSync(skillDir)) {
-			fs.mkdirSync(skillDir, { recursive: true });
+			fs.mkdirSync(skillDir);
 		}
+		assertExistingRealPathContained(fs, path, resolvedBase, skillDir, pkg.slug);
 
 		// Write all files
-		for (const [relativePath, file] of pkg.files) {
-			const fullPath = path.join(skillDir, relativePath);
-			assertContainedPath(path, resolvedSkillDir, fullPath, relativePath);
+		for (const { file, fullPath, relativePath } of validatedFiles) {
 			const dir = path.dirname(fullPath);
 
 			// Ensure directory exists
-			if (!fs.existsSync(dir)) {
-				fs.mkdirSync(dir, { recursive: true });
+			ensureContainedDirectory(
+				fs,
+				path,
+				resolvedSkillDir,
+				dir,
+				relativePath,
+			);
+			if (fs.existsSync(fullPath) && fs.lstatSync(fullPath).isSymbolicLink()) {
+				throwSkillPathTraversal(relativePath);
 			}
 
 			// Write file
@@ -426,9 +480,10 @@ export class FileSystemSkillStore implements ISkillStorage {
 	async deleteSkill(slug: string): Promise<boolean> {
 		if (!this.fs || !this.path) await this.initialize();
 		const { fs, path } = this.requireNodeModules();
-		const skillDir = path.join(this.basePath, slug);
-		assertContainedPath(path, path.resolve(this.basePath), skillDir, slug);
+		const resolvedBase = path.resolve(this.basePath);
+		const skillDir = resolveSkillDirectory(path, resolvedBase, slug);
 		if (!fs.existsSync(skillDir)) return false;
+		assertExistingRealPathContained(fs, path, resolvedBase, skillDir, slug);
 
 		// Recursive delete
 		fs.rmSync(skillDir, { recursive: true, force: true });
@@ -436,9 +491,10 @@ export class FileSystemSkillStore implements ISkillStorage {
 	}
 
 	getSkillPath(slug: string): string {
-		return this.path
-			? this.path.resolve(this.basePath, slug)
-			: `${this.basePath}/${slug}`;
+		assertSkillStorageSlug(slug);
+		if (!this.path) return `${this.basePath}/${slug}`;
+		const resolvedBase = this.path.resolve(this.basePath);
+		return resolveSkillDirectory(this.path, resolvedBase, slug);
 	}
 
 	/**
@@ -635,11 +691,108 @@ function assertContainedPath(
 		resolvedTarget === resolvedBase ||
 		!resolvedTarget.startsWith(resolvedBase + path.sep)
 	) {
-		throw new ElizaError("Skill path escapes the skill directory", {
-			code: "SKILL_PATH_TRAVERSAL",
-			context: { path: label },
-		});
+		throwSkillPathTraversal(label);
 	}
+}
+
+/** Resolve a target and return it only when it is strictly inside `base`. */
+function resolveContainedPath(
+	path: typeof import("path"),
+	base: string,
+	target: string,
+	label: string,
+): string {
+	const resolvedBase = path.resolve(base);
+	const resolvedTarget = path.resolve(resolvedBase, target);
+	assertContainedPath(path, resolvedBase, resolvedTarget, label);
+	return resolvedTarget;
+}
+
+/**
+ * Keep the storage key to one portable directory component. Domain-level
+ * skill-name validation is intentionally stricter and remains owned by the
+ * service boundary; this lower-level guard only prevents filesystem escape.
+ */
+function assertSkillStorageSlug(slug: string): void {
+	if (
+		!slug ||
+		slug === "." ||
+		slug === ".." ||
+		slug.includes("/") ||
+		slug.includes("\\") ||
+		slug.includes("\0") ||
+		/^[A-Za-z]:/.test(slug)
+	) {
+		throwSkillPathTraversal(slug);
+	}
+}
+
+/** Resolve a portable skill slug beneath the configured storage root. */
+function resolveSkillDirectory(
+	path: typeof import("path"),
+	resolvedBase: string,
+	slug: string,
+): string {
+	assertSkillStorageSlug(slug);
+	return resolveContainedPath(path, resolvedBase, slug, slug);
+}
+
+/**
+ * Reject an existing target whose real path escapes through a symlink. Lexical
+ * containment alone is insufficient for public read/write helpers because an
+ * otherwise safe child directory can be replaced with a link to arbitrary
+ * host files.
+ */
+function assertExistingRealPathContained(
+	fs: typeof import("fs"),
+	path: typeof import("path"),
+	base: string,
+	target: string,
+	label: string,
+): void {
+	if (!fs.existsSync(target)) return;
+	const realBase = fs.realpathSync(base);
+	const realTarget = fs.realpathSync(target);
+	if (realTarget !== realBase && !realTarget.startsWith(realBase + path.sep)) {
+		throwSkillPathTraversal(label);
+	}
+}
+
+/**
+ * Create each missing directory only after its existing parent has passed the
+ * real-path containment check. A recursive mkdir could otherwise traverse a
+ * stored symlink and mutate outside the skill root before the final check.
+ */
+function ensureContainedDirectory(
+	fs: typeof import("fs"),
+	path: typeof import("path"),
+	base: string,
+	target: string,
+	label: string,
+): void {
+	const resolvedBase = path.resolve(base);
+	const resolvedTarget = path.resolve(target);
+	if (resolvedTarget !== resolvedBase) {
+		assertContainedPath(path, resolvedBase, resolvedTarget, label);
+	}
+	assertExistingRealPathContained(fs, path, resolvedBase, resolvedBase, label);
+
+	const relative = path.relative(resolvedBase, resolvedTarget);
+	let current = resolvedBase;
+	for (const component of relative.split(path.sep).filter(Boolean)) {
+		current = path.join(current, component);
+		if (!fs.existsSync(current)) {
+			fs.mkdirSync(current);
+		}
+		assertExistingRealPathContained(fs, path, resolvedBase, current, label);
+	}
+}
+
+function throwSkillPathTraversal(label: string): never {
+	throw new ElizaError("Skill path escapes the skill directory", {
+		code: "SKILL_PATH_TRAVERSAL",
+		context: { path: label },
+	});
 }
 
 /**


### PR DESCRIPTION
## Summary

Hardens the exported filesystem skill store so every public read, write, list, delete, and path helper remains inside the configured skill root. The implementation validates a complete package before mutation, rejects non-portable multi-component storage keys, checks existing real paths, and stages a complete validated replacement before swapping it live, and rejects stored symlinks plus Windows superscript device aliases.

The detailed reproduction and affected-version analysis are recorded privately in the repository security advisory. This public PR intentionally limits itself to remediation and verifiable behavior.

## Validation

Exact head `9fc181345d87bc972574286a1c57760bf72efaac`, rebased on `develop@2210ad8da9277011a2ee1388b36db0b545c32e5d` with pinned Bun 1.3.14:

- filesystem storage suite: 44/44 passed, including traversal, symlink, and no-partial-mutation cases
- full `plugin-agent-skills` suite: 157/157 passed
- `plugin-agent-skills` typecheck: passed
- `plugin-agent-skills` build: passed
- Biome on both changed files: passed
- `git diff --check`: passed

## Risk and rollback

This deliberately tightens the public filesystem backend: storage slugs must now be one portable directory component, while the service's stricter domain-name validation remains unchanged. Normal nested files inside a skill remain supported. Rollback is the single commit, but should only be considered if an existing caller is proven to rely on an unsafe multi-directory storage key.

## Evidence Gate

<!-- evidence-head:9fc181345d87bc972574286a1c57760bf72efaac -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Node filesystem storage behavior only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Node filesystem storage behavior only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed service or process-boundary mutation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head real-filesystem validation transcript:

<details><summary>Filesystem boundary artifact</summary>

~~~text
$ bun --bun node_modules/.bin/vitest run plugins/plugin-agent-skills/src/storage.test.ts
Test Files  1 passed (1); Tests  52 passed (52)
Inspected temporary contained files, unchanged outside sentinels, and the absence of partial external directories after rejected writes.
~~~

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@310d08c4fd8f09aafca0fe34192a7df492b85591:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@310d08c4fd8f09aafca0fe34192a7df492b85591:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@310d08c4fd8f09aafca0fe34192a7df492b85591:packages/skills/skills/contribute-to-eliza"} -->