### PR TITLE
fix(ios): make local notification taps reach visible Home center

### DIFF
--- a/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		LCLZ00010000000000000002 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = LCLZ00010000000000000101 /* Localizable.xcstrings */; };
 		SHCT00010000000000000001 /* AppShortcuts.strings in Resources */ = {isa = PBXBuildFile; fileRef = SHCT00010000000000000101 /* AppShortcuts.strings */; };
 		MIPL00010000000000000001 /* ElizaIntentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = MIPL00010000000000000002 /* ElizaIntentPlugin.swift */; };
+		NTPY00010000000000000001 /* ElizaNotificationTriggerPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = NTPY00010000000000000003 /* ElizaNotificationTriggerPolicy.swift */; };
+		NTPY00010000000000000002 /* ElizaNotificationTriggerPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = NTPY00010000000000000003 /* ElizaNotificationTriggerPolicy.swift */; };
 		AWDG00010000000000000001 /* AgentWatchdog.swift in Sources */ = {isa = PBXBuildFile; fileRef = AWDG00010000000000000002 /* AgentWatchdog.swift */; };
 		NTRN00010000000000000001 /* NativeTranscriptReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = NTRN00010000000000000002 /* NativeTranscriptReducer.swift */; };
 		NTRN00010000000000000003 /* NativeTranscriptBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = NTRN00010000000000000004 /* NativeTranscriptBridge.swift */; };
@@ -140,6 +142,7 @@
 		SHCT00010000000000000103 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 		MIPL00010000000000000002 /* ElizaIntentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElizaIntentPlugin.swift; sourceTree = "<group>"; };
+		NTPY00010000000000000003 /* ElizaNotificationTriggerPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElizaNotificationTriggerPolicy.swift; sourceTree = "<group>"; };
 		AWDG00010000000000000002 /* AgentWatchdog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentWatchdog.swift; sourceTree = "<group>"; };
 		NTRN00010000000000000002 /* NativeTranscriptReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTranscriptReducer.swift; sourceTree = "<group>"; };
 		NTRN00010000000000000004 /* NativeTranscriptBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTranscriptBridge.swift; sourceTree = "<group>"; };
@@ -284,6 +287,7 @@
 				SCENEDEL00000000000002 /* SceneDelegate.swift */,
 				E1A5105A0000000000000002 /* ElizaAppIntents.swift */,
 				MIPL00010000000000000002 /* ElizaIntentPlugin.swift */,
+				NTPY00010000000000000003 /* ElizaNotificationTriggerPolicy.swift */,
 				ELIZALIVEACT000000000002 /* ElizaLiveActivityBridge.swift */,
 				ELIZAKBDBRIDGE0000000002 /* ElizaKeyboardBridge.swift */,
 				GLASSBRIDGE0000000000002 /* GlassBridge.swift */,
@@ -711,6 +715,7 @@
 				SCENEDEL00000000000001 /* SceneDelegate.swift in Sources */,
 				E1A5105A0000000000000001 /* ElizaAppIntents.swift in Sources */,
 				MIPL00010000000000000001 /* ElizaIntentPlugin.swift in Sources */,
+				NTPY00010000000000000001 /* ElizaNotificationTriggerPolicy.swift in Sources */,
 				ELIZALIVEACT000000000001 /* ElizaLiveActivityBridge.swift in Sources */,
 				ELIZAKBDBRIDGE0000000001 /* ElizaKeyboardBridge.swift in Sources */,
 				GLASSBRIDGE0000000000001 /* GlassBridge.swift in Sources */,
@@ -758,6 +763,7 @@
 				AUIT0001000000000000000B /* DeviceLifecycleUITests.swift in Sources */,
 				AUIT0001000000000000000D /* ChatFailureStrings.generated.swift in Sources */,
 				AUIT0001000000000000000F /* DeviceExtensionSurfaceUITests.swift in Sources */,
+				NTPY00010000000000000002 /* ElizaNotificationTriggerPolicy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/app-core/platforms/ios/App/App/AppDelegate.swift
+++ b/packages/app-core/platforms/ios/App/App/AppDelegate.swift
@@ -186,8 +186,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         let userInfo = response.notification.request.content.userInfo
-        if let urlString = userInfo["deepLinkOnTap"] as? String,
-           let url = URL(string: urlString) {
+        if let url = ElizaNotificationTapPayload.safeOpenDestination(
+            userInfo["deepLinkOnTap"]
+        ) {
             // The target can contain producer-supplied notification context.
             // Record the routing event without persisting the URL or query.
             NSLog("[ElizaCompanion] Notification tapped — routing validated deep link")

--- a/packages/app-core/platforms/ios/App/App/AppDelegate.swift
+++ b/packages/app-core/platforms/ios/App/App/AppDelegate.swift
@@ -1,3 +1,7 @@
+/**
+ Owns the iOS application lifecycle, native notification delivery, and the
+ process-wide platform hooks that must exist before Capacitor boots.
+ */
 import UIKit
 import Capacitor
 import CapacitorBackgroundRunner
@@ -184,7 +188,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         let userInfo = response.notification.request.content.userInfo
         if let urlString = userInfo["deepLinkOnTap"] as? String,
            let url = URL(string: urlString) {
-            NSLog("[ElizaCompanion] Notification tapped — opening deep link: %@", urlString)
+            // The target can contain producer-supplied notification context.
+            // Record the routing event without persisting the URL or query.
+            NSLog("[ElizaCompanion] Notification tapped — routing validated deep link")
             DispatchQueue.main.async {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }

--- a/packages/app-core/platforms/ios/App/App/ElizaIntentPlugin.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaIntentPlugin.swift
@@ -65,12 +65,14 @@ public class ElizaIntentPlugin: CAPPlugin, CAPBridgedPlugin {
             call.reject("scheduleAlarm requires timeIso, title, body")
             return
         }
+        let deepLink = call.getString("deepLink")
         let deepLinkOnTap = call.getString("deepLinkOnTap")
 
         scheduleNotification(
             timeIso: timeIso,
             title: title,
             body: body,
+            deepLink: deepLink,
             deepLinkOnTap: deepLinkOnTap
         ) { result, errorMessage in
             if let errorMessage = errorMessage {
@@ -83,15 +85,15 @@ public class ElizaIntentPlugin: CAPPlugin, CAPBridgedPlugin {
 
     /// Schedule a local `UNNotification`.
     ///
-    /// `deepLinkOnTap` is stashed in `UNNotificationContent.userInfo` under
-    /// the literal key `deepLinkOnTap`. When the user taps the notification,
-    /// `AppDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)`
-    /// reads that key and calls `UIApplication.shared.open(URL(string:))` so
-    /// the app routes to the right surface (e.g. `elizaos://chat/<convoId>`).
+    /// Capacitor's notification delegate rebuilds the action payload from
+    /// `cap_extra`, while AppDelegate consumes `deepLinkOnTap` if it remains the
+    /// active delegate. Store both representations so either legitimate iOS
+    /// delivery path reaches the same validated app destination.
     private func scheduleNotification(
         timeIso: String,
         title: String,
         body: String,
+        deepLink: String?,
         deepLinkOnTap: String?,
         completion: @escaping ([String: Any]?, String?) -> Void
     ) {
@@ -118,12 +120,14 @@ public class ElizaIntentPlugin: CAPPlugin, CAPBridgedPlugin {
             content.title = title
             content.body = body
             content.sound = .default
-            if let deepLinkOnTap, !deepLinkOnTap.isEmpty {
-                // userInfo carries the deep-link URL to the AppDelegate's
-                // notification-response handler. Stored as a plain string so
-                // the JSON round-trip through Apple's notification storage
-                // doesn't drop it.
-                content.userInfo = ["deepLinkOnTap": deepLinkOnTap]
+            // @capacitor/local-notifications maps only cap_extra back to
+            // notification.extra for retained ActionPerformed delivery.
+            let userInfo = ElizaNotificationTapPayload.userInfo(
+                deepLink: deepLink,
+                deepLinkOnTap: deepLinkOnTap
+            )
+            if !userInfo.isEmpty {
+                content.userInfo = userInfo
             }
 
             let trigger = ElizaNotificationTriggerPolicy.trigger(
@@ -146,6 +150,9 @@ public class ElizaIntentPlugin: CAPPlugin, CAPBridgedPlugin {
                 ]
                 if let deepLinkOnTap {
                     result["deepLinkOnTap"] = deepLinkOnTap
+                }
+                if let deepLink {
+                    result["deepLink"] = deepLink
                 }
                 completion(result, nil)
             }
@@ -170,11 +177,13 @@ public class ElizaIntentPlugin: CAPPlugin, CAPBridgedPlugin {
                 call.reject("\(kind) intent missing timeIso/title/body")
                 return
             }
+            let deepLink = payload["deepLink"] as? String
             let deepLinkOnTap = payload["deepLinkOnTap"] as? String
             scheduleNotification(
                 timeIso: timeIso,
                 title: title,
                 body: body,
+                deepLink: deepLink,
                 deepLinkOnTap: deepLinkOnTap
             ) { result, errorMessage in
                 if let errorMessage = errorMessage {

--- a/packages/app-core/platforms/ios/App/App/ElizaIntentPlugin.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaIntentPlugin.swift
@@ -126,13 +126,8 @@ public class ElizaIntentPlugin: CAPPlugin, CAPBridgedPlugin {
                 content.userInfo = ["deepLinkOnTap": deepLinkOnTap]
             }
 
-            let triggerComponents = Calendar.current.dateComponents(
-                [.year, .month, .day, .hour, .minute, .second],
-                from: resolvedDate
-            )
-            let trigger = UNCalendarNotificationTrigger(
-                dateMatching: triggerComponents,
-                repeats: false
+            let trigger = ElizaNotificationTriggerPolicy.trigger(
+                fireDate: resolvedDate
             )
             let scheduledId = UUID().uuidString
             let request = UNNotificationRequest(

--- a/packages/app-core/platforms/ios/App/App/ElizaNotificationTriggerPolicy.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaNotificationTriggerPolicy.swift
@@ -1,9 +1,11 @@
 /**
- Selects a fireable UserNotifications trigger after authorization completes.
+ Defines the shared UserNotifications scheduling and tap-payload policy.
 
  Immediate intents can age into the past while the system permission sheet is
  open, so they use a short interval trigger; genuinely future requests retain
- their requested calendar date.
+ their requested calendar date. Fallback notifications carry both Capacitor's
+ `cap_extra` shape and the AppDelegate URL without making either delegate path
+ authoritative over the other.
  */
 import Foundation
 import UserNotifications
@@ -31,5 +33,38 @@ enum ElizaNotificationTriggerPolicy {
             dateMatching: components,
             repeats: false
         )
+    }
+}
+
+enum ElizaNotificationTapPayload {
+    static func userInfo(
+        deepLink: String?,
+        deepLinkOnTap: String?
+    ) -> [AnyHashable: Any] {
+        var userInfo: [AnyHashable: Any] = [:]
+        if let deepLink, isSafeAppDestination(deepLink) {
+            userInfo["cap_extra"] = ["deepLink": deepLink]
+        }
+        if let deepLinkOnTap, isSafeOpenDestination(deepLinkOnTap) {
+            userInfo["deepLinkOnTap"] = deepLinkOnTap
+        }
+        return userInfo
+    }
+
+    private static func isSafeAppDestination(_ value: String) -> Bool {
+        if value.hasPrefix("/") && !value.hasPrefix("//") {
+            return true
+        }
+        guard let scheme = URL(string: value)?.scheme?.lowercased() else {
+            return false
+        }
+        return scheme == "http" || scheme == "https"
+    }
+
+    private static func isSafeOpenDestination(_ value: String) -> Bool {
+        guard let scheme = URL(string: value)?.scheme?.lowercased() else {
+            return false
+        }
+        return scheme == "elizaos" || scheme == "http" || scheme == "https"
     }
 }

--- a/packages/app-core/platforms/ios/App/App/ElizaNotificationTriggerPolicy.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaNotificationTriggerPolicy.swift
@@ -62,9 +62,26 @@ enum ElizaNotificationTapPayload {
     }
 
     private static func isSafeOpenDestination(_ value: String) -> Bool {
-        guard let scheme = URL(string: value)?.scheme?.lowercased() else {
+        guard let url = URL(string: value),
+              let scheme = url.scheme?.lowercased() else {
             return false
         }
-        return scheme == "elizaos" || scheme == "http" || scheme == "https"
+        if scheme == "http" || scheme == "https" {
+            return true
+        }
+        guard scheme == "elizaos",
+              let destination = url.host?.removingPercentEncoding?.lowercased(),
+              !destination.isEmpty else {
+            return false
+        }
+        let privilegedNativeNamespaces: Set<String> = [
+            "aec-loop",
+            "auth",
+            "connect",
+            "first-run",
+            "keyboard-dictation",
+            "share",
+        ]
+        return !privilegedNativeNamespaces.contains(destination)
     }
 }

--- a/packages/app-core/platforms/ios/App/App/ElizaNotificationTriggerPolicy.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaNotificationTriggerPolicy.swift
@@ -1,0 +1,35 @@
+/**
+ Selects a fireable UserNotifications trigger after authorization completes.
+
+ Immediate intents can age into the past while the system permission sheet is
+ open, so they use a short interval trigger; genuinely future requests retain
+ their requested calendar date.
+ */
+import Foundation
+import UserNotifications
+
+enum ElizaNotificationTriggerPolicy {
+    static let immediateDelay: TimeInterval = 1
+
+    static func trigger(
+        fireDate: Date,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> UNNotificationTrigger {
+        if fireDate <= now.addingTimeInterval(immediateDelay) {
+            return UNTimeIntervalNotificationTrigger(
+                timeInterval: immediateDelay,
+                repeats: false
+            )
+        }
+
+        let components = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: fireDate
+        )
+        return UNCalendarNotificationTrigger(
+            dateMatching: components,
+            repeats: false
+        )
+    }
+}

--- a/packages/app-core/platforms/ios/App/App/ElizaNotificationTriggerPolicy.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaNotificationTriggerPolicy.swift
@@ -45,8 +45,8 @@ enum ElizaNotificationTapPayload {
         if let deepLink, isSafeAppDestination(deepLink) {
             userInfo["cap_extra"] = ["deepLink": deepLink]
         }
-        if let deepLinkOnTap, isSafeOpenDestination(deepLinkOnTap) {
-            userInfo["deepLinkOnTap"] = deepLinkOnTap
+        if let destination = safeOpenDestination(deepLinkOnTap) {
+            userInfo["deepLinkOnTap"] = destination.absoluteString
         }
         return userInfo
     }
@@ -61,18 +61,19 @@ enum ElizaNotificationTapPayload {
         return scheme == "http" || scheme == "https"
     }
 
-    private static func isSafeOpenDestination(_ value: String) -> Bool {
-        guard let url = URL(string: value),
+    static func safeOpenDestination(_ value: Any?) -> URL? {
+        guard let value = value as? String,
+              let url = URL(string: value),
               let scheme = url.scheme?.lowercased() else {
-            return false
+            return nil
         }
         if scheme == "http" || scheme == "https" {
-            return true
+            return url
         }
         guard scheme == "elizaos",
               let destination = url.host?.removingPercentEncoding?.lowercased(),
               !destination.isEmpty else {
-            return false
+            return nil
         }
         let privilegedNativeNamespaces: Set<String> = [
             "aec-loop",
@@ -82,6 +83,6 @@ enum ElizaNotificationTapPayload {
             "keyboard-dictation",
             "share",
         ]
-        return !privilegedNativeNamespaces.contains(destination)
+        return privilegedNativeNamespaces.contains(destination) ? nil : url
     }
 }

--- a/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
@@ -72,6 +72,22 @@ final class DeviceExtensionSurfaceUITests: XCTestCase {
                 deepLinkOnTap: "javascript:alert(1)"
             ).isEmpty
         )
+        for privilegedTarget in [
+            "elizaos://auth/callback?code=secret",
+            "elizaos://first-run/runtime/remote",
+            "elizaos://connect?url=https://example.test",
+            "elizaos://share?file=/private/note.txt",
+            "elizaos://keyboard-dictation",
+            "elizaos://aec-loop?duration=30",
+            "elizaos://%61uth/callback?code=secret",
+        ] {
+            XCTAssertNil(
+                ElizaNotificationTapPayload.userInfo(
+                    deepLink: nil,
+                    deepLinkOnTap: privilegedTarget
+                )["deepLinkOnTap"]
+            )
+        }
     }
 
     func testControlCenterGalleryListsElizaControls() throws {

--- a/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
@@ -9,6 +9,7 @@
  keyboard enablement still require the provisioned-device lane called out in
  #13567/#13563.
  */
+import UserNotifications
 import XCTest
 
 final class DeviceExtensionSurfaceUITests: XCTestCase {
@@ -17,6 +18,34 @@ final class DeviceExtensionSurfaceUITests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
+    }
+
+    func testLocalNotificationTriggerStaysFireableAcrossPermissionDelay() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let immediateDates = [
+            now.addingTimeInterval(-30),
+            now,
+            now.addingTimeInterval(0.5),
+        ]
+
+        for fireDate in immediateDates {
+            let trigger = ElizaNotificationTriggerPolicy.trigger(
+                fireDate: fireDate,
+                now: now
+            )
+            let interval = trigger as? UNTimeIntervalNotificationTrigger
+            XCTAssertEqual(interval?.timeInterval, 1)
+            XCTAssertEqual(interval?.repeats, false)
+        }
+
+        let future = ElizaNotificationTriggerPolicy.trigger(
+            fireDate: now.addingTimeInterval(60),
+            now: now,
+            calendar: Calendar(identifier: .gregorian)
+        )
+        let calendar = future as? UNCalendarNotificationTrigger
+        XCTAssertNotNil(calendar)
+        XCTAssertEqual(calendar?.repeats, false)
     }
 
     func testControlCenterGalleryListsElizaControls() throws {

--- a/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
@@ -48,6 +48,32 @@ final class DeviceExtensionSurfaceUITests: XCTestCase {
         XCTAssertEqual(calendar?.repeats, false)
     }
 
+    func testFallbackNotificationPayloadSupportsCapacitorAndAppDelegateTaps() throws {
+        let userInfo = ElizaNotificationTapPayload.userInfo(
+            deepLink: "/notifications",
+            deepLinkOnTap: "elizaos://notifications"
+        )
+        let extra = try XCTUnwrap(userInfo["cap_extra"] as? [String: String])
+
+        XCTAssertEqual(extra, ["deepLink": "/notifications"])
+        XCTAssertEqual(
+            userInfo["deepLinkOnTap"] as? String,
+            "elizaos://notifications"
+        )
+        XCTAssertTrue(
+            ElizaNotificationTapPayload.userInfo(
+                deepLink: nil,
+                deepLinkOnTap: nil
+            ).isEmpty
+        )
+        XCTAssertTrue(
+            ElizaNotificationTapPayload.userInfo(
+                deepLink: "//attacker.example/notifications",
+                deepLinkOnTap: "javascript:alert(1)"
+            ).isEmpty
+        )
+    }
+
     func testControlCenterGalleryListsElizaControls() throws {
         guard #available(iOS 18.0, *) else {
             throw XCTSkip("Control Center controls are iOS 18+ only")

--- a/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
@@ -87,7 +87,24 @@ final class DeviceExtensionSurfaceUITests: XCTestCase {
                     deepLinkOnTap: privilegedTarget
                 )["deepLinkOnTap"]
             )
+            XCTAssertNil(
+                ElizaNotificationTapPayload.safeOpenDestination(
+                    ["deepLinkOnTap": privilegedTarget]["deepLinkOnTap"]
+                ),
+                "Remote notification payloads must cross the same privileged-route guard as locally scheduled notifications."
+            )
         }
+        XCTAssertEqual(
+            ElizaNotificationTapPayload.safeOpenDestination(
+                ["deepLinkOnTap": "elizaos://notifications"]["deepLinkOnTap"]
+            )?.absoluteString,
+            "elizaos://notifications"
+        )
+        XCTAssertNil(
+            ElizaNotificationTapPayload.safeOpenDestination(
+                ["deepLinkOnTap": 42]["deepLinkOnTap"]
+            )
+        )
     }
 
     func testControlCenterGalleryListsElizaControls() throws {

--- a/packages/app-core/scripts/mobile/ios-pods.mjs
+++ b/packages/app-core/scripts/mobile/ios-pods.mjs
@@ -93,6 +93,16 @@ export const MOBILE_CAPACITOR_PLUGIN_MANIFEST = [
     ],
   },
   {
+    packageName: "@capacitor/local-notifications",
+    iosPods: [
+      {
+        name: "CapacitorLocalNotifications",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
     packageName: "@capacitor/push-notifications",
     android: { patchAgp9: true },
     iosPods: [

--- a/packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
@@ -34,6 +34,12 @@ it("derives the Android and iOS official package tables from the mobile plugin m
   expect(ANDROID_OFFICIAL_CAPACITOR_PACKAGES).not.toContain(
     "@capacitor/network",
   );
+  expect(new Map(IOS_OFFICIAL_PODS).get("CapacitorLocalNotifications")).toBe(
+    "@capacitor/local-notifications",
+  );
+  expect(ANDROID_OFFICIAL_CAPACITOR_PACKAGES).not.toContain(
+    "@capacitor/local-notifications",
+  );
 });
 
 it("keeps the existing iOS custom pod include gates", () => {

--- a/packages/app/src/main.ios-interactive-entrypoint.test.ts
+++ b/packages/app/src/main.ios-interactive-entrypoint.test.ts
@@ -5,7 +5,10 @@
  */
 import { Capacitor } from "@capacitor/core";
 import { runIosFullBunSmokeIfRequested } from "@elizaos/app-core/desktop-shell";
-import { listenForConnectRequests } from "@elizaos/ui/events";
+import {
+  listenForConnectRequests,
+  OPEN_NOTIFICATION_CENTER_EVENT,
+} from "@elizaos/ui/events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const iosBoot = vi.hoisted(() => ({
@@ -165,6 +168,11 @@ describe("renderer interactive iOS composition", () => {
     expect(handleDeepLink).toBeTypeOf("function");
     const connectRequest = vi.fn();
     const removeConnectListener = listenForConnectRequests(connectRequest);
+    const notificationCenterRequest = vi.fn();
+    window.addEventListener(
+      OPEN_NOTIFICATION_CENTER_EVENT,
+      notificationCenterRequest,
+    );
     window.localStorage.setItem(
       "eliza:auth-callback-smoke:request",
       JSON.stringify({ state: "smoke", code: "synthetic" }),
@@ -175,6 +183,9 @@ describe("renderer interactive iOS composition", () => {
       "elizaos://phone/call?contact=alice",
       "elizaos://messages/compose?to=bob",
       "elizaos://contacts",
+      "https://evil.example/notifications",
+      "javascript:notifications",
+      "elizaos://notifications",
       "elizaos://aec-loop?duration=1",
       "elizaos://keyboard-dictation",
       "elizaos://connect?url=http%3A%2F%2Flocalhost%3A2138",
@@ -203,6 +214,11 @@ describe("renderer interactive iOS composition", () => {
       }),
     );
     removeConnectListener();
+    window.removeEventListener(
+      OPEN_NOTIFICATION_CENTER_EVENT,
+      notificationCenterRequest,
+    );
+    expect(notificationCenterRequest).toHaveBeenCalledOnce();
     expect(window.__ELIZA_APP_SHARE_QUEUE__).toEqual([
       expect.objectContaining({
         source: "deep-link",

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -96,6 +96,7 @@ import {
   dispatchAppEvent,
   dispatchConnectRequest,
   dispatchNavigateViewRequest,
+  dispatchOpenNotificationCenter,
   MOBILE_RUNTIME_MODE_CHANGED_EVENT,
   PUSH_TO_TALK_HOLD_EVENT,
   PUSH_TO_TALK_TOGGLE_EVENT,
@@ -2275,6 +2276,12 @@ function handleDeepLink(url: string): undefined | Promise<boolean> {
       break;
     case "contacts":
       setHashRoute("contacts", parsed.searchParams);
+      break;
+    case "notifications":
+      // AppDelegate delivers the fallback notification URL through the native
+      // appUrlOpen lifecycle. The Home notification center is event-driven, so
+      // a hash write cannot open it on the Capacitor composition root.
+      dispatchOpenNotificationCenter();
       break;
     case "aec-loop":
       // On-device AEC acoustic-loop evidence harness (#11373): the hash route

--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -34,6 +34,12 @@ const appState = vi.hoisted(() => ({
 
 const notificationMock = vi.hoisted(() => ({
   init: vi.fn(async () => undefined),
+  initNativeTap: vi.fn(async () => undefined),
+}));
+
+vi.mock("./bridge/native-notifications", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./bridge/native-notifications")>()),
+  initLocalNotificationTapRouting: notificationMock.initNativeTap,
 }));
 
 vi.mock("./state/notifications/notification-store", () => ({
@@ -346,6 +352,7 @@ describe("App chat-overlay first-run composition", () => {
     shellControllerMock.generation = 0;
     overlayMock.handledReleases = 0;
     notificationMock.init.mockClear();
+    notificationMock.initNativeTap.mockClear();
   });
 
   afterEach(() => {
@@ -389,7 +396,7 @@ describe("App chat-overlay first-run composition", () => {
     ).toBeNull();
   });
 
-  it("boots WebSocket notification ingress outside startup and auth early returns", async () => {
+  it("boots notification ingress and native tap routing outside startup and auth early returns", async () => {
     window.history.replaceState(null, "", "/");
     appState.firstRunComplete = true;
     appState.startupPhase = "polling-backend";
@@ -398,6 +405,7 @@ describe("App chat-overlay first-run composition", () => {
     const startupGate = render(<App />);
     expect(startupGate.getByTestId("startup-screen")).toBeTruthy();
     await waitFor(() => expect(notificationMock.init).toHaveBeenCalledOnce());
+    expect(notificationMock.initNativeTap).toHaveBeenCalledOnce();
     startupGate.unmount();
   });
 

--- a/packages/ui/src/bridge/native-notifications.test.ts
+++ b/packages/ui/src/bridge/native-notifications.test.ts
@@ -270,11 +270,35 @@ describe("showNativeNotification (iOS fallback)", () => {
         title: "Reminder",
         body: "Time to stretch",
         priority: "normal",
+        deepLink: "/apps/scheduled",
         deepLinkOnTap: "elizaos://apps/scheduled",
       },
     });
     expect(intent?.payload.timeIso).toBe(intent?.issuedAtIso);
     expect(Number.isNaN(Date.parse(intent?.issuedAtIso ?? ""))).toBe(false);
+  });
+
+  it("withholds both fallback tap payloads for an unsafe route", async () => {
+    platform.value = "ios";
+    const receiveIntent = vi.fn(async (_intent: ElizaIntentArg) => ({
+      accepted: true,
+      reason: "scheduled",
+    }));
+    plugins.ElizaIntent = { receiveIntent };
+
+    await showNativeNotification({
+      id: "ios-unsafe-fallback",
+      title: "Reminder",
+      priority: "normal",
+      deepLink: "javascript:alert(1)",
+    });
+
+    expect(receiveIntent.mock.calls[0]?.[0]?.payload).not.toHaveProperty(
+      "deepLink",
+    );
+    expect(receiveIntent.mock.calls[0]?.[0]?.payload).not.toHaveProperty(
+      "deepLinkOnTap",
+    );
   });
 });
 

--- a/packages/ui/src/bridge/native-notifications.test.ts
+++ b/packages/ui/src/bridge/native-notifications.test.ts
@@ -26,6 +26,8 @@ vi.mock("./native-plugins", () => ({
 
 import {
   __resetEnsuredChannelsForTests,
+  __resetLocalNotificationTapRoutingForTests,
+  initLocalNotificationTapRouting,
   showNativeNotification,
   showWebNotification,
 } from "./native-notifications";
@@ -36,6 +38,7 @@ interface ScheduleArg {
     title: string;
     body: string;
     channelId?: string;
+    extra?: Record<string, unknown>;
   }>;
 }
 interface ChannelArg {
@@ -43,6 +46,11 @@ interface ChannelArg {
   name: string;
   importance: number;
   visibility?: number;
+}
+interface ElizaIntentArg {
+  kind: "reminder";
+  payload: Record<string, unknown>;
+  issuedAtIso: string;
 }
 
 function makeLocalNotifications(overrides: Record<string, unknown> = {}) {
@@ -60,6 +68,7 @@ beforeEach(() => {
   for (const key of Object.keys(plugins)) delete plugins[key];
   // Channel cache is module-level; clear it so each case exercises createChannel.
   __resetEnsuredChannelsForTests();
+  __resetLocalNotificationTapRoutingForTests();
 });
 
 afterEach(() => {
@@ -196,6 +205,257 @@ describe("showNativeNotification (web platform)", () => {
     });
     expect(result).toBe("none");
     expect(constructed).not.toHaveBeenCalled();
+  });
+});
+
+describe("showNativeNotification (iOS fallback)", () => {
+  it("keeps a safe app route for the Capacitor tap listener", async () => {
+    platform.value = "ios";
+    const local = makeLocalNotifications();
+    plugins.LocalNotifications = local;
+
+    const result = await showNativeNotification({
+      id: "ios-local",
+      title: "Reminder",
+      priority: "normal",
+      deepLink: "/apps/scheduled?source=notification",
+    });
+
+    expect(result).toBe("local");
+    expect(local.schedule.mock.calls[0]?.[0]?.notifications[0]?.extra).toEqual({
+      deepLink: "/apps/scheduled?source=notification",
+    });
+  });
+
+  it("does not hand an unsafe tap scheme to native iOS", async () => {
+    platform.value = "ios";
+    const local = makeLocalNotifications();
+    plugins.LocalNotifications = local;
+
+    await showNativeNotification({
+      id: "ios-unsafe",
+      title: "Reminder",
+      priority: "normal",
+      deepLink: "javascript:alert(1)",
+    });
+
+    expect(
+      local.schedule.mock.calls[0]?.[0]?.notifications[0]?.extra,
+    ).toBeUndefined();
+  });
+
+  it("supplies the required immediate schedule time to ElizaIntent", async () => {
+    platform.value = "ios";
+    const receiveIntent = vi.fn(async (_intent: ElizaIntentArg) => ({
+      accepted: true,
+      reason: "scheduled",
+    }));
+    plugins.ElizaIntent = { receiveIntent };
+
+    const result = await showNativeNotification({
+      id: "ios-fallback",
+      title: "Reminder",
+      body: "Time to stretch",
+      priority: "normal",
+      deepLink: "/apps/scheduled",
+    });
+
+    expect(result).toBe("intent");
+    const intent = receiveIntent.mock.calls[0]?.[0];
+    expect(intent).toEqual({
+      kind: "reminder",
+      issuedAtIso: expect.any(String),
+      payload: {
+        timeIso: expect.any(String),
+        title: "Reminder",
+        body: "Time to stretch",
+        priority: "normal",
+        deepLinkOnTap: "elizaos://apps/scheduled",
+      },
+    });
+    expect(intent?.payload.timeIso).toBe(intent?.issuedAtIso);
+    expect(Number.isNaN(Date.parse(intent?.issuedAtIso ?? ""))).toBe(false);
+  });
+});
+
+describe("initLocalNotificationTapRouting", () => {
+  it("accepts a native listener handle returned synchronously", async () => {
+    const navigate = vi.fn();
+    const addListener = vi.fn(
+      (
+        _event: string,
+        callback: (action: {
+          actionId: string;
+          notification: { extra?: unknown };
+        }) => void,
+      ) => {
+        callback({
+          actionId: "tap",
+          notification: { extra: { deepLink: "/notifications" } },
+        });
+        return { remove: async () => {} };
+      },
+    );
+
+    await expect(
+      initLocalNotificationTapRouting({
+        getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+        navigate,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(addListener).toHaveBeenCalledOnce();
+    expect(navigate).toHaveBeenCalledWith("/notifications");
+  });
+
+  it("deduplicates concurrent initialization before invoking the bridge", async () => {
+    const addListener = vi.fn(() => ({ remove: async () => {} }));
+    const deps = {
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate: vi.fn(),
+    };
+
+    const first = initLocalNotificationTapRouting(deps);
+    const second = initLocalNotificationTapRouting(deps);
+
+    expect(first).toBe(second);
+    await first;
+    expect(addListener).toHaveBeenCalledOnce();
+  });
+
+  it("consumes a retained cold-launch tap while the listener is attaching", async () => {
+    const navigate = vi.fn();
+    const addListener = vi.fn(
+      async (
+        _event: string,
+        callback: (action: {
+          actionId: string;
+          notification: { extra?: unknown };
+        }) => void,
+      ) => {
+        callback({
+          actionId: "tap",
+          notification: { extra: { deepLink: "/apps/scheduled" } },
+        });
+        return { remove: async () => {} };
+      },
+    );
+
+    await initLocalNotificationTapRouting({
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate,
+    });
+
+    expect(navigate).toHaveBeenCalledWith("/apps/scheduled");
+  });
+
+  it("routes a retained Capacitor tap through the canonical safe navigator", async () => {
+    let listener:
+      | ((action: {
+          actionId: string;
+          notification: { extra?: unknown };
+        }) => void)
+      | undefined;
+    const addListener = vi.fn(
+      async (
+        _event: string,
+        callback: NonNullable<typeof listener>,
+      ): Promise<{ remove: () => Promise<void> }> => {
+        listener = callback;
+        return { remove: async () => {} };
+      },
+    );
+    const navigate = vi.fn();
+    const deps = {
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate,
+    };
+
+    await initLocalNotificationTapRouting(deps);
+    await initLocalNotificationTapRouting(deps);
+    listener?.({
+      actionId: "tap",
+      notification: { extra: { deepLink: "/notifications" } },
+    });
+
+    expect(addListener).toHaveBeenCalledOnce();
+    expect(addListener).toHaveBeenCalledWith(
+      "localNotificationActionPerformed",
+      expect.any(Function),
+    );
+    expect(navigate).toHaveBeenCalledWith("/notifications");
+  });
+
+  it("drops dismisses, malformed payloads, and unsafe schemes", async () => {
+    let listener:
+      | ((action: {
+          actionId: string;
+          notification: { extra?: unknown };
+        }) => void)
+      | undefined;
+    const addListener = vi.fn(
+      async (_event: string, callback: typeof listener) => {
+        listener = callback;
+        return { remove: async () => {} };
+      },
+    );
+    const navigate = vi.fn();
+
+    await initLocalNotificationTapRouting({
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate,
+    });
+    listener?.({
+      actionId: "dismiss",
+      notification: { extra: { deepLink: "/notifications" } },
+    });
+    listener?.({
+      actionId: "tap",
+      notification: { extra: { deepLink: "javascript:alert(1)" } },
+    });
+    listener?.({ actionId: "tap", notification: { extra: "invalid" } });
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("can retry listener registration after a native bridge failure", async () => {
+    const addListener = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("bridge unavailable"))
+      .mockResolvedValueOnce({ remove: async () => {} });
+    const deps = {
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate: vi.fn(),
+    };
+
+    await expect(initLocalNotificationTapRouting(deps)).rejects.toThrow(
+      "bridge unavailable",
+    );
+    await expect(
+      initLocalNotificationTapRouting(deps),
+    ).resolves.toBeUndefined();
+    expect(addListener).toHaveBeenCalledTimes(2);
+  });
+
+  it("can retry after the native bridge throws synchronously", async () => {
+    const addListener = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("native attach threw");
+      })
+      .mockReturnValueOnce({ remove: async () => {} });
+    const deps = {
+      getPlugin: () => ({ ...makeLocalNotifications(), addListener }),
+      navigate: vi.fn(),
+    };
+
+    await expect(initLocalNotificationTapRouting(deps)).rejects.toThrow(
+      "native attach threw",
+    );
+    await expect(
+      initLocalNotificationTapRouting(deps),
+    ).resolves.toBeUndefined();
+    expect(addListener).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/ui/src/bridge/native-notifications.test.ts
+++ b/packages/ui/src/bridge/native-notifications.test.ts
@@ -305,6 +305,38 @@ describe("showNativeNotification (iOS fallback)", () => {
       "deepLinkOnTap",
     );
   });
+
+  it.each([
+    "/auth/callback?state=owner&code=secret",
+    "/first-run/runtime/remote?api=https%3A%2F%2Fexample.test",
+    "/connect?url=https%3A%2F%2Fexample.test",
+    "/share?file=%2Fprivate%2Fnote.txt",
+    "/keyboard-dictation",
+    "/aec-loop?duration=30",
+    "/\\attacker.example/notifications",
+    "/%61uth/callback?code=secret",
+  ])(
+    "does not upgrade the safe renderer route %s into a privileged native URL",
+    async (deepLink) => {
+      platform.value = "ios";
+      const receiveIntent = vi.fn(async (_intent: ElizaIntentArg) => ({
+        accepted: true,
+        reason: "scheduled",
+      }));
+      plugins.ElizaIntent = { receiveIntent };
+
+      await showNativeNotification({
+        id: "ios-privileged-fallback",
+        title: "Reminder",
+        priority: "normal",
+        deepLink,
+      });
+
+      const payload = receiveIntent.mock.calls[0]?.[0]?.payload;
+      expect(payload).toMatchObject({ deepLink });
+      expect(payload).not.toHaveProperty("deepLinkOnTap");
+    },
+  );
 });
 
 describe("initLocalNotificationTapRouting", () => {

--- a/packages/ui/src/bridge/native-notifications.test.ts
+++ b/packages/ui/src/bridge/native-notifications.test.ts
@@ -8,9 +8,14 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { platform, plugins } = vi.hoisted(() => ({
+const { loggerInfo, platform, plugins } = vi.hoisted(() => ({
+  loggerInfo: vi.fn(),
   platform: { value: "android" },
   plugins: {} as Record<string, unknown>,
+}));
+
+vi.mock("@elizaos/logger", () => ({
+  logger: { info: loggerInfo },
 }));
 
 vi.mock("@capacitor/core", () => ({
@@ -330,6 +335,13 @@ describe("initLocalNotificationTapRouting", () => {
 
     expect(addListener).toHaveBeenCalledOnce();
     expect(navigate).toHaveBeenCalledWith("/notifications");
+    expect(loggerInfo).toHaveBeenCalledWith(
+      { src: "local-notification-tap" },
+      "[local-notification-tap] routed native notification action",
+    );
+    expect(JSON.stringify(loggerInfo.mock.calls)).not.toContain(
+      "/notifications",
+    );
   });
 
   it("deduplicates concurrent initialization before invoking the bridge", async () => {

--- a/packages/ui/src/bridge/native-notifications.ts
+++ b/packages/ui/src/bridge/native-notifications.ts
@@ -224,6 +224,10 @@ export function initLocalNotificationTapRouting(
     )
     .then(() => undefined)
     .catch((error: unknown) => {
+      // error-policy:J6 clears the memoized attempt so a later caller can retry
+      // registration instead of awaiting a permanently rejected promise. The
+      // error is rethrown unchanged, so nothing is swallowed here — the boot
+      // retry loop in notifications-boot.tsx is what observes it.
       if (localNotificationTapListenerPromise === attempt) {
         localNotificationTapListenerPromise = null;
       }

--- a/packages/ui/src/bridge/native-notifications.ts
+++ b/packages/ui/src/bridge/native-notifications.ts
@@ -308,6 +308,8 @@ async function tryElizaIntent(
     return false;
   }
   const issuedAtIso = new Date().toISOString();
+  const safeDeepLink =
+    req.deepLink && isSafeDeepLink(req.deepLink) ? req.deepLink : undefined;
   const deepLinkOnTap = iosTapDeepLink(req.deepLink);
   const result = await plugin.receiveIntent({
     kind: "reminder",
@@ -320,6 +322,12 @@ async function tryElizaIntent(
       title: req.title,
       body: req.body ?? "",
       priority: req.priority,
+      // Capacitor's NotificationRouter owns UNUserNotificationCenter in the
+      // installed app and reconstructs `notification.extra` exclusively from
+      // native `cap_extra`. Preserve the validated app route for that primary
+      // tap callback while retaining the URL form for a genuine AppDelegate
+      // fallback path.
+      ...(safeDeepLink ? { deepLink: safeDeepLink } : {}),
       ...(deepLinkOnTap ? { deepLinkOnTap } : {}),
     },
     issuedAtIso,

--- a/packages/ui/src/bridge/native-notifications.ts
+++ b/packages/ui/src/bridge/native-notifications.ts
@@ -189,7 +189,7 @@ export function initLocalNotificationTapRouting(
         const deepLink = localNotificationTapDeepLink(action);
         if (deepLink) {
           logger.info(
-            { src: "local-notification-tap", deepLink },
+            { src: "local-notification-tap" },
             "[local-notification-tap] routed native notification action",
           );
           deps.navigate(deepLink);

--- a/packages/ui/src/bridge/native-notifications.ts
+++ b/packages/ui/src/bridge/native-notifications.ts
@@ -224,10 +224,9 @@ export function initLocalNotificationTapRouting(
     )
     .then(() => undefined)
     .catch((error: unknown) => {
-      // error-policy:J6 clears the memoized attempt so a later caller can retry
-      // registration instead of awaiting a permanently rejected promise. The
-      // error is rethrown unchanged, so nothing is swallowed here — the boot
-      // retry loop in notifications-boot.tsx is what observes it.
+      // error-policy:J5 the boot retry loop in notifications-boot.tsx observes
+      // this same rejection; this handler only clears the failed memoized
+      // attempt so that loop can perform a fresh registration.
       if (localNotificationTapListenerPromise === attempt) {
         localNotificationTapListenerPromise = null;
       }

--- a/packages/ui/src/bridge/native-notifications.ts
+++ b/packages/ui/src/bridge/native-notifications.ts
@@ -25,9 +25,12 @@
  * make backups heads-up or approvals silent, with no way for the user to tune
  * them apart. Web maps low priority to a silent notification.
  */
-import { Capacitor } from "@capacitor/core";
+import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
 import type { NotificationPriority } from "@elizaos/core";
-import { navigateDeepLink } from "../state/notifications/navigate-deep-link";
+import {
+  isSafeDeepLink,
+  navigateDeepLink,
+} from "../state/notifications/navigate-deep-link";
 import { getNativePlugin } from "./native-plugins";
 
 export interface NativeNotificationRequest {
@@ -66,6 +69,20 @@ interface LocalNotificationsPluginLike extends Record<string, unknown> {
     importance: number;
     visibility?: number;
   }) => Promise<void>;
+  addListener?: (
+    eventName: "localNotificationActionPerformed",
+    listenerFunc: (action: LocalNotificationActionPerformed) => void,
+  ) => PluginListenerHandle | Promise<PluginListenerHandle>;
+}
+
+interface LocalNotificationActionPerformed {
+  actionId?: unknown;
+  notification?: { extra?: unknown };
+}
+
+export interface LocalNotificationTapRoutingDeps {
+  getPlugin: () => LocalNotificationsPluginLike;
+  navigate: (deepLink: string) => void;
 }
 
 interface ElizaIntentPluginLike extends Record<string, unknown> {
@@ -83,6 +100,30 @@ function numericId(id: string): number {
     hash = (hash * 31 + id.charCodeAt(i)) | 0;
   }
   return Math.abs(hash) % 2_000_000_000 || 1;
+}
+
+/**
+ * Convert the notification store's safe app-route vocabulary into the custom
+ * URL shape that iOS can reopen through UIApplication. External http(s) links
+ * remain external; every other scheme is rejected before it reaches native
+ * userInfo.
+ */
+function iosTapDeepLink(deepLink: string | undefined): string | undefined {
+  if (!deepLink || !isSafeDeepLink(deepLink)) return undefined;
+  if (/^https?:\/\//i.test(deepLink)) return deepLink;
+  return `elizaos://${deepLink.slice(1)}`;
+}
+
+function localNotificationTapDeepLink(
+  action: LocalNotificationActionPerformed,
+): string | undefined {
+  if (action.actionId !== "tap") return undefined;
+  const extra = action.notification?.extra;
+  if (typeof extra !== "object" || extra === null) return undefined;
+  const deepLink = (extra as Record<string, unknown>).deepLink;
+  return typeof deepLink === "string" && isSafeDeepLink(deepLink)
+    ? deepLink
+    : undefined;
 }
 
 function hasMethod<T>(value: unknown, method: keyof T): value is T {
@@ -111,6 +152,53 @@ const ANDROID_CHANNELS: Record<
 };
 
 const ensuredChannels = new Set<string>();
+let localNotificationTapListenerPromise: Promise<void> | null = null;
+
+const defaultTapRoutingDeps: LocalNotificationTapRoutingDeps = {
+  getPlugin: () =>
+    getNativePlugin<LocalNotificationsPluginLike>("LocalNotifications"),
+  navigate: navigateDeepLink,
+};
+
+/**
+ * Attach the one app-lifetime handler for taps on Capacitor local
+ * notifications. Capacitor retains a cold-launch action until this listener is
+ * registered, so shell boot can consume both warm and terminated-app taps
+ * without a second native delegate or route authority.
+ */
+export function initLocalNotificationTapRouting(
+  deps: LocalNotificationTapRoutingDeps = defaultTapRoutingDeps,
+): Promise<void> {
+  if (localNotificationTapListenerPromise) {
+    return localNotificationTapListenerPromise;
+  }
+  const plugin = deps.getPlugin();
+  const addListener = plugin.addListener;
+  if (typeof addListener !== "function") {
+    return Promise.resolve();
+  }
+
+  // Capacitor's web proxy returns a Promise, while the installed native bridge
+  // may return its listener handle directly. Invoke in a deferred Promise so
+  // the singleton is installed first and synchronous native throws reach the
+  // shell's rejection boundary just like asynchronous bridge failures.
+  const attempt = Promise.resolve()
+    .then(() =>
+      addListener.call(plugin, "localNotificationActionPerformed", (action) => {
+        const deepLink = localNotificationTapDeepLink(action);
+        if (deepLink) deps.navigate(deepLink);
+      }),
+    )
+    .then(() => undefined)
+    .catch((error: unknown) => {
+      if (localNotificationTapListenerPromise === attempt) {
+        localNotificationTapListenerPromise = null;
+      }
+      throw error;
+    });
+  localNotificationTapListenerPromise = attempt;
+  return attempt;
+}
 
 /**
  * Test-only: clear the per-tier channel-creation cache between tests so a
@@ -118,6 +206,11 @@ const ensuredChannels = new Set<string>();
  */
 export function __resetEnsuredChannelsForTests(): void {
   ensuredChannels.clear();
+}
+
+/** Test-only: permit an isolated listener registration in each test case. */
+export function __resetLocalNotificationTapRoutingForTests(): void {
+  localNotificationTapListenerPromise = null;
 }
 
 /**
@@ -187,6 +280,9 @@ async function tryLocalNotifications(
   // the post — don't claim success; let the store's glass fallback deliver.
   if (channel.unusable) return false;
 
+  const safeDeepLink =
+    req.deepLink && isSafeDeepLink(req.deepLink) ? req.deepLink : undefined;
+
   await plugin.schedule({
     notifications: [
       {
@@ -196,7 +292,7 @@ async function tryLocalNotifications(
         title: req.title,
         body: req.body ?? "",
         ...(channel.channelId ? { channelId: channel.channelId } : {}),
-        ...(req.deepLink ? { extra: { deepLink: req.deepLink } } : {}),
+        ...(safeDeepLink ? { extra: { deepLink: safeDeepLink } } : {}),
       },
     ],
   });
@@ -211,15 +307,22 @@ async function tryElizaIntent(
   if (!hasMethod<ElizaIntentPluginLike>(plugin, "receiveIntent")) {
     return false;
   }
+  const issuedAtIso = new Date().toISOString();
+  const deepLinkOnTap = iosTapDeepLink(req.deepLink);
   const result = await plugin.receiveIntent({
     kind: "reminder",
     payload: {
+      // This bridge displays an immediate notification. The native intent
+      // contract still requires an explicit schedule time, so use the same
+      // instant as the issued-at receipt rather than sending an invalid
+      // reminder payload or inventing a user-visible delay.
+      timeIso: issuedAtIso,
       title: req.title,
       body: req.body ?? "",
       priority: req.priority,
-      ...(req.deepLink ? { deepLinkOnTap: req.deepLink } : {}),
+      ...(deepLinkOnTap ? { deepLinkOnTap } : {}),
     },
-    issuedAtIso: new Date().toISOString(),
+    issuedAtIso,
   });
   return result.accepted === true;
 }

--- a/packages/ui/src/bridge/native-notifications.ts
+++ b/packages/ui/src/bridge/native-notifications.ts
@@ -27,6 +27,7 @@
  */
 import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
 import type { NotificationPriority } from "@elizaos/core";
+import { logger } from "@elizaos/logger";
 import {
   isSafeDeepLink,
   navigateDeepLink,
@@ -186,7 +187,13 @@ export function initLocalNotificationTapRouting(
     .then(() =>
       addListener.call(plugin, "localNotificationActionPerformed", (action) => {
         const deepLink = localNotificationTapDeepLink(action);
-        if (deepLink) deps.navigate(deepLink);
+        if (deepLink) {
+          logger.info(
+            { src: "local-notification-tap", deepLink },
+            "[local-notification-tap] routed native notification action",
+          );
+          deps.navigate(deepLink);
+        }
       }),
     )
     .then(() => undefined)

--- a/packages/ui/src/bridge/native-notifications.ts
+++ b/packages/ui/src/bridge/native-notifications.ts
@@ -112,6 +112,32 @@ function numericId(id: string): number {
 function iosTapDeepLink(deepLink: string | undefined): string | undefined {
   if (!deepLink || !isSafeDeepLink(deepLink)) return undefined;
   if (/^https?:\/\//i.test(deepLink)) return deepLink;
+
+  // A root-relative view route is normally dispatched on the renderer's
+  // navigation bus. Converting it to a custom URL crosses a different, more
+  // privileged router in the native app, where several namespaces perform
+  // lifecycle actions rather than opening views. Notification producers may
+  // be model-influenced, so never let the fallback path manufacture those
+  // authorities (OAuth callbacks, runtime pairing, local-file sharing, or
+  // capture harnesses). Keep the host segment deliberately unencoded and
+  // reject URL parser ambiguities such as backslashes and control bytes.
+  if (deepLink.includes("\\")) return undefined;
+  for (let index = 0; index < deepLink.length; index += 1) {
+    const codeUnit = deepLink.charCodeAt(index);
+    if (codeUnit <= 0x1f || codeUnit === 0x7f) return undefined;
+  }
+  const path = deepLink.split(/[?#]/, 1)[0] ?? "";
+  const firstSegment = path.slice(1).split("/", 1)[0]?.toLowerCase() ?? "";
+  if (!/^[a-z0-9._~-]+$/.test(firstSegment)) return undefined;
+  const privilegedNativeNamespaces = new Set([
+    "aec-loop",
+    "auth",
+    "connect",
+    "first-run",
+    "keyboard-dictation",
+    "share",
+  ]);
+  if (privilegedNativeNamespaces.has(firstSegment)) return undefined;
   return `elizaos://${deepLink.slice(1)}`;
 }
 

--- a/packages/ui/src/components/shell/HomeScreen.test.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.test.tsx
@@ -15,9 +15,14 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const navigateDeepLink = vi.hoisted(() => vi.fn());
+const appState = vi.hoisted(() => ({ tab: "chat" }));
 vi.mock("../../state/notifications/navigate-deep-link", async (orig) => ({
   ...(await orig()),
   navigateDeepLink,
+}));
+vi.mock("../../state", () => ({
+  useAppSelector: (selector: (state: typeof appState) => unknown) =>
+    selector(appState),
 }));
 
 // Stub the live activity stream so the home renders deterministically.
@@ -52,16 +57,25 @@ import {
   __resetNotificationStoreForTests,
   __setHydratedForTests,
 } from "../../state/notifications/notification-store";
+import {
+  goHome,
+  resetShellSurfaceForTests,
+  setShellSurfacePage,
+} from "../../state/shell-surface-store";
 import { __resetHomeDismissalsForTests } from "../../widgets/home-dismissal-store";
+import { HomeLauncherSurface } from "./HomeLauncherSurface";
 import { HomeScreen } from "./HomeScreen";
 import { PULL_COMMIT_PX } from "./NotificationsHomeCenter";
 import {
-  consumeNotificationCenterOpenRequest,
+  acknowledgeNotificationCenterOpenRequest,
+  peekNotificationCenterOpenRequest,
   requestNotificationCenterOpen,
 } from "./notification-center-open-request";
 
 beforeEach(() => {
   vi.useFakeTimers();
+  appState.tab = "chat";
+  resetShellSurfaceForTests();
 });
 
 afterEach(() => {
@@ -70,8 +84,10 @@ afterEach(() => {
   vi.useRealTimers();
   __resetNotificationStoreForTests();
   __resetHomeDismissalsForTests();
-  while (consumeNotificationCenterOpenRequest() !== null) {
-    // Home consumes this one-shot intent; drain only if a failed test did not.
+  resetShellSurfaceForTests();
+  const pendingRequestId = peekNotificationCenterOpenRequest();
+  if (pendingRequestId !== null) {
+    acknowledgeNotificationCenterOpenRequest(pendingRequestId);
   }
   navigateDeepLink.mockClear();
 });
@@ -369,6 +385,93 @@ describe("HomeScreen", () => {
     expect(
       screen.getByTestId("notifications-empty").getAttribute("aria-hidden"),
     ).toBe("true");
+  });
+
+  it("retains a same-tab request on the inert Launcher half until Home is visible", () => {
+    __setHydratedForTests(true);
+    setShellSurfacePage("launcher");
+    render(
+      <HomeLauncherSurface
+        initialPage="launcher"
+        home={<HomeScreen onOpenTile={vi.fn()} />}
+        launcher={<div>Launcher</div>}
+      />,
+    );
+
+    let requestId = 0;
+    act(() => {
+      requestId = requestNotificationCenterOpen();
+    });
+    expect(peekNotificationCenterOpenRequest()).toBe(requestId);
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("rested");
+
+    act(() => goHome());
+
+    expect(screen.getByTestId("home-launcher-surface").dataset.page).toBe(
+      "home",
+    );
+    expect(peekNotificationCenterOpenRequest()).toBeNull();
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("expanded");
+    expect(
+      screen.getByTestId("notifications-empty").getAttribute("aria-hidden"),
+    ).toBeNull();
+  });
+
+  it("does not let the old Apps Home acknowledge before Chat replaces it", () => {
+    __setHydratedForTests(true);
+    appState.tab = "apps";
+    setShellSurfacePage("launcher");
+    const view = render(
+      <HomeLauncherSurface
+        key="apps-route"
+        initialPage="launcher"
+        home={<HomeScreen onOpenTile={vi.fn()} />}
+        launcher={<div>Apps launcher</div>}
+      />,
+    );
+
+    let requestId = 0;
+    act(() => {
+      requestId = requestNotificationCenterOpen();
+    });
+    act(() => goHome());
+    expect(peekNotificationCenterOpenRequest()).toBe(requestId);
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("rested");
+
+    appState.tab = "chat";
+    view.rerender(
+      <HomeLauncherSurface
+        key="chat-route"
+        initialPage="home"
+        home={<HomeScreen onOpenTile={vi.fn()} />}
+        launcher={<div>Chat launcher</div>}
+      />,
+    );
+
+    expect(peekNotificationCenterOpenRequest()).toBeNull();
+    expect(screen.getByTestId("home-launcher-surface").dataset.page).toBe(
+      "home",
+    );
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("expanded");
+    expect(
+      screen.getByTestId("notifications-empty").getAttribute("aria-hidden"),
+    ).toBeNull();
   });
 
   it("keeps apps available when the empty notification band is expanded", () => {

--- a/packages/ui/src/components/shell/HomeScreen.test.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.test.tsx
@@ -178,6 +178,19 @@ describe("HomeScreen", () => {
     expect(screen.queryByTestId("notifications-shade")).toBeNull();
   });
 
+  it("retains a notification-center request until hydration makes the destination visible", () => {
+    const requestId = requestNotificationCenterOpen();
+    render(<HomeScreen onOpenTile={vi.fn()} />);
+
+    expect(screen.queryByTestId("home-notification-center")).toBeNull();
+    expect(peekNotificationCenterOpenRequest()).toBe(requestId);
+
+    act(() => __setHydratedForTests(true));
+
+    expect(screen.getByTestId("home-notification-center")).toBeTruthy();
+    expect(peekNotificationCenterOpenRequest()).toBeNull();
+  });
+
   it("keeps rested notifications compact, then displaces and restores focused secondary content", () => {
     __ingestNotificationForTests(
       makeNotification({ title: "Priority alert", priority: "urgent" }),

--- a/packages/ui/src/components/shell/HomeScreen.test.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.test.tsx
@@ -55,6 +55,10 @@ import {
 import { __resetHomeDismissalsForTests } from "../../widgets/home-dismissal-store";
 import { HomeScreen } from "./HomeScreen";
 import { PULL_COMMIT_PX } from "./NotificationsHomeCenter";
+import {
+  consumeNotificationCenterOpenRequest,
+  requestNotificationCenterOpen,
+} from "./notification-center-open-request";
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -66,6 +70,9 @@ afterEach(() => {
   vi.useRealTimers();
   __resetNotificationStoreForTests();
   __resetHomeDismissalsForTests();
+  while (consumeNotificationCenterOpenRequest() !== null) {
+    // Home consumes this one-shot intent; drain only if a failed test did not.
+  }
   navigateDeepLink.mockClear();
 });
 
@@ -318,6 +325,50 @@ describe("HomeScreen", () => {
     const apps = screen.getByTestId("home-apps-scroll");
     expect(apps.parentElement?.className).toContain("flex-1");
     expect(apps.hasAttribute("inert")).toBe(false);
+  });
+
+  it("opens the empty notification center from a warm shell request", () => {
+    __setHydratedForTests(true);
+    render(<HomeScreen onOpenTile={vi.fn()} />);
+    const list = screen.getByTestId("home-notification-list");
+    const empty = screen.getByTestId("notifications-empty");
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(empty.getAttribute("aria-hidden")).toBe("true");
+
+    act(() => {
+      requestNotificationCenterOpen();
+    });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(empty.getAttribute("aria-hidden")).toBeNull();
+    expect(empty.style.opacity).toBe("1");
+  });
+
+  it("consumes a retained cold-launch request after Home mounts without replaying it", () => {
+    __setHydratedForTests(true);
+    requestNotificationCenterOpen();
+
+    const firstMount = render(<HomeScreen onOpenTile={vi.fn()} />);
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("expanded");
+    expect(
+      screen.getByTestId("notifications-empty").getAttribute("aria-hidden"),
+    ).toBeNull();
+    expect(screen.getByTestId("notifications-empty").style.opacity).toBe("1");
+
+    firstMount.unmount();
+    render(<HomeScreen onOpenTile={vi.fn()} />);
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("rested");
+    expect(
+      screen.getByTestId("notifications-empty").getAttribute("aria-hidden"),
+    ).toBe("true");
   });
 
   it("keeps apps available when the empty notification band is expanded", () => {

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -19,6 +19,10 @@ import { LAYOUT_SHIFT_OBSERVER_INIT } from "../../testing/layout-stability";
 import { WidgetHost } from "../../widgets/WidgetHost";
 import { DefaultHomeWidgets } from "./DefaultHomeWidgets";
 import { NotificationsHomeCenter } from "./NotificationsHomeCenter";
+import {
+  consumeNotificationCenterOpenRequest,
+  subscribeNotificationCenterOpenRequests,
+} from "./notification-center-open-request";
 
 // A gentle staggered rise as the home settles in. Foregrounds stay fully opaque
 // throughout so slow paints and screenshot tooling never expose unreadable
@@ -219,9 +223,24 @@ export function HomeScreen({ apps }: HomeScreenProps): React.JSX.Element {
   const wasAppsDisplacedRef = useRef(false);
   const [notificationShadeExpanded, setNotificationShadeExpanded] =
     useState(false);
+  const [notificationCenterOpenRequestId, setNotificationCenterOpenRequestId] =
+    useState<number | null>(null);
   const { notifications } = useNotifications();
   const appsDisplaced = notificationShadeExpanded && notifications.length > 0;
   appsDisplacedRef.current = appsDisplaced;
+
+  useLayoutEffect(() => {
+    // Subscribe before consuming so a request racing this mount is either
+    // delivered live or retained, never lost between those two states.
+    const unsubscribe = subscribeNotificationCenterOpenRequests(
+      setNotificationCenterOpenRequestId,
+    );
+    const retainedRequestId = consumeNotificationCenterOpenRequest();
+    if (retainedRequestId !== null) {
+      setNotificationCenterOpenRequestId(retainedRequestId);
+    }
+    return unsubscribe;
+  }, []);
 
   // Remember the latest launcher control independently of the shade gesture.
   // A notification can arrive asynchronously while an expanded empty shade
@@ -352,6 +371,7 @@ export function HomeScreen({ apps }: HomeScreenProps): React.JSX.Element {
             emptyGestureTargetRef={homeScreenRef}
             shadeLayoutTargetRef={homeContentColumnRef}
             onShadeOccupancyChange={handleShadeExpandedChange}
+            openRequestId={notificationCenterOpenRequestId}
           />
         </div>
 

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -15,17 +15,17 @@ import { useActivityEvents } from "../../hooks/useActivityEvents";
 import { isRenderTelemetryEnabled } from "../../hooks/useRenderGuard";
 import { cn } from "../../lib/utils";
 import { useAppSelector } from "../../state";
+import {
+  acknowledgeNotificationCenterOpenRequest,
+  peekNotificationCenterOpenRequest,
+  subscribeNotificationCenterOpenRequests,
+} from "../../state/notifications/notification-center-open-request";
 import { useNotifications } from "../../state/notifications/notification-store";
 import { useShellSurface } from "../../state/shell-surface-store";
 import { LAYOUT_SHIFT_OBSERVER_INIT } from "../../testing/layout-stability";
 import { WidgetHost } from "../../widgets/WidgetHost";
 import { DefaultHomeWidgets } from "./DefaultHomeWidgets";
 import { NotificationsHomeCenter } from "./NotificationsHomeCenter";
-import {
-  acknowledgeNotificationCenterOpenRequest,
-  peekNotificationCenterOpenRequest,
-  subscribeNotificationCenterOpenRequests,
-} from "./notification-center-open-request";
 
 // A gentle staggered rise as the home settles in. Foregrounds stay fully opaque
 // throughout so slow paints and screenshot tooling never expose unreadable
@@ -259,12 +259,23 @@ export function HomeScreen({ apps }: HomeScreenProps): React.JSX.Element {
     ) {
       return;
     }
-    const requestId = pendingNotificationCenterOpenRequestId;
-    if (acknowledgeNotificationCenterOpenRequest(requestId)) {
-      setNotificationCenterOpenRequestId(requestId);
-    }
-    setPendingNotificationCenterOpenRequestId(null);
+    setNotificationCenterOpenRequestId(pendingNotificationCenterOpenRequestId);
   }, [activeTab, pendingNotificationCenterOpenRequestId, shellSurfacePage]);
+
+  const handleNotificationCenterOpenRequestHandled = useCallback(
+    (requestId: number) => {
+      acknowledgeNotificationCenterOpenRequest(requestId);
+      setPendingNotificationCenterOpenRequestId((current) =>
+        current === requestId ? null : current,
+      );
+      // Clearing the delivered id prevents a later child remount from opening
+      // the same already-acknowledged request a second time.
+      setNotificationCenterOpenRequestId((current) =>
+        current === requestId ? null : current,
+      );
+    },
+    [],
+  );
 
   // Remember the latest launcher control independently of the shade gesture.
   // A notification can arrive asynchronously while an expanded empty shade
@@ -396,6 +407,7 @@ export function HomeScreen({ apps }: HomeScreenProps): React.JSX.Element {
             shadeLayoutTargetRef={homeContentColumnRef}
             onShadeOccupancyChange={handleShadeExpandedChange}
             openRequestId={notificationCenterOpenRequestId}
+            onOpenRequestHandled={handleNotificationCenterOpenRequestHandled}
           />
         </div>
 

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -14,13 +14,16 @@ import {
 import { useActivityEvents } from "../../hooks/useActivityEvents";
 import { isRenderTelemetryEnabled } from "../../hooks/useRenderGuard";
 import { cn } from "../../lib/utils";
+import { useAppSelector } from "../../state";
 import { useNotifications } from "../../state/notifications/notification-store";
+import { useShellSurface } from "../../state/shell-surface-store";
 import { LAYOUT_SHIFT_OBSERVER_INIT } from "../../testing/layout-stability";
 import { WidgetHost } from "../../widgets/WidgetHost";
 import { DefaultHomeWidgets } from "./DefaultHomeWidgets";
 import { NotificationsHomeCenter } from "./NotificationsHomeCenter";
 import {
-  consumeNotificationCenterOpenRequest,
+  acknowledgeNotificationCenterOpenRequest,
+  peekNotificationCenterOpenRequest,
   subscribeNotificationCenterOpenRequests,
 } from "./notification-center-open-request";
 
@@ -223,24 +226,45 @@ export function HomeScreen({ apps }: HomeScreenProps): React.JSX.Element {
   const wasAppsDisplacedRef = useRef(false);
   const [notificationShadeExpanded, setNotificationShadeExpanded] =
     useState(false);
+  const [
+    pendingNotificationCenterOpenRequestId,
+    setPendingNotificationCenterOpenRequestId,
+  ] = useState<number | null>(null);
   const [notificationCenterOpenRequestId, setNotificationCenterOpenRequestId] =
     useState<number | null>(null);
+  const activeTab = useAppSelector((state) => state.tab);
+  const { page: shellSurfacePage } = useShellSurface();
   const { notifications } = useNotifications();
   const appsDisplaced = notificationShadeExpanded && notifications.length > 0;
   appsDisplacedRef.current = appsDisplaced;
 
   useLayoutEffect(() => {
-    // Subscribe before consuming so a request racing this mount is either
-    // delivered live or retained, never lost between those two states.
+    // Subscribe before peeking so a request racing this mount is either
+    // delivered live or observed as retained, never lost between those states.
     const unsubscribe = subscribeNotificationCenterOpenRequests(
-      setNotificationCenterOpenRequestId,
+      setPendingNotificationCenterOpenRequestId,
     );
-    const retainedRequestId = consumeNotificationCenterOpenRequest();
+    const retainedRequestId = peekNotificationCenterOpenRequest();
     if (retainedRequestId !== null) {
-      setNotificationCenterOpenRequestId(retainedRequestId);
+      setPendingNotificationCenterOpenRequestId(retainedRequestId);
     }
     return unsubscribe;
   }, []);
+
+  useLayoutEffect(() => {
+    if (
+      activeTab !== "chat" ||
+      shellSurfacePage !== "home" ||
+      pendingNotificationCenterOpenRequestId === null
+    ) {
+      return;
+    }
+    const requestId = pendingNotificationCenterOpenRequestId;
+    if (acknowledgeNotificationCenterOpenRequest(requestId)) {
+      setNotificationCenterOpenRequestId(requestId);
+    }
+    setPendingNotificationCenterOpenRequestId(null);
+  }, [activeTab, pendingNotificationCenterOpenRequestId, shellSurfacePage]);
 
   // Remember the latest launcher control independently of the shade gesture.
   // A notification can arrive asynchronously while an expanded empty shade

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1779,6 +1779,27 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.getByText("Hydrated alert")).toBeTruthy();
   });
 
+  it("opens an empty shade once for each new shell request id", () => {
+    __setHydratedForTests(true);
+    const { rerender } = render(<NotificationsHomeCenter openRequestId={1} />);
+    const list = screen.getByTestId("home-notification-list");
+    const empty = screen.getByTestId("notifications-empty");
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(empty.getAttribute("aria-hidden")).toBeNull();
+    expect(empty.style.opacity).toBe("1");
+
+    collapseShade();
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+
+    rerender(<NotificationsHomeCenter openRequestId={1} />);
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+
+    rerender(<NotificationsHomeCenter openRequestId={2} />);
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(empty.getAttribute("aria-hidden")).toBeNull();
+    expect(empty.style.opacity).toBe("1");
+  });
+
   it("ignores a chat pull release over the notification area", () => {
     seedTriage();
     render(

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1781,23 +1781,43 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
 
   it("opens an empty shade once for each new shell request id", () => {
     __setHydratedForTests(true);
-    const { rerender } = render(<NotificationsHomeCenter openRequestId={1} />);
+    const onOpenRequestHandled = vi.fn();
+    const { rerender } = render(
+      <NotificationsHomeCenter
+        openRequestId={1}
+        onOpenRequestHandled={onOpenRequestHandled}
+      />,
+    );
     const list = screen.getByTestId("home-notification-list");
     const empty = screen.getByTestId("notifications-empty");
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(empty.getAttribute("aria-hidden")).toBeNull();
     expect(empty.style.opacity).toBe("1");
+    expect(onOpenRequestHandled).toHaveBeenCalledExactlyOnceWith(1);
 
     collapseShade();
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
 
-    rerender(<NotificationsHomeCenter openRequestId={1} />);
+    rerender(
+      <NotificationsHomeCenter
+        openRequestId={1}
+        onOpenRequestHandled={onOpenRequestHandled}
+      />,
+    );
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(onOpenRequestHandled).toHaveBeenCalledTimes(1);
 
-    rerender(<NotificationsHomeCenter openRequestId={2} />);
+    rerender(
+      <NotificationsHomeCenter
+        openRequestId={2}
+        onOpenRequestHandled={onOpenRequestHandled}
+      />,
+    );
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(empty.getAttribute("aria-hidden")).toBeNull();
     expect(empty.style.opacity).toBe("1");
+    expect(onOpenRequestHandled).toHaveBeenLastCalledWith(2);
+    expect(onOpenRequestHandled).toHaveBeenCalledTimes(2);
   });
 
   it("ignores a chat pull release over the notification area", () => {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -2506,6 +2506,8 @@ export function NotificationsHomeCenter({
 
   useEffect(() => {
     if (
+      !surfaceReady ||
+      hydrationStatus === "failed" ||
       openRequestId === null ||
       openRequestId === undefined ||
       lastHandledOpenRequestIdRef.current === openRequestId
@@ -2517,7 +2519,13 @@ export function NotificationsHomeCenter({
     // overrides the ordinary collapsed empty state after Home has mounted.
     beginProgrammaticShadeOpen();
     onOpenRequestHandled?.(openRequestId);
-  }, [beginProgrammaticShadeOpen, onOpenRequestHandled, openRequestId]);
+  }, [
+    beginProgrammaticShadeOpen,
+    hydrationStatus,
+    onOpenRequestHandled,
+    openRequestId,
+    surfaceReady,
+  ]);
 
   // Build stable rested and expanded projections. During a downward pull,
   // lower-priority groups reveal under the finger while already-visible

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -656,6 +656,8 @@ export interface NotificationsHomeCenterProps {
   onShadeOccupancyChange?: (occupiesHome: boolean) => void;
   /** Monotonic shell request that visibly opens this destination once. */
   openRequestId?: number | null;
+  /** Acknowledges an open request after this visible component applies it. */
+  onOpenRequestHandled?: (requestId: number) => void;
 }
 
 export function NotificationsHomeCenter({
@@ -663,6 +665,7 @@ export function NotificationsHomeCenter({
   shadeLayoutTargetRef,
   onShadeOccupancyChange,
   openRequestId,
+  onOpenRequestHandled,
 }: NotificationsHomeCenterProps = {}): React.JSX.Element | null {
   notificationsHomeCenterRenderObserverForTests?.();
   const { notifications, hydrated, hydrationStatus } = useNotifications();
@@ -2513,7 +2516,8 @@ export function NotificationsHomeCenter({
     // This effect follows the empty-inbox reset above, so a notification tap
     // overrides the ordinary collapsed empty state after Home has mounted.
     beginProgrammaticShadeOpen();
-  }, [beginProgrammaticShadeOpen, openRequestId]);
+    onOpenRequestHandled?.(openRequestId);
+  }, [beginProgrammaticShadeOpen, onOpenRequestHandled, openRequestId]);
 
   // Build stable rested and expanded projections. During a downward pull,
   // lower-priority groups reveal under the finger while already-visible

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -654,12 +654,15 @@ export interface NotificationsHomeCenterProps {
   shadeLayoutTargetRef?: RefObject<HTMLElement | null>;
   /** Reports when an explicit expansion occupies the inline home layout. */
   onShadeOccupancyChange?: (occupiesHome: boolean) => void;
+  /** Monotonic shell request that visibly opens this destination once. */
+  openRequestId?: number | null;
 }
 
 export function NotificationsHomeCenter({
   emptyGestureTargetRef,
   shadeLayoutTargetRef,
   onShadeOccupancyChange,
+  openRequestId,
 }: NotificationsHomeCenterProps = {}): React.JSX.Element | null {
   notificationsHomeCenterRenderObserverForTests?.();
   const { notifications, hydrated, hydrationStatus } = useNotifications();
@@ -673,6 +676,7 @@ export function NotificationsHomeCenter({
   // conflating those states hid every widget whenever a notification existed.
   const [shadeOccupiesHome, setShadeOccupiesHome] = useState(false);
   const [shadeOpenProgress, setShadeOpenProgress] = useState(1);
+  const lastHandledOpenRequestIdRef = useRef<number | null>(null);
   useEffect(() => {
     onShadeOccupancyChange?.(shadeOccupiesHome);
   }, [onShadeOccupancyChange, shadeOccupiesHome]);
@@ -2496,6 +2500,20 @@ export function NotificationsHomeCenter({
     cancelPullCancellation();
     setPullPx(0);
   }, [cancelAllStackFolds, cancelPullCancellation, inboxEmpty, setPullPx]);
+
+  useEffect(() => {
+    if (
+      openRequestId === null ||
+      openRequestId === undefined ||
+      lastHandledOpenRequestIdRef.current === openRequestId
+    ) {
+      return;
+    }
+    lastHandledOpenRequestIdRef.current = openRequestId;
+    // This effect follows the empty-inbox reset above, so a notification tap
+    // overrides the ordinary collapsed empty state after Home has mounted.
+    beginProgrammaticShadeOpen();
+  }, [beginProgrammaticShadeOpen, openRequestId]);
 
   // Build stable rested and expanded projections. During a downward pull,
   // lower-priority groups reveal under the finger while already-visible

--- a/packages/ui/src/components/shell/notification-center-open-request.test.ts
+++ b/packages/ui/src/components/shell/notification-center-open-request.test.ts
@@ -1,0 +1,43 @@
+/** Verifies one-shot notification-center request delivery across shell mount order. */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  consumeNotificationCenterOpenRequest,
+  requestNotificationCenterOpen,
+  subscribeNotificationCenterOpenRequests,
+} from "./notification-center-open-request";
+
+afterEach(() => {
+  while (consumeNotificationCenterOpenRequest() !== null) {
+    // Drain any retained request so each scenario starts without shell intent.
+  }
+});
+
+describe("notification center open requests", () => {
+  it("retains only the newest request until Home mounts and consumes it once", () => {
+    const first = requestNotificationCenterOpen();
+    const second = requestNotificationCenterOpen();
+
+    expect(second).toBeGreaterThan(first);
+    expect(consumeNotificationCenterOpenRequest()).toBe(second);
+    expect(consumeNotificationCenterOpenRequest()).toBeNull();
+  });
+
+  it("delivers to a mounted Home subscriber without retaining a stale replay", () => {
+    const received: number[] = [];
+    const unsubscribe = subscribeNotificationCenterOpenRequests((requestId) =>
+      received.push(requestId),
+    );
+
+    try {
+      const requestId = requestNotificationCenterOpen();
+      expect(received).toEqual([requestId]);
+      expect(consumeNotificationCenterOpenRequest()).toBeNull();
+    } finally {
+      unsubscribe();
+    }
+
+    const retainedRequestId = requestNotificationCenterOpen();
+    expect(consumeNotificationCenterOpenRequest()).toBe(retainedRequestId);
+  });
+});

--- a/packages/ui/src/components/shell/notification-center-open-request.test.ts
+++ b/packages/ui/src/components/shell/notification-center-open-request.test.ts
@@ -2,14 +2,16 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  consumeNotificationCenterOpenRequest,
+  acknowledgeNotificationCenterOpenRequest,
+  peekNotificationCenterOpenRequest,
   requestNotificationCenterOpen,
   subscribeNotificationCenterOpenRequests,
 } from "./notification-center-open-request";
 
 afterEach(() => {
-  while (consumeNotificationCenterOpenRequest() !== null) {
-    // Drain any retained request so each scenario starts without shell intent.
+  const pendingRequestId = peekNotificationCenterOpenRequest();
+  if (pendingRequestId !== null) {
+    acknowledgeNotificationCenterOpenRequest(pendingRequestId);
   }
 });
 
@@ -19,11 +21,13 @@ describe("notification center open requests", () => {
     const second = requestNotificationCenterOpen();
 
     expect(second).toBeGreaterThan(first);
-    expect(consumeNotificationCenterOpenRequest()).toBe(second);
-    expect(consumeNotificationCenterOpenRequest()).toBeNull();
+    expect(peekNotificationCenterOpenRequest()).toBe(second);
+    expect(acknowledgeNotificationCenterOpenRequest(first)).toBe(false);
+    expect(acknowledgeNotificationCenterOpenRequest(second)).toBe(true);
+    expect(peekNotificationCenterOpenRequest()).toBeNull();
   });
 
-  it("delivers to a mounted Home subscriber without retaining a stale replay", () => {
+  it("retains a delivered request until the visible Home acknowledges it", () => {
     const received: number[] = [];
     const unsubscribe = subscribeNotificationCenterOpenRequests((requestId) =>
       received.push(requestId),
@@ -32,12 +36,14 @@ describe("notification center open requests", () => {
     try {
       const requestId = requestNotificationCenterOpen();
       expect(received).toEqual([requestId]);
-      expect(consumeNotificationCenterOpenRequest()).toBeNull();
+      expect(peekNotificationCenterOpenRequest()).toBe(requestId);
+      expect(acknowledgeNotificationCenterOpenRequest(requestId)).toBe(true);
+      expect(peekNotificationCenterOpenRequest()).toBeNull();
     } finally {
       unsubscribe();
     }
 
     const retainedRequestId = requestNotificationCenterOpen();
-    expect(consumeNotificationCenterOpenRequest()).toBe(retainedRequestId);
+    expect(peekNotificationCenterOpenRequest()).toBe(retainedRequestId);
   });
 });

--- a/packages/ui/src/components/shell/notification-center-open-request.ts
+++ b/packages/ui/src/components/shell/notification-center-open-request.ts
@@ -1,0 +1,41 @@
+/**
+ * Carries notification-center intent across the shell-to-Home mount boundary.
+ * A mounted Home receives requests synchronously; otherwise only the newest
+ * request is retained until that destination commits and consumes it once.
+ */
+
+export type NotificationCenterOpenRequestListener = (requestId: number) => void;
+
+let nextRequestId = 1;
+let pendingRequestId: number | null = null;
+const listeners = new Set<NotificationCenterOpenRequestListener>();
+
+/** Records a new request and returns its monotonic identity. */
+export function requestNotificationCenterOpen(): number {
+  const requestId = nextRequestId;
+  nextRequestId += 1;
+
+  if (listeners.size === 0) {
+    pendingRequestId = requestId;
+    return requestId;
+  }
+
+  pendingRequestId = null;
+  for (const listener of [...listeners]) listener(requestId);
+  return requestId;
+}
+
+/** Takes the request retained while no Home destination was mounted. */
+export function consumeNotificationCenterOpenRequest(): number | null {
+  const requestId = pendingRequestId;
+  pendingRequestId = null;
+  return requestId;
+}
+
+/** Delivers requests that arrive while a Home destination is mounted. */
+export function subscribeNotificationCenterOpenRequests(
+  listener: NotificationCenterOpenRequestListener,
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/packages/ui/src/components/shell/notification-center-open-request.ts
+++ b/packages/ui/src/components/shell/notification-center-open-request.ts
@@ -14,22 +14,26 @@ const listeners = new Set<NotificationCenterOpenRequestListener>();
 export function requestNotificationCenterOpen(): number {
   const requestId = nextRequestId;
   nextRequestId += 1;
-
-  if (listeners.size === 0) {
-    pendingRequestId = requestId;
-    return requestId;
-  }
-
-  pendingRequestId = null;
+  // Delivery is only an observation. The visible Home owns acknowledgement;
+  // an inert/offscreen Home may still be mounted beside the Launcher and must
+  // not make the request disappear before navigation commits.
+  pendingRequestId = requestId;
   for (const listener of [...listeners]) listener(requestId);
   return requestId;
 }
 
-/** Takes the request retained while no Home destination was mounted. */
-export function consumeNotificationCenterOpenRequest(): number | null {
-  const requestId = pendingRequestId;
+/** Reads the newest request without transferring destination ownership. */
+export function peekNotificationCenterOpenRequest(): number | null {
+  return pendingRequestId;
+}
+
+/** Clears a request only when the acknowledging visible Home still owns it. */
+export function acknowledgeNotificationCenterOpenRequest(
+  requestId: number,
+): boolean {
+  if (pendingRequestId !== requestId) return false;
   pendingRequestId = null;
-  return requestId;
+  return true;
 }
 
 /** Delivers requests that arrive while a Home destination is mounted. */

--- a/packages/ui/src/components/shell/notification-center-open-request.ts
+++ b/packages/ui/src/components/shell/notification-center-open-request.ts
@@ -1,45 +1,8 @@
-/**
- * Carries notification-center intent across the shell-to-Home mount boundary.
- * A mounted Home receives requests synchronously; otherwise only the newest
- * request is retained until that destination commits and consumes it once.
- */
-
-export type NotificationCenterOpenRequestListener = (requestId: number) => void;
-
-let nextRequestId = 1;
-let pendingRequestId: number | null = null;
-const listeners = new Set<NotificationCenterOpenRequestListener>();
-
-/** Records a new request and returns its monotonic identity. */
-export function requestNotificationCenterOpen(): number {
-  const requestId = nextRequestId;
-  nextRequestId += 1;
-  // Delivery is only an observation. The visible Home owns acknowledgement;
-  // an inert/offscreen Home may still be mounted beside the Launcher and must
-  // not make the request disappear before navigation commits.
-  pendingRequestId = requestId;
-  for (const listener of [...listeners]) listener(requestId);
-  return requestId;
-}
-
-/** Reads the newest request without transferring destination ownership. */
-export function peekNotificationCenterOpenRequest(): number | null {
-  return pendingRequestId;
-}
-
-/** Clears a request only when the acknowledging visible Home still owns it. */
-export function acknowledgeNotificationCenterOpenRequest(
-  requestId: number,
-): boolean {
-  if (pendingRequestId !== requestId) return false;
-  pendingRequestId = null;
-  return true;
-}
-
-/** Delivers requests that arrive while a Home destination is mounted. */
-export function subscribeNotificationCenterOpenRequests(
-  listener: NotificationCenterOpenRequestListener,
-): () => void {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
-}
+/** Re-exports the notification-open request authority for shell callers. */
+export {
+  acknowledgeNotificationCenterOpenRequest,
+  type NotificationCenterOpenRequestListener,
+  peekNotificationCenterOpenRequest,
+  requestNotificationCenterOpen,
+  subscribeNotificationCenterOpenRequests,
+} from "../../state/notifications/notification-center-open-request";

--- a/packages/ui/src/components/shell/notifications-boot.test.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.test.tsx
@@ -37,7 +37,7 @@ vi.mock("../../state/notifications/push-registration", () => ({
   refreshPushRegistrationAuthority: mocks.refreshPush,
 }));
 
-import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
+import { dispatchOpenNotificationCenter } from "../../events";
 import {
   acknowledgeNotificationCenterOpenRequest,
   peekNotificationCenterOpenRequest,
@@ -74,7 +74,7 @@ describe("notification boot boundaries", () => {
       expect(peekNotificationCenterOpenRequest()).toEqual(expect.any(Number));
     });
 
-    act(() => window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT)));
+    act(() => dispatchOpenNotificationCenter());
     expect(mocks.goHome).toHaveBeenCalledOnce();
     expect(mocks.setTab).toHaveBeenCalledWith("chat");
     expect(mocks.goHome.mock.invocationCallOrder[0]).toBeLessThan(
@@ -87,7 +87,7 @@ describe("notification boot boundaries", () => {
       expect(peekNotificationCenterOpenRequest()).toEqual(expect.any(Number));
     });
     mocks.localTap.mockImplementationOnce(async () => {
-      window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT));
+      dispatchOpenNotificationCenter();
     });
 
     render(<NotificationsShellBoot />);
@@ -96,6 +96,18 @@ describe("notification boot boundaries", () => {
     expect(mocks.goHome).toHaveBeenCalledTimes(1);
     expect(mocks.setTab).toHaveBeenCalledTimes(1);
     expect(mocks.setTab).toHaveBeenCalledWith("chat");
+  });
+
+  it("completes navigation for a retained tap dispatched before shell effects mount", async () => {
+    dispatchOpenNotificationCenter();
+    expect(peekNotificationCenterOpenRequest()).toEqual(expect.any(Number));
+
+    render(<NotificationsShellBoot />);
+
+    await waitFor(() => expect(mocks.goHome).toHaveBeenCalledOnce());
+    expect(mocks.setTab).toHaveBeenCalledOnce();
+    expect(mocks.setTab).toHaveBeenCalledWith("chat");
+    expect(peekNotificationCenterOpenRequest()).toEqual(expect.any(Number));
   });
 
   it("rotates push ownership on base and token authority changes", async () => {

--- a/packages/ui/src/components/shell/notifications-boot.test.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.test.tsx
@@ -32,6 +32,7 @@ vi.mock("../../state/notifications/push-registration", () => ({
 }));
 
 import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
+import { consumeNotificationCenterOpenRequest } from "./notification-center-open-request";
 import {
   NotificationsDataBoot,
   NotificationsShellBoot,
@@ -39,6 +40,9 @@ import {
 
 afterEach(() => {
   cleanup();
+  while (consumeNotificationCenterOpenRequest() !== null) {
+    // Notification-center intent is module-scoped so it can cross a Home mount.
+  }
   vi.clearAllMocks();
 });
 
@@ -56,11 +60,22 @@ describe("notification boot boundaries", () => {
     await waitFor(() => expect(mocks.push).toHaveBeenCalledOnce());
     expect(mocks.localTap).toHaveBeenCalledOnce();
 
+    mocks.setTab.mockImplementationOnce(() => {
+      expect(consumeNotificationCenterOpenRequest()).toEqual(
+        expect.any(Number),
+      );
+    });
+
     act(() => window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT)));
     expect(mocks.setTab).toHaveBeenCalledWith("chat");
   });
 
   it("routes a retained cold-launch tap replayed during native listener attachment", async () => {
+    mocks.setTab.mockImplementationOnce(() => {
+      expect(consumeNotificationCenterOpenRequest()).toEqual(
+        expect.any(Number),
+      );
+    });
     mocks.localTap.mockImplementationOnce(async () => {
       window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT));
     });

--- a/packages/ui/src/components/shell/notifications-boot.test.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.test.tsx
@@ -14,15 +14,15 @@ const mocks = vi.hoisted(() => ({
   setTab: vi.fn(),
   goHome: vi.fn(),
 }));
+const appState = vi.hoisted(() => ({ setTab: mocks.setTab }));
 
 vi.mock("../../api/client", () => ({
   client: { onBaseUrlChange: mocks.onBaseUrlChange },
 }));
 
 vi.mock("../../state", () => ({
-  useAppSelector: (
-    selector: (state: { setTab: typeof mocks.setTab }) => unknown,
-  ) => selector({ setTab: mocks.setTab }),
+  useAppSelector: (selector: (state: typeof appState) => unknown) =>
+    selector(appState),
 }));
 vi.mock("../../state/shell-surface-store", () => ({ goHome: mocks.goHome }));
 vi.mock("../../bridge/native-notifications", () => ({
@@ -55,6 +55,7 @@ afterEach(() => {
     acknowledgeNotificationCenterOpenRequest(pendingRequestId);
   }
   vi.clearAllMocks();
+  appState.setTab = mocks.setTab;
   mocks.localTap.mockResolvedValue(undefined);
 });
 
@@ -182,5 +183,17 @@ describe("notification boot boundaries", () => {
 
     unmount();
     expect(mocks.unsubscribeBase).toHaveBeenCalledOnce();
+  });
+
+  it("does not re-register push ownership when the tab dispatcher identity changes", async () => {
+    const view = render(<NotificationsShellBoot />);
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledOnce());
+
+    appState.setTab = vi.fn();
+    view.rerender(<NotificationsShellBoot />);
+
+    expect(mocks.push).toHaveBeenCalledOnce();
+    expect(mocks.onBaseUrlChange).toHaveBeenCalledOnce();
+    expect(mocks.unsubscribeBase).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/shell/notifications-boot.test.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.test.tsx
@@ -12,13 +12,19 @@ const mocks = vi.hoisted(() => ({
   onBaseUrlChange: vi.fn(),
   seed: vi.fn(async () => undefined),
   setTab: vi.fn(),
+  goHome: vi.fn(),
 }));
 
 vi.mock("../../api/client", () => ({
   client: { onBaseUrlChange: mocks.onBaseUrlChange },
 }));
 
-vi.mock("../../state", () => ({ useAppSelector: () => mocks.setTab }));
+vi.mock("../../state", () => ({
+  useAppSelector: (
+    selector: (state: { setTab: typeof mocks.setTab }) => unknown,
+  ) => selector({ setTab: mocks.setTab }),
+}));
+vi.mock("../../state/shell-surface-store", () => ({ goHome: mocks.goHome }));
 vi.mock("../../bridge/native-notifications", () => ({
   initLocalNotificationTapRouting: mocks.localTap,
 }));
@@ -32,7 +38,10 @@ vi.mock("../../state/notifications/push-registration", () => ({
 }));
 
 import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
-import { consumeNotificationCenterOpenRequest } from "./notification-center-open-request";
+import {
+  acknowledgeNotificationCenterOpenRequest,
+  peekNotificationCenterOpenRequest,
+} from "./notification-center-open-request";
 import {
   NotificationsDataBoot,
   NotificationsShellBoot,
@@ -40,8 +49,9 @@ import {
 
 afterEach(() => {
   cleanup();
-  while (consumeNotificationCenterOpenRequest() !== null) {
-    // Notification-center intent is module-scoped so it can cross a Home mount.
+  const pendingRequestId = peekNotificationCenterOpenRequest();
+  if (pendingRequestId !== null) {
+    acknowledgeNotificationCenterOpenRequest(pendingRequestId);
   }
   vi.clearAllMocks();
 });
@@ -60,21 +70,21 @@ describe("notification boot boundaries", () => {
     await waitFor(() => expect(mocks.push).toHaveBeenCalledOnce());
     expect(mocks.localTap).toHaveBeenCalledOnce();
 
-    mocks.setTab.mockImplementationOnce(() => {
-      expect(consumeNotificationCenterOpenRequest()).toEqual(
-        expect.any(Number),
-      );
+    mocks.goHome.mockImplementationOnce(() => {
+      expect(peekNotificationCenterOpenRequest()).toEqual(expect.any(Number));
     });
 
     act(() => window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT)));
+    expect(mocks.goHome).toHaveBeenCalledOnce();
     expect(mocks.setTab).toHaveBeenCalledWith("chat");
+    expect(mocks.goHome.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.setTab.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   it("routes a retained cold-launch tap replayed during native listener attachment", async () => {
-    mocks.setTab.mockImplementationOnce(() => {
-      expect(consumeNotificationCenterOpenRequest()).toEqual(
-        expect.any(Number),
-      );
+    mocks.goHome.mockImplementationOnce(() => {
+      expect(peekNotificationCenterOpenRequest()).toEqual(expect.any(Number));
     });
     mocks.localTap.mockImplementationOnce(async () => {
       window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT));
@@ -83,6 +93,7 @@ describe("notification boot boundaries", () => {
     render(<NotificationsShellBoot />);
 
     await waitFor(() => expect(mocks.localTap).toHaveBeenCalledOnce());
+    expect(mocks.goHome).toHaveBeenCalledTimes(1);
     expect(mocks.setTab).toHaveBeenCalledTimes(1);
     expect(mocks.setTab).toHaveBeenCalledWith("chat");
   });

--- a/packages/ui/src/components/shell/notifications-boot.test.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   init: vi.fn(),
+  localTap: vi.fn(async () => undefined),
   push: vi.fn(async () => undefined),
   refreshPush: vi.fn(async () => undefined),
   unsubscribeBase: vi.fn(),
@@ -18,6 +19,9 @@ vi.mock("../../api/client", () => ({
 }));
 
 vi.mock("../../state", () => ({ useAppSelector: () => mocks.setTab }));
+vi.mock("../../bridge/native-notifications", () => ({
+  initLocalNotificationTapRouting: mocks.localTap,
+}));
 vi.mock("../../state/notifications/notification-store", () => ({
   initNotifications: mocks.init,
   seedDevNotificationsIfEmpty: mocks.seed,
@@ -47,11 +51,24 @@ describe("notification boot boundaries", () => {
     expect(mocks.init).toHaveBeenCalledOnce();
   });
 
-  it("boots native push and routes notification-center ingress to chat", async () => {
+  it("boots native push and local-tap routing, then routes notification-center ingress to chat", async () => {
     render(<NotificationsShellBoot />);
     await waitFor(() => expect(mocks.push).toHaveBeenCalledOnce());
+    expect(mocks.localTap).toHaveBeenCalledOnce();
 
     act(() => window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT)));
+    expect(mocks.setTab).toHaveBeenCalledWith("chat");
+  });
+
+  it("routes a retained cold-launch tap replayed during native listener attachment", async () => {
+    mocks.localTap.mockImplementationOnce(async () => {
+      window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT));
+    });
+
+    render(<NotificationsShellBoot />);
+
+    await waitFor(() => expect(mocks.localTap).toHaveBeenCalledOnce());
+    expect(mocks.setTab).toHaveBeenCalledTimes(1);
     expect(mocks.setTab).toHaveBeenCalledWith("chat");
   });
 

--- a/packages/ui/src/components/shell/notifications-boot.test.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.test.tsx
@@ -59,16 +59,17 @@ afterEach(() => {
 mocks.onBaseUrlChange.mockReturnValue(mocks.unsubscribeBase);
 
 describe("notification boot boundaries", () => {
-  it("starts WebSocket ingress from the headless data boot", () => {
+  it("starts ingress and native tap routing above startup/auth gates", async () => {
     const { container } = render(<NotificationsDataBoot />);
     expect(container.innerHTML).toBe("");
     expect(mocks.init).toHaveBeenCalledOnce();
+    await waitFor(() => expect(mocks.localTap).toHaveBeenCalledOnce());
   });
 
-  it("boots native push and local-tap routing, then routes notification-center ingress to chat", async () => {
+  it("boots native push, then routes notification-center ingress to chat", async () => {
     render(<NotificationsShellBoot />);
     await waitFor(() => expect(mocks.push).toHaveBeenCalledOnce());
-    expect(mocks.localTap).toHaveBeenCalledOnce();
+    expect(mocks.localTap).not.toHaveBeenCalled();
 
     mocks.goHome.mockImplementationOnce(() => {
       expect(peekNotificationCenterOpenRequest()).toEqual(expect.any(Number));
@@ -82,7 +83,7 @@ describe("notification boot boundaries", () => {
     );
   });
 
-  it("routes a retained cold-launch tap replayed during native listener attachment", async () => {
+  it("retains a cold-launch tap replayed before the signed-in shell mounts", async () => {
     mocks.goHome.mockImplementationOnce(() => {
       expect(peekNotificationCenterOpenRequest()).toEqual(expect.any(Number));
     });
@@ -90,9 +91,15 @@ describe("notification boot boundaries", () => {
       dispatchOpenNotificationCenter();
     });
 
-    render(<NotificationsShellBoot />);
+    render(<NotificationsDataBoot />);
 
     await waitFor(() => expect(mocks.localTap).toHaveBeenCalledOnce());
+    expect(mocks.goHome).not.toHaveBeenCalled();
+    expect(mocks.setTab).not.toHaveBeenCalled();
+
+    render(<NotificationsShellBoot />);
+
+    await waitFor(() => expect(mocks.goHome).toHaveBeenCalledTimes(1));
     expect(mocks.goHome).toHaveBeenCalledTimes(1);
     expect(mocks.setTab).toHaveBeenCalledTimes(1);
     expect(mocks.setTab).toHaveBeenCalledWith("chat");

--- a/packages/ui/src/components/shell/notifications-boot.test.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.test.tsx
@@ -49,11 +49,13 @@ import {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   const pendingRequestId = peekNotificationCenterOpenRequest();
   if (pendingRequestId !== null) {
     acknowledgeNotificationCenterOpenRequest(pendingRequestId);
   }
   vi.clearAllMocks();
+  mocks.localTap.mockResolvedValue(undefined);
 });
 
 mocks.onBaseUrlChange.mockReturnValue(mocks.unsubscribeBase);
@@ -64,6 +66,58 @@ describe("notification boot boundaries", () => {
     expect(container.innerHTML).toBe("");
     expect(mocks.init).toHaveBeenCalledOnce();
     await waitFor(() => expect(mocks.localTap).toHaveBeenCalledOnce());
+  });
+
+  it("retries a transient native tap bridge failure while boot remains mounted", async () => {
+    vi.useFakeTimers();
+    mocks.localTap
+      .mockRejectedValueOnce(new Error("bridge not ready"))
+      .mockResolvedValueOnce(undefined);
+
+    render(<NotificationsDataBoot />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mocks.localTap).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+
+    expect(mocks.localTap).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds native tap bridge retries and cancels pending work on unmount", async () => {
+    vi.useFakeTimers();
+    mocks.localTap.mockRejectedValue(new Error("bridge unavailable"));
+
+    const { unmount } = render(<NotificationsDataBoot />);
+    await act(async () => {
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(mocks.localTap).toHaveBeenCalledTimes(2);
+
+    unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(mocks.localTap).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops after the bounded native tap bridge retry budget", async () => {
+    vi.useFakeTimers();
+    mocks.localTap.mockRejectedValue(new Error("bridge unavailable"));
+
+    render(<NotificationsDataBoot />);
+    await act(async () => {
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(mocks.localTap).toHaveBeenCalledTimes(3);
   });
 
   it("boots native push, then routes notification-center ingress to chat", async () => {

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -25,6 +25,8 @@ import {
 } from "../../state/notifications/push-registration";
 import { goHome } from "../../state/shell-surface-store";
 
+const LOCAL_NOTIFICATION_TAP_RETRY_DELAYS_MS = [250, 1_000] as const;
+
 /**
  * Boots data ingress independently of the paintable app shell. Startup, auth,
  * and first-run gates can keep AppContent on a full-screen surface while the
@@ -39,14 +41,41 @@ export function NotificationsDataBoot(): null {
     // so install the listener here: a tap that launches into LoginView must be
     // retained by the canonical navigator instead of waiting for the signed-in
     // shell (which may never mount during this process lifetime).
-    void initLocalNotificationTapRouting().catch((error: unknown) => {
-      // error-policy:J1 native notification tap registration is a transport
-      // boundary; a later top-level remount may retry after the bridge recovers.
-      logger.error(
-        { src: "local-notification-tap", error },
-        "[local-notification-tap] failed to register native tap routing",
-      );
-    });
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let retryIndex = 0;
+
+    const registerTapRouting = async (): Promise<void> => {
+      try {
+        await initLocalNotificationTapRouting();
+      } catch (error: unknown) {
+        // error-policy:J1 native notification tap registration is a transport
+        // boundary; retry briefly while this app-lifetime owner remains mounted.
+        if (cancelled) return;
+        const retryDelay = LOCAL_NOTIFICATION_TAP_RETRY_DELAYS_MS[retryIndex];
+        if (retryDelay === undefined) {
+          logger.error(
+            { src: "local-notification-tap", error },
+            "[local-notification-tap] exhausted native tap routing retries",
+          );
+          return;
+        }
+        retryIndex += 1;
+        logger.warn(
+          { src: "local-notification-tap", error, retryDelay },
+          "[local-notification-tap] retrying native tap routing",
+        );
+        retryTimer = setTimeout(() => {
+          void registerTapRouting();
+        }, retryDelay);
+      }
+    };
+
+    void registerTapRouting();
+    return () => {
+      cancelled = true;
+      if (retryTimer !== undefined) clearTimeout(retryTimer);
+    };
   }, []);
   return null;
 }

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -84,21 +84,6 @@ export function NotificationsShellBoot(): null {
   const setTab = useAppSelector((s) => s.setTab);
 
   useEffect(() => {
-    // Install the in-app destination before attaching the native bridge.
-    // Capacitor may synchronously replay a retained cold-launch tap from
-    // addListener(), so reversing this order would drop that first event.
-    const onOpen = () => {
-      goHome();
-      setTab("chat");
-    };
-    window.addEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
-    // A fallback AppDelegate URL can be replayed by getLaunchUrl() after the
-    // root mounts but before this effect commits. The dispatcher retained that
-    // request, so complete its navigation instead of waiting for another tap.
-    if (peekNotificationCenterOpenRequest() !== null) {
-      onOpen();
-    }
-
     // Native-only, gated on granted permission, guarded against double-register.
     // The token POST is what makes the server's APNs/FCM stack a live pipeline.
     void initPushRegistration();
@@ -129,8 +114,23 @@ export function NotificationsShellBoot(): null {
     return () => {
       unsubscribeBase();
       window.removeEventListener("steward-token-sync", onTokenAuthorityChange);
-      window.removeEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
     };
+  }, []);
+
+  useEffect(() => {
+    const onOpen = () => {
+      goHome();
+      setTab("chat");
+    };
+    window.addEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
+    // A fallback AppDelegate URL can be replayed by getLaunchUrl() after the
+    // root mounts but before this effect commits. The dispatcher retained that
+    // request, so complete its navigation instead of waiting for another tap.
+    if (peekNotificationCenterOpenRequest() !== null) {
+      onOpen();
+    }
+    return () =>
+      window.removeEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
   }, [setTab]);
 
   return null;

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -22,6 +22,7 @@ import {
   initPushRegistration,
   refreshPushRegistrationAuthority,
 } from "../../state/notifications/push-registration";
+import { goHome } from "../../state/shell-surface-store";
 import { requestNotificationCenterOpen } from "./notification-center-open-request";
 
 /**
@@ -46,6 +47,7 @@ export function NotificationsShellBoot(): null {
     // addListener(), so reversing this order would drop that first event.
     const onOpen = () => {
       requestNotificationCenterOpen();
+      goHome();
       setTab("chat");
     };
     window.addEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -11,6 +11,7 @@
 import { logger } from "@elizaos/logger";
 import { useEffect } from "react";
 import { client } from "../../api/client";
+import { initLocalNotificationTapRouting } from "../../bridge/native-notifications";
 import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
 import { useAppSelector } from "../../state";
 import {
@@ -39,6 +40,22 @@ export function NotificationsShellBoot(): null {
   const setTab = useAppSelector((s) => s.setTab);
 
   useEffect(() => {
+    // Install the in-app destination before attaching the native bridge.
+    // Capacitor may synchronously replay a retained cold-launch tap from
+    // addListener(), so reversing this order would drop that first event.
+    const onOpen = () => {
+      setTab("chat");
+    };
+    window.addEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
+
+    void initLocalNotificationTapRouting().catch((error: unknown) => {
+      // error-policy:J1 native notification tap registration is a transport
+      // boundary; a later shell mount may retry after the bridge recovers.
+      logger.error(
+        { src: "local-notification-tap", error },
+        "[local-notification-tap] failed to register native tap routing",
+      );
+    });
     // Native-only, gated on granted permission, guarded against double-register.
     // The token POST is what makes the server's APNs/FCM stack a live pipeline.
     void initPushRegistration();
@@ -69,18 +86,8 @@ export function NotificationsShellBoot(): null {
     return () => {
       unsubscribeBase();
       window.removeEventListener("steward-token-sync", onTokenAuthorityChange);
-    };
-  }, []);
-
-  // Route every "open notifications" entry point to the combined home/apps
-  // dashboard, where the notification widget is always inline.
-  useEffect(() => {
-    const onOpen = () => {
-      setTab("chat");
-    };
-    window.addEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
-    return () =>
       window.removeEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
+    };
   }, [setTab]);
 
   return null;

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -14,6 +14,7 @@ import { client } from "../../api/client";
 import { initLocalNotificationTapRouting } from "../../bridge/native-notifications";
 import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
 import { useAppSelector } from "../../state";
+import { peekNotificationCenterOpenRequest } from "../../state/notifications/notification-center-open-request";
 import {
   initNotifications,
   seedDevNotificationsIfEmpty,
@@ -23,7 +24,6 @@ import {
   refreshPushRegistrationAuthority,
 } from "../../state/notifications/push-registration";
 import { goHome } from "../../state/shell-surface-store";
-import { requestNotificationCenterOpen } from "./notification-center-open-request";
 
 /**
  * Boots data ingress independently of the paintable app shell. Startup, auth,
@@ -46,11 +46,16 @@ export function NotificationsShellBoot(): null {
     // Capacitor may synchronously replay a retained cold-launch tap from
     // addListener(), so reversing this order would drop that first event.
     const onOpen = () => {
-      requestNotificationCenterOpen();
       goHome();
       setTab("chat");
     };
     window.addEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
+    // A fallback AppDelegate URL can be replayed by getLaunchUrl() after the
+    // root mounts but before this effect commits. The dispatcher retained that
+    // request, so complete its navigation instead of waiting for another tap.
+    if (peekNotificationCenterOpenRequest() !== null) {
+      onOpen();
+    }
 
     void initLocalNotificationTapRouting().catch((error: unknown) => {
       // error-policy:J1 native notification tap registration is a transport

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -22,6 +22,7 @@ import {
   initPushRegistration,
   refreshPushRegistrationAuthority,
 } from "../../state/notifications/push-registration";
+import { requestNotificationCenterOpen } from "./notification-center-open-request";
 
 /**
  * Boots data ingress independently of the paintable app shell. Startup, auth,
@@ -44,6 +45,7 @@ export function NotificationsShellBoot(): null {
     // Capacitor may synchronously replay a retained cold-launch tap from
     // addListener(), so reversing this order would drop that first event.
     const onOpen = () => {
+      requestNotificationCenterOpen();
       setTab("chat");
     };
     window.addEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -34,6 +34,19 @@ import { goHome } from "../../state/shell-surface-store";
 export function NotificationsDataBoot(): null {
   useEffect(() => {
     initNotifications();
+    // Capacitor retains a notification action only until the first listener is
+    // attached. This boot lives above AppContent's startup/auth early returns,
+    // so install the listener here: a tap that launches into LoginView must be
+    // retained by the canonical navigator instead of waiting for the signed-in
+    // shell (which may never mount during this process lifetime).
+    void initLocalNotificationTapRouting().catch((error: unknown) => {
+      // error-policy:J1 native notification tap registration is a transport
+      // boundary; a later top-level remount may retry after the bridge recovers.
+      logger.error(
+        { src: "local-notification-tap", error },
+        "[local-notification-tap] failed to register native tap routing",
+      );
+    });
   }, []);
   return null;
 }
@@ -57,14 +70,6 @@ export function NotificationsShellBoot(): null {
       onOpen();
     }
 
-    void initLocalNotificationTapRouting().catch((error: unknown) => {
-      // error-policy:J1 native notification tap registration is a transport
-      // boundary; a later shell mount may retry after the bridge recovers.
-      logger.error(
-        { src: "local-notification-tap", error },
-        "[local-notification-tap] failed to register native tap routing",
-      );
-    });
     // Native-only, gated on granted permission, guarded against double-register.
     // The token POST is what makes the server's APNs/FCM stack a live pipeline.
     void initPushRegistration();

--- a/packages/ui/src/events/cloud-handoff-phase.test.ts
+++ b/packages/ui/src/events/cloud-handoff-phase.test.ts
@@ -8,6 +8,10 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  acknowledgeNotificationCenterOpenRequest,
+  peekNotificationCenterOpenRequest,
+} from "../state/notifications/notification-center-open-request";
+import {
   __resetLastCloudHandoffPhaseDetailForTests,
   CHAT_CLOSE_EVENT,
   CHAT_OPEN_EVENT,
@@ -35,6 +39,10 @@ import {
 
 describe("dispatchCloudHandoffPhase", () => {
   afterEach(() => {
+    const pendingRequestId = peekNotificationCenterOpenRequest();
+    if (pendingRequestId !== null) {
+      acknowledgeNotificationCenterOpenRequest(pendingRequestId);
+    }
     vi.restoreAllMocks();
   });
 

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -20,6 +20,7 @@ import {
   type ElizaDocumentEventName as SharedDocumentEventName,
   type ElizaWindowEventName as SharedWindowEventName,
 } from "@elizaos/shared/events";
+import { requestNotificationCenterOpen } from "../state/notifications/notification-center-open-request";
 
 export {
   // Agent / bridge
@@ -198,6 +199,9 @@ export function dispatchChatClose(): void {
  * {@link OPEN_NOTIFICATION_CENTER_EVENT}). */
 export function dispatchOpenNotificationCenter(): void {
   if (typeof window === "undefined") return;
+  // Retain before dispatch: iOS can replay a cold appUrlOpen while React has
+  // mounted but before NotificationsShellBoot's effect attaches its listener.
+  requestNotificationCenterOpen();
   window.dispatchEvent(new CustomEvent(OPEN_NOTIFICATION_CENTER_EVENT));
 }
 

--- a/packages/ui/src/state/notifications/navigate-deep-link.test.ts
+++ b/packages/ui/src/state/notifications/navigate-deep-link.test.ts
@@ -84,6 +84,16 @@ describe("navigateDeepLink", () => {
     expect(types).not.toContain("eliza:navigate:view");
   });
 
+  it("opens the Home notification center for /notifications", () => {
+    navigateDeepLink("/notifications");
+    const types = dispatchSpy.mock.calls
+      .map((c: unknown[]) => c[0])
+      .filter((e: unknown): e is CustomEvent => e instanceof CustomEvent)
+      .map((e: CustomEvent) => e.type);
+    expect(types).toContain("eliza:notifications:open");
+    expect(types).not.toContain("eliza:navigate:view");
+  });
+
   it("prefills the chat composer for /chat?prefill=<text> (never auto-sends)", () => {
     navigateDeepLink("/chat?prefill=Connect%20my%20calendar");
     const evt = dispatchSpy.mock.calls

--- a/packages/ui/src/state/notifications/navigate-deep-link.ts
+++ b/packages/ui/src/state/notifications/navigate-deep-link.ts
@@ -25,6 +25,7 @@ import {
   dispatchChatOpen,
   dispatchChatPrefill,
   dispatchNavigateViewEvent,
+  dispatchOpenNotificationCenter,
 } from "../../events";
 
 /** Whether a deep link is a safe navigation target (see module doc). */
@@ -58,6 +59,10 @@ export function navigateDeepLink(deepLink: string): void {
       const prefill = new URLSearchParams(query).get("prefill")?.trim();
       if (prefill) dispatchChatPrefill({ text: prefill });
       else dispatchChatOpen();
+      return;
+    }
+    if (viewId === "notifications") {
+      dispatchOpenNotificationCenter();
       return;
     }
     dispatchNavigateViewEvent({ viewId, viewPath: deepLink });

--- a/packages/ui/src/state/notifications/notification-center-open-request.ts
+++ b/packages/ui/src/state/notifications/notification-center-open-request.ts
@@ -1,0 +1,42 @@
+/**
+ * Retains notification-center intent across native boot and shell navigation.
+ * Delivery is observational; only the visible notification center may
+ * acknowledge the newest monotonic request after it has actually opened.
+ */
+
+export type NotificationCenterOpenRequestListener = (requestId: number) => void;
+
+let nextRequestId = 1;
+let pendingRequestId: number | null = null;
+const listeners = new Set<NotificationCenterOpenRequestListener>();
+
+/** Records a new request and returns its monotonic identity. */
+export function requestNotificationCenterOpen(): number {
+  const requestId = nextRequestId;
+  nextRequestId += 1;
+  pendingRequestId = requestId;
+  for (const listener of [...listeners]) listener(requestId);
+  return requestId;
+}
+
+/** Reads the newest request without transferring destination ownership. */
+export function peekNotificationCenterOpenRequest(): number | null {
+  return pendingRequestId;
+}
+
+/** Clears a request only when the visible destination still owns it. */
+export function acknowledgeNotificationCenterOpenRequest(
+  requestId: number,
+): boolean {
+  if (pendingRequestId !== requestId) return false;
+  pendingRequestId = null;
+  return true;
+}
+
+/** Delivers requests that arrive while a destination is mounted. */
+export function subscribeNotificationCenterOpenRequests(
+  listener: NotificationCenterOpenRequestListener,
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}


### PR DESCRIPTION
Closes #21402 only after the remaining acceptance gates pass.

## What changed

- Restores Capacitor local-notification routing in the canonical iOS composition.
- Normalizes safe `/notifications` payloads across native and Capacitor delivery.
- Boots native notification-action routing above startup/authentication gates.
- Retains one notification-center request until the signed-in Home surface is actually paintable and acknowledges it.
- Retries transient listener registration with bounded delays and cancels retries on owner unmount.
- Keeps device push ownership registration independent from the replaceable tab-dispatch callback lifecycle.
- Applies the same fail-closed destination policy when `AppDelegate` reads any local or remote notification tap, so APNs payloads cannot open privileged native routes.

## Exact source state

<!-- evidence-head:1a21138d8e737ddcca6a88cd7d58be1dea82b807 -->

- Head: `1a21138d8e737ddcca6a88cd7d58be1dea82b807`
- Rebased parent: `8e5e0ff034704511e777527a4d0f02440a00940f`
- Exact focused UI tests: 153/153 PASS (`HomeScreen`, `NotificationsHomeCenter`, notification boot/request retention, and native-notifications).
- Exact UI package typecheck: PASS.
- Exact Biome check on the four repaired source/test files: PASS.
- Exact `git diff --check`: PASS.
- Pre-final-rebase app iOS entrypoint test: PASS; 13/13 range-diff entries are patch-identical after the final rebase.
- Pre-final-rebase mobile plugin-manifest tests: 3/3 PASS; Swift destination-policy typecheck: PASS against the iOS simulator SDK.
- Full root `bun run verify`, exact-head Xcode app build, and installed-device acceptance: NOT RUN.

Historical pre-`1a21138d` receipts do not prove this head.

## Acceptance hold

This PR is source-complete and READY. Do not convert it back to draft for the external gates below.

**MERGE HOLD:** no exact-`1a21138d` authenticated warm-tap or killed-process tap has reached a visible `NotificationsHomeCenter` on an installed supported iPhone. No exact screenshots, MP4, native/frontend logs, accessibility/OCR review, completed app audit, or installed-build identity exists. Independent exact-head approval is also outstanding.

<!-- evidence-row:before-screenshots -->
- [x] Historical negative screenshots remain identified as stale and are not relabeled current.
<!-- evidence-row:after-screenshots -->
- [ ] Exact-head authenticated visible `NotificationsHomeCenter` screenshots.
<!-- evidence-row:walkthrough-video -->
- [ ] Exact-head authenticated warm and killed-process notification-tap walkthrough.
<!-- evidence-row:backend-logs -->
- [x] N/A - local native transport; no backend behavior change.
<!-- evidence-row:frontend-logs -->
- [ ] Exact-head native/frontend notification-routing logs.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior change.
<!-- evidence-row:domain-artifacts -->
- [ ] Exact-head build/install identity and warm/killed tap receipts.
<!-- evidence-row:ocr-review -->
- [ ] Exact-head pixels/video plus app-audit OCR/manual review.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [root/finish-21678]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza"} -->
