### PR TITLE
fix(cloud): reject malformed search JSON safely

### DIFF
--- a/packages/cloud/api/v1/search/route.json.test.ts
+++ b/packages/cloud/api/v1/search/route.json.test.ts
@@ -1,0 +1,70 @@
+/** Verifies the hosted-search JSON boundary with deterministic auth and provider mocks. */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const executeHostedGoogleSearch = mock(async () => ({ results: [] }));
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+  user: { id: "user-1", organization_id: "org-1" },
+  apiKey: { id: "key-1" },
+}));
+
+mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {}, STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/services/google-search", () => ({
+  executeHostedGoogleSearch,
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: () => undefined, info: () => undefined },
+}));
+
+const { default: app } = await import("./route");
+
+describe("POST /api/v1/search malformed JSON", () => {
+  beforeEach(() => {
+    executeHostedGoogleSearch.mockClear();
+  });
+
+  test("returns 400 instead of 500 and never searches", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(executeHostedGoogleSearch).not.toHaveBeenCalled();
+  });
+
+  test("preserves non-syntax request decoding failures as server errors", async () => {
+    const originalJson = Request.prototype.json;
+    Request.prototype.json = mock(async () => {
+      throw new Error("request stream failed");
+    }) as typeof Request.prototype.json;
+
+    try {
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query: "elizaos" }),
+      });
+      expect(response.status).toBe(500);
+      expect(executeHostedGoogleSearch).not.toHaveBeenCalled();
+    } finally {
+      Request.prototype.json = originalJson;
+    }
+  });
+
+  test("canonical JSON still runs hosted search", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "elizaos" }),
+    });
+    expect(response.status).toBe(200);
+    expect(executeHostedGoogleSearch).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/search/route.ts
+++ b/packages/cloud/api/v1/search/route.ts
@@ -28,7 +28,15 @@ const searchRequestSchema = z.object({
 async function handlePOST(req: Request) {
   try {
     const authResult = await requireAuthOrApiKeyWithOrg(req);
-    const bodyResult = searchRequestSchema.safeParse(await req.json());
+    let raw: unknown;
+    try {
+      raw = await req.json();
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+      // error-policy:J3 malformed JSON is an explicit invalid request.
+      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+    const bodyResult = searchRequestSchema.safeParse(raw);
 
     if (!bodyResult.success) {
       return Response.json(


### PR DESCRIPTION
# Relates to

Completes #21541 after the post-merge arrival #21685.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] Focused exact-head tests and Biome were run after sync; broader evidence is inherited from #21682 and the gap is recorded below.
- [x] The request behavior is directly verified without requiring code inspection.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5
<!-- attribution-row:client -->
- Agent tooling: Codex with parallel review agent
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@5bd5920c90f00cf12948a231cb4a5733365b0d1c:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased on `5bd5920c90f00cf12948a231cb4a5733365b0d1c`; zero conflicts.
- [x] Focused exact-head checks pass; current-develop aggregate TypeScript failures are documented in #21682.

# Risks

Low. The change is one Cloud request parser and its deterministic regression suite.

# Background

## What does this PR do?

Returns 400 for malformed search JSON while preserving the established 500 boundary for request-stream or internal decoder failures. This corrects #21685's broad catch, which mislabeled every `req.json()` rejection as caller syntax error.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/search/route.json.test.ts`.

## Detailed testing steps

`bun test packages/cloud/api/v1/search/route.json.test.ts` — 3 passed, 0 failed, 7 assertions. Biome passes on both changed files; `git diff --check` is clean.

# Evidence Gate

<!-- evidence-head:81c15de694decb6d3109638c7110c715dc1bfc86 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - parser-only HTTP boundary.
<!-- evidence-row:backend-logs -->
- [x] Focused tests assert malformed 400, canonical success, and internal-decoder 500 behavior.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - invalid input is rejected before search work.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

The focused route suite is the deterministic backend transcript: 3 tests and 7 assertions pass on the exact head.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio change.

## Known gaps / failures

The full aggregate validation and current-develop-only TypeScript blockers are documented in #21682. This follow-up is two Cloud files and passes its exact-head test and Biome gates.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@5bd5920c90f00cf12948a231cb4a5733365b0d1c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-ss251-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@5bd5920c90f00cf12948a231cb4a5733365b0d1c:packages/skills/skills/contribute-to-eliza"} -->
