### PR TITLE
fix(cloud): reject malformed browser-sessions JSON

### DIFF
--- a/packages/cloud/api/v1/browser/sessions/route.json.test.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.json.test.ts
@@ -1,0 +1,60 @@
+/**
+ * POST /api/v1/browser/sessions used to let c.req.json() throw into
+ * failureResponse, which maps SyntaxError to 500. Malformed JSON is caller
+ * error and must not create a hosted session.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const createHostedBrowserSession = mock(async () => ({
+  id: "sess-1",
+  url: "https://example.com",
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/browser-tools", () => ({
+  createHostedBrowserSession,
+  listHostedBrowserSessions: async () => [],
+  logHostedBrowserFailure: () => undefined,
+}));
+
+const { default: app } = await import("./route");
+
+describe("POST /api/v1/browser/sessions malformed JSON", () => {
+  beforeEach(() => {
+    createHostedBrowserSession.mockClear();
+  });
+
+  test("returns 400 instead of 500 and never creates a session", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(createHostedBrowserSession).not.toHaveBeenCalled();
+  });
+
+  test("canonical JSON still creates a session", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com" }),
+    });
+    expect(response.status).toBe(200);
+    expect(createHostedBrowserSession).toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/browser/sessions/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.ts
@@ -49,7 +49,16 @@ app.get("/", async (c) => {
 app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    const bodyResult = createSessionSchema.safeParse(await c.req.json());
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
+      // bare JSON.parse. SyntaxError must be a caller 400, not the
+      // failureResponse 500 that treats it as an unexpected server fault.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const bodyResult = createSessionSchema.safeParse(rawBody);
     if (!bodyResult.success) {
       return c.json(
         {

--- a/packages/cloud/api/v1/browser/sessions/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.ts
@@ -52,10 +52,10 @@ app.post("/", async (c) => {
     let rawBody: unknown;
     try {
       rawBody = await c.req.json();
-    } catch {
-      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
-      // bare JSON.parse. SyntaxError must be a caller 400, not the
-      // failureResponse 500 that treats it as an unexpected server fault.
+    } catch (error) {
+      // error-policy:J3 SyntaxError is caller garbage. Stream/decoder
+      // failures stay 500 — do not reprint leftover-tax #21685/#21690.
+      if (!(error instanceof SyntaxError)) throw error;
       return c.json({ error: "Invalid JSON body" }, 400);
     }
     const bodyResult = createSessionSchema.safeParse(rawBody);


### PR DESCRIPTION
# Relates to

Operator request: publish the unpublished browser/sessions JSON 500 that is still live on `develop`. Not a reprint of Shaw-closed leftover-tax `#21541` / `#21690`. Parent `packages/cloud/api/v1/browser/sessions/route.ts` still `safeParse(await c.req.json())` on develop. Does not touch `[id]/command` or `[id]/navigate`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Inner JSON parse only on `POST /api/v1/browser/sessions`. `SyntaxError`
becomes 400. Any other parse-path error is rethrown so stream/decoder failures
stay 500 (Shaw keep on `#21690`). Canonical `{ url }` still creates a session.

# Background

## What does this PR do?

`POST /api/v1/browser/sessions` called `createSessionSchema.safeParse(await c.req.json())`
inside the create try. Hono `c.req.json()` is a bare `JSON.parse`. A
`SyntaxError` is not Zod, so `failureResponse` mapped it to **500**.

- `"{"` → **400**
- `{ url }` → still creates a session

Stream/decoder failures that are not `SyntaxError` stay **500**.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Client garbage must not look like a hosted-browser session outage. This route
is still 500 on `develop`. Catch is `SyntaxError`-only so leftover-tax `#21685`
is not reprinted.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/browser/sessions/route.json.test.ts`

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/browser/sessions/route.json.test.ts
```

On develop: 1 failed / 1 passed (`{` was 500).
At this head: 2 passed / 0 failed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; browser/sessions JSON parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; browser/sessions JSON parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change; browser/sessions JSON parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused bun tests drive the real malformed token and assert 400 before createHostedBrowserSession; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no session write; malformed JSON 400s before createHostedBrowserSession.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - JSON contract is asserted in-process against the real handler.

## Walkthrough / demo

N/A - no rendered UI change.

# Compatibility

No API or schema change. Canonical `{ url }` still creates a session.
Malformed JSON that previously 500 now 400. Non-SyntaxError decode failures
stay 500. `[id]/command` and `[id]/navigate` are untouched.

# Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have added/updated tests where applicable
- [x] I have documented the changes where applicable (N/A - no docs needed)

# Known gaps / failures

`bun run verify` was not run. Focused browser/sessions JSON suite is green at this head.
The unrelated monorepo verify is out of scope for this two-file API contract fix.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4c00f4e67e1796768f1c52eac541209428d8600b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [grok]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
