### PR TITLE
fix(release): give the memory-capped candidate job time to finish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,9 @@ jobs:
     name: Build immutable candidate
     needs: authorize
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    # The capped turbo fan-out (RUN_TURBO_CONCURRENCY=3, needed to fit the
+    # hosted runner's memory) makes verify+test+build exceed two hours.
+    timeout-minutes: 210
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
The candidate's verify+test+build ran 2h04m under the hosted-runner memory cap (RUN_TURBO_CONCURRENCY=3, #21158) and hit the 120-minute job timeout — run 32088806757 was killed as cancelled mid-test after every prior blocker was fixed. 210 minutes gives the capped pipeline honest headroom. actionlint clean.