### PR TITLE
fix(wallet): add timeout to birdeye service fetch via getBirdeyeFetchOptions

### DIFF
--- a/plugins/plugin-wallet/src/analytics/birdeye/service.test.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/service.test.ts
@@ -94,7 +94,7 @@ describe("BirdeyeService market data caching", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://birdeye.test/defi/multi_price?list_address=0xabc&include_liquidity=true",
-      { headers: { accept: "application/json", "x-chain": "base" } },
+      expect.objectContaining({ headers: { accept: "application/json", "x-chain": "base" }, signal: expect.any(AbortSignal) }),
     );
     expect(result["0xabc"]).toMatchObject({
       priceUsd: 2.5,

--- a/plugins/plugin-wallet/src/analytics/birdeye/service.timeout.test.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/service.timeout.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Exercises BirdeyeService fetch deadline via injected fetch boundary.
+ * Verifies getBirdeyeFetchOptions propagates AbortSignal.timeout and that
+ * fetchBirdeyeJson aborts a stalled upstream.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_BIRDEYE_FETCH_TIMEOUT_MS } from "./constants";
+import { BirdeyeService } from "./service";
+
+const originalFetch = globalThis.fetch;
+
+describe("BirdeyeService fetch timeout", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("includes AbortSignal.timeout in getBirdeyeFetchOptions", () => {
+    const service = Object.create(BirdeyeService.prototype) as BirdeyeService;
+    // @ts-expect-error private access for test
+    (
+      service as unknown as { access: { headers: Record<string, string> } }
+    ).access = {
+      headers: {},
+    };
+    // @ts-expect-error private
+    const opts = service.getBirdeyeFetchOptions("solana");
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+    expect(opts.headers).toMatchObject({ "x-chain": "solana" });
+    expect((opts.signal as AbortSignal).aborted).toBe(false);
+  });
+
+  it("aborts a stalled fetchBirdeyeJson at the configured deadline", async () => {
+    const service = Object.create(BirdeyeService.prototype) as BirdeyeService;
+    (
+      service as unknown as {
+        access: { baseUrl: string; headers: Record<string, string> };
+      }
+    ).access = {
+      baseUrl: "https://birdeye.test",
+      headers: {},
+    };
+    (service as unknown as { birdeyeUrl: (p: string) => string }).birdeyeUrl = (
+      p: string,
+    ) => `https://birdeye.test/${p.replace(/^\/+/, "")}`;
+
+    const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() =>
+      originalTimeout(10),
+    );
+
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        if (!signal) throw new Error("expected abort signal");
+        signal.addEventListener("abort", () => reject(signal.reason), {
+          once: true,
+        });
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      // @ts-expect-error private
+      service.fetchBirdeyeJson("/defi/price", { address: "So111" }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("https://birdeye.test/defi/price"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("uses timeout constant from constants", () => {
+    expect(DEFAULT_BIRDEYE_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+});

--- a/plugins/plugin-wallet/src/analytics/birdeye/service.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/service.ts
@@ -21,7 +21,11 @@ import {
   type ServiceTypeName,
 } from "@elizaos/core";
 import Birdeye from "./birdeye-task";
-import { BIRDEYE_ENDPOINTS, BIRDEYE_SERVICE_NAME } from "./constants";
+import {
+  BIRDEYE_ENDPOINTS,
+  BIRDEYE_SERVICE_NAME,
+  DEFAULT_BIRDEYE_FETCH_TIMEOUT_MS,
+} from "./constants";
 import { searchBirdeyeTokens } from "./search-category";
 import type { DefiMultiPriceResponse } from "./types/api/defi";
 import type {
@@ -141,6 +145,7 @@ export class BirdeyeService extends Service {
 
   private getBirdeyeFetchOptions(chain = "solana"): RequestInit {
     return {
+      signal: AbortSignal.timeout(DEFAULT_BIRDEYE_FETCH_TIMEOUT_MS),
       headers: {
         accept: "application/json",
         "x-chain": chain,


### PR DESCRIPTION
# Relates to

Fixes `BirdeyeService` hang on `develop` @ `5929de21`. `getBirdeyeFetchOptions` returned only `headers` with no `signal`; `await fetch(birdeyeUrl(...))` on 8 paths could hang forever. Mirrors merged `21234`/`21198`/`21251`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `5929de21` (`5929de2162ecffa1fff069faabca65779d7dcb0f`); zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` completed; `bun run verify` stepwise: `check:agents-claude` PASS, `check:biome-version` PASS, `check:i18n` OK (4675 keys), `ci-bun-version-contract` PASS, `ci-turbo-cache-contract` PASS, `fix-deps:check` OK, `ensure-plugin-test-conventions:check` PASS, `audit:alias-read-guard` PASS, `audit:tsconfig-workspace-resolution` inspected 135 projects PASS; focused `vitest`+`biome`+`typecheck` for affected package PASS (see Testing). Full `typecheck lint:check --concurrency=8` is heavy (8GB×8) — CI will confirm; locally ran with `--concurrency=2` for core.

# Risks

Low. Single helper `getBirdeyeFetchOptions` now returns `{ signal: AbortSignal.timeout(10s), headers }`. No API or storage migration. 8 call sites (`fetchBirdeyeJson`, trending, etc.) now bounded. Existing `service.test.ts` updated to expect signal.

# Background

## What does this PR do?

Adds `signal: AbortSignal.timeout(DEFAULT_BIRDEYE_FETCH_TIMEOUT_MS)` to `BirdeyeService.getBirdeyeFetchOptions` so every Birdeye fetch aborts after 10s.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-wallet/src/analytics/birdeye/service.ts:142`
- `plugins/plugin-wallet/src/analytics/birdeye/service.timeout.test.ts`
- `plugins/plugin-wallet/src/analytics/birdeye/service.test.ts`

## Detailed testing steps

1. `bunx vitest run plugins/plugin-wallet/src/analytics/birdeye/service.timeout.test.ts` — - `getBirdeyeFetchOptions` returns `AbortSignal` not aborted
   - hang `fetchBirdeyeJson("/defi/price")` with mocked `AbortSignal.timeout(10)` -> `TimeoutError`
   - constant `10_000`
2. Existing `service.test.ts` now expects `signal: expect.any(AbortSignal)` and passes.
3. `bunx @biomejs/biome check` and `git diff --check` clean.

Post-rebase at `1d7ab6ba52ea15e821e92b853703bb091fc71b34` (rebased onto `5929de2162ecffa1fff069faabca65779d7dcb0f`):
```
service.timeout.test.ts (3 tests) passed
service.test.ts (existing) passed with signal expectation
Checked 2 files in 18ms. No fixes applied.
git diff --check: clean
```

# Evidence Gate

<!-- evidence-head:d95e22993e1f8056ac5d6909be7a6876ef56ce20 -->
<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only wallet service, no rendered UI`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only wallet service, no rendered UI`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - deterministic service timeout, no interactive flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not N/A, logs pasted in Testing`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - no domain artifact beyond test fetch mock`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/model change, pure fetch timeout.`

## Backend + frontend logs

Backend: `service.timeout.test.ts` 3 pass as above. Frontend: `N/A`.

## Screenshots (before / after) + video walkthrough

`N/A - backend-only change.`

## Audio / voice walkthrough

`N/A - no voice change.`

## Known gaps / failures

None.

AI provider/model: openai / gpt-5.6
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [byt61]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6","client":"Codex","skill_revision":"elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza"} -->


