### PR TITLE
fix(personal-assistant): reserve suffix length in google truncateForPreview

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/google/format-helpers.trunc.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/google/format-helpers.trunc.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Exercises truncateForPreview suffix reservation: payload must not exceed advertised max.
+ */
+import { describe, expect, it } from "vitest";
+import { truncateForPreview } from "./format-helpers";
+
+describe("truncateForPreview", () => {
+  it("never exceeds max inclusive of suffix", () => {
+    const out = truncateForPreview("a".repeat(100), 10);
+    expect(out.length).toBe(10);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("returns original when under cap", () => {
+    expect(truncateForPreview("hello", 10)).toBe("hello");
+  });
+
+  it("handles small max correctly", () => {
+    expect(truncateForPreview("hello world", 5).length).toBe(5);
+    expect(truncateForPreview("hello world", 5).endsWith("…")).toBe(true);
+    expect(truncateForPreview("hi", 5)).toBe("hi");
+  });
+
+  it("handles max=1 edge", () => {
+    const out = truncateForPreview("abc", 1);
+    expect(out.length).toBe(1);
+    expect(out).toBe("…");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/google/format-helpers.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/google/format-helpers.ts
@@ -26,11 +26,11 @@ import { getLocalDateKey, getZonedDateParts } from "../time.js";
 // Truncate snippet/preview text and append an ellipsis when we actually cut.
 // Without the marker the slice looks like a sentence the sender wrote, which
 // confuses readers when content gets clipped mid-word.
-function truncateForPreview(value: string, maxLength: number): string {
+export function truncateForPreview(value: string, maxLength: number): string {
   if (value.length <= maxLength) {
     return value;
   }
-  return `${value.slice(0, maxLength).trimEnd()}…`;
+  return `${value.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
 }
 
 // Build a "Display Name <email@host>" string when both are available, or


### PR DESCRIPTION
# Relates to

Fixes `truncateForPreview` off-by-one on `develop` @ `5929de21`. `value.slice(0, maxLength).trimEnd()+"…"` returned `maxLength+1` chars, overflowing the advertised cap. Mirrors merged sibling `resolve-request.ts:280` and open `21665`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `5929de21` (`5929de2162ecffa1fff069faabca65779d7dcb0f`); zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` completed; `bun run verify` stepwise: `check:agents-claude` PASS, `check:biome-version` PASS, `check:i18n` OK (4675 keys), `ci-bun-version-contract` PASS, `ci-turbo-cache-contract` PASS, `fix-deps:check` OK, `ensure-plugin-test-conventions:check` PASS, `audit:alias-read-guard` PASS, `audit:tsconfig-workspace-resolution` inspected 135 projects PASS; focused `vitest`+`biome`+`typecheck` for affected package PASS (see Testing). Full `typecheck lint:check --concurrency=8` is heavy (8GB×8) — CI will confirm; locally ran with `--concurrency=2` for core.

# Risks

Low. Single expression `value.slice(0, Math.max(0, maxLength - 1)).trimEnd()+"…"` replaces `value.slice(0, maxLength).trimEnd()+"…"`. Adds `export` for testability. Isolated to `truncateForPreview`; no storage or API change.

# Background

## What does this PR do?

Reserves suffix length in `truncateForPreview` so truncation at `maxLength` never returns `maxLength+1`. Exports helper for direct boundary execution in tests.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-personal-assistant/src/lifeops/google/format-helpers.ts:28`
- `plugins/plugin-personal-assistant/src/lifeops/google/format-helpers.trunc.test.ts`

## Detailed testing steps

1. `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/google/format-helpers.trunc.test.ts` — 4 tests:
   - `never exceeds max inclusive of suffix` — `a*100` at `10` → `10` + `…`
   - `returns original when under cap`
   - `handles small max correctly` — `5` → `5` with `…`
   - `handles max=1 edge` → `…`
2. `bunx @biomejs/biome check` clean; `git diff --check` clean.

```
format-helpers.trunc.test.ts (4 tests) passed
Checked 2 files in 17ms. No fixes applied.
git diff --check: clean
```

# Evidence Gate

<!-- evidence-head:2f77db541c23b0a5fade69682371799e3d61ec54 -->
<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only google preview helper, no rendered UI`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only google preview helper, no rendered UI`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - deterministic preview truncation, no interactive flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not N/A, logs pasted in Testing`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - no domain artifact beyond test truncation`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/model change, pure truncation fix.`

## Backend + frontend logs

Backend: `format-helpers.trunc.test.ts` 4 passes. Frontend: `N/A`.

## Screenshots (before / after) + video walkthrough

`N/A - backend-only change.`

## Audio / voice walkthrough

`N/A - no voice change.`

## Known gaps / failures

None.

AI provider/model: openai / gpt-5.6
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [byt61]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6","client":"Codex","skill_revision":"elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza"} -->


