### PR TITLE
chore(plugin-sql): restore Electric e2e format gate

### DIFF
--- a/plugins/plugin-sql/src/__tests__/integration/electric-sync-end-to-end.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/electric-sync-end-to-end.test.ts
@@ -174,72 +174,74 @@ async function createPostgresSchema(): Promise<void> {
 // ------------------------------------------------------------------
 // Test suite
 // ------------------------------------------------------------------
-describeElectricE2E("Electric Sync end-to-end", () => {
-  const cleanups: Array<{ dir: string; manager?: PGliteClientManager }> = [];
+describeElectricE2E(
+  "Electric Sync end-to-end",
+  () => {
+    const cleanups: Array<{ dir: string; manager?: PGliteClientManager }> = [];
 
-  beforeAll(async () => {
-    // A successful HTTP response alone does not identify Electric because this
-    // development port is commonly occupied by unrelated local servers.
-    const response = await fetch(ELECTRIC_HEALTH_URL, {
-      signal: AbortSignal.timeout(3000),
-    });
-    if (!response.ok) {
-      throw new Error(`Electric health check returned ${response.status}`);
-    }
-    const health: unknown = await response.json();
-    if (
-      typeof health !== "object" ||
-      health === null ||
-      !("status" in health) ||
-      health.status !== "active"
-    ) {
-      throw new Error("Electric health check did not report active status");
-    }
+    beforeAll(async () => {
+      // A successful HTTP response alone does not identify Electric because this
+      // development port is commonly occupied by unrelated local servers.
+      const response = await fetch(ELECTRIC_HEALTH_URL, {
+        signal: AbortSignal.timeout(3000),
+      });
+      if (!response.ok) {
+        throw new Error(`Electric health check returned ${response.status}`);
+      }
+      const health: unknown = await response.json();
+      if (
+        typeof health !== "object" ||
+        health === null ||
+        !("status" in health) ||
+        health.status !== "active"
+      ) {
+        throw new Error("Electric health check did not report active status");
+      }
 
-    const pg = await import("pg");
-    pgModule = pg;
-    // The suite requires both services. Bound the connection attempt so a
-    // listener that accepts TCP without speaking Postgres fails promptly.
-    const probeClient = new pg.Client({
-      connectionString: POSTGRES_URL,
-      connectionTimeoutMillis: 3000,
-    });
-    await probeClient.connect();
-    await probeClient.end();
-  }, 10_000);
+      const pg = await import("pg");
+      pgModule = pg;
+      // The suite requires both services. Bound the connection attempt so a
+      // listener that accepts TCP without speaking Postgres fails promptly.
+      const probeClient = new pg.Client({
+        connectionString: POSTGRES_URL,
+        connectionTimeoutMillis: 3000,
+      });
+      await probeClient.connect();
+      await probeClient.end();
+    }, 10_000);
 
-  afterEach(async () => {
-    for (const c of cleanups.splice(0)) {
-      if (c.manager) {
+    afterEach(async () => {
+      for (const c of cleanups.splice(0)) {
+        if (c.manager) {
+          try {
+            await c.manager.close();
+          } catch (error) {
+            // error-policy:J6 test teardown continues so all temporary resources are attempted.
+            console.warn("[e2e-sync] manager teardown failed", error);
+          }
+        }
         try {
-          await c.manager.close();
+          fs.rmSync(c.dir, { recursive: true, force: true });
         } catch (error) {
-          // error-policy:J6 test teardown continues so all temporary resources are attempted.
-          console.warn("[e2e-sync] manager teardown failed", error);
+          // error-policy:J6 test teardown reports filesystem cleanup failures.
+          console.warn("[e2e-sync] temporary directory cleanup failed", error);
         }
       }
-      try {
-        fs.rmSync(c.dir, { recursive: true, force: true });
-      } catch (error) {
-        // error-policy:J6 test teardown reports filesystem cleanup failures.
-        console.warn("[e2e-sync] temporary directory cleanup failed", error);
-      }
-    }
-  });
+    });
 
-  // ------------------------------------------------------------------
-  // 1. Data flows: Postgres → Electric → PGlite
-  // ------------------------------------------------------------------
-  it("synced data from Postgres flows to PGlite via Electric", async () => {
-    // 1. Create schema and insert test data in Postgres.
-    await createPostgresSchema();
+    // ------------------------------------------------------------------
+    // 1. Data flows: Postgres → Electric → PGlite
+    // ------------------------------------------------------------------
+    it("synced data from Postgres flows to PGlite via Electric", async () => {
+      // 1. Create schema and insert test data in Postgres.
+      await createPostgresSchema();
 
-    const agentId = v4();
-    const roomId = v4();
-    const memoryId = v4();
-    const now = Date.now() / 1000.0;
+      const agentId = v4();
+      const roomId = v4();
+      const memoryId = v4();
+      const now = Date.now() / 1000.0;
 
-    await pgExec(`
+      await pgExec(`
       INSERT INTO agents (id, name, created_at, updated_at)
       VALUES ('${agentId}', 'e2e-agent', to_timestamp(${now}), to_timestamp(${now}));
 
@@ -250,84 +252,84 @@ describeElectricE2E("Electric Sync end-to-end", () => {
       VALUES ('${memoryId}', 'test', '${agentId}', '${roomId}', '{"text":"hello from pg"}'::jsonb, to_timestamp(${now}));
     `);
 
-    // 2. Create PGlite with Electric sync and run migrations locally.
-    const dir = createTempDir("eliza-e2e-sync-");
-    const manager = new PGliteClientManager({
-      dataDir: dir,
-      syncUrl: ELECTRIC_SYNC_URL,
-      agentId,
-    });
-    cleanups.push({ dir, manager });
-    await manager.initialize();
+      // 2. Create PGlite with Electric sync and run migrations locally.
+      const dir = createTempDir("eliza-e2e-sync-");
+      const manager = new PGliteClientManager({
+        dataDir: dir,
+        syncUrl: ELECTRIC_SYNC_URL,
+        agentId,
+      });
+      cleanups.push({ dir, manager });
+      await manager.initialize();
 
-    const client = manager.getConnection();
-    const { drizzle } = await import("drizzle-orm/pglite");
-    const db = drizzle(client) as unknown as DrizzleDatabase;
+      const client = manager.getConnection();
+      const { drizzle } = await import("drizzle-orm/pglite");
+      const db = drizzle(client) as unknown as DrizzleDatabase;
 
-    const migrationService = new DatabaseMigrationService();
-    await migrationService.initializeWithDatabase(db);
-    migrationService.discoverAndRegisterPluginSchemas([
-      { name: "@elizaos/plugin-sql", description: "SQL plugin", schema },
-    ]);
-    await migrationService.runAllPluginMigrations();
+      const migrationService = new DatabaseMigrationService();
+      await migrationService.initializeWithDatabase(db);
+      migrationService.discoverAndRegisterPluginSchemas([
+        { name: "@elizaos/plugin-sql", description: "SQL plugin", schema },
+      ]);
+      await migrationService.runAllPluginMigrations();
 
-    // 3. Trigger sync.
-    await manager.ensureSync();
+      // 3. Trigger sync.
+      await manager.ensureSync();
 
-    // 4. Poll for sync completion (max 15s).
-    const deadline = Date.now() + 15_000;
-    let synced = false;
-    while (Date.now() < deadline) {
-      const status = manager.getSyncStatus();
-      if (status.status === "synced" || status.synced.length >= 3) {
-        synced = true;
-        break;
+      // 4. Poll for sync completion (max 15s).
+      const deadline = Date.now() + 15_000;
+      let synced = false;
+      while (Date.now() < deadline) {
+        const status = manager.getSyncStatus();
+        if (status.status === "synced" || status.synced.length >= 3) {
+          synced = true;
+          break;
+        }
+        if (status.status === "error") {
+          throw new Error(`Sync errored: ${status.error}`);
+        }
+        await new Promise((r) => setTimeout(r, 500));
       }
-      if (status.status === "error") {
-        throw new Error(`Sync errored: ${status.error}`);
-      }
-      await new Promise((r) => setTimeout(r, 500));
-    }
-    expect(synced).toBe(true);
+      expect(synced).toBe(true);
 
-    // 5. Verify synced data in PGlite matches Postgres.
-    const agentRows = await db.execute(
-      sql.raw(`SELECT id, name FROM agents WHERE id = '${agentId}'`)
-    );
-    const agents = agentRows.rows as Array<{ id: string; name: string }>;
-    expect(agents).toHaveLength(1);
-    expect(agents[0]?.name).toBe("e2e-agent");
+      // 5. Verify synced data in PGlite matches Postgres.
+      const agentRows = await db.execute(
+        sql.raw(`SELECT id, name FROM agents WHERE id = '${agentId}'`)
+      );
+      const agents = agentRows.rows as Array<{ id: string; name: string }>;
+      expect(agents).toHaveLength(1);
+      expect(agents[0]?.name).toBe("e2e-agent");
 
-    const roomRows = await db.execute(
-      sql.raw(`SELECT id, name FROM rooms WHERE agent_id = '${agentId}'`)
-    );
-    const rooms = roomRows.rows as Array<{ id: string; name: string }>;
-    expect(rooms).toHaveLength(1);
-    expect(rooms[0]?.name).toBe("e2e-room");
+      const roomRows = await db.execute(
+        sql.raw(`SELECT id, name FROM rooms WHERE agent_id = '${agentId}'`)
+      );
+      const rooms = roomRows.rows as Array<{ id: string; name: string }>;
+      expect(rooms).toHaveLength(1);
+      expect(rooms[0]?.name).toBe("e2e-room");
 
-    const memoryRows = await db.execute(
-      sql.raw(`SELECT id, content FROM memories WHERE agent_id = '${agentId}'`)
-    );
-    const memories = memoryRows.rows as Array<{ id: string; content: unknown }>;
-    expect(memories).toHaveLength(1);
-  }, 30_000);
+      const memoryRows = await db.execute(
+        sql.raw(`SELECT id, content FROM memories WHERE agent_id = '${agentId}'`)
+      );
+      const memories = memoryRows.rows as Array<{ id: string; content: unknown }>;
+      expect(memories).toHaveLength(1);
+    }, 30_000);
 
-  // ------------------------------------------------------------------
-  // 2. Per-agent isolation: agentA's PGlite only sees agentA's data
-  // ------------------------------------------------------------------
-  it("per-agent isolation: only the synced agent's rows appear in PGlite", async () => {
-    await createPostgresSchema();
+    // ------------------------------------------------------------------
+    // 2. Per-agent isolation: agentA's PGlite only sees agentA's data
+    // ------------------------------------------------------------------
+    it("per-agent isolation: only the synced agent's rows appear in PGlite", async () => {
+      await createPostgresSchema();
 
-    const agentA = v4();
-    const agentB = v4();
-    const roomA = v4();
-    const roomB = v4();
-    const memoryA = v4();
-    const memoryB = v4();
-    const now = Date.now() / 1000.0;
+      const agentA = v4();
+      const agentB = v4();
+      const roomA = v4();
+      const roomB = v4();
+      const memoryA = v4();
+      const memoryB = v4();
+      const now = Date.now() / 1000.0;
 
-    // Seed data for two agents in Postgres.
-    await pgExec(`
+      // Seed data for two agents in Postgres.
+      await pgExec(`
       INSERT INTO agents (id, name, created_at, updated_at)
       VALUES
         ('${agentA}', 'agent-a', to_timestamp(${now}), to_timestamp(${now})),
@@ -344,129 +346,131 @@ describeElectricE2E("Electric Sync end-to-end", () => {
         ('${memoryB}', 'test', '${agentB}', '${roomB}', '{"text":"b"}'::jsonb, to_timestamp(${now}));
     `);
 
-    // Sync PGlite as agentA — should only receive agentA's rows.
-    const dir = createTempDir("eliza-e2e-iso-");
-    const manager = new PGliteClientManager({
-      dataDir: dir,
-      syncUrl: ELECTRIC_SYNC_URL,
-      agentId: agentA,
-    });
-    cleanups.push({ dir, manager });
-    await manager.initialize();
+      // Sync PGlite as agentA — should only receive agentA's rows.
+      const dir = createTempDir("eliza-e2e-iso-");
+      const manager = new PGliteClientManager({
+        dataDir: dir,
+        syncUrl: ELECTRIC_SYNC_URL,
+        agentId: agentA,
+      });
+      cleanups.push({ dir, manager });
+      await manager.initialize();
 
-    const client = manager.getConnection();
-    const { drizzle } = await import("drizzle-orm/pglite");
-    const db = drizzle(client) as unknown as DrizzleDatabase;
+      const client = manager.getConnection();
+      const { drizzle } = await import("drizzle-orm/pglite");
+      const db = drizzle(client) as unknown as DrizzleDatabase;
 
-    const migrationService = new DatabaseMigrationService();
-    await migrationService.initializeWithDatabase(db);
-    migrationService.discoverAndRegisterPluginSchemas([
-      { name: "@elizaos/plugin-sql", description: "SQL plugin", schema },
-    ]);
-    await migrationService.runAllPluginMigrations();
+      const migrationService = new DatabaseMigrationService();
+      await migrationService.initializeWithDatabase(db);
+      migrationService.discoverAndRegisterPluginSchemas([
+        { name: "@elizaos/plugin-sql", description: "SQL plugin", schema },
+      ]);
+      await migrationService.runAllPluginMigrations();
 
-    await manager.ensureSync();
+      await manager.ensureSync();
 
-    // Poll for sync completion.
-    const deadline = Date.now() + 15_000;
-    let synced = false;
-    while (Date.now() < deadline) {
-      const status = manager.getSyncStatus();
-      if (status.status === "synced") {
-        synced = true;
-        break;
+      // Poll for sync completion.
+      const deadline = Date.now() + 15_000;
+      let synced = false;
+      while (Date.now() < deadline) {
+        const status = manager.getSyncStatus();
+        if (status.status === "synced") {
+          synced = true;
+          break;
+        }
+        if (status.status === "error") {
+          throw new Error(`Sync errored: ${status.error}`);
+        }
+        await new Promise((r) => setTimeout(r, 500));
       }
-      if (status.status === "error") {
-        throw new Error(`Sync errored: ${status.error}`);
-      }
-      await new Promise((r) => setTimeout(r, 500));
-    }
-    expect(synced).toBe(true);
+      expect(synced).toBe(true);
 
-    // agentA's data should be present.
-    const agentARows = await db.execute(
-      sql.raw(`SELECT id, name FROM agents WHERE id = '${agentA}'`)
-    );
-    expect((agentARows.rows as Array<{ name: string }>)[0]?.name).toBe("agent-a");
+      // agentA's data should be present.
+      const agentARows = await db.execute(
+        sql.raw(`SELECT id, name FROM agents WHERE id = '${agentA}'`)
+      );
+      expect((agentARows.rows as Array<{ name: string }>)[0]?.name).toBe("agent-a");
 
-    const roomARows = await db.execute(
-      sql.raw(`SELECT id, name FROM rooms WHERE agent_id = '${agentA}'`)
-    );
-    expect((roomARows.rows as Array<{ name: string }>)[0]?.name).toBe("room-a");
+      const roomARows = await db.execute(
+        sql.raw(`SELECT id, name FROM rooms WHERE agent_id = '${agentA}'`)
+      );
+      expect((roomARows.rows as Array<{ name: string }>)[0]?.name).toBe("room-a");
 
-    const memoryARows = await db.execute(
-      sql.raw(`SELECT id FROM memories WHERE agent_id = '${agentA}'`)
-    );
-    expect(memoryARows.rows).toHaveLength(1);
+      const memoryARows = await db.execute(
+        sql.raw(`SELECT id FROM memories WHERE agent_id = '${agentA}'`)
+      );
+      expect(memoryARows.rows).toHaveLength(1);
 
-    // agentB's data should NOT be present (filtered by agent_id = $1).
-    const agentBRows = await db.execute(sql.raw(`SELECT id FROM agents WHERE id = '${agentB}'`));
-    expect(agentBRows.rows).toHaveLength(0);
+      // agentB's data should NOT be present (filtered by agent_id = $1).
+      const agentBRows = await db.execute(sql.raw(`SELECT id FROM agents WHERE id = '${agentB}'`));
+      expect(agentBRows.rows).toHaveLength(0);
 
-    const roomBRows = await db.execute(
-      sql.raw(`SELECT id FROM rooms WHERE agent_id = '${agentB}'`)
-    );
-    expect(roomBRows.rows).toHaveLength(0);
+      const roomBRows = await db.execute(
+        sql.raw(`SELECT id FROM rooms WHERE agent_id = '${agentB}'`)
+      );
+      expect(roomBRows.rows).toHaveLength(0);
 
-    const memoryBRows = await db.execute(
-      sql.raw(`SELECT id FROM memories WHERE agent_id = '${agentB}'`)
-    );
-    expect(memoryBRows.rows).toHaveLength(0);
-  }, 30_000);
+      const memoryBRows = await db.execute(
+        sql.raw(`SELECT id FROM memories WHERE agent_id = '${agentB}'`)
+      );
+      expect(memoryBRows.rows).toHaveLength(0);
+    }, 30_000);
 
-  // ------------------------------------------------------------------
-  // 3. Sync status transitions: disabled → syncing → synced
-  // ------------------------------------------------------------------
-  it("sync status transitions from disabled through syncing to synced", async () => {
-    await createPostgresSchema();
+    // ------------------------------------------------------------------
+    // 3. Sync status transitions: disabled → syncing → synced
+    // ------------------------------------------------------------------
+    it("sync status transitions from disabled through syncing to synced", async () => {
+      await createPostgresSchema();
 
-    const agentId = v4();
-    const now = Date.now() / 1000.0;
+      const agentId = v4();
+      const now = Date.now() / 1000.0;
 
-    await pgExec(`
+      await pgExec(`
       INSERT INTO agents (id, name, created_at, updated_at)
       VALUES ('${agentId}', 'status-agent', to_timestamp(${now}), to_timestamp(${now}));
     `);
 
-    const dir = createTempDir("eliza-e2e-status-");
-    const manager = new PGliteClientManager({
-      dataDir: dir,
-      syncUrl: ELECTRIC_SYNC_URL,
-      agentId,
-    });
-    cleanups.push({ dir, manager });
+      const dir = createTempDir("eliza-e2e-status-");
+      const manager = new PGliteClientManager({
+        dataDir: dir,
+        syncUrl: ELECTRIC_SYNC_URL,
+        agentId,
+      });
+      cleanups.push({ dir, manager });
 
-    // Before initialize, status is disabled.
-    expect(manager.getSyncStatus().status).toBe("disabled");
+      // Before initialize, status is disabled.
+      expect(manager.getSyncStatus().status).toBe("disabled");
 
-    await manager.initialize();
+      await manager.initialize();
 
-    const client = manager.getConnection();
-    const { drizzle } = await import("drizzle-orm/pglite");
-    const db = drizzle(client) as unknown as DrizzleDatabase;
+      const client = manager.getConnection();
+      const { drizzle } = await import("drizzle-orm/pglite");
+      const db = drizzle(client) as unknown as DrizzleDatabase;
 
-    const migrationService = new DatabaseMigrationService();
-    await migrationService.initializeWithDatabase(db);
-    migrationService.discoverAndRegisterPluginSchemas([
-      { name: "@elizaos/plugin-sql", description: "SQL plugin", schema },
-    ]);
-    await migrationService.runAllPluginMigrations();
+      const migrationService = new DatabaseMigrationService();
+      await migrationService.initializeWithDatabase(db);
+      migrationService.discoverAndRegisterPluginSchemas([
+        { name: "@elizaos/plugin-sql", description: "SQL plugin", schema },
+      ]);
+      await migrationService.runAllPluginMigrations();
 
-    // Trigger sync — status should transition. Poll until outcome.
-    await manager.ensureSync();
+      // Trigger sync — status should transition. Poll until outcome.
+      await manager.ensureSync();
 
-    const deadline = Date.now() + 15_000;
-    let finalStatus = "";
-    while (Date.now() < deadline) {
-      const { status, error } = manager.getSyncStatus();
-      finalStatus = status;
-      if (status === "synced") break;
-      if (status === "error") {
-        throw new Error(`Sync errored: ${error}`);
+      const deadline = Date.now() + 15_000;
+      let finalStatus = "";
+      while (Date.now() < deadline) {
+        const { status, error } = manager.getSyncStatus();
+        finalStatus = status;
+        if (status === "synced") break;
+        if (status === "error") {
+          throw new Error(`Sync errored: ${error}`);
+        }
+        await new Promise((r) => setTimeout(r, 500));
       }
-      await new Promise((r) => setTimeout(r, 500));
-    }
 
-    expect(finalStatus).toBe("synced");
-  }, 30_000);
-}, 90_000);
+      expect(finalStatus).toBe("synced");
+    }, 30_000);
+  },
+  90_000
+);


### PR DESCRIPTION
Closes #21659

## Summary

Applies the repository-pinned Biome formatter to
`plugins/plugin-sql/src/__tests__/integration/electric-sync-end-to-end.test.ts`
so that `bun run --cwd plugins/plugin-sql lint:check` passes and the root
`bun run verify` gate is unblocked.

## Changes

- Mechanical formatting only — no token-stream or behavioral change.
- `bun run --cwd plugins/plugin-sql lint:check` now passes.

## Evidence

```
Checked 1 file in 13ms. Fixed 1 file.
Checked 205 files in 92ms. No fixes applied.
```

## Contribution provenance

- AI assistance: yes
- AI provider/model: Google / Gemini
- Attribution status: self-reported