### PR TITLE
fix(plugin-local-inference): bound embedding-server health and embed fetches

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/embedding-server-timeout.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/embedding-server-timeout.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Behavioral embedding-server health vs embed deadlines. Executes /health GET
+ * and /v1/embeddings POST under abort — not a source-grep of embedding-server.ts.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	EMBEDDING_SERVER_EMBED_TIMEOUT_MS,
+	EMBEDDING_SERVER_HEALTH_TIMEOUT_MS,
+	embedWithFetch,
+	probeEmbeddingServerHealthWithFetch,
+} from "./embedding-server";
+
+const HEALTH_URL = "http://127.0.0.1:9/health";
+const BASE_URL = "http://127.0.0.1:9";
+const VECTOR = Array.from({ length: 64 }, () => 1);
+
+function stallUntilAborted(): typeof fetch {
+	return ((_input, init) =>
+		new Promise<Response>((_resolve, reject) => {
+			const signal = init?.signal;
+			if (!signal) throw new Error("expected embedding-server abort signal");
+			signal.addEventListener("abort", () => reject(signal.reason), {
+				once: true,
+			});
+		})) as typeof fetch;
+}
+
+describe("embedding-server probe vs embed deadlines", () => {
+	it("keeps a short health budget separate from the longer embed hop", () => {
+		expect(EMBEDDING_SERVER_HEALTH_TIMEOUT_MS).toBe(2_000);
+		expect(EMBEDDING_SERVER_EMBED_TIMEOUT_MS).toBe(30_000);
+		expect(EMBEDDING_SERVER_HEALTH_TIMEOUT_MS).toBeLessThan(
+			EMBEDDING_SERVER_EMBED_TIMEOUT_MS,
+		);
+	});
+
+	it("treats a stalled health probe as not-ready after the injected deadline", async () => {
+		await expect(
+			probeEmbeddingServerHealthWithFetch(HEALTH_URL, stallUntilAborted(), 10),
+		).resolves.toBe(false);
+	});
+
+	it("treats a completed health probe error as not-ready", async () => {
+		const fetchImpl: typeof fetch = async () =>
+			new Response("", { status: 503, statusText: "Service Unavailable" });
+
+		await expect(
+			probeEmbeddingServerHealthWithFetch(HEALTH_URL, fetchImpl, 1_000),
+		).resolves.toBe(false);
+	});
+
+	it("uses the injected fetch for a successful health probe", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchImpl: typeof fetch = async (_input, init) => {
+			if (init?.signal) signals.push(init.signal);
+			return new Response("ok", { status: 200 });
+		};
+
+		await expect(
+			probeEmbeddingServerHealthWithFetch(HEALTH_URL, fetchImpl, 1_000),
+		).resolves.toBe(true);
+		expect(signals).toHaveLength(1);
+		expect(signals[0]?.aborted).toBe(false);
+	});
+
+	it("aborts a stalled embed POST at the injected deadline", async () => {
+		await expect(
+			embedWithFetch(BASE_URL, ["hello"], 64, stallUntilAborted(), 10),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+	});
+
+	it("surfaces a provider error from a completed embed POST", async () => {
+		const fetchImpl: typeof fetch = async () =>
+			new Response("busy", { status: 502, statusText: "Bad Gateway" });
+
+		await expect(
+			embedWithFetch(BASE_URL, ["hello"], 64, fetchImpl, 1_000),
+		).rejects.toThrow("502");
+	});
+
+	it("uses the injected fetch for a successful embed POST", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchImpl: typeof fetch = async (_input, init) => {
+			if (init?.signal) signals.push(init.signal);
+			return Response.json({
+				data: [{ embedding: VECTOR }],
+			});
+		};
+
+		const rows = await embedWithFetch(BASE_URL, ["hello"], 64, fetchImpl, 1_000);
+
+		expect(signals).toHaveLength(1);
+		expect(signals[0]?.aborted).toBe(false);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toHaveLength(64);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/embedding-server.ts
+++ b/plugins/plugin-local-inference/src/services/voice/embedding-server.ts
@@ -28,6 +28,66 @@ interface EmbeddingServerConfig {
 	threads?: number;
 }
 
+/** Health GET is a short liveness check so waitUntilReady can keep iterating. */
+export const EMBEDDING_SERVER_HEALTH_TIMEOUT_MS = 2_000;
+
+/** Embedding POST can wait on a local GGUF forward pass — longer than the health probe. */
+export const EMBEDDING_SERVER_EMBED_TIMEOUT_MS = 30_000;
+
+export async function probeEmbeddingServerHealthWithFetch(
+	healthUrl: string,
+	fetchImpl: typeof fetch,
+	timeoutMs: number = EMBEDDING_SERVER_HEALTH_TIMEOUT_MS,
+): Promise<boolean> {
+	try {
+		const response = await fetchImpl(healthUrl, {
+			method: "GET",
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		return response.ok;
+	} catch {
+		return false;
+	}
+}
+
+export async function embedWithFetch(
+	baseUrl: string,
+	texts: string[],
+	dim: number,
+	fetchImpl: typeof fetch,
+	timeoutMs: number = EMBEDDING_SERVER_EMBED_TIMEOUT_MS,
+): Promise<number[][]> {
+	const response = await fetchImpl(`${baseUrl}/v1/embeddings`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ input: texts }),
+		signal: AbortSignal.timeout(timeoutMs),
+	});
+	if (!response.ok) {
+		const body = await response.text().catch(() => "");
+		throw new Error(
+			`[embedding-server] /v1/embeddings returned ${response.status}: ${body.slice(0, 200)}`,
+		);
+	}
+	const payload = (await response.json()) as {
+		data?: Array<{ embedding?: number[] }>;
+	};
+	const rows = payload.data ?? [];
+	if (rows.length !== texts.length) {
+		throw new Error(
+			`[embedding-server] expected ${texts.length} embedding rows, got ${rows.length}`,
+		);
+	}
+	return rows.map((row, index) => {
+		if (!Array.isArray(row.embedding)) {
+			throw new Error(
+				`[embedding-server] response row ${index} missing embedding vector`,
+			);
+		}
+		return truncateMatryoshka(row.embedding, dim);
+	});
+}
+
 export class EmbeddingServer {
 	private readonly config: EmbeddingServerConfig;
 	private child: ChildProcess | null = null;
@@ -54,34 +114,15 @@ export class EmbeddingServer {
 			throw new Error(`[embedding] dim ${dim} is not a valid Matryoshka width`);
 		}
 		await this.ensureStarted();
-		const response = await fetch(`${this.baseUrl}/v1/embeddings`, {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({ input: texts }),
-		});
-		if (!response.ok) {
-			const body = await response.text().catch(() => "");
-			throw new Error(
-				`[embedding-server] /v1/embeddings returned ${response.status}: ${body.slice(0, 200)}`,
-			);
+		if (!this.baseUrl) {
+			throw new Error("[embedding-server] sidecar started without a base URL");
 		}
-		const payload = (await response.json()) as {
-			data?: Array<{ embedding?: number[] }>;
-		};
-		const rows = payload.data ?? [];
-		if (rows.length !== texts.length) {
-			throw new Error(
-				`[embedding-server] expected ${texts.length} embedding rows, got ${rows.length}`,
-			);
-		}
-		return rows.map((row, index) => {
-			if (!Array.isArray(row.embedding)) {
-				throw new Error(
-					`[embedding-server] response row ${index} missing embedding vector`,
-				);
-			}
-			return truncateMatryoshka(row.embedding, dim);
-		});
+		return embedWithFetch(
+			this.baseUrl,
+			texts,
+			dim,
+			globalThis.fetch,
+		);
 	}
 
 	private async ensureStarted(): Promise<void> {
@@ -140,11 +181,13 @@ export class EmbeddingServer {
 					"[embedding-server] llama-server exited before /health became ready",
 				);
 			}
-			try {
-				const response = await fetch(`${this.baseUrl}/health`);
-				if (response.ok) return;
-			} catch {
-				// Server socket is not open yet.
+			if (
+				await probeEmbeddingServerHealthWithFetch(
+					`${this.baseUrl}/health`,
+					globalThis.fetch,
+				)
+			) {
+				return;
 			}
 			await new Promise((resolve) => setTimeout(resolve, 100));
 		}


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). Embedding-server **health GET** and **embed POST** `fetch` have no `AbortSignal`. A stalled `/health` hop also stalls `waitUntilReady` past its 20s outer loop because the first hung fetch never returns. Not `#21626` (owns `local-inference-routes.ts` — this PR does not touch that file). This PR is Fal `#21205` bar: injected fetch, TimeoutError on embed, health-unavailable on abort, provider-error, success, with **separate** health (2s) vs embed (30s) deadlines. Tests execute both hops under abort. OsAtlasPro already shipped (`#21751`). Stagehand already shipped (`#21743`). Not plugin-openai index test fetches. Not extra-decode. Not list-limit. Not payment. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Not Twilio. Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Public `EmbeddingServer` / `embeddingServerForRoute` signatures unchanged. Unfixed head: health and embed `fetch` had **no signal** and a hung fetch never settled (80ms race → `HUNG` on both hops). After: 10ms health deadline → not-ready `false`; 10ms embed deadline → `TimeoutError`. Health budget is 2s; embed budget is 30s.

# Background

## What does this PR do?

`embed()` and `waitUntilReady()` called `fetch` with no `signal`. A stalled sidecar hop never returns, and a hung `/health` fetch also prevents the 20s ready-loop from advancing. This PR injects `*WithFetch` (Fal `#21205` shape) and adds `AbortSignal.timeout` with separate health vs embed deadlines.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Routes file untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/src/services/voice/embedding-server-timeout.test.ts` — health timeout/unavailable, embed TimeoutError, provider-error, success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-local-inference && bunx vitest run --config ./vitest.config.ts src/services/voice/embedding-server-timeout.test.ts
```

Unfixed head `41bf857154`: health and embed `signal` were undefined and the calls hung. After the fix: 7 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:3d8ede20d34aa3bbe4ea4c9644c9039667d3fa06 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Provider fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live llama-server path. vitest asserts health unavailable, embed TimeoutError, provider 502, and success payload.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - embedding-server transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live llama-server. Unfixed `%` hang: no signal, 80ms race `HUNG` on health and embed. After the fix, vitest asserts health unavailable on abort and 503, embed TimeoutError, `502` on provider error, and a successful embedding row.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

## Audio / voice walkthrough

N/A - sidecar HTTP only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`7 pass` plus existing embedding route tests). Root verify is an unrelated full-repo cost. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
