### PR TITLE
test(plugin-anthropic-proxy): exclude module setup from routing timeout

### DIFF
--- a/plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from "node:events";
 import { get as httpGet } from "node:http";
 import type { ClientRequest, RequestOptions } from "node:https";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProxyServer } from "../src/proxy/server.js";
 
 const httpsMock = vi.hoisted(() => ({
   request: vi.fn(),
@@ -75,7 +76,6 @@ afterEach(() => {
 describe("ProxyServer routing", () => {
   it("does not synthesize JSON for empty-body proxied GET requests", async () => {
     installUpstream(200, '{"ok":true}');
-    const { ProxyServer } = await import("../src/proxy/server.js");
     const server = new ProxyServer({
       port: 0,
       bindHost: "127.0.0.1",


### PR DESCRIPTION
# Relates to

Closes #21688.

- [x] Targets `develop` and is rebased onto `5bd5920c90f00cf12948a231cb4a5733365b0d1c` with zero conflicts.
- [x] `bun install` is current; the unrelated base-branch root verification blocker is documented below.
- [x] Exact-head focused and full package runs demonstrate the timeout boundary.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5bd5920c90f00cf12948a231cb4a5733365b0d1c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] Root verification has the unrelated base-branch formatter blocker recorded below.

# Risks

Low. This changes only when the test harness imports `ProxyServer`; Vitest's hoisted HTTPS mock and every routing assertion remain unchanged. Production code is untouched.

# Background

## What does this PR do?

It moves `ProxyServer` module loading from inside the 30-second routing test body to module setup. Under resource pressure, module transformation previously consumed the test deadline before the HTTP contract ran.

## What kind of change is this?

Test reliability fix (non-breaking).

# Documentation changes needed?

No documentation change is needed.

# Testing

## Where should a reviewer start?

Review `plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts`; the one-line import is moved without changing the mock or assertions.

## Detailed testing steps

- Focused routing file: 1/1 passed; transform/import took about 7 seconds while the timed test body took 63 ms.
- Full plugin suite: 11 files, 65/65 tests passed; transform/import took about 50 seconds while the routing test body took 64 ms.
- Package typecheck: passed.
- Package build: Node, browser, CJS, and declarations passed on the merged parent before this test-only import move.
- Pinned Biome and `git diff --check`: passed.

# Evidence Gate

<!-- evidence-head:f5b1082fd42ceba691165d488eadd19116e1443f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive product flow exists; only module-load timing in a deterministic unit test changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production backend change; deterministic test results are summarized below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - test-harness-only change.

## Backend + frontend logs

N/A - no production backend or frontend change. Exact-head deterministic results: focused 1/1 passed in 63 ms of test time; full package 65/65 passed with the routing case at 64 ms.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

`bun run verify` on the merged parent stops at an unrelated `@elizaos/cloud-shared#lint:check` formatter failure in `packages/cloud/shared/src/lib/cache/redis-factory.ts`, a file this PR does not touch. The exact-head focused/full plugin tests, typecheck, Biome, and diff checks pass. A prior full root run before that base regression passed all 356/356 tasks.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5bd5920c90f00cf12948a231cb4a5733365b0d1c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5bd5920c90f00cf12948a231cb4a5733365b0d1c:packages/skills/skills/contribute-to-eliza"} -->
