### PR TITLE
fix(plugin-google-workspace): bound OAuth userinfo and token-exchange fetches

### DIFF
--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -45,6 +45,9 @@ import { GOOGLE_SERVICE_NAME } from "./types.js";
 
 const GOOGLE_USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo";
 
+/** Token exchange and userinfo are short hops; still need a hard cap. */
+export const GOOGLE_OAUTH_FETCH_TIMEOUT_MS = 15_000;
+
 const GROUP_PURPOSE: Record<GoogleCapabilityGroup, ConnectorAccountPurpose> = {
   gmail: "messaging" as ConnectorAccountPurpose,
   calendar: "calendar" as ConnectorAccountPurpose,
@@ -361,9 +364,14 @@ function parseIdTokenClaims(idToken: string | undefined): GoogleIdentity {
   }
 }
 
-async function fetchGoogleUserInfo(accessToken: string): Promise<GoogleIdentity> {
-  const response = await fetch(GOOGLE_USERINFO_ENDPOINT, {
+export async function fetchGoogleUserInfoWithFetch(
+  accessToken: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs: number = GOOGLE_OAUTH_FETCH_TIMEOUT_MS
+): Promise<GoogleIdentity> {
+  const response = await fetchImpl(GOOGLE_USERINFO_ENDPOINT, {
     headers: { Authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(timeoutMs),
   });
   if (!response.ok) {
     throw new Error(`Google userinfo request failed with ${response.status}`);
@@ -375,13 +383,21 @@ async function fetchGoogleUserInfo(accessToken: string): Promise<GoogleIdentity>
   return parsed;
 }
 
-async function exchangeAuthorizationCode(args: {
-  clientId: string;
-  clientSecret: string;
-  redirectUri: string;
-  code: string;
-  codeVerifier?: string;
-}): Promise<GoogleTokenResponse> {
+async function fetchGoogleUserInfo(accessToken: string): Promise<GoogleIdentity> {
+  return fetchGoogleUserInfoWithFetch(accessToken);
+}
+
+export async function exchangeAuthorizationCodeWithFetch(
+  args: {
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+    code: string;
+    codeVerifier?: string;
+  },
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs: number = GOOGLE_OAUTH_FETCH_TIMEOUT_MS
+): Promise<GoogleTokenResponse> {
   const params = new URLSearchParams({
     client_id: args.clientId,
     client_secret: args.clientSecret,
@@ -393,10 +409,11 @@ async function exchangeAuthorizationCode(args: {
     params.set("code_verifier", args.codeVerifier);
   }
 
-  const response = await fetch(GOOGLE_OAUTH_PROVIDER_METADATA.tokenEndpoint, {
+  const response = await fetchImpl(GOOGLE_OAUTH_PROVIDER_METADATA.tokenEndpoint, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: params.toString(),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   if (!response.ok) {
     const body = await response.text();
@@ -407,6 +424,16 @@ async function exchangeAuthorizationCode(args: {
     throw new Error("Google token exchange returned an invalid payload.");
   }
   return parsed;
+}
+
+async function exchangeAuthorizationCode(args: {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  code: string;
+  codeVerifier?: string;
+}): Promise<GoogleTokenResponse> {
+  return exchangeAuthorizationCodeWithFetch(args);
 }
 
 /**

--- a/plugins/plugin-google-workspace/src/connector-oauth-timeout.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-oauth-timeout.test.ts
@@ -27,7 +27,7 @@ function stallUntilAborted(): typeof fetch {
 describe("Google OAuth request deadlines", () => {
   it("aborts a stalled token exchange at the injected deadline", async () => {
     await expect(
-      exchangeAuthorizationCodeWithFetch(TOKEN_ARGS, stallUntilAborted(), 10),
+      exchangeAuthorizationCodeWithFetch(TOKEN_ARGS, stallUntilAborted(), 10)
     ).rejects.toMatchObject({ name: "TimeoutError" });
   });
 
@@ -36,7 +36,7 @@ describe("Google OAuth request deadlines", () => {
       new Response("invalid_grant", { status: 400, statusText: "Bad Request" });
 
     await expect(exchangeAuthorizationCodeWithFetch(TOKEN_ARGS, fetchImpl, 1_000)).rejects.toThrow(
-      "invalid_grant",
+      "invalid_grant"
     );
   });
 
@@ -57,7 +57,7 @@ describe("Google OAuth request deadlines", () => {
 
   it("aborts a stalled userinfo request at the injected deadline", async () => {
     await expect(
-      fetchGoogleUserInfoWithFetch("access-token", stallUntilAborted(), 10),
+      fetchGoogleUserInfoWithFetch("access-token", stallUntilAborted(), 10)
     ).rejects.toMatchObject({ name: "TimeoutError" });
   });
 
@@ -66,7 +66,7 @@ describe("Google OAuth request deadlines", () => {
       new Response("", { status: 429, statusText: "Too Many Requests" });
 
     await expect(fetchGoogleUserInfoWithFetch("access-token", fetchImpl, 1_000)).rejects.toThrow(
-      "429",
+      "429"
     );
   });
 

--- a/plugins/plugin-google-workspace/src/connector-oauth-timeout.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-oauth-timeout.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Behavioral Google OAuth deadlines. Executes userinfo and token-exchange
+ * under abort — not a source-grep of connector-account-provider.ts.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  exchangeAuthorizationCodeWithFetch,
+  fetchGoogleUserInfoWithFetch,
+} from "./connector-account-provider.js";
+
+const TOKEN_ARGS = {
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  redirectUri: "http://127.0.0.1:31437/api/connectors/google/oauth/callback",
+  code: "oauth-code",
+};
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected oauth abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+    })) as typeof fetch;
+}
+
+describe("Google OAuth request deadlines", () => {
+  it("aborts a stalled token exchange at the injected deadline", async () => {
+    await expect(
+      exchangeAuthorizationCodeWithFetch(TOKEN_ARGS, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed token exchange", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("invalid_grant", { status: 400, statusText: "Bad Request" });
+
+    await expect(exchangeAuthorizationCodeWithFetch(TOKEN_ARGS, fetchImpl, 1_000)).rejects.toThrow(
+      "invalid_grant",
+    );
+  });
+
+  it("uses the injected fetch for a successful token exchange", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({ access_token: "tok", expires_in: 3600, token_type: "Bearer" });
+    };
+
+    const tokens = await exchangeAuthorizationCodeWithFetch(TOKEN_ARGS, fetchImpl, 1_000);
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(tokens.access_token).toBe("tok");
+    expect(tokens.expires_in).toBe(3600);
+  });
+
+  it("aborts a stalled userinfo request at the injected deadline", async () => {
+    await expect(
+      fetchGoogleUserInfoWithFetch("access-token", stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed userinfo request", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("", { status: 429, statusText: "Too Many Requests" });
+
+    await expect(fetchGoogleUserInfoWithFetch("access-token", fetchImpl, 1_000)).rejects.toThrow(
+      "429",
+    );
+  });
+
+  it("uses the injected fetch for a successful userinfo request", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({ email: "ada@example.com", sub: "google-subject" });
+    };
+
+    const identity = await fetchGoogleUserInfoWithFetch("access-token", fetchImpl, 1_000);
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(identity.email).toBe("ada@example.com");
+    expect(identity.sub).toBe("google-subject");
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). Google connector **userinfo** and **token-exchange** `fetch` have no `AbortSignal`, so a stalled OAuth hop hangs the worker. Not `#21404` (closed: grepped source strings, never executed userinfo or token-exchange). Not `#21211`. This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, with a documented 15s OAuth deadline. Tests execute both hops under abort. Chat path already shipped (`#21738`) and is a different file. Not extra-decode. Not list-limit. Not payment. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Public `createGoogleConnectorAccountProvider` signature unchanged. Unfixed head: token-exchange `fetch` had **no signal** and a hung fetch never settled (80ms race → `HUNG`). After: 10ms deadline → `TimeoutError`. OAuth budget is 15s.

# Background

## What does this PR do?

`exchangeAuthorizationCode` and `fetchGoogleUserInfo` called `fetch` with no `signal`. A stalled Google OAuth hop never returns. This PR injects `*WithFetch` (Fal `#21205` shape) and adds `AbortSignal.timeout`.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Chat REST path untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-workspace/src/connector-oauth-timeout.test.ts` — token-exchange and userinfo timeout, provider-error, success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-google-workspace && bunx vitest run --config ./vitest.config.ts src/connector-oauth-timeout.test.ts
```

Unfixed head `310d08c4fd`: token-exchange `signal` was undefined and the call hung. After the fix: 6 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:dfdbd444ffd4d7905aa5efc045491e495d95b41e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Provider fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live Google OAuth path. vitest asserts TimeoutError, provider 400/429, and success payloads.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - Google OAuth transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live Google. Unfixed `%` hang: no signal, 80ms race `HUNG`. After the fix, vitest asserts TimeoutError on token-exchange and userinfo, `invalid_grant` on 400, `429` on userinfo, and successful token/identity payloads.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

## Audio / voice walkthrough

N/A - OAuth provider HTTP only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`6 pass`). Root verify is an unrelated full-repo cost. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
