### PR TITLE
fix(plugin-x): reject negative values in safeParseInt

### DIFF
--- a/plugins/plugin-x/src/environment.test.ts
+++ b/plugins/plugin-x/src/environment.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression coverage for the negative-interval gap: `safeParseInt` only
+ * rejected `NaN`, so an operator-set negative TWITTER_POST_INTERVAL_MIN
+ * passed getRandomInterval's `minInterval < maxInterval` guard and produced a
+ * mostly-negative "interval" in minutes. post.ts feeds that value straight
+ * into `setTimeout(resolve, postIntervalMinutes * 60 * 1000)`; a negative
+ * delay collapses to (near) 0, defeating the posting-rate limiter and
+ * risking spam/ban on the connected account.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getRandomInterval } from "./environment";
+
+function makeRuntime(settings: Record<string, string>): IAgentRuntime {
+  return {
+    getSetting: (key: string) => settings[key],
+  } as unknown as IAgentRuntime;
+}
+
+describe("getRandomInterval", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("clamps a negative min interval instead of returning a negative delay", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const runtime = makeRuntime({
+      TWITTER_POST_INTERVAL_MIN: "-9999999",
+      TWITTER_POST_INTERVAL_MAX: "180",
+    });
+
+    const interval = getRandomInterval(runtime, "post");
+
+    // Negative min is clamped to 0 by safeParseInt, so the random draw lands
+    // in [0, 180] instead of [-9999999, 180]. Math.random() is mocked to
+    // 0.5, so the midpoint of the clamped range is exact.
+    expect(interval).toBe(90);
+    expect(interval).toBeGreaterThanOrEqual(0);
+  });
+
+  it("falls back to the fixed interval when min and max are both negative", () => {
+    const runtime = makeRuntime({
+      TWITTER_POST_INTERVAL_MIN: "-100",
+      TWITTER_POST_INTERVAL_MAX: "-50",
+      TWITTER_POST_INTERVAL: "120",
+    });
+
+    const interval = getRandomInterval(runtime, "post");
+
+    // Both bounds clamp to the 0 default, so minInterval < maxInterval is
+    // false (0 < 0) and the function falls through to the fixed interval
+    // instead of returning a negative or nonsensical value.
+    expect(interval).toBe(120);
+  });
+
+  it("still returns a normal random interval when min/max are valid", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const runtime = makeRuntime({
+      TWITTER_POST_INTERVAL_MIN: "90",
+      TWITTER_POST_INTERVAL_MAX: "180",
+    });
+
+    const interval = getRandomInterval(runtime, "post");
+
+    expect(interval).toBe(135);
+  });
+});

--- a/plugins/plugin-x/src/environment.ts
+++ b/plugins/plugin-x/src/environment.ts
@@ -76,11 +76,16 @@ export type TwitterConfig = z.infer<typeof twitterEnvSchema>;
 
 /**
  * Parse safe integer with a default value.
+ * Rejects negative values (falls back to defaultValue) alongside NaN: every
+ * caller feeds a count, length, or interval, none of which is ever valid
+ * negative, and a negative interval reaching getRandomInterval's
+ * min/max comparison would produce a near-zero/negative setTimeout delay,
+ * defeating a posting-rate limiter.
  */
 function safeParseInt(value: string | undefined, defaultValue: number): number {
   if (!value) return defaultValue;
   const parsed = parseInt(value, 10);
-  return Number.isNaN(parsed) ? defaultValue : parsed;
+  return Number.isNaN(parsed) || parsed < 0 ? defaultValue : parsed;
 }
 
 /**


### PR DESCRIPTION
# Relates to

Closes #21558.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` (`6090860`) with zero conflicts — `environment.ts`'s blob on `develop` was byte-identical to the one this branch started from, so the rebase is a clean fast-forward with no merge.
- [x] `bun install`, then the package-local `test`, `lint:check`, and `typecheck` scripts for `plugins/plugin-x` were run after sync (`bun run --cwd packages/core build` first, to produce the `@elizaos/core` `dist/` types the plugin's `tsconfig.json` resolves against).
- [x] A reviewer can confirm the change from the mutation-test evidence below without re-running anything.

# Contribution provenance

- AI assistance: `yes`
- Model(s) used: `anthropic/claude-sonnet-5`
- Agent tooling: `Claude Code`
- Skill path: `N/A - no contribution skill used (direct interactive session, not run via packages/skills/skills/contribute-to-eliza)`
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `6090860`; zero conflicts. The all-local edit/test/lint/typecheck/mutation-test cycle below ran against a fresh clone at `9d6273b5`; the branch was then rebased directly onto the latest `develop` tip via the GitHub Git Data API (see note below) after confirming byte-for-byte that `environment.ts` was unchanged between the two commits, so the tested diff and the final pushed diff are identical.
- [x] Package-local `test`, `lint:check`, `typecheck` pass post-sync (see Testing).

**Note on how this branch got pushed:** local `git push` to my fork stalled/timed out repeatedly in this sandbox for this repo's pack size (dozens of retries across 60s-10min bounds, including one explicit HTTP 408 from GitHub). Rather than land it stale, I built the exact same tree/commit (byte-identical blobs, verified against the local commit's blob SHAs) directly on top of the current `develop` tip using the GitHub Git Data API (`git/blobs`, `git/trees`, `git/commits`, `git/refs`) — small JSON calls, no large pack transfer. Said honestly so a reviewer isn't surprised the branch has no local push in its reflog.

# Risks

Low. Single-function change in `plugins/plugin-x/src/environment.ts`: `safeParseInt` now also rejects negative parsed integers (falls back to the caller's default), the same way it already rejects `NaN`. Every current call site feeds it a count, length, or interval — none of which is ever valid negative — so no legitimate input changes behavior. An operator who was previously (accidentally) relying on a negative `TWITTER_*` setting silently producing a near-zero-delay posting loop will now get the caller's documented default instead.

# Background

## What does this PR do?

Fixes a real validation gap: `safeParseInt` (`plugins/plugin-x/src/environment.ts`, ~line 80) only rejected `NaN`, not negative values. `getRandomInterval` (~line 519) parses `TWITTER_POST_INTERVAL_MIN`/`MAX` (and the engagement/discovery equivalents) through `safeParseInt` and only guards `minInterval < maxInterval` before computing `Math.random() * (maxInterval - minInterval) + minInterval`. An operator setting e.g. `TWITTER_POST_INTERVAL_MIN=-9999999` with a normal `TWITTER_POST_INTERVAL_MAX=180` still passes the `min < max` check, and `getRandomInterval` returns a value uniformly distributed across `[-9999999, 180]` — almost always deeply negative.

`plugins/plugin-x/src/post.ts` feeds that value straight into a timer with no further clamping:

```ts
const postIntervalMinutes = getRandomInterval(this.runtime, "post");
const interval = postIntervalMinutes * 60 * 1000;
await new Promise((resolve) => setTimeout(resolve, interval));
```

A negative `setTimeout` delay is clamped to ~0 by the JS runtime, so the posting loop fires essentially immediately instead of respecting the configured rate limit, defeating the whole point of the limiter (spam/ban risk on the connected X account).

The fix makes `safeParseInt` reject negative parsed values the same way it already rejects `NaN` — falling back to the caller-supplied default. This is the root-cause layer: it protects every `safeParseInt` call site uniformly (post/engagement/discovery intervals, `TWITTER_RETRY_LIMIT`, `TWITTER_MAX_TWEET_LENGTH`, `TWITTER_MAX_ENGAGEMENTS_PER_RUN`, `TWITTER_DM_POLL_INTERVAL_SECONDS`), all of which are likewise never valid negative, rather than special-casing only the interval min/max call sites.

`plugins/plugin-x/src/base.ts` is untouched — out of scope for this PR (separate work).

## What kind of change is this?

Bug fix (non-breaking). No public API/type signature changes.

# Documentation changes needed?

No. `safeParseInt` is an internal (non-exported) helper; its documented contract (parse to a safe integer or fall back to the default) is unchanged, just now actually enforced for negative input too.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/environment.ts` (the one-line guard change in `safeParseInt`, ~line 88) and the new `plugins/plugin-x/src/environment.test.ts`.

## Detailed testing steps

Automated tests are the reproduction. `plugins/plugin-x/src/environment.test.ts` covers `getRandomInterval` with a fake `IAgentRuntime` and a mocked `Math.random()` for determinism:

1. `TWITTER_POST_INTERVAL_MIN=-9999999`, `TWITTER_POST_INTERVAL_MAX=180` → fixed code clamps the negative min to `0` and returns `90` (the midpoint of `[0, 180]` with `Math.random()` mocked to `0.5`).
2. `TWITTER_POST_INTERVAL_MIN=-100`, `TWITTER_POST_INTERVAL_MAX=-50` → both clamp to the `0` default, `0 < 0` is false, so the function falls through to the fixed `TWITTER_POST_INTERVAL` default (`120`) instead of returning a negative/nonsensical value.
3. A normal `MIN=90`/`MAX=180` case is unaffected (`135` with `Math.random()` mocked to `0.5`), confirming the fix doesn't touch legitimate ranges.

### Mutation test (revert → confirm fail → restore → confirm pass)

Reverted just the `safeParseInt` guard back to `Number.isNaN(parsed) ? defaultValue : parsed` and re-ran the new test file against the unmodified rest of the codebase:

```
❯ src/environment.test.ts (3 tests | 2 failed) 29ms
 × clamps a negative min interval instead of returning a negative delay
   AssertionError: expected -4999909.5 to be 90
 × falls back to the fixed interval when min and max are both negative
   AssertionError: expected -69.42673754087319 to be 120
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

`-4999909.5` matches the hand-computed old-code value for `Math.random()=0.5` over `[-9999999, 180]` — i.e. the actual bug behavior, not a fabricated number. Restored the fix and re-ran:

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

### Full package gates (fixed code)

```
$ bun run --cwd plugins/plugin-x test
 Test Files  29 passed | 1 skipped (30)
      Tests  201 passed | 13 skipped (214)

$ bun run --cwd plugins/plugin-x lint:check
Checked 86 files in 407ms. No fixes applied.

$ bun run --cwd plugins/plugin-x typecheck
(clean, no output)
```

## Known gaps / failures

None. `bun run --cwd packages/core build` was required once before `typecheck` would resolve `@elizaos/core` (the plugin's `tsconfig.json` resolves the workspace package via its built `dist/index.d.ts`, which doesn't exist in a fresh, unbuilt checkout) — noted here since it's a real prerequisite step, not a blocker specific to this change.

# Evidence Gate

<!-- evidence-head:eeed037808402ebd96558d7ca2dc6a60650ae634 -->

- Before/after screenshots: N/A - backend interval-computation logic, no rendered UI surface.
- Walkthrough video: N/A - no UI/user flow involved.
- Backend logs: N/A - covered by the deterministic unit test and mutation-test evidence above instead of live logs.
- Frontend logs: N/A - no frontend involved.
- Real-LLM trajectory: N/A - no agent/action/prompt/model behavior changes.
- Domain artifacts: N/A - no DB/memory/wallet/on-chain/generated-file output; the test-run transcripts above are the artifact.
- OCR review: N/A - no rendered visual surface.

— [claude-code-interactive]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"N/A - no contribution skill used"} -->
