### PR TITLE
test(shared): add unit test suite for asset-url utilities

### DIFF
--- a/packages/shared/src/utils/asset-url.test.ts
+++ b/packages/shared/src/utils/asset-url.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for asset and API URL resolution in packages/shared/src/utils/asset-url.ts.
+ * Exercises relative asset normalization, absolute URL preservation, custom currentUrl/baseUrl options,
+ * boot-config CDN base resolution, and API base URL prefixing.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_BOOT_CONFIG,
+  setBootConfig,
+} from "../config/boot-config-store.js";
+import { resolveApiUrl, resolveAppAssetUrl } from "./asset-url.js";
+
+describe("asset-url utilities", () => {
+  afterEach(() => {
+    setBootConfig(DEFAULT_BOOT_CONFIG);
+  });
+
+  describe("resolveAppAssetUrl", () => {
+    it("returns empty string for empty string input", () => {
+      expect(resolveAppAssetUrl("")).toBe("");
+    });
+
+    it("preserves already absolute URLs", () => {
+      expect(resolveAppAssetUrl("https://cdn.eliza.com/avatar.vrm")).toBe(
+        "https://cdn.eliza.com/avatar.vrm",
+      );
+      expect(resolveAppAssetUrl("http://localhost:3000/anim.glb")).toBe(
+        "http://localhost:3000/anim.glb",
+      );
+      expect(resolveAppAssetUrl("//assets.eliza.com/logo.png")).toBe(
+        "//assets.eliza.com/logo.png",
+      );
+      expect(resolveAppAssetUrl("file:///home/user/avatar.vrm")).toBe(
+        "file:///home/user/avatar.vrm",
+      );
+    });
+
+    it("normalizes and prepends root slash when runtime base is not available", () => {
+      expect(resolveAppAssetUrl("vrms/avatar.vrm")).toBe("/vrms/avatar.vrm");
+      expect(resolveAppAssetUrl("./vrms/avatar.vrm")).toBe("/vrms/avatar.vrm");
+      expect(resolveAppAssetUrl("/vrms/avatar.vrm")).toBe("/vrms/avatar.vrm");
+    });
+
+    it("resolves relative to currentUrl option", () => {
+      const resolvedWeb = resolveAppAssetUrl("vrms/1.vrm", {
+        currentUrl: "http://localhost:5173/chat",
+      });
+      expect(resolvedWeb).toBe("http://localhost:5173/vrms/1.vrm");
+
+      const resolvedFile = resolveAppAssetUrl("vrms/1.vrm", {
+        currentUrl: "file:///app/dist/index.html",
+      });
+      expect(resolvedFile).toBe("file:///app/dist/vrms/1.vrm");
+    });
+
+    it("resolves relative to currentUrl with custom baseUrl", () => {
+      const resolved = resolveAppAssetUrl("vrms/1.vrm", {
+        currentUrl: "file:///app/dist/sub/index.html",
+        baseUrl: "./",
+      });
+      expect(resolved).toBe("file:///app/dist/sub/vrms/1.vrm");
+    });
+
+    it("falls back to root-relative path when currentUrl is invalid", () => {
+      const resolved = resolveAppAssetUrl("vrms/1.vrm", {
+        currentUrl: "invalid-url",
+      });
+      expect(resolved).toBe("/vrms/1.vrm");
+    });
+
+    it("resolves against configured boot config assetBaseUrl", () => {
+      setBootConfig({
+        ...DEFAULT_BOOT_CONFIG,
+        assetBaseUrl: "https://static.elizaos.com/dist",
+      });
+      expect(resolveAppAssetUrl("models/agent.vrm")).toBe(
+        "https://static.elizaos.com/dist/models/agent.vrm",
+      );
+
+      setBootConfig({
+        ...DEFAULT_BOOT_CONFIG,
+        assetBaseUrl: "https://static.elizaos.com/dist/",
+      });
+      expect(resolveAppAssetUrl("models/agent.vrm")).toBe(
+        "https://static.elizaos.com/dist/models/agent.vrm",
+      );
+    });
+
+    it("falls back to runtime resolution when configured assetBaseUrl is invalid", () => {
+      setBootConfig({
+        ...DEFAULT_BOOT_CONFIG,
+        assetBaseUrl: "not-a-valid-url",
+      });
+      expect(resolveAppAssetUrl("models/agent.vrm")).toBe("/models/agent.vrm");
+    });
+  });
+
+  describe("resolveApiUrl", () => {
+    it("returns bare apiPath when no apiBase is set", () => {
+      expect(resolveApiUrl("/api/agents")).toBe("/api/agents");
+      expect(resolveApiUrl("api/status")).toBe("api/status");
+    });
+
+    it("prefixes apiBase from boot config and normalizes slashes", () => {
+      setBootConfig({
+        ...DEFAULT_BOOT_CONFIG,
+        apiBase: "http://127.0.0.1:3000",
+      });
+
+      expect(resolveApiUrl("/api/agents")).toBe(
+        "http://127.0.0.1:3000/api/agents",
+      );
+      expect(resolveApiUrl("api/agents")).toBe(
+        "http://127.0.0.1:3000/api/agents",
+      );
+    });
+
+    it("handles trailing slashes on apiBase without duplicate slashes", () => {
+      setBootConfig({
+        ...DEFAULT_BOOT_CONFIG,
+        apiBase: "http://127.0.0.1:3000///",
+      });
+
+      expect(resolveApiUrl("/api/agents")).toBe(
+        "http://127.0.0.1:3000/api/agents",
+      );
+      expect(resolveApiUrl("api/agents")).toBe(
+        "http://127.0.0.1:3000/api/agents",
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Relates to

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

Closes #21270.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@262f64ece98fe6175e1a38fbbeee21cb9eaec7dc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds a unit test file `packages/shared/src/utils/asset-url.test.ts` for existing pure URL resolution utilities without mutating any runtime code or interfaces.

# Background

## What does this PR do?

Adds a dedicated unit test suite in `packages/shared/src/utils/asset-url.test.ts` covering normal-string resolution and URL edge cases in `resolveAppAssetUrl` and `resolveApiUrl`.

This addresses maintainer review feedback on #21271 (which correctly noted that runtime typing should not be relaxed/fabricated on contract violations, but the valid test suite should be submitted).

## What kind of change is this?

Improvements (unit test suite for shared asset/API URL resolution utilities)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/utils/asset-url.test.ts`.

## Detailed testing steps

Run:
```bash
bun run --cwd packages/shared test src/utils/asset-url.test.ts
```

# Evidence Gate

<!-- evidence-head:fbc3b9eb7799dad11fe99f7b4baefd4e9a613fcf -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - shared URL resolution utility unit tests; no UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - shared URL resolution utility unit tests; no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - shared URL resolution utility unit tests; no UI changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - unit test only; no backend process modified.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend UI changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, wallet, memory, or artifact output.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI.

# Evidence Details

## Unit test transcript

```text
$ bun run --cwd packages/shared test src/utils/asset-url.test.ts
$ node ../scripts/run-vitest.mjs run --config ./vitest.config.ts src/utils/asset-url.test.ts

 RUN  v4.1.5 /home/deepanshu/os/eliza/packages/shared

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  08:54:07
   Duration  405ms (transform 174ms, setup 127ms, import 111ms, tests 8ms, environment 0ms)
```

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@262f64ece98fe6175e1a38fbbeee21cb9eaec7dc:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@262f64ece98fe6175e1a38fbbeee21cb9eaec7dc:packages/skills/skills/contribute-to-eliza"} -->
