### PR TITLE
test(shared): add unit test suite for cloud-status utilities

### DIFF
--- a/packages/shared/src/utils/cloud-status.test.ts
+++ b/packages/shared/src/utils/cloud-status.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for cloud status classification utilities in packages/shared/src/utils/cloud-status.ts.
+ * Exercises API-key-only reason classification, unknown/invalid reason handling, and authenticated
+ * status derivation across connection states.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isCloudStatusAuthenticated,
+  isCloudStatusReasonApiKeyOnly,
+} from "./cloud-status.js";
+
+describe("cloud-status utilities", () => {
+  describe("isCloudStatusReasonApiKeyOnly", () => {
+    it("returns true for exact API-key-only reason codes", () => {
+      expect(
+        isCloudStatusReasonApiKeyOnly("api_key_present_not_authenticated"),
+      ).toBe(true);
+      expect(
+        isCloudStatusReasonApiKeyOnly("api_key_present_runtime_not_started"),
+      ).toBe(true);
+    });
+
+    it("returns false for non-key-only reason codes", () => {
+      expect(isCloudStatusReasonApiKeyOnly("connected")).toBe(false);
+      expect(isCloudStatusReasonApiKeyOnly("disconnected")).toBe(false);
+      expect(isCloudStatusReasonApiKeyOnly("network_error")).toBe(false);
+      expect(isCloudStatusReasonApiKeyOnly("")).toBe(false);
+    });
+
+    it("returns false for nullish or non-string inputs", () => {
+      expect(isCloudStatusReasonApiKeyOnly(null)).toBe(false);
+      expect(isCloudStatusReasonApiKeyOnly(undefined)).toBe(false);
+      expect(isCloudStatusReasonApiKeyOnly(123 as unknown as string)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("isCloudStatusAuthenticated", () => {
+    it("returns true when connected is true and reason is not API-key-only", () => {
+      expect(isCloudStatusAuthenticated(true, undefined)).toBe(true);
+      expect(isCloudStatusAuthenticated(true, null)).toBe(true);
+      expect(isCloudStatusAuthenticated(true, "session_active")).toBe(true);
+    });
+
+    it("returns false when connected is true but reason is API-key-only", () => {
+      expect(
+        isCloudStatusAuthenticated(true, "api_key_present_not_authenticated"),
+      ).toBe(false);
+      expect(
+        isCloudStatusAuthenticated(true, "api_key_present_runtime_not_started"),
+      ).toBe(false);
+    });
+
+    it("returns false when connected is false regardless of reason", () => {
+      expect(isCloudStatusAuthenticated(false, undefined)).toBe(false);
+      expect(isCloudStatusAuthenticated(false, null)).toBe(false);
+      expect(isCloudStatusAuthenticated(false, "session_active")).toBe(false);
+      expect(
+        isCloudStatusAuthenticated(false, "api_key_present_not_authenticated"),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/utils/cloud-status.test.ts
+++ b/packages/shared/src/utils/cloud-status.test.ts
@@ -27,12 +27,9 @@ describe("cloud-status utilities", () => {
       expect(isCloudStatusReasonApiKeyOnly("")).toBe(false);
     });
 
-    it("returns false for nullish or non-string inputs", () => {
+    it("returns false for nullish inputs", () => {
       expect(isCloudStatusReasonApiKeyOnly(null)).toBe(false);
       expect(isCloudStatusReasonApiKeyOnly(undefined)).toBe(false);
-      expect(isCloudStatusReasonApiKeyOnly(123 as unknown as string)).toBe(
-        false,
-      );
     });
   });
 


### PR DESCRIPTION
# Relates to

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

Closes #21255.
Relates to #21183.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds a unit test file `packages/shared/src/utils/cloud-status.test.ts` verifying existing `isCloudStatusReasonApiKeyOnly` and `isCloudStatusAuthenticated` utilities without modifying runtime interfaces or relaxing enum constraints.

# Background

## What does this PR do?

Adds a dedicated unit test suite for cloud status classification helpers in `packages/shared/src/utils/cloud-status.test.ts`.

Addresses review feedback on #21259 and #21187:
- Does not modify or relax canonical protocol reason matching in `cloud-status.ts`.
- Tests exact matching of canonical `api_key_present_not_authenticated` and `api_key_present_runtime_not_started` reasons, non-matching reason strings, null/undefined inputs, and connected state combinations.

## What kind of change is this?

Improvements (unit test suite for shared cloud-status classification utilities)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/utils/cloud-status.test.ts`.

## Detailed testing steps

Run:
```bash
bun run --cwd packages/shared test src/utils/cloud-status.test.ts
```

# Evidence Gate

<!-- evidence-head:f7dbb26cc0a4c8de5f37997553ef67cf7824537c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - shared cloud-status utility unit tests; no UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - shared cloud-status utility unit tests; no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - shared cloud-status utility unit tests; no UI changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - unit test only; no backend process modified.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend UI changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, wallet, memory, or artifact output.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI.

# Evidence Details

## Unit test transcript

```text
$ bun run --cwd packages/shared test src/utils/cloud-status.test.ts
$ node ../scripts/run-vitest.mjs run --config ./vitest.config.ts src/utils/cloud-status.test.ts

 RUN  v4.1.5 /home/deepanshu/os/eliza/packages/shared

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  08:59:37
   Duration  269ms (transform 91ms, setup 106ms, import 26ms, tests 6ms, environment 0ms)
```

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@88ac1800e6ff422f25fc25cfc6e949ff940f81d1:packages/skills/skills/contribute-to-eliza"} -->
