### PR TITLE
fix(cloud): bound Atlas image submit and poll fetches

### DIFF
--- a/packages/cloud/shared/src/lib/providers/__tests__/atlas-image-timeout.test.ts
+++ b/packages/cloud/shared/src/lib/providers/__tests__/atlas-image-timeout.test.ts
@@ -1,0 +1,67 @@
+/** Exercises Atlas image submit/download deadlines through an injected fetch boundary. */
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("../language-model", () => ({
+  getAiProviderConfigurationError: () => "missing provider configuration",
+}));
+
+const { generateAtlasCloudImageWithFetch } = await import(
+  "../image/atlascloud-image-generation"
+);
+
+const request = {
+  model: "atlas-test",
+  prompt: "draw a bounded request",
+  apiKeys: {
+    ATLASCLOUD_API_KEY: "test-key",
+    ATLASCLOUD_BASE_URL: "https://atlas.invalid",
+  },
+};
+
+describe("Atlas image request deadlines", () => {
+  it("aborts a stalled submit at the configured deadline", async () => {
+    const fetchImpl: typeof fetch = async (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) throw new Error("expected submit abort signal");
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+
+    await expect(
+      generateAtlasCloudImageWithFetch(request, fetchImpl, 10),
+    ).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+  });
+
+  it("surfaces a provider error from a completed submit", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      Response.json({ msg: "quota exceeded" }, { status: 429 });
+
+    await expect(generateAtlasCloudImageWithFetch(request, fetchImpl, 1_000)).rejects.toThrow(
+      "quota exceeded",
+    );
+  });
+
+  it("uses the injected fetch for submit and image download", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      if (signals.length === 1) {
+        return Response.json({
+          data: { outputs: ["https://images.invalid/result.png"] },
+        });
+      }
+      return new Response(new Uint8Array([1, 2, 3]), {
+        headers: { "content-type": "image/png" },
+      });
+    };
+
+    const image = await generateAtlasCloudImageWithFetch(request, fetchImpl, 1_000);
+
+    expect(signals).toHaveLength(2);
+    expect(signals.every((signal) => !signal.aborted)).toBe(true);
+    expect(image.mimeType).toBe("image/png");
+    expect(image.bytes).toEqual(new Uint8Array([1, 2, 3]));
+  });
+});

--- a/packages/cloud/shared/src/lib/providers/__tests__/atlas-image-timeout.test.ts
+++ b/packages/cloud/shared/src/lib/providers/__tests__/atlas-image-timeout.test.ts
@@ -5,9 +5,7 @@ mock.module("../language-model", () => ({
   getAiProviderConfigurationError: () => "missing provider configuration",
 }));
 
-const { generateAtlasCloudImageWithFetch } = await import(
-  "../image/atlascloud-image-generation"
-);
+const { generateAtlasCloudImageWithFetch } = await import("../image/atlascloud-image-generation");
 
 const request = {
   model: "atlas-test",
@@ -27,9 +25,7 @@ describe("Atlas image request deadlines", () => {
         signal.addEventListener("abort", () => reject(signal.reason), { once: true });
       });
 
-    await expect(
-      generateAtlasCloudImageWithFetch(request, fetchImpl, 10),
-    ).rejects.toMatchObject({
+    await expect(generateAtlasCloudImageWithFetch(request, fetchImpl, 10)).rejects.toMatchObject({
       name: "TimeoutError",
     });
   });
@@ -41,6 +37,38 @@ describe("Atlas image request deadlines", () => {
     await expect(generateAtlasCloudImageWithFetch(request, fetchImpl, 1_000)).rejects.toThrow(
       "quota exceeded",
     );
+  });
+
+  it("aborts a stalled prediction poll within the poll deadline", async () => {
+    let callCount = 0;
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      callCount += 1;
+      if (callCount === 1) {
+        return Response.json({
+          data: {
+            id: "prediction-1",
+            urls: { get: "https://atlas.invalid/prediction-1" },
+          },
+        });
+      }
+
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) throw new Error("expected poll abort signal");
+        signal.addEventListener("abort", () => reject(signal.reason), {
+          once: true,
+        });
+      });
+    };
+
+    await expect(
+      generateAtlasCloudImageWithFetch(request, fetchImpl, 1_000, {
+        pollIntervalMs: 0,
+        pollTimeoutMs: 100,
+        pollRequestTimeoutMs: 10,
+      }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(callCount).toBe(2);
   });
 
   it("uses the injected fetch for submit and image download", async () => {

--- a/packages/cloud/shared/src/lib/providers/image/atlascloud-image-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/image/atlascloud-image-generation.ts
@@ -6,6 +6,7 @@ import type { GeneratedImage, ImageGenRequest, ImageProvider } from "./types";
 // OpenAI chat-completions surface). Submit returns a prediction id; poll the
 // prediction until status === "completed", then download outputs[0].
 const ATLAS_IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000;
+const ATLAS_IMAGE_SUBMIT_TIMEOUT_MS = 30_000;
 const ATLAS_IMAGE_MAX_BYTES = 20 * 1024 * 1024;
 const ATLAS_POLL_INTERVAL_MS = 2_000;
 const ATLAS_POLL_TIMEOUT_MS = 120_000;
@@ -58,8 +59,12 @@ async function readImageWithLimit(response: Response): Promise<Uint8Array> {
   return bytes;
 }
 
-async function imageUrlToGeneratedImage(url: string, text = ""): Promise<GeneratedImage> {
-  const response = await fetch(url, {
+async function imageUrlToGeneratedImage(
+  url: string,
+  text = "",
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<GeneratedImage> {
+  const response = await fetchImpl(url, {
     signal: AbortSignal.timeout(ATLAS_IMAGE_DOWNLOAD_TIMEOUT_MS),
   });
   if (!response.ok) {
@@ -112,7 +117,12 @@ function firstOutputUrl(outputs: unknown): string | undefined {
 const TERMINAL_OK = new Set(["completed", "succeeded", "success"]);
 const TERMINAL_FAIL = new Set(["failed", "error", "canceled", "cancelled"]);
 
-export async function generateAtlasCloudImage(request: ImageGenRequest): Promise<GeneratedImage> {
+/** Runs Atlas submit/poll/download through an injected fetch with per-request deadlines. */
+export async function generateAtlasCloudImageWithFetch(
+  request: ImageGenRequest,
+  fetchImpl: typeof fetch,
+  submitTimeoutMs = ATLAS_IMAGE_SUBMIT_TIMEOUT_MS,
+): Promise<GeneratedImage> {
   const apiKey = request.apiKeys.ATLASCLOUD_API_KEY;
   if (!apiKey) {
     throw new Error(getAiProviderConfigurationError());
@@ -141,10 +151,11 @@ export async function generateAtlasCloudImage(request: ImageGenRequest): Promise
     body.ratio = request.aspectRatio;
   }
 
-  const submitResponse = await fetch(`${baseUrl}/api/v1/model/generateImage`, {
+  const submitResponse = await fetchImpl(`${baseUrl}/api/v1/model/generateImage`, {
     method: "POST",
     headers: { ...authHeader, "content-type": "application/json" },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(submitTimeoutMs),
   });
 
   const submitPayload = (await submitResponse.json().catch(() => ({}))) as Record<string, unknown>;
@@ -161,7 +172,7 @@ export async function generateAtlasCloudImage(request: ImageGenRequest): Promise
   // Some models may return the image inline on submit; short-circuit if so.
   const inlineUrl = firstOutputUrl(submitted.outputs);
   if (inlineUrl) {
-    return await imageUrlToGeneratedImage(inlineUrl);
+    return await imageUrlToGeneratedImage(inlineUrl, "", fetchImpl);
   }
 
   const predictionId = submitted.id;
@@ -170,12 +181,19 @@ export async function generateAtlasCloudImage(request: ImageGenRequest): Promise
   }
   const pollUrl = submitted.urls?.get ?? `${baseUrl}/api/v1/model/prediction/${predictionId}`;
 
-  // 2. Poll the prediction until it terminates.
+  // 2. Poll the prediction until it terminates. The loop deadline only
+  //    gates successful iterations; each poll fetch must also abort or a
+  //    stalled Atlas GET hangs past ATLAS_POLL_TIMEOUT_MS.
   const deadline = Date.now() + ATLAS_POLL_TIMEOUT_MS;
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, ATLAS_POLL_INTERVAL_MS));
 
-    const pollResponse = await fetch(pollUrl, { headers: authHeader });
+    const pollResponse = await fetchImpl(pollUrl, {
+      headers: authHeader,
+      signal: AbortSignal.timeout(
+        Math.max(1, Math.min(ATLAS_IMAGE_SUBMIT_TIMEOUT_MS, deadline - Date.now())),
+      ),
+    });
     const pollPayload = (await pollResponse.json().catch(() => ({}))) as Record<string, unknown>;
     if (!pollResponse.ok) {
       throw new Error(`Atlas prediction poll failed: ${pollResponse.status}`);
@@ -195,11 +213,15 @@ export async function generateAtlasCloudImage(request: ImageGenRequest): Promise
       if (!url) {
         throw new Error("Atlas image provider completed without an output image");
       }
-      return await imageUrlToGeneratedImage(url);
+      return await imageUrlToGeneratedImage(url, "", fetchImpl);
     }
   }
 
   throw new Error("Atlas image generation timed out");
+}
+
+export async function generateAtlasCloudImage(request: ImageGenRequest): Promise<GeneratedImage> {
+  return generateAtlasCloudImageWithFetch(request, globalThis.fetch);
 }
 
 export const atlasCloudImageProvider: ImageProvider = {

--- a/packages/cloud/shared/src/lib/providers/image/atlascloud-image-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/image/atlascloud-image-generation.ts
@@ -1,4 +1,4 @@
-// Defines cloud shared atlascloud image generation behavior for backend service consumers.
+/** Implements Atlas Cloud's asynchronous image submit, poll, and download protocol. */
 import { getAiProviderConfigurationError } from "../language-model";
 import type { GeneratedImage, ImageGenRequest, ImageProvider } from "./types";
 
@@ -10,6 +10,12 @@ const ATLAS_IMAGE_SUBMIT_TIMEOUT_MS = 30_000;
 const ATLAS_IMAGE_MAX_BYTES = 20 * 1024 * 1024;
 const ATLAS_POLL_INTERVAL_MS = 2_000;
 const ATLAS_POLL_TIMEOUT_MS = 120_000;
+
+interface AtlasImageTimingOptions {
+  pollIntervalMs?: number;
+  pollTimeoutMs?: number;
+  pollRequestTimeoutMs?: number;
+}
 
 function bytesToBase64(bytes: Uint8Array): string {
   let binary = "";
@@ -122,6 +128,7 @@ export async function generateAtlasCloudImageWithFetch(
   request: ImageGenRequest,
   fetchImpl: typeof fetch,
   submitTimeoutMs = ATLAS_IMAGE_SUBMIT_TIMEOUT_MS,
+  timing: AtlasImageTimingOptions = {},
 ): Promise<GeneratedImage> {
   const apiKey = request.apiKeys.ATLASCLOUD_API_KEY;
   if (!apiKey) {
@@ -184,15 +191,20 @@ export async function generateAtlasCloudImageWithFetch(
   // 2. Poll the prediction until it terminates. The loop deadline only
   //    gates successful iterations; each poll fetch must also abort or a
   //    stalled Atlas GET hangs past ATLAS_POLL_TIMEOUT_MS.
-  const deadline = Date.now() + ATLAS_POLL_TIMEOUT_MS;
+  const pollIntervalMs = timing.pollIntervalMs ?? ATLAS_POLL_INTERVAL_MS;
+  const pollTimeoutMs = timing.pollTimeoutMs ?? ATLAS_POLL_TIMEOUT_MS;
+  const pollRequestTimeoutMs = timing.pollRequestTimeoutMs ?? ATLAS_IMAGE_SUBMIT_TIMEOUT_MS;
+  const deadline = Date.now() + pollTimeoutMs;
   while (Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, ATLAS_POLL_INTERVAL_MS));
+    const sleepMs = Math.min(Math.max(0, pollIntervalMs), Math.max(0, deadline - Date.now()));
+    await new Promise((resolve) => setTimeout(resolve, sleepMs));
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
 
     const pollResponse = await fetchImpl(pollUrl, {
       headers: authHeader,
-      signal: AbortSignal.timeout(
-        Math.max(1, Math.min(ATLAS_IMAGE_SUBMIT_TIMEOUT_MS, deadline - Date.now())),
-      ),
+      signal: AbortSignal.timeout(Math.max(1, Math.min(pollRequestTimeoutMs, remainingMs))),
     });
     const pollPayload = (await pollResponse.json().catch(() => ({}))) as Record<string, unknown>;
     if (!pollResponse.ok) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). Atlas image **submit** and **poll** `fetch` have no `AbortSignal`, so a stalled Atlas GET hangs the worker past `ATLAS_POLL_TIMEOUT_MS` (the loop only gates successful iterations). Download was already bounded. Not `#21203` (closed: grep-token test, no executed success/timeout/error paths). This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success. Not extra-decode. Not list-limit. Not payment. Not `#21385`. Not grok extract/search. Not cloud JSON reprints. Proof is `bun:test` of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Canonical inline-output and poll completion still download. Unfixed head: submit `fetch` had **no signal** and a hung fetch never settled (80ms race → `HUNG`). After: 10ms deadline → `TimeoutError`.

# Background

## What does this PR do?

`generateAtlasCloudImage` called `fetch` on `/generateImage` and the prediction poll URL with no `signal`. A stalled upstream never reaches the 120s poll deadline. This PR injects `generateAtlasCloudImageWithFetch` (Fal `#21205` shape), adds `AbortSignal.timeout` on submit and each poll, and keeps the existing download timeout.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Video Atlas path untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/providers/__tests__/atlas-image-timeout.test.ts` — timeout, provider-error, success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/cloud/shared && bun test --isolate src/lib/providers/__tests__/atlas-image-timeout.test.ts
```

Unfixed head `7aba8dee0c`: submit fetch `signal` was undefined and the call hung. After the fix: 3 passed on `a0560c4ff8`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:a0560c4ff8ecb95abef4e3d516a648694a35ec2e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Provider fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live Atlas path. bun:test asserts TimeoutError, provider 429 message, and inline download.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches poll or download.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - Atlas image transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live Atlas. Unfixed `%` hang: no signal, 80ms race `HUNG`. After the fix, bun:test asserts TimeoutError, `quota exceeded` on 429, and a 3-byte PNG download.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

## Audio / voice walkthrough

N/A - image provider HTTP only.

## Known gaps / failures

`bun run verify` was not run. Focused package test is the proof (`3 pass`). Root verify is an unrelated full-repo cost. No `bun install`. Video Atlas submits remain unbounded; out of this PR's one-file scope.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
