### PR TITLE
fix(agent): fail closed device-bridge WS upgrades when the bridge never attached (W9-AGENT-01)

### DIFF
--- a/packages/agent/src/api/server-auth-boundary.test.ts
+++ b/packages/agent/src/api/server-auth-boundary.test.ts
@@ -8,6 +8,11 @@
  *    boot phase) for callers that fail the trusted-local check.
  *  - W1-011: the device-bridge WS path fails closed (HTTP 404) when the
  *    bridge cannot be attached, instead of skipping WS auth unconditionally.
+ *  - W9-AGENT-01: the device-bridge WS path ALSO fails closed (HTTP 404) when
+ *    delegation is expected (bridge enabled + pairing token configured) but
+ *    the deferred bridge attach never landed a listener — an unconditional
+ *    early return would otherwise leave the raw pre-auth socket dangling
+ *    outside the W5-015 bounds.
  *  - W5-015: unauthenticated /ws sockets are bounded — a per-peer cap on
  *    concurrent pre-auth upgrades and a post-open auth grace period that
  *    closes sockets which never authenticate — while the post-open token
@@ -52,6 +57,7 @@ const touchedEnv = [
   "ELIZA_CONFIG_PATH",
   "ELIZA_DEVICE_BRIDGE_ENABLED",
   "ELIZA_DEVICE_BRIDGE_TOKEN",
+  "ELIZA_DEVICE_LOAD_TIMEOUT_MS",
   "ELIZA_DEVICE_PAIRING_TOKEN",
   "ELIZA_PERSIST_CONFIG_PATH",
   "ELIZA_PORT",
@@ -92,6 +98,7 @@ beforeEach(async () => {
   delete process.env.ELIZA_DEVICE_BRIDGE_ENABLED;
   delete process.env.ELIZA_DEVICE_PAIRING_TOKEN;
   delete process.env.ELIZA_DEVICE_BRIDGE_TOKEN;
+  delete process.env.ELIZA_DEVICE_LOAD_TIMEOUT_MS;
 });
 
 afterEach(async () => {
@@ -224,6 +231,79 @@ describe("device-bridge WS upgrade gate (W1-011)", () => {
       "/api/local-inference/device-bridge",
     );
     expect(raw.startsWith("HTTP/1.1 404 Not Found")).toBe(true);
+  }, 120_000);
+
+  it("rejects the device-bridge upgrade with 404 when delegation is expected but the bridge never attached (W9-AGENT-01)", async () => {
+    // Delegation is expected: the bridge is enabled and a pairing token is
+    // configured. But the deferred attach can never land a listener here —
+    // a malformed activation-time timeout makes attachMobileDeviceBridgeToServer
+    // reject before it registers its upgrade handler, and on bundles without
+    // the capacitor plugin the import itself rejects into the no-op fallback.
+    process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+    process.env.ELIZA_DEVICE_PAIRING_TOKEN = "auth-boundary-test-pairing-token";
+    process.env.ELIZA_DEVICE_LOAD_TIMEOUT_MS = "not-a-number";
+    const baseUrl = await bootServer();
+    const port = Number(new URL(baseUrl).port);
+
+    // Before the doomed attach settles the delegation has not landed yet:
+    // the upgrade must be answered with a closed rejection, not left to
+    // dangle outside the W5-015 pending-socket cap and auth grace period.
+    const duringAttach = await wsUpgradeResponse(
+      port,
+      "/api/local-inference/device-bridge",
+    );
+    expect(duringAttach.startsWith("HTTP/1.1 404 Not Found")).toBe(true);
+
+    // After the attach attempt has had time to fail, the path stays failed
+    // closed — the delegation never activates without a real listener.
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    const afterFailure = await wsUpgradeResponse(
+      port,
+      "/api/local-inference/device-bridge",
+    );
+    expect(afterFailure.startsWith("HTTP/1.1 404 Not Found")).toBe(true);
+  }, 120_000);
+
+  it("delegates the device-bridge upgrade once the bridge listener has actually attached", async () => {
+    // Healthy counterpart to the fail-closed cases: the deferred attach
+    // succeeds here, and the upgrade handler must then keep delegating the
+    // path to the bridge's own listener (pairing-token auth, 4001 close).
+    process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+    process.env.ELIZA_DEVICE_PAIRING_TOKEN = "auth-boundary-test-pairing-token";
+    const baseUrl = await bootServer();
+    const port = Number(new URL(baseUrl).port);
+
+    // The attach is deferred past listen (dynamic import): poll with the
+    // correct pairing token until the delegation activates. Fail-closed 404s
+    // answer while the bridge listener is not yet on the server.
+    await vi.waitFor(
+      async () => {
+        const raw = await wsUpgradeResponse(
+          port,
+          "/api/local-inference/device-bridge?token=auth-boundary-test-pairing-token",
+        );
+        expect(raw.startsWith("HTTP/1.1 101")).toBe(true);
+      },
+      { timeout: 30_000, interval: 250 },
+    );
+
+    // The answering handler is the bridge's own, not the API's WS stack: a
+    // wrong pairing token is upgraded and then closed with the bridge's 4001.
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${port}/api/local-inference/device-bridge?token=wrong-token`,
+    );
+    const closeCode = await new Promise<number>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("timed out waiting for the bridge 4001 close")),
+        10_000,
+      );
+      ws.once("close", (code: number) => {
+        clearTimeout(timer);
+        resolve(code);
+      });
+      ws.once("error", reject);
+    });
+    expect(closeCode).toBe(4001);
   }, 120_000);
 });
 

--- a/packages/agent/src/api/server-auth-boundary.test.ts
+++ b/packages/agent/src/api/server-auth-boundary.test.ts
@@ -334,6 +334,39 @@ describe("device-bridge WS upgrade gate (W1-011)", () => {
     });
     expect(closeCode).toBe(4001);
   }, 120_000);
+
+  it("does not let a skip-listen API instance occupy the process-global device bridge", async () => {
+    process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+    process.env.ELIZA_DEVICE_PAIRING_TOKEN = "auth-boundary-test-pairing-token";
+    const ipcApi = await startApiServer({
+      port: 0,
+      skipListen: true,
+      skipDeferredStartupWork: true,
+    });
+    try {
+      // Give the deferred optional-plugin import enough time to expose the
+      // historical race before starting the real listening API instance.
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+      const baseUrl = await bootServer();
+      const port = Number(new URL(baseUrl).port);
+      await vi.waitFor(
+        async () => {
+          const raw = await wsUpgradeResponse(
+            port,
+            "/api/local-inference/device-bridge?token=auth-boundary-test-pairing-token",
+          );
+          expect(raw.startsWith("HTTP/1.1 101")).toBe(true);
+        },
+        { timeout: 30_000, interval: 250 },
+      );
+    } finally {
+      await ipcApi.close();
+      const { mobileDeviceBridge } = await import(
+        "@elizaos/plugin-capacitor-bridge/mobile-device-bridge-bootstrap"
+      );
+      await mobileDeviceBridge.close();
+    }
+  }, 120_000);
 });
 
 describe("unauthenticated /ws bounds (W5-015)", () => {

--- a/packages/agent/src/api/server-auth-boundary.test.ts
+++ b/packages/agent/src/api/server-auth-boundary.test.ts
@@ -113,8 +113,16 @@ afterEach(async () => {
   restoreEnvironment();
 });
 
-async function bootServer(): Promise<string> {
-  api = await startApiServer({ port: 0, skipDeferredStartupWork: true });
+async function bootServer(
+  configureServer?: NonNullable<
+    Parameters<typeof startApiServer>[0]
+  >["configureServer"],
+): Promise<string> {
+  api = await startApiServer({
+    port: 0,
+    skipDeferredStartupWork: true,
+    configureServer,
+  });
   process.env.ELIZA_PORT = String(api.port);
   process.env.ELIZA_API_PORT = String(api.port);
   return `http://127.0.0.1:${api.port}`;
@@ -262,6 +270,27 @@ describe("device-bridge WS upgrade gate (W1-011)", () => {
       "/api/local-inference/device-bridge",
     );
     expect(afterFailure.startsWith("HTTP/1.1 404 Not Found")).toBe(true);
+  }, 120_000);
+
+  it("does not mistake an unrelated concurrent upgrade listener for the bridge", async () => {
+    process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+    process.env.ELIZA_DEVICE_PAIRING_TOKEN = "auth-boundary-test-pairing-token";
+    process.env.ELIZA_DEVICE_LOAD_TIMEOUT_MS = "not-a-number";
+    const baseUrl = await bootServer((server) => {
+      // Land a listener while the deferred plugin import/attach is in flight.
+      // A process-global listener-count delta cannot prove who registered it.
+      setImmediate(() => {
+        setImmediate(() => server.on("upgrade", () => undefined));
+      });
+    });
+    const port = Number(new URL(baseUrl).port);
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+
+    const raw = await wsUpgradeResponse(
+      port,
+      "/api/local-inference/device-bridge",
+    );
+    expect(raw.startsWith("HTTP/1.1 404 Not Found")).toBe(true);
   }, 120_000);
 
   it("delegates the device-bridge upgrade once the bridge listener has actually attached", async () => {

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -3825,9 +3825,18 @@ export async function startApiServer(opts?: {
   // listening. Use the bridge's explicit attachment result; listener counts
   // are process-global observations and can be changed by unrelated features.
   let deviceBridgeUpgradeHandlerAttached = false;
+  let deviceBridgeAttachAllowed = !opts?.skipListen;
+  server.once("close", () => {
+    // The optional plugin import is deliberately deferred beyond bind. If the
+    // server closes before it resolves, do not attach the process-global bridge
+    // to a dead server and prevent a replacement API server from acquiring it.
+    deviceBridgeAttachAllowed = false;
+    deviceBridgeUpgradeHandlerAttached = false;
+  });
   if (
-    isMobilePlatform() ||
-    process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1"
+    deviceBridgeAttachAllowed &&
+    (isMobilePlatform() ||
+      process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1")
   ) {
     // Defer to a macrotask: resolving @elizaos/plugin-capacitor-bridge (and its
     // device-bridge attach) measured ~15s of blocking on the mobile bundle and
@@ -3841,11 +3850,14 @@ export async function startApiServer(opts?: {
           server: http.Server,
         ) => Promise<boolean>;
       }>("capacitor")
-        .then(({ attachMobileDeviceBridgeToServer }) =>
-          attachMobileDeviceBridgeToServer(server),
-        )
+        .then(({ attachMobileDeviceBridgeToServer }) => {
+          if (!deviceBridgeAttachAllowed) return false;
+          return attachMobileDeviceBridgeToServer(server);
+        })
         .then((attached) => {
-          deviceBridgeUpgradeHandlerAttached = attached === true;
+          if (deviceBridgeAttachAllowed) {
+            deviceBridgeUpgradeHandlerAttached = attached === true;
+          }
         })
         .catch((err: unknown) => {
           logger.warn(

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -3816,6 +3816,14 @@ export async function startApiServer(opts?: {
   });
   const server = http.createServer((req, res) => routeKernel.handle(req, res));
   await opts?.configureServer?.(server);
+  // W9-AGENT-01: the WS upgrade handler delegates the device-bridge path to
+  // the capacitor bridge's own upgrade listener, so that delegation is only
+  // safe once such a listener has REALLY attached here. A settled attach
+  // promise is not proof of that: an optional-plugin import rejection resolves
+  // through the no-op fallback API, and the bridge attach itself returns early
+  // when the bridge is disabled for the platform — in both cases nothing is
+  // listening. Track the upgrade-listener delta the attach actually produces.
+  let deviceBridgeUpgradeHandlerAttached = false;
   if (
     isMobilePlatform() ||
     process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1"
@@ -3827,6 +3835,7 @@ export async function startApiServer(opts?: {
     // The bridge only needs to attach a WS upgrade handler to the server object,
     // which works fine once the server is already listening.
     setImmediate(() => {
+      const upgradeListenersBeforeAttach = server.listenerCount("upgrade");
       void getOptionalPluginApi<{
         attachMobileDeviceBridgeToServer: (
           server: http.Server,
@@ -3835,6 +3844,10 @@ export async function startApiServer(opts?: {
         .then(({ attachMobileDeviceBridgeToServer }) =>
           attachMobileDeviceBridgeToServer(server),
         )
+        .then(() => {
+          deviceBridgeUpgradeHandlerAttached =
+            server.listenerCount("upgrade") > upgradeListenersBeforeAttach;
+        })
         .catch((err: unknown) => {
           logger.warn(
             "[eliza-api] Failed to attach mobile device bridge:",
@@ -4088,7 +4101,12 @@ export async function startApiServer(opts?: {
   // bridge can actually be attached: the plugin refuses to attach without a
   // pairing token, so with none configured nothing is listening on the path —
   // fall through to the standard upgrade rejection instead of skipping auth
-  // and leaving the socket unanswered (W1-011).
+  // and leaving the socket unanswered (W1-011). The same fail-closed rule
+  // applies when delegation is EXPECTED but the deferred attach never landed
+  // a listener — an import rejection resolves through the no-op fallback API
+  // and a failed attach only logs, so an unconditional early return would
+  // leave the raw pre-auth socket unanswered indefinitely, outside the
+  // W5-015 pending-socket cap and auth grace period (W9-AGENT-01).
   const isDeviceBridgeDelegationExpected = (): boolean => {
     if (
       !isMobilePlatform() &&
@@ -4127,7 +4145,8 @@ export async function startApiServer(opts?: {
       );
       if (
         wsUrl.pathname === "/api/local-inference/device-bridge" &&
-        isDeviceBridgeDelegationExpected()
+        isDeviceBridgeDelegationExpected() &&
+        deviceBridgeUpgradeHandlerAttached
       ) {
         return;
       }

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -3822,7 +3822,8 @@ export async function startApiServer(opts?: {
   // promise is not proof of that: an optional-plugin import rejection resolves
   // through the no-op fallback API, and the bridge attach itself returns early
   // when the bridge is disabled for the platform — in both cases nothing is
-  // listening. Track the upgrade-listener delta the attach actually produces.
+  // listening. Use the bridge's explicit attachment result; listener counts
+  // are process-global observations and can be changed by unrelated features.
   let deviceBridgeUpgradeHandlerAttached = false;
   if (
     isMobilePlatform() ||
@@ -3835,18 +3836,16 @@ export async function startApiServer(opts?: {
     // The bridge only needs to attach a WS upgrade handler to the server object,
     // which works fine once the server is already listening.
     setImmediate(() => {
-      const upgradeListenersBeforeAttach = server.listenerCount("upgrade");
       void getOptionalPluginApi<{
         attachMobileDeviceBridgeToServer: (
           server: http.Server,
-        ) => Promise<void>;
+        ) => Promise<boolean>;
       }>("capacitor")
         .then(({ attachMobileDeviceBridgeToServer }) =>
           attachMobileDeviceBridgeToServer(server),
         )
-        .then(() => {
-          deviceBridgeUpgradeHandlerAttached =
-            server.listenerCount("upgrade") > upgradeListenersBeforeAttach;
+        .then((attached) => {
+          deviceBridgeUpgradeHandlerAttached = attached === true;
         })
         .catch((err: unknown) => {
           logger.warn(

--- a/plugins/plugin-capacitor-bridge/AGENTS.md
+++ b/plugins/plugin-capacitor-bridge/AGENTS.md
@@ -16,7 +16,7 @@ The plugin owns service lifecycle; its bootstrap registers model handlers direct
 |---|---|
 | `mobileDeviceBridgePlugin` | Registers the canonical `MobileDeviceBridgeService`; the pre-initialize bootstrap installs this same plugin so later plugin registration remains idempotent. |
 | `ensureMobileDeviceBridgeInferenceHandlers(runtime)` | Registers the canonical `MobileDeviceBridgeService` before initialization, then registers `TEXT_SMALL`, `TEXT_LARGE`, and `TEXT_EMBEDDING` handlers only after a bionic host or real device can serve them. Android path only (iOS uses native IPC). Gated by `ELIZA_DEVICE_BRIDGE_ENABLED=1`. |
-| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the canonical singleton's WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server`. The server close boundary removes the hook, closes clients, cancels pending calls, and clears heartbeat timers; runtime stop releases only that runtime's subscription. |
+| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the canonical singleton's WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server` and returns whether that exact server owns the active handler. The server close boundary removes the hook, closes clients, cancels pending calls, and clears heartbeat timers; runtime stop releases only that runtime's subscription. |
 | `getMobileDeviceBridgeStatus()` | Returns `MobileDeviceBridgeStatus`: enabled, connected devices, loaded model path, pending request counts. |
 | `loadMobileDeviceBridgeModel(modelPath, modelId?)` | Imperatively load a GGUF into the connected Android device. |
 | `unloadMobileDeviceBridgeModel()` | Unload the current model from the connected Android device. |

--- a/plugins/plugin-capacitor-bridge/CLAUDE.md
+++ b/plugins/plugin-capacitor-bridge/CLAUDE.md
@@ -16,7 +16,7 @@ The plugin owns service lifecycle; its bootstrap registers model handlers direct
 |---|---|
 | `mobileDeviceBridgePlugin` | Registers the canonical `MobileDeviceBridgeService`; the pre-initialize bootstrap installs this same plugin so later plugin registration remains idempotent. |
 | `ensureMobileDeviceBridgeInferenceHandlers(runtime)` | Registers the canonical `MobileDeviceBridgeService` before initialization, then registers `TEXT_SMALL`, `TEXT_LARGE`, and `TEXT_EMBEDDING` handlers only after a bionic host or real device can serve them. Android path only (iOS uses native IPC). Gated by `ELIZA_DEVICE_BRIDGE_ENABLED=1`. |
-| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the canonical singleton's WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server`. The server close boundary removes the hook, closes clients, cancels pending calls, and clears heartbeat timers; runtime stop releases only that runtime's subscription. |
+| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the canonical singleton's WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server` and returns whether that exact server owns the active handler. The server close boundary removes the hook, closes clients, cancels pending calls, and clears heartbeat timers; runtime stop releases only that runtime's subscription. |
 | `getMobileDeviceBridgeStatus()` | Returns `MobileDeviceBridgeStatus`: enabled, connected devices, loaded model path, pending request counts. |
 | `loadMobileDeviceBridgeModel(modelPath, modelId?)` | Imperatively load a GGUF into the connected Android device. |
 | `unloadMobileDeviceBridgeModel()` | Unload the current model from the connected Android device. |

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.no-token.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.no-token.test.ts
@@ -31,7 +31,9 @@ describe("mobile device bridge with no pairing token (W1-011)", () => {
 		const bridge = await import("./mobile-device-bridge-bootstrap");
 		const server = http.createServer((_req, res) => res.end("ok"));
 		try {
-			await bridge.attachMobileDeviceBridgeToServer(server);
+			await expect(
+				bridge.attachMobileDeviceBridgeToServer(server),
+			).resolves.toBe(false);
 			expect(bridge.mobileDeviceBridge.status().enabled).toBe(false);
 			expect(bridge.mobileDeviceBridge.status().connected).toBe(false);
 		} finally {

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -423,13 +423,16 @@ class MobileDeviceBridge {
 		};
 	}
 
-	async attachToHttpServer(server: HttpServer): Promise<void> {
-		if (!SERVICE_ENABLED || this.wss) return;
+	async attachToHttpServer(server: HttpServer): Promise<boolean> {
+		if (!SERVICE_ENABLED) return false;
+		if (this.wss) {
+			return this.attachedServer === server && this.upgradeHandler !== null;
+		}
 		if (!this.expectedPairingToken) {
 			logger.warn(
 				"[mobile-device-bridge] Disabled: ELIZA_DEVICE_PAIRING_TOKEN is required when ELIZA_DEVICE_BRIDGE_ENABLED=1",
 			);
-			return;
+			return false;
 		}
 		// Resolve and validate every device-bridge timeout once, here at the
 		// real activation boundary, before any transport or device state is
@@ -471,7 +474,7 @@ class MobileDeviceBridge {
 		}
 		if (generation !== this.lifecycleGeneration || this.wss) {
 			server.off("close", serverCloseHandler);
-			return;
+			return this.attachedServer === server && this.upgradeHandler !== null;
 		}
 		if (!isWsModule(wsModule)) {
 			server.off("close", serverCloseHandler);
@@ -503,6 +506,7 @@ class MobileDeviceBridge {
 		logger.info(
 			`[mobile-device-bridge] Listening for Capacitor device bridge at ${DEVICE_BRIDGE_PATH}`,
 		);
+		return true;
 	}
 
 	private handleConnection(
@@ -2175,8 +2179,8 @@ export const mobileDeviceBridgePlugin: Plugin = {
 
 export async function attachMobileDeviceBridgeToServer(
 	server: HttpServer,
-): Promise<void> {
-	await mobileDeviceBridge.attachToHttpServer(server);
+): Promise<boolean> {
+	return mobileDeviceBridge.attachToHttpServer(server);
 }
 
 /**

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-headless-boot.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-headless-boot.test.ts
@@ -108,10 +108,12 @@ describe("canonical mobile device bridge headless boot", () => {
 				),
 			).toHaveLength(1);
 
-			await Promise.all([
-				bridge.attachMobileDeviceBridgeToServer(server),
-				bridge.attachMobileDeviceBridgeToServer(server),
-			]);
+			await expect(
+				Promise.all([
+					bridge.attachMobileDeviceBridgeToServer(server),
+					bridge.attachMobileDeviceBridgeToServer(server),
+				]),
+			).resolves.toEqual([true, true]);
 			expect(server.listenerCount("upgrade")).toBe(1);
 			const port = await listen(server);
 			socket = new WebSocket(


### PR DESCRIPTION
null

## Independent lifecycle correction

Final head 29c5b69b47b7ee7251e185efc2c0168be8a8d4e4 additionally suppresses attachment for skipListen servers, invalidates pending attachment when a server closes, and rechecks liveness before and after the asynchronous bridge import. This prevents a non-listening or already-closed server from poisoning the process-global bridge. Pinned focused validation: auth-boundary 13/13, bridge 7/7, capacitor typecheck, Biome, guide parity, and diff-check pass. Exact-head CI is queued; real Android/WebView evidence remains required before merge.