### PR TITLE
fix(cloud): gate migrations on postgres resilience

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -45,6 +45,13 @@ jobs:
     timeout-minutes: 10
     env:
       MIGRATION_DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
+      DATABASE_RESILIENCE_GATE_MODE: ${{ vars.DATABASE_RESILIENCE_GATE_MODE || 'off' }}
+      DATABASE_RESILIENCE_MAX_BACKUP_AGE_HOURS: ${{ vars.DATABASE_RESILIENCE_MAX_BACKUP_AGE_HOURS || '36' }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+      RAILWAY_POSTGRES_SERVICE_ID: ${{ vars.RAILWAY_POSTGRES_SERVICE_ID }}
+      RAILWAY_PRODUCTION_POSTGRES_SERVICE_RECEIPT: ${{ vars.RAILWAY_PRODUCTION_POSTGRES_SERVICE_RECEIPT }}
+      RAILWAY_PRODUCTION_POSTGRES_VOLUME_RECEIPT: ${{ vars.RAILWAY_PRODUCTION_POSTGRES_VOLUME_RECEIPT }}
     outputs:
       # "true" only for the neutral supersession skip; downstream deploy jobs
       # and the caller's certification job gate on it.
@@ -113,6 +120,190 @@ jobs:
             source_args+=(--force)
           fi
           node packages/cloud/scripts/canonical-deploy-source-guard.mjs "${source_args[@]}"
+
+      - name: Validate Railway PostgreSQL resilience gate configuration
+        id: database_resilience
+        if: ${{ steps.source_guard.outputs.superseded != 'true' }}
+        env:
+          TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+          HAS_RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+          case "$DATABASE_RESILIENCE_GATE_MODE" in
+            off)
+              echo "enabled=false" >> "$GITHUB_OUTPUT"
+              echo "Railway PostgreSQL resilience gate is disabled; no Railway query performed."
+              exit 0
+              ;;
+            report|enforce)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::DATABASE_RESILIENCE_GATE_MODE must be off, report, or enforce"
+              exit 1
+              ;;
+          esac
+
+          required=(
+            RAILWAY_PROJECT_ID
+            RAILWAY_ENVIRONMENT_ID
+            RAILWAY_POSTGRES_SERVICE_ID
+          )
+          if [ "$TARGET_ENVIRONMENT" = "staging" ]; then
+            required+=(
+              RAILWAY_PRODUCTION_POSTGRES_SERVICE_RECEIPT
+              RAILWAY_PRODUCTION_POSTGRES_VOLUME_RECEIPT
+            )
+          fi
+          missing=()
+          for name in "${required[@]}"; do
+            value="${!name:-}"
+            if [ -z "${value//[[:space:]]/}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "$HAS_RAILWAY_TOKEN" != "true" ]; then
+            missing+=("RAILWAY_TOKEN")
+          fi
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required protected PostgreSQL resilience setting name(s): ${missing[*]}"
+            exit 1
+          fi
+          for name in RAILWAY_PROJECT_ID RAILWAY_ENVIRONMENT_ID RAILWAY_POSTGRES_SERVICE_ID; do
+            value="${!name}"
+            if [[ ! "$value" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+              echo "::error::$name must be a lowercase Railway UUID"
+              exit 1
+            fi
+          done
+          if [ "$TARGET_ENVIRONMENT" = "staging" ]; then
+            for name in RAILWAY_PRODUCTION_POSTGRES_SERVICE_RECEIPT RAILWAY_PRODUCTION_POSTGRES_VOLUME_RECEIPT; do
+              value="${!name}"
+              if [[ ! "$value" =~ ^[0-9a-f]{64}$ ]]; then
+                echo "::error::$name must be a lowercase SHA-256 receipt"
+                exit 1
+              fi
+            done
+          fi
+          if [[ ! "$DATABASE_RESILIENCE_MAX_BACKUP_AGE_HOURS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::DATABASE_RESILIENCE_MAX_BACKUP_AGE_HOURS must be a positive integer"
+            exit 1
+          fi
+          echo "Protected PostgreSQL resilience setting names and formats are valid; values were not printed."
+
+      - name: Install pinned Railway CLI for resilience proof
+        if: ${{ steps.database_resilience.outputs.enabled == 'true' }}
+        run: |
+          set -euo pipefail
+          cli_root="$RUNNER_TEMP/railway-cli"
+          archive="$RUNNER_TEMP/railway-v5.38.0.tar.gz"
+          mkdir -p "$cli_root"
+          curl \
+            --fail \
+            --location \
+            --silent \
+            --show-error \
+            --retry 3 \
+            --output "$archive" \
+            "https://github.com/railwayapp/cli/releases/download/v5.38.0/railway-v5.38.0-x86_64-unknown-linux-gnu.tar.gz"
+          printf '%s  %s\n' \
+            "72835c48a710c48c4542141bf12264823cf3a029b514f9e27994096c036c539e" \
+            "$archive" | sha256sum --check --status
+          tar -xzf "$archive" -C "$cli_root" railway
+          chmod 0755 "$cli_root/railway"
+          echo "$cli_root" >> "$GITHUB_PATH"
+          "$cli_root/railway" --version | grep -F "railway 5.38.0"
+
+      - name: Capture read-only Railway PostgreSQL evidence
+        if: ${{ steps.database_resilience.outputs.enabled == 'true' }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          set -euo pipefail
+          evidence_dir="$RUNNER_TEMP/postgres-resilience"
+          mkdir -m 0700 "$evidence_dir"
+          capture() {
+            local label="$1"
+            local output="$2"
+            shift 2
+            if ! "$@" > "$output" 2>"$evidence_dir/${label}.stderr"; then
+              echo "::error::Railway $label query failed; raw output was not printed"
+              exit 1
+            fi
+          }
+          common=(
+            --project "$RAILWAY_PROJECT_ID"
+            --environment "$RAILWAY_ENVIRONMENT_ID"
+          )
+          postgres=(
+            "${common[@]}"
+            --service "$RAILWAY_POSTGRES_SERVICE_ID"
+            --json
+          )
+          capture status "$evidence_dir/status.json" \
+            railway status "${common[@]}" --json
+          capture services "$evidence_dir/services.json" \
+            railway service list "${common[@]}" --json
+          capture volumes "$evidence_dir/volumes.json" \
+            railway api \
+              'query VolumeEvidence($id: String!) { environment(id: $id) { id volumeInstances { edges { node { id environmentId serviceId volumeId mountPath state deletedAt isPendingDeletion sizeMB } } } } }' \
+              --raw-var "id=$RAILWAY_ENVIRONMENT_ID" \
+              --compact
+          capture pitr "$evidence_dir/pitr.json" \
+            railway postgres pitr status "${postgres[@]}"
+          capture schedules "$evidence_dir/schedules.json" \
+            railway postgres pitr schedule list "${postgres[@]}"
+          capture backups "$evidence_dir/backups.json" \
+            railway postgres pitr backup list "${postgres[@]}"
+          echo "Read-only Railway PostgreSQL evidence captured without printing resource inventory."
+
+      - name: Verify backup, PITR, and physical-isolation evidence
+        if: ${{ steps.database_resilience.outputs.enabled == 'true' }}
+        env:
+          TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+        run: |
+          set -euo pipefail
+          evidence_dir="$RUNNER_TEMP/postgres-resilience"
+          args=(
+            --mode "$DATABASE_RESILIENCE_GATE_MODE"
+            --environment "$TARGET_ENVIRONMENT"
+            --project-id "$RAILWAY_PROJECT_ID"
+            --environment-id "$RAILWAY_ENVIRONMENT_ID"
+            --service-id "$RAILWAY_POSTGRES_SERVICE_ID"
+            --max-backup-age-hours "$DATABASE_RESILIENCE_MAX_BACKUP_AGE_HOURS"
+            --status-json "$evidence_dir/status.json"
+            --services-json "$evidence_dir/services.json"
+            --volumes-json "$evidence_dir/volumes.json"
+            --pitr-json "$evidence_dir/pitr.json"
+            --schedules-json "$evidence_dir/schedules.json"
+            --backups-json "$evidence_dir/backups.json"
+          )
+          if [ "$TARGET_ENVIRONMENT" = "staging" ]; then
+            args+=(
+              --production-service-receipt "$RAILWAY_PRODUCTION_POSTGRES_SERVICE_RECEIPT"
+              --production-volume-receipt "$RAILWAY_PRODUCTION_POSTGRES_VOLUME_RECEIPT"
+            )
+          fi
+          receipt="$evidence_dir/receipt.json"
+          set +e
+          bun packages/cloud/scripts/admin/preflight-railway-postgres-resilience.ts \
+            "${args[@]}" > "$receipt"
+          gate_status="$?"
+          set -e
+          verdict="$(jq -er '.verdict' "$receipt")"
+          jq -r '.checks | to_entries[] | "- \(.key): \(.value)"' "$receipt" \
+            >> "$GITHUB_STEP_SUMMARY"
+          jq -r \
+            '.receipts | to_entries[] | select(.value != null) | "- \(.key)Receipt: \(.value)"' \
+            "$receipt" >> "$GITHUB_STEP_SUMMARY"
+          echo "- verdict: $verdict" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$DATABASE_RESILIENCE_GATE_MODE" = "report" ] && [ "$verdict" != "pass" ]; then
+            echo "::warning::Railway PostgreSQL resilience report found unmet checks; report mode does not block migrations"
+          fi
+          if [ "$gate_status" -ne 0 ]; then
+            echo "::error::Railway PostgreSQL resilience enforcement failed before migrations"
+            exit "$gate_status"
+          fi
 
       - name: Run migrations
         if: ${{ steps.source_guard.outputs.superseded != 'true' }}

--- a/packages/cloud/infra/cloud/RAILWAY.md
+++ b/packages/cloud/infra/cloud/RAILWAY.md
@@ -79,7 +79,9 @@ resilience preflight before schema mutation. It is inert by default:
 - Staging enforcement also requires protected SHA-256 receipts for the
   production Postgres service and immutable volume-instance ID and proves the
   selected staging service and volume differ. Mutable volume labels are never
-  isolation evidence. The gate emits receipts and booleans only; it does
+  isolation evidence. A volume receipt is emitted only after that instance is
+  bound to the selected project, environment, service, and Postgres data mount.
+  The gate emits receipts and booleans only; it does
   not print connection strings, Railway inventory, raw service IDs, or volume
   names.
 

--- a/packages/cloud/infra/cloud/RAILWAY.md
+++ b/packages/cloud/infra/cloud/RAILWAY.md
@@ -63,6 +63,58 @@ The repository cannot infer Railway service/volume or backup state from a
 PostgreSQL connection, and `report` mode is not evidence that those protected
 resources exist.
 
+### PostgreSQL recovery and staging-isolation gate
+
+The `migrate-db` job in `cloud-cf-release.yml` owns a read-only Railway
+resilience preflight before schema mutation. It is inert by default:
+
+- `DATABASE_RESILIENCE_GATE_MODE=off` performs no Railway query.
+- `report` queries only project/service, immutable volume-instance, PITR,
+  schedule, and backup metadata; unmet checks are recorded without blocking
+  migrations.
+- `enforce` fails before migrations unless the selected Postgres 18 service has
+  exactly one ready data volume, PITR storage is wired, daily and weekly backup
+  schedules exist, and a scheduled backup is within
+  `DATABASE_RESILIENCE_MAX_BACKUP_AGE_HOURS` (36 by default).
+- Staging enforcement also requires protected SHA-256 receipts for the
+  production Postgres service and immutable volume-instance ID and proves the
+  selected staging service and volume differ. Mutable volume labels are never
+  isolation evidence. The gate emits receipts and booleans only; it does
+  not print connection strings, Railway inventory, raw service IDs, or volume
+  names.
+
+The protected environment supplies `RAILWAY_PROJECT_ID`,
+`RAILWAY_ENVIRONMENT_ID`, `RAILWAY_POSTGRES_SERVICE_ID`, and `RAILWAY_TOKEN`.
+Staging additionally supplies `RAILWAY_PRODUCTION_POSTGRES_SERVICE_RECEIPT`
+and `RAILWAY_PRODUCTION_POSTGRES_VOLUME_RECEIPT`. Generate those receipts from
+a successful production `report` run; never copy a production credential into
+staging.
+
+Activation order is fail-closed:
+
+1. Enable PITR plus daily and weekly schedules on the existing production
+   service through a separately reviewed protected operator change. Capture a
+   successful scheduled backup and restore drill before enforcement.
+2. Run production in `report`, retain its nonsecret service/volume receipts,
+   then set production to `enforce` only after the restore evidence is reviewed.
+3. Provision a separate staging Postgres 18 service, role, and volume. Enable
+   and prove the same recovery policy before copying staging data.
+4. Record the production receipts in the protected staging variables, run
+   staging in `report`, and require every physical-isolation and recovery check
+   to pass before the bounded write quiesce and final sync.
+5. Set staging to `enforce` before changing either the protected migration
+   authority or Hyperdrive origin. Keep both authorities together throughout
+   cutover and rollback; the separate database-identity gate verifies their
+   logical/cluster authority before migrations.
+6. Do not remove the old staging database until the new target passes schema,
+   count/digest, authenticated API, Shared-agent, provisioning, backup restore,
+   and rollback proof. After post-cutover writes, reconcile forward before any
+   repoint instead of blindly switching back.
+
+This gate does not provision, enable PITR, restore, copy, repoint, or delete
+resources. Those mutations remain explicit protected operations with their own
+review and rollback evidence.
+
 Steward (the auth provider) runs **embedded in the Worker**: `bootstrap-app.ts`
 mounts the embedded handler at `/steward*`
 (`packages/cloud/api/src/steward/embedded.ts`); the `STEWARD_*` secrets in

--- a/packages/cloud/scripts/admin/preflight-railway-postgres-resilience.test.ts
+++ b/packages/cloud/scripts/admin/preflight-railway-postgres-resilience.test.ts
@@ -287,6 +287,12 @@ describe("Railway PostgreSQL resilience preflight", () => {
         errors: [{ message: "redacted" }],
       },
     });
+    const foreignProject = evidence({
+      status: {
+        ...evidence().status,
+        id: "60000000-0000-4000-8000-000000000006",
+      },
+    });
 
     expect(
       verifyRailwayPostgresResilience(foreignTarget, expectation(), NOW).checks
@@ -296,6 +302,13 @@ describe("Railway PostgreSQL resilience preflight", () => {
       verifyRailwayPostgresResilience(errored, expectation(), NOW).checks
         .immutableVolumeBound,
     ).toBe(false);
+    const foreignProjectResult = verifyRailwayPostgresResilience(
+      foreignProject,
+      expectation(),
+      NOW,
+    );
+    expect(foreignProjectResult.checks.immutableVolumeBound).toBe(false);
+    expect(foreignProjectResult.receipts.volume).toBeNull();
   });
 
   test("requires exact project, environment, service, image, and volume bindings", () => {

--- a/packages/cloud/scripts/admin/preflight-railway-postgres-resilience.test.ts
+++ b/packages/cloud/scripts/admin/preflight-railway-postgres-resilience.test.ts
@@ -1,0 +1,408 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseCliArgs,
+  type ResilienceEvidence,
+  verifyRailwayPostgresResilience,
+} from "./preflight-railway-postgres-resilience";
+
+const PROJECT = "10000000-0000-4000-8000-000000000001";
+const STAGING_ENV = "20000000-0000-4000-8000-000000000002";
+const SERVICE = "30000000-0000-4000-8000-000000000003";
+const VOLUME = "40000000-0000-4000-8000-000000000004";
+const VOLUME_INSTANCE = "50000000-0000-4000-8000-000000000005";
+const NOW = new Date("2026-08-18T04:00:00.000Z");
+
+function evidence(
+  overrides: Partial<ResilienceEvidence> = {},
+): ResilienceEvidence {
+  return {
+    status: {
+      id: PROJECT,
+      environments: { edges: [{ node: { id: STAGING_ENV, name: "staging" } }] },
+      services: {
+        edges: [{ node: { id: SERVICE, name: "Postgres-staging" } }],
+      },
+    },
+    services: [
+      {
+        id: SERVICE,
+        name: "Postgres-staging",
+        source: { image: "ghcr.io/railwayapp-templates/postgres-ssl:18" },
+        volumes: [
+          {
+            name: "staging-postgres-volume",
+            mountPath: "/var/lib/postgresql/data",
+            sizeMb: 50_000,
+            state: "READY",
+          },
+        ],
+      },
+    ],
+    volumes: {
+      data: {
+        environment: {
+          id: STAGING_ENV,
+          volumeInstances: {
+            edges: [
+              {
+                node: {
+                  id: VOLUME_INSTANCE,
+                  volumeId: VOLUME,
+                  environmentId: STAGING_ENV,
+                  serviceId: SERVICE,
+                  mountPath: "/var/lib/postgresql/data",
+                  sizeMB: 50_000,
+                  state: "READY",
+                  deletedAt: null,
+                  isPendingDeletion: false,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    pitr: {
+      service: { id: SERVICE, name: "Postgres-staging" },
+      root: { id: SERVICE, name: "Postgres-staging" },
+      environment: { id: STAGING_ENV, name: "staging" },
+      enabled: true,
+      bucketWired: true,
+    },
+    schedules: [
+      { id: "daily", kind: "DAILY", retentionSeconds: 604_800 },
+      { id: "weekly", kind: "WEEKLY", retentionSeconds: 2_592_000 },
+    ],
+    backups: [
+      {
+        id: "backup-1",
+        createdAt: "2026-08-18T03:00:00.000Z",
+        scheduleId: "daily",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function expectation() {
+  return {
+    environment: "staging" as const,
+    projectId: PROJECT,
+    environmentId: STAGING_ENV,
+    serviceId: SERVICE,
+    productionServiceReceipt: "a".repeat(64),
+    productionVolumeReceipt: "b".repeat(64),
+    maxBackupAgeHours: 36,
+  };
+}
+
+describe("Railway PostgreSQL resilience preflight", () => {
+  test("passes only with recovery coverage and physical staging isolation", () => {
+    const result = verifyRailwayPostgresResilience(
+      evidence(),
+      expectation(),
+      NOW,
+    );
+
+    expect(result.verdict).toBe("pass");
+    expect(Object.values(result.checks).every(Boolean)).toBe(true);
+    expect(result.receipts.service).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.receipts.volume).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(result)).not.toContain("staging-postgres-volume");
+    expect(JSON.stringify(result)).not.toContain(SERVICE);
+  });
+
+  test.each([
+    ["PITR disabled", { pitr: { ...evidence().pitr, enabled: false } }],
+    ["bucket missing", { pitr: { ...evidence().pitr, bucketWired: false } }],
+    ["daily schedule missing", { schedules: evidence().schedules.slice(1) }],
+    [
+      "weekly schedule missing",
+      { schedules: evidence().schedules.slice(0, 1) },
+    ],
+    [
+      "scheduled backup stale",
+      {
+        backups: [
+          {
+            id: "old",
+            createdAt: "2026-08-15T00:00:00.000Z",
+            scheduleId: "daily",
+          },
+        ],
+      },
+    ],
+    [
+      "manual backup only",
+      {
+        backups: [
+          { id: "manual", createdAt: NOW.toISOString(), scheduleId: null },
+        ],
+      },
+    ],
+  ])("fails closed when %s", (_name, override) => {
+    expect(
+      verifyRailwayPostgresResilience(
+        evidence(override as Partial<ResilienceEvidence>),
+        expectation(),
+        NOW,
+      ).verdict,
+    ).toBe("fail");
+  });
+
+  test("rejects a shared production service or volume receipt", () => {
+    const baseline = verifyRailwayPostgresResilience(
+      evidence(),
+      expectation(),
+      NOW,
+    );
+    expect(
+      verifyRailwayPostgresResilience(
+        evidence(),
+        {
+          ...expectation(),
+          productionServiceReceipt: baseline.receipts.service ?? "",
+        },
+        NOW,
+      ).checks.physicallyDistinctService,
+    ).toBe(false);
+    expect(
+      verifyRailwayPostgresResilience(
+        evidence(),
+        {
+          ...expectation(),
+          productionVolumeReceipt: baseline.receipts.volume ?? "",
+        },
+        NOW,
+      ).checks.physicallyDistinctVolume,
+    ).toBe(false);
+  });
+
+  test("hashes immutable volume-instance identity, not mutable labels", () => {
+    const baseline = verifyRailwayPostgresResilience(
+      evidence(),
+      expectation(),
+      NOW,
+    );
+    const renamed = evidence({
+      services: [
+        {
+          ...evidence().services[0],
+          volumes: [
+            {
+              ...evidence().services[0].volumes?.[0],
+              name: "renamed-service-volume-label",
+            },
+          ],
+        },
+      ],
+      volumes: {
+        ...evidence().volumes,
+        data: {
+          environment: {
+            ...evidence().volumes.data?.environment,
+            volumeInstances: {
+              edges: [
+                {
+                  node: {
+                    ...evidence().volumes.data?.environment?.volumeInstances
+                      ?.edges?.[0].node,
+                    id: VOLUME_INSTANCE,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const result = verifyRailwayPostgresResilience(
+      renamed,
+      {
+        ...expectation(),
+        productionVolumeReceipt: baseline.receipts.volume ?? "",
+      },
+      NOW,
+    );
+    expect(result.receipts.volume).toBe(baseline.receipts.volume);
+    expect(result.checks.physicallyDistinctVolume).toBe(false);
+
+    const distinctInstance = evidence({
+      volumes: {
+        ...evidence().volumes,
+        data: {
+          environment: {
+            ...evidence().volumes.data?.environment,
+            volumeInstances: {
+              edges: [
+                {
+                  node: {
+                    ...evidence().volumes.data?.environment?.volumeInstances
+                      ?.edges?.[0].node,
+                    id: "70000000-0000-4000-8000-000000000007",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const distinctResult = verifyRailwayPostgresResilience(
+      distinctInstance,
+      {
+        ...expectation(),
+        productionVolumeReceipt: baseline.receipts.volume ?? "",
+      },
+      NOW,
+    );
+    expect(distinctResult.receipts.volume).not.toBe(baseline.receipts.volume);
+    expect(distinctResult.checks.physicallyDistinctVolume).toBe(true);
+  });
+
+  test("fails closed when immutable volume evidence is unbound or errored", () => {
+    const foreignTarget = evidence({
+      volumes: {
+        data: {
+          environment: {
+            id: STAGING_ENV,
+            volumeInstances: {
+              edges: [
+                {
+                  node: {
+                    ...evidence().volumes.data?.environment?.volumeInstances
+                      ?.edges?.[0].node,
+                    serviceId: "60000000-0000-4000-8000-000000000006",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const errored = evidence({
+      volumes: {
+        ...evidence().volumes,
+        errors: [{ message: "redacted" }],
+      },
+    });
+
+    expect(
+      verifyRailwayPostgresResilience(foreignTarget, expectation(), NOW).checks
+        .immutableVolumeBound,
+    ).toBe(false);
+    expect(
+      verifyRailwayPostgresResilience(errored, expectation(), NOW).checks
+        .immutableVolumeBound,
+    ).toBe(false);
+  });
+
+  test("requires exact project, environment, service, image, and volume bindings", () => {
+    const result = verifyRailwayPostgresResilience(
+      evidence({
+        status: {
+          id: "wrong",
+          environments: { edges: [] },
+          services: { edges: [] },
+        },
+        services: [
+          {
+            id: SERVICE,
+            source: { image: "postgres:17" },
+            volumes: [
+              {
+                name: "wrong",
+                mountPath: "/data",
+                sizeMb: 10,
+                state: "READY",
+              },
+            ],
+          },
+        ],
+        pitr: { ...evidence().pitr, service: { id: "wrong" } },
+      }),
+      expectation(),
+      NOW,
+    );
+
+    expect(result.verdict).toBe("fail");
+    expect(result.checks).toMatchObject({
+      projectBound: false,
+      environmentBound: false,
+      serviceBound: false,
+      exactPostgres18Service: false,
+      exactReadyVolume: false,
+      pitrTargetBound: false,
+    });
+  });
+
+  test("production emits canonical receipts without requiring isolation inputs", () => {
+    const production = evidence({
+      status: {
+        id: PROJECT,
+        environments: {
+          edges: [{ node: { id: STAGING_ENV, name: "production" } }],
+        },
+        services: { edges: [{ node: { id: SERVICE, name: "Postgres" } }] },
+      },
+      pitr: {
+        ...evidence().pitr,
+        environment: { id: STAGING_ENV, name: "production" },
+      },
+    });
+    const result = verifyRailwayPostgresResilience(
+      production,
+      {
+        environment: "production",
+        projectId: PROJECT,
+        environmentId: STAGING_ENV,
+        serviceId: SERVICE,
+        maxBackupAgeHours: 36,
+      },
+      NOW,
+    );
+    expect(result.verdict).toBe("pass");
+    expect(result.checks.physicallyDistinctService).toBeUndefined();
+  });
+
+  test("CLI parsing rejects report/enforce ambiguity and malformed receipts", () => {
+    const common = [
+      "--mode",
+      "enforce",
+      "--environment",
+      "staging",
+      "--project-id",
+      PROJECT,
+      "--environment-id",
+      STAGING_ENV,
+      "--service-id",
+      SERVICE,
+      "--status-json",
+      "/tmp/status.json",
+      "--services-json",
+      "/tmp/services.json",
+      "--pitr-json",
+      "/tmp/pitr.json",
+      "--volumes-json",
+      "/tmp/volumes.json",
+      "--schedules-json",
+      "/tmp/schedules.json",
+      "--backups-json",
+      "/tmp/backups.json",
+    ];
+    expect(
+      parseCliArgs([
+        ...common,
+        "--production-service-receipt",
+        "a".repeat(64),
+        "--production-volume-receipt",
+        "b".repeat(64),
+      ]).mode,
+    ).toBe("enforce");
+    expect(() => parseCliArgs(common)).not.toThrow();
+    expect(() => parseCliArgs(["--mode", "off", ...common.slice(2)])).toThrow(
+      "--mode must be report or enforce",
+    );
+  });
+});

--- a/packages/cloud/scripts/admin/preflight-railway-postgres-resilience.ts
+++ b/packages/cloud/scripts/admin/preflight-railway-postgres-resilience.ts
@@ -207,6 +207,7 @@ export function verifyRailwayPostgresResilience(
     ({ id }) => id === expected.serviceId,
   );
   const service = matching.length === 1 ? matching[0] : undefined;
+  const projectBound = evidence.status.id === expected.projectId;
   const volumes = (service?.volumes ?? []).filter(
     (volume) =>
       volume.mountPath === POSTGRES_MOUNT &&
@@ -239,7 +240,15 @@ export function verifyRailwayPostgresResilience(
   const immutableVolume =
     immutableVolumes.length === 1 ? immutableVolumes[0] : undefined;
   const immutableVolumeId = canonicalString(immutableVolume?.id);
-  const volumeReceipt = immutableVolumeId ? sha256(immutableVolumeId) : null;
+  const immutableVolumeBound =
+    projectBound &&
+    evidence.volumes.errors === undefined &&
+    evidence.volumes.data?.environment?.id === expected.environmentId &&
+    immutableVolumes.length === 1;
+  const volumeReceipt =
+    immutableVolumeBound && immutableVolumeId
+      ? sha256(immutableVolumeId)
+      : null;
 
   const backupCandidates = evidence.backups
     .map((backup) => ({ backup, time: scheduledBackupTime(backup) }))
@@ -262,7 +271,7 @@ export function verifyRailwayPostgresResilience(
     : [];
 
   const checks: Record<string, boolean> = {
-    projectBound: evidence.status.id === expected.projectId,
+    projectBound,
     environmentBound: hasResource(
       evidence.status.environments?.edges,
       expected.environmentId,
@@ -277,10 +286,7 @@ export function verifyRailwayPostgresResilience(
       typeof service?.source?.image === "string" &&
       /(?:^|\/)postgres[^:]*:18(?:$|[-.])/.test(service.source.image),
     exactReadyVolume: volumes.length === 1,
-    immutableVolumeBound:
-      evidence.volumes.errors === undefined &&
-      evidence.volumes.data?.environment?.id === expected.environmentId &&
-      immutableVolumes.length === 1,
+    immutableVolumeBound,
     pitrTargetBound:
       evidence.pitr.service?.id === expected.serviceId &&
       evidence.pitr.root?.id === expected.serviceId &&

--- a/packages/cloud/scripts/admin/preflight-railway-postgres-resilience.ts
+++ b/packages/cloud/scripts/admin/preflight-railway-postgres-resilience.ts
@@ -1,0 +1,406 @@
+/**
+ * Validates Railway PostgreSQL recovery and staging-isolation evidence captured
+ * by the protected Cloud release workflow. The command is read-only: Railway
+ * CLI calls happen in the workflow, while this process consumes their JSON and
+ * emits only boolean checks plus SHA-256 receipts.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+const MAX_INPUT_BYTES = 2 * 1024 * 1024;
+const POSTGRES_MOUNT = "/var/lib/postgresql/data";
+
+export type GateMode = "report" | "enforce";
+export type TargetEnvironment = "staging" | "production";
+
+interface ResourceRef {
+  id?: unknown;
+  name?: unknown;
+}
+
+interface StatusDocument {
+  id?: unknown;
+  environments?: { edges?: Array<{ node?: ResourceRef }> };
+  services?: { edges?: Array<{ node?: ResourceRef }> };
+}
+
+interface ServiceDocument extends ResourceRef {
+  source?: { image?: unknown } | null;
+  volumes?: Array<{
+    name?: unknown;
+    mountPath?: unknown;
+    sizeMb?: unknown;
+    state?: unknown;
+  }>;
+}
+
+interface PitrDocument {
+  service?: ResourceRef;
+  environment?: ResourceRef;
+  root?: ResourceRef;
+  enabled?: unknown;
+  bucketWired?: unknown;
+  blockers?: unknown;
+}
+
+interface VolumeInventoryDocument {
+  data?: {
+    environment?: {
+      id?: unknown;
+      volumeInstances?: {
+        edges?: Array<{
+          node?: {
+            id?: unknown;
+            environmentId?: unknown;
+            serviceId?: unknown;
+            volumeId?: unknown;
+            mountPath?: unknown;
+            sizeMB?: unknown;
+            state?: unknown;
+            deletedAt?: unknown;
+            isPendingDeletion?: unknown;
+          };
+        }>;
+      };
+    };
+  };
+  errors?: unknown;
+}
+
+interface ScheduleDocument {
+  id?: unknown;
+  kind?: unknown;
+  retentionSeconds?: unknown;
+}
+
+interface BackupDocument {
+  id?: unknown;
+  createdAt?: unknown;
+  scheduleId?: unknown;
+}
+
+export interface ResilienceEvidence {
+  status: StatusDocument;
+  services: ServiceDocument[];
+  volumes: VolumeInventoryDocument;
+  pitr: PitrDocument;
+  schedules: ScheduleDocument[];
+  backups: BackupDocument[];
+}
+
+export interface ResilienceExpectation {
+  environment: TargetEnvironment;
+  projectId: string;
+  environmentId: string;
+  serviceId: string;
+  productionServiceReceipt?: string;
+  productionVolumeReceipt?: string;
+  maxBackupAgeHours: number;
+}
+
+export interface ResilienceReceipt {
+  schemaVersion: 1;
+  environment: TargetEnvironment;
+  verdict: "pass" | "fail";
+  checks: Record<string, boolean>;
+  receipts: {
+    service: string | null;
+    volume: string | null;
+    latestScheduledBackup: string | null;
+  };
+}
+
+export interface CliArgs extends ResilienceExpectation {
+  mode: GateMode;
+  statusPath: string;
+  servicesPath: string;
+  volumesPath: string;
+  pitrPath: string;
+  schedulesPath: string;
+  backupsPath: string;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 && value === value.trim()
+    ? value
+    : null;
+}
+
+function requireUuid(value: string, name: string): string {
+  if (!UUID.test(value))
+    throw new TypeError(`${name} must be a lowercase UUID`);
+  return value;
+}
+
+function requireReceipt(value: string | undefined, name: string): string {
+  if (!value || !SHA256.test(value)) {
+    throw new TypeError(`${name} must be a lowercase SHA-256 receipt`);
+  }
+  return value;
+}
+
+function readJson(path: string): unknown {
+  const bytes = readFileSync(path);
+  if (bytes.byteLength > MAX_INPUT_BYTES) {
+    throw new TypeError(
+      `Railway evidence file exceeds ${MAX_INPUT_BYTES} bytes`,
+    );
+  }
+  return JSON.parse(bytes.toString("utf8")) as unknown;
+}
+
+function hasResource(
+  edges: Array<{ node?: ResourceRef }> | undefined,
+  id: string,
+  expectedName?: string,
+): boolean {
+  return (edges ?? []).some(
+    ({ node }) =>
+      node?.id === id &&
+      (expectedName === undefined || node?.name === expectedName),
+  );
+}
+
+function validSchedule(schedule: ScheduleDocument, kind: string): boolean {
+  if (schedule.kind !== kind || !canonicalString(schedule.id)) return false;
+  return (
+    schedule.retentionSeconds === null ||
+    (typeof schedule.retentionSeconds === "number" &&
+      Number.isSafeInteger(schedule.retentionSeconds) &&
+      schedule.retentionSeconds > 0)
+  );
+}
+
+function scheduledBackupTime(backup: BackupDocument): number | null {
+  if (!canonicalString(backup.id) || !canonicalString(backup.scheduleId))
+    return null;
+  const createdAt = canonicalString(backup.createdAt);
+  if (!createdAt) return null;
+  const time = Date.parse(createdAt);
+  return Number.isFinite(time) ? time : null;
+}
+
+export function verifyRailwayPostgresResilience(
+  evidence: ResilienceEvidence,
+  expected: ResilienceExpectation,
+  now = new Date(),
+): ResilienceReceipt {
+  requireUuid(expected.projectId, "projectId");
+  requireUuid(expected.environmentId, "environmentId");
+  requireUuid(expected.serviceId, "serviceId");
+  if (
+    !Number.isSafeInteger(expected.maxBackupAgeHours) ||
+    expected.maxBackupAgeHours < 1
+  ) {
+    throw new TypeError("maxBackupAgeHours must be a positive integer");
+  }
+
+  const matching = evidence.services.filter(
+    ({ id }) => id === expected.serviceId,
+  );
+  const service = matching.length === 1 ? matching[0] : undefined;
+  const volumes = (service?.volumes ?? []).filter(
+    (volume) =>
+      volume.mountPath === POSTGRES_MOUNT &&
+      volume.state === "READY" &&
+      typeof volume.sizeMb === "number" &&
+      Number.isFinite(volume.sizeMb) &&
+      volume.sizeMb > 0 &&
+      canonicalString(volume.name),
+  );
+  const serviceReceipt = service ? sha256(String(service.id)) : null;
+  const immutableVolumes = (
+    evidence.volumes.data?.environment?.volumeInstances?.edges ?? []
+  )
+    .map(({ node }) => node)
+    .filter(
+      (candidate) =>
+        candidate !== undefined &&
+        UUID.test(canonicalString(candidate.id) ?? "") &&
+        UUID.test(canonicalString(candidate.volumeId) ?? "") &&
+        candidate.environmentId === expected.environmentId &&
+        candidate.serviceId === expected.serviceId &&
+        candidate.mountPath === POSTGRES_MOUNT &&
+        candidate.state === "READY" &&
+        candidate.deletedAt === null &&
+        candidate.isPendingDeletion === false &&
+        typeof candidate.sizeMB === "number" &&
+        Number.isSafeInteger(candidate.sizeMB) &&
+        candidate.sizeMB > 0,
+    );
+  const immutableVolume =
+    immutableVolumes.length === 1 ? immutableVolumes[0] : undefined;
+  const immutableVolumeId = canonicalString(immutableVolume?.id);
+  const volumeReceipt = immutableVolumeId ? sha256(immutableVolumeId) : null;
+
+  const backupCandidates = evidence.backups
+    .map((backup) => ({ backup, time: scheduledBackupTime(backup) }))
+    .filter(
+      (entry): entry is { backup: BackupDocument; time: number } =>
+        entry.time !== null,
+    )
+    .sort((a, b) => b.time - a.time);
+  const latestBackup = backupCandidates[0];
+  const latestBackupId = canonicalString(latestBackup?.backup.id);
+  const latestBackupReceipt = latestBackupId ? sha256(latestBackupId) : null;
+  const ageMs = latestBackup
+    ? now.getTime() - latestBackup.time
+    : Number.POSITIVE_INFINITY;
+  const backupFresh =
+    ageMs >= -5 * 60 * 1000 &&
+    ageMs <= expected.maxBackupAgeHours * 60 * 60 * 1000;
+  const blockers = Array.isArray(evidence.pitr.blockers)
+    ? evidence.pitr.blockers
+    : [];
+
+  const checks: Record<string, boolean> = {
+    projectBound: evidence.status.id === expected.projectId,
+    environmentBound: hasResource(
+      evidence.status.environments?.edges,
+      expected.environmentId,
+      expected.environment,
+    ),
+    serviceBound: hasResource(
+      evidence.status.services?.edges,
+      expected.serviceId,
+    ),
+    exactPostgres18Service:
+      matching.length === 1 &&
+      typeof service?.source?.image === "string" &&
+      /(?:^|\/)postgres[^:]*:18(?:$|[-.])/.test(service.source.image),
+    exactReadyVolume: volumes.length === 1,
+    immutableVolumeBound:
+      evidence.volumes.errors === undefined &&
+      evidence.volumes.data?.environment?.id === expected.environmentId &&
+      immutableVolumes.length === 1,
+    pitrTargetBound:
+      evidence.pitr.service?.id === expected.serviceId &&
+      evidence.pitr.root?.id === expected.serviceId &&
+      evidence.pitr.environment?.id === expected.environmentId,
+    pitrEnabled:
+      evidence.pitr.enabled === true &&
+      evidence.pitr.bucketWired === true &&
+      blockers.length === 0,
+    dailyBackupScheduled: evidence.schedules.some((schedule) =>
+      validSchedule(schedule, "DAILY"),
+    ),
+    weeklyBackupScheduled: evidence.schedules.some((schedule) =>
+      validSchedule(schedule, "WEEKLY"),
+    ),
+    recentScheduledBackup: backupFresh,
+  };
+
+  if (expected.environment === "staging") {
+    const productionServiceReceipt = requireReceipt(
+      expected.productionServiceReceipt,
+      "productionServiceReceipt",
+    );
+    const productionVolumeReceipt = requireReceipt(
+      expected.productionVolumeReceipt,
+      "productionVolumeReceipt",
+    );
+    checks.physicallyDistinctService =
+      serviceReceipt !== null && serviceReceipt !== productionServiceReceipt;
+    checks.physicallyDistinctVolume =
+      volumeReceipt !== null && volumeReceipt !== productionVolumeReceipt;
+  }
+
+  return {
+    schemaVersion: 1,
+    environment: expected.environment,
+    verdict: Object.values(checks).every(Boolean) ? "pass" : "fail",
+    checks,
+    receipts: {
+      service: serviceReceipt,
+      volume: volumeReceipt,
+      latestScheduledBackup: latestBackupReceipt,
+    },
+  };
+}
+
+export function parseCliArgs(argv: string[]): CliArgs {
+  const parsed = parseArgs({
+    args: argv,
+    strict: true,
+    options: {
+      mode: { type: "string" },
+      environment: { type: "string" },
+      "project-id": { type: "string" },
+      "environment-id": { type: "string" },
+      "service-id": { type: "string" },
+      "production-service-receipt": { type: "string" },
+      "production-volume-receipt": { type: "string" },
+      "max-backup-age-hours": { type: "string", default: "36" },
+      "status-json": { type: "string" },
+      "services-json": { type: "string" },
+      "volumes-json": { type: "string" },
+      "pitr-json": { type: "string" },
+      "schedules-json": { type: "string" },
+      "backups-json": { type: "string" },
+    },
+  });
+  const value = (name: keyof typeof parsed.values): string => {
+    const found = parsed.values[name];
+    if (
+      typeof found !== "string" ||
+      found.length === 0 ||
+      found !== found.trim()
+    ) {
+      throw new TypeError(`--${name} is required and must be canonical`);
+    }
+    return found;
+  };
+  const mode = value("mode");
+  const environment = value("environment");
+  if (mode !== "report" && mode !== "enforce") {
+    throw new TypeError("--mode must be report or enforce");
+  }
+  if (environment !== "staging" && environment !== "production") {
+    throw new TypeError("--environment must be staging or production");
+  }
+  const maxBackupAgeHours = Number(value("max-backup-age-hours"));
+  return {
+    mode,
+    environment,
+    projectId: requireUuid(value("project-id"), "projectId"),
+    environmentId: requireUuid(value("environment-id"), "environmentId"),
+    serviceId: requireUuid(value("service-id"), "serviceId"),
+    productionServiceReceipt: parsed.values["production-service-receipt"],
+    productionVolumeReceipt: parsed.values["production-volume-receipt"],
+    maxBackupAgeHours,
+    statusPath: value("status-json"),
+    servicesPath: value("services-json"),
+    volumesPath: value("volumes-json"),
+    pitrPath: value("pitr-json"),
+    schedulesPath: value("schedules-json"),
+    backupsPath: value("backups-json"),
+  };
+}
+
+function main(): void {
+  const args = parseCliArgs(process.argv.slice(2));
+  const receipt = verifyRailwayPostgresResilience(
+    {
+      status: readJson(args.statusPath) as StatusDocument,
+      services: readJson(args.servicesPath) as ServiceDocument[],
+      volumes: readJson(args.volumesPath) as VolumeInventoryDocument,
+      pitr: readJson(args.pitrPath) as PitrDocument,
+      schedules: readJson(args.schedulesPath) as ScheduleDocument[],
+      backups: readJson(args.backupsPath) as BackupDocument[],
+    },
+    args,
+  );
+  process.stdout.write(`${JSON.stringify(receipt)}\n`);
+  if (args.mode === "enforce" && receipt.verdict !== "pass")
+    process.exitCode = 1;
+}
+
+if (import.meta.main) main();

--- a/packages/scripts/__tests__/cloud-postgres-resilience-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-postgres-resilience-workflow.test.ts
@@ -1,0 +1,108 @@
+/** Guards the inert-by-default, fail-closed Railway PostgreSQL release gate. */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const workflow = readFileSync(
+  new URL("../../../.github/workflows/cloud-cf-release.yml", import.meta.url),
+  "utf8",
+);
+const parsed = Bun.YAML.parse(workflow) as {
+  jobs?: { "migrate-db"?: { env?: Record<string, string> } };
+};
+
+describe("Cloud PostgreSQL resilience release gate", () => {
+  test("is off by default and performs no Railway query in off mode", () => {
+    expect(workflow).toContain(
+      "DATABASE_RESILIENCE_GATE_MODE: $" +
+        "{{ vars.DATABASE_RESILIENCE_GATE_MODE || 'off' }}",
+    );
+    expect(workflow).toContain('case "$DATABASE_RESILIENCE_GATE_MODE" in');
+    expect(workflow).toContain("off)");
+    expect(workflow).toContain('echo "enabled=false"');
+    expect(workflow).toContain(
+      "if: $" + "{{ steps.database_resilience.outputs.enabled == 'true' }}",
+    );
+  });
+
+  test("uses only protected setting names and exact Railway target arguments", () => {
+    for (const name of [
+      "RAILWAY_PROJECT_ID",
+      "RAILWAY_ENVIRONMENT_ID",
+      "RAILWAY_POSTGRES_SERVICE_ID",
+    ]) {
+      expect(workflow).toContain(`\n            ${name}\n`);
+    }
+    expect(workflow).toContain(
+      "HAS_RAILWAY_TOKEN: $" + "{{ secrets.RAILWAY_TOKEN != '' }}",
+    );
+    expect(workflow).toContain('missing+=("RAILWAY_TOKEN")');
+    expect(workflow).toContain('--project "$RAILWAY_PROJECT_ID"');
+    expect(workflow).toContain('--environment "$RAILWAY_ENVIRONMENT_ID"');
+    expect(workflow).toContain('--service "$RAILWAY_POSTGRES_SERVICE_ID"');
+    expect(workflow).not.toContain('echo "$RAILWAY_TOKEN"');
+    expect(workflow).not.toContain("railway variable list");
+    expect(parsed.jobs?.["migrate-db"]?.env?.RAILWAY_TOKEN).toBeUndefined();
+  });
+
+  test("pins and verifies the Railway CLI artifact", () => {
+    expect(workflow).toContain("v5.38.0");
+    expect(workflow).toContain(
+      "72835c48a710c48c4542141bf12264823cf3a029b514f9e27994096c036c539e",
+    );
+    expect(workflow).toContain("sha256sum --check --status");
+  });
+
+  test("captures only read-only status, service, PITR, schedule, and backup lists", () => {
+    for (const command of [
+      "railway status",
+      "railway service list",
+      "railway api",
+      "railway postgres pitr status",
+      "railway postgres pitr schedule list",
+      "railway postgres pitr backup list",
+    ]) {
+      expect(workflow).toContain(command);
+    }
+    for (const mutation of [
+      "railway postgres pitr enable",
+      "railway postgres pitr restore",
+      "railway postgres pitr schedule set",
+      "railway postgres pitr backup create",
+      "railway add",
+      "railway delete",
+      "mutation VolumeEvidence",
+    ]) {
+      expect(workflow).not.toContain(mutation);
+    }
+  });
+
+  test("runs before migrations and preserves enforce failure", () => {
+    const preflight = workflow.indexOf(
+      "Verify backup, PITR, and physical-isolation evidence",
+    );
+    const migrations = workflow.indexOf("name: Run migrations");
+    expect(preflight).toBeGreaterThan(-1);
+    expect(migrations).toBeGreaterThan(preflight);
+    expect(workflow).toContain(
+      "bun packages/cloud/scripts/admin/preflight-railway-postgres-resilience.ts",
+    );
+    expect(workflow).toContain('gate_status="$?"');
+    expect(workflow).toContain('if [ "$gate_status" -ne 0 ]');
+    expect(workflow).toContain('"- \\(.key)Receipt: \\(.value)"');
+    expect(workflow).not.toContain(
+      "continue-on-error: true\n        env:\n          TARGET_ENVIRONMENT",
+    );
+  });
+
+  test("requires production service and volume receipts for staging", () => {
+    expect(workflow).toContain("RAILWAY_PRODUCTION_POSTGRES_SERVICE_RECEIPT");
+    expect(workflow).toContain("RAILWAY_PRODUCTION_POSTGRES_VOLUME_RECEIPT");
+    expect(workflow).toContain(
+      '--production-service-receipt "$RAILWAY_PRODUCTION_POSTGRES_SERVICE_RECEIPT"',
+    );
+    expect(workflow).toContain(
+      '--production-volume-receipt "$RAILWAY_PRODUCTION_POSTGRES_VOLUME_RECEIPT"',
+    );
+    expect(workflow).toContain('--volumes-json "$evidence_dir/volumes.json"');
+  });
+});


### PR DESCRIPTION
# Relates to

Advances #21594 with the read-only Railway PostgreSQL recovery and physical-isolation release gate. It composes with the merged logical database identity gate from #21710.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Exact source

- Base: `310d08c4fd8f09aafca0fe34192a7df492b85591`
- Head: `5c88a58c8d70865661146244caae519c9f160a03`
- Tree: `1670a5bbcaa18486d3018f1acafe70145d0cfa16`

# What changed

- Adds the disabled-by-default `off | report | enforce` resilience gate before migrations.
- Uses Railway CLI v5.38.0 read-only inventory and hashes the immutable volume-instance ID, never the mutable volume label.
- Emits the volume receipt only after binding the instance to the selected project, environment, service, Postgres data mount, ready state, deletion state, and positive size.
- Requires PITR storage wiring, daily and weekly schedules, and a recent scheduled backup.
- Publishes only booleans and SHA-256 receipts; raw Railway inventory and credentials remain private.
- Adds adversarial same-instance/different-label, distinct-instance/same-label, foreign service, foreign project, and GraphQL-error coverage.

# Validation

All validation below used fixtures/static source only. This repair did not query or mutate live Railway.

```text
Network-denied fixture tests
bun test packages/cloud/scripts/admin/preflight-railway-postgres-resilience.test.ts packages/scripts/__tests__/cloud-postgres-resilience-workflow.test.ts
19 pass, 0 fail, 73 expect calls

Biome on changed TypeScript
PASS

actionlint .github/workflows/cloud-cf-release.yml
PASS

bun run audit:workflow-triggers
verified 53 workflows; 18 develop push surfaces

git diff --check origin/develop..HEAD
PASS
```

`bun run audit:scripts` was attempted from the isolated sparse clone and produced missing-path findings because unrelated workspaces were intentionally not hydrated; it did not identify a changed-file-specific failure. A full-checkout rerun remains an independent review gate.

Official Railway CLI v5.38.0 source/schema was inspected statically: `environment.volumeInstances` exposes the immutable instance `id`, `environmentId`, `serviceId`, `mountPath`, `volumeId`, state/deletion fields, and size. The CLI PITR implementation itself resolves backup targets by volume-instance ID.

# Evidence gate

<!-- evidence-head:5c88a58c8d70865661146244caae519c9f160a03 -->

- Before/after screenshots: N/A, backend release guard.
- Walkthrough video: N/A, no interactive flow or infrastructure mutation.
- Backend evidence: deterministic fixture output above.
- Frontend logs: N/A, no frontend change.
- LLM trajectory: N/A, no model behavior change.
- Domain artifacts: N/A, no live Railway query was performed or claimed in this repair.

# Activation boundary

`off` performs no Railway query. `report` remains read-only and non-blocking. `enforce` fails before migrations. Do not enable or dispatch enforcement until this exact head receives independent review and protected operator evidence under #21594.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [database-resilience-hardening]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza"} -->