### PR TITLE
fix(cloud): reject malformed admin-redemptions JSON

### DIFF
--- a/packages/cloud/api/admin/redemptions/route.json.test.ts
+++ b/packages/cloud/api/admin/redemptions/route.json.test.ts
@@ -1,0 +1,65 @@
+/**
+ * POST /api/admin/redemptions used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is caller error.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const approveRedemption = mock(async () => ({ success: true }));
+const requireAdmin = mock(async () => ({
+  user: { id: "admin-1" },
+  role: "super_admin",
+}));
+
+mock.module("@/db/repositories/token-redemptions", () => ({
+  tokenRedemptionsRepository: {
+    listForAdmin: async () => [],
+    countByStatusForAdmin: async () => [],
+  },
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({ requireAdmin }));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {}, STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/services/token-redemption-secure", () => ({
+  secureTokenRedemptionService: { approveRedemption },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: () => undefined, error: () => undefined },
+}));
+
+const { default: app } = await import("./route");
+
+const CANONICAL_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("POST /api/admin/redemptions malformed JSON", () => {
+  beforeEach(() => {
+    approveRedemption.mockClear();
+  });
+
+  test("returns 400 instead of 500 and never approves", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(approveRedemption).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still approves the redemption", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        redemptionId: CANONICAL_ID,
+        action: "approve",
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(approveRedemption).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/admin/redemptions/route.ts
+++ b/packages/cloud/api/admin/redemptions/route.ts
@@ -212,7 +212,14 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
 app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const { user: adminUser } = await requireAdmin(c);
-    const body = await c.req.json();
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request body — malformed JSON is caller
+      // error (400), not failureResponse(SyntaxError) → 500.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
     const validation = AdminActionSchema.safeParse(body);
 
     if (!validation.success) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Request-boundary leftover-tax: malformed JSON on `POST /api/admin/redemptions` currently 500s. `await c.req.json()` sits in the outer try; `SyntaxError` is not Zod, so `failureResponse` maps it to 500. Sibling of domains-buy `#21672`. Not extract (grok unpublished). Not domains/search (grok unpublished). Not crypto/payments (payment stay-off). Not generate-video / wallets/provision / x402 / models/status (grok). Not shared-runtime-conversation. Not advertising. Not path encoding. Not extra-decode. Not list-limit. Not cookies. Not #21385. Not GET status identity `#20934`. Proof is `bun:test` of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Request-facing leftover-tax only. Canonical approve JSON still approves. Malformed `{` now 400s before approve/reject instead of `SyntaxError` → `failureResponse` 500. Proven on the unfixed head: POST `{` received **500** `internal_error`.

# Background

## What does this PR do?

`POST /api/admin/redemptions` ran `await c.req.json()` inside the route try. Hono's `c.req.json()` throws `SyntaxError` on `{`. Zod never sees the body. `failureResponse` maps that to HTTP 500 / `internal_error`. This PR returns `{ error: "Invalid JSON body" }` with status 400 before schema parse or approve/reject.

## What kind of change is this?

Bug fix (non-breaking leftover-tax). Canonical approve bodies unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/admin/redemptions/route.json.test.ts` and the `c.req.json()` catch in the POST handler.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/api && bun test --isolate ./admin/redemptions/route.json.test.ts
```

Unfixed head: `POST /api/admin/redemptions` with body `{` returned **500**. After the fix: 2 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Parser-only leftover-tax on the admin-redemptions HTTP boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Malformed JSON is rejected before approve/reject.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path. Bun test asserts 400 and that a canonical body still approves.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing leftover-tax. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet / generated-file change. Invalid JSON never reaches approve/reject.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request-facing leftover-tax on admin-redemptions JSON. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live backend path. Unfixed `{` was 500; after the fix, Bun test asserts 400 and a canonical body still approves.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Parser-only leftover-tax on the admin-redemptions HTTP boundary.

## Audio / voice walkthrough

N/A - leftover-tax is the JSON POST boundary, not a payout.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`2 pass`). Root verify is an unrelated full-repo cost and is not required to show the 500→400 boundary. No `bun install`.

<!-- evidence-head:aebe3abac87caa7896dfd001ac5c2582239900c4 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
