### PR TITLE
fix(cloud): gate provisioning-worker deploy on same-SHA migrations

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -120,15 +120,14 @@ jobs:
       cancel-in-progress: false
       queue: max
     environment: ${{ needs.determine-env.outputs.environment }}
-    # The three bounded remote phases (5m prerequisites, 40m deploy including
-    # a possible wait for an orphaned prior SSH process, 5m health) can each
-    # use their ceiling without the enclosing job becoming the first timeout;
-    # the remaining five minutes cover action startup and teardown.
-    timeout-minutes: 55
+    # Every pre-SSH step has its own fence (38m worst case total). The three
+    # bounded remote phases (5m prerequisites, 40m deploy including a possible
+    # wait for an orphaned prior SSH process, 5m health) can then each use their
+    # ceiling without the enclosing job becoming the first timeout; the
+    # remaining seven minutes cover action startup and teardown.
+    timeout-minutes: 95
     env:
       SYSTEMD_UNIT: eliza-provisioning-worker.service
-      DEPLOY_HOST: ${{ secrets.ELIZA_PROVISIONING_HOST }}
-      DEPLOY_SSH_KEY: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
       DEPLOY_BRANCH: ${{ needs.determine-env.outputs.branch }}
       DEPLOY_SHA: ${{ needs.determine-env.outputs.deployment_sha }}
       # Headscale wiring for the provisioning worker (the CONSUMER of the
@@ -138,17 +137,14 @@ jobs:
       # the protected environment below and stays loopback-only; it is not an
       # operator variable that can redirect the protected bearer key.
       HEADSCALE_PUBLIC_URL: ${{ vars.HEADSCALE_PUBLIC_URL }}
-      HEADSCALE_API_KEY: ${{ secrets.HEADSCALE_API_KEY }}
       # Base64 private key used by the daemon to reach dedicated-agent nodes.
       # Keep this in the protected environment instead of relying on a
       # hand-copied file that can drift or disappear when the CP host is rebuilt.
-      CONTAINERS_SSH_KEY: ${{ secrets.CONTAINERS_SSH_KEY }}
       # Sandbox-registry Redis (TCP redis:// proxy, sandbox-reachable — never a
       # *.railway.internal host) so provisioned sandboxes self-register and
       # Discord/Telegram inbound routing works (#8621 / #8756). Reconciled into
       # /opt/eliza/cloud/.env.local the same way as HEADSCALE_*. This integration
       # remains optional and skip-empty preserves a hand-set value when absent.
-      SANDBOX_REGISTRY_REDIS_URL: ${{ secrets.SANDBOX_REGISTRY_REDIS_URL }}
       # Cloud database DSN for the provisioning worker + agent router. Same
       # fallback chain as the migrator jobs (cloud-cf-deploy.yml /
       # cloud deployment) so the CP daemon always resolves the exact
@@ -157,14 +153,12 @@ jobs:
       # the CP silently kept polling the abandoned Neon DB for 3 weeks
       # (#15160). The deploy preflight now rejects an absent value before SSH;
       # the host can no longer silently preserve a stale hand-set database.
-      DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
       # Field-encryption root secret used to unwrap per-org DEKs for encrypted
       # agent environment variables. Must match the Cloudflare Worker secret:
       # the Worker writes encrypted env vars, and this provisioning worker
       # decrypts them while creating the agent container (#15385). Cloudflare
       # never reveals an existing value, so an absent GitHub secret preserves the
       # host value; the remote preflight verifies only that the name is populated.
-      SECRETS_MASTER_KEY: ${{ secrets.SECRETS_MASTER_KEY }}
       # Operator pin for the canonical managed-agent image
       # (containersEnv.defaultAgentImageOverride; falls back to
       # ghcr.io/elizaos/eliza:stable when unset everywhere). This pin decides
@@ -198,8 +192,13 @@ jobs:
     steps:
       - name: Validate canonical deploy configuration and shared secrets
         id: deploy_config
+        timeout-minutes: 2
         env:
           TARGET_ENVIRONMENT: ${{ needs.determine-env.outputs.environment }}
+          DEPLOY_HOST: ${{ secrets.ELIZA_PROVISIONING_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
+          HEADSCALE_API_KEY: ${{ secrets.HEADSCALE_API_KEY }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
         run: |
           set -euo pipefail
 
@@ -257,13 +256,90 @@ jobs:
           echo "HEADSCALE_API_URL=$resolved_headscale_api_url" >> "$GITHUB_ENV"
           echo "configured=true" >> "$GITHUB_OUTPUT"
 
+      # This deploy workflow runs independently of Cloud CF. Bind every worker
+      # activation to the canonical migration runner from the exact immutable
+      # deployment snapshot before the first SSH mutation. A failed install,
+      # missing protected DSN, invalid ledger, or failed migration stops here
+      # while the currently running host checkout and daemons remain untouched.
+      - name: Checkout exact deployment source for migration gate
+        if: steps.deploy_config.outputs.configured == 'true'
+        timeout-minutes: 5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ needs.determine-env.outputs.deployment_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact migration source
+        if: steps.deploy_config.outputs.configured == 'true'
+        timeout-minutes: 1
+        env:
+          EXPECTED_DEPLOY_SHA: ${{ needs.determine-env.outputs.deployment_sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          [ "$actual_sha" = "$EXPECTED_DEPLOY_SHA" ] || {
+            echo "::error::Migration checkout resolved $actual_sha, expected $EXPECTED_DEPLOY_SHA"
+            exit 1
+          }
+          [ -z "$(git status --porcelain)" ] || {
+            echo "::error::Migration checkout is not clean"
+            exit 1
+          }
+
+      - name: Setup Node for migration gate
+        if: steps.deploy_config.outputs.configured == 'true'
+        timeout-minutes: 5
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup Bun for migration gate
+        if: steps.deploy_config.outputs.configured == 'true'
+        timeout-minutes: 5
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install exact migration dependencies
+        if: steps.deploy_config.outputs.configured == 'true'
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if [ "$attempt" -eq 3 ]; then
+              bun install --frozen-lockfile --no-save --ignore-scripts --verbose && exit 0
+            else
+              bun install --frozen-lockfile --no-save --ignore-scripts && exit 0
+            fi
+            echo "bun install attempt $attempt failed; retrying in 10s..."
+            sleep 10
+          done
+          exit 1
+
+      - name: Run exact-SHA canonical database migrations
+        if: steps.deploy_config.outputs.configured == 'true'
+        timeout-minutes: 10
+        env:
+          # Resolve only from the already-selected protected environment. The
+          # value is passed directly to the migrator and is never printed.
+          DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          [ -n "${DATABASE_URL//[[:space:]]/}" ] || {
+            echo "::error::Protected DATABASE_URL is required before provisioning-worker deploy"
+            exit 1
+          }
+          node packages/shared/scripts/generate-keywords.mjs
+          bun run db:cloud:migrate
+
       - name: Ensure host prereqs (Node 24, swap, bunx symlink)
         if: steps.deploy_config.outputs.configured == 'true'
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
         with:
-          host: ${{ env.DEPLOY_HOST }}
+          host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
           username: deploy
-          key: ${{ env.DEPLOY_SSH_KEY }}
+          key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
           command_timeout: 5m
           script: |
             set -euo pipefail
@@ -302,11 +378,17 @@ jobs:
 
       - name: Deploy and restart worker
         if: steps.deploy_config.outputs.configured == 'true'
+        env:
+          HEADSCALE_API_KEY: ${{ secrets.HEADSCALE_API_KEY }}
+          CONTAINERS_SSH_KEY: ${{ secrets.CONTAINERS_SSH_KEY }}
+          SANDBOX_REGISTRY_REDIS_URL: ${{ secrets.SANDBOX_REGISTRY_REDIS_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
+          SECRETS_MASTER_KEY: ${{ secrets.SECRETS_MASTER_KEY }}
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
         with:
-          host: ${{ env.DEPLOY_HOST }}
+          host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
           username: deploy
-          key: ${{ env.DEPLOY_SSH_KEY }}
+          key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
           # Preserve setup/build headroom plus one prior deploy's bounded lock
           # wait without weakening the preflight's own eight-minute fail-closed
           # fence near the end of this remote script.
@@ -606,9 +688,9 @@ jobs:
         if: steps.deploy_config.outputs.configured == 'true'
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
         with:
-          host: ${{ env.DEPLOY_HOST }}
+          host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
           username: deploy
-          key: ${{ env.DEPLOY_SSH_KEY }}
+          key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
           command_timeout: 5m
           envs: SYSTEMD_UNIT,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST
           script: |

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -19,6 +19,31 @@ const services = [
   ),
 ];
 
+interface WorkflowStep {
+  env?: Record<string, string>;
+  name?: string;
+  "timeout-minutes"?: number;
+  uses?: string;
+  with?: Record<string, string>;
+}
+
+interface WorkflowJob {
+  env?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+
+const parsedWorkflow = Bun.YAML.parse(workflow) as {
+  jobs?: Record<string, WorkflowJob>;
+};
+
+function deployStep(name: string): WorkflowStep {
+  const found = parsedWorkflow.jobs?.deploy?.steps?.find(
+    (candidate) => candidate.name === name,
+  );
+  if (!found) throw new Error(`Missing deploy step: ${name}`);
+  return found;
+}
+
 describe("provisioning worker deployment contract", () => {
   it("routes both jobs only to the healthy Hetzner fleet", () => {
     expect(
@@ -60,6 +85,144 @@ describe("provisioning worker deployment contract", () => {
     );
   });
 
+  it("runs canonical migrations from the exact SHA before any SSH mutation", () => {
+    const checkout = workflow.indexOf(
+      "- name: Checkout exact deployment source for migration gate",
+    );
+    const verify = workflow.indexOf("- name: Verify exact migration source");
+    const migration = workflow.indexOf(
+      "- name: Run exact-SHA canonical database migrations",
+    );
+    const firstSsh = workflow.indexOf(
+      "- name: Ensure host prereqs (Node 24, swap, bunx symlink)",
+    );
+    const restart = workflow.indexOf('sudo systemctl restart "$SYSTEMD_UNIT"');
+
+    expect(checkout).toBeGreaterThan(-1);
+    expect(verify).toBeGreaterThan(checkout);
+    expect(migration).toBeGreaterThan(verify);
+    expect(firstSsh).toBeGreaterThan(migration);
+    expect(restart).toBeGreaterThan(firstSsh);
+    expect(workflow).toContain(
+      "ref: $" + "{{ needs.determine-env.outputs.deployment_sha }}",
+    );
+    expect(workflow).toContain(
+      "EXPECTED_DEPLOY_SHA: $" +
+        "{{ needs.determine-env.outputs.deployment_sha }}",
+    );
+    expect(workflow).toContain(
+      '[ "$actual_sha" = "$EXPECTED_DEPLOY_SHA" ] || {',
+    );
+    expect(workflow).toContain("bun run db:cloud:migrate");
+  });
+
+  it("fails closed on missing protected DB authority and uses the pinned toolchain", () => {
+    const migrationGate = workflow.slice(
+      workflow.indexOf(
+        "- name: Checkout exact deployment source for migration gate",
+      ),
+      workflow.indexOf(
+        "- name: Ensure host prereqs (Node 24, swap, bunx symlink)",
+      ),
+    );
+
+    expect(migrationGate).toContain(
+      "Protected DATABASE_URL is required before provisioning-worker deploy",
+    );
+    expect(migrationGate).toContain('node-version: "24.15.0"');
+    expect(migrationGate).toContain('bun-version: "1.3.14"');
+    expect(migrationGate).toContain(
+      "bun install --frozen-lockfile --no-save --ignore-scripts",
+    );
+    expect(workflow).toContain("timeout-minutes: 95");
+  });
+
+  it("scopes protected values away from checkout, setup, and install actions", () => {
+    const secretNames = [
+      "DEPLOY_HOST",
+      "DEPLOY_SSH_KEY",
+      "HEADSCALE_API_KEY",
+      "CONTAINERS_SSH_KEY",
+      "SANDBOX_REGISTRY_REDIS_URL",
+      "DATABASE_URL",
+      "SECRETS_MASTER_KEY",
+    ];
+    const deployJob = parsedWorkflow.jobs?.deploy;
+    expect(deployJob).toBeDefined();
+    for (const name of secretNames) {
+      expect(deployJob?.env?.[name]).toBeUndefined();
+    }
+
+    for (const name of [
+      "Checkout exact deployment source for migration gate",
+      "Verify exact migration source",
+      "Setup Node for migration gate",
+      "Setup Bun for migration gate",
+      "Install exact migration dependencies",
+    ]) {
+      const step = deployStep(name);
+      for (const secretName of secretNames) {
+        expect(step.env?.[secretName]).toBeUndefined();
+      }
+    }
+
+    const migration = deployStep("Run exact-SHA canonical database migrations");
+    expect(Object.keys(migration.env ?? {})).toEqual(["DATABASE_URL"]);
+    expect(migration.env?.DATABASE_URL).toContain("secrets.DATABASE_URL");
+    expect(migration.env?.DATABASE_URL).not.toContain("env.DATABASE_URL");
+
+    const validate = deployStep(
+      "Validate canonical deploy configuration and shared secrets",
+    );
+    for (const name of [
+      "DEPLOY_HOST",
+      "DEPLOY_SSH_KEY",
+      "HEADSCALE_API_KEY",
+      "DATABASE_URL",
+    ]) {
+      expect(validate.env?.[name]).toContain("secrets.");
+    }
+    expect(validate.env?.CONTAINERS_SSH_KEY).toBeUndefined();
+    expect(validate.env?.SECRETS_MASTER_KEY).toBeUndefined();
+
+    const remoteDeploy = deployStep("Deploy and restart worker");
+    for (const name of [
+      "HEADSCALE_API_KEY",
+      "CONTAINERS_SSH_KEY",
+      "SANDBOX_REGISTRY_REDIS_URL",
+      "DATABASE_URL",
+      "SECRETS_MASTER_KEY",
+    ]) {
+      expect(remoteDeploy.env?.[name]).toContain("secrets.");
+    }
+    expect(remoteDeploy.env?.DEPLOY_SSH_KEY).toBeUndefined();
+    expect(remoteDeploy.with?.key).toContain(
+      "secrets.ELIZA_PROVISIONING_SSH_KEY",
+    );
+  });
+
+  it("bounds every pre-SSH step below the enclosing deployment fence", () => {
+    const expectedBounds = new Map<string, number>([
+      ["Validate canonical deploy configuration and shared secrets", 2],
+      ["Checkout exact deployment source for migration gate", 5],
+      ["Verify exact migration source", 1],
+      ["Setup Node for migration gate", 5],
+      ["Setup Bun for migration gate", 5],
+      ["Install exact migration dependencies", 10],
+      ["Run exact-SHA canonical database migrations", 10],
+    ]);
+    let totalPreSshMinutes = 0;
+    for (const [name, expectedMinutes] of expectedBounds) {
+      const bound = deployStep(name)["timeout-minutes"];
+      expect(bound).toBe(expectedMinutes);
+      totalPreSshMinutes += bound ?? 0;
+    }
+
+    expect(totalPreSshMinutes).toBe(38);
+    expect(workflow).toContain("timeout-minutes: 95");
+    expect(totalPreSshMinutes + 5 + 40 + 5).toBeLessThan(95);
+  });
+
   it("reports the resolved branch and immutable deployment SHA in both Discord receipts", () => {
     const receipt = [
       "description: |",
@@ -86,7 +249,7 @@ describe("provisioning worker deployment contract", () => {
       workflow.indexOf("cd /opt/eliza"),
     );
     expect(workflow).toContain("command_timeout: 40m");
-    expect(workflow).toContain("timeout-minutes: 55");
+    expect(workflow).toContain("timeout-minutes: 95");
   });
 
   it("regenerates before deploy and self-heals both services", () => {
@@ -107,7 +270,7 @@ describe("provisioning worker deployment contract", () => {
     // the GitHub environment VARIABLE through the SSH env passthrough into the
     // skip-empty EnvironmentFile reconcile loop.
     expect(workflow).toContain(
-      "WARM_POOL_ENABLED: ${{ vars.WARM_POOL_ENABLED }}",
+      "WARM_POOL_ENABLED: $" + "{{ vars.WARM_POOL_ENABLED }}",
     );
     expect(workflow).toMatch(/envs: [^\n]*\bWARM_POOL_ENABLED\b/);
     expect(workflow).toContain('"WARM_POOL_ENABLED=$WARM_POOL_ENABLED" \\');


### PR DESCRIPTION
# Relates to

Closes #21701

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`5a4604073bd7649a5e8a718a9c1615a193ada8fc`).
- [x] `bun install --frozen-lockfile --no-save --ignore-scripts` passed after sync.
- [x] A reviewer can confirm the ordering, secret boundary, and fail-closed contract from focused tests and static workflow validation below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `5a4604073bd7649a5e8a718a9c1615a193ada8fc`; zero conflicts.
- [ ] `bun run verify` passes post-sync. The exact unrelated local blocker is documented below.

# Risks

Medium deployment-workflow risk. This adds one frozen dependency install and canonical migration run to the already protected worker-deploy job. Every pre-SSH step has an explicit timeout (38 minutes total); the three existing remote phases retain 5/40/5-minute fences; the enclosing job is 95 minutes, leaving seven minutes of teardown/startup headroom. It prevents all SSH mutation until the exact-SHA migration succeeds. The migration runner already owns advisory locking and ledger validation. Staging and production keep their existing GitHub Environment selection, secrets, and concurrency contracts.

Protected values are no longer job-level environment variables. Checkout, setup, verification, and dependency installation inherit none. Validation receives only host/key/Headscale/DB names it validates; the migration step receives only the database authority; the remote deploy receives only its runtime secrets; SSH host/key are direct action inputs.

# Background

## What does this PR do?

The provisioning-worker deploy workflow runs independently of the canonical Cloud CF release. Its existing host startup preflight authenticates the migration-0194 job-interruption catalog only; it cannot detect later schema dependencies. A staging canary exposed that gap when worker code selecting migration-0236 columns restarted while the database ledger remained at 0235.

This change makes the protected deploy job:

1. check out its already-resolved immutable deployment SHA before any SSH action;
2. verify the checkout matches that SHA and is clean;
3. install with pinned Node 24.15.0, Bun 1.3.14, and the frozen lockfile without ambient deploy secrets;
4. run the canonical `bun run db:cloud:migrate` with only the selected protected environment's database authority; and
5. begin host prerequisites/deploy/restart only after that same-SHA migration succeeds.

Missing DB authority, install failure, ledger drift, migration failure, cancellation, or step timeout therefore leaves the currently running host checkout and daemons untouched. The catalog-specific systemd preflight remains as crash/reboot defense in depth.

## What kind of change is this?

Bug fix and deployment safety hardening.

# Documentation changes needed?

No product documentation change. The workflow comments and focused contract tests document the operational invariant in its authoritative location.

# Testing

## Where should a reviewer start?

- `.github/workflows/deploy-eliza-provisioning-worker.yml`
- `packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts`

## Detailed testing steps

```text
bun install --frozen-lockfile --no-save --ignore-scripts
# PASS

bun test packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
# 39 pass, 0 fail, 477 assertions

bunx biome check packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
# clean

actionlint .github/workflows/deploy-eliza-provisioning-worker.yml
# clean

bun -e 'import { parse } from "yaml"; const value=parse(await Bun.file(".github/workflows/deploy-eliza-provisioning-worker.yml").text()); if (!value?.jobs?.deploy) throw new Error("missing deploy job"); console.log("workflow yaml parsed")'
# workflow yaml parsed

git diff --check origin/develop...HEAD
# clean
```

# Evidence Gate

<!-- evidence-head:73b08adb7a1de587cb59d9d1dba9659240c59027 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - deployment workflow only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - deployment workflow only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - deployment workflow only; no rendered UI.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - source-only PR intentionally did not mutate a live protected database or host; deterministic workflow-contract output is included above.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, model, prompt, provider, or action behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no live database or infrastructure mutation was performed while preparing this source fix.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model/prompt/provider behavior change.

## Backend + frontend logs

N/A - the focused deterministic workflow-contract proof is included under Testing. Protected live execution belongs after maintainer review/merge.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

`bun run verify` reached 116/136 Turbo tasks before an unrelated host-local `@elizaos/capacitor-gateway#lint:check` failure: SourceKitten could not load `sourcekitdInProc.framework`. The changed workflow and test are outside that native package; their focused tests, Biome, actionlint, YAML parse, frozen install, and diff checks all pass on the exact current head.

# Deployment notes

After maintainer merge, the next protected staging worker deployment will run canonical migrations for its exact immutable SHA before the first SSH mutation. Do not self-approve or self-merge this PR. No production or staging operation was dispatched from this branch.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-worker-migration-gate]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza"} -->
