### PR TITLE
fix(cloud): bind database identity to migration session

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -326,15 +326,15 @@ jobs:
           # never builds core, so generate the file first (mirrors core's prebuild).
           node packages/shared/scripts/generate-keywords.mjs
           # Recheck inside the mutation step after all preparation. The branch
-          # can advance between workflow steps; only the preflight is eligible
-          # for a neutral supersession. Once this step is running, any mismatch
-          # must fail immediately before the database mutation.
+          # can advance between workflow steps. Once this step is running, any
+          # mismatch must fail immediately before the database mutation.
           source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
           if [ "$FORCE" = "true" ]; then
             source_args+=(--force)
           fi
           node packages/cloud/scripts/canonical-deploy-source-guard.mjs "${source_args[@]}"
-          bun --conditions=eliza-source packages/cloud/scripts/admin/preflight-database-identity.ts
+          # The migrator evaluates identity after acquiring its advisory lock,
+          # on the exact PostgreSQL session that performs the schema writes.
           bun run db:cloud:migrate
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/cloud-deploy-backend.yml
+++ b/.github/workflows/cloud-deploy-backend.yml
@@ -105,6 +105,10 @@ jobs:
       - name: Run migrations
         env:
           DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
+          DATABASE_IDENTITY_GATE_MODE: ${{ vars.DATABASE_IDENTITY_GATE_MODE || 'off' }}
+          DATABASE_IDENTITY_ENVIRONMENT: ${{ needs.determine-env.outputs.environment }}
+          DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256 }}
+          DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256 }}
         run: |
           # The migrate entry imports @elizaos/core, whose i18n barrel pulls in the
           # gitignored generated keyword data. Source-mode (eliza-source) migrate

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -324,6 +324,10 @@ jobs:
           # Resolve only from the already-selected protected environment. The
           # value is passed directly to the migrator and is never printed.
           DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
+          DATABASE_IDENTITY_GATE_MODE: ${{ vars.DATABASE_IDENTITY_GATE_MODE || 'off' }}
+          DATABASE_IDENTITY_ENVIRONMENT: ${{ needs.determine-env.outputs.environment }}
+          DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256 }}
+          DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256 }}
         run: |
           set -euo pipefail
           [ -n "${DATABASE_URL//[[:space:]]/}" ] || {

--- a/packages/cloud/infra/cloud/RAILWAY.md
+++ b/packages/cloud/infra/cloud/RAILWAY.md
@@ -64,6 +64,11 @@ activation, prove that the protected migration role can execute
 `pg_catalog.pg_control_system()` through `pg_monitor` membership or a narrower
 explicit function grant.
 
+Every protected workflow that invokes the remote migrator forwards this same
+environment-scoped gate configuration: the canonical Cloudflare release, the
+manual legacy migration, and the exact-SHA provisioning-worker predeploy. None
+uses the standalone receipt tool as mutation admission.
+
 This gate proves only the GitHub migration authority. Do not enable `enforce`
 until an operator has provisioned an independent staging Railway PostgreSQL
 service, role, volume, backup/PITR policy, and restore drill, and has separately

--- a/packages/cloud/infra/cloud/RAILWAY.md
+++ b/packages/cloud/infra/cloud/RAILWAY.md
@@ -39,11 +39,14 @@ runs on Kubernetes.
 
 ### Database identity activation boundary
 
-The migration job owns a read-only PostgreSQL identity preflight immediately
-before schema mutation. It hashes the physical PostgreSQL system identifier and
-the environment/cluster/role/database tuple; raw connection strings, hosts,
-roles, and database names are never written to logs. Protected environment
-variables control activation:
+The migration runner evaluates a read-only PostgreSQL identity gate on the
+exact session that performs migrations, after acquiring its database-wide
+advisory lock and before its first schema DDL. This session binding prevents a
+separate preflight connection from approving one resolved database while a
+later connection mutates another. The gate hashes the physical PostgreSQL
+system identifier and the environment/cluster/role/database tuple; raw
+connection strings, hosts, roles, and database names are never written to
+logs. Protected environment variables control activation:
 
 - `DATABASE_IDENTITY_GATE_MODE=off` is the default, performs no query, and
   does not parse any prepared expected receipts.
@@ -54,6 +57,12 @@ variables control activation:
 - `enforce` requires both `DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256` and
   `DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256` and fails before migrations on
   any mismatch.
+
+The standalone `preflight-database-identity.ts` command remains a read-only
+receipt preparation tool; it is not the release enforcement boundary. Before
+activation, prove that the protected migration role can execute
+`pg_catalog.pg_control_system()` through `pg_monitor` membership or a narrower
+explicit function grant.
 
 This gate proves only the GitHub migration authority. Do not enable `enforce`
 until an operator has provisioned an independent staging Railway PostgreSQL

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.database-identity.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.database-identity.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Proves identity enforcement uses the locked migration session and rejects a
+ * mismatched cluster or authority before that session issues any DDL.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { runMigrations } from "./migrate-with-diagnostics";
+
+const OPTIONS = {
+  timeoutMs: 1,
+  maxAttempts: 1,
+  baseDelayMs: 1,
+  maxDelayMs: 1,
+};
+
+const IDENTITY_ROW = {
+  system_identifier: "7432159876543210000",
+  database_name: "staging_database",
+  role_name: "staging_role",
+  server_version_num: "180002",
+};
+
+const MUTATION_PATTERN =
+  /\b(?:ALTER|CREATE|DELETE|DROP|INSERT|TRUNCATE|UPDATE)\b/i;
+
+function statefulMigrationClient() {
+  const queries: string[] = [];
+  let lockHeld = false;
+  let ended = false;
+
+  return {
+    client: {
+      backend: "postgres" as const,
+      query: async <T = unknown>(text: string): Promise<{ rows: T[] }> => {
+        queries.push(text);
+        if (text.includes("pg_advisory_lock")) {
+          lockHeld = true;
+          return { rows: [] };
+        }
+        if (text.includes("pg_control_system")) {
+          if (!lockHeld) {
+            throw new Error("identity query ran outside the migration lock");
+          }
+          return { rows: [IDENTITY_ROW] as unknown as T[] };
+        }
+        if (text.includes("pg_advisory_unlock")) {
+          lockHeld = false;
+          return { rows: [{ unlocked: true }] as unknown as T[] };
+        }
+        return { rows: [] };
+      },
+      end: async () => {
+        ended = true;
+      },
+    },
+    state: () => ({ ended, lockHeld, queries }),
+  };
+}
+
+describe("migration-session database identity enforcement", () => {
+  for (const mismatch of ["cluster", "authority"] as const) {
+    const article = mismatch === "authority" ? "an" : "a";
+    test(`rejects ${article} ${mismatch} mismatch before the first DDL`, async () => {
+      const harness = statefulMigrationClient();
+      const config = {
+        environment: "staging" as const,
+        mode: "enforce" as const,
+        expectedClusterSha256:
+          mismatch === "cluster"
+            ? "0".repeat(64)
+            : "81bfebb15c27ed9707778f3fd9029b0aafe2d71f206ee234ba5f105c63b65e03",
+        expectedAuthoritySha256:
+          mismatch === "authority"
+            ? "1".repeat(64)
+            : "8808885f422f805df4781fce4e60e75ecc8e7ab740c90a9793c457d03ff410af",
+      };
+
+      await expect(
+        runMigrations(harness.client, [], OPTIONS, config),
+      ).rejects.toThrow(`database identity mismatch: ${mismatch}`);
+
+      const state = harness.state();
+      const lockIndex = state.queries.findIndex((query) =>
+        query.includes("pg_advisory_lock"),
+      );
+      const identityIndex = state.queries.findIndex((query) =>
+        query.includes("pg_control_system"),
+      );
+      const unlockIndex = state.queries.findIndex((query) =>
+        query.includes("pg_advisory_unlock"),
+      );
+      expect(lockIndex).toBeGreaterThan(-1);
+      expect(identityIndex).toBeGreaterThan(lockIndex);
+      expect(unlockIndex).toBeGreaterThan(identityIndex);
+      expect(
+        state.queries.filter((query) => MUTATION_PATTERN.test(query)),
+      ).toEqual([]);
+      expect(state.lockHeld).toBe(false);
+      expect(state.ended).toBe(true);
+    });
+  }
+});

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
@@ -3,10 +3,11 @@
  * migrations) under a database-wide advisory lock with per-statement failure
  * diagnostics instead of drizzle-kit's opaque errors. Ledger validation and
  * bounded lock retries make concurrent deploys serialize without accepting
- * partial, duplicated, or reordered migration history. Invoked as
- * `db:cloud:migrate` at the repo root and `db:migrate` in
- * packages/cloud/shared, including the deploy pipeline's migrate-db gate;
- * enforces TLS for remote databases.
+ * partial, duplicated, or reordered migration history. The protected database
+ * identity gate runs on this same locked session before the first DDL. Invoked
+ * as `db:cloud:migrate` at the repo root and `db:migrate` in packages/cloud/shared,
+ * including the deploy pipeline's migrate-db gate; enforces TLS for remote
+ * databases.
  */
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
@@ -19,6 +20,13 @@ import {
   runCleanupSteps,
   runWithCleanup,
 } from "./error-preserving-cleanup";
+import {
+  type DatabaseIdentityConfig,
+  type IdentityPreflightResult,
+  publishDatabaseIdentityResult,
+  readDatabaseIdentityConfig,
+  runDatabaseIdentityPreflight,
+} from "./preflight-database-identity";
 
 const { Client } = pg;
 
@@ -91,6 +99,11 @@ interface LockRetryOptions {
 interface ValidatedMigrationLedger {
   lastAppliedJournalIndex: number;
 }
+
+type IdentityResultReporter = (
+  config: DatabaseIdentityConfig,
+  result: IdentityPreflightResult,
+) => Promise<void>;
 
 // Historical SQL files were edited after deployment, so their stored hashes
 // and some deployed schemas have no matching ledger row. The catalog-guard
@@ -508,6 +521,8 @@ export async function runMigrations(
   client: MigrationClient,
   migrations: Migration[],
   retryOptions: LockRetryOptions,
+  identityConfig?: DatabaseIdentityConfig,
+  reportIdentityResult?: IdentityResultReporter,
 ): Promise<void> {
   let lockHeld = false;
   await runWithCleanup(
@@ -519,6 +534,13 @@ export async function runMigrations(
         console.log(
           "[db:migrate] PGlite backend uses its single-writer database lock",
         );
+      }
+      if (identityConfig) {
+        const identityResult = await runDatabaseIdentityPreflight(
+          identityConfig,
+          client,
+        );
+        await reportIdentityResult?.(identityConfig, identityResult);
       }
       await ensureMigrationsTable(client);
 
@@ -564,7 +586,8 @@ export async function runMigrations(
 }
 
 async function main(): Promise<void> {
-  const databaseUrl = process.env.DATABASE_URL;
+  const environment: Readonly<Record<string, string | undefined>> = process.env;
+  const databaseUrl = environment.DATABASE_URL;
   if (!databaseUrl) {
     throw new Error("DATABASE_URL is required to run database migrations.");
   }
@@ -574,12 +597,36 @@ async function main(): Promise<void> {
     journal.entries.map((entry) => readMigration(entry)),
   );
   const retryOptions = lockRetryOptions();
+  const configuredIdentityMode =
+    environment.DATABASE_IDENTITY_GATE_MODE?.trim().toLowerCase();
+  const identityConfig =
+    environment.DATABASE_IDENTITY_ENVIRONMENT !== undefined ||
+    (configuredIdentityMode !== undefined && configuredIdentityMode !== "off")
+      ? readDatabaseIdentityConfig(environment)
+      : undefined;
 
   const client: MigrationClient = databaseUrl.startsWith("pglite://")
     ? await createPGliteClient(databaseUrl)
     : await createPgClient(databaseUrl);
 
-  await runMigrations(client, migrations, retryOptions);
+  await runMigrations(
+    client,
+    migrations,
+    retryOptions,
+    identityConfig,
+    async (config, result) => {
+      try {
+        await publishDatabaseIdentityResult(config, result);
+      } catch (error) {
+        // error-policy:J1 report mode must not turn an evidence-output failure
+        // into permission to skip or block the migration identity decision.
+        if (config.mode !== "report") throw error;
+        process.stdout.write(
+          "::warning::database identity report output unavailable; inspect protected operator logs\n",
+        );
+      }
+    },
+  );
 }
 
 if (import.meta.main) {

--- a/packages/cloud/scripts/admin/preflight-database-identity.ts
+++ b/packages/cloud/scripts/admin/preflight-database-identity.ts
@@ -1,6 +1,7 @@
 /**
- * Produces a redacted PostgreSQL identity receipt before Cloud migrations.
- * The gate is inert by default and never changes database or provider state.
+ * Produces redacted PostgreSQL identity receipts for preparation and for the
+ * migration runner's same-session enforcement boundary. The standalone entry
+ * is read-only; authoritative release enforcement happens inside the migrator.
  */
 
 import { createHash } from "node:crypto";
@@ -268,7 +269,10 @@ async function clientConfig(databaseUrl: string): Promise<ClientConfig> {
   };
 }
 
-function summary(result: IdentityPreflightResult): string {
+/** Formats a redacted receipt for operator logs and GitHub step summaries. */
+function formatDatabaseIdentitySummary(
+  result: IdentityPreflightResult,
+): string {
   const lines = [
     "### PostgreSQL identity preflight",
     "",
@@ -286,6 +290,34 @@ function summary(result: IdentityPreflightResult): string {
     lines.push(`- Mismatch classes: \`${result.mismatches.join(",")}\``);
   }
   return `${lines.join("\n")}\n`;
+}
+
+/** Publishes only redacted identity results and generic diagnostic classes. */
+export async function publishDatabaseIdentityResult(
+  config: DatabaseIdentityConfig,
+  result: IdentityPreflightResult,
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): Promise<void> {
+  const output = formatDatabaseIdentitySummary(result);
+  process.stdout.write(output);
+  if (environment.GITHUB_STEP_SUMMARY) {
+    await appendFile(environment.GITHUB_STEP_SUMMARY, output, "utf8");
+  }
+  if (result.status === "mismatch" && config.mode === "report") {
+    process.stdout.write(
+      "::warning::database identity report differs from the protected authority\n",
+    );
+  }
+  if (result.status === "unavailable") {
+    process.stdout.write(
+      "::warning::database identity report unavailable; inspect protected operator logs\n",
+    );
+  }
+  if (config.ignoredExpectedDigests?.length) {
+    process.stdout.write(
+      "::warning::database identity report ignored malformed protected expected digest(s)\n",
+    );
+  }
 }
 
 async function main(): Promise<void> {
@@ -314,26 +346,7 @@ async function main(): Promise<void> {
     client = new Client(await clientConfig(databaseUrl));
     await client.connect();
     const result = await runDatabaseIdentityPreflight(config, client);
-    const output = summary(result);
-    process.stdout.write(output);
-    if (environment.GITHUB_STEP_SUMMARY) {
-      await appendFile(environment.GITHUB_STEP_SUMMARY, output, "utf8");
-    }
-    if (result.status === "mismatch" && config.mode === "report") {
-      process.stdout.write(
-        "::warning::database identity report differs from the protected authority\n",
-      );
-    }
-    if (result.status === "unavailable") {
-      process.stdout.write(
-        "::warning::database identity report unavailable; inspect protected operator logs\n",
-      );
-    }
-    if (config.ignoredExpectedDigests?.length) {
-      process.stdout.write(
-        "::warning::database identity report ignored malformed protected expected digest(s)\n",
-      );
-    }
+    await publishDatabaseIdentityResult(config, result, environment);
   } catch (error) {
     // error-policy:J1 the CLI boundary emits only a generic class so provider
     // errors cannot leak connection strings, hosts, roles, or database names.

--- a/packages/scripts/__tests__/cloud-database-identity-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-database-identity-workflow.test.ts
@@ -9,12 +9,10 @@ const source = readFileSync(
 );
 
 describe("Cloud database identity workflow", () => {
-  test("runs the read-only identity preflight immediately before migrations", () => {
-    const preflight = source.indexOf("preflight-database-identity.ts");
-    const migration = source.indexOf("bun run db:cloud:migrate", preflight);
-    expect(preflight).toBeGreaterThan(0);
-    expect(migration).toBeGreaterThan(preflight);
-    const block = source.slice(preflight - 2_500, migration);
+  test("delegates identity enforcement to the migration session", () => {
+    const migration = source.indexOf("bun run db:cloud:migrate");
+    expect(migration).toBeGreaterThan(0);
+    const block = source.slice(migration - 2_500, migration + 100);
     expect(block).toContain(
       "DATABASE_IDENTITY_GATE_MODE: $" +
         "{{ vars.DATABASE_IDENTITY_GATE_MODE || 'off' }}",
@@ -24,6 +22,10 @@ describe("Cloud database identity workflow", () => {
     );
     expect(block).toContain("DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256");
     expect(block).toContain("DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256");
+    expect(block).toContain("exact PostgreSQL session");
+    expect(block).not.toContain(
+      "bun --conditions=eliza-source packages/cloud/scripts/admin/preflight-database-identity.ts",
+    );
     expect(block).not.toContain("railway variables --set");
     expect(block).not.toContain("wrangler hyperdrive update");
   });

--- a/packages/scripts/__tests__/cloud-database-identity-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-database-identity-workflow.test.ts
@@ -3,30 +3,68 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
-const source = readFileSync(
+const canonicalSource = readFileSync(
   new URL("../../../.github/workflows/cloud-cf-release.yml", import.meta.url),
   "utf8",
 );
+const legacySource = readFileSync(
+  new URL(
+    "../../../.github/workflows/cloud-deploy-backend.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const provisioningSource = readFileSync(
+  new URL(
+    "../../../.github/workflows/deploy-eliza-provisioning-worker.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+function expectSameSessionGate(
+  source: string,
+  environmentExpression: string,
+): void {
+  const migration = source.indexOf("bun run db:cloud:migrate");
+  expect(migration).toBeGreaterThan(0);
+  const block = source.slice(migration - 3_000, migration + 100);
+  expect(block).toContain(
+    "DATABASE_IDENTITY_GATE_MODE: $" +
+      "{{ vars.DATABASE_IDENTITY_GATE_MODE || 'off' }}",
+  );
+  expect(block).toContain(environmentExpression);
+  expect(block).toContain("DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256");
+  expect(block).toContain("DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256");
+  expect(block).not.toContain(
+    "bun --conditions=eliza-source packages/cloud/scripts/admin/preflight-database-identity.ts",
+  );
+  expect(block).not.toContain("railway variables --set");
+  expect(block).not.toContain("wrangler hyperdrive update");
+}
 
 describe("Cloud database identity workflow", () => {
-  test("delegates identity enforcement to the migration session", () => {
-    const migration = source.indexOf("bun run db:cloud:migrate");
-    expect(migration).toBeGreaterThan(0);
-    const block = source.slice(migration - 2_500, migration + 100);
-    expect(block).toContain(
-      "DATABASE_IDENTITY_GATE_MODE: $" +
-        "{{ vars.DATABASE_IDENTITY_GATE_MODE || 'off' }}",
-    );
-    expect(block).toContain(
+  test("delegates canonical release enforcement to its migration session", () => {
+    expectSameSessionGate(
+      canonicalSource,
       "DATABASE_IDENTITY_ENVIRONMENT: $" + "{{ inputs.target_environment }}",
     );
-    expect(block).toContain("DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256");
-    expect(block).toContain("DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256");
-    expect(block).toContain("exact PostgreSQL session");
-    expect(block).not.toContain(
-      "bun --conditions=eliza-source packages/cloud/scripts/admin/preflight-database-identity.ts",
+    expect(canonicalSource).toContain("exact PostgreSQL session");
+  });
+
+  test("gates the explicit legacy migration on its selected environment", () => {
+    expectSameSessionGate(
+      legacySource,
+      "DATABASE_IDENTITY_ENVIRONMENT: $" +
+        "{{ needs.determine-env.outputs.environment }}",
     );
-    expect(block).not.toContain("railway variables --set");
-    expect(block).not.toContain("wrangler hyperdrive update");
+  });
+
+  test("gates exact-SHA provisioning migrations on their selected environment", () => {
+    expectSameSessionGate(
+      provisioningSource,
+      "DATABASE_IDENTITY_ENVIRONMENT: $" +
+        "{{ needs.determine-env.outputs.environment }}",
+    );
   });
 });

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -167,9 +167,27 @@ describe("provisioning worker deployment contract", () => {
     }
 
     const migration = deployStep("Run exact-SHA canonical database migrations");
-    expect(Object.keys(migration.env ?? {})).toEqual(["DATABASE_URL"]);
+    expect(Object.keys(migration.env ?? {})).toEqual([
+      "DATABASE_URL",
+      "DATABASE_IDENTITY_GATE_MODE",
+      "DATABASE_IDENTITY_ENVIRONMENT",
+      "DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256",
+      "DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256",
+    ]);
     expect(migration.env?.DATABASE_URL).toContain("secrets.DATABASE_URL");
     expect(migration.env?.DATABASE_URL).not.toContain("env.DATABASE_URL");
+    expect(migration.env?.DATABASE_IDENTITY_GATE_MODE).toContain(
+      "vars.DATABASE_IDENTITY_GATE_MODE",
+    );
+    expect(migration.env?.DATABASE_IDENTITY_ENVIRONMENT).toContain(
+      "needs.determine-env.outputs.environment",
+    );
+    expect(migration.env?.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256).toContain(
+      "vars.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256",
+    );
+    expect(
+      migration.env?.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256,
+    ).toContain("vars.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256");
 
     const validate = deployStep(
       "Validate canonical deploy configuration and shared secrets",


### PR DESCRIPTION
Closes #21745.

## Summary

Moves authoritative Cloud database-identity enforcement into `migrate-with-diagnostics` so the check runs on the exact PostgreSQL session that holds the migration advisory lock, immediately before the first DDL. The workflow no longer treats a separate preflight process as mutation admission. The standalone preflight remains a read-only receipt-preparation tool. The canonical release, manual legacy migration, and exact-SHA provisioning predeploy now all forward the same protected environment configuration to the same-session migrator.

Stateful mismatch tests prove that both a wrong cluster and wrong authority fail after lock acquisition, issue zero DDL/DML, release the lock, and close the same client. Operator guidance now records the `pg_control_system()` privilege requirement that must be proven on the protected migration role before enforce mode is enabled.

## Validation

Exact head `7f249420c16e673bb31b9a4cf3c0327c87ca4eeb`, rebased on `develop@2210ad8da9277011a2ee1388b36db0b545c32e5d`, using pinned Bun 1.3.14 and Node 24.15.0:

- frozen install: passed;
- same-session cluster/authority zero-DDL mismatch tests: 2/2, 14 assertions;
- focused identity, cleanup, and three-workflow contract suites: 39/39, 283 assertions;
- adjacent workflow authority, action pinning, and actionlint-config suites: 20/20, 68 assertions;
- broader migration ledger/PostgreSQL suite: 2 passed, 12 live-PostgreSQL tests explicitly skipped without a configured test database;
- Cloud shared typecheck/lint, core build (59/59), plugin-sql build, changed-file Biome, Actionlint, diff-check, 53-workflow trigger audit, and scripts audit: passed.

Root `verify` reaches only the known untouched duplicate `cloud.invoiceDetail.invalidInvoiceUrl` key in `packages/ui/src/i18n/locales/en.json`; no changed-file diagnostic occurred. No live or protected database was queried. Enabling enforce remains operationally blocked until a protected-environment operator proves the migration role has `pg_monitor` or a narrower `EXECUTE` grant for `pg_catalog.pg_control_system()`.

## Risk and rollback

The gate remains inert when configured off. In report/enforce modes it adds one read-only identity query to the already locked migration session before schema inspection. A failed identity or unavailable authority prevents DDL in enforce mode. Rollback would restore the unsafe two-session admission gap and is not recommended.

## Evidence Gate

<!-- evidence-head:7f249420c16e673bb31b9a4cf3c0327c87ca4eeb -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - migration and workflow behavior only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - migration and workflow behavior only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Deterministic same-session failure transcript:

<details><summary>Migration boundary transcript</summary>

~~~text
Cluster mismatch: advisory lock -> identity query -> advisory unlock -> client close; mutation queries: 0.
Authority mismatch: advisory lock -> identity query -> advisory unlock -> client close; mutation queries: 0.
Both failures surface before ensureMigrationsTable, the first DDL boundary.
~~~

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no live database artifact was created; exact test and workflow-contract evidence is included above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop / multi-agent review`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@310d08c4fd8f09aafca0fe34192a7df492b85591:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent review
Contribution skill revision: elizaOS/eliza@310d08c4fd8f09aafca0fe34192a7df492b85591:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent review","skill_revision":"elizaOS/eliza@310d08c4fd8f09aafca0fe34192a7df492b85591:packages/skills/skills/contribute-to-eliza"} -->