### PR TITLE
fix(agent-skills): reserve suffix length in truncateEvidence

### DIFF
--- a/plugins/plugin-agent-skills/src/security/truncateEvidence.trunc.test.ts
+++ b/plugins/plugin-agent-skills/src/security/truncateEvidence.trunc.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Exercises truncateEvidence suffix reservation: payload must not exceed advertised max.
+ */
+import { describe, expect, it } from "vitest";
+import { truncateEvidence } from "./types";
+
+describe("truncateEvidence", () => {
+  it("never exceeds max inclusive of suffix", () => {
+    const out = truncateEvidence("a".repeat(200), 120);
+    expect(out.length).toBe(120);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("returns original when under cap", () => {
+    expect(truncateEvidence("hello", 120)).toBe("hello");
+    expect(truncateEvidence("hello", 5)).toBe("hello");
+  });
+
+  it("handles small max correctly", () => {
+    expect(truncateEvidence("hello world", 5).length).toBe(5);
+    expect(truncateEvidence("hello world", 5).endsWith("…")).toBe(true);
+    expect(truncateEvidence("hi", 5)).toBe("hi");
+  });
+
+  it("handles max=1 edge", () => {
+    const out = truncateEvidence("hello", 1);
+    expect(out.length).toBe(1);
+    expect(out).toBe("…");
+  });
+});

--- a/plugins/plugin-agent-skills/src/security/types.ts
+++ b/plugins/plugin-agent-skills/src/security/types.ts
@@ -50,7 +50,7 @@ export interface SkillScanOptions {
 
 export function truncateEvidence(evidence: string, maxLen = 120): string {
 	if (evidence.length <= maxLen) return evidence;
-	return `${evidence.slice(0, maxLen)}…`;
+	return `${evidence.slice(0, Math.max(0, maxLen - 1))}…`;
 }
 
 /** Line-level rule: matches per-line, fires at most once per file. */


### PR DESCRIPTION
# Relates to

Fixes `truncateEvidence` off-by-one on `develop` @ `5929de21`. `evidence.slice(0, maxLen)+"…"` returned `maxLen+1` chars, overflowing the advertised `120` cap. Mirrors merged sibling `resolve-request.ts:280` and open `21665`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `5929de21` (`5929de2162ecffa1fff069faabca65779d7dcb0f`); zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` completed; `bun run verify` stepwise: `check:agents-claude` PASS, `check:biome-version` PASS, `check:i18n` OK (4675 keys), `ci-bun-version-contract` PASS, `ci-turbo-cache-contract` PASS, `fix-deps:check` OK, `ensure-plugin-test-conventions:check` PASS, `audit:alias-read-guard` PASS, `audit:tsconfig-workspace-resolution` inspected 135 projects PASS; focused `vitest`+`biome`+`typecheck` for affected package PASS (see Testing). Full `typecheck lint:check --concurrency=8` is heavy (8GB×8) — CI will confirm; locally ran with `--concurrency=2` for core.

# Risks

Low. Single expression `evidence.slice(0, Math.max(0, maxLen - 1))+"…"` replaces `evidence.slice(0, maxLen)+"…"`. Isolated to `truncateEvidence`; no API or storage change beyond fixing overflow.

# Background

## What does this PR do?

Reserves suffix length in `truncateEvidence` so truncation at `maxLen` never returns `maxLen+1`.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-agent-skills/src/security/types.ts:53`
- `plugins/plugin-agent-skills/src/security/truncateEvidence.trunc.test.ts`

## Detailed testing steps

1. `bunx vitest run plugins/plugin-agent-skills/src/security/truncateEvidence.trunc.test.ts` — 4 tests:
   - `never exceeds max inclusive of suffix` — `a*200` at `120` → `120` + `…`
   - `returns original when under cap`
   - `handles small max correctly` — `5` → `5` with `…`
   - `handles max=1 edge` → `…`
2. `bunx @biomejs/biome check` clean; `git diff --check` clean.

```
truncateEvidence.trunc.test.ts (4 tests) passed
Checked 2 files in 4ms. No fixes applied.
git diff --check: clean
```

# Evidence Gate

<!-- evidence-head:fb77521501a740fa1c52e7888e7d04ee1f10f35b -->
<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only evidence helper, no rendered UI`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only evidence helper, no rendered UI`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - deterministic evidence truncation, no interactive flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not N/A, logs pasted in Testing`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - no domain artifact beyond test truncation`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/model change, pure truncation fix.`

## Backend + frontend logs

Backend: `truncateEvidence.trunc.test.ts` 4 passes. Frontend: `N/A`.

## Screenshots (before / after) + video walkthrough

`N/A - backend-only change.`

## Audio / voice walkthrough

`N/A - no voice change.`

## Known gaps / failures

None.

AI provider/model: openai / gpt-5.6
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [byt61]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6","client":"Codex","skill_revision":"elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza"} -->


