### PR TITLE
fix(coding-tools): WEB_FETCH htmlToReadableText degrades out-of-range numeric HTML entities instead of throwing

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
@@ -18,7 +18,7 @@ import {
   __setWebHttpLookupFnForTests,
   __setWebHttpPinnedFetchImplForTests,
 } from "../lib/web-http.js";
-import { webFetchAction } from "./web-fetch.js";
+import { htmlToReadableText, webFetchAction } from "./web-fetch.js";
 
 vi.mock("@elizaos/logger", () => {
   const logger = {
@@ -275,6 +275,50 @@ describe("coding-tools WEB_FETCH", () => {
       kind: "json",
       truncated: false,
     });
+  });
+
+  it("decodes valid numeric and named HTML entities in readable text", () => {
+    expect(htmlToReadableText("<p>&#65; &#x41; &amp; &lt; &gt;</p>")).toBe(
+      "A A & < >",
+    );
+    expect(htmlToReadableText("<p>&quot;&apos;&nbsp;x</p>")).toBe("\"' x");
+  });
+
+  it("degrades out-of-range numeric entities without throwing and keeps surrounding text", () => {
+    // String.fromCodePoint throws RangeError above 0x10FFFF; the decoder must
+    // leave the malformed reference literal instead of hard-failing the fetch.
+    const hex = htmlToReadableText("<p>hello &#x110000; world</p>");
+    expect(hex).toContain("hello");
+    expect(hex).toContain("world");
+    expect(hex).toContain("&#x110000;");
+
+    const dec = htmlToReadableText("<p>hi &#1114112; there</p>");
+    expect(dec).toContain("hi");
+    expect(dec).toContain("there");
+    expect(dec).toContain("&#1114112;");
+  });
+
+  it("degrades a malformed numeric entity to readable text through the handler instead of io_error", async () => {
+    usePinnedRoutes({
+      "https://public.example.test/bad-entity": new Response(
+        "<html><body><p>alpha &#x110000; omega</p></body></html>",
+        {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        },
+      ),
+    });
+
+    const result = await runFetch({
+      url: "https://public.example.test/bad-entity",
+    });
+
+    // On unpatched develop htmlToReadableText throws RangeError, which the
+    // handler surfaces as an io_error failure. The fix keeps the fetch success.
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("alpha");
+    expect(result.text).toContain("omega");
+    expect(result.data).toMatchObject({ kind: "html" });
   });
 
   it("falls back to the full JSON when the extract path is missing", async () => {

--- a/plugins/plugin-coding-tools/src/actions/web-fetch.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.ts
@@ -42,13 +42,23 @@ function decodeHtmlEntity(entity: string): string {
     nbsp: " ",
     quot: '"',
   };
-  if (entity.startsWith("#x")) {
-    const code = Number.parseInt(entity.slice(2), 16);
-    return Number.isFinite(code) ? String.fromCodePoint(code) : `&${entity};`;
-  }
   if (entity.startsWith("#")) {
-    const code = Number.parseInt(entity.slice(1), 10);
-    return Number.isFinite(code) ? String.fromCodePoint(code) : `&${entity};`;
+    const code = entity.startsWith("#x")
+      ? Number.parseInt(entity.slice(2), 16)
+      : Number.parseInt(entity.slice(1), 10);
+    // String.fromCodePoint throws RangeError for negatives and any value above
+    // the Unicode ceiling (0x10FFFF), cases Number.isFinite does not reject.
+    // A single malformed reference must degrade to its literal source, never
+    // hard-fail the best-effort fetch. The try/catch is belt-and-suspenders.
+    if (Number.isInteger(code) && code >= 0 && code <= 0x10ffff) {
+      try {
+        return String.fromCodePoint(code);
+      } catch {
+        // error-policy:J4 malformed entity degrades to its literal source text
+        return `&${entity};`;
+      }
+    }
+    return `&${entity};`;
   }
   return named[entity] ?? `&${entity};`;
 }


### PR DESCRIPTION
# Relates to

Closes #21694

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and package `test`/`typecheck`/`lint:check` were run after sync; repo-wide `bun run verify` is not completed on this machine (see **Known gaps / failures**).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5bc247fc11c860d46b2967a6a482aa69b35714bf:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — not run to completion here; unrelated blocker documented in **Known gaps / failures**.

# Risks

Low. The change is confined to one private helper (`decodeHtmlEntity`) in the
plugin-local WEB_FETCH action. It only narrows an unsafe `String.fromCodePoint`
call so an out-of-range/negative numeric HTML entity degrades to its literal
source instead of throwing. Valid entity decoding and the named-entity map are
byte-for-byte unchanged. No public export, type, or route changed.

# Background

## What does this PR do?

`decodeHtmlEntity` in `plugins/plugin-coding-tools/src/actions/web-fetch.ts`
decoded numeric HTML character references (`&#N;` / `&#xH;`) with
`String.fromCodePoint(code)` guarded only by `Number.isFinite(code)`.
`String.fromCodePoint` throws `RangeError: Invalid code point` for any value
above the Unicode ceiling `0x10FFFF` and for negatives — cases `Number.isFinite`
does **not** reject. Because `htmlToReadableText` runs inside `extractBody` in the
WEB_FETCH handler try-block, a fetched HTML page containing a single malformed
numeric entity such as `&#x110000;` or `&#1114112;` made the whole fetch
hard-fail with an `io_error` `ActionResult`, contradicting the module's
deliberate best-effort/degrade design.

The fix merges the `#x` and `#` branches into one guarded path that only calls
`String.fromCodePoint` for an integer code point in `[0, 0x10FFFF]`, with a
belt-and-suspenders `try/catch` that falls back to the literal `&${entity};`.
Surrounding text is preserved; the malformed reference degrades to its literal
source. Named-entity handling is unchanged.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior for
valid input is unchanged; only a crash path is turned into the documented
best-effort degrade.

# Testing

## Where should a reviewer start?

`plugins/plugin-coding-tools/src/actions/web-fetch.test.ts` — three added tests
in the existing `coding-tools WEB_FETCH` suite, reusing the injected HTTP seam
(`__setWebHttpFetchImplForTests` / `usePinnedRoutes` / `__resetWebHttpTestOverrides`).

## Detailed testing steps

```bash
cd plugins/plugin-coding-tools
bun run test          # 36 files / 584 tests pass
bun run typecheck     # clean
bun run lint:check    # clean
```

# Evidence Gate

<!-- evidence-head:d6bd531b12dffb38f36c6eecb95a542a2c0a121b -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no UI surface; change is a plugin-local library helper in a headless coding-tools action.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no UI surface; change is a plugin-local library helper in a headless coding-tools action.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no interactive user flow; the change is exercised by unit + handler tests shown below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - full verbose handler-test log is inline in the PR body (Backend logs); the fork account agent-cortex is not an elizaOS/eliza collaborator and cannot upload release/attachment assets
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend; WEB_FETCH is a headless action with no rendered surface.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no prompt/model/provider behavior changed; this is deterministic HTML-entity text decoding with no model call on the changed path.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the failing-before/passing-after reproduction is inline in the PR body; the fork account cannot upload release/attachment assets to elizaOS/eliza
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changed on this path; the fix is deterministic string decoding.`

## Backend + frontend logs

Backend: the added handler-level test injects an HTML body containing an
out-of-range numeric entity through the shared HTTP seam and drives the real
WEB_FETCH handler. On unpatched `develop` this throws `RangeError` inside
`extractBody`, which the handler catches and returns as an `io_error` failure.
After the fix it returns `success: true` with readable text and `kind: html`.

<details><summary>Handler + unit tests (after fix) — <code>bun run test src/actions/web-fetch.test.ts</code></summary>

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
   Duration  11.0s
```

Relevant added cases:
```
 ✓ decodes valid numeric and named HTML entities in readable text
 ✓ degrades out-of-range numeric entities without throwing and keeps surrounding text
 ✓ degrades a malformed numeric entity to readable text through the handler instead of io_error
```

</details>

Frontend: `N/A - headless action, no frontend.`

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface (rendered under packages/app, packages/ui, apps/app). The change is a plugin-local library helper in a headless coding-tools action.`

### Failing-before / passing-after

The two new regression tests were verified red against the unmodified
`origin/develop` source (new tests + old helper), then green with the fix.

<details><summary>BEFORE (develop <code>web-fetch.ts</code> + new tests) — 2 failed</summary>

```
 × degrades out-of-range numeric entities without throwing and keeps surrounding text
 × degrades a malformed numeric entity to readable text through the handler instead of io_error
 FAIL  ... > degrades out-of-range numeric entities without throwing and keeps surrounding text
RangeError: Invalid code point 1114112
 FAIL  ... > degrades a malformed numeric entity to readable text through the handler instead of io_error
AssertionError: expected false to be true // Object.is equality
 Test Files  1 failed (1)
      Tests  2 failed | 13 passed (15)
```

</details>

<details><summary>AFTER (fix applied) — all pass</summary>

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

</details>

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- Repo-wide `bun run verify` was not run to completion on this machine. The
  owning-package gates were run and pass: `bun run test` (36 files / 584 tests),
  `bun run typecheck` (clean), and `bun run lint:check` (clean) in
  `plugins/plugin-coding-tools`. Reason: this is a scoped, single-helper library
  fix with no cross-package surface; the full verify lane pulls the entire
  monorepo build/test graph which is disproportionate to a one-file degrade fix.
- `bun install` required an install-time note: a machine-global
  `minimumReleaseAge` policy blocks a few unrelated freshly-published transitive
  versions (viem/pepr/etc.) pinned by the committed lockfile; the workspace was
  installed against the trusted committed lockfile for this scoped fix. No
  dependency in `plugin-coding-tools` changed.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@5bc247fc11c860d46b2967a6a482aa69b35714bf:packages/skills/skills/contribute-to-eliza"} -->

