### PR TITLE
fix(cloud): reject malformed extract JSON

### DIFF
--- a/packages/cloud/api/v1/extract/route.json.test.ts
+++ b/packages/cloud/api/v1/extract/route.json.test.ts
@@ -1,0 +1,125 @@
+/**
+ * POST /api/v1/extract untrusted JSON body contract.
+ *
+ * Hono 4.13 `c.req.json()` is a bare `JSON.parse`. The handler catch maps
+ * SyntaxError through `failureResponse` to HTTP 500 instead of a caller 400.
+ * Hosted-page extract must not run on client garbage.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const USER_ID = "00000000-0000-4000-8000-0000000000aa";
+const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: USER_ID,
+  organization_id: ORG_ID,
+}));
+
+const extractHostedPage = mock(async () => {
+  throw new Error("extractHostedPage must not run");
+});
+
+const logHostedBrowserFailure = mock(() => undefined);
+
+const failureResponse = mock(
+  (c: { json: (body: unknown, status: number) => unknown }) =>
+    c.json({ success: false, error: "An unexpected error occurred" }, 500),
+);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/browser-tools", () => ({
+  extractHostedPage,
+  logHostedBrowserFailure,
+}));
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+const { default: app } = await import("./route");
+
+function post(raw: string) {
+  return app.fetch(
+    new Request("http://test.local/", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_test_key",
+        "Content-Type": "application/json",
+      },
+      body: raw,
+    }),
+  );
+}
+
+describe("POST /api/v1/extract JSON body", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    extractHostedPage.mockClear();
+    logHostedBrowserFailure.mockClear();
+    failureResponse.mockClear();
+    extractHostedPage.mockImplementation(async () => {
+      throw new Error("extractHostedPage must not run");
+    });
+  });
+
+  test.each(["", "   ", "{", "not-json"])(
+    "rejects malformed extract body %j with 400",
+    async (raw) => {
+      const res = await post(raw);
+
+      expect(res.status).toBe(400);
+      expect((await res.json()) as Record<string, unknown>).toEqual({
+        success: false,
+        error: "Invalid JSON body",
+      });
+      expect(requireUserOrApiKeyWithOrg).toHaveBeenCalled();
+      expect(extractHostedPage).not.toHaveBeenCalled();
+      expect(logHostedBrowserFailure).not.toHaveBeenCalled();
+      expect(failureResponse).not.toHaveBeenCalled();
+    },
+  );
+
+  test("still 400s a parseable object missing url via zod", async () => {
+    const res = await post("{}");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("Invalid extract request");
+    expect(extractHostedPage).not.toHaveBeenCalled();
+  });
+
+  test("still extracts a canonical object body", async () => {
+    extractHostedPage.mockResolvedValue({
+      markdown: "# ok",
+      url: "https://example.com",
+    });
+
+    const res = await post(JSON.stringify({ url: "https://example.com" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      markdown: "# ok",
+      url: "https://example.com",
+    });
+    expect(extractHostedPage).toHaveBeenCalledTimes(1);
+    expect(extractHostedPage.mock.calls[0]?.[0]).toMatchObject({
+      url: "https://example.com",
+    });
+    expect(extractHostedPage.mock.calls[0]?.[1]).toMatchObject({
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      requestSource: "api",
+    });
+  });
+});

--- a/packages/cloud/api/v1/extract/route.json.test.ts
+++ b/packages/cloud/api/v1/extract/route.json.test.ts
@@ -7,6 +7,11 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+  HostedBrowserAuthContext,
+  HostedExtractOptions,
+  HostedExtractResult,
+} from "@/lib/services/browser-tools";
 
 const USER_ID = "00000000-0000-4000-8000-0000000000aa";
 const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
@@ -16,9 +21,14 @@ const requireUserOrApiKeyWithOrg = mock(async () => ({
   organization_id: ORG_ID,
 }));
 
-const extractHostedPage = mock(async () => {
-  throw new Error("extractHostedPage must not run");
-});
+const extractHostedPage = mock(
+  async (
+    _options: HostedExtractOptions,
+    _auth?: HostedBrowserAuthContext,
+  ): Promise<HostedExtractResult> => {
+    throw new Error("extractHostedPage must not run");
+  },
+);
 
 const logHostedBrowserFailure = mock(() => undefined);
 
@@ -101,8 +111,13 @@ describe("POST /api/v1/extract JSON body", () => {
 
   test("still extracts a canonical object body", async () => {
     extractHostedPage.mockResolvedValue({
+      provider: "firecrawl",
       markdown: "# ok",
       url: "https://example.com",
+      html: null,
+      screenshot: null,
+      links: [],
+      metadata: {},
     });
 
     const res = await post(JSON.stringify({ url: "https://example.com" }));

--- a/packages/cloud/api/v1/extract/route.ts
+++ b/packages/cloud/api/v1/extract/route.ts
@@ -38,10 +38,10 @@ app.post("/", async (c) => {
     let body: unknown;
     try {
       body = await c.req.json();
-    } catch {
-      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
-      // bare JSON.parse. SyntaxError must be a caller 400, not the
-      // failureResponse 500 that treats it as an unexpected server fault.
+    } catch (error) {
+      // error-policy:J3 SyntaxError is caller garbage. Stream/decoder
+      // failures stay 500 — do not reprint leftover-tax #21685/#21690.
+      if (!(error instanceof SyntaxError)) throw error;
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
     const bodyResult = extractRequestSchema.safeParse(body);

--- a/packages/cloud/api/v1/extract/route.ts
+++ b/packages/cloud/api/v1/extract/route.ts
@@ -35,7 +35,16 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    const bodyResult = extractRequestSchema.safeParse(await c.req.json());
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
+      // bare JSON.parse. SyntaxError must be a caller 400, not the
+      // failureResponse 500 that treats it as an unexpected server fault.
+      return c.json({ success: false, error: "Invalid JSON body" }, 400);
+    }
+    const bodyResult = extractRequestSchema.safeParse(body);
 
     if (!bodyResult.success) {
       return c.json(


### PR DESCRIPTION
# Relates to

Operator request: publish the unpublished extract JSON 500 that is still live on `develop`. Not a reprint of Shaw-closed leftover-tax `#21541` / `#21690`. This file still `safeParse(await c.req.json())` on develop.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Inner JSON parse only on `POST /api/v1/extract`. `SyntaxError` becomes 400.
Any other parse-path error is rethrown so stream/decoder failures stay 500
(Shaw keep on `#21690`). Zod `{}` still 400. Canonical `{ url }` still extracts.

# Background

## What does this PR do?

`POST /api/v1/extract` called `extractRequestSchema.safeParse(await c.req.json())`
inside the extract try. Hono `c.req.json()` is a bare `JSON.parse`. A
`SyntaxError` is not Zod, so `failureResponse` mapped it to **500**.

- `""` / `"   "` / `"{"` / `"not-json"` → **400**
- `{}` → still 400 via zod (`Invalid extract request`)
- `{ url }` → still extracts

Stream/decoder failures that are not `SyntaxError` stay **500**.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Client garbage must not look like a hosted-page extract outage. This route is
still 500 on `develop`. Catch is `SyntaxError`-only so leftover-tax `#21685`
is not reprinted.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/extract/route.json.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/extract/route.json.test.ts
```

On develop: 4 failed / 2 passed (`""`, `"   "`, `"{"`, `"not-json"` were 500).
At this head: 6 passed / 0 failed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; extract JSON parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; extract JSON parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; extract JSON parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused bun tests drive the real malformed tokens and assert 400 before extractHostedPage; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no hosted-page extract write; malformed JSON 400s before extractHostedPage.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - JSON contract is asserted in-process against the real handler.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical `{ url }` still extracts. Malformed JSON
that previously 500 now 400. Non-SyntaxError decode failures stay 500.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

# Known gaps / failures

`bun run verify` was not run. Focused extract JSON suite is green at this head.
The unrelated monorepo verify is out of scope for this two-file API contract fix.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0fef7384057fbb941fdfc474ac5a547ddbe1e81e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
