### PR TITLE
fix(cloud): gate migrations on database identity

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -119,8 +119,9 @@ jobs:
         env:
           DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
           # Explicit activation boundary for #21594. `off` performs no query;
-          # `report` emits only SHA-256 receipts and never blocks; `enforce`
-          # fails closed against both protected nonsecret authority digests.
+          # `report` emits only SHA-256 receipts and never blocks (malformed
+          # prepared receipts stay unreviewed); `enforce` fails closed against
+          # both protected nonsecret authority digests.
           DATABASE_IDENTITY_GATE_MODE: ${{ vars.DATABASE_IDENTITY_GATE_MODE || 'off' }}
           DATABASE_IDENTITY_ENVIRONMENT: ${{ inputs.target_environment }}
           DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256 }}

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -118,6 +118,13 @@ jobs:
         if: ${{ steps.source_guard.outputs.superseded != 'true' }}
         env:
           DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
+          # Explicit activation boundary for #21594. `off` performs no query;
+          # `report` emits only SHA-256 receipts and never blocks; `enforce`
+          # fails closed against both protected nonsecret authority digests.
+          DATABASE_IDENTITY_GATE_MODE: ${{ vars.DATABASE_IDENTITY_GATE_MODE || 'off' }}
+          DATABASE_IDENTITY_ENVIRONMENT: ${{ inputs.target_environment }}
+          DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256 }}
+          DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256 }}
           CANONICAL_REF: ${{ inputs.target_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
           FORCE: ${{ inputs.force }}
         run: |
@@ -135,6 +142,7 @@ jobs:
             source_args+=(--force)
           fi
           node packages/cloud/scripts/canonical-deploy-source-guard.mjs "${source_args[@]}"
+          bun --conditions=eliza-source packages/cloud/scripts/admin/preflight-database-identity.ts
           bun run db:cloud:migrate
 
   # ---------------------------------------------------------------------------

--- a/packages/cloud/infra/cloud/RAILWAY.md
+++ b/packages/cloud/infra/cloud/RAILWAY.md
@@ -37,6 +37,29 @@ The `operator` service (Pepr Kubernetes operator) and the kind cluster under
 [`local/`](./local/) are **local development only** — nothing in production
 runs on Kubernetes.
 
+### Database identity activation boundary
+
+The migration job owns a read-only PostgreSQL identity preflight immediately
+before schema mutation. It hashes the physical PostgreSQL system identifier and
+the environment/cluster/role/database tuple; raw connection strings, hosts,
+roles, and database names are never written to logs. Protected environment
+variables control activation:
+
+- `DATABASE_IDENTITY_GATE_MODE=off` is the default and performs no query.
+- `report` emits nonsecret SHA-256 cluster and authority receipts without
+  blocking a release. Operators use this only to prepare and review a cutover.
+- `enforce` requires both `DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256` and
+  `DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256` and fails before migrations on
+  any mismatch.
+
+This gate proves only the GitHub migration authority. Do not enable `enforce`
+until an operator has provisioned an independent staging Railway PostgreSQL
+service, role, volume, backup/PITR policy, and restore drill, and has separately
+proved that the staging Hyperdrive origin produces the same reviewed identity.
+The repository cannot infer Railway service/volume or backup state from a
+PostgreSQL connection, and `report` mode is not evidence that those protected
+resources exist.
+
 Steward (the auth provider) runs **embedded in the Worker**: `bootstrap-app.ts`
 mounts the embedded handler at `/steward*`
 (`packages/cloud/api/src/steward/embedded.ts`); the `STEWARD_*` secrets in

--- a/packages/cloud/infra/cloud/RAILWAY.md
+++ b/packages/cloud/infra/cloud/RAILWAY.md
@@ -45,9 +45,12 @@ the environment/cluster/role/database tuple; raw connection strings, hosts,
 roles, and database names are never written to logs. Protected environment
 variables control activation:
 
-- `DATABASE_IDENTITY_GATE_MODE=off` is the default and performs no query.
+- `DATABASE_IDENTITY_GATE_MODE=off` is the default, performs no query, and
+  does not parse any prepared expected receipts.
 - `report` emits nonsecret SHA-256 cluster and authority receipts without
-  blocking a release. Operators use this only to prepare and review a cutover.
+  blocking a release. Malformed prepared receipts are ignored as unreviewed,
+  and connection or query failures produce only a sanitized warning. Operators
+  use this mode only to prepare and review a cutover.
 - `enforce` requires both `DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256` and
   `DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256` and fails before migrations on
   any mismatch.

--- a/packages/cloud/scripts/admin/preflight-database-identity.test.ts
+++ b/packages/cloud/scripts/admin/preflight-database-identity.test.ts
@@ -14,8 +14,12 @@ const row = {
   server_version_num: "180002",
 };
 
+let observedQuery = "";
 const client = {
-  query: async () => ({ rows: [row] }),
+  query: async (text: string) => {
+    observedQuery = text;
+    return { rows: [row] };
+  },
 };
 
 describe("database identity preflight", () => {
@@ -35,6 +39,9 @@ describe("database identity preflight", () => {
 
   test("emits stable hashes without raw database identity fields", async () => {
     const receipt = await readDatabaseIdentityReceipt(client, "staging");
+    expect(observedQuery).toContain("pg_catalog.pg_control_system()");
+    expect(observedQuery).toContain("pg_catalog.current_database()");
+    expect(observedQuery).toContain("pg_catalog.current_setting(");
     expect(receipt.postgresMajor).toBe(18);
     expect(receipt.clusterSha256).toMatch(/^[0-9a-f]{64}$/);
     expect(receipt.authoritySha256).toMatch(/^[0-9a-f]{64}$/);
@@ -84,6 +91,56 @@ describe("database identity preflight", () => {
     ).resolves.toMatchObject({ status: "reported", mismatches: [] });
   });
 
+  test("off mode ignores prepared digests without touching the database", async () => {
+    const config = readDatabaseIdentityConfig({
+      DATABASE_IDENTITY_ENVIRONMENT: "staging",
+      DATABASE_IDENTITY_GATE_MODE: "off",
+      DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: "not-a-digest",
+      DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256: "also-not-a-digest",
+    });
+    expect(config).toEqual({
+      environment: "staging",
+      mode: "off",
+      expectedClusterSha256: undefined,
+      expectedAuthoritySha256: undefined,
+    });
+    let queried = false;
+    await expect(
+      runDatabaseIdentityPreflight(config, {
+        query: async () => {
+          queried = true;
+          throw new Error("query must remain unreachable");
+        },
+      }),
+    ).resolves.toEqual({ status: "disabled", mismatches: [] });
+    expect(queried).toBe(false);
+  });
+
+  test("report mode ignores malformed expectations and sanitizes query failures", async () => {
+    const config = readDatabaseIdentityConfig({
+      DATABASE_IDENTITY_ENVIRONMENT: "staging",
+      DATABASE_IDENTITY_GATE_MODE: "report",
+      DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: "raw-cluster-identity",
+      DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256: "raw-authority-identity",
+    });
+    expect(config).toEqual({
+      environment: "staging",
+      mode: "report",
+      expectedClusterSha256: undefined,
+      expectedAuthoritySha256: undefined,
+      ignoredExpectedDigests: ["cluster", "authority"],
+    });
+    const result = await runDatabaseIdentityPreflight(config, {
+      query: async () => {
+        throw new Error(
+          "connection to raw-host as raw-role for raw-database failed",
+        );
+      },
+    });
+    expect(result).toEqual({ status: "unavailable", mismatches: [] });
+    expect(JSON.stringify(result)).not.toContain("raw-");
+  });
+
   test("enforce mode requires both authorities and fails closed on mismatch", async () => {
     expect(() =>
       readDatabaseIdentityConfig({
@@ -130,8 +187,9 @@ describe("database identity preflight", () => {
     expect(() =>
       readDatabaseIdentityConfig({
         DATABASE_IDENTITY_ENVIRONMENT: "staging",
-        DATABASE_IDENTITY_GATE_MODE: "report",
+        DATABASE_IDENTITY_GATE_MODE: "enforce",
         DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: "not-a-digest",
+        DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256: "1".repeat(64),
       }),
     ).toThrow("must be a lowercase SHA-256 digest");
   });

--- a/packages/cloud/scripts/admin/preflight-database-identity.test.ts
+++ b/packages/cloud/scripts/admin/preflight-database-identity.test.ts
@@ -1,0 +1,138 @@
+/** Verifies the deterministic, redacted PostgreSQL identity gate with a mocked query boundary. */
+
+import { describe, expect, test } from "bun:test";
+import {
+  readDatabaseIdentityConfig,
+  readDatabaseIdentityReceipt,
+  runDatabaseIdentityPreflight,
+} from "./preflight-database-identity";
+
+const row = {
+  system_identifier: "7432159876543210000",
+  database_name: "staging_database",
+  role_name: "staging_role",
+  server_version_num: "180002",
+};
+
+const client = {
+  query: async () => ({ rows: [row] }),
+};
+
+describe("database identity preflight", () => {
+  test("is inert by default and requires an explicit environment", () => {
+    expect(() => readDatabaseIdentityConfig({})).toThrow(
+      "DATABASE_IDENTITY_ENVIRONMENT must be staging or production",
+    );
+    expect(
+      readDatabaseIdentityConfig({ DATABASE_IDENTITY_ENVIRONMENT: "staging" }),
+    ).toEqual({
+      environment: "staging",
+      mode: "off",
+      expectedClusterSha256: undefined,
+      expectedAuthoritySha256: undefined,
+    });
+  });
+
+  test("emits stable hashes without raw database identity fields", async () => {
+    const receipt = await readDatabaseIdentityReceipt(client, "staging");
+    expect(receipt.postgresMajor).toBe(18);
+    expect(receipt.clusterSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(receipt.authoritySha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(receipt)).not.toContain(row.system_identifier);
+    expect(JSON.stringify(receipt)).not.toContain(row.database_name);
+    expect(JSON.stringify(receipt)).not.toContain(row.role_name);
+    expect(await readDatabaseIdentityReceipt(client, "staging")).toEqual(
+      receipt,
+    );
+    expect(
+      (await readDatabaseIdentityReceipt(client, "production")).authoritySha256,
+    ).not.toBe(receipt.authoritySha256);
+  });
+
+  test("report mode records mismatch classes without failing", async () => {
+    const result = await runDatabaseIdentityPreflight(
+      {
+        environment: "staging",
+        mode: "report",
+        expectedClusterSha256: "0".repeat(64),
+        expectedAuthoritySha256: "1".repeat(64),
+      },
+      client,
+    );
+    expect(result.status).toBe("mismatch");
+    expect(result.mismatches).toEqual(["cluster", "authority"]);
+  });
+
+  test("report mode never labels an unreviewed receipt as a match", async () => {
+    await expect(
+      runDatabaseIdentityPreflight(
+        { environment: "staging", mode: "report" },
+        client,
+      ),
+    ).resolves.toMatchObject({ status: "reported", mismatches: [] });
+
+    const receipt = await readDatabaseIdentityReceipt(client, "staging");
+    await expect(
+      runDatabaseIdentityPreflight(
+        {
+          environment: "staging",
+          mode: "report",
+          expectedClusterSha256: receipt.clusterSha256,
+        },
+        client,
+      ),
+    ).resolves.toMatchObject({ status: "reported", mismatches: [] });
+  });
+
+  test("enforce mode requires both authorities and fails closed on mismatch", async () => {
+    expect(() =>
+      readDatabaseIdentityConfig({
+        DATABASE_IDENTITY_ENVIRONMENT: "staging",
+        DATABASE_IDENTITY_GATE_MODE: "enforce",
+      }),
+    ).toThrow("requires both expected database identity SHA-256 digests");
+
+    await expect(
+      runDatabaseIdentityPreflight(
+        {
+          environment: "staging",
+          mode: "enforce",
+          expectedClusterSha256: "0".repeat(64),
+          expectedAuthoritySha256: "1".repeat(64),
+        },
+        client,
+      ),
+    ).rejects.toThrow("database identity mismatch: cluster,authority");
+  });
+
+  test("enforce mode accepts the exact cluster and authority receipts", async () => {
+    const receipt = await readDatabaseIdentityReceipt(client, "staging");
+    await expect(
+      runDatabaseIdentityPreflight(
+        {
+          environment: "staging",
+          mode: "enforce",
+          expectedClusterSha256: receipt.clusterSha256,
+          expectedAuthoritySha256: receipt.authoritySha256,
+        },
+        client,
+      ),
+    ).resolves.toMatchObject({ status: "match", mismatches: [] });
+  });
+
+  test("rejects malformed query rows and authority digests", async () => {
+    await expect(
+      readDatabaseIdentityReceipt(
+        { query: async () => ({ rows: [] }) },
+        "staging",
+      ),
+    ).rejects.toThrow("invalid row");
+    expect(() =>
+      readDatabaseIdentityConfig({
+        DATABASE_IDENTITY_ENVIRONMENT: "staging",
+        DATABASE_IDENTITY_GATE_MODE: "report",
+        DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: "not-a-digest",
+      }),
+    ).toThrow("must be a lowercase SHA-256 digest");
+  });
+});

--- a/packages/cloud/scripts/admin/preflight-database-identity.ts
+++ b/packages/cloud/scripts/admin/preflight-database-identity.ts
@@ -12,10 +12,10 @@ const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 const IDENTITY_QUERY = `
 SELECT
   control.system_identifier::text AS system_identifier,
-  current_database()::text AS database_name,
+  pg_catalog.current_database()::text AS database_name,
   current_user::text AS role_name,
-  current_setting('server_version_num')::text AS server_version_num
-FROM pg_control_system() AS control
+  pg_catalog.current_setting('server_version_num')::text AS server_version_num
+FROM pg_catalog.pg_control_system() AS control
 `;
 
 export type DatabaseIdentityGateMode = "off" | "report" | "enforce";
@@ -24,6 +24,7 @@ export interface DatabaseIdentityConfig {
   environment: "staging" | "production";
   expectedAuthoritySha256?: string;
   expectedClusterSha256?: string;
+  ignoredExpectedDigests?: Array<"cluster" | "authority">;
   mode: DatabaseIdentityGateMode;
 }
 
@@ -49,7 +50,7 @@ export interface IdentityQueryClient {
 export interface IdentityPreflightResult {
   mismatches: Array<"cluster" | "authority">;
   receipt?: DatabaseIdentityReceipt;
-  status: "disabled" | "match" | "mismatch" | "reported";
+  status: "disabled" | "match" | "mismatch" | "reported" | "unavailable";
 }
 
 function readMode(value: string | undefined): DatabaseIdentityGateMode {
@@ -69,10 +70,12 @@ function readMode(value: string | undefined): DatabaseIdentityGateMode {
 function readOptionalDigest(
   value: string | undefined,
   name: string,
+  strict: boolean,
 ): string | undefined {
   const normalized = value?.trim().toLowerCase();
   if (!normalized) return undefined;
   if (!SHA256_PATTERN.test(normalized)) {
+    if (!strict) return undefined;
     throw new Error(`${name} must be a lowercase SHA-256 digest`);
   }
   return normalized;
@@ -92,16 +95,43 @@ export function readDatabaseIdentityConfig(
   }
   const config: DatabaseIdentityConfig = {
     environment: target,
+    expectedAuthoritySha256: undefined,
+    expectedClusterSha256: undefined,
     mode,
-    expectedClusterSha256: readOptionalDigest(
-      environment.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256,
-      "DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256",
-    ),
-    expectedAuthoritySha256: readOptionalDigest(
-      environment.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256,
-      "DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256",
-    ),
   };
+  // Off mode must remain inert even while operators prepare or rotate the
+  // protected expected receipts.
+  if (mode === "off") return config;
+
+  const strict = mode === "enforce";
+  config.expectedClusterSha256 = readOptionalDigest(
+    environment.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256,
+    "DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256",
+    strict,
+  );
+  config.expectedAuthoritySha256 = readOptionalDigest(
+    environment.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256,
+    "DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256",
+    strict,
+  );
+  if (mode === "report") {
+    const ignoredExpectedDigests: Array<"cluster" | "authority"> = [];
+    if (
+      environment.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256?.trim() &&
+      !config.expectedClusterSha256
+    ) {
+      ignoredExpectedDigests.push("cluster");
+    }
+    if (
+      environment.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256?.trim() &&
+      !config.expectedAuthoritySha256
+    ) {
+      ignoredExpectedDigests.push("authority");
+    }
+    if (ignoredExpectedDigests.length > 0) {
+      config.ignoredExpectedDigests = ignoredExpectedDigests;
+    }
+  }
   if (
     mode === "enforce" &&
     (!config.expectedClusterSha256 || !config.expectedAuthoritySha256)
@@ -182,7 +212,15 @@ export async function runDatabaseIdentityPreflight(
     throw new Error(
       "database identity client is required when the gate is active",
     );
-  const receipt = await readDatabaseIdentityReceipt(client, config.environment);
+  let receipt: DatabaseIdentityReceipt;
+  try {
+    receipt = await readDatabaseIdentityReceipt(client, config.environment);
+  } catch (error) {
+    if (config.mode === "report") {
+      return { status: "unavailable", mismatches: [] };
+    }
+    throw error;
+  }
   const mismatches: Array<"cluster" | "authority"> = [];
   if (
     config.expectedClusterSha256 &&
@@ -271,8 +309,9 @@ async function main(): Promise<void> {
       "DATABASE_URL is required when database identity enforcement is active",
     );
   }
-  const client = new Client(await clientConfig(databaseUrl));
+  let client: InstanceType<typeof Client> | undefined;
   try {
+    client = new Client(await clientConfig(databaseUrl));
     await client.connect();
     const result = await runDatabaseIdentityPreflight(config, client);
     const output = summary(result);
@@ -283,6 +322,16 @@ async function main(): Promise<void> {
     if (result.status === "mismatch" && config.mode === "report") {
       process.stdout.write(
         "::warning::database identity report differs from the protected authority\n",
+      );
+    }
+    if (result.status === "unavailable") {
+      process.stdout.write(
+        "::warning::database identity report unavailable; inspect protected operator logs\n",
+      );
+    }
+    if (config.ignoredExpectedDigests?.length) {
+      process.stdout.write(
+        "::warning::database identity report ignored malformed protected expected digest(s)\n",
       );
     }
   } catch (error) {
@@ -296,7 +345,7 @@ async function main(): Promise<void> {
     }
     throw error;
   } finally {
-    await client.end().catch(() => {
+    await client?.end().catch(() => {
       // error-policy:J6 teardown failure cannot replace the primary gate result.
       process.stderr.write(
         "[database-identity] warning: database client close failed\n",

--- a/packages/cloud/scripts/admin/preflight-database-identity.ts
+++ b/packages/cloud/scripts/admin/preflight-database-identity.ts
@@ -1,0 +1,315 @@
+/**
+ * Produces a redacted PostgreSQL identity receipt before Cloud migrations.
+ * The gate is inert by default and never changes database or provider state.
+ */
+
+import { createHash } from "node:crypto";
+import { appendFile } from "node:fs/promises";
+import pg, { type ClientConfig } from "pg";
+
+const { Client } = pg;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const IDENTITY_QUERY = `
+SELECT
+  control.system_identifier::text AS system_identifier,
+  current_database()::text AS database_name,
+  current_user::text AS role_name,
+  current_setting('server_version_num')::text AS server_version_num
+FROM pg_control_system() AS control
+`;
+
+export type DatabaseIdentityGateMode = "off" | "report" | "enforce";
+
+export interface DatabaseIdentityConfig {
+  environment: "staging" | "production";
+  expectedAuthoritySha256?: string;
+  expectedClusterSha256?: string;
+  mode: DatabaseIdentityGateMode;
+}
+
+interface DatabaseIdentityRow {
+  database_name: string;
+  role_name: string;
+  server_version_num: string;
+  system_identifier: string;
+}
+
+export interface DatabaseIdentityReceipt {
+  authoritySha256: string;
+  clusterSha256: string;
+  environment: "staging" | "production";
+  postgresMajor: number;
+  version: 1;
+}
+
+export interface IdentityQueryClient {
+  query(text: string): Promise<{ rows: unknown[] }>;
+}
+
+export interface IdentityPreflightResult {
+  mismatches: Array<"cluster" | "authority">;
+  receipt?: DatabaseIdentityReceipt;
+  status: "disabled" | "match" | "mismatch" | "reported";
+}
+
+function readMode(value: string | undefined): DatabaseIdentityGateMode {
+  const normalized = (value ?? "off").trim().toLowerCase();
+  if (
+    normalized === "off" ||
+    normalized === "report" ||
+    normalized === "enforce"
+  ) {
+    return normalized;
+  }
+  throw new Error(
+    "DATABASE_IDENTITY_GATE_MODE must be off, report, or enforce",
+  );
+}
+
+function readOptionalDigest(
+  value: string | undefined,
+  name: string,
+): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (!SHA256_PATTERN.test(normalized)) {
+    throw new Error(`${name} must be a lowercase SHA-256 digest`);
+  }
+  return normalized;
+}
+
+/** Reads the nonsecret identity authority and its explicit activation mode. */
+export function readDatabaseIdentityConfig(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): DatabaseIdentityConfig {
+  const mode = readMode(environment.DATABASE_IDENTITY_GATE_MODE);
+  const target =
+    environment.DATABASE_IDENTITY_ENVIRONMENT?.trim().toLowerCase();
+  if (target !== "staging" && target !== "production") {
+    throw new Error(
+      "DATABASE_IDENTITY_ENVIRONMENT must be staging or production",
+    );
+  }
+  const config: DatabaseIdentityConfig = {
+    environment: target,
+    mode,
+    expectedClusterSha256: readOptionalDigest(
+      environment.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256,
+      "DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256",
+    ),
+    expectedAuthoritySha256: readOptionalDigest(
+      environment.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256,
+      "DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256",
+    ),
+  };
+  if (
+    mode === "enforce" &&
+    (!config.expectedClusterSha256 || !config.expectedAuthoritySha256)
+  ) {
+    throw new Error(
+      "enforce mode requires both expected database identity SHA-256 digests",
+    );
+  }
+  return config;
+}
+
+function isIdentityRow(value: unknown): value is DatabaseIdentityRow {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "system_identifier" in value &&
+    typeof value.system_identifier === "string" &&
+    /^\d+$/.test(value.system_identifier) &&
+    "database_name" in value &&
+    typeof value.database_name === "string" &&
+    value.database_name.length > 0 &&
+    "role_name" in value &&
+    typeof value.role_name === "string" &&
+    value.role_name.length > 0 &&
+    "server_version_num" in value &&
+    typeof value.server_version_num === "string" &&
+    /^\d+$/.test(value.server_version_num)
+  );
+}
+
+function digest(parts: readonly string[]): string {
+  const hash = createHash("sha256");
+  for (const part of parts) {
+    hash.update(part, "utf8");
+    hash.update("\0", "utf8");
+  }
+  return hash.digest("hex");
+}
+
+/** Queries only stable, nonsecret PostgreSQL identity fields and hashes raw names. */
+export async function readDatabaseIdentityReceipt(
+  client: IdentityQueryClient,
+  environment: "staging" | "production",
+): Promise<DatabaseIdentityReceipt> {
+  const result = await client.query(IDENTITY_QUERY);
+  if (result.rows.length !== 1 || !isIdentityRow(result.rows[0])) {
+    throw new Error("database identity query returned an invalid row");
+  }
+  const row = result.rows[0];
+  const postgresMajor = Math.floor(Number(row.server_version_num) / 10_000);
+  if (!Number.isSafeInteger(postgresMajor) || postgresMajor < 10) {
+    throw new Error(
+      "database identity query returned an invalid PostgreSQL version",
+    );
+  }
+  return {
+    version: 1,
+    environment,
+    postgresMajor,
+    clusterSha256: digest(["eliza-postgres-cluster-v1", row.system_identifier]),
+    authoritySha256: digest([
+      "eliza-postgres-authority-v1",
+      environment,
+      row.system_identifier,
+      row.role_name,
+      row.database_name,
+    ]),
+  };
+}
+
+/** Evaluates the receipt without exposing the underlying server, role, or database names. */
+export async function runDatabaseIdentityPreflight(
+  config: DatabaseIdentityConfig,
+  client?: IdentityQueryClient,
+): Promise<IdentityPreflightResult> {
+  if (config.mode === "off") return { status: "disabled", mismatches: [] };
+  if (!client)
+    throw new Error(
+      "database identity client is required when the gate is active",
+    );
+  const receipt = await readDatabaseIdentityReceipt(client, config.environment);
+  const mismatches: Array<"cluster" | "authority"> = [];
+  if (
+    config.expectedClusterSha256 &&
+    receipt.clusterSha256 !== config.expectedClusterSha256
+  ) {
+    mismatches.push("cluster");
+  }
+  if (
+    config.expectedAuthoritySha256 &&
+    receipt.authoritySha256 !== config.expectedAuthoritySha256
+  ) {
+    mismatches.push("authority");
+  }
+  if (config.mode === "enforce" && mismatches.length > 0) {
+    throw new Error(`database identity mismatch: ${mismatches.join(",")}`);
+  }
+  const hasCompleteExpectedIdentity = Boolean(
+    config.expectedClusterSha256 && config.expectedAuthoritySha256,
+  );
+  return {
+    status:
+      mismatches.length > 0
+        ? "mismatch"
+        : hasCompleteExpectedIdentity
+          ? "match"
+          : "reported",
+    mismatches,
+    receipt,
+  };
+}
+
+async function clientConfig(databaseUrl: string): Promise<ClientConfig> {
+  // Keep the heavy Cloud database module outside the pure receipt/test path.
+  const { enforceTlsForRemote } = await import(
+    "@elizaos/cloud-shared/db/client"
+  );
+  const { url, ssl } = enforceTlsForRemote(databaseUrl);
+  return {
+    connectionString: url,
+    connectionTimeoutMillis: 5_000,
+    statement_timeout: 5_000,
+    query_timeout: 5_000,
+    application_name: "eliza-database-identity-preflight",
+    ...(ssl ? { ssl } : {}),
+  };
+}
+
+function summary(result: IdentityPreflightResult): string {
+  const lines = [
+    "### PostgreSQL identity preflight",
+    "",
+    `- Status: \`${result.status}\``,
+  ];
+  if (result.receipt) {
+    lines.push(
+      `- Environment: \`${result.receipt.environment}\``,
+      `- PostgreSQL major: \`${result.receipt.postgresMajor}\``,
+      `- Cluster receipt: \`${result.receipt.clusterSha256}\``,
+      `- Authority receipt: \`${result.receipt.authoritySha256}\``,
+    );
+  }
+  if (result.mismatches.length > 0) {
+    lines.push(`- Mismatch classes: \`${result.mismatches.join(",")}\``);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function main(): Promise<void> {
+  const environment: Readonly<Record<string, string | undefined>> = process.env;
+  const config = readDatabaseIdentityConfig(environment);
+  if (config.mode === "off") {
+    process.stdout.write(
+      "[database-identity] gate disabled; no database query performed\n",
+    );
+    return;
+  }
+  const databaseUrl = environment.DATABASE_URL;
+  if (!databaseUrl) {
+    if (config.mode === "report") {
+      process.stdout.write(
+        "::warning::database identity report unavailable: DATABASE_URL is missing\n",
+      );
+      return;
+    }
+    throw new Error(
+      "DATABASE_URL is required when database identity enforcement is active",
+    );
+  }
+  const client = new Client(await clientConfig(databaseUrl));
+  try {
+    await client.connect();
+    const result = await runDatabaseIdentityPreflight(config, client);
+    const output = summary(result);
+    process.stdout.write(output);
+    if (environment.GITHUB_STEP_SUMMARY) {
+      await appendFile(environment.GITHUB_STEP_SUMMARY, output, "utf8");
+    }
+    if (result.status === "mismatch" && config.mode === "report") {
+      process.stdout.write(
+        "::warning::database identity report differs from the protected authority\n",
+      );
+    }
+  } catch (error) {
+    // error-policy:J1 the CLI boundary emits only a generic class so provider
+    // errors cannot leak connection strings, hosts, roles, or database names.
+    if (config.mode === "report") {
+      process.stdout.write(
+        "::warning::database identity report unavailable; inspect protected operator logs\n",
+      );
+      return;
+    }
+    throw error;
+  } finally {
+    await client.end().catch(() => {
+      // error-policy:J6 teardown failure cannot replace the primary gate result.
+      process.stderr.write(
+        "[database-identity] warning: database client close failed\n",
+      );
+    });
+  }
+}
+
+if (import.meta.main) {
+  main().catch(() => {
+    process.stderr.write(
+      "[database-identity] fatal: identity enforcement failed\n",
+    );
+    process.exit(1);
+  });
+}

--- a/packages/scripts/__tests__/cloud-database-identity-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-database-identity-workflow.test.ts
@@ -1,0 +1,30 @@
+/** Verifies Cloud migrations keep database identity checks explicitly gated and pre-mutation. */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("../../../.github/workflows/cloud-cf-release.yml", import.meta.url),
+  "utf8",
+);
+
+describe("Cloud database identity workflow", () => {
+  test("runs the read-only identity preflight immediately before migrations", () => {
+    const preflight = source.indexOf("preflight-database-identity.ts");
+    const migration = source.indexOf("bun run db:cloud:migrate", preflight);
+    expect(preflight).toBeGreaterThan(0);
+    expect(migration).toBeGreaterThan(preflight);
+    const block = source.slice(preflight - 2_500, migration);
+    expect(block).toContain(
+      "DATABASE_IDENTITY_GATE_MODE: $" +
+        "{{ vars.DATABASE_IDENTITY_GATE_MODE || 'off' }}",
+    );
+    expect(block).toContain(
+      "DATABASE_IDENTITY_ENVIRONMENT: $" + "{{ inputs.target_environment }}",
+    );
+    expect(block).toContain("DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256");
+    expect(block).toContain("DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256");
+    expect(block).not.toContain("railway variables --set");
+    expect(block).not.toContain("wrangler hyperdrive update");
+  });
+});


### PR DESCRIPTION
# Relates to

Advances #21594 without claiming that protected infrastructure is already isolated.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d4f9c6f5e058f28b1c48be490e8ea1be32b7351a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop` `d4f9c6f5e058f28b1c48be490e8ea1be32b7351a` with zero conflicts.
- [x] Exact evidence head: `a9f1bd1b25ee7af263b2bc13a7799d49ec85d3af`.
- [x] Focused tests and workflow gates rerun after rebase.

# What this changes

Adds a read-only PostgreSQL identity preflight immediately before Cloud migrations:

- `off` is the default and performs no database query.
- `report` emits only SHA-256 receipts for the physical PostgreSQL cluster and the environment/cluster/role/database authority. It never labels an unreviewed or partial receipt as a match and never blocks a release.
- `enforce` requires both protected nonsecret expected digests and fails before schema mutation on cluster or authority mismatch.
- Raw connection strings, hosts, system identifiers, roles, and database names are not logged.\n- Review hardening schema-qualifies PostgreSQL identity functions and verifies adversarial off/report/enforce behavior: off ignores malformed prepared receipts without querying, report sanitizes and does not block on malformed expectations or query failures, and enforce alone fails closed.
- The topology guide makes activation prerequisites explicit: independent staging Railway service/role/volume, backup/PITR and restore drill, plus a separately verified matching Hyperdrive origin.

The script performs one read-only `pg_control_system()` identity query. It contains no Railway, Cloudflare, secret, database-write, or deployment mutation.

# Risks

Low while disabled, medium when an operator deliberately enables enforcement. The default is inert. Report mode cannot block releases. Enforce mode is intentionally fail-closed and must not be activated until the protected infrastructure receipts exist.

# Testing

Exact-head results:

```text
bun test   packages/cloud/scripts/admin/preflight-database-identity.test.ts   packages/scripts/__tests__/cloud-database-identity-workflow.test.ts   packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
34 pass, 0 fail, 412 assertions

bunx @biomejs/biome check <three changed TypeScript test/source files>
PASS

actionlint .github/workflows/cloud-cf-release.yml
PASS

bun run audit:workflow-triggers
verified 53 workflows; 18 develop push surfaces

bun run audit:scripts
PASS

DATABASE_IDENTITY_ENVIRONMENT=staging DATABASE_IDENTITY_GATE_MODE=off   bun --conditions=eliza-source packages/cloud/scripts/admin/preflight-database-identity.ts
[database-identity] gate disabled; no database query performed

git diff --check\nPASS\n\nExact-head CLI adversarial checks: off with malformed prepared receipts performed no query; report with invalid connection data exited 0 with sanitized output; enforce with malformed receipts exited 1 without exposing raw inputs. Root `bun run verify` reached an unrelated incomplete dependency bootstrap (`vitest/config` absent) after the clean install was interrupted by concurrent workspace installs; focused executable and repository audits above completed on the exact head.
```

A syntax bundle with `@elizaos/cloud-shared/*` externalized also passed. A full bundle attempt was invalid in the linked-dependency review checkout because unrelated workspace dependencies such as `uuid`, `drizzle-orm`, and `@noble/*` were absent.

# Evidence Gate

<!-- evidence-head:a9f1bd1b25ee7af263b2bc13a7799d49ec85d3af -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend deployment guard with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend deployment guard with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow and no infrastructure mutation.
<!-- evidence-row:backend-logs -->
- [x] Deterministic off-mode output and focused mocked-query receipts are recorded under Testing. No live database was queried.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, model, action, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A for protected resources - no Railway/Cloudflare/database state was mutated. The SHA-256 receipt contract is covered deterministically.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

# Known gaps / activation prerequisites

This PR does not satisfy the full infrastructure issue by itself. Before enabling `enforce`, an authorized operator must:

1. provision staging on an independent PostgreSQL 18 service, role, volume, and logical database;
2. enable recurring backup/PITR retention and complete a restore drill;
3. record the expected cluster and authority receipts from the migration connection;
4. separately prove the staging Hyperdrive origin resolves to the same identity;
5. run schema, count/digest, authenticated API, Shared-agent, provisioning, cutover, and rollback evidence.

The repository cannot infer Railway service/volume or backup state from a PostgreSQL connection. Report mode is explicitly not evidence that those resources exist.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@d4f9c6f5e058f28b1c48be490e8ea1be32b7351a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nubs-gap-cloud]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@d4f9c6f5e058f28b1c48be490e8ea1be32b7351a:packages/skills/skills/contribute-to-eliza"} -->