### PR TITLE
fix(cloud): protect persistent Hetzner resources

### DIFF
--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/README.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/README.md
@@ -112,3 +112,24 @@ gates every connection.
 - `tenant_db_public_ip` — SSH/admin only.
 - `tenant_db_admin_dsn` — **sensitive**; seed into `tenant_db_clusters` (`:5432`, direct).
 - `tenant_db_pooler_endpoint` — `10.30.1.10:6432`; set as `tenant_db_clusters.host` to route apps through pgbouncer (after rolling the node).
+
+## Persistent-resource safeguards and rollback
+
+The shared tenant Postgres VM has Hetzner backups plus delete and rebuild
+protection. Its attached PGDATA volume and private network have delete
+protection. Provider backups are a short-term host safeguard only: they do not
+provide application-consistent Postgres recovery, point-in-time recovery, or
+environment isolation. Those require a separate reviewed design and recurring
+restore proof.
+
+Before any apply, run the protected `Infrastructure` workflow with
+`component=apps-shared`, `environment=production`, and `operation=plan`, then
+review the exact bound plan artifact. Adoption should be in-place. Any server,
+volume, or network replacement is a stop condition.
+
+Rollback must preserve the data dependency order: keep volume and network
+delete protection enabled while the database uses them; disable server rebuild
+protection only for an explicitly reviewed replacement; and remove volume or
+network delete protection only in a later retirement plan after a verified
+off-host restore. Never detach or destroy the volume as a shortcut for rolling
+back backup billing.

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/README.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/README.md
@@ -87,13 +87,14 @@ gates every connection.
 ### Operator rollout (the pooler is INERT until you do step 2)
 
 1. **Roll the tenant-db node** so the new cloud-init runs (installs + configures
-   pgbouncer). `user_data` is under `lifecycle.ignore_changes`, so editing the
-   template alone does nothing — taint and replace:
-   ```bash
-   terraform apply -var-file=shared.tfvars -replace=hcloud_server.tenant_db
-   ```
-   The data volume (PGDATA) survives the replace; it's a disruptive restart.
-   (Currently gated on the staging Hetzner server limit — see #8318.)
+   pgbouncer). `user_data` is under `lifecycle.ignore_changes`, and
+   `lifecycle.prevent_destroy` deliberately blocks `terraform taint` or
+   `-replace` from destroying the server. Use a separately reviewed maintenance
+   change that temporarily removes only the server guard, keeps the PGDATA
+   volume and network guarded, and proves in its exact plan that only the
+   intended VM is replaced. The replacement is a disruptive restart; restore
+   the server guard immediately afterward. (Currently gated on the staging
+   Hetzner server limit — see #8318.)
 2. **Route apps through the pooler:** set the `tenant_db_clusters.host` column
    (the **app-facing** per-tenant DSN host) to the `tenant_db_pooler_endpoint`
    output (`10.30.1.10:6432`). New per-tenant DSNs then point at the pooler;
@@ -122,14 +123,21 @@ provide application-consistent Postgres recovery, point-in-time recovery, or
 environment isolation. Those require a separate reviewed design and recurring
 restore proof.
 
+The server, volume, and network also use Terraform
+`lifecycle.prevent_destroy`. Hetzner's provider removes API delete protection
+when Terraform intentionally destroys a resource, so provider protection alone
+does not block an accidental replacement from an apply. Removing a resource
+block also removes the lifecycle guard and requires a separately reviewed
+retirement plan.
+
 Before any apply, run the protected `Infrastructure` workflow with
 `component=apps-shared`, `environment=production`, and `operation=plan`, then
 review the exact bound plan artifact. Adoption should be in-place. Any server,
 volume, or network replacement is a stop condition.
 
 Rollback must preserve the data dependency order: keep volume and network
-delete protection enabled while the database uses them; disable server rebuild
-protection only for an explicitly reviewed replacement; and remove volume or
-network delete protection only in a later retirement plan after a verified
-off-host restore. Never detach or destroy the volume as a shortcut for rolling
-back backup billing.
+lifecycle guards and delete protection enabled while the database uses them;
+remove the server lifecycle guard or rebuild protection only for an explicitly
+reviewed replacement; and remove volume or network guards only in a later
+retirement plan after a verified off-host restore. Never detach or destroy the
+volume as a shortcut for rolling back backup billing.

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/main.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/main.tf
@@ -55,9 +55,10 @@ resource "random_password" "pgbouncer_auth" {
 
 # ── Private network: apps + tenant DB only; isolated from the agent plane ─────
 resource "hcloud_network" "apps" {
-  name     = "eliza-apps"
-  ip_range = var.network_cidr
-  labels   = local.common_labels
+  name              = "eliza-apps"
+  ip_range          = var.network_cidr
+  labels            = local.common_labels
+  delete_protection = true
 
   # Same convention as the rest of the shared module: ignore Hetzner-side
   # renames so the legacy `eliza-apps-staging` left over from the pre-shared
@@ -76,12 +77,13 @@ resource "hcloud_network_subnet" "apps" {
 
 # ── Block storage for all tenant databases (PGDATA) ───────────────────────────
 resource "hcloud_volume" "tenant_db_data" {
-  name      = "eliza-app-tenant-data"
-  size      = var.tenant_db_volume_size_gb
-  location  = var.hcloud_location
-  format    = "ext4"
-  labels    = local.common_labels
-  automount = false
+  name              = "eliza-app-tenant-data"
+  size              = var.tenant_db_volume_size_gb
+  location          = var.hcloud_location
+  format            = "ext4"
+  labels            = local.common_labels
+  automount         = false
+  delete_protection = true
 
   # Volume rename via Hetzner Console is operator-cosmetic; the state-mv migration
   # from the per-env apps-data-plane leaves the legacy `eliza-apps-tenantdb-staging`
@@ -122,12 +124,15 @@ resource "hcloud_firewall" "tenant_db" {
 # staging` left over from the pre-shared layout) don't cause drift; operators
 # can rename via the Hetzner Console at their discretion (cosmetic only).
 resource "hcloud_server" "tenant_db" {
-  name         = "eliza-app-tenant"
-  location     = var.hcloud_location
-  server_type  = var.tenant_db_server_type
-  image        = var.hcloud_image
-  firewall_ids = [hcloud_firewall.tenant_db.id]
-  labels       = merge(local.common_labels, { "role" = "tenant-db" })
+  name               = "eliza-app-tenant"
+  location           = var.hcloud_location
+  server_type        = var.tenant_db_server_type
+  image              = var.hcloud_image
+  backups            = true
+  delete_protection  = true
+  rebuild_protection = true
+  firewall_ids       = [hcloud_firewall.tenant_db.id]
+  labels             = merge(local.common_labels, { "role" = "tenant-db" })
 
   user_data = templatefile("${path.module}/cloud-init/tenant-db.yaml.tftpl", {
     hostname                = "eliza-app-tenant"

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/main.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/main.tf
@@ -64,7 +64,8 @@ resource "hcloud_network" "apps" {
   # renames so the legacy `eliza-apps-staging` left over from the pre-shared
   # layout doesn't show as a diff. Operators can rename via Console (cosmetic).
   lifecycle {
-    ignore_changes = [name]
+    prevent_destroy = true
+    ignore_changes  = [name]
   }
 }
 
@@ -91,7 +92,8 @@ resource "hcloud_volume" "tenant_db_data" {
   # in-place rename. Ignoring keeps the post-migration plan a true no-op so the
   # operator's verification gate ("plan should be clean") is honest.
   lifecycle {
-    ignore_changes = [name]
+    prevent_destroy = true
+    ignore_changes  = [name]
   }
 }
 
@@ -142,10 +144,11 @@ resource "hcloud_server" "tenant_db" {
   })
 
   # Same convention as control-plane / apps-data-plane: allow in-place rename
-  # via Hetzner Console without TF drift; user_data + image swaps re-apply only
-  # on `terraform apply -replace=hcloud_server.tenant_db`.
+  # via Hetzner Console without TF drift. user_data + image swaps require the
+  # separately reviewed guarded replacement procedure in README.md.
   lifecycle {
-    ignore_changes = [user_data, image, name, ssh_keys]
+    prevent_destroy = true
+    ignore_changes  = [user_data, image, name, ssh_keys]
   }
 }
 

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
@@ -93,11 +93,15 @@ the record manually via the Cloudflare dashboard (preferred — no NXDOMAIN
 window) or via a one-off `terraform state rm` + re-apply round-trip if you
 want the new content to land back in state.
 
-**Cloud-init changes need `terraform taint`** to land on existing VMs.
-`user_data` is in `lifecycle.ignore_changes` so subsequent applies are
-no-ops for an already-provisioned CP. To roll a bootstrap fix, taint the
-VM and re-apply — but that wipes local state (headscale DB, TLS certs,
-/opt/eliza checkout). Plan that out before touching prod.
+**Cloud-init changes require a separately reviewed replacement** to land on
+existing VMs. `user_data` is in `lifecycle.ignore_changes`, and
+`lifecycle.prevent_destroy` deliberately blocks `terraform taint` or
+`-replace` from destroying an existing CP. A replacement maintenance change
+must temporarily remove the server's lifecycle guard, preserve the network
+guard, and prove in its exact plan that only the intended VM is replaced. That
+replacement wipes local state (Headscale DB, TLS certificates, and the
+`/opt/eliza` checkout), so copy and verify state before the apply and restore
+the guard immediately afterward.
 
 **Headscale arm/handoff on a CP.** Cloud-init installs the `headscale` package
 (binary, systemd unit, `/var/lib/headscale` state dir owned by the package user)
@@ -187,11 +191,19 @@ runtime-created workers. These provider backups reduce host-loss recovery time;
 they do not replace an application-consistent backup of Headscale state or the
 control-plane daemon configuration.
 
+The persistent server and network also use Terraform
+`lifecycle.prevent_destroy`. Hetzner's provider removes API delete protection
+when Terraform intentionally destroys a resource, so provider protection alone
+does not prevent an accidental replacement from an apply. Removing the
+resource block itself also removes the lifecycle guard; configuration deletion
+therefore requires the same separately reviewed retirement plan.
+
 Always dispatch `Infrastructure` with `operation=plan` from the canonical
 branch for the selected protected environment and review the exact bound plan
 artifact before an apply. The first adoption plan should contain only in-place
-protection/backup updates plus one network attachment per control-plane VM; a
-server replacement, network replacement, or DNS change is a stop condition.
+protection/backup updates plus one subnet-specific network attachment per
+control-plane VM; a server replacement, network replacement, or DNS change is
+a stop condition.
 
 Rollback is intentionally ordered and requires a separately reviewed plan:
 
@@ -201,8 +213,10 @@ Rollback is intentionally ordered and requires a separately reviewed plan:
    route depends on it.
 3. Disable backups only after an independent state-backup/recovery path is
    proven and the recurring-cost change is accepted.
-4. Remove rebuild protection before delete protection only when an explicitly
-   reviewed replacement or retirement requires it.
+4. Remove `lifecycle.prevent_destroy`, rebuild protection, and delete
+   protection only through an explicitly reviewed replacement or retirement
+   change; restore every retained resource's lifecycle guard immediately after
+   the operation.
 
 Never use an ad-hoc provider mutation to bypass protection. A protected
 resource that Terraform cannot update cleanly must stop at plan review.

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
@@ -179,6 +179,34 @@ the exact "node registers against the wrong service" failure mode.
 These are tracked as follow-ups in
 [`../ARCHITECTURE.md`](../ARCHITECTURE.md#followups).
 
+## Persistent-resource safeguards
+
+Each control-plane VM has Hetzner backups plus delete and rebuild protection,
+and Terraform attaches it to the same protected private network used by its
+runtime-created workers. These provider backups reduce host-loss recovery time;
+they do not replace an application-consistent backup of Headscale state or the
+control-plane daemon configuration.
+
+Always dispatch `Infrastructure` with `operation=plan` from the canonical
+branch for the selected protected environment and review the exact bound plan
+artifact before an apply. The first adoption plan should contain only in-place
+protection/backup updates plus one network attachment per control-plane VM; a
+server replacement, network replacement, or DNS change is a stop condition.
+
+Rollback is intentionally ordered and requires a separately reviewed plan:
+
+1. Keep delete/rebuild protection enabled while validating public ingress,
+   Headscale, and daemon health.
+2. Detach the private-network resource only after proving no daemon or worker
+   route depends on it.
+3. Disable backups only after an independent state-backup/recovery path is
+   proven and the recurring-cost change is accepted.
+4. Remove rebuild protection before delete protection only when an explicitly
+   reviewed replacement or retirement requires it.
+
+Never use an ad-hoc provider mutation to bypass protection. A protected
+resource that Terraform cannot update cleanly must stop at plan review.
+
 ## Cost
 
 | Component                    | Resource    | Monthly (€) |

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
@@ -213,8 +213,8 @@ runcmd:
   # because Cloudflare zone is in "Full" SSL mode (CF terminates with visitor,
   # accepts any cert on the origin — only "Full (Strict)" verifies). The
   # cert is generated once at first-boot (cloud-init runcmd has per-instance
-  # semantics, not per-boot), valid 10 years; VM rebuild or `terraform taint`
-  # regenerates. If anyone flips the zone to Strict the chain breaks
+  # semantics, not per-boot), valid 10 years; the guarded VM replacement
+  # procedure regenerates it. If anyone flips the zone to Strict the chain breaks
   # silently — track this as an operational gotcha.
   - install -d -m 0755 /etc/nginx/ssl
   - openssl req -x509 -nodes -newkey rsa:2048 -days 3650 -keyout /etc/nginx/ssl/eliza-agent-router.key -out /etc/nginx/ssl/eliza-agent-router.crt -subj "/CN=*.eliza.app" -addext "subjectAltName=DNS:*.eliza.app,DNS:eliza.app,DNS:*.elizacloud.ai,DNS:elizacloud.ai"

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -15,9 +15,10 @@ locals {
 # The autoscaler reads this network's id from CONTAINERS_HCLOUD_NETWORK_IDS in
 # /opt/eliza/cloud/.env.local on the CP (see node-autoscaler.ts).
 resource "hcloud_network" "data_plane" {
-  name     = "eliza-${var.environment}-private"
-  ip_range = var.data_plane_network_cidr
-  labels   = local.common_labels
+  name              = "eliza-${var.environment}-private"
+  ip_range          = var.data_plane_network_cidr
+  labels            = local.common_labels
+  delete_protection = true
 
   # Same convention as the apps-shared module: ignore Hetzner-side renames so
   # legacy names left over from out-of-band creation don't show as drift.
@@ -58,11 +59,14 @@ resource "hcloud_server" "control_plane" {
   # public internet OR from agent containers, and we don't have a clean
   # inventory of every bound port. Defense is pubkey-only SSH + per-service
   # auth on the bound ports.
-  name        = "eliza-${var.environment}-${each.value}"
-  location    = var.hcloud_location
-  server_type = var.hcloud_server_type
-  image       = var.hcloud_image
-  ssh_keys    = [for k in hcloud_ssh_key.operators : k.id]
+  name               = "eliza-${var.environment}-${each.value}"
+  location           = var.hcloud_location
+  server_type        = var.hcloud_server_type
+  image              = var.hcloud_image
+  backups            = true
+  delete_protection  = true
+  rebuild_protection = true
+  ssh_keys           = [for k in hcloud_ssh_key.operators : k.id]
   labels = merge(local.common_labels, {
     "control-plane-index" = each.value
   })
@@ -91,6 +95,16 @@ resource "hcloud_server" "control_plane" {
       server_type, # cross-arch flips (cax21 ARM ↔ cpx32 x86) are ForceNew, not in-place; would wipe headscale + TLS-cert state on adopt-existing-vm import. Resize must go through `terraform taint` or out-of-band `hcloud server change-type` before plan/apply.
     ]
   }
+}
+
+# The control plane and every runtime-created worker share this environment's
+# private LAN. Keeping the attachment in Terraform closes the provider-side
+# drift where worker nodes were attached but the control plane was not.
+resource "hcloud_server_network" "control_plane" {
+  for_each = hcloud_server.control_plane
+
+  server_id  = each.value.id
+  network_id = hcloud_network.data_plane.id
 }
 
 resource "cloudflare_dns_record" "control_plane" {

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -23,7 +23,8 @@ resource "hcloud_network" "data_plane" {
   # Same convention as the apps-shared module: ignore Hetzner-side renames so
   # legacy names left over from out-of-band creation don't show as drift.
   lifecycle {
-    ignore_changes = [name]
+    prevent_destroy = true
+    ignore_changes  = [name]
   }
 }
 
@@ -82,17 +83,20 @@ resource "hcloud_server" "control_plane" {
   #
   # OPS NOTE: changes to cloud-init/bootstrap.yaml.tftpl (nginx vhost, cert
   # generation, git clone retry, etc.) are no-ops on already-provisioned VMs
-  # because user_data is in ignore_changes. To roll a bootstrap fix onto an
-  # existing CP, run `terraform taint hcloud_server.control_plane["<idx>"]`
-  # then `apply` — recreates the VM, losing local state (headscale DB,
-  # TLS certs, /opt/eliza checkout). Plan that ahead of the apply.
+  # because user_data is in ignore_changes. Replacing an existing CP also
+  # requires a separately reviewed maintenance change that temporarily removes
+  # prevent_destroy; the replacement loses Headscale DB, TLS certificates, and
+  # the /opt/eliza checkout. Preserve and verify state before that apply.
   lifecycle {
+    prevent_destroy = true
     ignore_changes = [
-      user_data,   # bootstrap runs once at first boot
-      image,       # updating image rebuilds — explicit `terraform taint` to opt in
-      name,        # legacy VMs may not follow the env-prefixed naming convention; renaming is out of band
-      ssh_keys,    # operator key rotations don't recreate the box (keys are baked into authorized_keys at boot)
-      server_type, # cross-arch flips (cax21 ARM ↔ cpx32 x86) are ForceNew, not in-place; would wipe headscale + TLS-cert state on adopt-existing-vm import. Resize must go through `terraform taint` or out-of-band `hcloud server change-type` before plan/apply.
+      user_data, # bootstrap runs once at first boot
+      image,     # updating image rebuilds; use the guarded replacement procedure in README.md
+      name,      # legacy VMs may not follow the env-prefixed naming convention; renaming is out of band
+      ssh_keys,  # operator key rotations don't recreate the box (keys are baked into authorized_keys at boot)
+      # Cross-architecture flips are ForceNew, not in-place. Use the guarded
+      # replacement procedure or an independently reviewed out-of-band resize.
+      server_type,
     ]
   }
 }
@@ -103,8 +107,8 @@ resource "hcloud_server" "control_plane" {
 resource "hcloud_server_network" "control_plane" {
   for_each = hcloud_server.control_plane
 
-  server_id  = each.value.id
-  network_id = hcloud_network.data_plane.id
+  server_id = each.value.id
+  subnet_id = hcloud_network_subnet.data_plane.id
 }
 
 resource "cloudflare_dns_record" "control_plane" {

--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -34,6 +34,22 @@ const PROD_OPS_DIR = join(
   "hetzner",
   "prod-ops",
 );
+const HETZNER_CONTROL_PLANE_DIR = join(
+  import.meta.dir,
+  "..",
+  "cloud",
+  "terraform",
+  "hetzner",
+  "control-plane",
+);
+const HETZNER_APPS_SHARED_DIR = join(
+  import.meta.dir,
+  "..",
+  "cloud",
+  "terraform",
+  "hetzner",
+  "apps-shared",
+);
 
 function readK8sTerraform(file: string): string {
   return readFileSync(join(K8S_TERRAFORM_DIR, file), "utf-8");
@@ -129,6 +145,60 @@ describe("Protected production-operations runner", () => {
     expect(readme).toContain("two live doctor passes");
     expect(readme).toContain("switch back to");
     expect(readme).toContain("`ubuntu-24.04`");
+  });
+});
+
+describe("Persistent Hetzner resource safeguards", () => {
+  const controlPlane = readFileSync(
+    join(HETZNER_CONTROL_PLANE_DIR, "main.tf"),
+    "utf-8",
+  );
+  const appsShared = readFileSync(
+    join(HETZNER_APPS_SHARED_DIR, "main.tf"),
+    "utf-8",
+  );
+
+  test("protects and backs up persistent control-plane servers", () => {
+    const server = controlPlane.match(
+      /resource "hcloud_server" "control_plane" \{([\s\S]*?)\n\}/,
+    )?.[1];
+
+    expect(server).toBeDefined();
+    expect(server).toContain("backups            = true");
+    expect(server).toContain("delete_protection  = true");
+    expect(server).toContain("rebuild_protection = true");
+  });
+
+  test("attaches every control plane to its protected private network", () => {
+    const network = controlPlane.match(
+      /resource "hcloud_network" "data_plane" \{([\s\S]*?)\n\}/,
+    )?.[1];
+    const attachment = controlPlane.match(
+      /resource "hcloud_server_network" "control_plane" \{([\s\S]*?)\n\}/,
+    )?.[1];
+
+    expect(network).toContain("delete_protection = true");
+    expect(attachment).toContain("for_each = hcloud_server.control_plane");
+    expect(attachment).toContain("server_id  = each.value.id");
+    expect(attachment).toContain("network_id = hcloud_network.data_plane.id");
+  });
+
+  test("protects and backs up the shared tenant database failure domain", () => {
+    const network = appsShared.match(
+      /resource "hcloud_network" "apps" \{([\s\S]*?)\n\}/,
+    )?.[1];
+    const volume = appsShared.match(
+      /resource "hcloud_volume" "tenant_db_data" \{([\s\S]*?)\n\}/,
+    )?.[1];
+    const server = appsShared.match(
+      /resource "hcloud_server" "tenant_db" \{([\s\S]*?)\n\}/,
+    )?.[1];
+
+    expect(network).toContain("delete_protection = true");
+    expect(volume).toContain("delete_protection = true");
+    expect(server).toContain("backups            = true");
+    expect(server).toContain("delete_protection  = true");
+    expect(server).toContain("rebuild_protection = true");
   });
 });
 

--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -55,6 +55,24 @@ function readK8sTerraform(file: string): string {
   return readFileSync(join(K8S_TERRAFORM_DIR, file), "utf-8");
 }
 
+function terraformResource(source: string, type: string, name: string): string {
+  const declaration = `resource "${type}" "${name}"`;
+  const declarationStart = source.indexOf(declaration);
+  expect(declarationStart).toBeGreaterThanOrEqual(0);
+
+  const blockStart = source.indexOf("{", declarationStart);
+  expect(blockStart).toBeGreaterThan(declarationStart);
+
+  let depth = 0;
+  for (let index = blockStart; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") depth -= 1;
+    if (depth === 0) return source.slice(blockStart + 1, index);
+  }
+
+  throw new Error(`Unclosed Terraform resource: ${type}.${name}`);
+}
+
 describe("Terraform redis-rest deployment", () => {
   const main = readK8sTerraform("main.tf");
 
@@ -159,46 +177,57 @@ describe("Persistent Hetzner resource safeguards", () => {
   );
 
   test("protects and backs up persistent control-plane servers", () => {
-    const server = controlPlane.match(
-      /resource "hcloud_server" "control_plane" \{([\s\S]*?)\n\}/,
-    )?.[1];
+    const server = terraformResource(
+      controlPlane,
+      "hcloud_server",
+      "control_plane",
+    );
 
-    expect(server).toBeDefined();
     expect(server).toContain("backups            = true");
     expect(server).toContain("delete_protection  = true");
     expect(server).toContain("rebuild_protection = true");
+    expect(server).toContain("prevent_destroy = true");
   });
 
   test("attaches every control plane to its protected private network", () => {
-    const network = controlPlane.match(
-      /resource "hcloud_network" "data_plane" \{([\s\S]*?)\n\}/,
-    )?.[1];
-    const attachment = controlPlane.match(
-      /resource "hcloud_server_network" "control_plane" \{([\s\S]*?)\n\}/,
-    )?.[1];
+    const network = terraformResource(
+      controlPlane,
+      "hcloud_network",
+      "data_plane",
+    );
+    const attachment = terraformResource(
+      controlPlane,
+      "hcloud_server_network",
+      "control_plane",
+    );
 
     expect(network).toContain("delete_protection = true");
+    expect(network).toContain("prevent_destroy = true");
     expect(attachment).toContain("for_each = hcloud_server.control_plane");
-    expect(attachment).toContain("server_id  = each.value.id");
-    expect(attachment).toContain("network_id = hcloud_network.data_plane.id");
+    expect(attachment).toContain("server_id = each.value.id");
+    expect(attachment).toContain(
+      "subnet_id = hcloud_network_subnet.data_plane.id",
+    );
+    expect(attachment).not.toContain("network_id =");
   });
 
   test("protects and backs up the shared tenant database failure domain", () => {
-    const network = appsShared.match(
-      /resource "hcloud_network" "apps" \{([\s\S]*?)\n\}/,
-    )?.[1];
-    const volume = appsShared.match(
-      /resource "hcloud_volume" "tenant_db_data" \{([\s\S]*?)\n\}/,
-    )?.[1];
-    const server = appsShared.match(
-      /resource "hcloud_server" "tenant_db" \{([\s\S]*?)\n\}/,
-    )?.[1];
+    const network = terraformResource(appsShared, "hcloud_network", "apps");
+    const volume = terraformResource(
+      appsShared,
+      "hcloud_volume",
+      "tenant_db_data",
+    );
+    const server = terraformResource(appsShared, "hcloud_server", "tenant_db");
 
     expect(network).toContain("delete_protection = true");
+    expect(network).toContain("prevent_destroy = true");
     expect(volume).toContain("delete_protection = true");
+    expect(volume).toContain("prevent_destroy = true");
     expect(server).toContain("backups            = true");
     expect(server).toContain("delete_protection  = true");
     expect(server).toContain("rebuild_protection = true");
+    expect(server).toContain("prevent_destroy = true");
   });
 });
 


### PR DESCRIPTION
# Relates to

Closes #21727.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Persistent resources carry both provider-side protection and Terraform destruction guards.
- [x] Exact-head Terraform validation, formatting, static tests, and package tests pass in a credential-free sandbox.
- [x] No plan, apply, or live infrastructure mutation was performed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@038a153946fc5503682e5719a1c0f8dc6a899976:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@310d08c4fd8f09aafca0fe34192a7df492b85591`; zero conflicts.
- [x] Original implementation commit remained patch-identical across the rebase (`git range-diff`: `83ec449626 = cdc61e7892`).
- [x] Exact evidence head: `038a153946fc5503682e5719a1c0f8dc6a899976`.

# What does this PR do?

- Enables Hetzner backups plus delete/rebuild protection for persistent control-plane and tenant-database servers.
- Enables Hetzner delete protection for the persistent private networks and tenant PGDATA volume.
- Adds `lifecycle.prevent_destroy` to every persistent server, network, and volume. Hetzner's provider documentation explicitly states that provider delete protection is lifted during Terraform deletion, so provider protection alone does not stop an accidental replacement.
- Attaches each control-plane VM to its managed environment subnet through `subnet_id`; this avoids the provider's order-dependent “last subnet” behavior when only `network_id` is supplied.
- Uses balanced resource-block extraction in the static tests so nested lifecycle assertions are actually scoped to the intended HCL resource.
- Documents guarded replacement and dependency-safe retirement procedures; old `taint`/`-replace` instructions now acknowledge that a separately reviewed maintenance change must temporarily remove only the server guard.

# State, replacement, and operational review

- The inspected read-only posture receipt reports no existing control-plane private-network attachments, so the new `hcloud_server_network` resources are creates, not imports. Existing tenant DB attachment state is unchanged.
- Official hcloud v1.65.0 source handles `backups`, server protection, network protection, and volume protection in resource update paths; those additions are in-place provider updates rather than ForceNew fields.
- `server_id`, `subnet_id`, and attachment IP are replacement attributes for `hcloud_server_network`. This PR creates the absent attachment against the exact managed subnet and does not change an existing attachment.
- `prevent_destroy` blocks Terraform replacement while the resource block remains configured. Removing the resource block also removes the guard, so deletion still requires a separately reviewed retirement change and exact plan.
- A protected canonical plan after merge remains mandatory. Any server, volume, network, or DNS replacement is a stop condition. After apply, operators must verify the guest acquired the private interface/IP and can route over the intended subnet before relying on it.

# Testing

Executed at exact head `038a153946fc5503682e5719a1c0f8dc6a899976` with no cloud credentials and no backend access:

- Terraform 1.15.8 `init -backend=false -lockfile=readonly` from a checksummed read-only provider cache, then `validate`: success in both changed roots (`hcloud` 1.65.0, `cloudflare` 5.19.1, `random` 3.9.0 as applicable).
- `terraform fmt -check -recursive`: pass in both changed roots.
- `bun test packages/cloud/infra/tests/terraform-static.test.ts`: 24 passed, 225 assertions.
- `bun test packages/cloud/infra/tests`: 60 passed, 500 assertions.
- Biome: zero errors; two unchanged warnings elsewhere in `terraform-static.test.ts` for literal Terraform interpolation strings.
- `git diff --check`: pass.

No Terraform plan/apply, provider API call, state read/write, server/network/volume mutation, backup enablement, protection mutation, DNS change, or deployment occurred.

# Evidence Gate

<!-- evidence-head:038a153946fc5503682e5719a1c0f8dc6a899976 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Terraform and operator documentation only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Terraform and operator documentation only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow or visual surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - no application runtime path; protected plan/apply is a post-merge operator gate.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Read-only Hetzner posture receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21732-hetzner-posture.md), manually inspected during review; it contains no credentials or resource identifiers and records no mutation.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI surface.

# Residual gate

The first live effect is intentionally deferred to the canonical protected infrastructure workflow. Review its exact bound plan and stop on any replacement or DNS change. This PR does not claim live backup/protection/attachment acceptance before that plan and apply are separately authorized.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@038a153946fc5503682e5719a1c0f8dc6a899976:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hetzner-resilience]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@038a153946fc5503682e5719a1c0f8dc6a899976:packages/skills/skills/contribute-to-eliza"} -->
