### PR TITLE
fix(cloud): reject malformed wallets provision JSON

### DIFF
--- a/packages/cloud/api/v1/user/wallets/provision/route.json.test.ts
+++ b/packages/cloud/api/v1/user/wallets/provision/route.json.test.ts
@@ -1,0 +1,176 @@
+/**
+ * POST /api/v1/user/wallets/provision untrusted JSON body contract.
+ *
+ * Hono 4.13 `c.req.json()` is a bare `JSON.parse`. The handler catch maps
+ * SyntaxError through `failureResponse` to HTTP 500 instead of a caller 400.
+ * Wallet provision must not run on client garbage.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const USER_ID = "00000000-0000-4000-8000-0000000000aa";
+const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
+const CLIENT_ADDRESS = "0x1111111111111111111111111111111111111111";
+
+const requireUserOrApiKey = mock(async () => ({
+  id: USER_ID,
+  organization: { id: ORG_ID },
+}));
+
+const provisionServerWallet = mock(async () => {
+  throw new Error("provisionServerWallet must not run");
+});
+
+const failureResponse = mock(
+  (c: { json: (body: unknown, status: number) => unknown }) =>
+    c.json({ success: false, error: "An unexpected error occurred" }, 500),
+);
+
+mock.module("viem", () => ({
+  isAddress: (value: string) => /^0x[0-9a-fA-F]{40}$/.test(value),
+}));
+
+mock.module("drizzle-orm", () => ({
+  and: mock(() => ({})),
+  eq: mock(() => ({})),
+}));
+
+mock.module("@/db/helpers", () => ({
+  dbWrite: {
+    select: mock(() => ({
+      from: mock(() => ({
+        where: mock(() => ({
+          limit: mock(async () => []),
+        })),
+      })),
+    })),
+  },
+}));
+
+mock.module("@/db/schemas/agent-server-wallets", () => ({
+  agentServerWallets: {
+    id: "id",
+    address: "address",
+    chain_type: "chain_type",
+    client_address: "client_address",
+    organization_id: "organization_id",
+  },
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKey,
+}));
+
+mock.module("@/lib/services/server-wallets", () => ({
+  provisionServerWallet,
+}));
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    error: mock(() => undefined),
+    warn: mock(() => undefined),
+    info: mock(() => undefined),
+  },
+}));
+
+const { default: app } = await import("./route");
+
+function post(raw: string) {
+  return app.fetch(
+    new Request("http://test.local/", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_test_key",
+        "Content-Type": "application/json",
+      },
+      body: raw,
+    }),
+  );
+}
+
+const validBody = {
+  chainType: "evm",
+  clientAddress: CLIENT_ADDRESS,
+  controlProof: {
+    signature: "0xab",
+    timestamp: 1,
+    nonce: "n1",
+  },
+};
+
+describe("POST /api/v1/user/wallets/provision JSON body", () => {
+  beforeEach(() => {
+    requireUserOrApiKey.mockClear();
+    provisionServerWallet.mockClear();
+    failureResponse.mockClear();
+    provisionServerWallet.mockImplementation(async () => {
+      throw new Error("provisionServerWallet must not run");
+    });
+  });
+
+  test.each(["", "   ", "{", "not-json"])(
+    "rejects malformed provision body %j with 400",
+    async (raw) => {
+      const res = await post(raw);
+
+      expect(res.status).toBe(400);
+      expect((await res.json()) as Record<string, unknown>).toEqual({
+        success: false,
+        error: "Invalid JSON body",
+      });
+      expect(requireUserOrApiKey).toHaveBeenCalled();
+      expect(provisionServerWallet).not.toHaveBeenCalled();
+      expect(failureResponse).not.toHaveBeenCalled();
+    },
+  );
+
+  test("still 400s a parseable object missing fields via zod", async () => {
+    const res = await post("{}");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { success?: boolean; error?: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Validation error");
+    expect(provisionServerWallet).not.toHaveBeenCalled();
+  });
+
+  test("still provisions a canonical object body", async () => {
+    provisionServerWallet.mockResolvedValue({
+      id: "wallet-1",
+      address: "0x2222222222222222222222222222222222222222",
+      chain_type: "evm",
+      client_address: CLIENT_ADDRESS,
+    });
+
+    const res = await post(JSON.stringify(validBody));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      success: true,
+      data: {
+        id: "wallet-1",
+        address: "0x2222222222222222222222222222222222222222",
+        chainType: "evm",
+        clientAddress: CLIENT_ADDRESS,
+      },
+    });
+    expect(provisionServerWallet).toHaveBeenCalledTimes(1);
+    expect(provisionServerWallet.mock.calls[0]?.[0]).toMatchObject({
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      clientAddress: CLIENT_ADDRESS,
+      chainType: "evm",
+    });
+  });
+});

--- a/packages/cloud/api/v1/user/wallets/provision/route.json.test.ts
+++ b/packages/cloud/api/v1/user/wallets/provision/route.json.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ProvisionWalletParams } from "@/lib/services/server-wallets";
 
 const USER_ID = "00000000-0000-4000-8000-0000000000aa";
 const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
@@ -17,9 +18,18 @@ const requireUserOrApiKey = mock(async () => ({
   organization: { id: ORG_ID },
 }));
 
-const provisionServerWallet = mock(async () => {
-  throw new Error("provisionServerWallet must not run");
-});
+const provisionServerWallet = mock(
+  async (
+    _params: ProvisionWalletParams,
+  ): Promise<{
+    id: string;
+    address: string;
+    chain_type: string;
+    client_address: string;
+  }> => {
+    throw new Error("provisionServerWallet must not run");
+  },
+);
 
 const failureResponse = mock(
   (c: { json: (body: unknown, status: number) => unknown }) =>

--- a/packages/cloud/api/v1/user/wallets/provision/route.ts
+++ b/packages/cloud/api/v1/user/wallets/provision/route.ts
@@ -50,7 +50,15 @@ app.post("/", async (c) => {
 
   try {
     user = await requireUserOrApiKey(c);
-    const body = await c.req.json();
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
+      // bare JSON.parse. SyntaxError must be a caller 400, not the
+      // failureResponse 500 that treats it as an unexpected server fault.
+      return c.json({ success: false, error: "Invalid JSON body" }, 400);
+    }
     validated = provisionWalletSchema.parse(body);
     const clientAddress = validated.clientAddress.toLowerCase();
 

--- a/packages/cloud/api/v1/user/wallets/provision/route.ts
+++ b/packages/cloud/api/v1/user/wallets/provision/route.ts
@@ -53,10 +53,10 @@ app.post("/", async (c) => {
     let body: unknown;
     try {
       body = await c.req.json();
-    } catch {
-      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
-      // bare JSON.parse. SyntaxError must be a caller 400, not the
-      // failureResponse 500 that treats it as an unexpected server fault.
+    } catch (error) {
+      // error-policy:J3 SyntaxError is caller garbage. Stream/decoder
+      // failures stay 500 — do not reprint leftover-tax #21685/#21690.
+      if (!(error instanceof SyntaxError)) throw error;
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
     validated = provisionWalletSchema.parse(body);


### PR DESCRIPTION
# Relates to

Operator request: publish the unpublished wallets/provision JSON 500 that is still live on `develop`. Not a reprint of Shaw-closed leftover-tax `#21541` / `#21690`. This file still `await c.req.json()` in the provision try on develop. Not x402 / payment.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Inner JSON parse only on `POST /api/v1/user/wallets/provision`.
`SyntaxError` becomes 400. Any other parse-path error is rethrown so
stream/decoder failures stay 500 (Shaw keep on `#21690`). Zod `{}` still 400.
Canonical provision object still provisions.

# Background

## What does this PR do?

`POST /api/v1/user/wallets/provision` called `c.req.json()` inside the
provision try. Hono `c.req.json()` is a bare `JSON.parse`. A `SyntaxError`
is not Zod, so `failureResponse` mapped it to **500**.

- `""` / `"   "` / `"{"` / `"not-json"` → **400**
- `{}` → still 400 via zod
- canonical provision object → still provisions

Stream/decoder failures that are not `SyntaxError` stay **500**.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Client garbage must not look like a wallet-provision outage. This route is
still 500 on `develop`. Catch is `SyntaxError`-only so leftover-tax `#21685`
is not reprinted.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/user/wallets/provision/route.json.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/user/wallets/provision/route.json.test.ts
```

On develop: 4 failed / 2 passed (syntax/empty were 500).
At this head: 6 passed / 0 failed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; wallets/provision JSON parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; wallets/provision JSON parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; wallets/provision JSON parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused bun tests drive the real malformed tokens and assert 400 before provision; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no wallet write; malformed JSON 400s before provision.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - JSON contract is asserted in-process against the real handler.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical provision objects still provision.
Malformed JSON that previously 500 now 400. Non-SyntaxError decode failures
stay 500.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

# Known gaps / failures

`bun run verify` was not run. Focused wallets/provision JSON suite is green at this head.
The unrelated monorepo verify is out of scope for this two-file API contract fix.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:712189ef2c3c3b2353706fb23dbdf5b9eb6c2504 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
