### PR TITLE
test(shared): add unit test suite for eliza-cloud-model-route utilities

### DIFF
--- a/packages/shared/src/utils/eliza-cloud-model-route.test.ts
+++ b/packages/shared/src/utils/eliza-cloud-model-route.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for Eliza Cloud hosted model route classification in packages/shared/src/utils/eliza-cloud-model-route.ts.
+ * Exercises heuristic detection for Kimi, Moonshot, and Eliza Cloud combined route model identifiers.
+ */
+import { describe, expect, it } from "vitest";
+import { modelLooksLikeElizaCloudHosted } from "./eliza-cloud-model-route.js";
+
+describe("eliza-cloud-model-route utilities", () => {
+  describe("modelLooksLikeElizaCloudHosted", () => {
+    it("returns true for Kimi model identifiers", () => {
+      expect(modelLooksLikeElizaCloudHosted("kimi-k1.5")).toBe(true);
+      expect(modelLooksLikeElizaCloudHosted("moonshot-kimi-preview")).toBe(
+        true,
+      );
+      expect(modelLooksLikeElizaCloudHosted("KIMI-CHAT")).toBe(true);
+    });
+
+    it("returns true for Moonshot model identifiers", () => {
+      expect(modelLooksLikeElizaCloudHosted("moonshot-v1-8k")).toBe(true);
+      expect(modelLooksLikeElizaCloudHosted("moonshot-v1-32k")).toBe(true);
+      expect(modelLooksLikeElizaCloudHosted("MOONSHOT-V1-128K")).toBe(true);
+    });
+
+    it("returns true for models containing both 'eliza' and 'cloud'", () => {
+      expect(modelLooksLikeElizaCloudHosted("eliza-cloud-gpt-4o")).toBe(true);
+      expect(modelLooksLikeElizaCloudHosted("cloud/eliza-1-fast")).toBe(true);
+      expect(modelLooksLikeElizaCloudHosted("ELIZA_CLOUD_DEFAULT")).toBe(true);
+    });
+
+    it("returns false for models containing only 'eliza' or only 'cloud'", () => {
+      expect(modelLooksLikeElizaCloudHosted("eliza-local-1")).toBe(false);
+      expect(modelLooksLikeElizaCloudHosted("google-cloud-vertex")).toBe(false);
+      expect(modelLooksLikeElizaCloudHosted("cloudflare-workers-ai")).toBe(
+        false,
+      );
+    });
+
+    it("returns false for external third-party model identifiers", () => {
+      expect(modelLooksLikeElizaCloudHosted("gpt-4o")).toBe(false);
+      expect(modelLooksLikeElizaCloudHosted("claude-3-5-sonnet")).toBe(false);
+      expect(modelLooksLikeElizaCloudHosted("meta-llama-3-8b")).toBe(false);
+    });
+
+    it("returns false for empty or undefined inputs", () => {
+      expect(modelLooksLikeElizaCloudHosted("")).toBe(false);
+      expect(modelLooksLikeElizaCloudHosted(undefined)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
# Relates to

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

Closes #21218.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds a unit test file `packages/shared/src/utils/eliza-cloud-model-route.test.ts` verifying existing `modelLooksLikeElizaCloudHosted` heuristics without mutating runtime code.

# Background

## What does this PR do?

Adds a dedicated unit test suite for Eliza Cloud hosted model route classification in `packages/shared/src/utils/eliza-cloud-model-route.test.ts`.

Addresses maintainer review feedback on #21221:
- Does not modify production code with redundant `.trim()` or speculative type-widening on substring-based classifiers.
- Tests existing heuristic classification across Kimi, Moonshot, combined Eliza+Cloud model names, single-keyword non-hosted names, third-party models, and empty/undefined inputs.

## What kind of change is this?

Improvements (unit test suite for shared eliza-cloud-model-route utility)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/utils/eliza-cloud-model-route.test.ts`.

## Detailed testing steps

Run:
```bash
bun run --cwd packages/shared test src/utils/eliza-cloud-model-route.test.ts
```

# Evidence Gate

<!-- evidence-head:d213fcce6b38abe1ca78fb6a6459005abe5ba4df -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - shared model route classifier unit tests; no UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - shared model route classifier unit tests; no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - shared model route classifier unit tests; no UI changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - unit test only; no backend process modified.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend UI changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, wallet, memory, or artifact output.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI.

# Evidence Details

## Unit test transcript

```text
$ bun run --cwd packages/shared test src/utils/eliza-cloud-model-route.test.ts
$ node ../scripts/run-vitest.mjs run --config ./vitest.config.ts src/utils/eliza-cloud-model-route.test.ts

 RUN  v4.1.5 /home/deepanshu/os/eliza/packages/shared

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  09:06:24
   Duration  261ms (transform 89ms, setup 105ms, import 22ms, tests 7ms, environment 0ms)
```

---
AI assistance: yes
AI provider/model: Google / gemini-3.7-flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [agent-lane]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@79949c086f68c347f42d2a4c143926cb12b55f13:packages/skills/skills/contribute-to-eliza"} -->
