### PR TITLE
fix(desktop): validate persisted external agent readiness

### DIFF
--- a/packages/app-core/platforms/electrobun/src/api-base.test.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.test.ts
@@ -203,12 +203,14 @@ describe("readPersistedDeployment — eliza.json reader", () => {
           runtime: "cloud",
           provider: "elizacloud",
           remoteApiBase: CLOUD_AGENT_URL,
+          remoteAccessToken: " remote-secret ",
         },
       }),
     );
     expect(readPersistedDeployment({ ELIZA_CONFIG_PATH: file })).toEqual({
       runtime: "cloud",
       remoteApiBase: CLOUD_AGENT_URL,
+      remoteAccessToken: "remote-secret",
     });
   });
 
@@ -221,6 +223,7 @@ describe("readPersistedDeployment — eliza.json reader", () => {
     expect(readPersistedDeployment({ ELIZA_CONFIG_PATH: file })).toEqual({
       runtime: "local",
       remoteApiBase: null,
+      remoteAccessToken: null,
     });
   });
 

--- a/packages/app-core/platforms/electrobun/src/api-base.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.ts
@@ -118,6 +118,8 @@ export type PersistedDeploymentRuntime = "local" | "cloud" | "remote" | null;
 export interface PersistedDeployment {
   runtime: NonNullable<PersistedDeploymentRuntime>;
   remoteApiBase: string | null;
+  /** Bearer credential bound to the persisted remote target, if configured. */
+  remoteAccessToken?: string | null;
 }
 
 /**

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -125,6 +125,7 @@ import {
   resolveRendererAssetDir,
 } from "./runtime-layout";
 import { mergeRuntimePermissionStates } from "./runtime-permissions";
+import { resolveDesktopRuntimeForBoot } from "./runtime-preflight";
 import { startScreenCaptureBridgeServer } from "./screen-capture-bridge-server";
 import { startScreenshotDevServer } from "./screenshot-dev-server";
 import { registerShellSyncEndpoint } from "./shell-sync-relay";
@@ -233,12 +234,19 @@ onAgentReadyChange(() => setupApplicationMenu());
  * base resolves to `external` so the embedded agent is skipped; topology 1
  * (local agent → cloud inference) and topology 2 (all-local) keep `local`.
  */
+let preparedDesktopRuntime: ReturnType<
+  typeof resolveDesktopRuntimeModeWithDeployment
+> | null = null;
+
 function resolveDesktopRuntime(): ReturnType<
   typeof resolveDesktopRuntimeModeWithDeployment
 > {
-  return resolveDesktopRuntimeModeWithDeployment(
-    process.env as Record<string, string | undefined>,
-    getPersistedDeployment(),
+  return (
+    preparedDesktopRuntime ??
+    resolveDesktopRuntimeModeWithDeployment(
+      process.env as Record<string, string | undefined>,
+      getPersistedDeployment(),
+    )
   );
 }
 
@@ -2519,6 +2527,25 @@ async function main(): Promise<void> {
   if (cloudOnlyHydration.applied.length > 0) {
     console.log(
       `[Env] cloud-only brand flag raised: ${cloudOnlyHydration.applied.join(", ")}`,
+    );
+  }
+  const desktopEnv = process.env as Record<string, string | undefined>;
+  const persistedDeployment = getPersistedDeployment();
+  const unverifiedDesktopRuntime = resolveDesktopRuntimeModeWithDeployment(
+    desktopEnv,
+    persistedDeployment,
+  );
+  preparedDesktopRuntime = await resolveDesktopRuntimeForBoot({
+    env: desktopEnv,
+    deployment: persistedDeployment,
+  });
+  if (
+    unverifiedDesktopRuntime.mode === "external" &&
+    preparedDesktopRuntime.mode === "local" &&
+    persistedDeployment?.runtime !== "local"
+  ) {
+    logger.warn(
+      "[Main] Persisted external target is not a ready Eliza agent; using the embedded runtime for this launch without changing the saved deployment target.",
     );
   }
   // Start the static renderer server in parallel with the rest of pre-window

--- a/packages/app-core/platforms/electrobun/src/persisted-deployment.ts
+++ b/packages/app-core/platforms/electrobun/src/persisted-deployment.ts
@@ -27,10 +27,11 @@ function resolveElizaConfigPath(
 
 /**
  * Read the persisted `deploymentTarget` from `eliza.json` as a
- * {@link PersistedDeployment} (`runtime` + the cloud-hosted/external agent's
- * `remoteApiBase`). Best-effort and fail-safe: any missing file, parse error,
- * or absent deployment target resolves to `null`, which the caller treats as
- * "no cloud-hosted target" and keeps the existing local-agent boot path. The
+ * {@link PersistedDeployment} (runtime plus the cloud-hosted/external agent's
+ * API base and bound access token). Best-effort and fail-safe: any missing
+ * file, parse error, or absent deployment target resolves to `null`, which the
+ * caller treats as "no cloud-hosted target" and keeps the existing local-agent
+ * boot path. The
  * persisted config is written by `saveElizaConfig` as strict JSON, so a strict
  * `JSON.parse` is sufficient.
  */
@@ -73,6 +74,7 @@ export function readPersistedDeployment(
   return {
     runtime: deploymentTarget.runtime,
     remoteApiBase: deploymentTarget.remoteApiBase ?? null,
+    remoteAccessToken: deploymentTarget.remoteAccessToken ?? null,
   };
 }
 

--- a/packages/app-core/platforms/electrobun/src/runtime-preflight.test.ts
+++ b/packages/app-core/platforms/electrobun/src/runtime-preflight.test.ts
@@ -15,6 +15,7 @@ type EndpointResponse = {
   status?: number;
   body: string;
   contentType?: string;
+  requiredBearer?: string;
 };
 
 function sendResponse(res: ServerResponse, response: EndpointResponse): void {
@@ -32,9 +33,17 @@ async function withProbeServer(
   const server = createServer((req, res) => {
     const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
     requests.push(pathname);
+    const endpoint = endpoints[pathname];
+    if (
+      endpoint?.requiredBearer &&
+      req.headers.authorization !== `Bearer ${endpoint.requiredBearer}`
+    ) {
+      sendResponse(res, { status: 401, body: '{"error":"unauthorized"}' });
+      return;
+    }
     sendResponse(
       res,
-      endpoints[pathname] ?? { status: 404, body: '{"error":"not_found"}' },
+      endpoint ?? { status: 404, body: '{"error":"not_found"}' },
     );
   });
 
@@ -73,6 +82,24 @@ describe("probeExternalAgent", () => {
       await expect(probeExternalAgent(`${base}/`)).resolves.toBe(true);
       expect(requests).toEqual(["/api/health", "/api/status"]);
     });
+  });
+
+  it("authenticates the protected status contract for a persisted agent", async () => {
+    await withProbeServer(
+      {
+        ...readyElizaEndpoints,
+        "/api/status": {
+          ...readyElizaEndpoints["/api/status"],
+          requiredBearer: "remote-secret",
+        },
+      },
+      async (base, requests) => {
+        await expect(probeExternalAgent(base, "remote-secret")).resolves.toBe(
+          true,
+        );
+        expect(requests).toEqual(["/api/health", "/api/status"]);
+      },
+    );
   });
 
   it.each([
@@ -135,6 +162,24 @@ describe("resolveDesktopRuntimeForBoot", () => {
     expect(result.mode).toBe("external");
     expect(result.externalApi.base).toBe("http://127.0.0.1:2250");
     expect(probe).toHaveBeenCalledOnce();
+  });
+
+  it("passes only the persisted target token to the readiness probe", async () => {
+    const probe = vi.fn(async () => true);
+    const result = await resolveDesktopRuntimeForBoot({
+      env: {},
+      deployment: {
+        ...remoteDeployment,
+        remoteAccessToken: " remote-secret ",
+      },
+      probe,
+    });
+
+    expect(result.mode).toBe("external");
+    expect(probe).toHaveBeenCalledWith(
+      "http://127.0.0.1:2250",
+      "remote-secret",
+    );
   });
 
   it("recovers an unreachable persisted remote target to embedded local", async () => {

--- a/packages/app-core/platforms/electrobun/src/runtime-preflight.test.ts
+++ b/packages/app-core/platforms/electrobun/src/runtime-preflight.test.ts
@@ -1,0 +1,175 @@
+/** Verifies desktop runtime recovery against real HTTP health/status responses. */
+import { createServer, type ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import {
+  probeExternalAgent,
+  resolveDesktopRuntimeForBoot,
+} from "./runtime-preflight";
+
+const remoteDeployment = {
+  runtime: "remote" as const,
+  remoteApiBase: "http://127.0.0.1:2250",
+};
+
+type EndpointResponse = {
+  status?: number;
+  body: string;
+  contentType?: string;
+};
+
+function sendResponse(res: ServerResponse, response: EndpointResponse): void {
+  res.writeHead(response.status ?? 200, {
+    "content-type": response.contentType ?? "application/json",
+  });
+  res.end(response.body);
+}
+
+async function withProbeServer(
+  endpoints: Record<string, EndpointResponse>,
+  run: (base: string, requests: string[]) => Promise<void>,
+): Promise<void> {
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+    requests.push(pathname);
+    sendResponse(
+      res,
+      endpoints[pathname] ?? { status: 404, body: '{"error":"not_found"}' },
+    );
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  try {
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("probe test server did not expose a TCP port");
+    }
+    await run(`http://127.0.0.1:${address.port}`, requests);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const readyElizaEndpoints: Record<string, EndpointResponse> = {
+  "/api/health": { body: '{"ready":true}' },
+  "/api/status": {
+    body: JSON.stringify({
+      state: "running",
+      agentName: "Eliza",
+      canRespond: true,
+    }),
+  },
+};
+
+describe("probeExternalAgent", () => {
+  it("accepts a ready Eliza agent through both public contracts", async () => {
+    await withProbeServer(readyElizaEndpoints, async (base, requests) => {
+      await expect(probeExternalAgent(`${base}/`)).resolves.toBe(true);
+      expect(requests).toEqual(["/api/health", "/api/status"]);
+    });
+  });
+
+  it.each([
+    [
+      "authentication challenge",
+      { status: 401, body: '{"error":"unauthorized"}' },
+    ],
+    ["404", { status: 404, body: '{"error":"not_found"}' }],
+    ["wrong-service", { body: '{"ok":true,"service":"nginx"}' }],
+    ["malformed", { body: "not-json", contentType: "text/plain" }],
+    ["not-ready", { body: '{"ready":false}' }],
+  ])("rejects a %s health response", async (_label, health) => {
+    await withProbeServer(
+      { ...readyElizaEndpoints, "/api/health": health },
+      async (base, requests) => {
+        await expect(probeExternalAgent(base)).resolves.toBe(false);
+        expect(requests).toEqual(["/api/health"]);
+      },
+    );
+  });
+
+  it.each([
+    [
+      "authentication challenge",
+      { status: 401, body: '{"error":"unauthorized"}' },
+    ],
+    ["404", { status: 404, body: '{"error":"not_found"}' }],
+    ["wrong-service", { body: '{"state":"ok","name":"api"}' }],
+    ["malformed", { body: "<html>ok</html>", contentType: "text/html" }],
+    [
+      "not-ready",
+      {
+        body: JSON.stringify({
+          state: "starting",
+          agentName: "Eliza",
+          canRespond: false,
+        }),
+      },
+    ],
+  ])("rejects a %s Eliza status response", async (_label, status) => {
+    await withProbeServer(
+      { ...readyElizaEndpoints, "/api/status": status },
+      async (base, requests) => {
+        await expect(probeExternalAgent(base)).resolves.toBe(false);
+        expect(requests).toEqual(["/api/health", "/api/status"]);
+      },
+    );
+  });
+});
+
+describe("resolveDesktopRuntimeForBoot", () => {
+  it("keeps a reachable persisted remote target external", async () => {
+    const probe = vi.fn(async () => true);
+    const result = await resolveDesktopRuntimeForBoot({
+      env: {},
+      deployment: remoteDeployment,
+      probe,
+    });
+
+    expect(result.mode).toBe("external");
+    expect(result.externalApi.base).toBe("http://127.0.0.1:2250");
+    expect(probe).toHaveBeenCalledOnce();
+  });
+
+  it("recovers an unreachable persisted remote target to embedded local", async () => {
+    const result = await resolveDesktopRuntimeForBoot({
+      env: {},
+      deployment: remoteDeployment,
+      probe: async () => false,
+    });
+
+    expect(result.mode).toBe("local");
+    expect(result.externalApi.base).toBeNull();
+  });
+
+  it("does not fabricate local runtime in a cloud-only package", async () => {
+    const probe = vi.fn(async () => false);
+    const result = await resolveDesktopRuntimeForBoot({
+      env: { ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT: "1" },
+      deployment: remoteDeployment,
+      probe,
+    });
+
+    expect(result.mode).toBe("external");
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit env targets without probing persisted state", async () => {
+    const probe = vi.fn(async () => false);
+    const result = await resolveDesktopRuntimeForBoot({
+      env: { ELIZA_DESKTOP_API_BASE: "http://127.0.0.1:9999" },
+      deployment: remoteDeployment,
+      probe,
+    });
+
+    expect(result.mode).toBe("external");
+    expect(result.externalApi.base).toBe("http://127.0.0.1:9999");
+    expect(probe).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/runtime-preflight.ts
+++ b/packages/app-core/platforms/electrobun/src/runtime-preflight.ts
@@ -1,0 +1,104 @@
+/**
+ * Resolves the desktop runtime topology after verifying persisted external
+ * targets. Direct packages recover to their embedded runtime when a previously
+ * selected remote agent is unavailable, while explicit env targets and
+ * runtime-less cloud-only packages remain authoritative.
+ */
+import {
+  type DesktopRuntimeModeResolution,
+  type PersistedDeployment,
+  resolveDesktopRuntimeMode,
+  resolveDesktopRuntimeModeWithDeployment,
+} from "./api-base";
+
+const EXTERNAL_REACHABILITY_TIMEOUT_MS = 1_500;
+
+export type ExternalReachabilityProbe = (base: string) => Promise<boolean>;
+
+function hasExplicitExternalTarget(
+  env: Record<string, string | undefined>,
+): boolean {
+  return (
+    resolveDesktopRuntimeMode(env).mode === "external" ||
+    Boolean(env.ELIZA_DESKTOP_CLOUD_AGENT_BASE?.trim())
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isReadyHealth(body: unknown): boolean {
+  return isRecord(body) && body.ready === true;
+}
+
+function isReadyElizaStatus(body: unknown): boolean {
+  return (
+    isRecord(body) &&
+    body.state === "running" &&
+    body.canRespond === true &&
+    typeof body.agentName === "string" &&
+    body.agentName.trim().length > 0
+  );
+}
+
+async function fetchJson(
+  url: string,
+  signal: AbortSignal,
+): Promise<unknown | null> {
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+    signal,
+  });
+  if (response.status !== 200) return null;
+  return response.json();
+}
+
+export async function probeExternalAgent(base: string): Promise<boolean> {
+  try {
+    const signal = AbortSignal.timeout(EXTERNAL_REACHABILITY_TIMEOUT_MS);
+    const normalizedBase = base.replace(/\/+$/, "");
+    const health = await fetchJson(`${normalizedBase}/api/health`, signal);
+    if (!isReadyHealth(health)) return false;
+
+    // Public remote health intentionally exposes only `{ ready }`. Pair it
+    // with the agent status contract so an unrelated service cannot suppress
+    // the embedded runtime merely by answering on the persisted port.
+    const status = await fetchJson(`${normalizedBase}/api/status`, signal);
+    return isReadyElizaStatus(status);
+  } catch {
+    // error-policy:J1 desktop startup probe converts transport and malformed
+    // response failures into the explicit local-recovery decision below.
+    return false;
+  }
+}
+
+export async function resolveDesktopRuntimeForBoot(options: {
+  env: Record<string, string | undefined>;
+  deployment: PersistedDeployment | null;
+  probe?: ExternalReachabilityProbe;
+}): Promise<DesktopRuntimeModeResolution> {
+  const { env, deployment, probe = probeExternalAgent } = options;
+  const resolved = resolveDesktopRuntimeModeWithDeployment(env, deployment);
+
+  if (
+    resolved.mode !== "external" ||
+    !resolved.externalApi.base ||
+    hasExplicitExternalTarget(env)
+  ) {
+    return resolved;
+  }
+
+  // A runtime-less package cannot recover to an agent it does not ship.
+  const envOnly = resolveDesktopRuntimeMode(env);
+  if (envOnly.mode === "disabled") {
+    return resolved;
+  }
+
+  if (await probe(resolved.externalApi.base)) {
+    return resolved;
+  }
+
+  return envOnly;
+}

--- a/packages/app-core/platforms/electrobun/src/runtime-preflight.ts
+++ b/packages/app-core/platforms/electrobun/src/runtime-preflight.ts
@@ -13,7 +13,10 @@ import {
 
 const EXTERNAL_REACHABILITY_TIMEOUT_MS = 1_500;
 
-export type ExternalReachabilityProbe = (base: string) => Promise<boolean>;
+export type ExternalReachabilityProbe = (
+  base: string,
+  accessToken?: string,
+) => Promise<boolean>;
 
 function hasExplicitExternalTarget(
   env: Record<string, string | undefined>,
@@ -45,27 +48,43 @@ function isReadyElizaStatus(body: unknown): boolean {
 async function fetchJson(
   url: string,
   signal: AbortSignal,
+  accessToken?: string,
 ): Promise<unknown | null> {
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
   const response = await fetch(url, {
     method: "GET",
-    headers: { Accept: "application/json" },
+    headers,
     signal,
   });
   if (response.status !== 200) return null;
   return response.json();
 }
 
-export async function probeExternalAgent(base: string): Promise<boolean> {
+export async function probeExternalAgent(
+  base: string,
+  accessToken?: string,
+): Promise<boolean> {
   try {
     const signal = AbortSignal.timeout(EXTERNAL_REACHABILITY_TIMEOUT_MS);
     const normalizedBase = base.replace(/\/+$/, "");
-    const health = await fetchJson(`${normalizedBase}/api/health`, signal);
+    const health = await fetchJson(
+      `${normalizedBase}/api/health`,
+      signal,
+      accessToken,
+    );
     if (!isReadyHealth(health)) return false;
 
     // Public remote health intentionally exposes only `{ ready }`. Pair it
     // with the agent status contract so an unrelated service cannot suppress
     // the embedded runtime merely by answering on the persisted port.
-    const status = await fetchJson(`${normalizedBase}/api/status`, signal);
+    const status = await fetchJson(
+      `${normalizedBase}/api/status`,
+      signal,
+      accessToken,
+    );
     return isReadyElizaStatus(status);
   } catch {
     // error-policy:J1 desktop startup probe converts transport and malformed
@@ -96,7 +115,12 @@ export async function resolveDesktopRuntimeForBoot(options: {
     return resolved;
   }
 
-  if (await probe(resolved.externalApi.base)) {
+  if (
+    await probe(
+      resolved.externalApi.base,
+      deployment?.remoteAccessToken?.trim() || undefined,
+    )
+  ) {
     return resolved;
   }
 


### PR DESCRIPTION
Part of #20714.

## What this fixes

A persisted remote URL previously suppressed the embedded desktop runtime whenever `/api/health` returned any status below 500. An unrelated service, a 404, malformed JSON, or an Eliza runtime that was not ready could therefore strand the full desktop app without a usable agent.

This focused stack:

- requires `/api/health` to return HTTP 200 JSON with `ready: true`;
- requires `/api/status` to match the current Eliza contract: `state: running`, `canRespond: true`, and a nonempty `agentName`;
- reads the normalized persisted target token and authenticates the protected status contract without logging or re-persisting the credential;
- falls back to the embedded runtime only for an unverified persisted target;
- preserves explicit env targets and runtime-less cloud-only packages;
- does not mutate the persisted deployment choice.

## Exact source

- head: `396df4b943bcf94fb1193f38bd8af191d6d9de98`
- tree: `8fe3fb0df1b9e0f52332cf53efc6dea78d1f4e36`
- base/current develop: `5a4604073bd7649a5e8a718a9c1615a193ada8fc`
- paths: 6

## Tests

- Electrobun focused Vitest: **49/49 PASS** (`runtime-preflight.test.ts` and `api-base.test.ts`).
- Real loopback cases cover protected `/api/status` with the persisted bearer token, missing/wrong auth, 404, wrong-service JSON, malformed JSON, not-ready state, token trimming/binding, persisted projection, and local fallback.
- Exact six-path Biome: **PASS**.
- `git diff --check`: **PASS**.
- Full Electrobun typecheck was attempted after a clean Bun install but remains blocked by missing built optional workspace package outputs outside these six paths; no changed-path diagnostic was reported.

## Evidence boundary

- The focused tests use a real loopback HTTP server and prove request order and the authenticated status contract.
- Native screenshots/video: **N/A for this internal pre-window decision** because it has no independent visual state.
- No signed/package startup claim is made. The repository exposes no focused packaged harness for injecting both a protected persisted target and an unreachable target at this boundary; broader signed desktop/bootstrap acceptance remains outside this scoped source PR.
- No live-model, provider, credential-store, deployment, or production mutation was performed.

## Risk

Fail-closed behavior intentionally prefers the embedded runtime only when a persisted target cannot prove it is a ready, responding Eliza agent. The bearer credential is the existing token bound to that same normalized persisted target; it remains in memory, is never logged, and is not written by this path. Explicit operator env targets remain authoritative and are not probed.

## Contribution provenance

- AI assistance: `yes`
- Model: `OpenAI/gpt-5.6-sol`
- Client: `Codex Desktop`
- Skill path: `elizaOS/eliza@5a4604073bd7649a5e8a718a9c1615a193ada8fc:packages/skills/skills/contribute-to-eliza`
- Provenance: `self-reported`

<!-- evidence-head:396df4b943bcf94fb1193f38bd8af191d6d9de98 -->
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5a4604073bd7649a5e8a718a9c1615a193ada8fc:packages/skills/skills/contribute-to-eliza"} -->
