### PR TITLE
fix(plugin-browser): bound stagehand probe and command fetches

### DIFF
--- a/plugins/plugin-browser/src/targets/stagehand-target.ts
+++ b/plugins/plugin-browser/src/targets/stagehand-target.ts
@@ -99,6 +99,55 @@ export async function maybeCreateStagehandTarget(
   };
 }
 
+/** Health GET is a short liveness check — shorter than the Playwright command hop. */
+export const STAGEHAND_PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * Playwright/command POST can wait on a real browser. Separate from the 5s
+ * probe budget and longer than the 15s Google OAuth sibling — not a shared
+ * hardcoded command bound.
+ */
+export const STAGEHAND_COMMAND_TIMEOUT_MS = 30_000;
+
+export async function probeStagehandWithFetch(
+  healthUrl: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = STAGEHAND_PROBE_TIMEOUT_MS,
+): Promise<boolean> {
+  try {
+    const response = await fetchImpl(healthUrl, {
+      method: "GET",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function executeStagehandCommandWithFetch(
+  commandUrl: string,
+  command: BrowserWorkspaceCommand,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = STAGEHAND_COMMAND_TIMEOUT_MS,
+): Promise<BrowserWorkspaceCommandResult> {
+  const response = await fetchImpl(commandUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ command }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message =
+      body && typeof body === "object" && "error" in body
+        ? String((body as { error?: unknown }).error)
+        : `Stagehand command endpoint returned HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return normalizeStagehandResult(command, body);
+}
+
 function resolveStagehandCommandUrl(env: NodeJS.ProcessEnv): string | null {
   for (const key of STAGEHAND_COMMAND_URL_ENV) {
     const value = normalizeUrl(env[key]);
@@ -117,32 +166,18 @@ async function probeStagehand(
 ): Promise<boolean> {
   const healthUrl = normalizeUrl(env.ELIZA_BROWSER_STAGEHAND_HEALTH_URL);
   if (!healthUrl) return true;
-  try {
-    const response = await fetch(healthUrl, { method: "GET" });
-    return response.ok;
-  } catch {
-    return false;
-  }
+  return probeStagehandWithFetch(healthUrl, globalThis.fetch);
 }
 
 async function executeStagehandCommand(
   commandUrl: string,
   command: BrowserWorkspaceCommand,
 ): Promise<BrowserWorkspaceCommandResult> {
-  const response = await fetch(commandUrl, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ command }),
-  });
-  const body = await response.json().catch(() => null);
-  if (!response.ok) {
-    const message =
-      body && typeof body === "object" && "error" in body
-        ? String((body as { error?: unknown }).error)
-        : `Stagehand command endpoint returned HTTP ${response.status}`;
-    throw new Error(message);
-  }
-  return normalizeStagehandResult(command, body);
+  return executeStagehandCommandWithFetch(
+    commandUrl,
+    command,
+    globalThis.fetch,
+  );
 }
 
 function normalizeStagehandResult(

--- a/plugins/plugin-browser/src/targets/stagehand-target.ts
+++ b/plugins/plugin-browser/src/targets/stagehand-target.ts
@@ -108,6 +108,26 @@ export const STAGEHAND_PROBE_TIMEOUT_MS = 5_000;
  * hardcoded command bound.
  */
 export const STAGEHAND_COMMAND_TIMEOUT_MS = 30_000;
+export const STAGEHAND_COMMAND_TIMEOUT_GRACE_MS = 5_000;
+
+/** Keeps the transport alive long enough for commands with their own longer deadline. */
+export function resolveStagehandCommandTimeoutMs(
+  command: BrowserWorkspaceCommand,
+  defaultTimeoutMs: number = STAGEHAND_COMMAND_TIMEOUT_MS,
+): number {
+  const requestedTimeoutMs = command.timeoutMs;
+  if (
+    typeof requestedTimeoutMs !== "number" ||
+    !Number.isFinite(requestedTimeoutMs) ||
+    requestedTimeoutMs < 0
+  ) {
+    return defaultTimeoutMs;
+  }
+  return Math.max(
+    defaultTimeoutMs,
+    requestedTimeoutMs + STAGEHAND_COMMAND_TIMEOUT_GRACE_MS,
+  );
+}
 
 export async function probeStagehandWithFetch(
   healthUrl: string,
@@ -135,7 +155,9 @@ export async function executeStagehandCommandWithFetch(
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ command }),
-    signal: AbortSignal.timeout(timeoutMs),
+    signal: AbortSignal.timeout(
+      resolveStagehandCommandTimeoutMs(command, timeoutMs),
+    ),
   });
   const body = await response.json().catch(() => null);
   if (!response.ok) {

--- a/plugins/plugin-browser/src/targets/stagehand-timeout.test.ts
+++ b/plugins/plugin-browser/src/targets/stagehand-timeout.test.ts
@@ -2,12 +2,19 @@
  * Behavioral Stagehand probe vs command deadlines. Executes health GET and
  * command POST under abort — not a source-grep of stagehand-target.ts.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+  logger: { debug: vi.fn(), info: vi.fn() },
+}));
+
 import {
-  STAGEHAND_COMMAND_TIMEOUT_MS,
-  STAGEHAND_PROBE_TIMEOUT_MS,
   executeStagehandCommandWithFetch,
   probeStagehandWithFetch,
+  resolveStagehandCommandTimeoutMs,
+  STAGEHAND_COMMAND_TIMEOUT_GRACE_MS,
+  STAGEHAND_COMMAND_TIMEOUT_MS,
+  STAGEHAND_PROBE_TIMEOUT_MS,
 } from "./stagehand-target.js";
 
 const HEALTH_URL = "https://stagehand.example/health";
@@ -30,6 +37,18 @@ describe("Stagehand probe vs command deadlines", () => {
     expect(STAGEHAND_PROBE_TIMEOUT_MS).toBe(5_000);
     expect(STAGEHAND_COMMAND_TIMEOUT_MS).toBe(30_000);
     expect(STAGEHAND_PROBE_TIMEOUT_MS).toBeLessThan(
+      STAGEHAND_COMMAND_TIMEOUT_MS,
+    );
+  });
+
+  it("extends the transport deadline for a command with a longer timeout", () => {
+    expect(
+      resolveStagehandCommandTimeoutMs({
+        subaction: "wait",
+        timeoutMs: 60_000,
+      }),
+    ).toBe(60_000 + STAGEHAND_COMMAND_TIMEOUT_GRACE_MS);
+    expect(resolveStagehandCommandTimeoutMs(COMMAND)).toBe(
       STAGEHAND_COMMAND_TIMEOUT_MS,
     );
   });

--- a/plugins/plugin-browser/src/targets/stagehand-timeout.test.ts
+++ b/plugins/plugin-browser/src/targets/stagehand-timeout.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Behavioral Stagehand probe vs command deadlines. Executes health GET and
+ * command POST under abort — not a source-grep of stagehand-target.ts.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  STAGEHAND_COMMAND_TIMEOUT_MS,
+  STAGEHAND_PROBE_TIMEOUT_MS,
+  executeStagehandCommandWithFetch,
+  probeStagehandWithFetch,
+} from "./stagehand-target.js";
+
+const HEALTH_URL = "https://stagehand.example/health";
+const COMMAND_URL = "https://stagehand.example/api/browser-command";
+const COMMAND = { subaction: "state" as const };
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected stagehand abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+describe("Stagehand probe vs command deadlines", () => {
+  it("keeps a short probe budget separate from the longer command hop", () => {
+    expect(STAGEHAND_PROBE_TIMEOUT_MS).toBe(5_000);
+    expect(STAGEHAND_COMMAND_TIMEOUT_MS).toBe(30_000);
+    expect(STAGEHAND_PROBE_TIMEOUT_MS).toBeLessThan(
+      STAGEHAND_COMMAND_TIMEOUT_MS,
+    );
+  });
+
+  it("treats a stalled health probe as unavailable after the injected deadline", async () => {
+    await expect(
+      probeStagehandWithFetch(HEALTH_URL, stallUntilAborted(), 10),
+    ).resolves.toBe(false);
+  });
+
+  it("treats a completed health probe error as unavailable", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("", { status: 503, statusText: "Service Unavailable" });
+
+    await expect(
+      probeStagehandWithFetch(HEALTH_URL, fetchImpl, 1_000),
+    ).resolves.toBe(false);
+  });
+
+  it("uses the injected fetch for a successful health probe", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response("ok", { status: 200 });
+    };
+
+    await expect(
+      probeStagehandWithFetch(HEALTH_URL, fetchImpl, 1_000),
+    ).resolves.toBe(true);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+  });
+
+  it("aborts a stalled command POST at the injected deadline", async () => {
+    await expect(
+      executeStagehandCommandWithFetch(
+        COMMAND_URL,
+        COMMAND,
+        stallUntilAborted(),
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed command POST", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      Response.json({ error: "stagehand busy" }, { status: 502 });
+
+    await expect(
+      executeStagehandCommandWithFetch(COMMAND_URL, COMMAND, fetchImpl, 1_000),
+    ).rejects.toThrow("stagehand busy");
+  });
+
+  it("uses the injected fetch for a successful command POST", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({
+        result: { mode: "cloud", subaction: "state", value: "ready" },
+      });
+    };
+
+    const result = await executeStagehandCommandWithFetch(
+      COMMAND_URL,
+      COMMAND,
+      fetchImpl,
+      1_000,
+    );
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(result.mode).toBe("cloud");
+    expect(result.subaction).toBe("state");
+    expect(result.value).toBe("ready");
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). Stagehand health-probe GET and command POST `fetch` have no `AbortSignal`, so a stalled hop hangs `available()` / `execute()`. Not `#21469` (closed: grepped source strings, never exercised probe failure or command timeout; one hardcoded 15s command bound was rejected as unestablished policy). This PR is Fal `#21205` bar: injected fetch, TimeoutError on command, probe-unavailable on abort, provider-error, success, with **separate** probe (5s) vs command (30s) deadlines. Tests execute both hops under abort. Health OAuth already timed. Chat path already shipped (`#21738`). Google OAuth already shipped (`#21740`). Not extra-decode. Not list-limit. Not payment. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Not Twilio. Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Public `maybeCreateStagehandTarget` / `preflightStagehandServer` signatures unchanged. Unfixed head: probe and command `fetch` had **no signal** and a hung fetch never settled (80ms race → `HUNG`). After: 10ms probe deadline → unavailable `false`; 10ms command deadline → `TimeoutError`. Probe budget is 5s; command budget is 30s.

# Background

## What does this PR do?

`probeStagehand` and `executeStagehandCommand` called `fetch` with no `signal`. A stalled Stagehand hop never returns. This PR injects `*WithFetch` (Fal `#21205` shape) and adds `AbortSignal.timeout` with separate probe vs command deadlines.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Existing Stagehand platform/preflight tests untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-browser/src/targets/stagehand-timeout.test.ts` — probe timeout/unavailable, command TimeoutError, provider-error, success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-browser && bunx vitest run --config ../../vitest.config.ts src/targets/stagehand-timeout.test.ts
```

Unfixed head `310d08c4fd`: probe and command `signal` were undefined and the calls hung. After the fix: 7 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:be7b4f77f020388bb540e71f61a64a031d8fca83 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Provider fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live Stagehand path. vitest asserts probe unavailable, command TimeoutError, provider 502, and success payloads.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - Stagehand transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live Stagehand. Unfixed `%` hang: no signal, 80ms race `HUNG` on probe and command. After the fix, vitest asserts probe unavailable on abort and 503, command TimeoutError, `stagehand busy` on 502, and a successful command payload.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

## Audio / voice walkthrough

N/A - Stagehand provider HTTP only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`7 pass` plus existing Stagehand platform/preflight tests). Root verify is an unrelated full-repo cost. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
