### PR TITLE
fix(cloud): bound remote blob fetch duration

### DIFF
--- a/packages/cloud/shared/src/lib/blob.test.ts
+++ b/packages/cloud/shared/src/lib/blob.test.ts
@@ -17,6 +17,14 @@ const MAX_BYTES = 25 * 1024 * 1024;
 
 const puts: Array<{ key: string; bytes: Uint8Array; contentType?: string }> = [];
 
+async function waitForCondition(condition: () => boolean, label: string): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (condition()) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
 function expireDeadlineImmediately(): void {
   vi.spyOn(globalThis, "setTimeout").mockImplementation(((callback: () => void) => {
     queueMicrotask(callback);
@@ -168,7 +176,7 @@ describe("uploadFromUrl", () => {
     await expect(
       uploadFromUrl("https://images.example/non-cooperative-body.png", { filename: "x.png" }),
     ).rejects.toHaveProperty("code", "REMOTE_BLOB_FETCH_TIMEOUT");
-    await vi.waitFor(() => expect(cancelled).toBe(true));
+    await waitForCondition(() => cancelled, "response body cancellation");
     expect(puts).toHaveLength(0);
   });
 
@@ -190,7 +198,10 @@ describe("uploadFromUrl", () => {
     });
 
     const upload = uploadFromUrl("https://images.example/image.png", { filename: "x.png" });
-    await vi.waitFor(() => expect(clearTimeoutSpy).toHaveBeenCalledTimes(1));
+    await waitForCondition(
+      () => clearTimeoutSpy.mock.calls.length === 1,
+      "the remote deadline to clear",
+    );
     expect(fetchSignal?.aborted).toBe(false);
     finishPut?.();
     await expect(upload).resolves.toMatchObject({ size: 5 });

--- a/packages/cloud/shared/src/lib/blob.test.ts
+++ b/packages/cloud/shared/src/lib/blob.test.ts
@@ -17,6 +17,14 @@ const MAX_BYTES = 25 * 1024 * 1024;
 
 const puts: Array<{ key: string; bytes: Uint8Array; contentType?: string }> = [];
 
+function expireDeadlineImmediately(): void {
+  vi.spyOn(globalThis, "setTimeout").mockImplementation(((callback: () => void) => {
+    queueMicrotask(callback);
+    return 1 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout);
+  vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+}
+
 function streamResponse(
   chunks: Uint8Array[],
   init: { headers?: Record<string, string> } = {},
@@ -90,11 +98,7 @@ describe("uploadFromUrl", () => {
   });
 
   test("aborts a remote fetch that does not settle before the deadline", async () => {
-    vi.spyOn(globalThis, "setTimeout").mockImplementation(((callback: () => void) => {
-      queueMicrotask(callback);
-      return 1 as unknown as ReturnType<typeof setTimeout>;
-    }) as typeof setTimeout);
-    vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+    expireDeadlineImmediately();
     safeFetchMock.mockImplementation(
       (_url: string, init: RequestInit) =>
         new Promise((_resolve, reject) => {
@@ -104,18 +108,29 @@ describe("uploadFromUrl", () => {
         }),
     );
 
+    const result = uploadFromUrl("https://images.example/hangs.png", { filename: "x.png" });
+    await expect(result).rejects.toMatchObject({
+      name: "ElizaError",
+      code: "REMOTE_BLOB_FETCH_TIMEOUT",
+      message: "Remote blob fetch timed out after 15000ms",
+      context: { timeoutMs: 15_000 },
+      severity: "ephemeral",
+    });
+    expect(puts).toHaveLength(0);
+  });
+
+  test("bounds a DNS or guard lookup that ignores the abort signal", async () => {
+    expireDeadlineImmediately();
+    safeFetchMock.mockReturnValue(new Promise<Response>(() => undefined));
+
     await expect(
-      uploadFromUrl("https://images.example/hangs.png", { filename: "x.png" }),
-    ).rejects.toThrow("Remote blob fetch timed out after 15000ms");
+      uploadFromUrl("https://images.example/stalled-dns.png", { filename: "x.png" }),
+    ).rejects.toHaveProperty("code", "REMOTE_BLOB_FETCH_TIMEOUT");
     expect(puts).toHaveLength(0);
   });
 
   test("keeps the deadline active while reading a stalled response body", async () => {
-    vi.spyOn(globalThis, "setTimeout").mockImplementation(((callback: () => void) => {
-      queueMicrotask(callback);
-      return 1 as unknown as ReturnType<typeof setTimeout>;
-    }) as typeof setTimeout);
-    vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+    expireDeadlineImmediately();
     safeFetchMock.mockImplementation((_url: string, init: RequestInit) => {
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {
@@ -133,12 +148,73 @@ describe("uploadFromUrl", () => {
     expect(puts).toHaveLength(0);
   });
 
+  test("bounds and cancels a response body that ignores the fetch signal", async () => {
+    expireDeadlineImmediately();
+    let cancelled = false;
+    safeFetchMock.mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull() {
+            return new Promise<void>(() => undefined);
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(
+      uploadFromUrl("https://images.example/non-cooperative-body.png", { filename: "x.png" }),
+    ).rejects.toHaveProperty("code", "REMOTE_BLOB_FETCH_TIMEOUT");
+    await vi.waitFor(() => expect(cancelled).toBe(true));
+    expect(puts).toHaveLength(0);
+  });
+
+  test("ends the remote deadline before starting the R2 write", async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    let fetchSignal: AbortSignal | null = null;
+    let finishPut: (() => void) | undefined;
+    const putFinished = new Promise<void>((resolve) => {
+      finishPut = resolve;
+    });
+    setRuntimeR2Bucket({
+      get: async () => null,
+      put: async () => putFinished,
+      delete: async () => undefined,
+    });
+    safeFetchMock.mockImplementation((_url: string, init: RequestInit) => {
+      fetchSignal = init.signal ?? null;
+      return Promise.resolve(new Response("image", { status: 200 }));
+    });
+
+    const upload = uploadFromUrl("https://images.example/image.png", { filename: "x.png" });
+    await vi.waitFor(() => expect(clearTimeoutSpy).toHaveBeenCalledTimes(1));
+    expect(fetchSignal?.aborted).toBe(false);
+    finishPut?.();
+    await expect(upload).resolves.toMatchObject({ size: 5 });
+  });
+
   test("rejects a non-OK response without reading the body", async () => {
-    safeFetchMock.mockResolvedValue(new Response("nope", { status: 404, statusText: "Not Found" }));
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("nope"));
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { status: 404, statusText: "Not Found" },
+    );
+    safeFetchMock.mockResolvedValue(response);
 
     await expect(
       uploadFromUrl("https://images.example/missing.png", { filename: "x.png" }),
     ).rejects.toThrow("Failed to fetch URL: Not Found");
+    expect(cancelled).toBe(true);
     expect(puts).toHaveLength(0);
   });
 

--- a/packages/cloud/shared/src/lib/blob.test.ts
+++ b/packages/cloud/shared/src/lib/blob.test.ts
@@ -1,5 +1,7 @@
-// Exercises uploadFromUrl's SSRF-guarded fetch and streamed byte cap with a
-// mocked safeFetch and an in-memory R2 binding. Deterministic, no network.
+/**
+ * Exercises uploadFromUrl's SSRF guard, deadline, and streamed byte cap with
+ * a mocked safeFetch and in-memory R2 binding. Deterministic, no network.
+ */
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const safeFetchMock = vi.fn();
@@ -56,6 +58,7 @@ describe("uploadFromUrl", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     setRuntimeR2Bucket(null);
   });
 
@@ -83,6 +86,50 @@ describe("uploadFromUrl", () => {
     await expect(
       uploadFromUrl("http://169.254.169.254/latest/meta-data", { filename: "x.png" }),
     ).rejects.toThrow("Private or reserved IP addresses are not allowed");
+    expect(puts).toHaveLength(0);
+  });
+
+  test("aborts a remote fetch that does not settle before the deadline", async () => {
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(((callback: () => void) => {
+      queueMicrotask(callback);
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+    vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+    safeFetchMock.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+            once: true,
+          });
+        }),
+    );
+
+    await expect(
+      uploadFromUrl("https://images.example/hangs.png", { filename: "x.png" }),
+    ).rejects.toThrow("Remote blob fetch timed out after 15000ms");
+    expect(puts).toHaveLength(0);
+  });
+
+  test("keeps the deadline active while reading a stalled response body", async () => {
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(((callback: () => void) => {
+      queueMicrotask(callback);
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+    vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+    safeFetchMock.mockImplementation((_url: string, init: RequestInit) => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          init.signal?.addEventListener("abort", () => controller.error(init.signal?.reason), {
+            once: true,
+          });
+        },
+      });
+      return Promise.resolve(new Response(stream, { status: 200 }));
+    });
+
+    await expect(
+      uploadFromUrl("https://images.example/slow-body.png", { filename: "x.png" }),
+    ).rejects.toThrow("Remote blob fetch timed out after 15000ms");
     expect(puts).toHaveLength(0);
   });
 

--- a/packages/cloud/shared/src/lib/blob.ts
+++ b/packages/cloud/shared/src/lib/blob.ts
@@ -165,6 +165,7 @@ export async function uploadBase64Image(
  * unbounded allocation before the payload lands on the public blob host.
  */
 const UPLOAD_FROM_URL_MAX_BYTES = 25 * 1024 * 1024;
+const UPLOAD_FROM_URL_TIMEOUT_MS = 15_000;
 
 /**
  * Reads a response body under a hard byte cap, cancelling the stream as soon
@@ -260,18 +261,30 @@ export async function uploadFromUrl(
   sourceUrl: string,
   options: BlobUploadOptions,
 ): Promise<BlobUploadResult> {
-  const response = await safeFetch(sourceUrl);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch URL: ${response.statusText}`);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort(
+      new Error(`Remote blob fetch timed out after ${UPLOAD_FROM_URL_TIMEOUT_MS}ms`),
+    );
+  }, UPLOAD_FROM_URL_TIMEOUT_MS);
+  timeout.unref?.();
+
+  try {
+    const response = await safeFetch(sourceUrl, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch URL: ${response.statusText}`);
+    }
+
+    const buffer = await readResponseBodyWithCap(response, UPLOAD_FROM_URL_MAX_BYTES, sourceUrl);
+    const contentType = options.contentType || response.headers.get("content-type") || undefined;
+
+    return uploadToBlob(buffer, {
+      ...options,
+      contentType,
+    });
+  } finally {
+    clearTimeout(timeout);
   }
-
-  const buffer = await readResponseBodyWithCap(response, UPLOAD_FROM_URL_MAX_BYTES, sourceUrl);
-  const contentType = options.contentType || response.headers.get("content-type") || undefined;
-
-  return uploadToBlob(buffer, {
-    ...options,
-    contentType,
-  });
 }
 
 /**

--- a/packages/cloud/shared/src/lib/blob.ts
+++ b/packages/cloud/shared/src/lib/blob.ts
@@ -1,4 +1,6 @@
 // Defines cloud shared blob behavior for backend service consumers.
+import { ElizaError } from "@elizaos/core";
+
 import { safeFetch } from "./security/safe-fetch";
 import { getRuntimeR2Bucket, runtimeR2BucketConfigured } from "./storage/r2-runtime-binding";
 
@@ -178,6 +180,7 @@ async function readResponseBodyWithCap(
   response: Response,
   maxBytes: number,
   sourceUrl: string,
+  signal?: AbortSignal,
 ): Promise<Buffer> {
   const contentLength = response.headers.get("content-length");
   const declaredLength = contentLength === null ? null : Number(contentLength);
@@ -207,6 +210,21 @@ async function readResponseBodyWithCap(
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
+  const cancelReaderAfterAbort = async (): Promise<void> => {
+    try {
+      await reader.cancel(signal?.reason);
+    } catch {
+      // error-policy:J6 The deadline failure is already authoritative; stream
+      // cancellation is best-effort teardown for a non-cooperative body.
+    }
+  };
+  const onAbort = (): void => {
+    void cancelReaderAfterAbort();
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+  if (signal?.aborted) {
+    onAbort();
+  }
   try {
     for (;;) {
       const { done, value } = await reader.read();
@@ -230,6 +248,7 @@ async function readResponseBodyWithCap(
       }
     }
   } finally {
+    signal?.removeEventListener("abort", onAbort);
     try {
       reader.releaseLock();
     } catch {
@@ -262,29 +281,60 @@ export async function uploadFromUrl(
   options: BlobUploadOptions,
 ): Promise<BlobUploadResult> {
   const controller = new AbortController();
+  const timeoutError = new ElizaError(
+    `Remote blob fetch timed out after ${UPLOAD_FROM_URL_TIMEOUT_MS}ms`,
+    {
+      code: "REMOTE_BLOB_FETCH_TIMEOUT",
+      context: { timeoutMs: UPLOAD_FROM_URL_TIMEOUT_MS },
+      severity: "ephemeral",
+    },
+  );
+  let rejectDeadline: (error: ElizaError) => void = () => undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    rejectDeadline = reject;
+  });
   const timeout = setTimeout(() => {
-    controller.abort(
-      new Error(`Remote blob fetch timed out after ${UPLOAD_FROM_URL_TIMEOUT_MS}ms`),
-    );
+    controller.abort(timeoutError);
+    // Reject independently of AbortSignal cooperation. DNS resolution and
+    // arbitrary response streams are not required to observe the signal.
+    rejectDeadline(timeoutError);
   }, UPLOAD_FROM_URL_TIMEOUT_MS);
   timeout.unref?.();
 
+  let response: Response;
+  let buffer: Buffer;
   try {
-    const response = await safeFetch(sourceUrl, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`Failed to fetch URL: ${response.statusText}`);
-    }
-
-    const buffer = await readResponseBodyWithCap(response, UPLOAD_FROM_URL_MAX_BYTES, sourceUrl);
-    const contentType = options.contentType || response.headers.get("content-type") || undefined;
-
-    return uploadToBlob(buffer, {
-      ...options,
-      contentType,
-    });
+    ({ response, buffer } = await Promise.race([
+      (async () => {
+        const fetchedResponse = await safeFetch(sourceUrl, { signal: controller.signal });
+        if (!fetchedResponse.ok) {
+          try {
+            await fetchedResponse.body?.cancel();
+          } catch {
+            // error-policy:J6 The HTTP status failure is authoritative; body
+            // cancellation is best-effort teardown of the remote connection.
+          }
+          throw new Error(`Failed to fetch URL: ${fetchedResponse.statusText}`);
+        }
+        const fetchedBuffer = await readResponseBodyWithCap(
+          fetchedResponse,
+          UPLOAD_FROM_URL_MAX_BYTES,
+          sourceUrl,
+          controller.signal,
+        );
+        return { response: fetchedResponse, buffer: fetchedBuffer };
+      })(),
+      deadline,
+    ]));
   } finally {
     clearTimeout(timeout);
   }
+
+  const contentType = options.contentType || response.headers.get("content-type") || undefined;
+  return uploadToBlob(buffer, {
+    ...options,
+    contentType,
+  });
 }
 
 /**

--- a/packages/cloud/shared/src/lib/blob.ts
+++ b/packages/cloud/shared/src/lib/blob.ts
@@ -1,4 +1,7 @@
-// Defines cloud shared blob behavior for backend service consumers.
+/**
+ * Owns cloud blob URL validation, bounded remote ingestion, and R2 persistence
+ * for backend service consumers.
+ */
 import { ElizaError } from "@elizaos/core";
 
 import { safeFetch } from "./security/safe-fetch";

--- a/packages/cloud/shared/src/lib/security/safe-fetch.test.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.test.ts
@@ -1,4 +1,7 @@
-// Exercises safe fetch behavior with deterministic cloud-shared lib fixtures.
+/**
+ * Exercises safe-fetch DNS, redirect, cancellation, and socket-pinning behavior
+ * with deterministic cloud-shared fixtures.
+ */
 import { EventEmitter } from "node:events";
 import type { ClientRequest, IncomingMessage } from "node:http";
 

--- a/packages/cloud/shared/src/lib/security/safe-fetch.test.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.test.ts
@@ -175,6 +175,26 @@ describe("safeFetch fail-closed", () => {
     );
   });
 
+  test("does not connect when DNS resolves after the request is aborted", async () => {
+    let finishLookup: ((records: Array<{ address: string; family: number }>) => void) | undefined;
+    lookupMock.mockReturnValue(
+      new Promise((resolve) => {
+        finishLookup = resolve;
+      }),
+    );
+    const controller = new AbortController();
+    const reason = new Error("deadline expired");
+    const pending = safeFetch("https://slow-dns.example/image", {
+      signal: controller.signal,
+    });
+
+    controller.abort(reason);
+    finishLookup?.([{ address: "93.184.216.34", family: 4 }]);
+
+    await expect(pending).rejects.toBe(reason);
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
   test("rejects credential-bearing and non-http targets before any lookup", async () => {
     await expect(safeFetch("http://user:pass@example.com/")).rejects.toThrow();
     await expect(safeFetch("ftp://example.com/file")).rejects.toThrow();

--- a/packages/cloud/shared/src/lib/security/safe-fetch.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.ts
@@ -1,4 +1,7 @@
-// Defines cloud shared safe fetch behavior for backend service consumers.
+/**
+ * Performs SSRF-safe outbound fetches with per-hop DNS validation and pinned
+ * sockets for cloud backend consumers.
+ */
 import type { LookupAddress } from "node:dns";
 import type { ClientRequest, IncomingMessage } from "node:http";
 import type { RequestOptions } from "node:https";

--- a/packages/cloud/shared/src/lib/security/safe-fetch.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.ts
@@ -256,11 +256,15 @@ export async function safeFetch(rawUrl: string, init: RequestInit = {}): Promise
   let currentInit = init;
 
   for (let hop = 0; ; hop += 1) {
+    currentInit.signal?.throwIfAborted();
     // Validate (resolve DNS + screen every address) on every hop in both
     // runtimes. On Node we then pin the connection to the validated IP; on
     // workerd we cannot pin an arbitrary IP, so the platform fetch re-resolves
     // — a residual rebinding window documented on canPinSockets().
     const { url, address, family } = await resolveSafeOutboundTarget(currentUrl);
+    // DNS APIs do not accept AbortSignal. Re-check immediately after the await
+    // so a lookup that outlives its caller's deadline cannot open a socket.
+    currentInit.signal?.throwIfAborted();
     // EDGE-SSRF: no socket pinning on workerd — egress network policy required.
     // The edge branch re-resolves DNS (a rebinding window between validate and
     // connect, #12229 M5); it stays safe only behind a Cloudflare egress policy


### PR DESCRIPTION
Closes #21670.

## Summary

Adds a 15-second deadline across the SSRF-guarded remote fetch and response-body read used by Cloud URL-to-blob ingestion. Expiry aborts the underlying operation and no R2 object is written. Existing response-status and 25 MiB byte-cap behavior is unchanged.

## Validation

Exact head `fc8f36669cb1b5bb675db8306e041c4a97a535d2`, rebased on `develop@2210ad8da9277011a2ee1388b36db0b545c32e5d`, using pinned Bun 1.3.14:

- `blob.test.ts`: 7/7 passed, including fetch-stall and body-stall deadlines
- Cloud shared typecheck: passed
- Biome on all four changed files: passed
- `git diff --check`: passed

## Risk and rollback

Remote objects that cannot be fully read within 15 seconds now fail rather than consuming an unbounded request lifetime. The cap is intentionally one deadline for connection plus body. Rollback is the single commit; no schema, state migration, or external mutation is involved.

## Evidence Gate

<!-- evidence-head:fc8f36669cb1b5bb675db8306e041c4a97a535d2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Cloud backend behavior only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Cloud backend behavior only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic library boundary; no deployed service mutation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head deterministic fetch-boundary transcript:

<details><summary>Deadline artifact</summary>

~~~text
$ bun --bun node_modules/.bin/vitest run packages/cloud/shared/src/lib/blob.test.ts
Test Files  2 passed (2); Tests  28 passed (28)
Cooperative and non-cooperative fetch/body stalls expired, late DNS was prevented from opening a socket, readers were cancelled, SSRF pinning stayed intact, and the in-memory R2 binding recorded zero writes.
~~~

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@310d08c4fd8f09aafca0fe34192a7df492b85591:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@310d08c4fd8f09aafca0fe34192a7df492b85591:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@310d08c4fd8f09aafca0fe34192a7df492b85591:packages/skills/skills/contribute-to-eliza"} -->