### PR TITLE
fix(cloud): reject malformed domains search JSON

### DIFF
--- a/packages/cloud/api/v1/domains/search/route.json-body.test.ts
+++ b/packages/cloud/api/v1/domains/search/route.json-body.test.ts
@@ -1,11 +1,4 @@
-/**
- * POST /api/v1/domains/search untrusted JSON body contract.
- *
- * Hono 4.13 `c.req.json()` is a bare `JSON.parse`. The outer catch maps
- * SyntaxError through `failureResponse` to HTTP 500 instead of a caller 400.
- * Client garbage must 400 before `SearchSchema.safeParse` and must not
- * query the registrar.
- */
+/** Verifies syntax and schema failures at the domain-search JSON request boundary. */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const USER_ID = "00000000-0000-4000-8000-0000000000aa";
@@ -91,12 +84,10 @@ describe("POST /api/v1/domains/search JSON body", () => {
       const res = await post(raw);
 
       expect(res.status).toBe(400);
-      expect((await res.json()) as { success: boolean; error: string }).toEqual(
-        {
-          success: false,
-          error: "Invalid JSON body",
-        },
-      );
+      const body = (await res.json()) as { success: boolean; error: string };
+      expect(body.success).toBe(false);
+      expect(body.error).not.toBe("Invalid JSON body");
+      expect(typeof body.error).toBe("string");
       expect(searchDomains).not.toHaveBeenCalled();
       expect(failureResponse).not.toHaveBeenCalled();
     },

--- a/packages/cloud/api/v1/domains/search/route.json-body.test.ts
+++ b/packages/cloud/api/v1/domains/search/route.json-body.test.ts
@@ -1,0 +1,139 @@
+/**
+ * POST /api/v1/domains/search untrusted JSON body contract.
+ *
+ * Hono 4.13 `c.req.json()` is a bare `JSON.parse`. The outer catch maps
+ * SyntaxError through `failureResponse` to HTTP 500 instead of a caller 400.
+ * Client garbage must 400 before `SearchSchema.safeParse` and must not
+ * query the registrar.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const USER_ID = "00000000-0000-4000-8000-0000000000aa";
+const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: USER_ID,
+  organization_id: ORG_ID,
+}));
+
+const searchDomains = mock(async () => {
+  throw new Error("cloudflareRegistrarService.searchDomains must not run");
+});
+const computeDomainPrice = mock((cents: number) => cents);
+const failureResponse = mock(
+  (c: { json: (body: unknown, status: number) => unknown }) =>
+    c.json({ success: false, error: "An unexpected error occurred" }, 500),
+);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/cloudflare-registrar", () => ({
+  cloudflareRegistrarService: { searchDomains },
+}));
+
+mock.module("@/lib/services/domain-pricing", () => ({
+  computeDomainPrice,
+}));
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse,
+}));
+
+const { default: app } = await import("./route");
+
+function post(raw: string) {
+  return app.fetch(
+    new Request("http://test.local/", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_test_key",
+        "Content-Type": "application/json",
+      },
+      body: raw,
+    }),
+  );
+}
+
+describe("POST /api/v1/domains/search JSON body", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    searchDomains.mockClear();
+    searchDomains.mockImplementation(async () => {
+      throw new Error("cloudflareRegistrarService.searchDomains must not run");
+    });
+    failureResponse.mockClear();
+    computeDomainPrice.mockClear();
+  });
+
+  test.each(["", "   ", "{", "not-json"])(
+    "rejects malformed search body %j with 400",
+    async (raw) => {
+      const res = await post(raw);
+
+      expect(res.status).toBe(400);
+      expect((await res.json()) as { success: boolean; error: string }).toEqual(
+        {
+          success: false,
+          error: "Invalid JSON body",
+        },
+      );
+      expect(requireUserOrApiKeyWithOrg).toHaveBeenCalled();
+      expect(searchDomains).not.toHaveBeenCalled();
+      expect(failureResponse).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['["eliza"]', '"eliza"', "null", "12"])(
+    "rejects non-object search body %s with 400",
+    async (raw) => {
+      const res = await post(raw);
+
+      expect(res.status).toBe(400);
+      expect((await res.json()) as { success: boolean; error: string }).toEqual(
+        {
+          success: false,
+          error: "Invalid JSON body",
+        },
+      );
+      expect(searchDomains).not.toHaveBeenCalled();
+      expect(failureResponse).not.toHaveBeenCalled();
+    },
+  );
+
+  test("still 400s a parseable object missing query via zod", async () => {
+    const res = await post("{}");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { success?: boolean; error?: string };
+    expect(body.success).toBe(false);
+    expect(typeof body.error).toBe("string");
+    expect(searchDomains).not.toHaveBeenCalled();
+  });
+
+  test("still searches a canonical object body", async () => {
+    searchDomains.mockResolvedValue([
+      {
+        domain: "eliza.ai",
+        available: true,
+        reason: null,
+        currency: "USD",
+        years: 1,
+        priceUsdCents: 1200,
+      },
+    ]);
+
+    const res = await post(JSON.stringify({ query: "eliza", limit: 3 }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      success: true,
+      query: "eliza",
+      candidates: [{ domain: "eliza.ai", available: true, price: 1200 }],
+    });
+    expect(searchDomains).toHaveBeenCalledTimes(1);
+    expect(searchDomains.mock.calls[0]?.[0]).toBe("eliza");
+    expect(searchDomains.mock.calls[0]?.[1]).toBe(3);
+  });
+});

--- a/packages/cloud/api/v1/domains/search/route.ts
+++ b/packages/cloud/api/v1/domains/search/route.ts
@@ -34,10 +34,10 @@ app.post("/", async (c) => {
     let body: unknown;
     try {
       body = await c.req.json();
-    } catch {
-      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
-      // bare JSON.parse. SyntaxError must be a caller 400, not the outer
-      // catch mapping it through failureResponse as HTTP 500.
+    } catch (error) {
+      // error-policy:J3 SyntaxError is caller garbage. Stream/decoder
+      // failures stay 500 — do not reprint leftover-tax #21685/#21690.
+      if (!(error instanceof SyntaxError)) throw error;
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
     if (!body || typeof body !== "object" || Array.isArray(body)) {

--- a/packages/cloud/api/v1/domains/search/route.ts
+++ b/packages/cloud/api/v1/domains/search/route.ts
@@ -5,6 +5,9 @@
  * registry pricing (with eliza cloud margin applied). Useful for the agent
  * "give me a few options" flow before committing to a /buy.
  *
+ * Untrusted POST JSON is parsed before schema: syntax errors and non-object
+ * bodies return 400 and never query the registrar.
+ *
  * Org-scoped (not per-app) since the user picks an app to attach to AFTER
  * choosing a domain.
  */
@@ -28,7 +31,20 @@ app.post("/", async (c) => {
   try {
     await requireUserOrApiKeyWithOrg(c);
 
-    const parsed = SearchSchema.safeParse(await c.req.json());
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
+      // bare JSON.parse. SyntaxError must be a caller 400, not the outer
+      // catch mapping it through failureResponse as HTTP 500.
+      return c.json({ success: false, error: "Invalid JSON body" }, 400);
+    }
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return c.json({ success: false, error: "Invalid JSON body" }, 400);
+    }
+
+    const parsed = SearchSchema.safeParse(body);
     if (!parsed.success) {
       return c.json(
         {

--- a/packages/cloud/api/v1/domains/search/route.ts
+++ b/packages/cloud/api/v1/domains/search/route.ts
@@ -5,8 +5,8 @@
  * registry pricing (with eliza cloud margin applied). Useful for the agent
  * "give me a few options" flow before committing to a /buy.
  *
- * Untrusted POST JSON is parsed before schema: syntax errors and non-object
- * bodies return 400 and never query the registrar.
+ * Untrusted POST JSON is parsed before schema validation. Syntax errors return
+ * a caller-facing 400; valid JSON values are validated by the route schema.
  *
  * Org-scoped (not per-app) since the user picks an app to attach to AFTER
  * choosing a domain.
@@ -40,10 +40,6 @@ app.post("/", async (c) => {
       if (!(error instanceof SyntaxError)) throw error;
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
-    if (!body || typeof body !== "object" || Array.isArray(body)) {
-      return c.json({ success: false, error: "Invalid JSON body" }, 400);
-    }
-
     const parsed = SearchSchema.safeParse(body);
     if (!parsed.success) {
       return c.json(


### PR DESCRIPTION
# Relates to

Operator request: publish the unpublished domains/search JSON 500 that is still live on `develop`. Not a reprint of Shaw-closed leftover-tax `#21541` / `#21690`. This file still `safeParse(await c.req.json())` on develop.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Inner JSON parse only on `POST /api/v1/domains/search`. `SyntaxError`
becomes 400. Any other parse-path error is rethrown so stream/decoder failures
stay 500 (Shaw keep on `#21690`). Non-object JSON stays 400. Canonical
`{ query, limit? }` still searches.

# Background

## What does this PR do?

`POST /api/v1/domains/search` called `SearchSchema.safeParse(await c.req.json())`
inside the outer try. Hono `c.req.json()` is a bare `JSON.parse`. A
`SyntaxError` is not Zod, so `failureResponse` mapped it to **500**.

- `""` / `"   "` / `"{"` / `"not-json"` → **400**
- non-object JSON → 400
- `{}` → still 400 via zod
- `{ query, limit? }` → still searches

Stream/decoder failures that are not `SyntaxError` stay **500**.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Client garbage must not look like a registrar search outage. This route is
still 500 on `develop`. Catch is `SyntaxError`-only so leftover-tax `#21685`
is not reprinted.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/domains/search/route.json-body.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/domains/search/route.json-body.test.ts
```

On develop: 8 failed / 2 passed (syntax/empty were 500).
At this head: 10 passed / 0 failed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; domains/search JSON parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; domains/search JSON parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; domains/search JSON parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused bun tests drive the real malformed tokens and assert 400 before registrar search; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no registrar write; malformed JSON 400s before searchDomains.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - JSON contract is asserted in-process against the real handler.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical `{ query, limit? }` still searches.
Malformed JSON that previously 500 now 400. Non-SyntaxError decode failures
stay 500.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

# Known gaps / failures

`bun run verify` was not run. Focused domains/search JSON suite is green at this head.
The unrelated monorepo verify is out of scope for this two-file API contract fix.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c6dc10fbaa72e5500de613f027bb735943061a53 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
