### PR TITLE
fix: make scheduling ready before LifeOps startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "elizaos": {
     "app": {
       "defaults": {
+        "scheduling": {
+          "enabled": true,
+          "requiredForReady": true
+        },
         "personal-assistant": {
           "enabled": true,
           "requiredForReady": true

--- a/packages/agent/src/runtime/blocking-core-boot.ts
+++ b/packages/agent/src/runtime/blocking-core-boot.ts
@@ -1,0 +1,147 @@
+/**
+ * Registers core plugins in dependency waves and owns the pre-initialization
+ * barrier for readiness-critical services. Required plugins fail boot closed;
+ * already registered plugins are skipped across blocking and deferred phases.
+ */
+import { type AgentRuntime, ElizaError, logger } from "@elizaos/core";
+import { formatError } from "@elizaos/shared";
+import { CORE_PLUGINS } from "./core-plugins.ts";
+import type { ResolvedPlugin } from "./plugin-types.ts";
+import { applyHostActionOwnership } from "./runtime-action-ownership.ts";
+
+const CORE_PLUGIN_BOOT_DEPENDENCIES = new Map<string, readonly string[]>([
+  ["@elizaos/plugin-agent-skills", ["@elizaos/plugin-coding-tools"]],
+]);
+
+export async function preregisterCorePluginsInDependencyWaves(args: {
+  runtime: AgentRuntime;
+  resolvedPlugins: ResolvedPlugin[];
+  alreadyPreRegistered: Set<string>;
+  requiredPluginNames?: ReadonlySet<string>;
+  label?: string;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  const registered = new Set([
+    ...args.alreadyPreRegistered,
+    ...(args.runtime.plugins ?? [])
+      .map((plugin) => plugin.name)
+      .filter((name): name is string => typeof name === "string"),
+  ]);
+  const pending = new Map<string, ResolvedPlugin>();
+  for (const name of CORE_PLUGINS) {
+    if (registered.has(name)) continue;
+    const resolved = args.resolvedPlugins.find(
+      (plugin) => plugin.name === name,
+    );
+    if (!resolved) {
+      if (args.requiredPluginNames?.has(name)) {
+        throw new ElizaError(
+          `Required core plugin ${name} was not resolved for pre-registration`,
+          {
+            code: "REQUIRED_CORE_PLUGIN_REGISTRATION_FAILED",
+            severity: "fatal",
+            context: { plugin: name, phase: args.label ?? "core" },
+          },
+        );
+      }
+      logger.debug(
+        `[eliza] Core plugin ${name} not resolved — skipping pre-registration`,
+      );
+      continue;
+    }
+    pending.set(name, resolved);
+  }
+
+  const context = args.label ? `${args.label}: ` : "";
+  const registerOne = async (
+    name: string,
+    resolved: ResolvedPlugin,
+  ): Promise<void> => {
+    try {
+      args.abortSignal?.throwIfAborted();
+      const startedAt = Date.now();
+      logger.debug(`[eliza] ${context}Pre-registering core plugin: ${name}...`);
+      await args.runtime.registerPlugin(
+        applyHostActionOwnership(args.runtime, resolved.plugin),
+      );
+      registered.add(name);
+      logger.debug(
+        `[eliza] ${context}✓ ${name} pre-registered (${Date.now() - startedAt}ms)`,
+      );
+    } catch (error) {
+      if (args.abortSignal?.aborted) throw error;
+      if (args.requiredPluginNames?.has(name)) {
+        throw new ElizaError(
+          `Required core plugin ${name} failed pre-registration`,
+          {
+            code: "REQUIRED_CORE_PLUGIN_REGISTRATION_FAILED",
+            severity: "fatal",
+            context: { plugin: name, phase: args.label ?? "core" },
+            cause: error,
+          },
+        );
+      }
+      registered.add(name);
+      logger.warn(
+        `[eliza] ${context}Core plugin ${name} pre-registration failed: ${formatError(error)}`,
+      );
+    } finally {
+      pending.delete(name);
+    }
+  };
+
+  while (pending.size > 0) {
+    args.abortSignal?.throwIfAborted();
+    const ready: Array<[string, ResolvedPlugin]> = [];
+    for (const [name, resolved] of pending) {
+      const dependencies = [
+        ...(resolved.plugin.dependencies ?? []),
+        ...(CORE_PLUGIN_BOOT_DEPENDENCIES.get(name) ?? []),
+      ];
+      if (
+        !dependencies.some(
+          (dependency) =>
+            pending.has(dependency) && !registered.has(dependency),
+        )
+      ) {
+        ready.push([name, resolved]);
+      }
+    }
+
+    const wave = ready.length > 0 ? ready : Array.from(pending);
+    await Promise.all(
+      wave.map(([name, resolved]) => registerOne(name, resolved)),
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  }
+}
+
+export async function initializeBlockingCoreRuntimeForBoot(args: {
+  blockDeferredPluginImports: boolean;
+  runtime: AgentRuntime;
+  resolvedPlugins: ResolvedPlugin[];
+  requiredPluginNames: ReadonlySet<string>;
+  waitForBlockingEnvironment: () => Promise<void>;
+  initializeCoreRuntime: () => Promise<void>;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  if (args.blockDeferredPluginImports) {
+    await args.waitForBlockingEnvironment();
+  }
+  args.abortSignal?.throwIfAborted();
+  await preregisterCorePluginsInDependencyWaves({
+    runtime: args.runtime,
+    resolvedPlugins: args.resolvedPlugins,
+    alreadyPreRegistered: new Set<string>([
+      "@elizaos/plugin-sql",
+      "@elizaos/plugin-local-inference",
+    ]),
+    requiredPluginNames: args.requiredPluginNames,
+    label: "blocking",
+    ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
+  });
+  args.abortSignal?.throwIfAborted();
+  await args.initializeCoreRuntime();
+}

--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -369,6 +369,11 @@ export const LEAN_CHAT_EXCLUDED_PLUGINS: readonly string[] = [
 export const BLOCKING_CORE_PLUGINS: readonly string[] = [
   "@elizaos/plugin-sql", // required database adapter
   "@elizaos/plugin-local-inference", // pre-init local model/embedding handler wiring
+  // Required by app-manifest readiness plugins (Personal Assistant and
+  // Calendar) whose service start hooks resolve ScheduledTaskRunnerService.
+  // Registering it after runtime.initialize() makes those concurrent starts
+  // fail permanently even though scheduling appears moments later.
+  "@elizaos/plugin-scheduling",
 ];
 
 /**

--- a/packages/agent/src/runtime/eliza-blocking-core-boot.test.ts
+++ b/packages/agent/src/runtime/eliza-blocking-core-boot.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Exercises the production blocking-core boot seam with a deterministic runtime harness.
+ * The harness records real scheduling-plugin registration and models Personal Assistant
+ * service startup at the runtime initialization boundary without external providers.
+ */
+import { isElizaError, type Plugin } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  initializeBlockingCoreRuntimeForBoot,
+  preregisterCorePluginsInDependencyWaves,
+} from "./blocking-core-boot.ts";
+import type { ResolvedPlugin } from "./plugin-types.ts";
+
+const SCHEDULED_TASK_RUNNER_SERVICE_TYPE = "scheduled-task-runner";
+const deterministicScheduledTaskRunnerService = {
+  serviceType: SCHEDULED_TASK_RUNNER_SERVICE_TYPE,
+};
+const schedulingPlugin: Plugin = {
+  name: "@elizaos/plugin-scheduling",
+  description: "Deterministic scheduling declaration for boot-order tests.",
+  dependencies: ["@elizaos/plugin-sql"],
+  services: [deterministicScheduledTaskRunnerService as never],
+};
+
+function createBootHarness(options: { failScheduling?: boolean } = {}) {
+  const events: string[] = [];
+  const plugins: Plugin[] = [];
+  let runnerRegistered = false;
+  const runtime = {
+    plugins,
+    registerPlugin: async (plugin: Plugin) => {
+      events.push(`register:${plugin.name}`);
+      if (
+        options.failScheduling &&
+        plugin.name === "@elizaos/plugin-scheduling"
+      ) {
+        throw new Error("injected scheduling registration failure");
+      }
+      plugins.push(plugin);
+      runnerRegistered =
+        runnerRegistered ||
+        Boolean(
+          plugin.services?.some(
+            (service) =>
+              service.serviceType === SCHEDULED_TASK_RUNNER_SERVICE_TYPE,
+          ),
+        );
+    },
+  };
+  const resolvedPlugins: ResolvedPlugin[] = [
+    { name: "@elizaos/plugin-scheduling", plugin: schedulingPlugin },
+  ];
+
+  return {
+    events,
+    runtime,
+    resolvedPlugins,
+    hasRunner: () => runnerRegistered,
+  };
+}
+
+describe("blocking core runtime boot", () => {
+  for (const blockDeferredPluginImports of [false, true]) {
+    it(`registers scheduling exactly once before Personal Assistant startup when blockDeferredPluginImports=${blockDeferredPluginImports}`, async () => {
+      const harness = createBootHarness();
+
+      await initializeBlockingCoreRuntimeForBoot({
+        blockDeferredPluginImports,
+        runtime: harness.runtime as never,
+        resolvedPlugins: harness.resolvedPlugins,
+        requiredPluginNames: new Set(["@elizaos/plugin-scheduling"]),
+        waitForBlockingEnvironment: async () => {
+          harness.events.push("blocking-environment");
+        },
+        initializeCoreRuntime: async () => {
+          harness.events.push("personal-assistant:start");
+          expect(harness.hasRunner()).toBe(true);
+        },
+      });
+
+      await preregisterCorePluginsInDependencyWaves({
+        runtime: harness.runtime as never,
+        resolvedPlugins: harness.resolvedPlugins,
+        alreadyPreRegistered: new Set([
+          "@elizaos/plugin-sql",
+          "@elizaos/plugin-local-inference",
+        ]),
+        label: "deferred",
+      });
+
+      expect(
+        harness.events.filter(
+          (event) => event === "register:@elizaos/plugin-scheduling",
+        ),
+      ).toHaveLength(1);
+      expect(
+        harness.events.indexOf("register:@elizaos/plugin-scheduling"),
+      ).toBeLessThan(harness.events.indexOf("personal-assistant:start"));
+      expect(harness.events.includes("blocking-environment")).toBe(
+        blockDeferredPluginImports,
+      );
+    });
+  }
+
+  it("fails closed before runtime initialization when required scheduling registration fails", async () => {
+    const harness = createBootHarness({ failScheduling: true });
+
+    try {
+      await initializeBlockingCoreRuntimeForBoot({
+        blockDeferredPluginImports: false,
+        runtime: harness.runtime as never,
+        resolvedPlugins: harness.resolvedPlugins,
+        requiredPluginNames: new Set(["@elizaos/plugin-scheduling"]),
+        waitForBlockingEnvironment: async () => {},
+        initializeCoreRuntime: async () => {
+          harness.events.push("personal-assistant:start");
+        },
+      });
+      expect.unreachable("required scheduling registration must fail boot");
+    } catch (error) {
+      expect(isElizaError(error)).toBe(true);
+      if (isElizaError(error)) {
+        expect(error.code).toBe("REQUIRED_CORE_PLUGIN_REGISTRATION_FAILED");
+        expect(error.severity).toBe("fatal");
+        expect(error.context).toMatchObject({
+          plugin: "@elizaos/plugin-scheduling",
+          phase: "blocking",
+        });
+      }
+    }
+    expect(harness.events).not.toContain("personal-assistant:start");
+    expect(harness.hasRunner()).toBe(false);
+  });
+});

--- a/packages/agent/src/runtime/eliza-deferred-plugin-boot-order.test.ts
+++ b/packages/agent/src/runtime/eliza-deferred-plugin-boot-order.test.ts
@@ -11,6 +11,25 @@ import { describe, expect, it } from "vitest";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const elizaSource = readFileSync(path.join(here, "eliza.ts"), "utf8");
+const personalAssistantSource = readFileSync(
+  path.resolve(
+    here,
+    "../../../../plugins/plugin-personal-assistant/src/plugin.ts",
+  ),
+  "utf8",
+);
+const rootManifest = JSON.parse(
+  readFileSync(path.resolve(here, "../../../../package.json"), "utf8"),
+) as {
+  elizaos?: {
+    app?: {
+      defaults?: Record<
+        string,
+        { enabled?: boolean; requiredForReady?: boolean }
+      >;
+    };
+  };
+};
 
 function extractRunDeferredBootBody(source: string): string {
   const marker = "const runDeferredBoot = async (";
@@ -50,7 +69,89 @@ function extractDeferredRegistrationBody(source: string): string {
   throw new Error("Could not find the end of registerDeferredRuntimePlugins");
 }
 
+function extractInitializeRuntimeServicesBody(source: string): string {
+  const marker = "const initializeRuntimeServices = async (";
+  const start = source.indexOf(marker);
+  expect(start, "initializeRuntimeServices closure must exist").toBeGreaterThan(
+    -1,
+  );
+
+  const bodyStart = source.indexOf("{", start);
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const character = source[index];
+    if (character === "{") depth += 1;
+    if (character === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(bodyStart, index + 1);
+    }
+  }
+
+  throw new Error("Could not find the end of initializeRuntimeServices");
+}
+
 describe("deferred plugin boot ordering", () => {
+  it("makes the app's scheduled-task runtime a readiness dependency", () => {
+    expect(rootManifest.elizaos?.app?.defaults?.scheduling).toEqual({
+      enabled: true,
+      requiredForReady: true,
+    });
+    expect(rootManifest.elizaos?.app?.defaults?.["personal-assistant"]).toEqual(
+      {
+        enabled: true,
+        requiredForReady: true,
+      },
+    );
+  });
+
+  it("pre-registers blocking core dependencies before concurrent runtime service startup", () => {
+    const body = extractInitializeRuntimeServicesBody(elizaSource);
+    const conditionalIndex = body.indexOf("if (blockDeferredPluginImports)");
+    const conditionalEnd = body.indexOf("\n    }", conditionalIndex);
+    const coreWaveIndex = body.indexOf(
+      "await preregisterCorePluginsInDependencyWaves({",
+    );
+    const initializeIndex = body.indexOf("await initializeCoreRuntime()");
+
+    expect(conditionalIndex).toBeGreaterThan(-1);
+    expect(conditionalEnd).toBeGreaterThan(conditionalIndex);
+    expect(coreWaveIndex).toBeGreaterThan(conditionalEnd);
+    expect(initializeIndex).toBeGreaterThan(coreWaveIndex);
+  });
+
+  it("waits for the scheduling runner before Personal Assistant boot jobs use it", () => {
+    for (const [label, operation] of [
+      [
+        'label: "deferred message reconciliation"',
+        "reconcileInterruptedMessageDraftDispatches(runtime)",
+      ],
+      [
+        'label: "default-pack boot seed"',
+        "getProductionScheduledTaskRunner(runtime",
+      ],
+    ] as const) {
+      const labelIndex = personalAssistantSource.indexOf(label);
+      const operationIndex = personalAssistantSource.indexOf(
+        operation,
+        labelIndex,
+      );
+      const barrierIndex = personalAssistantSource.indexOf(
+        "waitForScheduledTaskRunnerService(runtime)",
+        labelIndex,
+      );
+
+      expect(labelIndex, `${label} must exist`).toBeGreaterThan(-1);
+      expect(
+        operationIndex,
+        `${operation} must follow ${label}`,
+      ).toBeGreaterThan(labelIndex);
+      expect(barrierIndex, `${label} must wait for its runner`).toBeGreaterThan(
+        labelIndex,
+      );
+      expect(barrierIndex).toBeLessThan(operationIndex);
+    }
+  });
+
   it("registers core services before feature plugins", () => {
     const body = extractRunDeferredBootBody(elizaSource);
     const coreWaveIndex = body.indexOf(

--- a/packages/agent/src/runtime/eliza-deferred-plugin-boot-order.test.ts
+++ b/packages/agent/src/runtime/eliza-deferred-plugin-boot-order.test.ts
@@ -104,19 +104,17 @@ describe("deferred plugin boot ordering", () => {
     );
   });
 
-  it("pre-registers blocking core dependencies before concurrent runtime service startup", () => {
+  it("runs the blocking core initialization seam before post-runtime services", () => {
     const body = extractInitializeRuntimeServicesBody(elizaSource);
-    const conditionalIndex = body.indexOf("if (blockDeferredPluginImports)");
-    const conditionalEnd = body.indexOf("\n    }", conditionalIndex);
     const coreWaveIndex = body.indexOf(
-      "await preregisterCorePluginsInDependencyWaves({",
+      "await initializeBlockingCoreRuntimeForBoot({",
     );
-    const initializeIndex = body.indexOf("await initializeCoreRuntime()");
+    const credentialStoreStartIndex = body.indexOf(
+      "await ensureConnectorCredentialStoreStarted()",
+    );
 
-    expect(conditionalIndex).toBeGreaterThan(-1);
-    expect(conditionalEnd).toBeGreaterThan(conditionalIndex);
-    expect(coreWaveIndex).toBeGreaterThan(conditionalEnd);
-    expect(initializeIndex).toBeGreaterThan(coreWaveIndex);
+    expect(coreWaveIndex).toBeGreaterThan(-1);
+    expect(credentialStoreStartIndex).toBeGreaterThan(coreWaveIndex);
   });
 
   it("waits for the scheduling runner before Personal Assistant boot jobs use it", () => {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -538,14 +538,14 @@ type CoreStaticPluginRegistration = {
   load: () => Promise<unknown>;
 };
 
-// Blocking-phase loaders. These two plugins each need a bespoke loader (the
-// required SQL adapter with a workspace-source fallback; the local-inference
-// pre-init hook), so they are the only descriptor rows whose `load` is not the
-// generic optional loader. Their membership + required-ness is derived from
-// BLOCKING_CORE_PLUGINS (the single source of truth for the blocking set) rather
-// than re-listed here — buildBlockingStaticRegistrations() below asserts the two
-// stay in lockstep so a change to BLOCKING_CORE_PLUGINS can't silently orphan a
-// loader or register a plugin with no loader.
+// Blocking-phase loaders. These plugins each need an explicit literal loader:
+// SQL has a workspace-source fallback, local-inference installs its pre-init
+// model hooks, and scheduling must be bundled on mobile and register its runner
+// before app-readiness feature services start. Their membership + required-ness
+// is derived from BLOCKING_CORE_PLUGINS (the single source of truth for the
+// blocking set) rather than re-listed here — buildBlockingStaticRegistrations()
+// below asserts the sets stay in lockstep so a change to BLOCKING_CORE_PLUGINS
+// can't silently orphan a loader or register a plugin with no loader.
 const BLOCKING_STATIC_PLUGIN_LOADERS: Readonly<
   Record<string, { required: boolean; load: () => Promise<unknown> }>
 > = {
@@ -553,6 +553,10 @@ const BLOCKING_STATIC_PLUGIN_LOADERS: Readonly<
   "@elizaos/plugin-local-inference": {
     required: false,
     load: () => getPluginLocalEmbedding(),
+  },
+  "@elizaos/plugin-scheduling": {
+    required: true,
+    load: () => import("@elizaos/plugin-scheduling"),
   },
 };
 
@@ -5510,17 +5514,26 @@ export async function startEliza(
       // In block-deferred mode the Discord/GitHub plugins register here (not in
       // runDeferredBoot), so join the env-var lookups before this wave.
       await Promise.all([discordAppIdPromise, cloudGithubTokenPromise]);
-      await preregisterCorePluginsInDependencyWaves({
-        runtime,
-        resolvedPlugins,
-        alreadyPreRegistered: new Set<string>([
-          "@elizaos/plugin-sql",
-          "@elizaos/plugin-local-inference",
-        ]),
-        label: "blocking",
-      });
-      bootTimer.lap("register-core-plugin-waves");
     }
+
+    // Every core plugin selected by the blocking resolver must be registered
+    // before runtime.initialize(). Feature plugins selected by an app manifest
+    // are constructor plugins and may resolve a core service in their start
+    // hook. Keeping this wave behind blockDeferredPluginImports caused normal
+    // two-phase app boots to drop a readiness-promoted core dependency between
+    // phases: it was removed from the runtime constructor by PREREGISTER_PLUGINS
+    // but never registered here, while the deferred resolver correctly
+    // excluded it as already owned by the blocking phase.
+    await preregisterCorePluginsInDependencyWaves({
+      runtime,
+      resolvedPlugins,
+      alreadyPreRegistered: new Set<string>([
+        "@elizaos/plugin-sql",
+        "@elizaos/plugin-local-inference",
+      ]),
+      label: "blocking",
+    });
+    bootTimer.lap("register-core-plugin-waves");
 
     await initializeCoreRuntime();
     bootTimer.lap("svc:runtime.initialize");

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -16,6 +16,10 @@ import process from "node:process";
 import * as readline from "node:readline";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+import {
+  initializeBlockingCoreRuntimeForBoot,
+  preregisterCorePluginsInDependencyWaves,
+} from "./blocking-core-boot.ts";
 import { runBootHooks } from "./boot-hooks.ts";
 import {
   type BootContext,
@@ -74,10 +78,7 @@ import {
   setEnvIfMissing,
 } from "./provider-model-defaults.ts";
 import { shouldLoadRemoteCodingRunnerForBoot } from "./remote-coding-runner-gate.ts";
-import {
-  applyHostActionOwnership,
-  registerFallbackActionIfAbsent,
-} from "./runtime-action-ownership.ts";
+import { registerFallbackActionIfAbsent } from "./runtime-action-ownership.ts";
 import { runRuntimeStartupMaintenance } from "./runtime-maintenance.ts";
 import {
   buildRuntimeSettingsProjection,
@@ -3475,88 +3476,11 @@ async function registerSqlPluginWithRecovery(
   await initializeDatabaseAdapter(runtime, config);
 }
 
-const CORE_PLUGIN_BOOT_DEPENDENCIES = new Map<string, readonly string[]>([
-  ["@elizaos/plugin-agent-skills", ["@elizaos/plugin-coding-tools"]],
-]);
-
-async function preregisterCorePluginsInDependencyWaves(args: {
-  runtime: AgentRuntime;
-  resolvedPlugins: RuntimeResolvedPlugin[];
-  alreadyPreRegistered: Set<string>;
-  label?: string;
-  abortSignal?: AbortSignal;
-}): Promise<void> {
-  const pending = new Map<string, RuntimeResolvedPlugin>();
-  for (const name of CORE_PLUGINS) {
-    if (args.alreadyPreRegistered.has(name)) continue;
-    const resolved = args.resolvedPlugins.find((p) => p.name === name);
-    if (!resolved) {
-      logger.debug(
-        `[eliza] Core plugin ${name} not resolved — skipping pre-registration`,
-      );
-      continue;
-    }
-    pending.set(name, resolved);
-  }
-
-  const registered = new Set(args.alreadyPreRegistered);
-  const context = args.label ? `${args.label}: ` : "";
-
-  const registerOne = async (
-    name: string,
-    resolved: RuntimeResolvedPlugin,
-  ): Promise<void> => {
-    try {
-      args.abortSignal?.throwIfAborted();
-      const regStart = Date.now();
-      logger.debug(`[eliza] ${context}Pre-registering core plugin: ${name}...`);
-      await args.runtime.registerPlugin(
-        applyHostActionOwnership(args.runtime, resolved.plugin),
-      );
-      registered.add(name);
-      logger.debug(
-        `[eliza] ${context}✓ ${name} pre-registered (${Date.now() - regStart}ms)`,
-      );
-    } catch (err) {
-      if (args.abortSignal?.aborted) throw err;
-      registered.add(name);
-      logger.warn(
-        `[eliza] ${context}Core plugin ${name} pre-registration failed: ${formatError(err)}`,
-      );
-    } finally {
-      pending.delete(name);
-    }
-  };
-
-  while (pending.size > 0) {
-    args.abortSignal?.throwIfAborted();
-    const ready: Array<[string, RuntimeResolvedPlugin]> = [];
-    for (const [name, resolved] of pending) {
-      const declaredDependencies = resolved.plugin.dependencies ?? [];
-      const bootDependencies = CORE_PLUGIN_BOOT_DEPENDENCIES.get(name) ?? [];
-      const dependencies = [...declaredDependencies, ...bootDependencies];
-      const hasPendingDependency = dependencies.some(
-        (dependency) => pending.has(dependency) && !registered.has(dependency),
-      );
-      if (!hasPendingDependency) {
-        ready.push([name, resolved]);
-      }
-    }
-
-    const wave = ready.length > 0 ? ready : Array.from(pending);
-    await Promise.all(
-      wave.map(([name, resolved]) => registerOne(name, resolved)),
-    );
-    // Yield to the event loop between waves so the bound HTTP server can serve
-    // /api/health and other I/O between CPU-bound wave registrations, instead
-    // of starving it until every wave finishes. Mirrors the deferred
-    // static-import yield above; pure scheduling, every plugin still registers
-    // in the same wave order.
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-  }
-}
+const REQUIRED_BLOCKING_CORE_PLUGINS = new Set(
+  Object.entries(BLOCKING_STATIC_PLUGIN_LOADERS)
+    .filter(([, loader]) => loader.required)
+    .map(([packageName]) => packageName),
+);
 
 export {
   buildCharacterFromConfig,
@@ -5510,12 +5434,6 @@ export async function startEliza(
     await registerRemoteCodingRunner();
     bootTimer.lap("svc:pre-init");
 
-    if (blockDeferredPluginImports) {
-      // In block-deferred mode the Discord/GitHub plugins register here (not in
-      // runDeferredBoot), so join the env-var lookups before this wave.
-      await Promise.all([discordAppIdPromise, cloudGithubTokenPromise]);
-    }
-
     // Every core plugin selected by the blocking resolver must be registered
     // before runtime.initialize(). Feature plugins selected by an app manifest
     // are constructor plugins and may resolve a core service in their start
@@ -5524,18 +5442,20 @@ export async function startEliza(
     // phases: it was removed from the runtime constructor by PREREGISTER_PLUGINS
     // but never registered here, while the deferred resolver correctly
     // excluded it as already owned by the blocking phase.
-    await preregisterCorePluginsInDependencyWaves({
+    await initializeBlockingCoreRuntimeForBoot({
+      blockDeferredPluginImports,
       runtime,
       resolvedPlugins,
-      alreadyPreRegistered: new Set<string>([
-        "@elizaos/plugin-sql",
-        "@elizaos/plugin-local-inference",
-      ]),
-      label: "blocking",
+      requiredPluginNames: REQUIRED_BLOCKING_CORE_PLUGINS,
+      waitForBlockingEnvironment: async () => {
+        // In block-deferred mode the Discord/GitHub plugins register here (not
+        // in runDeferredBoot), so join the env-var lookups before this wave.
+        await Promise.all([discordAppIdPromise, cloudGithubTokenPromise]);
+      },
+      initializeCoreRuntime,
+      ...(opts?.abortSignal ? { abortSignal: opts.abortSignal } : {}),
     });
     bootTimer.lap("register-core-plugin-waves");
-
-    await initializeCoreRuntime();
     bootTimer.lap("svc:runtime.initialize");
     await ensureConnectorCredentialStoreStarted();
     bootTimer.lap("svc:connector-credential-store-start");

--- a/packages/agent/src/runtime/optional-plugin-imports.generated.ts
+++ b/packages/agent/src/runtime/optional-plugin-imports.generated.ts
@@ -22,7 +22,6 @@ export const OPTIONAL_PLUGIN_IMPORTERS: Record<string, () => Promise<unknown>> =
       // biome-ignore lint/suspicious/noTsIgnore: optional literal imports may be unbuilt in sibling source typechecks.
       // @ts-ignore: optional mobile bundle plugin is outside sibling typecheck build graph; runtime import is guarded.
       import("@elizaos/plugin-native-filesystem"),
-    "@elizaos/plugin-scheduling": () => import("@elizaos/plugin-scheduling"),
     "@elizaos/plugin-inbox": () =>
       // biome-ignore lint/suspicious/noTsIgnore: optional literal imports may be unbuilt in sibling source typechecks.
       // @ts-ignore: runtime subpath export is intentional; not every package tsconfig resolves its declaration condition.

--- a/packages/agent/src/runtime/optional-plugins.ts
+++ b/packages/agent/src/runtime/optional-plugins.ts
@@ -51,7 +51,6 @@ export const OPTIONAL_STATIC_PLUGIN_PACKAGES: readonly string[] = [
   // health still reporting failed:0. The bundle-loadability drift guard in
   // core-plugins-profile-metadata.test.ts pins this invariant.
   "@elizaos/plugin-native-filesystem",
-  "@elizaos/plugin-scheduling",
   "@elizaos/plugin-inbox",
   "@elizaos/plugin-app-control",
   "@elizaos/plugin-notes",

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -48,6 +48,7 @@ import {
 } from "@elizaos/plugin-health";
 import { inboxPlugin } from "@elizaos/plugin-inbox/plugin";
 import { remindersPlugin } from "@elizaos/plugin-reminders";
+import { waitForScheduledTaskRunnerService } from "@elizaos/plugin-scheduling";
 import { XDmAdapter } from "@elizaos/plugin-x/lifeops-message-adapter";
 import type {
   IPermissionsRegistry,
@@ -1141,6 +1142,7 @@ const rawPersonalAssistantPlugin: Plugin = {
         prefix: "[lifeops]",
         label: "deferred message reconciliation",
         ensure: async () => {
+          await waitForScheduledTaskRunnerService(runtime);
           await reconcileInterruptedMessageDraftDispatches(runtime);
         },
       });
@@ -1174,6 +1176,7 @@ const rawPersonalAssistantPlugin: Plugin = {
         prefix: "[lifeops]",
         label: "default-pack boot seed",
         ensure: async () => {
+          await waitForScheduledTaskRunnerService(runtime);
           const runner = getProductionScheduledTaskRunner(runtime, {
             agentId: runtime.agentId,
           });
@@ -1264,10 +1267,7 @@ export {
   stopAppBlock,
 } from "@elizaos/plugin-blocker/services/app-blocker/index";
 export { workThreadAction } from "./actions/work-thread.js";
-export type {
-  OverdueDigest,
-  OverdueFollowup,
-} from "./followup/index.js";
+export type { OverdueDigest, OverdueFollowup } from "./followup/index.js";
 export {
   computeOverdueFollowups,
   FOLLOWUP_DEFAULT_THRESHOLD_DAYS,


### PR DESCRIPTION
Fixes #21735.

## Summary

- promote `@elizaos/plugin-scheduling` into the blocking readiness phase;
- register blocking core plugins before runtime initialization in both deferred-import modes;
- wait for the scheduling runner before Personal Assistant reconciliation and default-pack jobs;
- fail startup closed if required scheduling resolution or registration fails;
- skip already registered runtime plugins so scheduling remains exact-once across later waves.

## Exact revision

- Base: `a4789f06508a9d8d2699bf6606b63ad23572887f`
- Head: `a8226c9aedf618daa4250688a10cc5f0cbe1cc18`
- Tree: `de8509c40e0f3a34f41f8dcc6c4489086acc106e`
- Rebase: clean; intervening develop changes were confined to app, app-core, cloud, and workflow paths.

## Verification

Executed at the exact head with network access and common credential stores denied:

```text
bun test eliza-blocking-core-boot.test.ts eliza-deferred-plugin-boot-order.test.ts
9 pass, 0 fail, 40 assertions
Biome: 8 changed TypeScript files checked, no fixes
git diff --check origin/develop...HEAD: clean
```

The deterministic production-seam harness covers both `blockDeferredPluginImports` values, exact-once scheduling registration across a repeated wave, runner declaration before the modeled Personal Assistant start boundary, and fatal rejection before initialization on injected required-plugin failure. The prior source-order tests remain as drift guards.

The package-wide TypeScript gate was attempted but could not complete in the sparse isolated checkout because unrelated workspace packages such as `@elizaos/vault`, provider plugins, and optional app plugins were intentionally not hydrated. Filtering the compiler output after repairing the test fixture showed no diagnostics in the new boot module or its tests. Root `bun run verify` was not run.

No provider, connector, deployment, staging, or production operation was performed.

## Evidence Gate

<!-- evidence-head:a8226c9aedf618daa4250688a10cc5f0cbe1cc18 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend startup ordering only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend startup ordering only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic host-startup behavior has no visual interaction.
<!-- evidence-row:backend-logs -->
- [x] Exact-head denied-sandbox transcript:

<details><summary>Focused startup gates</summary>

```text
blocking core boot: both deferred-import modes register scheduling exactly once before initialization
required scheduling registration failure: fatal boot rejection before Personal Assistant startup
combined focused result: 9 pass, 0 fail, 40 assertions; Biome and diff-check clean
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, or inference path changed.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic startup-order artifact:

<details><summary>Boot contract assertions</summary>

```text
mode false: scheduling service declaration precedes the Personal Assistant initialization boundary
mode true: blocking environment joins first, then scheduling precedes Personal Assistant initialization
repeat/failure: later wave preserves one registration; required registration rejection prevents initialization
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface or visual artifact changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [nubscarson-pr21698-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza"} -->
