### PR TITLE
fix(app): align iOS Cloud onboarding completion

### DIFF
--- a/packages/app/scripts/ios-cloud-onboarding-smoke.mjs
+++ b/packages/app/scripts/ios-cloud-onboarding-smoke.mjs
@@ -418,9 +418,12 @@ async function runMode({ udid, appId, mode, privateKey }) {
         `iOS cloud onboarding ${mode} completed with ok=false: ${JSON.stringify(result)}`,
       );
     }
-    if (result.firstRunPostCount !== 1) {
+    // Direct Cloud agent bases serve chat, not the app-shell setup endpoint.
+    // Durable local completion plus the authenticated Cloud server are the
+    // authority; any /api/first-run POST would target a guaranteed 404.
+    if (result.firstRunPostCount !== 0) {
       throw new Error(
-        `iOS cloud onboarding ${mode} expected exactly one /api/first-run POST, got ${result.firstRunPostCount}`,
+        `iOS cloud onboarding ${mode} expected no /api/first-run POST, got ${result.firstRunPostCount}`,
       );
     }
     if (mode === "tap" && result.signInGreetingVisible !== true) {

--- a/packages/app/src/ios-cloud-onboarding-smoke.ts
+++ b/packages/app/src/ios-cloud-onboarding-smoke.ts
@@ -61,6 +61,33 @@ export interface IosCloudOnboardingSmokeRequest {
   livenessPrompt: string;
 }
 
+/** State the in-app verifier must prove before reporting onboarding complete. */
+export interface IosCloudOnboardingCompletionState {
+  homeVisible: boolean;
+  composerVisible: boolean;
+  onboardingHidden: boolean;
+  cloudActiveServer: boolean;
+  firstRunPostCount: number;
+}
+
+/**
+ * Enforce the direct-Cloud completion contract shared with the Android lane.
+ * A provisioned Cloud agent is already the chat runtime, so posting the
+ * app-shell `/api/first-run` endpoint to that base is an architecture error;
+ * durable client state and the authenticated Cloud server prove completion.
+ */
+export function isIosCloudOnboardingComplete(
+  state: IosCloudOnboardingCompletionState,
+): boolean {
+  return (
+    state.homeVisible &&
+    state.composerVisible &&
+    state.onboardingHidden &&
+    state.cloudActiveServer &&
+    state.firstRunPostCount === 0
+  );
+}
+
 const DEFAULT_LIVENESS_PROMPT = "In one short sentence, say hello.";
 
 /**

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -201,6 +201,7 @@ import { runIosAttachmentSmokeIfRequested } from "./ios-attachment-smoke";
 import {
   extractIosLivenessChallengeToken,
   type IosCloudOnboardingSmokeRequest,
+  isIosCloudOnboardingComplete,
   isIosLivenessReplyRow as isIosLivenessReplyRowFromContract,
   parseIosCloudOnboardingSmokeRequest as parseIosCloudOnboardingSmokeRequestFromContract,
 } from "./ios-cloud-onboarding-smoke";
@@ -1408,12 +1409,13 @@ async function runIosCloudOnboardingSmokeIfRequested(): Promise<boolean> {
     );
 
     await writeIosCloudOnboardingSmokeResult({
-      ok:
-        Boolean(home) &&
-        Boolean(composer) &&
-        onboardingHidden &&
-        cloudActiveServer &&
-        firstRunPostCount === 1,
+      ok: isIosCloudOnboardingComplete({
+        homeVisible: Boolean(home),
+        composerVisible: Boolean(composer),
+        onboardingHidden,
+        cloudActiveServer,
+        firstRunPostCount,
+      }),
       phase: "complete",
       mode: request.mode,
       finishedAt: new Date().toISOString(),

--- a/packages/app/test/ios-cloud-onboarding-smoke.test.ts
+++ b/packages/app/test/ios-cloud-onboarding-smoke.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 // Unit test for the iOS cloud-onboarding smoke contract helpers (#16936):
-// request parsing (blank/bare/JSON/invalid) and the fail-closed reply-row
+// request parsing, direct-Cloud completion, and the fail-closed reply-row
 // classification the in-app liveness driver relies on. Deterministic, jsdom —
 // no simulator or Playwright harness; the overlay DOM shapes below mirror the
 // real renderer (`overlay-assistant-turn-body` phases from
@@ -9,9 +9,44 @@ import { describe, expect, it } from "vitest";
 
 import {
   extractIosLivenessChallengeToken,
+  isIosCloudOnboardingComplete,
   isIosLivenessReplyRow,
   parseIosCloudOnboardingSmokeRequest,
 } from "../src/ios-cloud-onboarding-smoke";
+
+describe("isIosCloudOnboardingComplete", () => {
+  const completeState = {
+    homeVisible: true,
+    composerVisible: true,
+    onboardingHidden: true,
+    cloudActiveServer: true,
+    firstRunPostCount: 0,
+  };
+
+  it("accepts durable direct-Cloud completion without an app-shell POST", () => {
+    expect(isIosCloudOnboardingComplete(completeState)).toBe(true);
+  });
+
+  it("rejects the retired /api/first-run completion shape", () => {
+    expect(
+      isIosCloudOnboardingComplete({
+        ...completeState,
+        firstRunPostCount: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    "homeVisible",
+    "composerVisible",
+    "onboardingHidden",
+    "cloudActiveServer",
+  ] as const)("requires %s", (field) => {
+    expect(
+      isIosCloudOnboardingComplete({ ...completeState, [field]: false }),
+    ).toBe(false);
+  });
+});
 
 function overlayRow(phase: "status" | "reply", text: string): Element {
   const row = document.createElement("div");


### PR DESCRIPTION
# Relates to

Progresses #16936; do not close until signed supported-device onboarding and live-reply evidence is attached.

- [x] Targets `develop` and is rebased onto `origin/develop@d4f9c6f5e058` with zero conflicts.
- [x] `bun install --frozen-lockfile` and exact-head focused/package gates were run.
- [x] The deterministic smoke-contract evidence below is reviewable without reading implementation code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d4f9c6f5e058f28b1c48be490e8ea1be32b7351a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@d4f9c6f5e058f28b1c48be490e8ea1be32b7351a`; zero conflicts.
- [x] Exact-head focused tests, Biome, app typecheck, and diff checks pass.

# Risks

Low. This changes only the hidden iOS Cloud onboarding smoke completion oracle. It makes the iOS contract agree with the existing Android/direct-Cloud architecture: a provisioned Cloud agent base serves chat and must receive zero app-shell `/api/first-run` POSTs. It does not change ordinary onboarding rendering or user interaction.

# Background

## What does this PR do?

The existing iOS liveness harness required exactly one `/api/first-run` POST even though direct Cloud agent bases do not expose that app-shell route. That made a healthy signed-in Cloud onboarding run fail its own evidence oracle after the underlying liveness wiring had landed.

This PR adds one exported completion predicate, uses it in the hidden smoke driver, aligns the outer simulator harness with zero direct-Cloud setup POSTs, and adds positive/negative contract coverage.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No public documentation change. The source comments and executable contract state why the direct-Cloud path must not call the app-shell setup endpoint.

# Testing

## Where should a reviewer start?

Run the focused contract test, then inspect its six completion cases:

```bash
bunx vitest run --config packages/app/vitest.config.ts packages/app/test/ios-cloud-onboarding-smoke.test.ts
```

## Detailed testing steps

At exact head `1eb0ddca639b122ba7d52f2271923d876234f136`:

```text
Test Files  1 passed (1)
Tests      16 passed (16)
```

Also passed at the same exact head:

```bash
bunx biome check packages/app/scripts/ios-cloud-onboarding-smoke.mjs packages/app/src/ios-cloud-onboarding-smoke.ts packages/app/src/main.tsx packages/app/test/ios-cloud-onboarding-smoke.test.ts
bun run --cwd packages/app typecheck
node --check packages/app/scripts/ios-cloud-onboarding-smoke.mjs
bun test packages/app/scripts/android-cloud-onboarding-command.test.mjs
git diff origin/develop --check
```

The full dependency/app build passed on rebased predecessor `753248546725` (93 tasks, 93 successful); the final rebase was conflict-free, and focused tests, Biome, app typecheck, Android/static checks, and diff checks were rerun at the exact head above. The two UI route-invariant suites passed before the final no-conflict rebase (2 files, 6 tests); a final rerun was stopped after Vitest stalled before collection, so it is not represented as exact-head evidence.

# Evidence Gate

<!-- evidence-head:1eb0ddca639b122ba7d52f2271923d876234f136 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21673-before.jpg) - generic chooser-only audit capture; not native acceptance evidence
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21673-after.jpg) - byte-identical to before, as expected for a hidden non-rendering smoke branch; not native acceptance evidence
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21673-walkthrough.mp4 - generic boot/chooser capture only; it does not show Cloud sign-in, provisioning, home, chat, or a live reply
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend path changed
<!-- evidence-row:frontend-logs -->
- [x] [21673-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21673-frontend.log) - audit-attempt log containing backend 502/API-unavailable errors; not live Cloud evidence
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, provider, model, action, or planner behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, schedule, wallet, audio, or generated-domain artifact changed
<!-- evidence-row:ocr-review -->
- [x] [21673-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21673-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent or model behavior changes.

## Backend + frontend logs

The focused exact-head Vitest transcript above covers the deterministic completion oracle: the valid direct-Cloud shape succeeds with zero setup POSTs, the retired one-POST shape fails, and each required UI/server state fails closed when absent. The attached frontend log is not success evidence: it contains repeated 502/API-unavailable failures and is retained only to document the audit attempt.

## Screenshots (before / after) + video walkthrough

The linked 1440x1000 before/after images are byte-identical generic chooser captures, and the 10-second video reaches only boot/chooser. That is consistent with a hidden non-rendering smoke branch, but none of these artifacts demonstrates native Cloud onboarding or a live reply.

## Audio / voice walkthrough

N/A - no audio/voice behavior changed.

## Known gaps / failures

- No signed iOS physical-device run or Android supported-device/emulator live SIWE run is attached.
- No structured native smoke-result JSON, manually reviewed non-stub reply quote, or end-to-end backend/device log is attached.
- The generic visual artifacts do not satisfy #16936. This PR corrects only the false-negative oracle; #16936 must remain open until its full supported-device acceptance evidence exists.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: elizaOS/eliza@d4f9c6f5e058f28b1c48be490e8ea1be32b7351a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [issue-16936-ios-cloud-contract]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"elizaOS/eliza@d4f9c6f5e058f28b1c48be490e8ea1be32b7351a:packages/skills/skills/contribute-to-eliza"} -->


