### PR TITLE
fix(telegram): validate connConfig.appId like the env-var tier

### DIFF
--- a/plugins/plugin-telegram/src/account-setup-routes.test.ts
+++ b/plugins/plugin-telegram/src/account-setup-routes.test.ts
@@ -99,4 +99,34 @@ describe("resolveTelegramAppCredentials", () => {
       apiHash: "cfgHashcfgHashcfgHashcfgHashcfg2",
     });
   });
+
+  it("ignores a non-numeric configured appId and falls through to deployment settings", () => {
+    const creds = resolveTelegramAppCredentials(
+      makeRuntime({
+        TELEGRAM_APP_ID: "555",
+        TELEGRAM_APP_HASH: "envHashenvHashenvHashenvHashenv5",
+      }),
+      { appId: "abc", appHash: "cfgHashcfgHashcfgHashcfgHashcfg3" },
+    );
+    expect(creds).toEqual({
+      apiId: 555,
+      apiHash: "envHashenvHashenvHashenvHashenv5",
+    });
+  });
+
+  it("ignores a negative configured appId and falls through to the bundled default", () => {
+    const creds = resolveTelegramAppCredentials(makeRuntime(), {
+      appId: "-1",
+      appHash: "cfgHashcfgHashcfgHashcfgHashcfg4",
+    });
+    expect(creds).toEqual(BUNDLED);
+  });
+
+  it("ignores a fractional configured appId and falls through to the bundled default", () => {
+    const creds = resolveTelegramAppCredentials(makeRuntime(), {
+      appId: 12.5,
+      appHash: "cfgHashcfgHashcfgHashcfgHashcfg5",
+    });
+    expect(creds).toEqual(BUNDLED);
+  });
 });

--- a/plugins/plugin-telegram/src/account-setup-routes.ts
+++ b/plugins/plugin-telegram/src/account-setup-routes.ts
@@ -202,14 +202,18 @@ export function resolveTelegramAppCredentials(
   runtime: IAgentRuntime,
   connConfig: Record<string, unknown>,
 ): { apiId: number; apiHash: string } {
+  const parsedConfigId =
+    typeof connConfig.appId === "string" || typeof connConfig.appId === "number"
+      ? Number(connConfig.appId)
+      : Number.NaN;
   if (
-    (typeof connConfig.appId === "string" ||
-      typeof connConfig.appId === "number") &&
+    Number.isInteger(parsedConfigId) &&
+    parsedConfigId > 0 &&
     typeof connConfig.appHash === "string" &&
     connConfig.appHash.trim().length > 0
   ) {
     return {
-      apiId: Number(connConfig.appId),
+      apiId: parsedConfigId,
       apiHash: connConfig.appHash.trim(),
     };
   }


### PR DESCRIPTION
# Relates to

Closes #21557.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] Focused package tests, lint, and typecheck pass on the exact head, see Testing below.
- [x] A reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched directly off the current `origin/develop` tip (`e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88`).

# Risks

Low. This only tightens validation on the first-priority credential tier to match the guard the second-priority (env-var) tier already enforces. A per-account `appId` that is a positive integer (string or number) behaves exactly as before; only a malformed value (non-numeric, negative, zero, or fractional) changes behavior — from "silently accepted as an invalid id" to "falls through to the next tier," which is what the function's own doc comment already claims happens.

# Background

## What does this PR do?

`resolveTelegramAppCredentials` in `plugins/plugin-telegram/src/account-setup-routes.ts` resolves MTProto app credentials for personal-account Telegram login in three tiers: (1) per-account `connConfig.appId`/`appHash`, (2) deployment settings `TELEGRAM_APP_ID`/`TELEGRAM_APP_HASH`, (3) a bundled default. Its doc comment states it "never returns null," so the fragile my.telegram.org provisioning scrape is never reached.

The tier-2 (env) path already validates the parsed id with `Number.isInteger(parsedEnvId) && parsedEnvId > 0` and falls through to the bundled default when that fails. The tier-1 (`connConfig.appId`, first priority) path had no equivalent guard — it only checked `typeof === "string" | "number"` and returned `apiId: Number(connConfig.appId)` unchecked. A malformed per-account `appId` (`"abc"` → `NaN`, `"-1"` → `-1`, `12.5` → a fractional id) passed the `typeof` check and was returned as-is, silently skipping the documented fallback to tier 2/3 — contradicting the function's own contract, and handing an invalid `apiId` straight to the MTProto login call in `handleStart`.

Fix: parse and validate `connConfig.appId` the same way the env tier already validates `TELEGRAM_APP_ID` (`Number.isInteger(...) && ... > 0`), falling through to tier 2/3 on failure. No refactor beyond this — mirrors the existing pattern already used two branches below in the same function.

## What kind of change is this?

Bug fix, non-breaking. Any per-account `appId` that was already a valid positive integer (string or number) resolves identically; only a malformed value now falls through instead of silently producing an invalid credential.

# Documentation changes needed?

No. The fix makes the code match the behavior already documented in the function's own doc comment ("Never returns null... invalid").

# Testing

## Where should a reviewer start?

`plugins/plugin-telegram/src/account-setup-routes.test.ts`, the three new cases (non-numeric, negative, fractional `connConfig.appId`), then the guard added to `resolveTelegramAppCredentials` in `account-setup-routes.ts`.

## Detailed testing steps

```text
$ bun run test src/account-setup-routes.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)

$ bun run test
 Test Files  21 passed (21)
      Tests  180 passed (180)

$ bun run typecheck
$ (clean, no output)

$ bun run lint:check
Checked 58 files in 108ms. No fixes applied.
```

Mutation-tested the new regression cases: reverted only the source fix (`git apply -R`) with the new tests still present, reran the focused file —

```text
 FAIL  src/account-setup-routes.test.ts > resolveTelegramAppCredentials > ignores a non-numeric configured appId and falls through to deployment settings
AssertionError: expected { apiId: NaN, … } to deeply equal { apiId: 555, … }

 FAIL  src/account-setup-routes.test.ts > resolveTelegramAppCredentials > ignores a negative configured appId and falls through to the bundled default
AssertionError: expected { apiId: -1, … } to deeply equal { apiId: 2040, … }

 FAIL  src/account-setup-routes.test.ts > resolveTelegramAppCredentials > ignores a fractional configured appId and falls through to the bundled default
AssertionError: expected { apiId: 12.5, … } to deeply equal { apiId: 2040, … }

 Test Files  1 failed (1)
      Tests  3 failed | 7 passed (10)
```

— exactly the 3 new cases fail with the exact pre-fix bug behavior (`NaN`/`-1`/`12.5` flowing through unvalidated), the 7 pre-existing cases stay green. Restored the fix (`git apply`), reran: 10/10 green again.

# Evidence Gate

<!-- evidence-head:843678ce557b4ad5b0649ffbc8514c19131ae18d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend credential-resolution logic with no rendered frontend surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend credential-resolution logic with no rendered frontend surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive frontend flow; the pure function is exercised directly in unit tests
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure function with no logging in this code path; the unit test output above is the evidence
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or browser network path changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, action, or evaluator behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, or on-chain output produced by this code path
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

## Known gaps / failures

None in the touched surface. Full focused package suite green (180/180), typecheck clean, lint clean. The full monorepo root `bun run verify` was not run (out of scope for a single-package fix; this package's own test/typecheck/lint scripts were run directly against the exact head instead).

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code, direct interactive session
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Attribution status: self-reported
