### PR TITLE
test(shared): add unit test suite for documents-upload-image utilities

### DIFF
--- a/packages/shared/src/utils/documents-upload-image.test.ts
+++ b/packages/shared/src/utils/documents-upload-image.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for document image upload utilities in packages/shared/src/utils/documents-upload-image.ts.
+ * Exercises MIME type and file extension detection, processing size thresholds, and image compression bypass paths.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type DocumentImageCompressionPlatform,
+  type DocumentImageUploadFile,
+  isDocumentImageFile,
+  MAX_DOCUMENT_IMAGE_PROCESSING_BYTES,
+  maybeCompressDocumentUploadImage,
+} from "./documents-upload-image.js";
+
+describe("documents-upload-image utilities", () => {
+  describe("isDocumentImageFile", () => {
+    it("identifies image files by MIME type", () => {
+      expect(
+        isDocumentImageFile({ name: "document.bin", type: "image/png" }),
+      ).toBe(true);
+      expect(
+        isDocumentImageFile({ name: "upload.dat", type: "image/jpeg" }),
+      ).toBe(true);
+      expect(
+        isDocumentImageFile({ name: "picture.dat", type: "image/webp" }),
+      ).toBe(true);
+      expect(
+        isDocumentImageFile({ name: "graphic.dat", type: "image/gif" }),
+      ).toBe(true);
+    });
+
+    it("identifies image files by extension when MIME type is generic or empty", () => {
+      expect(
+        isDocumentImageFile({
+          name: "screenshot.png",
+          type: "application/octet-stream",
+        }),
+      ).toBe(true);
+      expect(isDocumentImageFile({ name: "photo.jpg", type: "" })).toBe(true);
+      expect(isDocumentImageFile({ name: "photo.JPEG", type: "" })).toBe(true);
+      expect(isDocumentImageFile({ name: "graphic.webp", type: "" })).toBe(
+        true,
+      );
+      expect(isDocumentImageFile({ name: "animation.gif", type: "" })).toBe(
+        true,
+      );
+    });
+
+    it("returns false for non-image files", () => {
+      expect(
+        isDocumentImageFile({
+          name: "contract.pdf",
+          type: "application/pdf",
+        }),
+      ).toBe(false);
+      expect(
+        isDocumentImageFile({ name: "notes.txt", type: "text/plain" }),
+      ).toBe(false);
+      expect(
+        isDocumentImageFile({
+          name: "archive.zip",
+          type: "application/zip",
+        }),
+      ).toBe(false);
+      expect(
+        isDocumentImageFile({
+          name: "spreadsheet.xlsx",
+          type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("MAX_DOCUMENT_IMAGE_PROCESSING_BYTES", () => {
+    it("exports the 5MB processing threshold (5,242,880 bytes)", () => {
+      expect(MAX_DOCUMENT_IMAGE_PROCESSING_BYTES).toBe(5 * 1024 * 1024);
+    });
+  });
+
+  describe("maybeCompressDocumentUploadImage", () => {
+    it("skips non-image files without attempting compression", async () => {
+      const nonImageFile = new File(["dummy pdf content"], "doc.pdf", {
+        type: "application/pdf",
+      }) as DocumentImageUploadFile;
+
+      const result = await maybeCompressDocumentUploadImage(nonImageFile);
+      expect(result.optimized).toBe(false);
+      expect(result.file).toBe(nonImageFile);
+      expect(result.originalSize).toBe(nonImageFile.size);
+      expect(result.optimizedSize).toBe(nonImageFile.size);
+    });
+
+    it("skips images within size threshold", async () => {
+      const smallImageFile = new File(["small image data"], "image.png", {
+        type: "image/png",
+      }) as DocumentImageUploadFile;
+
+      const result = await maybeCompressDocumentUploadImage(smallImageFile);
+      expect(result.optimized).toBe(false);
+      expect(result.file).toBe(smallImageFile);
+    });
+
+    it("returns unoptimized when compression platform is unavailable", async () => {
+      const mockPlatform: DocumentImageCompressionPlatform = {
+        isAvailable: () => false,
+        loadImageSource: async () => ({
+          source: {} as CanvasImageSource,
+          width: 3000,
+          height: 2000,
+        }),
+        renderBlob: async () => new Blob(["compressed"]),
+      };
+
+      const largeImageBytes = new Uint8Array(
+        MAX_DOCUMENT_IMAGE_PROCESSING_BYTES + 1024,
+      );
+      const largeImageFile = new File([largeImageBytes], "large.jpg", {
+        type: "image/jpeg",
+      }) as DocumentImageUploadFile;
+
+      const result = await maybeCompressDocumentUploadImage(
+        largeImageFile,
+        mockPlatform,
+      );
+      expect(result.optimized).toBe(false);
+      expect(result.file).toBe(largeImageFile);
+    });
+  });
+});


### PR DESCRIPTION
# Relates to

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

Closes #21223.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds a unit test file `packages/shared/src/utils/documents-upload-image.test.ts` verifying existing `isDocumentImageFile`, `MAX_DOCUMENT_IMAGE_PROCESSING_BYTES`, and `maybeCompressDocumentUploadImage` behavior using standard `File` descriptors without modifying production runtime code.

# Background

## What does this PR do?

Adds a dedicated unit test suite for document image upload preparation helpers in `packages/shared/src/utils/documents-upload-image.test.ts`.

Addresses maintainer review feedback on #21226:
- Does not modify production code with loose type-guards that hide invalid producers or route corrupted objects deeper into file handlers.
- Validates canonical `File` / descriptor behavior: MIME type detection (`image/*`), fallback extension matching (`.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`), rejection of non-image types (`.pdf`, `.txt`, `.zip`, `.xlsx`), processing threshold constants, and compression bypass paths.

## What kind of change is this?

Improvements (unit test suite for shared document image upload utility)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/utils/documents-upload-image.test.ts`.

## Detailed testing steps

Run:
```bash
bun run --cwd packages/shared test src/utils/documents-upload-image.test.ts
```

# Evidence Gate

<!-- evidence-head:d869224e7aa24351eaf4e09d8a671a9dea1cc627 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - shared document image utility unit tests; no UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - shared document image utility unit tests; no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - shared document image utility unit tests; no UI changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - unit test only; no backend process modified.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend UI changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, wallet, memory, or artifact output.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI.

# Evidence Details

## Unit test transcript

```text
$ bun run --cwd packages/shared test src/utils/documents-upload-image.test.ts
$ node ../scripts/run-vitest.mjs run --config ./vitest.config.ts src/utils/documents-upload-image.test.ts

 RUN  v4.1.5 /home/deepanshu/os/eliza/packages/shared

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  09:04:25
   Duration  273ms (transform 90ms, setup 98ms, import 31ms, tests 19ms, environment 0ms)
```

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza"} -->
