### PR TITLE
fix(plugin-openai): bound embedding fetch when caller omits signal

### DIFF
--- a/plugins/plugin-openai/__tests__/embedding-timeout.test.ts
+++ b/plugins/plugin-openai/__tests__/embedding-timeout.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Behavioral deadline for OpenAI text embeddings.
+ * Caller abort is composed with a documented provider timeout (not source-grep).
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return {
+    ...actual,
+    toWellFormedUnicode: (text: string) => text,
+    truncateWellFormed: (text: string) => text,
+  };
+});
+
+import { handleTextEmbeddingWithFetch } from "../models/embedding";
+
+const DIM = 384;
+
+function createRuntime(): IAgentRuntime {
+  return {
+    character: { name: "Embedding timeout" },
+    getSetting(key: string) {
+      const values: Record<string, string> = {
+        OPENAI_API_KEY: "test-key",
+        OPENAI_BASE_URL: "https://api.openai.invalid/v1",
+        OPENAI_EMBEDDING_DIMENSIONS: String(DIM),
+      };
+      return values[key];
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected embedding abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+    })) as typeof fetch;
+}
+
+function vector(): number[] {
+  return Array.from({ length: DIM }, (_, i) => (i === 0 ? 0.1 : 0));
+}
+
+describe("OpenAI embedding request deadlines", () => {
+  it("aborts a stalled embedding at the injected deadline", async () => {
+    await expect(
+      handleTextEmbeddingWithFetch(createRuntime(), "embed a bounded line", stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed embedding", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("quota exceeded", { status: 429, statusText: "Too Many Requests" });
+
+    await expect(
+      handleTextEmbeddingWithFetch(createRuntime(), "embed a bounded line", fetchImpl, 1_000),
+    ).rejects.toThrow("quota exceeded");
+  });
+
+  it("uses the injected fetch for a successful embedding", async () => {
+    const signals: AbortSignal[] = [];
+    const embedding = vector();
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({ data: [{ embedding }] });
+    };
+
+    const result = await handleTextEmbeddingWithFetch(
+      createRuntime(),
+      "embed a bounded line",
+      fetchImpl,
+      1_000,
+    );
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(result).toEqual(embedding);
+  });
+});

--- a/plugins/plugin-openai/__tests__/embedding-timeout.test.ts
+++ b/plugins/plugin-openai/__tests__/embedding-timeout.test.ts
@@ -48,7 +48,7 @@ function vector(): number[] {
 describe("OpenAI embedding request deadlines", () => {
   it("aborts a stalled embedding at the injected deadline", async () => {
     await expect(
-      handleTextEmbeddingWithFetch(createRuntime(), "embed a bounded line", stallUntilAborted(), 10),
+      handleTextEmbeddingWithFetch(createRuntime(), "embed a bounded line", stallUntilAborted(), 10)
     ).rejects.toMatchObject({ name: "TimeoutError" });
   });
 
@@ -57,7 +57,7 @@ describe("OpenAI embedding request deadlines", () => {
       new Response("quota exceeded", { status: 429, statusText: "Too Many Requests" });
 
     await expect(
-      handleTextEmbeddingWithFetch(createRuntime(), "embed a bounded line", fetchImpl, 1_000),
+      handleTextEmbeddingWithFetch(createRuntime(), "embed a bounded line", fetchImpl, 1_000)
     ).rejects.toThrow("quota exceeded");
   });
 
@@ -73,7 +73,7 @@ describe("OpenAI embedding request deadlines", () => {
       createRuntime(),
       "embed a bounded line",
       fetchImpl,
-      1_000,
+      1_000
     );
 
     expect(signals).toHaveLength(1);

--- a/plugins/plugin-openai/models/embedding.ts
+++ b/plugins/plugin-openai/models/embedding.ts
@@ -125,9 +125,7 @@ export async function handleTextEmbeddingWithFetch(
   const embeddingDimension = validateDimension(getEmbeddingDimensions(runtime));
   const callerSignal = extractSignal(params);
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
-  const signal = callerSignal
-    ? AbortSignal.any([callerSignal, timeoutSignal])
-    : timeoutSignal;
+  const signal = callerSignal ? AbortSignal.any([callerSignal, timeoutSignal]) : timeoutSignal;
 
   const text = extractText(params);
   if (text === null) {

--- a/plugins/plugin-openai/models/embedding.ts
+++ b/plugins/plugin-openai/models/embedding.ts
@@ -112,13 +112,22 @@ function createDeterministicEmbedding(text: string, dimension: VectorDimension):
   return vector.map((value) => value / norm);
 }
 
-export async function handleTextEmbedding(
+/** Retrieval embeddings are shorter than image/audio jobs, but still need a hard cap. */
+export const TEXT_EMBEDDING_TIMEOUT_MS = 30_000;
+
+export async function handleTextEmbeddingWithFetch(
   runtime: IAgentRuntime,
-  params: TextEmbeddingParams | string | null
+  params: TextEmbeddingParams | string | null,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs: number = TEXT_EMBEDDING_TIMEOUT_MS
 ): Promise<number[]> {
   const embeddingModel = getEmbeddingModel(runtime);
   const embeddingDimension = validateDimension(getEmbeddingDimensions(runtime));
-  const signal = extractSignal(params);
+  const callerSignal = extractSignal(params);
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = callerSignal
+    ? AbortSignal.any([callerSignal, timeoutSignal])
+    : timeoutSignal;
 
   const text = extractText(params);
   if (text === null) {
@@ -158,7 +167,7 @@ export async function handleTextEmbedding(
   logger.debug(`[OpenAI] Generating embedding with model: ${embeddingModel}`);
 
   // @trajectory-allow Embeddings return numeric retrieval vectors, not generative LLM text.
-  const response = await fetch(url, {
+  const response = await fetchImpl(url, {
     method: "POST",
     headers: {
       ...getAuthHeader(runtime, true),
@@ -169,7 +178,7 @@ export async function handleTextEmbedding(
       input: trimmedText,
       ...(hasExplicitEmbeddingDimensions(runtime) ? { dimensions: embeddingDimension } : {}),
     }),
-    ...(signal ? { signal } : {}),
+    signal,
   });
 
   if (!response.ok) {
@@ -211,4 +220,11 @@ export async function handleTextEmbedding(
 
   logger.debug(`[OpenAI] Generated embedding with ${embedding.length} dimensions`);
   return embedding;
+}
+
+export async function handleTextEmbedding(
+  runtime: IAgentRuntime,
+  params: TextEmbeddingParams | string | null
+): Promise<number[]> {
+  return handleTextEmbeddingWithFetch(runtime, params);
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). OpenAI **embedding** `fetch` only attaches a caller `signal` when present, so a stalled provider POST hangs when the caller omits one. Not `#21424` (closed: plugin-embeddings grep-token test, no executed abort/fallback). Not `#21211`. Not `#21184`. Not `#21203`. This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, with a documented embedding deadline composed via `AbortSignal.any` when the caller does pass a signal. Image/audio paths already shipped (`#21730` / `#21733`) and untouched here. Not extra-decode. Not list-limit. Not payment. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Public `handleTextEmbedding` signature unchanged. Local Cerebras fallback still skips the network. Unfixed head: omitted caller `signal` meant **no fetch signal** and a hung fetch never settled (80ms race → `HUNG`). After: 10ms deadline → `TimeoutError`. Embedding budget is 30s.

# Background

## What does this PR do?

`handleTextEmbedding` called provider `fetch` with `signal` only when the caller supplied one. A stalled OpenAI POST never returns. This PR injects `handleTextEmbeddingWithFetch` (Fal `#21205` shape), always attaches `AbortSignal.timeout`, and composes a caller signal with `AbortSignal.any`.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Image and audio OpenAI paths untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-openai/__tests__/embedding-timeout.test.ts` — timeout, provider-error, success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-openai && bunx vitest run --config ./vitest.config.ts __tests__/embedding-timeout.test.ts
```

Unfixed head `8e2feabdf8`: omitted-signal fetch `signal` was undefined and the call hung. After the fix: 3 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:1f80ed17097632206c21fbe9cb201f585f5b6fa2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Provider fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live OpenAI path. vitest asserts TimeoutError, provider 429 message, and a 384-d vector.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - OpenAI embedding transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live OpenAI. Unfixed `%` hang: no signal, 80ms race `HUNG`. After the fix, vitest asserts TimeoutError, `quota exceeded` on 429, and a 384-d success vector.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

## Audio / voice walkthrough

N/A - embedding provider HTTP only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`3 pass`). Root verify is an unrelated full-repo cost. No `bun install`. plugin-embeddings and Google Chat remain out of this PR's one-file scope (do not reprint `#21424` / `#21211`).

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
