### PR TITLE
fix(plugin-openai): bound transcription and TTS fetches

### DIFF
--- a/plugins/plugin-openai/__tests__/audio-timeout.test.ts
+++ b/plugins/plugin-openai/__tests__/audio-timeout.test.ts
@@ -35,7 +35,7 @@ function stallUntilAborted(): typeof fetch {
 describe("OpenAI audio request deadlines", () => {
   it("aborts a stalled transcription at the injected deadline", async () => {
     await expect(
-      handleTranscriptionWithFetch(createRuntime(), clip(), stallUntilAborted(), 10),
+      handleTranscriptionWithFetch(createRuntime(), clip(), stallUntilAborted(), 10)
     ).rejects.toMatchObject({ name: "TimeoutError" });
   });
 
@@ -44,7 +44,7 @@ describe("OpenAI audio request deadlines", () => {
       new Response("quota exceeded", { status: 429, statusText: "Too Many Requests" });
 
     await expect(
-      handleTranscriptionWithFetch(createRuntime(), clip(), fetchImpl, 1_000),
+      handleTranscriptionWithFetch(createRuntime(), clip(), fetchImpl, 1_000)
     ).rejects.toThrow("quota exceeded");
   });
 
@@ -64,7 +64,7 @@ describe("OpenAI audio request deadlines", () => {
 
   it("aborts a stalled TTS request at the injected deadline", async () => {
     await expect(
-      handleTextToSpeechWithFetch(createRuntime(), "say a bounded line", stallUntilAborted(), 10),
+      handleTextToSpeechWithFetch(createRuntime(), "say a bounded line", stallUntilAborted(), 10)
     ).rejects.toMatchObject({ name: "TimeoutError" });
   });
 
@@ -73,7 +73,7 @@ describe("OpenAI audio request deadlines", () => {
       new Response("speech quota exceeded", { status: 429, statusText: "Too Many Requests" });
 
     await expect(
-      handleTextToSpeechWithFetch(createRuntime(), "say a bounded line", fetchImpl, 1_000),
+      handleTextToSpeechWithFetch(createRuntime(), "say a bounded line", fetchImpl, 1_000)
     ).rejects.toThrow("speech quota exceeded");
   });
 
@@ -89,7 +89,7 @@ describe("OpenAI audio request deadlines", () => {
       createRuntime(),
       "say a bounded line",
       fetchImpl,
-      1_000,
+      1_000
     );
 
     expect(signals).toHaveLength(1);

--- a/plugins/plugin-openai/__tests__/audio-timeout.test.ts
+++ b/plugins/plugin-openai/__tests__/audio-timeout.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Behavioral deadlines for OpenAI transcription and TTS.
+ * ASR upload and speech synth use separate named budgets (not one 30s fit-all).
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { handleTextToSpeechWithFetch, handleTranscriptionWithFetch } from "../models/audio";
+
+function createRuntime(): IAgentRuntime {
+  return {
+    character: { name: "Audio timeout" },
+    getSetting(key: string) {
+      const values: Record<string, string> = {
+        OPENAI_API_KEY: "test-key",
+        OPENAI_BASE_URL: "https://api.openai.invalid/v1",
+      };
+      return values[key];
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function clip(): Blob {
+  return new Blob([new Uint8Array([1, 2, 3])], { type: "audio/webm" });
+}
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected audio abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+    })) as typeof fetch;
+}
+
+describe("OpenAI audio request deadlines", () => {
+  it("aborts a stalled transcription at the injected deadline", async () => {
+    await expect(
+      handleTranscriptionWithFetch(createRuntime(), clip(), stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed transcription", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("quota exceeded", { status: 429, statusText: "Too Many Requests" });
+
+    await expect(
+      handleTranscriptionWithFetch(createRuntime(), clip(), fetchImpl, 1_000),
+    ).rejects.toThrow("quota exceeded");
+  });
+
+  it("uses the injected fetch for a successful transcription", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({ text: "a bounded transcript" });
+    };
+
+    const text = await handleTranscriptionWithFetch(createRuntime(), clip(), fetchImpl, 1_000);
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(text).toBe("a bounded transcript");
+  });
+
+  it("aborts a stalled TTS request at the injected deadline", async () => {
+    await expect(
+      handleTextToSpeechWithFetch(createRuntime(), "say a bounded line", stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed TTS request", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("speech quota exceeded", { status: 429, statusText: "Too Many Requests" });
+
+    await expect(
+      handleTextToSpeechWithFetch(createRuntime(), "say a bounded line", fetchImpl, 1_000),
+    ).rejects.toThrow("speech quota exceeded");
+  });
+
+  it("uses the injected fetch for a successful TTS request", async () => {
+    const signals: AbortSignal[] = [];
+    const bytes = new Uint8Array([9, 8, 7]);
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response(bytes, { headers: { "content-type": "audio/mpeg" } });
+    };
+
+    const audio = await handleTextToSpeechWithFetch(
+      createRuntime(),
+      "say a bounded line",
+      fetchImpl,
+      1_000,
+    );
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(new Uint8Array(audio)).toEqual(bytes);
+  });
+});

--- a/plugins/plugin-openai/models/audio.ts
+++ b/plugins/plugin-openai/models/audio.ts
@@ -68,9 +68,17 @@ function isCoreTranscriptionParams(value: unknown): value is CoreTranscriptionPa
   );
 }
 
-export async function handleTranscription(
+/** Whisper-style ASR plus upload of a long clip exceeds a 30s chat deadline. */
+export const AUDIO_TRANSCRIPTION_TIMEOUT_MS = 120_000;
+
+/** Speech synth of up to 4096 chars is shorter than long-file transcription. */
+export const AUDIO_TTS_TIMEOUT_MS = 60_000;
+
+export async function handleTranscriptionWithFetch(
   runtime: IAgentRuntime,
-  input: TranscriptionInput
+  input: TranscriptionInput,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs: number = AUDIO_TRANSCRIPTION_TIMEOUT_MS
 ): Promise<string> {
   let modelName = getTranscriptionModel(runtime);
   let blob: Blob;
@@ -158,10 +166,11 @@ export async function handleTranscription(
     actionType: "openai.audio.transcriptions.create",
   };
   const data = await recordLlmCall(runtime, details, async () => {
-    const response = await fetch(`${baseURL}/audio/transcriptions`, {
+    const response = await fetchImpl(`${baseURL}/audio/transcriptions`, {
       method: "POST",
       headers: getAuthHeader(runtime),
       body: formData,
+      signal: AbortSignal.timeout(timeoutMs),
     });
 
     if (!response.ok) {
@@ -178,9 +187,18 @@ export async function handleTranscription(
   return data.text;
 }
 
-export async function handleTextToSpeech(
+export async function handleTranscription(
   runtime: IAgentRuntime,
-  input: TTSInput
+  input: TranscriptionInput
+): Promise<string> {
+  return handleTranscriptionWithFetch(runtime, input);
+}
+
+export async function handleTextToSpeechWithFetch(
+  runtime: IAgentRuntime,
+  input: TTSInput,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs: number = AUDIO_TTS_TIMEOUT_MS
 ): Promise<ArrayBuffer> {
   let text: string;
   let voice: string | undefined;
@@ -247,7 +265,7 @@ export async function handleTextToSpeech(
     actionType: "openai.audio.speech.create",
   };
   return recordLlmCall(runtime, details, async () => {
-    const response = await fetch(`${baseURL}/audio/speech`, {
+    const response = await fetchImpl(`${baseURL}/audio/speech`, {
       method: "POST",
       headers: {
         ...getAuthHeader(runtime),
@@ -255,6 +273,7 @@ export async function handleTextToSpeech(
         ...(format === "mp3" ? { Accept: "audio/mpeg" } : {}),
       },
       body: JSON.stringify(requestBody),
+      signal: AbortSignal.timeout(timeoutMs),
     });
 
     if (!response.ok) {
@@ -268,4 +287,11 @@ export async function handleTextToSpeech(
     details.response = `[audio bytes=${audioBuffer.byteLength} format=${format}]`;
     return audioBuffer;
   });
+}
+
+export async function handleTextToSpeech(
+  runtime: IAgentRuntime,
+  input: TTSInput
+): Promise<ArrayBuffer> {
+  return handleTextToSpeechWithFetch(runtime, input);
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). OpenAI **transcription** and **TTS** `fetch` have no `AbortSignal`, so a stalled provider POST hangs the worker. Not `#21184` (closed: one hard-coded 30s across audio+image, grep-token tests). Not `#21203`. This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, with **separate** transcription vs TTS deadlines. Image path already shipped (`#21730`) and untouched here. Not extra-decode. Not list-limit. Not payment. Not `#21385`. Not grok JSON posts. Not cloud JSON reprints. Not Atlas video (`#19302`). Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Public `handleTranscription` / `handleTextToSpeech` signatures unchanged. URL-audio load still goes through the existing SSRF-guarded fetcher. Unfixed head: both provider fetches had **no signal** and a hung fetch never settled (80ms race → `HUNG`). After: 10ms deadline → `TimeoutError`. Transcription budget is 120s; TTS is 60s.

# Background

## What does this PR do?

`handleTranscription` and `handleTextToSpeech` called provider `fetch` with no `signal`. A stalled OpenAI POST never returns. This PR injects `*WithFetch` (Fal `#21205` shape), adds `AbortSignal.timeout` with modality-specific deadlines, and keeps image.ts and the media URL loader out of scope.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Image OpenAI path untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-openai/__tests__/audio-timeout.test.ts` — timeout, provider-error, success for transcription and TTS.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-openai && bunx vitest run --config ./vitest.config.ts __tests__/audio-timeout.test.ts
```

Unfixed head `d4f9c6f5e0`: both provider fetches `signal` were undefined and the call hung. After the fix: 6 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:015857f3a769dcd030bf253286923b2a0f038c42 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Provider fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live OpenAI path. vitest asserts TimeoutError, provider 429 message, and success payloads.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - OpenAI audio transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live OpenAI. Unfixed `%` hang: no signal, 80ms race `HUNG`. After the fix, vitest asserts TimeoutError, `quota exceeded` on 429, a transcript string, and a 3-byte MPEG body.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

## Audio / voice walkthrough

N/A - provider HTTP timeout only. No live TTS playback.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`6 pass`). Root verify is an unrelated full-repo cost. No `bun install`. URL-audio SSRF loader and other plugin-openai model fetches are out of this PR's one-file scope.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
