### PR TITLE
feat(orchestrator): securely prewarm elizaos ACP children

### DIFF
--- a/packages/examples/code/src/acp-bootstrap.test.ts
+++ b/packages/examples/code/src/acp-bootstrap.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Exercises the ACP credential and PATH bootstrap in an isolated Bun process
+ * so process-global authority state cannot leak between test cases.
+ */
+import { expect, it } from "bun:test";
+
+it("deletes the warm token before imports and captures only claimed PATH", () => {
+  const bootstrapUrl = new URL("./acp-bootstrap.ts", import.meta.url).href;
+  const sharedUrl = new URL(
+    "../../../shared/src/host-execution-env.ts",
+    import.meta.url,
+  ).href;
+  const script = `
+    const bootstrap = await import(${JSON.stringify(bootstrapUrl)});
+    const shared = await import(${JSON.stringify(sharedUrl)});
+    const before = {
+      exposed: process.env.ELIZA_ACP_WARM_CLAIM_TOKEN,
+      token: bootstrap.consumeWarmClaimToken(),
+      baseline: shared.getHostExecutionBaseline().path,
+    };
+    process.env.PATH = "/claimed/wrapper:/usr/bin";
+    shared.captureHostExecutionBaseline();
+    process.stdout.write(JSON.stringify({
+      before,
+      after: shared.getHostExecutionBaseline().path,
+    }));
+  `;
+  const result = Bun.spawnSync(
+    [process.execPath, "--conditions=eliza-source", "-e", script],
+    {
+      env: {
+        ...process.env,
+        ELIZA_ACP_WARM_CLAIM_TOKEN: "single-use-secret",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+
+  expect(result.exitCode, result.stderr.toString()).toBe(0);
+  expect(JSON.parse(result.stdout.toString())).toEqual({
+    before: { token: "single-use-secret" },
+    after: "/claimed/wrapper:/usr/bin",
+  });
+});

--- a/packages/examples/code/src/acp-bootstrap.ts
+++ b/packages/examples/code/src/acp-bootstrap.ts
@@ -1,0 +1,18 @@
+/**
+ * Seals the warm-child authenticator before the ACP module graph can observe
+ * process credentials, while preserving boot-time PATH capture for cold ACP
+ * children. Warm children capture PATH only after their authenticated session
+ * claim installs the per-session Git wrapper.
+ */
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+
+let warmClaimToken = process.env.ELIZA_ACP_WARM_CLAIM_TOKEN?.trim() ?? "";
+delete process.env.ELIZA_ACP_WARM_CLAIM_TOKEN;
+
+if (!warmClaimToken) captureHostExecutionBaseline();
+
+export function consumeWarmClaimToken(): string {
+  const token = warmClaimToken;
+  warmClaimToken = "";
+  return token;
+}

--- a/packages/examples/code/src/acp-session-claim.test.ts
+++ b/packages/examples/code/src/acp-session-claim.test.ts
@@ -1,0 +1,79 @@
+/** Exercises authenticated warm-child claims without starting a runtime or exposing live credentials. */
+import { describe, expect, it } from "bun:test";
+import { AcpWarmSessionClaim } from "./acp-session-claim";
+
+describe("AcpWarmSessionClaim", () => {
+  it("applies one authenticated environment and clears every claimed value", () => {
+    const source = { ELIZA_ACP_WARM_CLAIM_TOKEN: "claim-secret", PATH: "/bin" };
+    const target: Record<string, string | undefined> = {};
+    const claim = new AcpWarmSessionClaim(source);
+
+    expect(source.ELIZA_ACP_WARM_CLAIM_TOKEN).toBeUndefined();
+    claim.apply(
+      {
+        elizaSessionClaim: {
+          token: "claim-secret",
+          env: {
+            ORCHESTRATOR_SESSION_ID: "session-a",
+            OPENAI_API_KEY: "lease-a",
+          },
+        },
+      },
+      target,
+    );
+    expect(target).toEqual({
+      ORCHESTRATOR_SESSION_ID: "session-a",
+      OPENAI_API_KEY: "lease-a",
+    });
+    expect(() =>
+      claim.apply(
+        {
+          elizaSessionClaim: {
+            token: "claim-secret",
+            env: { ORCHESTRATOR_SESSION_ID: "session-b" },
+          },
+        },
+        target,
+      ),
+    ).toThrow("already consumed");
+
+    claim.clear(target);
+    expect(target).toEqual({});
+  });
+
+  it("rejects wrong tokens and invalid entries without partially mutating env", () => {
+    for (const attempted of [
+      { token: "wrong-secret", env: { OPENAI_API_KEY: "lease-b" } },
+      {
+        token: "claim-secret",
+        env: {
+          OPENAI_API_KEY: "lease-b",
+          ELIZA_ACP_WARM_CLAIM_TOKEN: "replace-authenticator",
+        },
+      },
+      { token: "claim-secret", env: { "mixed-Case": "lease-b" } },
+    ]) {
+      const target = { EXISTING: "preserved" };
+      const claim = new AcpWarmSessionClaim({
+        ELIZA_ACP_WARM_CLAIM_TOKEN: "claim-secret",
+      });
+      expect(() =>
+        claim.apply({ elizaSessionClaim: attempted }, target),
+      ).toThrow();
+      expect(target).toEqual({ EXISTING: "preserved" });
+      expect(claim.wasConsumed).toBe(false);
+    }
+  });
+
+  it("rejects claim material when the child was not pre-authorized", () => {
+    const claim = new AcpWarmSessionClaim({});
+    expect(() =>
+      claim.apply({
+        elizaSessionClaim: {
+          token: "injected",
+          env: { OPENAI_API_KEY: "lease" },
+        },
+      }),
+    ).toThrow("unexpected warm-session claim");
+  });
+});

--- a/packages/examples/code/src/acp-session-claim.test.ts
+++ b/packages/examples/code/src/acp-session-claim.test.ts
@@ -4,11 +4,9 @@ import { AcpWarmSessionClaim } from "./acp-session-claim";
 
 describe("AcpWarmSessionClaim", () => {
   it("applies one authenticated environment and clears every claimed value", () => {
-    const source = { ELIZA_ACP_WARM_CLAIM_TOKEN: "claim-secret", PATH: "/bin" };
     const target: Record<string, string | undefined> = {};
-    const claim = new AcpWarmSessionClaim(source);
+    const claim = new AcpWarmSessionClaim("claim-secret");
 
-    expect(source.ELIZA_ACP_WARM_CLAIM_TOKEN).toBeUndefined();
     claim.apply(
       {
         elizaSessionClaim: {
@@ -54,9 +52,7 @@ describe("AcpWarmSessionClaim", () => {
       { token: "claim-secret", env: { "mixed-Case": "lease-b" } },
     ]) {
       const target = { EXISTING: "preserved" };
-      const claim = new AcpWarmSessionClaim({
-        ELIZA_ACP_WARM_CLAIM_TOKEN: "claim-secret",
-      });
+      const claim = new AcpWarmSessionClaim("claim-secret");
       expect(() =>
         claim.apply({ elizaSessionClaim: attempted }, target),
       ).toThrow();
@@ -66,7 +62,7 @@ describe("AcpWarmSessionClaim", () => {
   });
 
   it("rejects claim material when the child was not pre-authorized", () => {
-    const claim = new AcpWarmSessionClaim({});
+    const claim = new AcpWarmSessionClaim();
     expect(() =>
       claim.apply({
         elizaSessionClaim: {

--- a/packages/examples/code/src/acp-session-claim.test.ts
+++ b/packages/examples/code/src/acp-session-claim.test.ts
@@ -1,5 +1,7 @@
 /** Exercises authenticated warm-child claims without starting a runtime or exposing live credentials. */
+
 import { describe, expect, it } from "bun:test";
+import { delimiter } from "node:path";
 import { AcpWarmSessionClaim } from "./acp-session-claim";
 
 describe("AcpWarmSessionClaim", () => {
@@ -14,7 +16,11 @@ describe("AcpWarmSessionClaim", () => {
           env: {
             ORCHESTRATOR_SESSION_ID: "session-a",
             OPENAI_API_KEY: "lease-a",
+            PATH: "/caller-controlled/bin",
           },
+          executionPath: ["/trusted/session-git/bin", "/usr/bin"].join(
+            delimiter,
+          ),
         },
       },
       target,
@@ -22,6 +28,7 @@ describe("AcpWarmSessionClaim", () => {
     expect(target).toEqual({
       ORCHESTRATOR_SESSION_ID: "session-a",
       OPENAI_API_KEY: "lease-a",
+      PATH: ["/trusted/session-git/bin", "/usr/bin"].join(delimiter),
     });
     expect(() =>
       claim.apply(
@@ -29,6 +36,7 @@ describe("AcpWarmSessionClaim", () => {
           elizaSessionClaim: {
             token: "claim-secret",
             env: { ORCHESTRATOR_SESSION_ID: "session-b" },
+            executionPath: "/usr/bin",
           },
         },
         target,
@@ -48,8 +56,18 @@ describe("AcpWarmSessionClaim", () => {
           OPENAI_API_KEY: "lease-b",
           ELIZA_ACP_WARM_CLAIM_TOKEN: "replace-authenticator",
         },
+        executionPath: "/usr/bin",
       },
-      { token: "claim-secret", env: { "mixed-Case": "lease-b" } },
+      {
+        token: "claim-secret",
+        env: { "mixed-Case": "lease-b" },
+        executionPath: "/usr/bin",
+      },
+      {
+        token: "claim-secret",
+        env: { OPENAI_API_KEY: "lease-b" },
+        executionPath: "relative/bin",
+      },
     ]) {
       const target = { EXISTING: "preserved" };
       const claim = new AcpWarmSessionClaim("claim-secret");
@@ -68,6 +86,7 @@ describe("AcpWarmSessionClaim", () => {
         elizaSessionClaim: {
           token: "injected",
           env: { OPENAI_API_KEY: "lease" },
+          executionPath: "/usr/bin",
         },
       }),
     ).toThrow("unexpected warm-session claim");

--- a/packages/examples/code/src/acp-session-claim.ts
+++ b/packages/examples/code/src/acp-session-claim.ts
@@ -14,9 +14,8 @@ export class AcpWarmSessionClaim {
   private consumed = false;
   private readonly appliedKeys = new Set<string>();
 
-  constructor(sourceEnv: NodeJS.ProcessEnv = process.env) {
-    this.token = sourceEnv.ELIZA_ACP_WARM_CLAIM_TOKEN?.trim() ?? "";
-    delete sourceEnv.ELIZA_ACP_WARM_CLAIM_TOKEN;
+  constructor(token = "") {
+    this.token = token.trim();
   }
 
   get wasConsumed(): boolean {

--- a/packages/examples/code/src/acp-session-claim.ts
+++ b/packages/examples/code/src/acp-session-claim.ts
@@ -4,9 +4,14 @@
  * reusable: callers clear the applied environment and dispose its process.
  */
 import { timingSafeEqual } from "node:crypto";
+import { delimiter, isAbsolute } from "node:path";
 
 export type AcpSessionClaimMeta = {
-  elizaSessionClaim?: { token?: unknown; env?: unknown };
+  elizaSessionClaim?: {
+    token?: unknown;
+    env?: unknown;
+    executionPath?: unknown;
+  };
 };
 
 export class AcpWarmSessionClaim {
@@ -62,10 +67,19 @@ export class AcpWarmSessionClaim {
       }
       validatedEntries.push([key, value]);
     }
+    if (
+      typeof claim.executionPath !== "string" ||
+      !isTrustedExecutionPath(claim.executionPath)
+    ) {
+      throw new Error("invalid warm-session execution path");
+    }
     for (const [key, value] of validatedEntries) {
+      if (key === "PATH") continue;
       targetEnv[key] = value;
       this.appliedKeys.add(key);
     }
+    targetEnv.PATH = claim.executionPath;
+    this.appliedKeys.add("PATH");
     this.consumed = true;
     this.token = "";
   }
@@ -84,4 +98,11 @@ export class AcpWarmSessionClaim {
       timingSafeEqual(expected, received)
     );
   }
+}
+
+function isTrustedExecutionPath(value: string): boolean {
+  if (!value || value.includes("\0")) return false;
+  return value
+    .split(delimiter)
+    .every((entry) => entry.length > 0 && isAbsolute(entry));
 }

--- a/packages/examples/code/src/acp-session-claim.ts
+++ b/packages/examples/code/src/acp-session-claim.ts
@@ -1,0 +1,88 @@
+/**
+ * Authenticates and applies the single session-environment handoff consumed by
+ * a pre-initialized eliza-code ACP child. A claimed child is deliberately not
+ * reusable: callers clear the applied environment and dispose its process.
+ */
+import { timingSafeEqual } from "node:crypto";
+
+export type AcpSessionClaimMeta = {
+  elizaSessionClaim?: { token?: unknown; env?: unknown };
+};
+
+export class AcpWarmSessionClaim {
+  private token: string;
+  private consumed = false;
+  private readonly appliedKeys = new Set<string>();
+
+  constructor(sourceEnv: NodeJS.ProcessEnv = process.env) {
+    this.token = sourceEnv.ELIZA_ACP_WARM_CLAIM_TOKEN?.trim() ?? "";
+    delete sourceEnv.ELIZA_ACP_WARM_CLAIM_TOKEN;
+  }
+
+  get wasConsumed(): boolean {
+    return this.consumed;
+  }
+
+  apply(meta: unknown, targetEnv = process.env): void {
+    const record =
+      meta && typeof meta === "object" && !Array.isArray(meta)
+        ? (meta as AcpSessionClaimMeta)
+        : undefined;
+    const claim = record?.elizaSessionClaim;
+    if (this.consumed) throw new Error("warm-session claim already consumed");
+    if (!this.token) {
+      if (claim) throw new Error("unexpected warm-session claim");
+      return;
+    }
+    if (
+      !claim ||
+      typeof claim.token !== "string" ||
+      !this.equalToken(claim.token)
+    ) {
+      throw new Error("invalid warm-session claim");
+    }
+    if (
+      !claim.env ||
+      typeof claim.env !== "object" ||
+      Array.isArray(claim.env)
+    ) {
+      throw new Error("invalid warm-session environment");
+    }
+    const entries = Object.entries(claim.env as Record<string, unknown>);
+    if (entries.length > 256) {
+      throw new Error("warm-session environment is too large");
+    }
+    const validatedEntries: Array<[string, string]> = [];
+    for (const [key, value] of entries) {
+      if (
+        !/^[A-Z_][A-Z0-9_]*$/.test(key) ||
+        key === "ELIZA_ACP_WARM_CLAIM_TOKEN" ||
+        typeof value !== "string"
+      ) {
+        throw new Error("invalid warm-session environment entry");
+      }
+      validatedEntries.push([key, value]);
+    }
+    for (const [key, value] of validatedEntries) {
+      targetEnv[key] = value;
+      this.appliedKeys.add(key);
+    }
+    this.consumed = true;
+    this.token = "";
+  }
+
+  clear(targetEnv = process.env): void {
+    for (const key of this.appliedKeys) delete targetEnv[key];
+    this.appliedKeys.clear();
+  }
+
+  private equalToken(candidate: string): boolean {
+    const expected = Buffer.from(this.token);
+    const received = Buffer.from(candidate);
+    return (
+      expected.length > 0 &&
+      expected.length === received.length &&
+      timingSafeEqual(expected, received)
+    );
+  }
+}

--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -39,6 +39,7 @@ import {
   SessionCwdService,
 } from "@elizaos/plugin-coding-tools";
 import { publishParsedReply } from "./acp-response.js";
+import { AcpWarmSessionClaim } from "./acp-session-claim.js";
 import { initializeAgent } from "./lib/agent.js";
 import { getAgentClient } from "./lib/agent-client.js";
 import {
@@ -63,6 +64,7 @@ function log(message: string, extra?: unknown): void {
 // Lazily-initialized shared runtime (one per ACP server process).
 let runtimePromise: Promise<AgentRuntime> | null = null;
 let identity: SessionIdentity | null = null;
+const warmSessionClaim = new AcpWarmSessionClaim();
 
 async function ensureRuntime(cwd?: string): Promise<AgentRuntime> {
   if (!runtimePromise) {
@@ -229,7 +231,11 @@ const _connection = new AgentSideConnection(
     async authenticate() {
       return {};
     },
-    async newSession(params: { cwd?: string }) {
+    async newSession(params: {
+      cwd?: string;
+      _meta?: Record<string, unknown> | null;
+    }) {
+      warmSessionClaim.apply(params._meta);
       const runtime = await ensureRuntime(params.cwd);
       const id = randomUUID();
       const session = identity as SessionIdentity;
@@ -349,6 +355,13 @@ const _connection = new AgentSideConnection(
     async closeSession(params: { sessionId?: string }) {
       const sessionId = params?.sessionId;
       if (sessionId) sessions.delete(sessionId);
+      if (warmSessionClaim.wasConsumed) {
+        warmSessionClaim.clear();
+        // A warm child is single-claim by design. Runtime/provider instances
+        // may retain derived credentials even after process.env is cleared, so
+        // true cross-session isolation requires process disposal, not reuse.
+        setTimeout(() => process.exit(0), 0).unref?.();
+      }
       log("session closed", { sessionId });
       return {};
     },

--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * eliza-code ACP server — lets eliza-code run AS a coding sub-agent that the
  * elizaOS orchestrator (plugin-agent-orchestrator) can spawn over the Agent
@@ -24,13 +25,12 @@
  * @module example-code/acp
  */
 
-// FIRST import: captures this process's executable-search authority before any
-// runtime/plugin module body can mutate process.env. Without it the sub-agent's
-// baseline stays empty, plugin-coding-tools resolves ZERO authority
-// directories, and every SHELL command (builtins included) dies with exit -1
-// "No boot-authorized shell was detected" — the exact live failure observed in
-// spawned eliza-code sessions on 2026-08-16 while FILE tools kept working.
-import "./host-baseline.js";
+// FIRST import: removes the warm authenticator before any runtime/plugin module
+// can inspect process.env. Cold children also capture their launch PATH here;
+// warm children defer capture until the authenticated claim installs the
+// per-session Git wrapper.
+// biome-ignore assist/source/organizeImports: dependency evaluation order is the credential boundary.
+import { consumeWarmClaimToken } from "./acp-bootstrap.js";
 import { randomUUID } from "node:crypto";
 import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk";
 import type { AgentRuntime } from "@elizaos/core";
@@ -38,6 +38,7 @@ import {
   SandboxService,
   SessionCwdService,
 } from "@elizaos/plugin-coding-tools";
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { publishParsedReply } from "./acp-response.js";
 import { AcpWarmSessionClaim } from "./acp-session-claim.js";
 import { initializeAgent } from "./lib/agent.js";
@@ -64,7 +65,7 @@ function log(message: string, extra?: unknown): void {
 // Lazily-initialized shared runtime (one per ACP server process).
 let runtimePromise: Promise<AgentRuntime> | null = null;
 let identity: SessionIdentity | null = null;
-const warmSessionClaim = new AcpWarmSessionClaim();
+const warmSessionClaim = new AcpWarmSessionClaim(consumeWarmClaimToken());
 
 async function ensureRuntime(cwd?: string): Promise<AgentRuntime> {
   if (!runtimePromise) {
@@ -120,7 +121,10 @@ async function ensureRuntime(cwd?: string): Promise<AgentRuntime> {
       process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE ??= "1";
       // Headless coding sub-agent: only sql + provider + shell + coding-tools.
       // codingOnly drops mcp/goals AND the orchestrator (recursion guard).
-      const runtime = await initializeAgent({ codingOnly: true });
+      const runtime = await initializeAgent({
+        codingOnly: true,
+        loadDotenv: false,
+      });
       // Mark the session user as OWNER via the RUNTIME SETTING the role resolver
       // actually reads (getConfiguredOwnerEntityIds → runtime.getSetting), not just
       // process.env — otherwise the sender stays GUEST and FILE/SHELL are gated off.
@@ -236,6 +240,7 @@ const _connection = new AgentSideConnection(
       _meta?: Record<string, unknown> | null;
     }) {
       warmSessionClaim.apply(params._meta);
+      captureHostExecutionBaseline();
       const runtime = await ensureRuntime(params.cwd);
       const id = randomUUID();
       const session = identity as SessionIdentity;

--- a/packages/examples/code/src/host-baseline.test.ts
+++ b/packages/examples/code/src/host-baseline.test.ts
@@ -5,15 +5,21 @@
  * Deterministic; no live runtime.
  */
 import { readFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { describe, expect, it } from "vitest";
 
 describe("eliza-code host execution baseline", () => {
   it("captures a non-empty PATH baseline via the side-effect module", async () => {
-    await import("./host-baseline.js");
-    const baseline = getHostExecutionBaseline();
-    expect(baseline.path).toBeDefined();
-    expect(baseline.path?.length).toBeGreaterThan(0);
+    const previousPath = process.env.PATH;
+    const executableDirectory = dirname(process.execPath);
+    process.env.PATH = executableDirectory;
+    try {
+      await import("./host-baseline.js");
+      expect(getHostExecutionBaseline().path).toBe(executableDirectory);
+    } finally {
+      process.env.PATH = previousPath;
+    }
   });
 
   it.each([

--- a/packages/examples/code/src/host-baseline.test.ts
+++ b/packages/examples/code/src/host-baseline.test.ts
@@ -1,14 +1,11 @@
 /**
- * Pins the executable-search authority contract shared by the ACP, one-shot,
- * and TUI entrypoints. Importing the capture module produces a real PATH
- * baseline, and both executable entries keep that module as their first import
- * so no runtime module body can beat it. Deterministic; no live runtime.
+ * Pins executable-search authority for the ACP, one-shot, and TUI entrypoints.
+ * The normal entry captures immediately; the warm ACP bootstrap removes its
+ * authenticator before loading dependencies and captures only after claim.
+ * Deterministic; no live runtime.
  */
 import { readFileSync } from "node:fs";
-import {
-  getHostExecutionBaseline,
-  resolveHostExecutable,
-} from "@elizaos/shared/host-execution-env";
+import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { describe, expect, it } from "vitest";
 
 describe("eliza-code host execution baseline", () => {
@@ -16,8 +13,7 @@ describe("eliza-code host execution baseline", () => {
     await import("./host-baseline.js");
     const baseline = getHostExecutionBaseline();
     expect(baseline.path).toBeDefined();
-    expect(baseline.path).toContain("/");
-    expect(resolveHostExecutable(process.execPath)).toBe(process.execPath);
+    expect(baseline.path?.length).toBeGreaterThan(0);
   });
 
   it.each([
@@ -34,4 +30,11 @@ describe("eliza-code host execution baseline", () => {
       expect(firstImport).toBe(expected);
     },
   );
+
+  it("captures the claimed PATH before runtime initialization", () => {
+    const acp = readFileSync(new URL("./acp.ts", import.meta.url), "utf8");
+    expect(acp.indexOf("warmSessionClaim.apply(params._meta)")).toBeLessThan(
+      acp.indexOf("captureHostExecutionBaseline()"),
+    );
+  });
 });

--- a/packages/examples/code/src/host-baseline.test.ts
+++ b/packages/examples/code/src/host-baseline.test.ts
@@ -20,15 +20,18 @@ describe("eliza-code host execution baseline", () => {
     expect(resolveHostExecutable(process.execPath)).toBe(process.execPath);
   });
 
-  it.each(["acp.ts", "index.ts"])(
-    "keeps host-baseline as the FIRST import of %s",
-    (entry) => {
+  it.each([
+    ["acp.ts", 'import { consumeWarmClaimToken } from "./acp-bootstrap.js";'],
+    ["index.ts", 'import "./host-baseline.js";'],
+  ])(
+    "keeps the authority bootstrap as the FIRST import of %s",
+    (entry, expected) => {
       const source = readFileSync(
         new URL(`./${entry}`, import.meta.url),
         "utf8",
       );
       const firstImport = source.match(/^import .*$/m)?.[0] ?? "";
-      expect(firstImport).toBe('import "./host-baseline.js";');
+      expect(firstImport).toBe(expected);
     },
   );
 });

--- a/packages/examples/code/src/lib/agent.ts
+++ b/packages/examples/code/src/lib/agent.ts
@@ -1,5 +1,4 @@
-// Provides shared support logic for the Code example.
-import "dotenv/config";
+/** Provides shared runtime assembly for interactive and ACP Code agents. */
 import { AgentRuntime, type Character, type Plugin } from "@elizaos/core";
 import {
   applyOpencodeProviderEnv,
@@ -67,6 +66,8 @@ The current working directory is dynamically provided.`,
  * Initialize the Eliza runtime with coding capabilities
  */
 export interface InitializeAgentOptions {
+  /** Load the interactive entrypoint's repository-local `.env` (default true). */
+  loadDotenv?: boolean;
   /**
    * Load `@elizaos/plugin-agent-orchestrator` (default true). Set false when
    * eliza-code itself runs AS a coding sub-agent (e.g. the ACP server) so it
@@ -85,6 +86,7 @@ export interface InitializeAgentOptions {
 export async function initializeAgent(
   options: InitializeAgentOptions = {},
 ): Promise<AgentRuntime> {
+  if (options.loadDotenv !== false) await import("dotenv/config");
   const includeOrchestrator = options.includeOrchestrator !== false;
   applyOpencodeProviderEnv(process.env);
   const provider = resolveModelProvider(process.env);

--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -274,6 +274,7 @@ README → "GitHub credentials".
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport: `native` (embedded JSON-RPC) or `cli`/`acpx` (legacy shell wrapper) |
 | `ELIZA_ACP_CLI` | `acpx` | Path/command for the CLI transport |
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `opencode` |
+| `ELIZA_ACP_WARM_SPAWN` | unset | Set to `1` to pre-initialize one native `elizaos` ACP child. The child receives no session credentials until an authenticated, single-use claim and exits after that session; stale unclaimed children are recycled. |
 | `ELIZA_DEFAULT_AGENT_TYPE` | `elizaos` | Compatibility alias for `ELIZA_ACP_DEFAULT_AGENT` |
 | `ELIZA_AGENT_SELECTION_STRATEGY` | `fixed` | Adapter selection policy: `fixed` or `dynamic` |
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -274,6 +274,7 @@ README → "GitHub credentials".
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport: `native` (embedded JSON-RPC) or `cli`/`acpx` (legacy shell wrapper) |
 | `ELIZA_ACP_CLI` | `acpx` | Path/command for the CLI transport |
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `opencode` |
+| `ELIZA_ACP_WARM_SPAWN` | unset | Set to `1` to pre-initialize one native `elizaos` ACP child. The child receives no session credentials until an authenticated, single-use claim and exits after that session; stale unclaimed children are recycled. |
 | `ELIZA_DEFAULT_AGENT_TYPE` | `elizaos` | Compatibility alias for `ELIZA_ACP_DEFAULT_AGENT` |
 | `ELIZA_AGENT_SELECTION_STRATEGY` | `fixed` | Adapter selection policy: `fixed` or `dynamic` |
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -148,6 +148,7 @@ second credential broker, and child trajectories retain their session join key.
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport mode. Accepted values include `native`/`direct` and `cli`/`acpx`. |
 | `ELIZA_ACP_CLI` | `acpx` | ACPX executable name or absolute path for the CLI transport. |
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type. Primary choices: `elizaos`, `pi-agent`, `opencode`. |
+| `ELIZA_ACP_WARM_SPAWN` | unset | Set to `1` to keep one pre-initialized native `elizaos` child ready. It starts without session credentials, accepts one authenticated environment claim, and is disposed after that session; unclaimed children are recycled after two minutes. |
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command. |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command. |
 | `ELIZA_CODEX_ACP_COMMAND` | `npx -y @agentclientprotocol/codex-acp@1.1.2` | Native Codex ACP command. The manifest default and the legacy `@zed-industries` default select the isolated managed successor; any other custom command is executed verbatim. |

--- a/plugins/plugin-agent-orchestrator/__tests__/setup.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/setup.ts
@@ -5,6 +5,19 @@
  * production defaults remain enabled through shouldUseSmithersTaskRunner.
  */
 import { tmpdir } from "node:os";
+import { delimiter, isAbsolute } from "node:path";
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+
+// Production entrypoints capture PATH before runtime configuration. Mirror
+// that boundary in tests while excluding ambient shell shorthand such as `~`,
+// which is not an executable-search authority accepted by the host contract.
+const ambientPath = process.env.PATH;
+process.env.PATH = ambientPath
+  ?.split(delimiter)
+  .filter((entry) => isAbsolute(entry))
+  .join(delimiter);
+captureHostExecutionBaseline();
+process.env.PATH = ambientPath;
 
 if (process.env.ELIZA_ORCHESTRATOR_SMITHERS === undefined) {
   process.env.ELIZA_ORCHESTRATOR_SMITHERS = "0";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -174,6 +174,10 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     client.configureClaimedSession({
       cwd: "/tmp/native-acp/claimed",
       approvalPreset: "verifier",
+      env: {
+        ORCHESTRATOR_SESSION_ID: "session-a",
+        PATH: "/tmp/native-acp/git-bin:/usr/bin",
+      },
       onEvent: (event) => events.push(event),
     });
     const created = client.createSession("/tmp/native-acp/claimed", {
@@ -182,6 +186,7 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
         ORCHESTRATOR_SESSION_ID: "session-a",
         OPENAI_API_KEY: "lease-secret-a",
       },
+      executionPath: "/tmp/native-acp/git-bin:/usr/bin",
     });
     await waitForWrites(p, 2);
     expect(writeAt(p, 1)).toMatchObject({

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -166,6 +166,52 @@ afterEach(() => {
 });
 
 describe("NativeAcpClient JSON-RPC lifecycle", () => {
+  it("hands off a warm session claim without exposing values to observers", async () => {
+    const events: unknown[] = [];
+    const { client, p } = await startClient({
+      onEvent: (event) => events.push(event),
+    });
+    client.configureClaimedSession({
+      cwd: "/tmp/native-acp/claimed",
+      approvalPreset: "verifier",
+      onEvent: (event) => events.push(event),
+    });
+    const created = client.createSession("/tmp/native-acp/claimed", {
+      token: "single-use-claim",
+      env: {
+        ORCHESTRATOR_SESSION_ID: "session-a",
+        OPENAI_API_KEY: "lease-secret-a",
+      },
+    });
+    await waitForWrites(p, 2);
+    expect(writeAt(p, 1)).toMatchObject({
+      method: "session/new",
+      params: {
+        cwd: "/tmp/native-acp/claimed",
+        _meta: {
+          elizaSessionClaim: {
+            token: "single-use-claim",
+            env: { OPENAI_API_KEY: "lease-secret-a" },
+          },
+        },
+      },
+    });
+    const observed = JSON.stringify(events);
+    expect(observed).not.toContain("single-use-claim");
+    expect(observed).not.toContain("lease-secret-a");
+    expect(observed).toContain("[REDACTED]");
+    expect(observed).toContain("OPENAI_API_KEY");
+    emitJson(p, {
+      jsonrpc: "2.0",
+      id: 2,
+      result: { sessionId: "claimed-protocol-session" },
+    });
+    await expect(created).resolves.toEqual({
+      sessionId: "claimed-protocol-session",
+      agentSessionId: undefined,
+    });
+  });
+
   it("sends JSON-RPC requests and resolves responses", async () => {
     const events: unknown[] = [];
     const p = queueProc();

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -823,11 +823,11 @@ describe("AcpService", () => {
       );
       const firstClaim = firstWarm?.createSession.mock.calls[0]?.[1];
       expect(firstClaim?.env?.ELIZA_ACP_WARM_CLAIM_TOKEN).toBeUndefined();
-      expect(firstClaim?.env?.PATH).toBe(process.env.PATH);
-      expect(firstClaim?.env?.PATH).not.toContain("caller-controlled");
+      expect(firstClaim?.env?.PATH).toBeUndefined();
       expect(
         firstClaim?.env?.ELIZA_HOST_EXECUTION_BASELINE_PATH,
       ).toBeUndefined();
+      expect(firstClaim?.executionPath).toBe(process.env.PATH);
 
       await waitForNativeClients(2);
       const secondWarm = nativeClientMock.instances[1];

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -37,6 +37,7 @@ type NativeOptions = {
   timeoutMs?: number;
   terminal?: boolean;
   env?: NodeJS.ProcessEnv;
+  mcpServers?: unknown[];
   onEvent?: NativeEventHandler;
   onStderr?: (chunk: string) => void;
 };
@@ -52,6 +53,7 @@ type MockNativeClient = {
   approvesPermissionRequest: ReturnType<typeof vi.fn>;
   setEventHandler: (handler: NativeEventHandler | undefined) => void;
   setTimeoutMs: (timeoutMs: number | undefined) => void;
+  configureClaimedSession: (opts: NativeOptions) => void;
   emit: (event: AcpJsonRpcMessage, sessionId?: string) => void;
 };
 type NativeMockState = {
@@ -84,7 +86,7 @@ vi.mock("../../src/services/acp-native-transport.js", () => {
     start = vi.fn(async () => {
       await getNativeMockState().startImplementation?.(this);
     });
-    createSession = vi.fn(async (workdir: string) =>
+    createSession = vi.fn(async (workdir: string, _claim?: unknown) =>
       getNativeMockState().createSessionImplementation
         ? await getNativeMockState().createSessionImplementation(this, workdir)
         : {
@@ -114,6 +116,11 @@ vi.mock("../../src/services/acp-native-transport.js", () => {
 
     setTimeoutMs(timeoutMs: number | undefined) {
       this.opts.timeoutMs = timeoutMs;
+    }
+
+    configureClaimedSession(opts: NativeOptions) {
+      this.opts = { ...this.opts, ...opts };
+      this.eventHandler = opts.onEvent;
     }
 
     emit(event: AcpJsonRpcMessage, sessionId?: string) {
@@ -306,6 +313,17 @@ async function waitForSessionStatus(
   const session = await service.getSession(sessionId);
   throw new Error(
     `expected session ${sessionId} to reach ${status}, got ${session?.status}`,
+  );
+}
+
+async function waitForNativeClients(count: number): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 1_000) {
+    if (nativeClientMock.instances.length >= count) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(
+    `expected ${count} native clients, got ${nativeClientMock.instances.length}`,
   );
 }
 
@@ -761,6 +779,66 @@ describe("AcpService", () => {
     expect(
       nativeClientMock.instances[0]?.opts.env?.ORCHESTRATOR_SESSION_ID,
     ).toBe(spawned.sessionId);
+  });
+
+  it("single-claims warm elizaos children without credentials at process spawn", async () => {
+    const previous = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "host-credential-must-not-reach-warm-child";
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ELIZA_ACP_DEFAULT_AGENT: "elizaos",
+        ELIZA_ACP_WARM_SPAWN: "1",
+      }),
+    );
+    try {
+      await service.start();
+      await waitForNativeClients(1);
+      const firstWarm = nativeClientMock.instances[0];
+      const firstToken = firstWarm?.opts.env?.ELIZA_ACP_WARM_CLAIM_TOKEN;
+      expect(firstToken).toMatch(/^[a-f0-9]{64}$/);
+      expect(firstWarm?.opts.env?.OPENAI_API_KEY).toBeUndefined();
+      expect(firstWarm?.opts.env?.ORCHESTRATOR_SESSION_ID).toBeUndefined();
+
+      const first = await service.spawnSession({
+        name: "warm-a",
+        agentType: "elizaos",
+        workdir: "/tmp/acp-test",
+        env: { OPENAI_API_KEY: "lease-a" },
+      });
+      expect(firstWarm?.createSession).toHaveBeenCalledTimes(1);
+      expect(firstWarm?.createSession).toHaveBeenCalledWith(
+        RESOLVED_ACP_WORKDIR,
+        expect.objectContaining({
+          token: firstToken,
+          env: expect.objectContaining({
+            ORCHESTRATOR_SESSION_ID: first.sessionId,
+            OPENAI_API_KEY: "lease-a",
+          }),
+        }),
+      );
+
+      await waitForNativeClients(2);
+      const secondWarm = nativeClientMock.instances[1];
+      await service.spawnSession({
+        name: "warm-b",
+        agentType: "elizaos",
+        workdir: "/tmp/acp-test",
+        env: { OPENAI_API_KEY: "lease-b" },
+      });
+      expect(secondWarm).not.toBe(firstWarm);
+      expect(firstWarm?.createSession).toHaveBeenCalledTimes(1);
+      expect(secondWarm?.createSession).toHaveBeenCalledWith(
+        RESOLVED_ACP_WORKDIR,
+        expect.objectContaining({
+          env: expect.objectContaining({ OPENAI_API_KEY: "lease-b" }),
+        }),
+      );
+    } finally {
+      await service.stop();
+      if (previous === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = previous;
+    }
   });
 
   it("pins the default coding git identity over inherited GIT env on native spawns", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -11,6 +11,7 @@ import {
 import os, { tmpdir } from "node:os";
 import path, { join } from "node:path";
 import { Writable } from "node:stream";
+import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // The ACP implementation runs every workdir through `path.resolve`, which on
@@ -827,7 +828,7 @@ describe("AcpService", () => {
       expect(
         firstClaim?.env?.ELIZA_HOST_EXECUTION_BASELINE_PATH,
       ).toBeUndefined();
-      expect(firstClaim?.executionPath).toBe(process.env.PATH);
+      expect(firstClaim?.executionPath).toBe(getHostExecutionBaseline().path);
 
       await waitForNativeClients(2);
       const secondWarm = nativeClientMock.instances[1];

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -804,7 +804,11 @@ describe("AcpService", () => {
         name: "warm-a",
         agentType: "elizaos",
         workdir: "/tmp/acp-test",
-        env: { OPENAI_API_KEY: "lease-a" },
+        env: {
+          OPENAI_API_KEY: "lease-a",
+          ELIZA_ACP_WARM_CLAIM_TOKEN: "caller-injected-token",
+          PATH: "/caller-controlled/bin",
+        },
       });
       expect(firstWarm?.createSession).toHaveBeenCalledTimes(1);
       expect(firstWarm?.createSession).toHaveBeenCalledWith(
@@ -817,6 +821,13 @@ describe("AcpService", () => {
           }),
         }),
       );
+      const firstClaim = firstWarm?.createSession.mock.calls[0]?.[1];
+      expect(firstClaim?.env?.ELIZA_ACP_WARM_CLAIM_TOKEN).toBeUndefined();
+      expect(firstClaim?.env?.PATH).toBe(process.env.PATH);
+      expect(firstClaim?.env?.PATH).not.toContain("caller-controlled");
+      expect(
+        firstClaim?.env?.ELIZA_HOST_EXECUTION_BASELINE_PATH,
+      ).toBeUndefined();
 
       await waitForNativeClients(2);
       const secondWarm = nativeClientMock.instances[1];

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-env-deny.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-env-deny.test.ts
@@ -17,6 +17,7 @@ describe("isDeniedSubAgentEnvKey (customCredentials deny-list)", () => {
       "eliza_vault_passphrase",
       "TERMINAL_RUN_TOKEN",
       "ELIZA_TERMINAL_RUN_TOKEN",
+      "ELIZA_ACP_WARM_CLAIM_TOKEN",
     ]) {
       expect(isDeniedSubAgentEnvKey(key)).toBe(true);
     }

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -144,6 +144,13 @@
         "default": "elizaos",
         "sensitive": false
       },
+      "ELIZA_ACP_WARM_SPAWN": {
+        "type": "boolean",
+        "description": "Pre-initialize one native elizaos ACP child without session credentials and claim it once at spawn time.",
+        "required": false,
+        "default": false,
+        "sensitive": false
+      },
       "ELIZA_DEFAULT_AGENT_TYPE": {
         "type": "string",
         "description": "Compatibility alias for the default coding agent adapter. Use elizaos, pi-agent, or opencode to switch the default code agent from settings.",

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-index-isolation.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-index-isolation.test.ts
@@ -8,6 +8,8 @@
 
 import { execFileSync } from "node:child_process";
 import {
+  accessSync,
+  constants,
   existsSync,
   mkdtempSync,
   readdirSync,
@@ -78,6 +80,64 @@ type TrustedExecutionPathResolver = {
     metadata?: Record<string, string>;
   }): string;
 };
+
+function executableOnPath(name: string): string {
+  for (const entry of (process.env.PATH ?? "").split(path.delimiter)) {
+    const candidate = path.join(entry, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // error-policy:J3 probing continues until an executable is found.
+    }
+  }
+  throw new Error(`${name} is not available on PATH`);
+}
+
+function runClaimedGitChild(
+  repo: string,
+  prepared:
+    | { env: Record<string, string>; metadata: Record<string, string> }
+    | undefined,
+  token: string,
+  commands: string[][],
+): { resolvedGit: string } {
+  if (!prepared) throw new Error("session git index was not prepared");
+  const wrapperDir = prepared.metadata.gitWrapperDir;
+  if (!wrapperDir) throw new Error("session git wrapper was not prepared");
+  if (!bootExecutionPath)
+    throw new Error("test host PATH baseline was not captured");
+  const claimEnv = { ...prepared.env };
+  delete claimEnv.PATH;
+  const fixture = path.join(
+    import.meta.dirname,
+    "fixtures",
+    "acp-warm-git-claim-child.ts",
+  );
+  const result = execFileSync(
+    executableOnPath("bun"),
+    ["--conditions=eliza-source", fixture],
+    {
+      cwd: path.resolve(import.meta.dirname, "../../../.."),
+      env: {
+        HOME: os.homedir(),
+        PATH: "/bootstrap/must-not-win:/usr/bin:/bin",
+        ELIZA_ACP_WARM_CLAIM_TOKEN: token,
+      },
+      input: JSON.stringify({
+        claim: {
+          token,
+          env: claimEnv,
+          executionPath: [wrapperDir, bootExecutionPath].join(path.delimiter),
+        },
+        cwd: repo,
+        commands,
+      }),
+      encoding: "utf8",
+    },
+  );
+  return JSON.parse(result) as { resolvedGit: string };
+}
 
 function claimWarmSessionEnv(
   prepared:
@@ -253,4 +313,48 @@ describe("ACP per-session git index isolation (#13773)", () => {
       }),
     ).toThrow("Session git wrapper is outside its owned root");
   });
+
+  it.skipIf(process.platform === "win32")(
+    "commits both trees through real authenticated warm-child processes",
+    async () => {
+      const service = new AcpService(makeRuntime(), {
+        store: new InMemorySessionStore(),
+      });
+      const prepare = (
+        service as unknown as GitIndexPreparer
+      ).prepareSessionGitIndex.bind(service);
+      const baselineSha = git(repo, ["rev-parse", "HEAD"]);
+      const preparedA = await prepare(
+        repo,
+        `${sessionPrefix}child-a`,
+        baselineSha,
+      );
+      const preparedB = await prepare(
+        repo,
+        `${sessionPrefix}child-b`,
+        baselineSha,
+      );
+      writeFileSync(path.join(repo, "child-a.txt"), "from child a\n");
+      writeFileSync(path.join(repo, "child-b.txt"), "from child b\n");
+
+      const receiptA = runClaimedGitChild(repo, preparedA, "child-token-a", [
+        ["add", "child-a.txt"],
+        ["commit", "-m", "claimed child a"],
+      ]);
+      const receiptB = runClaimedGitChild(repo, preparedB, "child-token-b", [
+        ["add", "child-b.txt"],
+        ["commit", "-m", "claimed child b"],
+      ]);
+
+      expect(receiptA.resolvedGit).toBe(
+        path.join(preparedA?.metadata.gitWrapperDir ?? "", "git"),
+      );
+      expect(receiptB.resolvedGit).toBe(
+        path.join(preparedB?.metadata.gitWrapperDir ?? "", "git"),
+      );
+      expect(git(repo, ["ls-tree", "--name-only", "-r", "HEAD"])).toBe(
+        ["README.md", "child-a.txt", "child-b.txt"].join("\n"),
+      );
+    },
+  );
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-index-isolation.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-index-isolation.test.ts
@@ -18,10 +18,19 @@ import {
 import * as os from "node:os";
 import * as path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AcpWarmSessionClaim } from "../../../../packages/examples/code/src/acp-session-claim.js";
 import { AcpService } from "../services/acp-service.js";
 import { InMemorySessionStore } from "../services/session-store.js";
+
+const originalTestPath = process.env.PATH;
+process.env.PATH = originalTestPath
+  ?.split(path.delimiter)
+  .filter((entry) => path.isAbsolute(entry))
+  .join(path.delimiter);
+const bootExecutionPath = captureHostExecutionBaseline().path;
+process.env.PATH = originalTestPath;
 
 function makeRuntime(): IAgentRuntime {
   return {
@@ -63,6 +72,13 @@ type GitIndexPreparer = {
   >;
 };
 
+type TrustedExecutionPathResolver = {
+  trustedSessionExecutionPath(session: {
+    id: string;
+    metadata?: Record<string, string>;
+  }): string;
+};
+
 function claimWarmSessionEnv(
   prepared:
     | { env: Record<string, string>; metadata: Record<string, string> }
@@ -79,7 +95,7 @@ function claimWarmSessionEnv(
       elizaSessionClaim: {
         token,
         env: prepared.env,
-        executionPath: [wrapperDir, process.env.PATH]
+        executionPath: [wrapperDir, bootExecutionPath]
           .filter(Boolean)
           .join(path.delimiter),
       },
@@ -199,5 +215,42 @@ describe("ACP per-session git index isolation (#13773)", () => {
     expect(git(repo, ["ls-tree", "--name-only", "-r", "HEAD"])).toBe(
       ["README.md", "warm-a.txt", "warm-b.txt"].join("\n"),
     );
+  });
+
+  it("builds the warm claim PATH from boot authority and the owned wrapper only", async () => {
+    expect(bootExecutionPath).toBeTruthy();
+    const sessionId = `${sessionPrefix}trusted-path`;
+    const service = new AcpService(makeRuntime(), {
+      store: new InMemorySessionStore(),
+    });
+    const prepare = (
+      service as unknown as GitIndexPreparer
+    ).prepareSessionGitIndex.bind(service);
+    const resolveTrustedPath = (
+      service as unknown as TrustedExecutionPathResolver
+    ).trustedSessionExecutionPath.bind(service);
+    const prepared = await prepare(repo, sessionId);
+    if (!prepared) throw new Error("session git index was not prepared");
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = "/tmp/untrusted-runtime-path";
+    try {
+      expect(
+        resolveTrustedPath({ id: sessionId, metadata: prepared.metadata }),
+      ).toBe(
+        [prepared.metadata.gitWrapperDir, bootExecutionPath].join(
+          path.delimiter,
+        ),
+      );
+    } finally {
+      process.env.PATH = previousPath;
+    }
+
+    expect(() =>
+      resolveTrustedPath({
+        id: sessionId,
+        metadata: { gitWrapperDir: path.join(tmpRoot, "forged", "bin") },
+      }),
+    ).toThrow("Session git wrapper is outside its owned root");
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-index-isolation.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-index-isolation.test.ts
@@ -1,5 +1,6 @@
 /**
- * Proves same-worktree ACP sessions get independent git index files (#13773).
+ * Proves same-worktree ACP sessions get independent git index files (#13773),
+ * including when a prewarmed child receives its session wrapper at claim time.
  * Without GIT_INDEX_FILE isolation, concurrent `git add` calls in two
  * isolate=false sessions mutate the repo's single .git/index and each session's
  * staged set clobbers the other.
@@ -18,6 +19,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AcpWarmSessionClaim } from "../../../../packages/examples/code/src/acp-session-claim.js";
 import { AcpService } from "../services/acp-service.js";
 import { InMemorySessionStore } from "../services/session-store.js";
 
@@ -60,6 +62,32 @@ type GitIndexPreparer = {
     | undefined
   >;
 };
+
+function claimWarmSessionEnv(
+  prepared:
+    | { env: Record<string, string>; metadata: Record<string, string> }
+    | undefined,
+  token: string,
+): NodeJS.ProcessEnv {
+  if (!prepared) throw new Error("session git index was not prepared");
+  const wrapperDir = prepared.metadata.gitWrapperDir;
+  if (!wrapperDir) throw new Error("session git wrapper was not prepared");
+  const target: NodeJS.ProcessEnv = {};
+  const claim = new AcpWarmSessionClaim(token);
+  claim.apply(
+    {
+      elizaSessionClaim: {
+        token,
+        env: prepared.env,
+        executionPath: [wrapperDir, process.env.PATH]
+          .filter(Boolean)
+          .join(path.delimiter),
+      },
+    },
+    target,
+  );
+  return target;
+}
 
 describe("ACP per-session git index isolation (#13773)", () => {
   let tmpRoot: string;
@@ -128,6 +156,48 @@ describe("ACP per-session git index isolation (#13773)", () => {
 
     expect(git(repo, ["ls-tree", "--name-only", "-r", "HEAD"])).toBe(
       ["README.md", "a.txt", "b.txt"].join("\n"),
+    );
+  });
+
+  it("lands both commits through independently claimed warm-child wrapper paths", async () => {
+    const service = new AcpService(makeRuntime(), {
+      store: new InMemorySessionStore(),
+    });
+    const prepare = (
+      service as unknown as GitIndexPreparer
+    ).prepareSessionGitIndex.bind(service);
+    const baselineSha = git(repo, ["rev-parse", "HEAD"]);
+    const preparedA = await prepare(
+      repo,
+      `${sessionPrefix}warm-a`,
+      baselineSha,
+    );
+    const preparedB = await prepare(
+      repo,
+      `${sessionPrefix}warm-b`,
+      baselineSha,
+    );
+    const envA = claimWarmSessionEnv(preparedA, "warm-token-a");
+    const envB = claimWarmSessionEnv(preparedB, "warm-token-b");
+
+    expect(envA.PATH?.split(path.delimiter)[0]).toBe(
+      preparedA?.metadata.gitWrapperDir,
+    );
+    expect(envB.PATH?.split(path.delimiter)[0]).toBe(
+      preparedB?.metadata.gitWrapperDir,
+    );
+    expect(envA.PATH).not.toContain("bootstrap/must-not-win");
+    expect(envB.PATH).not.toContain("bootstrap/must-not-win");
+
+    writeFileSync(path.join(repo, "warm-a.txt"), "from warm a\n");
+    writeFileSync(path.join(repo, "warm-b.txt"), "from warm b\n");
+    git(repo, ["add", "warm-a.txt"], envA);
+    git(repo, ["add", "warm-b.txt"], envB);
+    git(repo, ["commit", "-m", "warm session a"], envA);
+    git(repo, ["commit", "-m", "warm session b"], envB);
+
+    expect(git(repo, ["ls-tree", "--name-only", "-r", "HEAD"])).toBe(
+      ["README.md", "warm-a.txt", "warm-b.txt"].join("\n"),
     );
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/fixtures/acp-warm-git-claim-child.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/fixtures/acp-warm-git-claim-child.ts
@@ -1,0 +1,41 @@
+/**
+ * Runs Git commands after a real warm-session claim and executable-authority
+ * capture. The parent integration test launches this as a separate Bun process
+ * so bootstrap credentials and host PATH state cannot leak across sessions.
+ */
+import { spawnSync } from "node:child_process";
+import {
+  applyHostExecutionBaseline,
+  captureHostExecutionBaseline,
+  resolveHostExecutable,
+} from "@elizaos/shared/host-execution-env";
+import { consumeWarmClaimToken } from "../../../../../packages/examples/code/src/acp-bootstrap.js";
+import { AcpWarmSessionClaim } from "../../../../../packages/examples/code/src/acp-session-claim.js";
+
+type ChildInput = {
+  claim: { token: string; env: Record<string, string>; executionPath: string };
+  cwd: string;
+  commands: string[][];
+};
+
+const input = JSON.parse(await Bun.stdin.text()) as ChildInput;
+const claim = new AcpWarmSessionClaim(consumeWarmClaimToken());
+claim.apply({ elizaSessionClaim: input.claim });
+captureHostExecutionBaseline();
+const git = resolveHostExecutable("git");
+if (!git)
+  throw new Error("claimed Git wrapper did not become executable authority");
+const env = applyHostExecutionBaseline(process.env);
+for (const args of input.commands) {
+  const result = spawnSync(git, args, {
+    cwd: input.cwd,
+    env,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      result.stderr || `git exited ${result.status ?? "unknown"}`,
+    );
+  }
+}
+process.stdout.write(JSON.stringify({ resolvedGit: git }));

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -89,6 +89,12 @@ export type NativeAcpSession = {
   agentSessionId?: string;
 };
 
+/** Single-use bootstrap material for a session-less warm ACP child. */
+export type NativeAcpSessionClaim = {
+  token: string;
+  env: Record<string, string>;
+};
+
 export type NativeAcpPromptResult = {
   stopReason: string;
 };
@@ -156,6 +162,22 @@ export class NativeAcpClient {
     this.opts.timeoutMs = timeoutMs;
   }
 
+  configureClaimedSession(opts: {
+    cwd: string;
+    approvalPreset: ApprovalPreset;
+    mcpServers?: AcpMcpServerConfig[];
+    timeoutMs?: number;
+    onEvent?: NativeAcpEventCallback;
+    onStderr?: (chunk: string) => void;
+  }): void {
+    this.opts.cwd = opts.cwd;
+    this.opts.approvalPreset = opts.approvalPreset;
+    this.opts.mcpServers = opts.mcpServers;
+    this.opts.timeoutMs = opts.timeoutMs;
+    this.opts.onEvent = opts.onEvent;
+    this.opts.onStderr = opts.onStderr;
+  }
+
   async start(): Promise<void> {
     if (this.proc) return;
     const { command, args } = splitCommandLine(this.opts.command);
@@ -213,15 +235,42 @@ export class NativeAcpClient {
     );
   }
 
-  async createSession(cwd = this.opts.cwd): Promise<NativeAcpSession> {
+  async createSession(
+    cwd = this.opts.cwd,
+    claim?: NativeAcpSessionClaim,
+  ): Promise<NativeAcpSession> {
+    const params = {
+      cwd,
+      ...(claim
+        ? {
+            _meta: {
+              elizaSessionClaim: claim,
+            },
+          }
+        : {}),
+      // Forward the parent's MCP servers so the sub-agent has the same tools
+      // (Codex / Claude-Code parity). Opt-in via ELIZA_ACP_MCP_SERVERS;
+      // defaults to [] (prior behavior) so spawning never regresses.
+      mcpServers: this.opts.mcpServers ?? parseAcpMcpServersEnv(),
+    };
     const result = asRecord(
-      await this.request("session/new", {
-        cwd,
-        // Forward the parent's MCP servers so the sub-agent has the same tools
-        // (Codex / Claude-Code parity). Opt-in via ELIZA_ACP_MCP_SERVERS;
-        // defaults to [] (prior behavior) so spawning never regresses.
-        mcpServers: this.opts.mcpServers ?? parseAcpMcpServersEnv(),
-      }),
+      await this.request(
+        "session/new",
+        params,
+        DEFAULT_TIMEOUT_MS,
+        undefined,
+        claim
+          ? {
+              ...params,
+              _meta: {
+                elizaSessionClaim: {
+                  token: "[REDACTED]",
+                  envKeys: Object.keys(claim.env).sort(),
+                },
+              },
+            }
+          : params,
+      ),
     );
     const sessionId = stringValue(result?.sessionId);
     if (!sessionId) throw new Error("ACP agent did not return a sessionId");
@@ -309,12 +358,13 @@ export class NativeAcpClient {
     params: unknown,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     onTimeout?: () => void,
+    emittedParams: unknown = params,
   ): Promise<unknown> {
     if (this.closed) throw new Error("ACP client is closed");
     const id = this.nextId++;
     const proc = this.requireProcess();
     const payload = { jsonrpc: "2.0", id, method, params };
-    this.emitEvent(payload as AcpJsonRpcMessage);
+    this.emitEvent({ ...payload, params: emittedParams } as AcpJsonRpcMessage);
     proc.stdin.write(`${JSON.stringify(payload)}\n`);
     return new Promise((resolve, reject) => {
       const timer =

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -93,6 +93,7 @@ export type NativeAcpSession = {
 export type NativeAcpSessionClaim = {
   token: string;
   env: Record<string, string>;
+  executionPath: string;
 };
 
 export type NativeAcpPromptResult = {
@@ -165,6 +166,7 @@ export class NativeAcpClient {
   configureClaimedSession(opts: {
     cwd: string;
     approvalPreset: ApprovalPreset;
+    env: NodeJS.ProcessEnv;
     mcpServers?: AcpMcpServerConfig[];
     timeoutMs?: number;
     onEvent?: NativeAcpEventCallback;
@@ -172,6 +174,7 @@ export class NativeAcpClient {
   }): void {
     this.opts.cwd = opts.cwd;
     this.opts.approvalPreset = opts.approvalPreset;
+    this.opts.env = opts.env;
     this.opts.mcpServers = opts.mcpServers;
     this.opts.timeoutMs = opts.timeoutMs;
     this.opts.onEvent = opts.onEvent;
@@ -266,6 +269,7 @@ export class NativeAcpClient {
                 elizaSessionClaim: {
                   token: "[REDACTED]",
                   envKeys: Object.keys(claim.env).sort(),
+                  executionPath: "[REDACTED]",
                 },
               },
             }

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -19,12 +19,13 @@ import {
   spawn,
   spawnSync,
 } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import {
   chmod,
   copyFile,
   mkdir,
+  mkdtemp,
   readdir,
   rm,
   stat,
@@ -106,6 +107,7 @@ import {
   canonicalForwardedEnvKey,
   isCloudKeyForwardingOptIn,
   isDeniedSubAgentEnvKey,
+  SUB_AGENT_SYSTEM_ENV_KEYS,
 } from "./sub-agent-env-policy.js";
 import { writeWorkspaceIdentity } from "./sub-agent-identity.js";
 import {
@@ -714,6 +716,15 @@ function sessionGitWrapper(): string {
   return `#!${interpreter}\n${SESSION_GIT_WRAPPER_BODY}`;
 }
 const ACP_HEALTH_CHECK_INTERVAL_MS = 60_000;
+const ACP_WARM_CLIENT_MAX_AGE_MS = 120_000;
+
+type WarmNativeClientSlot = {
+  client: NativeAcpClient;
+  command: string;
+  claimToken: string;
+  createdAt: number;
+  bootstrapHome: string;
+};
 // Terminal (stopped/errored) sessions are kept this long for any post-completion
 // reference, then reclaimed by the health-check sweep so the durable session
 // store and the per-session maps don't grow without bound on a long-lived bot.
@@ -850,6 +861,9 @@ export class AcpService extends Service {
   private readonly nativePromptSessionIds = new Set<string>();
   private readonly nativeCancelledPromptSessionIds = new Set<string>();
   private readonly nativeStoppingSessionIds = new Set<string>();
+  private warmNativeClient?: WarmNativeClientSlot;
+  private warmNativeClientStarting?: Promise<void>;
+  private readonly warmSpawnEnabled: boolean;
   private readonly outputBuffers = new Map<string, string[]>();
   // Full session output remains available for history, while custom validators
   // need the exact latest prompt turn so a retry cannot re-consume an older
@@ -930,6 +944,11 @@ export class AcpService extends Service {
       this.setting("ACPX_DEFAULT_TIMEOUT_MS") ??
         this.setting("ELIZA_ACP_PROMPT_TIMEOUT_MS"),
     );
+    this.warmSpawnEnabled =
+      boolSetting(this.setting("ELIZA_ACP_WARM_SPAWN")) === true &&
+      this.transportMode === "native" &&
+      (normalizeTaskAgentAdapter(this.defaultAgent) ?? this.defaultAgent) ===
+        "elizaos";
   }
 
   static async start(runtime: IAgentRuntime): Promise<AcpService> {
@@ -978,6 +997,106 @@ export class AcpService extends Service {
       process.once("SIGINT", AcpService.sharedShutdownHandler);
       AcpService.shutdownHookInstalled = true;
     }
+    this.scheduleWarmNativeClient();
+  }
+
+  private scheduleWarmNativeClient(): void {
+    if (
+      !this.started ||
+      !this.warmSpawnEnabled ||
+      this.warmNativeClient ||
+      this.warmNativeClientStarting
+    ) {
+      return;
+    }
+    this.warmNativeClientStarting = this.createWarmNativeClient()
+      .catch((err) => {
+        this.log("warn", "warm ACP child pre-initialization failed", {
+          error: errorMessage(err),
+        });
+      })
+      .finally(() => {
+        this.warmNativeClientStarting = undefined;
+      });
+  }
+
+  private async createWarmNativeClient(): Promise<void> {
+    const bootstrapHome = await mkdtemp(join(tmpdir(), "eliza-acp-warm-"));
+    const claimToken = randomBytes(32).toString("hex");
+    const projected = applySubAgentEnvPolicy(process.env);
+    const allowedBootstrapKeys = new Set<string>(SUB_AGENT_SYSTEM_ENV_KEYS);
+    const env: NodeJS.ProcessEnv = Object.fromEntries(
+      Object.entries(projected).filter(([key]) =>
+        allowedBootstrapKeys.has(key),
+      ),
+    );
+    env.HOME = bootstrapHome;
+    if (env.USERPROFILE) env.USERPROFILE = bootstrapHome;
+    env.ELIZA_ACP_WARM_CLAIM_TOKEN = claimToken;
+    const command = this.nativeAgentCommand("elizaos");
+    const client = new NativeAcpClient({
+      command,
+      cwd: process.cwd(),
+      env,
+      approvalPreset: this.defaultApprovalPreset,
+      timeoutMs: this.sessionTimeoutMs,
+      terminal: !this.shouldDisableTerminalCapability(),
+      mcpServers: readConfigMcpServers(),
+    });
+    try {
+      await client.start();
+      if (!this.started || this.warmNativeClient) {
+        await client.close();
+        await rm(bootstrapHome, { recursive: true, force: true });
+        return;
+      }
+      this.warmNativeClient = {
+        client,
+        command,
+        claimToken,
+        createdAt: Date.now(),
+        bootstrapHome,
+      };
+      this.log("debug", "warm ACP child ready", { agentType: "elizaos" });
+    } catch (err) {
+      await client.close().catch(() => undefined);
+      await rm(bootstrapHome, { recursive: true, force: true }).catch(
+        () => undefined,
+      );
+      throw err;
+    }
+  }
+
+  private async disposeWarmNativeClient(
+    slot: WarmNativeClientSlot,
+  ): Promise<void> {
+    await slot.client.close().catch(() => undefined);
+    await rm(slot.bootstrapHome, { recursive: true, force: true }).catch(
+      () => undefined,
+    );
+  }
+
+  private takeWarmNativeClient(
+    agentType: AgentType,
+  ): WarmNativeClientSlot | undefined {
+    if (
+      !this.warmSpawnEnabled ||
+      (normalizeTaskAgentAdapter(agentType) ?? agentType) !== "elizaos"
+    ) {
+      return undefined;
+    }
+    const slot = this.warmNativeClient;
+    this.warmNativeClient = undefined;
+    this.scheduleWarmNativeClient();
+    if (!slot) return undefined;
+    if (
+      slot.command !== this.nativeAgentCommand(agentType) ||
+      Date.now() - slot.createdAt > ACP_WARM_CLIENT_MAX_AGE_MS
+    ) {
+      void this.disposeWarmNativeClient(slot);
+      return undefined;
+    }
+    return slot;
   }
 
   private async reconcileOrphanedSessions(): Promise<void> {
@@ -1052,6 +1171,7 @@ export class AcpService extends Service {
   }
 
   async stop(): Promise<void> {
+    this.started = false;
     if (this.healthCheckTimer) {
       clearInterval(this.healthCheckTimer);
       this.healthCheckTimer = undefined;
@@ -1070,6 +1190,8 @@ export class AcpService extends Service {
       process.off("SIGINT", AcpService.sharedShutdownHandler);
       AcpService.shutdownHookInstalled = false;
     }
+    const warm = this.warmNativeClient;
+    this.warmNativeClient = undefined;
     const stops = Array.from(this.activeProcesses.keys()).map((sessionId) =>
       this.stopTrackedProcess(sessionId),
     );
@@ -1081,8 +1203,13 @@ export class AcpService extends Service {
     const leaseRevokes = Array.from(this.modelLeases.keys()).map((sessionId) =>
       this.revokeModelLease(sessionId, "service_stop"),
     );
-    await Promise.allSettled([...stops, ...nativeStops, ...leaseRevokes]);
-    this.started = false;
+    await Promise.allSettled([
+      ...stops,
+      ...nativeStops,
+      ...leaseRevokes,
+      ...(warm ? [this.disposeWarmNativeClient(warm)] : []),
+      ...(this.warmNativeClientStarting ? [this.warmNativeClientStarting] : []),
+    ]);
   }
 
   private acpxStateRoot(): string {
@@ -1550,6 +1677,12 @@ export class AcpService extends Service {
 
   private async runHealthCheck(): Promise<void> {
     if (!this.started) return;
+    const warm = this.warmNativeClient;
+    if (warm && Date.now() - warm.createdAt > ACP_WARM_CLIENT_MAX_AGE_MS) {
+      this.warmNativeClient = undefined;
+      await this.disposeWarmNativeClient(warm);
+      this.scheduleWarmNativeClient();
+    }
     let sessions: SessionInfo[];
     try {
       sessions = await this.store.list();
@@ -2970,58 +3103,64 @@ export class AcpService extends Service {
     },
   ): { client: NativeAcpClient; command: string } {
     const command = this.nativeAgentCommand(session.agentType);
+    const client = new NativeAcpClient({
+      command,
+      cwd: session.workdir,
+      approvalPreset: session.approvalPreset,
+      timeoutMs: opts.timeoutMs ?? this.sessionTimeoutMs,
+      terminal: !this.shouldDisableTerminalCapability(),
+      env: this.buildEnv(
+        opts.env,
+        opts.customCredentials,
+        opts.model,
+        session.agentType,
+        session.id,
+        opts.codexInitialAgentModeOverride,
+      ),
+      mcpServers: readConfigMcpServers(),
+    });
+    this.configureNativeClientForSession(client, session, opts);
     return {
       command,
-      client: new NativeAcpClient({
-        command,
-        cwd: session.workdir,
-        approvalPreset: session.approvalPreset,
-        timeoutMs: opts.timeoutMs ?? this.sessionTimeoutMs,
-        terminal: !this.shouldDisableTerminalCapability(),
-        env: this.buildEnv(
-          opts.env,
-          opts.customCredentials,
-          opts.model,
-          session.agentType,
-          session.id,
-          opts.codexInitialAgentModeOverride,
-        ),
-        // Auto-inherit the parent runtime's configured MCP servers (config
-        // `mcp.servers`) so the sub-agent gets the same MCP tools. Undefined when
-        // none are configured → the transport falls back to ELIZA_ACP_MCP_SERVERS.
-        mcpServers: readConfigMcpServers(),
-        onEvent: (event, protocolSessionId) => {
-          this.handleAcpEvent(
-            event,
-            session.id,
-            "",
-            Date.now(),
-            false,
-            new Set<string>(),
-          );
-          if (protocolSessionId && protocolSessionId !== session.id) {
-            void this.store
-              .update(session.id, { acpxSessionId: protocolSessionId })
-              // error-policy:J7 mapping write runs inside the ACP event
-              // callback and must not throw into the transport, but a swallowed
-              // failure leaves the acpxSessionId unpersisted so later protocol
-              // lookups silently miss the session — report it.
-              .catch((err) =>
-                this.runtime.reportError(
-                  "AcpService.persistAcpxSessionId",
-                  err,
-                  {
-                    sessionId: session.id,
-                  },
-                ),
-              );
-          }
-        },
-        onStderr: (chunk) => {
-          opts.stderr.push(chunk);
-        },
-      }),
+      client,
     };
+  }
+
+  private configureNativeClientForSession(
+    client: NativeAcpClient,
+    session: SessionInfo,
+    opts: { timeoutMs?: number; stderr: string[] },
+  ): void {
+    client.configureClaimedSession({
+      cwd: session.workdir,
+      approvalPreset: session.approvalPreset,
+      mcpServers: readConfigMcpServers(),
+      timeoutMs: opts.timeoutMs ?? this.sessionTimeoutMs,
+      onEvent: (event, protocolSessionId) => {
+        this.handleAcpEvent(
+          event,
+          session.id,
+          "",
+          Date.now(),
+          false,
+          new Set<string>(),
+        );
+        if (protocolSessionId && protocolSessionId !== session.id) {
+          void this.store
+            .update(session.id, { acpxSessionId: protocolSessionId })
+            // error-policy:J7 mapping persistence runs inside an ACP event
+            // callback and must report without throwing into the transport.
+            .catch((err) =>
+              this.runtime.reportError("AcpService.persistAcpxSessionId", err, {
+                sessionId: session.id,
+              }),
+            );
+        }
+      },
+      onStderr: (chunk) => {
+        opts.stderr.push(chunk);
+      },
+    });
   }
 
   private async attachNativeClientWithManagedCodexFallback(opts: {
@@ -3037,6 +3176,46 @@ export class AcpService extends Service {
     stderr: string[];
   }> {
     let stderr: string[] = [];
+    const warm = this.takeWarmNativeClient(opts.session.agentType);
+    if (warm) {
+      this.configureNativeClientForSession(warm.client, opts.session, {
+        timeoutMs: opts.timeoutMs,
+        stderr,
+      });
+      try {
+        const builtEnv = this.buildEnv(
+          opts.env,
+          opts.customCredentials,
+          opts.model,
+          opts.session.agentType,
+          opts.session.id,
+        );
+        const claimEnv: Record<string, string> = {};
+        for (const [key, value] of Object.entries(builtEnv)) {
+          if (typeof value === "string") claimEnv[key] = value;
+        }
+        const nativeSession = await warm.client.createSession(
+          opts.session.workdir,
+          {
+            token: warm.claimToken,
+            env: claimEnv,
+          },
+        );
+        await rm(warm.bootstrapHome, { recursive: true, force: true });
+        this.log("debug", "claimed warm ACP child", {
+          sessionId: opts.session.id,
+          agentType: opts.session.agentType,
+        });
+        return { client: warm.client, nativeSession, stderr };
+      } catch (err) {
+        await this.disposeWarmNativeClient(warm);
+        this.log("warn", "warm ACP child claim failed; falling back cold", {
+          sessionId: opts.session.id,
+          error: errorMessage(err),
+        });
+        stderr = [];
+      }
+    }
     let { client, command } = this.createNativeClient(opts.session, {
       env: opts.env,
       customCredentials: opts.customCredentials,

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -3194,6 +3194,18 @@ export class AcpService extends Service {
         for (const [key, value] of Object.entries(builtEnv)) {
           if (typeof value === "string") claimEnv[key] = value;
         }
+        // The authenticated claim must not turn caller-provided PATH into shell
+        // authority. The only allowed extension is the wrapper directory that
+        // this service recorded while creating the session's isolated index;
+        // otherwise retain the host's filtered launch PATH.
+        const trustedExecutionPath =
+          this.gitIndexEnvForSession(opts.session)?.PATH ??
+          forwardableSubAgentEnv(process.env).PATH;
+        if (trustedExecutionPath) claimEnv.PATH = trustedExecutionPath;
+        else delete claimEnv.PATH;
+        // The child captures and rewrites this mirror from trusted PATH after
+        // applying the claim. Never accept a caller/parent mirror as authority.
+        delete claimEnv.ELIZA_HOST_EXECUTION_BASELINE_PATH;
         const nativeSession = await warm.client.createSession(
           opts.session.workdir,
           {
@@ -4455,7 +4467,14 @@ export class AcpService extends Service {
       env[canonicalForwardedEnvKey(key)] = value;
     }
     for (const [key, value] of Object.entries(extra ?? {})) {
-      if (typeof value === "string") env[canonicalForwardedEnvKey(key)] = value;
+      if (typeof value !== "string") continue;
+      if (isDeniedSubAgentEnvKey(key)) {
+        this.log("warn", "rejecting spawn env matching env deny-list", {
+          key,
+        });
+        continue;
+      }
+      env[canonicalForwardedEnvKey(key)] = value;
     }
     if (model) {
       const normalizedModel =

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -3118,8 +3118,31 @@ export class AcpService extends Service {
         opts.codexInitialAgentModeOverride,
       ),
       mcpServers: readConfigMcpServers(),
+      onEvent: (event, protocolSessionId) => {
+        this.handleAcpEvent(
+          event,
+          session.id,
+          "",
+          Date.now(),
+          false,
+          new Set<string>(),
+        );
+        if (protocolSessionId && protocolSessionId !== session.id) {
+          void this.store
+            .update(session.id, { acpxSessionId: protocolSessionId })
+            // error-policy:J7 mapping persistence runs inside an ACP event
+            // callback and must report without throwing into the transport.
+            .catch((err) =>
+              this.runtime.reportError("AcpService.persistAcpxSessionId", err, {
+                sessionId: session.id,
+              }),
+            );
+        }
+      },
+      onStderr: (chunk) => {
+        opts.stderr.push(chunk);
+      },
     });
-    this.configureNativeClientForSession(client, session, opts);
     return {
       command,
       client,
@@ -3129,11 +3152,12 @@ export class AcpService extends Service {
   private configureNativeClientForSession(
     client: NativeAcpClient,
     session: SessionInfo,
-    opts: { timeoutMs?: number; stderr: string[] },
+    opts: { env: NodeJS.ProcessEnv; timeoutMs?: number; stderr: string[] },
   ): void {
     client.configureClaimedSession({
       cwd: session.workdir,
       approvalPreset: session.approvalPreset,
+      env: opts.env,
       mcpServers: readConfigMcpServers(),
       timeoutMs: opts.timeoutMs ?? this.sessionTimeoutMs,
       onEvent: (event, protocolSessionId) => {
@@ -3178,10 +3202,6 @@ export class AcpService extends Service {
     let stderr: string[] = [];
     const warm = this.takeWarmNativeClient(opts.session.agentType);
     if (warm) {
-      this.configureNativeClientForSession(warm.client, opts.session, {
-        timeoutMs: opts.timeoutMs,
-        stderr,
-      });
       try {
         const builtEnv = this.buildEnv(
           opts.env,
@@ -3190,27 +3210,30 @@ export class AcpService extends Service {
           opts.session.agentType,
           opts.session.id,
         );
+        const trustedExecutionPath = this.trustedSessionExecutionPath(
+          opts.session,
+        );
+        builtEnv.PATH = trustedExecutionPath;
+        delete builtEnv.ELIZA_HOST_EXECUTION_BASELINE_PATH;
+        this.configureNativeClientForSession(warm.client, opts.session, {
+          env: builtEnv,
+          timeoutMs: opts.timeoutMs,
+          stderr,
+        });
         const claimEnv: Record<string, string> = {};
         for (const [key, value] of Object.entries(builtEnv)) {
           if (typeof value === "string") claimEnv[key] = value;
         }
-        // The authenticated claim must not turn caller-provided PATH into shell
-        // authority. The only allowed extension is the wrapper directory that
-        // this service recorded while creating the session's isolated index;
-        // otherwise retain the host's filtered launch PATH.
-        const trustedExecutionPath =
-          this.gitIndexEnvForSession(opts.session)?.PATH ??
-          forwardableSubAgentEnv(process.env).PATH;
-        if (trustedExecutionPath) claimEnv.PATH = trustedExecutionPath;
-        else delete claimEnv.PATH;
-        // The child captures and rewrites this mirror from trusted PATH after
-        // applying the claim. Never accept a caller/parent mirror as authority.
+        // PATH is separate claim authority: the child never accepts an
+        // arbitrary environment entry as executable-search authority.
+        delete claimEnv.PATH;
         delete claimEnv.ELIZA_HOST_EXECUTION_BASELINE_PATH;
         const nativeSession = await warm.client.createSession(
           opts.session.workdir,
           {
             token: warm.claimToken,
             env: claimEnv,
+            executionPath: trustedExecutionPath,
           },
         );
         await rm(warm.bootstrapHome, { recursive: true, force: true });
@@ -3302,6 +3325,14 @@ export class AcpService extends Service {
         throw new Error(message);
       }
     }
+  }
+
+  private trustedSessionExecutionPath(session: SessionInfo): string {
+    const wrapperDir = session.metadata?.[ACP_METADATA_GIT_WRAPPER_DIR];
+    const basePath = process.env.PATH ?? "";
+    return typeof wrapperDir === "string" && wrapperDir.trim()
+      ? [wrapperDir, basePath].filter(Boolean).join(delimiter)
+      : basePath;
   }
 
   private async sendNativePrompt(

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -42,6 +42,7 @@ import {
   TRACE_ENV,
 } from "@elizaos/core";
 import { isAndroidMobile } from "@elizaos/shared";
+import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { NativeAcpClient } from "./acp-native-transport.js";
 import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
 import {
@@ -3329,10 +3330,25 @@ export class AcpService extends Service {
 
   private trustedSessionExecutionPath(session: SessionInfo): string {
     const wrapperDir = session.metadata?.[ACP_METADATA_GIT_WRAPPER_DIR];
-    const basePath = process.env.PATH ?? "";
-    return typeof wrapperDir === "string" && wrapperDir.trim()
-      ? [wrapperDir, basePath].filter(Boolean).join(delimiter)
-      : basePath;
+    const basePath = getHostExecutionBaseline().path;
+    if (!basePath) {
+      throw new ElizaError("Host executable-search authority is unavailable", {
+        code: "ACP_HOST_EXECUTION_PATH_UNAVAILABLE",
+        context: { sessionId: session.id },
+        severity: "fatal",
+      });
+    }
+    if (typeof wrapperDir !== "string" || !wrapperDir.trim()) return basePath;
+
+    const expectedWrapperDir = resolve(this.acpGitIndexRoot(session.id), "bin");
+    if (resolve(wrapperDir) !== expectedWrapperDir) {
+      throw new ElizaError("Session git wrapper is outside its owned root", {
+        code: "ACP_GIT_WRAPPER_AUTHORITY_INVALID",
+        context: { sessionId: session.id },
+        severity: "fatal",
+      });
+    }
+    return [expectedWrapperDir, basePath].join(delimiter);
   }
 
   private async sendNativePrompt(

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
@@ -14,6 +14,10 @@ const DENY_ENV_PATTERNS = [
   // hand a child process a credential that re-authorizes arbitrary host command
   // execution with zero legitimate use for it.
   /TERMINAL_RUN_TOKEN/i,
+  // One-time authenticator for a session-less warm ACP child. Only the pool
+  // bootstrap may inject it; host or caller forwarding would defeat the claim
+  // boundary and could make a cold child accept session metadata.
+  /^ELIZA_ACP_WARM_CLAIM_TOKEN$/i,
   // Repo-scoped GitHub host credentials must not be injected into sub-agents,
   // including through customCredentials. Registry push uses the dedicated
   // GHCR_* or ELIZA_APP_IMAGE_REGISTRY_* names instead.

--- a/plugins/plugin-agent-orchestrator/vitest.config.ts
+++ b/plugins/plugin-agent-orchestrator/vitest.config.ts
@@ -8,6 +8,12 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   resolve: {
     alias: {
+      "@elizaos/shared/host-execution-env": fileURLToPath(
+        new URL(
+          "../../packages/shared/src/host-execution-env.ts",
+          import.meta.url,
+        ),
+      ),
       "@elizaos/auth/token-expiry": fileURLToPath(
         new URL("../../packages/auth/src/token-expiry.ts", import.meta.url),
       ),


### PR DESCRIPTION
Closes #20770

## Summary

- opt in to one pre-initialized native `elizaos` ACP child with `ELIZA_ACP_WARM_SPAWN=1`
- start the warm child with only OS bootstrap variables, an isolated temporary home, and a random claim authenticator; session IDs, model leases, and provider credentials are not present at process spawn
- consume and delete the authenticator before the remaining ESM graph loads; ACP mode never implicitly loads the repository `.env`
- hand off the complete per-session environment through an authenticated, single-use `session/new` claim before runtime initialization
- bind executable authority to the immutable boot PATH plus the exact service-owned per-session Git wrapper; runtime PATH mutation and forged wrapper metadata fail closed
- redact claim values from transport observers, reject host/caller forwarding of the authenticator, clear claimed environment values, and retire every claimed child after one session
- recycle unclaimed children after two minutes, reject children whose command changed, replenish the single slot, and fall back to the existing cold path on any claim/start failure

## Security invariants

- A warm child cannot initialize its runtime before a valid claim.
- The one-time authenticator is removed before other application modules evaluate.
- A claim is accepted once and cannot partially mutate the environment on invalid input.
- Caller/runtime PATH is never accepted as executable authority; the claim uses the process boot authority captured before runtime configuration.
- A Git wrapper is accepted only when its resolved path is exactly `<service-owned git-index root>/<session id>/bin`.
- Warm coding-tools resolve Git through that wrapper, preserving independent indexes and concurrent commits.
- A claimed process is never returned to the pool; runtime/provider objects that may retain derived credentials die with that process.
- Transport telemetry receives only `[REDACTED]` plus sorted environment key names, never the token, path, or values.
- The pool remains disabled by default and currently applies only to the first-party native `elizaos` adapter.

## Evidence (exact head `10ec8e3d4a05bd0c69402b23a25ad2f911cb46a3`)

| Evidence | Result |
| --- | --- |
| Frozen install | Bun 1.3.14 `bun install --frozen-lockfile --ignore-scripts` — PASS, 3,597 installs checked, no changes |
| Bootstrap, PATH, and claim adversarial tests | focused Bun tests — PASS, 8/8 |
| Orchestrator lifecycle, transport, env-policy, and real Git-index tests | canonical Vitest — PASS, 107/107; includes two independent wrapper commits, boot-PATH mutation resistance, and forged-wrapper rejection |
| Orchestrator typecheck | `bun run --cwd plugins/plugin-agent-orchestrator typecheck` — PASS |
| eliza-code typecheck | `bun run --cwd packages/examples/code typecheck` — PASS |
| eliza-code production build | `bun run --cwd packages/examples/code build` — PASS; both entrypoints bundled, ACP entry 106 modules |
| Touched lint | pinned Biome 2.5.7 across all six corrective files — PASS |
| Guide parity | `bun run check:agents-claude` — PASS, 155 pairs |
| Diff integrity | `git diff --check origin/develop...HEAD` — PASS |
| UI screenshots / video | N/A: no user interface or rendered state changes |
| Live model trajectory | N/A: the change occurs before model prompt execution and does not alter model inputs or outputs |
| Production timing / live native target | Not claimed at this exact head; keep draft until an authenticated live ACP spawn→claim→session receipt and exact-head CI are independently reviewed |

## Contribution provenance

- Contributor: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Skill: `contribute-to-eliza`
- Skill revision: `bd7e819a0e86f76267bd0e021acebad91d6af2f1`
- Lane: `[nubs-gap-recent]`


