### PR TITLE
fix(cloud): preserve internal JSON decoder failures

### DIFF
--- a/packages/cloud/api/admin/redemptions/route.ts
+++ b/packages/cloud/api/admin/redemptions/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { secureTokenRedemptionService } from "@/lib/services/token-redemption-secure";
 import { parseClampedLimit } from "@/lib/utils/clamp-limit";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -212,13 +213,12 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
 app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const { user: adminUser } = await requireAdmin(c);
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is an explicit invalid request.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validation = AdminActionSchema.safeParse(body);
 
     if (!validation.success) {

--- a/packages/cloud/api/compat/agents/route.ts
+++ b/packages/cloud/api/compat/agents/route.ts
@@ -35,6 +35,7 @@ import {
   checkProvisioningWorkerHealth,
   provisioningWorkerFailureBody,
 } from "@/lib/services/provisioning-worker-health";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -109,13 +110,12 @@ app.get("/", async (c) => {
 app.post("/", async (c) => {
   try {
     const { user, authMethod } = await requireCompatAuth(c);
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
 
     const parsed = createAgentSchema.safeParse(body);
     if (!parsed.success) {

--- a/packages/cloud/api/elevenlabs/voices/[id]/route.ts
+++ b/packages/cloud/api/elevenlabs/voices/[id]/route.ts
@@ -1,9 +1,11 @@
 /** Handles cloud API elevenlabs voices id route traffic with route-local auth expectations. */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import { getErrorStatusCode, nextJsonFromCaughtError } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { voiceCloningService } from "@/lib/services/voice-cloning";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -196,13 +198,12 @@ async function __hono_PATCH(
     const { user } = await requireAuthOrApiKeyWithOrg(request);
     const params = await context.params;
     const voiceId = params.id;
-    let rawBody: unknown;
-    try {
-      rawBody = await request.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(request);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return Response.json({ error: "Invalid JSON body" }, { status: 400 });
     }
+    const rawBody = decodedRawBody.value;
     const parsed = updateVoiceBodySchema.safeParse(rawBody);
     if (!parsed.success) {
       return Response.json(

--- a/packages/cloud/api/feedback/route.ts
+++ b/packages/cloud/api/feedback/route.ts
@@ -1,5 +1,7 @@
 /** Handles cloud API feedback route traffic with route-local auth expectations. */
+
 import { escapeHtml } from "@elizaos/cloud-shared/lib/utils/html";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 /**
  * POST /api/feedback
  * Sends user feedback to the developer email.
@@ -26,13 +28,12 @@ const app = new Hono<AppEnv>();
 app.use("*", rateLimit(RateLimitPresets.STRICT));
 
 app.post("/", async (c) => {
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
+  const decodedBody = await decodeRequestJson(c.req);
+  if (!decodedBody.ok) {
     // error-policy:J3 malformed JSON is invalid request input.
     return c.json({ error: "Invalid JSON body" }, 400);
   }
+  const body = decodedBody.value;
   const { name, email, comment } = feedbackSchema.parse(body);
   const timestamp = new Date().toISOString();
   const displayName = name || "Anonymous";

--- a/packages/cloud/api/internal/auth/token/route.ts
+++ b/packages/cloud/api/internal/auth/token/route.ts
@@ -6,7 +6,6 @@
  */
 
 import { createHash, timingSafeEqual } from "node:crypto";
-
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isJWKSConfigured } from "@/lib/auth/jwks";
@@ -15,6 +14,7 @@ import {
   isShortLivedGatewayService,
   signInternalToken,
 } from "@/lib/auth/jwt-internal";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -40,13 +40,12 @@ app.post("/*", async (c) => {
       return c.json({ error: "Unauthorized" }, 401);
     }
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
       return c.json({ error: "Invalid request body" }, 400);
     }

--- a/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
@@ -7,6 +7,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
@@ -35,13 +36,12 @@ app.post("/", async (c) => {
     const authMs = performance.now() - authStartedAt;
 
     const validationStartedAt = performance.now();
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const body = messageSchema.parse(rawBody);
     const validationMs = performance.now() - validationStartedAt;
     if (body.guildId) {

--- a/packages/cloud/api/internal/discord/events/route.ts
+++ b/packages/cloud/api/internal/discord/events/route.ts
@@ -1,8 +1,10 @@
 /** Handles internal cloud API internal discord events route traffic with service-to-service auth. */
+
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { routeDiscordEvent } from "@/lib/services/gateway-discord/event-router";
 import { DiscordEventPayloadSchema } from "@/lib/services/gateway-discord/schemas";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../_auth";
@@ -14,13 +16,12 @@ app.post("/", async (c) => {
     const auth = await requireInternalAuth(c);
     if (auth instanceof Response) return auth;
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const payload = DiscordEventPayloadSchema.parse(rawBody);
     const result = await routeDiscordEvent(payload);
     return c.json({ success: true, ...result });

--- a/packages/cloud/api/internal/discord/gateway/failover/route.ts
+++ b/packages/cloud/api/internal/discord/gateway/failover/route.ts
@@ -1,8 +1,10 @@
 /** Handles internal cloud API internal discord gateway failover route traffic with service-to-service auth. */
+
 import { Hono } from "hono";
 import { discordConnectionsRepository } from "@/db/repositories/discord-connections";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { FailoverRequestSchema } from "@/lib/services/gateway-discord/schemas";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
@@ -16,13 +18,12 @@ app.post("/", async (c) => {
     const auth = await requireInternalAuth(c);
     if (auth instanceof Response) return auth;
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const body = FailoverRequestSchema.parse(rawBody);
     if (body.claiming_pod === body.dead_pod) {
       return c.json({ error: "cannot_claim_self" }, 400);

--- a/packages/cloud/api/internal/discord/gateway/heartbeat/route.ts
+++ b/packages/cloud/api/internal/discord/gateway/heartbeat/route.ts
@@ -1,8 +1,10 @@
 /** Handles internal cloud API internal discord gateway heartbeat route traffic with service-to-service auth. */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import { discordConnectionsRepository } from "@/db/repositories/discord-connections";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
@@ -36,13 +38,12 @@ app.post("/", async (c) => {
     const auth = await requireInternalAuth(c);
     if (auth instanceof Response) return auth;
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const body = heartbeatSchema.parse(rawBody);
     const updated = await discordConnectionsRepository.updateHeartbeatBatch(
       body.pod_name,

--- a/packages/cloud/api/internal/discord/gateway/status/route.ts
+++ b/packages/cloud/api/internal/discord/gateway/status/route.ts
@@ -1,9 +1,11 @@
 /** Handles internal cloud API internal discord gateway status route traffic with service-to-service auth. */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import { discordConnectionsRepository } from "@/db/repositories/discord-connections";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { ConnectionStatusUpdateSchema } from "@/lib/services/gateway-discord/schemas";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
@@ -51,13 +53,12 @@ app.post("/", async (c) => {
     const auth = await requireInternalAuth(c);
     if (auth instanceof Response) return auth;
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const body = ConnectionStatusUpdateSchema.parse(rawBody);
     const connection = await discordConnectionsRepository.updateStatus(
       body.connection_id,

--- a/packages/cloud/api/my-agents/characters/[id]/route.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/route.ts
@@ -13,6 +13,7 @@ import { cache } from "@/lib/cache/client";
 import { CacheKeys } from "@/lib/cache/keys";
 import { charactersService } from "@/lib/services/characters/characters";
 import type { ElizaCharacter } from "@/lib/types";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -39,13 +40,12 @@ app.put("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const id = c.req.param("id") ?? "";
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
       return c.json({ error: "Invalid request body" }, 400);
     }

--- a/packages/cloud/api/my-agents/characters/[id]/share/route.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/share/route.ts
@@ -16,6 +16,7 @@ import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys } from "@/lib/cache/keys";
 import { charactersService } from "@/lib/services/characters/characters";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -69,13 +70,12 @@ app.put("/", async (c) => {
       );
     }
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validation = ShareSchema.safeParse(body);
     if (!validation.success) {
       return c.json(

--- a/packages/cloud/api/my-agents/characters/route.ts
+++ b/packages/cloud/api/my-agents/characters/route.ts
@@ -18,6 +18,7 @@ import { discordService } from "@/lib/services/discord";
 import type { ElizaCharacter } from "@/lib/types";
 import type { CategoryId, SortBy, SortOrder } from "@/lib/types/my-agents";
 import { parseClampedLimit } from "@/lib/utils/clamp-limit";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -137,13 +138,12 @@ app.get("/", async (c) => {
 app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
       return c.json({ error: "Invalid request body" }, 400);
     }

--- a/packages/cloud/api/organizations/credentials/[credentialId]/route.ts
+++ b/packages/cloud/api/organizations/credentials/[credentialId]/route.ts
@@ -23,6 +23,7 @@ import {
   TeamCredentialPoolError,
   updatePooledCredential,
 } from "@/lib/services/team-credential-pool/service";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { assertOrgMembership } from "../../../src/middleware/org-membership";
 
@@ -73,13 +74,12 @@ app.patch("/", async (c) => {
       );
     }
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const validated = updateSchema.parse(rawBody);
     const credential = await updatePooledCredential({
       credentialId,

--- a/packages/cloud/api/organizations/invites/route.ts
+++ b/packages/cloud/api/organizations/invites/route.ts
@@ -12,6 +12,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { invitesService } from "@/lib/services/invites";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const createInviteSchema = z.object({
@@ -31,13 +32,12 @@ app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
       );
     }
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validated = createInviteSchema.parse(body);
 
     const result = await invitesService.createInvite({

--- a/packages/cloud/api/organizations/members/[userId]/route.ts
+++ b/packages/cloud/api/organizations/members/[userId]/route.ts
@@ -12,6 +12,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { usersService } from "@/lib/services/users";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -38,13 +39,12 @@ app.patch("/", async (c) => {
     if (!userId)
       return c.json({ success: false, error: "Invalid request" }, 400);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validated = updateMemberSchema.parse(body);
 
     const targetUser = await usersService.getById(userId);

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -12,6 +12,7 @@ import type {
   OnboardingSession,
 } from "@/lib/services/eliza-app/onboarding-chat";
 import { onboardingCoordinatorErrorResponse } from "@/lib/services/eliza-app/onboarding-coordinator-transport";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -960,13 +961,12 @@ export class OnboardingSessionCoordinator {
         if (pathname !== "/turn") {
           return Response.json({ error: "Not found" }, { status: 404 });
         }
-        let body: unknown;
-        try {
-          body = await request.json();
-        } catch {
+        const decodedBody = await decodeRequestJson(request);
+        if (!decodedBody.ok) {
           // error-policy:J3 malformed JSON is an explicit invalid request.
           return Response.json({ error: "Invalid JSON body" }, { status: 400 });
         }
+        const body = decodedBody.value;
         if (!isCoordinatorRequest(body)) {
           return Response.json(
             { error: "Invalid coordinator request" },

--- a/packages/cloud/api/v1/admin/ai-pricing/route.ts
+++ b/packages/cloud/api/v1/admin/ai-pricing/route.ts
@@ -24,6 +24,7 @@ import {
   PRICING_BILLING_SOURCES,
   PRICING_PRODUCT_FAMILIES,
 } from "@/lib/services/ai-pricing-definitions";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
@@ -159,13 +160,12 @@ app.post("/", async (c) => {
   try {
     await requireAdmin(c);
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const body = RefreshSchema.parse(rawBody);
     const refresh = await refreshPricingCatalog(body.sources);
     return c.json(refresh, refresh.success ? 200 : 207);
@@ -178,13 +178,12 @@ app.put("/", async (c) => {
   try {
     const { user } = await requireAdmin(c);
 
-    let overrideBody: unknown;
-    try {
-      overrideBody = await c.req.json();
-    } catch {
+    const decodedOverrideBody = await decodeRequestJson(c.req);
+    if (!decodedOverrideBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const overrideBody = decodedOverrideBody.value;
     const body = OverrideSchema.parse(overrideBody);
     const dimensions = normalizePricingDimensions(body.dimensions);
     const dimensionKey = buildDimensionKey(dimensions);

--- a/packages/cloud/api/v1/affiliates/link/route.ts
+++ b/packages/cloud/api/v1/affiliates/link/route.ts
@@ -15,6 +15,7 @@ import {
   ERRORS as AFFILIATE_ERRORS,
   affiliatesService,
 } from "@/lib/services/affiliates";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -30,13 +31,12 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validation = LinkSchema.safeParse(body);
     if (!validation.success) {
       return c.json({ error: "Invalid affiliate code format." }, 400);

--- a/packages/cloud/api/v1/affiliates/route.ts
+++ b/packages/cloud/api/v1/affiliates/route.ts
@@ -15,6 +15,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { affiliatesService } from "@/lib/services/affiliates";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -40,13 +41,12 @@ app.get("/", async (c) => {
 app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validation = MarkupSchema.safeParse(body);
     if (!validation.success) {
       return c.json(
@@ -69,13 +69,12 @@ app.post("/", async (c) => {
 app.put("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validation = MarkupSchema.safeParse(body);
     if (!validation.success) {
       return c.json(

--- a/packages/cloud/api/v1/agents/[agentId]/monetization/route.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/monetization/route.ts
@@ -19,6 +19,7 @@ import {
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { agentMonetizationService } from "@/lib/services/agent-monetization";
 import { charactersService } from "@/lib/services/characters/characters";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -70,13 +71,12 @@ app.put("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const agentId = c.req.param("agentId") ?? "";
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validation = UpdateMonetizationSchema.safeParse(body);
     if (!validation.success) {
       throw ValidationError("Invalid request", {

--- a/packages/cloud/api/v1/api-keys/[id]/route.ts
+++ b/packages/cloud/api/v1/api-keys/[id]/route.ts
@@ -14,6 +14,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { apiKeysService } from "@/lib/services/api-keys";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -79,13 +80,12 @@ app.patch("/", async (c) => {
       c,
     });
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const { name, description, rate_limit, is_active, expires_at } =
       updateApiKeySchema.parse(body);
 

--- a/packages/cloud/api/v1/app-auth/connect/route.ts
+++ b/packages/cloud/api/v1/app-auth/connect/route.ts
@@ -21,6 +21,7 @@ import { requireUserOrApiKey } from "@/lib/auth/workers-hono-auth";
 import { isAllowedOrigin } from "@/lib/security/origin-validation";
 import { issueAppAuthCode } from "@/lib/services/app-auth-codes";
 import { appsService } from "@/lib/services/apps";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -35,13 +36,12 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKey(c);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const parsed = ConnectSchema.safeParse(body);
 
     if (!parsed.success) {

--- a/packages/cloud/api/v1/app-credits/checkout/route.json.test.ts
+++ b/packages/cloud/api/v1/app-credits/checkout/route.json.test.ts
@@ -56,15 +56,18 @@ describe("POST /api/v1/app-credits/checkout malformed JSON", () => {
   });
 
   test("returns 400 instead of 500 and never creates a session", async () => {
+    const secret = "checkout-secret-must-not-leak";
     const response = await app.request("/", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: "{",
+      body: `{"token":"${secret}`,
     });
     expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toMatchObject({
+    const responseBody = await response.json();
+    expect(responseBody).toMatchObject({
       error: "Invalid JSON body",
     });
+    expect(JSON.stringify(responseBody)).not.toContain(secret);
     expect(createSession).not.toHaveBeenCalled();
   });
 
@@ -76,6 +79,22 @@ describe("POST /api/v1/app-credits/checkout malformed JSON", () => {
     });
     request.text = async () => {
       throw new TypeError("request stream unavailable");
+    };
+
+    const response = await app.fetch(request);
+
+    expect(response.status).toBe(500);
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  test("preserves an internal decoder SyntaxError as a server error", async () => {
+    const request = new Request("http://localhost/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validBody),
+    });
+    request.text = async () => {
+      throw new SyntaxError("internal decoder invariant failed");
     };
 
     const response = await app.fetch(request);

--- a/packages/cloud/api/v1/app-credits/checkout/route.json.test.ts
+++ b/packages/cloud/api/v1/app-credits/checkout/route.json.test.ts
@@ -1,5 +1,5 @@
-/** Exercises malformed request input with deterministic route collaborators. */
-import { describe, expect, mock, test } from "bun:test";
+/** Exercises malformed and internally failed request decoding with deterministic route collaborators. */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const APP_ID = "00000000-0000-4000-8000-0000000000aa";
 const createSession = mock(async () => ({
@@ -51,6 +51,10 @@ const validBody = {
 };
 
 describe("POST /api/v1/app-credits/checkout malformed JSON", () => {
+  beforeEach(() => {
+    createSession.mockClear();
+  });
+
   test("returns 400 instead of 500 and never creates a session", async () => {
     const response = await app.request("/", {
       method: "POST",
@@ -61,6 +65,22 @@ describe("POST /api/v1/app-credits/checkout malformed JSON", () => {
     await expect(response.json()).resolves.toMatchObject({
       error: "Invalid JSON body",
     });
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  test("preserves an internal request stream failure as a server error", async () => {
+    const request = new Request("http://localhost/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validBody),
+    });
+    request.text = async () => {
+      throw new TypeError("request stream unavailable");
+    };
+
+    const response = await app.fetch(request);
+
+    expect(response.status).toBe(500);
     expect(createSession).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/api/v1/app-credits/checkout/route.ts
+++ b/packages/cloud/api/v1/app-credits/checkout/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/security/redirect-validation";
 import { appsService } from "@/lib/services/apps";
 import { requireStripe } from "@/lib/stripe";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -31,13 +32,12 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validation = CheckoutSchema.safeParse(body);
     if (!validation.success) {
       return c.json(

--- a/packages/cloud/api/v1/app/agents/route.ts
+++ b/packages/cloud/api/v1/app/agents/route.ts
@@ -20,6 +20,7 @@ import {
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { charactersService } from "@/lib/services/characters/characters";
 import { isUniqueConstraintError } from "@/lib/utils/db-errors";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import { normalizeTokenAddress } from "@/lib/utils/token-address";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -82,13 +83,12 @@ app.post("/", async (c) => {
       );
     }
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validationResult = CreateAgentSchema.safeParse(body);
     if (!validationResult.success) {
       return c.json(

--- a/packages/cloud/api/v1/apps/[id]/characters/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/characters/route.ts
@@ -1,10 +1,12 @@
 /** Handles character associations for an authenticated cloud application. */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { appsService } from "@/lib/services/apps";
 import { charactersService } from "@/lib/services/characters/characters";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -163,16 +165,15 @@ async function __hono_PUT(
       );
     }
 
-    let rawBody: unknown;
-    try {
-      rawBody = await request.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(request);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return Response.json(
         { success: false, error: "Invalid JSON in request body" },
         { status: 400 },
       );
     }
+    const rawBody = decodedRawBody.value;
     const parsedBody = LinkCharactersBody.safeParse(rawBody);
     if (!parsedBody.success) {
       return Response.json(

--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { cloudflareDnsService } from "@/lib/services/cloudflare-dns";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 import { loadCloudflareManagedDomain } from "../../../guards";
@@ -64,13 +65,12 @@ app.patch("/", async (c) => {
     if ("error" in ctx)
       return c.json({ success: false, error: ctx.error }, ctx.status);
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const parsed = PatchRecordSchema.safeParse(rawBody);
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/route.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { cloudflareDnsService } from "@/lib/services/cloudflare-dns";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { loadCloudflareManagedDomain } from "../../guards";
@@ -53,13 +54,12 @@ app.post("/", async (c) => {
     if ("error" in ctx)
       return c.json({ success: false, error: ctx.error }, ctx.status);
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const parsed = CreateRecordSchema.safeParse(rawBody);
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/apps/[id]/domains/check/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/check/route.ts
@@ -9,6 +9,7 @@ import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { cloudflareRegistrarService } from "@/lib/services/cloudflare-registrar";
 import { computeDomainPrice } from "@/lib/services/domain-pricing";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { loadOwnedApp } from "../guards";
@@ -22,13 +23,12 @@ app.post("/", async (c) => {
     if ("error" in ctx)
       return c.json({ success: false, error: ctx.error }, ctx.status);
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const parsed = CheckSchema.safeParse(rawBody);
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/apps/[id]/domains/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/route.ts
@@ -14,6 +14,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { appDomainsCompat } from "@/lib/services/app-domains-compat";
 import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { loadOwnedApp } from "./guards";
@@ -59,13 +60,12 @@ app.post("/", async (c) => {
     if ("error" in ctx)
       return c.json({ success: false, error: ctx.error }, ctx.status);
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const parsed = DomainSchema.safeParse(rawBody);
     if (!parsed.success) {
       return c.json(
@@ -161,13 +161,12 @@ app.delete("/", async (c) => {
     if ("error" in ctx)
       return c.json({ success: false, error: ctx.error }, ctx.status);
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const parsed = DomainSchema.safeParse(rawBody);
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
@@ -10,6 +10,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { cloudflareRegistrarService } from "@/lib/services/cloudflare-registrar";
 import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { loadOwnedApp } from "../guards";
@@ -24,13 +25,12 @@ app.post("/", async (c) => {
       return c.json({ success: false, error: ctx.error }, ctx.status);
     const { user, appId } = ctx;
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const parsed = StatusSchema.safeParse(rawBody);
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/apps/[id]/domains/verify/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/verify/route.ts
@@ -14,6 +14,7 @@ import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { loadOwnedApp } from "../guards";
@@ -28,13 +29,12 @@ app.post("/", async (c) => {
       return c.json({ success: false, error: ctx.error }, ctx.status);
     const { user, appId } = ctx;
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const parsed = VerifySchema.safeParse(rawBody);
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/apps/[id]/monetization/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/monetization/route.ts
@@ -1,4 +1,5 @@
 /** Handles monetization settings for an authenticated cloud application. */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
@@ -6,6 +7,7 @@ import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { appCreditsService } from "@/lib/services/app-credits";
 import { isAppMonetizationApproved } from "@/lib/services/app-review";
 import { appsService } from "@/lib/services/apps";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -116,16 +118,15 @@ async function __hono_PUT(
       );
     }
 
-    let body: unknown;
-    try {
-      body = await request.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(request);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return Response.json(
         { success: false, error: "Invalid JSON in request body" },
         { status: 400 },
       );
     }
+    const body = decodedBody.value;
     const validationResult = UpdateMonetizationSchema.safeParse(body);
 
     if (!validationResult.success) {

--- a/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
@@ -1,6 +1,8 @@
 /** Generates authenticated promotion previews for cloud applications. */
+
 import { Hono } from "hono";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -45,13 +47,12 @@ async function __hono_POST(
   const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
+  const decodedBody = await decodeRequestJson(request);
+  if (!decodedBody.ok) {
     // error-policy:J3 malformed JSON is invalid request input.
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
+  const body = decodedBody.value;
   const parsed = PreviewRequestSchema.safeParse(body);
 
   if (!parsed.success) {

--- a/packages/cloud/api/v1/apps/[id]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.ts
@@ -18,6 +18,7 @@ import { appCleanupService } from "@/lib/services/app-cleanup";
 import { buildReviewCandidate } from "@/lib/services/app-review";
 import { appsService } from "@/lib/services/apps";
 import { charactersService } from "@/lib/services/characters/characters";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -94,13 +95,12 @@ async function updateApp(c: AppContext, verb: "PUT" | "PATCH") {
     return c.json({ success: false, error: "Access denied" }, 403);
   }
 
-  let rawBody: unknown;
-  try {
-    rawBody = await c.req.json();
-  } catch {
+  const decodedRawBody = await decodeRequestJson(c.req);
+  if (!decodedRawBody.ok) {
     // error-policy:J3 malformed JSON is invalid request input.
     return c.json({ error: "Invalid JSON body" }, 400);
   }
+  const rawBody = decodedRawBody.value;
   const validationResult = UpdateAppSchema.safeParse(rawBody);
   if (!validationResult.success) {
     return c.json(

--- a/packages/cloud/api/v1/apps/[id]/twitter-automation/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/twitter-automation/route.ts
@@ -1,10 +1,12 @@
 /** Handles Twitter automation configuration for cloud applications. */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { twitterAppAutomationService } from "@/lib/services/twitter-automation/app-automation";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -48,13 +50,12 @@ async function __hono_POST(
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
+  const decodedBody = await decodeRequestJson(request);
+  if (!decodedBody.ok) {
     // error-policy:J3 malformed JSON is invalid request input.
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
+  const body = decodedBody.value;
   const parsed = TwitterAutomationConfigSchema.safeParse(body);
 
   if (!parsed.success) {

--- a/packages/cloud/api/v1/apps/check-name/route.ts
+++ b/packages/cloud/api/v1/apps/check-name/route.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appsService } from "@/lib/services/apps";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -20,13 +21,12 @@ app.post("/", async (c) => {
   try {
     await requireUserOrApiKeyWithOrg(c);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validationResult = CheckNameSchema.safeParse(body);
 
     if (!validationResult.success) {

--- a/packages/cloud/api/v1/apps/route.ts
+++ b/packages/cloud/api/v1/apps/route.ts
@@ -17,6 +17,7 @@ import {
   AppNameConflictError,
   appsService,
 } from "@/lib/services/apps";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -76,13 +77,12 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const validationResult = CreateAppSchema.safeParse(rawBody);
     if (!validationResult.success) {
       return c.json(

--- a/packages/cloud/api/v1/billing/settings/route.ts
+++ b/packages/cloud/api/v1/billing/settings/route.ts
@@ -23,6 +23,7 @@ import {
   AutoTopUpSettingsValidationError,
   autoTopUpService,
 } from "@/lib/services/auto-top-up";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -87,13 +88,12 @@ app.put(
     try {
       const user = await requireUserOrApiKeyWithOrg(c);
 
-      let body: unknown;
-      try {
-        body = await c.req.json();
-      } catch {
+      const decodedBody = await decodeRequestJson(c.req);
+      if (!decodedBody.ok) {
         // error-policy:J3 malformed JSON is an explicit invalid request.
         return c.json({ error: "Invalid JSON body" }, 400);
       }
+      const body = decodedBody.value;
       const validation = UpdateSettingsSchema.safeParse(body);
 
       if (!validation.success) {

--- a/packages/cloud/api/v1/blooio/webhook-secret/route.ts
+++ b/packages/cloud/api/v1/blooio/webhook-secret/route.ts
@@ -10,6 +10,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { blooioAutomationService } from "@/lib/services/blooio-automation";
 import { invalidateOAuthState } from "@/lib/services/oauth/invalidation";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -24,13 +25,12 @@ app.post("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const orgId = user.organization_id;
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const parsed = WebhookSecretBody.safeParse(rawBody);
     if (!parsed.success) {
       return c.json({ error: "Webhook secret is required" }, 400);

--- a/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
@@ -1,4 +1,5 @@
 /** Executes validated commands in an authenticated hosted-browser session. */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
@@ -16,6 +17,7 @@ import {
   executeHostedBrowserCommand,
   logHostedBrowserFailure,
 } from "@/lib/services/browser-tools";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const commandSchema = z.object({
@@ -50,13 +52,12 @@ async function handlePOST(
   try {
     const authResult = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await context.params;
-    let rawBody: unknown;
-    try {
-      rawBody = await request.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(request);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return Response.json({ error: "Invalid JSON body" }, { status: 400 });
     }
+    const rawBody = decodedRawBody.value;
     const bodyResult = commandSchema.safeParse(rawBody);
     if (!bodyResult.success) {
       return Response.json(

--- a/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
@@ -1,4 +1,5 @@
 /** Navigates an authenticated hosted-browser session. */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
@@ -16,6 +17,7 @@ import {
   logHostedBrowserFailure,
   navigateHostedBrowserSession,
 } from "@/lib/services/browser-tools";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const navigateSchema = z.object({
@@ -29,13 +31,12 @@ async function handlePOST(
   try {
     const authResult = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await context.params;
-    let rawBody: unknown;
-    try {
-      rawBody = await request.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(request);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return Response.json({ error: "Invalid JSON body" }, { status: 400 });
     }
+    const rawBody = decodedRawBody.value;
     const bodyResult = navigateSchema.safeParse(rawBody);
     if (!bodyResult.success) {
       return Response.json(

--- a/packages/cloud/api/v1/credits/checkout/route.ts
+++ b/packages/cloud/api/v1/credits/checkout/route.ts
@@ -26,6 +26,7 @@ import {
 import { organizationsService } from "@/lib/services/organizations";
 import { usersService } from "@/lib/services/users";
 import { requireStripe } from "@/lib/stripe";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -42,13 +43,12 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   try {
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validation = CheckoutSchema.safeParse(body);
     if (!validation.success) {
       return c.json(

--- a/packages/cloud/api/v1/eliza/google/calendar/events/[eventId]/route.ts
+++ b/packages/cloud/api/v1/eliza/google/calendar/events/[eventId]/route.ts
@@ -1,8 +1,10 @@
 /** Updates and deletes managed Google Calendar events. */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { agentGoogleRouteDeps } from "@/lib/services/agent-google-route-deps";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const attendeeSchema = z.object({
@@ -32,13 +34,12 @@ async function __hono_PATCH(
     const { user } =
       await agentGoogleRouteDeps.requireAuthOrApiKeyWithOrg(request);
     const { eventId } = await params;
-    let rawBody: unknown;
-    try {
-      rawBody = await request.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(request);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return Response.json({ error: "Invalid JSON body" }, { status: 400 });
     }
+    const rawBody = decodedRawBody.value;
     const parsed = patchRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       return Response.json(

--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -1,4 +1,5 @@
 /** Handles authenticated music generation, billing, and generation history persistence. */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import {
@@ -27,6 +28,7 @@ import {
   recordGenerativeSuccess,
 } from "@/lib/services/generative-provider-health";
 import { putPublicObject } from "@/lib/storage/r2-public-object";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv, Bindings } from "@/types/cloud-worker-env";
 
@@ -149,13 +151,12 @@ app.post("/", async (c) => {
   try {
     const { user, apiKeyId, admissionSnapshot } =
       await requireGenerativeRouteCaller(c, { rateLimitEndpoint: "strict" });
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is an explicit invalid request.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const request = musicRequestSchema.parse(rawBody);
     const definition = getSupportedMusicModelDefinition(request.model);
     if (!definition) {

--- a/packages/cloud/api/v1/generate-sfx/route.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.ts
@@ -30,6 +30,7 @@ import { contentSafetyService } from "@/lib/services/content-safety";
 import { InsufficientCreditsError } from "@/lib/services/credits";
 import { generationsService } from "@/lib/services/generations";
 import { putPublicObject } from "@/lib/storage/r2-public-object";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv, Bindings } from "@/types/cloud-worker-env";
 
@@ -123,13 +124,12 @@ app.post("/", async (c) => {
   try {
     const { user, apiKeyId, admissionSnapshot } =
       await requireGenerativeRouteCaller(c, { rateLimitEndpoint: "strict" });
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is an explicit invalid request.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const request = sfxRequestSchema.parse(rawBody);
     const definition = getSupportedSfxModelDefinition(request.model);
     if (!definition) {

--- a/packages/cloud/api/v1/pii-scrub/jobs/route.ts
+++ b/packages/cloud/api/v1/pii-scrub/jobs/route.ts
@@ -1,4 +1,5 @@
 /** Handles v1 cloud API PII scrub job enqueue traffic with route-local auth expectations. */
+
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
@@ -15,6 +16,7 @@ import {
   PiiScrubJobDataError,
   toPiiScrubJobDto,
 } from "@/lib/services/pii-scrub-jobs";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const enqueueSchema = z.object({
@@ -60,13 +62,12 @@ export function createPiiScrubJobsRoute(
   app.post("/", async (c) => {
     try {
       const user = await dependencies.requireUserOrApiKeyWithOrg(c);
-      let rawBody: unknown;
-      try {
-        rawBody = await c.req.json();
-      } catch {
+      const decodedRawBody = await decodeRequestJson(c.req);
+      if (!decodedRawBody.ok) {
         // error-policy:J3 malformed JSON is invalid request input.
         return c.json({ error: "Invalid JSON body" }, 400);
       }
+      const rawBody = decodedRawBody.value;
       const body = enqueueSchema.parse(rawBody);
       const job = await dependencies.enqueuePiiScrubBatch({
         organizationId: user.organization_id,

--- a/packages/cloud/api/v1/reports/bug/route.ts
+++ b/packages/cloud/api/v1/reports/bug/route.ts
@@ -1,5 +1,7 @@
 /** Validates and delivers authenticated client bug reports. */
+
 import { escapeHtml } from "@elizaos/cloud-shared/lib/utils/html";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 /**
  * POST /api/v1/reports/bug
  * Receives structured bug reports from clients (Agent) and forwards them
@@ -58,13 +60,12 @@ app.use("*", rateLimit(RateLimitPresets.STRICT));
 
 app.post("/", async (c) => {
   try {
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validated = bugReportSchema.parse(body);
 
     const reportId = `rpt_${crypto.randomUUID()}`;

--- a/packages/cloud/api/v1/security/audit/route.ts
+++ b/packages/cloud/api/v1/security/audit/route.ts
@@ -15,6 +15,7 @@ import {
 import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleton";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserWithOrg } from "@/lib/auth/workers-hono-auth";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -67,13 +68,12 @@ function clientIp(c: AppContext): string | undefined {
 app.post("/", async (c) => {
   try {
     const user = await requireUserWithOrg(c);
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const input = clientAuditSchema.parse(rawBody);
     const event = await getAuditDispatcher().emit({
       actor: { type: "user", id: user.id },

--- a/packages/cloud/api/v1/steward/tenants/route.ts
+++ b/packages/cloud/api/v1/steward/tenants/route.ts
@@ -19,6 +19,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { isStewardPlatformConfigured } from "@/lib/services/steward-platform-users";
 import { ensureStewardTenant } from "@/lib/services/steward-tenant-config";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -28,13 +29,12 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
       return c.json({ error: "Invalid request body" }, 400);
     }

--- a/packages/cloud/api/v1/user/email/route.ts
+++ b/packages/cloud/api/v1/user/email/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { isElizaLabsAdminEmail } from "@/lib/services/admin";
 import { usersService } from "@/lib/services/users";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const updateEmailSchema = z.object({
@@ -44,13 +45,12 @@ app.patch("/", async (c) => {
       );
     }
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const parsed = updateEmailSchema.safeParse(body);
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/voice/[id]/route.ts
+++ b/packages/cloud/api/v1/voice/[id]/route.ts
@@ -1,5 +1,7 @@
 /** Manages an authenticated user's individual cloned voice. */
+
 import { Hono } from "hono";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -228,13 +230,12 @@ async function __hono_PATCH(
       return invalidVoiceIdResponse;
     }
 
-    let rawBody: unknown;
-    try {
-      rawBody = await request.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(request);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return Response.json({ error: "Invalid JSON body" }, { status: 400 });
     }
+    const rawBody = decodedRawBody.value;
     const parsed = VoiceUpdateBody.safeParse(rawBody);
     if (!parsed.success) {
       return Response.json(

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -1,5 +1,7 @@
 /** Handles authenticated cloud text-to-speech generation, safety checks, and billing. */
+
 import { Hono } from "hono";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -186,13 +188,12 @@ async function __hono_POST(c: AppContext) {
     timings.authMs = Date.now() - requestStart;
     const admissionStart = Date.now();
 
-    let rawBody: unknown;
-    try {
-      rawBody = await request.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(request);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is an explicit invalid request.
       return Response.json({ error: "Invalid JSON body" }, { status: 400 });
     }
+    const rawBody = decodedRawBody.value;
     const parsed = TtsBody.safeParse(rawBody);
     if (!parsed.success) {
       return Response.json(

--- a/packages/cloud/api/v1/whatsapp/connect/route.ts
+++ b/packages/cloud/api/v1/whatsapp/connect/route.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { whatsappAutomationService } from "@/lib/services/whatsapp-automation";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -27,13 +28,12 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedRawBody.value;
     const parsed = WhatsappConnectBody.safeParse(rawBody);
     if (!parsed.success) {
       const message = parsed.error.issues[0]?.message || "Invalid request body";

--- a/packages/cloud/shared/src/lib/utils/json-parsing.test.ts
+++ b/packages/cloud/shared/src/lib/utils/json-parsing.test.ts
@@ -7,7 +7,39 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { parseJsonErrorBody, parseJsonResponse } from "./json-parsing";
+import { decodeRequestJson, parseJsonErrorBody, parseJsonResponse } from "./json-parsing";
+
+describe("decodeRequestJson", () => {
+  test("returns an explicit invalid result for malformed JSON syntax", async () => {
+    const syntaxError = new SyntaxError("Unexpected end of JSON input");
+    await expect(
+      decodeRequestJson({
+        json: async () => {
+          throw syntaxError;
+        },
+      }),
+    ).resolves.toEqual({ ok: false, error: syntaxError });
+  });
+
+  test("rethrows non-syntax decoder failures for the route 5xx boundary", async () => {
+    const streamError = new TypeError("request stream unavailable");
+    await expect(
+      decodeRequestJson({
+        json: async () => {
+          throw streamError;
+        },
+      }),
+    ).rejects.toBe(streamError);
+  });
+
+  test("returns canonical decoded values unchanged", async () => {
+    const value = { query: "elizaOS" };
+    await expect(decodeRequestJson({ json: async () => value })).resolves.toEqual({
+      ok: true,
+      value,
+    });
+  });
+});
 
 describe("parseJsonResponse", () => {
   test("parses non-empty JSON response bodies", async () => {

--- a/packages/cloud/shared/src/lib/utils/json-parsing.test.ts
+++ b/packages/cloud/shared/src/lib/utils/json-parsing.test.ts
@@ -1,40 +1,152 @@
 /**
- * Response JSON parsing tests for cloud service clients.
+ * JSON boundary tests using real Fetch bodies plus deterministic fault sources.
  *
- * Provider success payloads must fail closed when malformed, while provider
- * error payloads can degrade to "no parsed detail" because HTTP status remains
- * the failure signal.
+ * Request syntax failures are sanitized, body transport failures propagate,
+ * and provider response parsing retains its strict-success/best-effort-error
+ * split.
  */
 
 import { describe, expect, test } from "bun:test";
 import { decodeRequestJson, parseJsonErrorBody, parseJsonResponse } from "./json-parsing";
 
 describe("decodeRequestJson", () => {
-  test("returns an explicit invalid result for malformed JSON syntax", async () => {
-    const syntaxError = new SyntaxError("Unexpected end of JSON input");
-    await expect(
-      decodeRequestJson({
-        json: async () => {
-          throw syntaxError;
-        },
+  test("returns a sanitized invalid result for malformed JSON syntax", async () => {
+    const secret = "never-echo-this-request-secret";
+    const result = await decodeRequestJson(
+      new Request("https://example.test", {
+        method: "POST",
+        body: `{"token":"${secret}`,
       }),
-    ).resolves.toEqual({ ok: false, error: syntaxError });
+    );
+
+    expect(result).toEqual({ ok: false });
+    expect(JSON.stringify(result)).not.toContain(secret);
   });
 
-  test("rethrows non-syntax decoder failures for the route 5xx boundary", async () => {
+  test("rethrows stream failures for the route 5xx boundary", async () => {
     const streamError = new TypeError("request stream unavailable");
     await expect(
       decodeRequestJson({
-        json: async () => {
+        text: async () => {
           throw streamError;
         },
       }),
     ).rejects.toBe(streamError);
   });
 
+  test("does not mistake an internal SyntaxError for invalid caller JSON", async () => {
+    const decoderError = new SyntaxError("internal decoder invariant failed");
+    await expect(
+      decodeRequestJson({
+        text: async () => {
+          throw decoderError;
+        },
+      }),
+    ).rejects.toBe(decoderError);
+  });
+
+  test("preserves abort failures without translating them to invalid JSON", async () => {
+    const abortError = new DOMException("request aborted", "AbortError");
+    await expect(
+      decodeRequestJson({
+        text: async () => {
+          throw abortError;
+        },
+      }),
+    ).rejects.toBe(abortError);
+  });
+
+  test("preserves typed failure identity, code, context, and cause", async () => {
+    const cause = new Error("socket closed");
+    const decoderError = Object.assign(new Error("body decoder failed", { cause }), {
+      code: "REQUEST_BODY_DECODE_FAILED",
+      context: { requestId: "req-1" },
+    });
+    const promise = decodeRequestJson({
+      text: async () => {
+        throw decoderError;
+      },
+    });
+
+    await expect(promise).rejects.toBe(decoderError);
+    expect(decoderError.cause).toBe(cause);
+    expect(decoderError.code).toBe("REQUEST_BODY_DECODE_FAILED");
+    expect(decoderError.context).toEqual({ requestId: "req-1" });
+  });
+
+  test("rejects a decoder contract violation without exposing its value", async () => {
+    const decoded = { token: "never-log-this" };
+    await expect(
+      decodeRequestJson({
+        text: async () => decoded,
+      } as unknown as { text(): Promise<string> }),
+    ).rejects.toThrow("Request body decoder returned a non-string value");
+  });
+
+  test.each(["", "  \n\t"])("treats an empty body as invalid JSON", async (body) => {
+    await expect(
+      decodeRequestJson(new Request("https://example.test", { method: "POST", body })),
+    ).resolves.toEqual({ ok: false });
+  });
+
+  test("decodes streamed JSON independently of content type", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"query":'));
+        controller.enqueue(encoder.encode('"elizaOS"}'));
+        controller.close();
+      },
+    });
+    const request = new Request("https://example.test", {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+      body: stream,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    await expect(decodeRequestJson(request)).resolves.toEqual({
+      ok: true,
+      value: { query: "elizaOS" },
+    });
+  });
+
+  test("propagates a consumed-body failure", async () => {
+    const request = new Request("https://example.test", {
+      method: "POST",
+      body: '{"ok":true}',
+    });
+    await request.text();
+
+    await expect(decodeRequestJson(request)).rejects.toBeInstanceOf(TypeError);
+  });
+
+  test("decodes a large body without truncation or fabricated defaults", async () => {
+    const value = "x".repeat(1024 * 1024);
+    const request = new Request("https://example.test", {
+      method: "POST",
+      body: JSON.stringify({ value }),
+    });
+
+    const result = await decodeRequestJson(request);
+    expect(result).toEqual({ ok: true, value: { value } });
+  });
+
   test("returns canonical decoded values unchanged", async () => {
     const value = { query: "elizaOS" };
-    await expect(decodeRequestJson({ json: async () => value })).resolves.toEqual({
+    await expect(decodeRequestJson({ text: async () => JSON.stringify(value) })).resolves.toEqual({
+      ok: true,
+      value,
+    });
+  });
+
+  test.each([
+    ["null", null],
+    ['"text"', "text"],
+    ["42", 42],
+    ["true", true],
+  ])("keeps valid primitive JSON distinct from invalid syntax", async (body, value) => {
+    await expect(decodeRequestJson({ text: async () => body })).resolves.toEqual({
       ok: true,
       value,
     });

--- a/packages/cloud/shared/src/lib/utils/json-parsing.ts
+++ b/packages/cloud/shared/src/lib/utils/json-parsing.ts
@@ -9,25 +9,28 @@
 
 import { extractErrorMessage } from "./error-handling";
 
-export type RequestJsonDecodeResult =
-  | { ok: true; value: unknown }
-  | { ok: false; error: SyntaxError };
+export type RequestJsonDecodeResult = { ok: true; value: unknown } | { ok: false };
 
 /**
  * Decode an untrusted request body without disguising transport/runtime faults
- * as malformed caller input. Fetch and Hono surface invalid JSON as a
- * `SyntaxError`; every other rejection belongs to the route's normal 5xx
- * boundary and must keep propagating.
+ * as malformed caller input. Body acquisition completes before the narrow
+ * `JSON.parse` boundary, so stream, abort, and decoder failures propagate to
+ * the route's normal 5xx handler. Syntax details are discarded because engine
+ * diagnostics can quote sensitive request content.
  */
 export async function decodeRequestJson(source: {
-  json(): Promise<unknown>;
+  text(): Promise<string>;
 }): Promise<RequestJsonDecodeResult> {
+  const text = await source.text();
+  if (typeof text !== "string") {
+    throw new TypeError("Request body decoder returned a non-string value");
+  }
   try {
-    return { ok: true, value: await source.json() };
+    return { ok: true, value: JSON.parse(text) as unknown };
   } catch (error) {
     if (!(error instanceof SyntaxError)) throw error;
     // error-policy:J3 malformed JSON is explicit invalid request input.
-    return { ok: false, error };
+    return { ok: false };
   }
 }
 

--- a/packages/cloud/shared/src/lib/utils/json-parsing.ts
+++ b/packages/cloud/shared/src/lib/utils/json-parsing.ts
@@ -1,5 +1,5 @@
 /**
- * Response JSON helpers for cloud service clients.
+ * JSON helpers for Cloud request boundaries and service-client responses.
  *
  * Success responses parse strictly so malformed provider payloads surface as
  * integration failures. Error responses have a separate best-effort parser
@@ -8,6 +8,28 @@
  */
 
 import { extractErrorMessage } from "./error-handling";
+
+export type RequestJsonDecodeResult =
+  | { ok: true; value: unknown }
+  | { ok: false; error: SyntaxError };
+
+/**
+ * Decode an untrusted request body without disguising transport/runtime faults
+ * as malformed caller input. Fetch and Hono surface invalid JSON as a
+ * `SyntaxError`; every other rejection belongs to the route's normal 5xx
+ * boundary and must keep propagating.
+ */
+export async function decodeRequestJson(source: {
+  json(): Promise<unknown>;
+}): Promise<RequestJsonDecodeResult> {
+  try {
+    return { ok: true, value: await source.json() };
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error;
+    // error-policy:J3 malformed JSON is explicit invalid request input.
+    return { ok: false, error };
+  }
+}
 
 /**
  * Parse a response body as JSON, preserving empty or malformed payloads as


### PR DESCRIPTION
Closes #21726.

## Summary

Preserves the intended `400 Invalid JSON` response for malformed request syntax while allowing decoder, stream, and runtime failures to reach each Cloud route's existing 5xx boundary. A shared `decodeRequestJson` helper now owns that distinction, and all 57 broad JSON-decode catches introduced across 54 production routes by #21682 use it without changing authentication order, schema validation, or route-specific error envelopes.

## Validation

Exact head `20a1e67b493cbeb17231c6947c90dfbcfa0477d9`, rebased on `develop@5929de2162ecffa1fff069faabca65779d7dcb0f`, using pinned Bun 1.3.14 and Node 24.15.0:

- All 56 current `route.json.test.ts` suites passed independently; 57 production decoder sites across 54 production files remain migrated and zero affected broad catches remain.
- Focused shared-helper plus real Hono route regression: 26/26 passed. The representative route proves malformed syntax is 400, a request-stream `TypeError` reaches the 500 boundary, and Stripe is not invoked.
- `packages/cloud/shared` typecheck passed.
- Cloud API Worker production dry-run bundle passed.
- Cloud shared/API `lint:check` and Biome on the three follow-up files passed.
- `git diff --check` passed.

The aggregate Cloud API typecheck still reports six pre-existing DB-test diagnostics unrelated to this change; no changed-file diagnostic is present. Root `verify` reaches an unrelated duplicate translation key in `packages/ui/src/i18n/locales/en.json`.

## Risk and rollback

Malformed JSON retains each route's current client-visible 400 response. The behavioral correction is limited to non-syntax failures that were previously misclassified as client input and now follow the existing server-error path. Rollback is the single commit; there is no schema, state, dependency, or deployment mutation.

## Evidence Gate

<!-- evidence-head:20a1e67b493cbeb17231c6947c90dfbcfa0477d9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Cloud request-boundary behavior only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Cloud request-boundary behavior only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head deterministic route-boundary transcript; no live service was mutated.

<details><summary>Backend boundary transcript</summary>

~~~text
Malformed JSON syntax -> HTTP 400; Stripe session calls: 0.
Injected request-stream TypeError -> existing HTTP 500 boundary; Stripe session calls: 0.
Canonical JSON -> HTTP 200 and the checkout service is invoked exactly once.
~~~

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head affected-family audit and Worker bundle transcript:

<details><summary>Boundary evidence</summary>

~~~text
$ bun test packages/cloud/shared/src/lib/utils/json-parsing.test.ts packages/cloud/api/v1/app-credits/checkout/route.json.test.ts
26 pass, 0 fail

Current Cloud API JSON-route corpus: 56/56 suites passed independently; 57 production decode sites across 54 production files; 0 affected old broad catches remain.

$ bun run --cwd packages/cloud/shared typecheck
PASS

$ bun run --cwd packages/cloud/api check:worker-bundle
Wrangler production dry-run bundle completed successfully.
~~~

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop / multi-agent review`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a4789f06508a9d8d2699bf6606b63ad23572887f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent review
Contribution skill revision: elizaOS/eliza@a4789f06508a9d8d2699bf6606b63ad23572887f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent review","skill_revision":"elizaOS/eliza@a4789f06508a9d8d2699bf6606b63ad23572887f:packages/skills/skills/contribute-to-eliza"} -->