### PR TITLE
fix(plugin-anthropic-proxy): make shutdown deterministic

### DIFF
--- a/plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { EventEmitter } from "node:events";
+import { get as httpGet } from "node:http";
 import type { ClientRequest, RequestOptions } from "node:https";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -48,6 +49,23 @@ function installUpstream(statusCode = 200, body = "{}") {
   );
 }
 
+async function getJson(url: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const request = httpGet(url, { headers: { connection: "close" } }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer) => chunks.push(chunk));
+      response.on("end", () => {
+        try {
+          resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+    request.on("error", reject);
+  });
+}
+
 afterEach(() => {
   httpsMock.request.mockReset();
   httpsMock.upstreamBodies.length = 0;
@@ -65,8 +83,9 @@ describe("ProxyServer routing", () => {
     });
     await server.start();
     try {
-      const response = await fetch(`${server.getUrl()}/v1/models`);
-      await expect(response.json()).resolves.toEqual({ ok: true });
+      const response = getJson(`${server.getUrl()}/v1/models`);
+      await vi.waitFor(() => expect(httpsMock.request).toHaveBeenCalledOnce(), { timeout: 5_000 });
+      await expect(response).resolves.toEqual({ ok: true });
 
       expect(httpsMock.upstreamBodies).toHaveLength(1);
       expect(httpsMock.upstreamBodies[0].toString("utf8")).toBe("");

--- a/plugins/plugin-anthropic-proxy/src/proxy/server.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/server.ts
@@ -172,6 +172,7 @@ export class ProxyServer {
         this.listening = false;
         resolve();
       });
+      server.closeAllConnections();
     });
     this.server = null;
   }


### PR DESCRIPTION
# Relates to

Closes #21654.

- [x] This PR targets `develop` and was rebased onto `origin/develop` at `f9f9530568a6902621b283f074bf752a901f4b60` with zero conflicts.
- [x] `bun install` completed after sync. The current root verification blocker is recorded below.
- [x] The deterministic routing test and complete package suite demonstrate the corrected lifecycle.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f9f9530568a6902621b283f074bf752a901f4b60:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `f9f9530568a6902621b283f074bf752a901f4b60`; zero conflicts.
- [ ] `bun run verify` reaches an unrelated formatter failure already present on the base branch; exact details are below.

# Risks

Low. The change affects only local proxy shutdown. It closes server-owned connections after stopping acceptance of new requests; routing and upstream transport behavior are unchanged.

# Background

## What does this PR do?

It makes `ProxyServer.stop()` deterministic when active or keep-alive sockets remain, and makes the routing contract explicitly close its client connection so request completion and teardown are independently observed.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed; the public plugin contract is unchanged.

# Testing

## Where should a reviewer start?

Review `plugins/plugin-anthropic-proxy/src/proxy/server.ts` and `plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts`.

## Detailed testing steps

- `bunx vitest run --config ./vitest.config.ts --maxWorkers=1 --no-file-parallelism --reporter=default` from `plugins/plugin-anthropic-proxy`: 11 files, 65 tests passed.
- `bun run typecheck` from `plugins/plugin-anthropic-proxy`: passed.
- `bun run build` from `plugins/plugin-anthropic-proxy`: Node, browser, CJS, and declarations passed.
- Pinned Biome on both touched files: passed.
- `git diff --check origin/develop...HEAD`: passed.

# Evidence Gate

<!-- evidence-head:decb666dfa05035d3df2cf11c79e172981076bc4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interactive flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend changes; the local server lifecycle is covered by the deterministic routing test transcript summarized below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network flow changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - the change is confined to local HTTP server lifecycle management.

## Backend + frontend logs

The exact-head package run passed all 65 tests, including `does not synthesize JSON for empty-body proxied GET requests`, and completed teardown without timing out. Frontend logs are N/A.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

After the final sync, `bun run verify` stopped at `@elizaos/cloud-shared#lint:check` because the base-branch file `packages/cloud/shared/src/lib/cache/redis-factory.ts` does not match pinned Biome formatting. This PR does not touch that package or file. Before that new base regression landed, the same plugin changes completed the entire root verification gate with 356/356 tasks passing. The exact rebased plugin package suite, typecheck, build, Biome, and diff checks are green.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@f9f9530568a6902621b283f074bf752a901f4b60:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@f9f9530568a6902621b283f074bf752a901f4b60:packages/skills/skills/contribute-to-eliza"} -->
