### PR TITLE
fix(cloud): require exp and cap token TTL in the Steward JWT verifier (wave 10)

### DIFF
--- a/packages/cloud/api/__tests__/sso-bridge.test.ts
+++ b/packages/cloud/api/__tests__/sso-bridge.test.ts
@@ -88,7 +88,9 @@ async function mintToken(
   opts: { iatOffsetSec?: number; expOffsetSec?: number } = {},
 ): Promise<string> {
   const iatOffset = opts.iatOffsetSec ?? 0;
-  const ttl = (opts.expOffsetSec ?? 3600) - iatOffset;
+  // Keep the signed issued lifetime at the production one-hour contract: the
+  // verifier caps exp-iat, so the clock shift may not inflate the TTL.
+  const ttl = opts.expOffsetSec ?? 3600;
   const realNow = Date.now();
   try {
     if (iatOffset !== 0) setSystemTime(new Date(realNow + iatOffset * 1000));
@@ -392,7 +394,9 @@ describe("code lifecycle", () => {
   });
 
   test("an expired code fails", async () => {
-    const token = await mintToken("user-expiry", { expOffsetSec: 7200 });
+    // The standard one-hour token outlives the 61s clock jump below; a longer
+    // issued lifetime would no longer verify at /mint.
+    const token = await mintToken("user-expiry");
     const { verifier, challenge } = await makeVerifierPair();
     const code = await mintCode(token, challenge);
     const realNow = Date.now();

--- a/packages/cloud/api/__tests__/steward-session-logout-marker-gate.test.ts
+++ b/packages/cloud/api/__tests__/steward-session-logout-marker-gate.test.ts
@@ -63,7 +63,9 @@ async function mintToken(
       // The gate only applies to bridge-issued tokens, so gate cases mint with
       // the same `bridged` stamp the sso-bridge exchange re-mint applies.
       { userId, expiration: 0, issuedAt: 0, bridged: opts.bridged === true },
-      3600 - iatOffsetSec,
+      // Keep the signed issued lifetime at the production one-hour contract.
+      // The clock shift exists only to order the token around the logout mark.
+      3600,
     );
     if (!minted) throw new Error("test token mint failed");
     return minted.token;

--- a/packages/cloud/api/auth/sso-bridge/route.ts
+++ b/packages/cloud/api/auth/sso-bridge/route.ts
@@ -49,6 +49,7 @@ import { ELIZA_DOMAIN_CONTRACTS } from "@elizaos/shared/elizacloud";
 import { Hono } from "hono";
 import {
   mintStewardTokenFromClaims,
+  STEWARD_ACCESS_TOKEN_TTL_SECONDS,
   type StewardVerifyEnv,
   verifyStewardTokenCached,
 } from "@/lib/auth/steward-client";
@@ -264,8 +265,15 @@ app.post("/exchange", async (c) => {
     // endpoint consults the logout marker (fail closed) ONLY for stamped
     // tokens, so ordinary logins never acquire the marker store as a hard
     // availability dependency.
-    const remainingSeconds =
-      record.tokenExpiresAt - Math.floor(Date.now() / 1000);
+    // The verifier caps the signed issued lifetime at the access-token TTL,
+    // while an original token minted on a slightly-ahead issuer clock is
+    // accepted with remaining = TTL + skew. Clamp the re-mint to the TTL so
+    // the bridge never hands out a token its own platform rejects; the clamp
+    // can only shorten the session, never extend it past the original exp.
+    const remainingSeconds = Math.min(
+      STEWARD_ACCESS_TOKEN_TTL_SECONDS,
+      record.tokenExpiresAt - Math.floor(Date.now() / 1000),
+    );
     if (remainingSeconds <= 0) {
       return c.json(errorBody("Session no longer valid", "invalid_token"), 401);
     }

--- a/packages/cloud/shared/src/lib/auth/jwt-lifetime.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-lifetime.ts
@@ -1,0 +1,53 @@
+/**
+ * Validates the bounded lifetime shared by Cloud's symmetric bearer-token verifiers.
+ * Clock tolerance applies to verifier/issuer disagreement, never to the minted lifetime.
+ */
+
+import type { JWTPayload } from "jose";
+
+export interface JwtLifetimePolicy {
+  maxTtlSeconds: number;
+  clockToleranceSeconds: number;
+  nowSeconds?: number;
+}
+
+export type JwtLifetimeResult = { valid: true } | { valid: false; reason: string };
+
+function isNumericDate(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+/** Validate required issued-at/expiry claims and their relationship. */
+export function validateJwtLifetime(
+  payload: Pick<JWTPayload, "exp" | "iat" | "nbf">,
+  policy: JwtLifetimePolicy,
+): JwtLifetimeResult {
+  const now = policy.nowSeconds ?? Math.floor(Date.now() / 1000);
+
+  if (!isNumericDate(payload.iat)) {
+    return { valid: false, reason: "iat must be a non-negative safe-integer NumericDate" };
+  }
+  if (!isNumericDate(payload.exp)) {
+    return { valid: false, reason: "exp must be a non-negative safe-integer NumericDate" };
+  }
+  if (payload.nbf !== undefined && !isNumericDate(payload.nbf)) {
+    return { valid: false, reason: "nbf must be a non-negative safe-integer NumericDate" };
+  }
+  if (payload.exp <= payload.iat) {
+    return { valid: false, reason: "exp must be later than iat" };
+  }
+  if (payload.exp - payload.iat > policy.maxTtlSeconds) {
+    return { valid: false, reason: "issued lifetime exceeds the configured maximum" };
+  }
+  if (payload.iat > now + policy.clockToleranceSeconds) {
+    return { valid: false, reason: "iat is beyond the allowed future clock tolerance" };
+  }
+  if (payload.exp <= now - policy.clockToleranceSeconds) {
+    return { valid: false, reason: "exp is outside the allowed clock tolerance" };
+  }
+  if (payload.nbf !== undefined && payload.nbf > payload.exp) {
+    return { valid: false, reason: "nbf must not be later than exp" };
+  }
+
+  return { valid: true };
+}

--- a/packages/cloud/shared/src/lib/auth/service-jwt.test.ts
+++ b/packages/cloud/shared/src/lib/auth/service-jwt.test.ts
@@ -93,11 +93,38 @@ describe("verifyServiceJwt — token lifecycle claims", () => {
     expect(await verify(token)).toBeNull();
   });
 
+  test("rejects a long-lived token presented during its final hour", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({ userId: "waifu:svc" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(now - 23 * 60 * 60)
+      .setExpirationTime(now + 60 * 60)
+      .sign(secretKey());
+    expect(await verify(token)).toBeNull();
+  });
+
+  test("rejects exp without iat and malformed NumericDate relationships", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const invalidClaims = [
+      ["missing iat", { exp: now + 60 }],
+      ["inverted", { iat: now, exp: now }],
+      ["fractional", { iat: now + 0.5, exp: now + 60 }],
+      ["future iat", { iat: now + 301, exp: now + 601 }],
+      ["nbf after exp", { iat: now, exp: now + 60, nbf: now + 61 }],
+    ] as const;
+    for (const [label, claims] of invalidClaims) {
+      const token = await new SignJWT({ userId: "waifu:svc", ...claims })
+        .setProtectedHeader({ alg: "HS256" })
+        .sign(secretKey());
+      expect(await verify(token), label).toBeNull();
+    }
+  });
+
   test("rejects an already-expired token", async () => {
     const token = await new SignJWT({ userId: "waifu:svc" })
       .setProtectedHeader({ alg: "HS256" })
-      .setIssuedAt(Math.floor(Date.now() / 1000) - 120)
-      .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 420)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 301)
       .sign(secretKey());
     expect(await verify(token)).toBeNull();
   });

--- a/packages/cloud/shared/src/lib/auth/service-jwt.ts
+++ b/packages/cloud/shared/src/lib/auth/service-jwt.ts
@@ -11,6 +11,7 @@
 import * as jose from "jose";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
+import { validateJwtLifetime } from "./jwt-lifetime";
 import { STAGING_SESSION_TOKEN_TYP } from "./staging-session-binding";
 
 export interface ServiceJwtPayload {
@@ -28,6 +29,7 @@ const AUDIENCE_ENV_KEY = "ELIZA_SERVICE_JWT_AUDIENCE";
  * call; an hour covers the mint→verify round trip with clock-skew headroom.
  */
 const MAX_SERVICE_JWT_TTL_SECONDS = 3600;
+const SERVICE_JWT_CLOCK_TOLERANCE_SECONDS = 5 * 60;
 
 let _secret: Uint8Array | null = null;
 let _secretRaw: string | null = null;
@@ -71,6 +73,7 @@ export async function verifyServiceJwt(
   try {
     const { payload, protectedHeader } = await jose.jwtVerify(token, secret, {
       algorithms: ["HS256"],
+      clockTolerance: SERVICE_JWT_CLOCK_TOLERANCE_SECONDS,
       ...(issuer ? { issuer } : {}),
       ...(audience ? { audience } : {}),
     });
@@ -89,12 +92,12 @@ export async function verifyServiceJwt(
     // one would never expire. Service tokens are short-lived S2S credentials:
     // require an expiry and cap its horizon so a leaked token's usefulness is
     // bounded.
-    if (typeof payload.exp !== "number") {
-      logger.warn("[service-jwt] Rejected token without an exp claim");
-      return null;
-    }
-    if (payload.exp * 1000 - Date.now() > MAX_SERVICE_JWT_TTL_SECONDS * 1000) {
-      logger.warn("[service-jwt] Rejected token whose TTL exceeds the service maximum");
+    const lifetime = validateJwtLifetime(payload, {
+      maxTtlSeconds: MAX_SERVICE_JWT_TTL_SECONDS,
+      clockToleranceSeconds: SERVICE_JWT_CLOCK_TOLERANCE_SECONDS,
+    });
+    if (!lifetime.valid) {
+      logger.warn(`[service-jwt] Rejected token: ${lifetime.reason}`);
       return null;
     }
 

--- a/packages/cloud/shared/src/lib/auth/steward-client.test.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-client.test.ts
@@ -7,11 +7,15 @@
  * staging-session binding module names dbRead at module scope).
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHash } from "crypto";
 import { SignJWT } from "jose";
 
 const SECRET = "steward-client-test-secret-0123456789abcdef";
 const ENV = { STEWARD_JWT_SECRET: SECRET };
+const memoryCache = new Map<string, unknown>();
+let distributedCacheValue: unknown = null;
+let tokenSequence = 0;
 
 mock.module("../../db/helpers", () => ({
   dbRead: {},
@@ -23,9 +27,26 @@ mock.module("../../db/helpers", () => ({
 
 mock.module("../cache/client", () => ({
   cache: {
-    get: async () => null,
+    get: async () => distributedCacheValue,
     set: async () => undefined,
     del: async () => undefined,
+  },
+}));
+
+mock.module("../cache/in-memory-lru-cache", () => ({
+  InMemoryLRUCache: class {
+    get(key: string) {
+      return memoryCache.get(key) ?? null;
+    }
+    set(key: string, value: unknown) {
+      memoryCache.set(key, value);
+    }
+    delete(key: string) {
+      memoryCache.delete(key);
+    }
+    clear() {
+      memoryCache.clear();
+    }
   },
 }));
 
@@ -42,9 +63,14 @@ function secretKey(): Uint8Array {
 }
 
 async function mint(claims: Record<string, unknown> = {}): Promise<string> {
-  return await new SignJWT({ sub: "steward-user-1", ...claims })
+  tokenSequence += 1;
+  return await new SignJWT({
+    sub: "steward-user-1",
+    jti: `test-${tokenSequence}`,
+    iat: Math.floor(Date.now() / 1000),
+    ...claims,
+  })
     .setProtectedHeader({ alg: "HS256", typ: "JWT" })
-    .setIssuedAt()
     .sign(secretKey());
 }
 
@@ -53,6 +79,16 @@ async function verify(token: string) {
 }
 
 describe("verifyStewardTokenCached — token lifecycle claims", () => {
+  beforeEach(() => {
+    memoryCache.clear();
+    distributedCacheValue = null;
+  });
+
+  afterEach(() => {
+    memoryCache.clear();
+    distributedCacheValue = null;
+  });
+
   test("accepts a token minted at the standard Steward access-token TTL", async () => {
     const minted = await mintStewardTokenFromClaims(ENV, {
       userId: "steward-user-standard",
@@ -82,23 +118,130 @@ describe("verifyStewardTokenCached — token lifecycle claims", () => {
     expect(await verify(token)).toBeNull();
   });
 
-  test("accepts a token just inside the issuer clock-skew allowance", async () => {
-    const expiresAt = Math.floor(Date.now() / 1000) + STEWARD_ACCESS_TOKEN_TTL_SECONDS + 240;
+  test("accepts a one-hour token whose issuer clock is just ahead", async () => {
+    const issuedAt = Math.floor(Date.now() / 1000) + 240;
     const token = await new SignJWT({ sub: "steward-user-skew" })
       .setProtectedHeader({ alg: "HS256", typ: "JWT" })
-      .setIssuedAt()
-      .setExpirationTime(expiresAt)
+      .setIssuedAt(issuedAt)
+      .setExpirationTime(issuedAt + STEWARD_ACCESS_TOKEN_TTL_SECONDS)
       .sign(secretKey());
     const claims = await verify(token);
     expect(claims?.userId).toBe("steward-user-skew");
+  });
+
+  test("rejects a 24-hour token presented during its final hour", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({ sub: "steward-user-old-longttl" })
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .setIssuedAt(now - 23 * 60 * 60)
+      .setExpirationTime(now + 60 * 60)
+      .sign(secretKey());
+    expect(await verify(token)).toBeNull();
+  });
+
+  test("rejects a token with exp but no iat", async () => {
+    const token = await new SignJWT({ sub: "steward-user-noiat" })
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .setExpirationTime("5m")
+      .sign(secretKey());
+    expect(await verify(token)).toBeNull();
+  });
+
+  test("rejects inverted, fractional, and too-far-future NumericDates", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const invalidClaims = [
+      { iat: now, exp: now },
+      { iat: now + 0.5, exp: now + 60 },
+      { iat: now, exp: now + 60.5 },
+      { iat: now + 301, exp: now + 601 },
+      { iat: now, exp: now + 60, nbf: now + 61 },
+    ];
+    for (const claims of invalidClaims) {
+      const token = await mint(claims);
+      expect(await verify(token)).toBeNull();
+    }
+  });
+
+  test("requires the ordinary Steward JWT token class and sub claim", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const wrongType = await new SignJWT({ sub: "steward-user", iat: now, exp: now + 60 })
+      .setProtectedHeader({ alg: "HS256", typ: "not-a-steward-session" })
+      .sign(secretKey());
+    const userIdOnly = await new SignJWT({ userId: "legacy-user", iat: now, exp: now + 60 })
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .sign(secretKey());
+    expect(await verify(wrongType)).toBeNull();
+    expect(await verify(userIdOnly)).toBeNull();
+  });
+
+  test("revalidates lifetime on distributed cache hits", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const signingKeyFingerprint = createHash("sha256")
+      .update(secretKey())
+      .digest("hex")
+      .substring(0, 16);
+    distributedCacheValue = {
+      userId: "cached-user",
+      tenantId: "expected-tenant",
+      issuedAt: now - 23 * 60 * 60,
+      expiration: now + 60 * 60,
+      cachedAt: Date.now(),
+      signingKeyFingerprint,
+    };
+    const token = await mint({ tenantId: "expected-tenant", exp: now + 60 });
+    expect(
+      await verifyStewardTokenCached({ ...ENV, STEWARD_TENANT_ID: "expected-tenant" }, token),
+    ).toBeNull();
+  });
+
+  test("revalidates tenant policy on distributed cache hits", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const signingKeyFingerprint = createHash("sha256")
+      .update(secretKey())
+      .digest("hex")
+      .substring(0, 16);
+    distributedCacheValue = {
+      userId: "cached-user",
+      tenantId: "wrong-tenant",
+      issuedAt: now,
+      expiration: now + 60,
+      cachedAt: Date.now(),
+      signingKeyFingerprint,
+    };
+    const token = await mint({ tenantId: "expected-tenant", exp: now + 60 });
+    expect(
+      await verifyStewardTokenCached({ ...ENV, STEWARD_TENANT_ID: "expected-tenant" }, token),
+    ).toBeNull();
+  });
+
+  test("revalidates lifecycle on an in-memory cache hit", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await mint({ iat: now, exp: now + 60 });
+    expect(await verify(token)).not.toBeNull();
+    const cached = [...memoryCache.values()][0] as { issuedAt: number; expiration: number };
+    cached.issuedAt = now - 23 * 60 * 60;
+    cached.expiration = now + 60 * 60;
+    expect(await verify(token)).toBeNull();
+  });
+
+  test("does not reuse a verification memo after signing-key rotation", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await mint({ iat: now, exp: now + 60 });
+    expect(await verify(token)).not.toBeNull();
+    expect(
+      await verifyStewardTokenCached(
+        { STEWARD_JWT_SECRET: "rotated-steward-secret-0123456789abcdef" },
+        token,
+      ),
+    ).toBeNull();
   });
 
   test("rejects an already-expired token", async () => {
     const now = Math.floor(Date.now() / 1000);
     const token = await new SignJWT({ sub: "steward-user-expired" })
       .setProtectedHeader({ alg: "HS256", typ: "JWT" })
-      .setIssuedAt(now - 120)
-      .setExpirationTime(now - 60)
+      .setIssuedAt(now - 420)
+      .setExpirationTime(now - 301)
       .sign(secretKey());
     expect(await verify(token)).toBeNull();
   });

--- a/packages/cloud/shared/src/lib/auth/steward-client.test.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-client.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Steward JWT lifecycle claims: a token under the shared HS256 secret must
+ * carry an `exp` (jose only enforces it when present, so a no-exp token would
+ * never expire) whose horizon stays within the Steward access-token TTL plus
+ * the issuer clock-skew allowance. Real jose verification through
+ * `verifyStewardTokenCached`; Redis cache, db helpers, and logger mocked (the
+ * staging-session binding module names dbRead at module scope).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { SignJWT } from "jose";
+
+const SECRET = "steward-client-test-secret-0123456789abcdef";
+const ENV = { STEWARD_JWT_SECRET: SECRET };
+
+mock.module("../../db/helpers", () => ({
+  dbRead: {},
+  dbWrite: {},
+  writeTransaction: async () => {
+    throw new Error("transaction is outside this steward-client test path");
+  },
+}));
+
+mock.module("../cache/client", () => ({
+  cache: {
+    get: async () => null,
+    set: async () => undefined,
+    del: async () => undefined,
+  },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} },
+  redact: { id: (v: string) => v, orgId: (v: string) => v, userId: (v: string) => v },
+}));
+
+const { mintStewardTokenFromClaims, STEWARD_ACCESS_TOKEN_TTL_SECONDS, verifyStewardTokenCached } =
+  await import("./steward-client");
+
+function secretKey(): Uint8Array {
+  return new TextEncoder().encode(SECRET);
+}
+
+async function mint(claims: Record<string, unknown> = {}): Promise<string> {
+  return await new SignJWT({ sub: "steward-user-1", ...claims })
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setIssuedAt()
+    .sign(secretKey());
+}
+
+async function verify(token: string) {
+  return await verifyStewardTokenCached(ENV, token);
+}
+
+describe("verifyStewardTokenCached — token lifecycle claims", () => {
+  test("accepts a token minted at the standard Steward access-token TTL", async () => {
+    const minted = await mintStewardTokenFromClaims(ENV, {
+      userId: "steward-user-standard",
+      expiration: 0,
+      issuedAt: 0,
+    });
+    expect(minted).not.toBeNull();
+    if (!minted) return;
+    expect(minted.expiresIn).toBe(STEWARD_ACCESS_TOKEN_TTL_SECONDS);
+
+    const claims = await verify(minted.token);
+    expect(claims?.userId).toBe("steward-user-standard");
+    expect(claims?.expiration).toBe(minted.expiresAt);
+  });
+
+  test("rejects a token with no exp claim (would never expire)", async () => {
+    const token = await mint({ sub: "steward-user-noexp" });
+    expect(await verify(token)).toBeNull();
+  });
+
+  test("rejects a token whose TTL exceeds the Steward maximum", async () => {
+    const token = await new SignJWT({ sub: "steward-user-longttl" })
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .setIssuedAt()
+      .setExpirationTime("24h")
+      .sign(secretKey());
+    expect(await verify(token)).toBeNull();
+  });
+
+  test("accepts a token just inside the issuer clock-skew allowance", async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + STEWARD_ACCESS_TOKEN_TTL_SECONDS + 240;
+    const token = await new SignJWT({ sub: "steward-user-skew" })
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .setIssuedAt()
+      .setExpirationTime(expiresAt)
+      .sign(secretKey());
+    const claims = await verify(token);
+    expect(claims?.userId).toBe("steward-user-skew");
+  });
+
+  test("rejects an already-expired token", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({ sub: "steward-user-expired" })
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .setIssuedAt(now - 120)
+      .setExpirationTime(now - 60)
+      .sign(secretKey());
+    expect(await verify(token)).toBeNull();
+  });
+
+  test("rejects a token signed with a different secret", async () => {
+    const token = await new SignJWT({ sub: "steward-user-wrongkey" })
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .setIssuedAt()
+      .setExpirationTime("1h")
+      .sign(new TextEncoder().encode("attacker-controlled-secret"));
+    expect(await verify(token)).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/auth/steward-client.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-client.ts
@@ -22,6 +22,7 @@ import { cache } from "../cache/client";
 import { InMemoryLRUCache } from "../cache/in-memory-lru-cache";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
+import { validateJwtLifetime } from "./jwt-lifetime";
 import {
   readStagingSessionSigningConfig,
   STAGING_SESSION_EXCHANGE_VERSION,
@@ -77,6 +78,8 @@ export interface StewardTokenClaims {
   expiration: number;
   /** Token issued-at (unix timestamp) */
   issuedAt: number;
+  /** Token not-before time, when the issuer supplied one. */
+  notBefore?: number;
 }
 
 /**
@@ -93,7 +96,10 @@ interface CachedStewardClaims {
   stagingSessionBinding?: StagingSessionBinding;
   expiration: number;
   issuedAt: number;
+  notBefore?: number;
   cachedAt: number;
+  /** Binds a memo to the signing key so rotation invalidates old verification results. */
+  signingKeyFingerprint: string;
 }
 
 /**
@@ -134,13 +140,10 @@ export const STEWARD_ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
 const STEWARD_VERIFY_CLOCK_SKEW_SECONDS = 5 * 60;
 
 /**
- * Maximum remaining lifetime a presented Steward token may claim. jose
- * enforces `exp` only when the claim exists, so a token minted without one
- * would never expire; requiring the claim and capping its horizon bounds a
- * leaked token's usefulness. Mirrors the service-jwt verifier.
+ * Maximum issued lifetime a presented Steward token may claim. Clock skew is
+ * handled separately and cannot lengthen this interval.
  */
-const MAX_STEWARD_TOKEN_TTL_SECONDS =
-  STEWARD_ACCESS_TOKEN_TTL_SECONDS + STEWARD_VERIFY_CLOCK_SKEW_SECONDS;
+const MAX_STEWARD_TOKEN_TTL_SECONDS = STEWARD_ACCESS_TOKEN_TTL_SECONDS;
 
 // Cache the encoded secret keyed by raw value, so repeated requests with the
 // same secret skip the TextEncoder allocation. Bounded at one entry — secrets
@@ -294,12 +297,16 @@ function hashToken(token: string): string {
   return createHash("sha256").update(token).digest("hex").substring(0, 32);
 }
 
+function fingerprintSigningKey(secret: Uint8Array): string {
+  return createHash("sha256").update(secret).digest("hex").substring(0, 16);
+}
+
 /**
  * In-memory LRU cache for Steward token verification (30s TTL, max 200).
  * Eliminates Redis round-trip for repeated requests within the same
  * serverless function instance.
  */
-const IN_MEMORY_STEWARD_CACHE = new InMemoryLRUCache<StewardTokenClaims>(200, 30_000);
+const IN_MEMORY_STEWARD_CACHE = new InMemoryLRUCache<CachedStewardClaims>(200, 30_000);
 
 /**
  * Extract StewardTokenClaims from a raw jose JWTPayload.
@@ -354,6 +361,7 @@ function extractClaims(payload: JWTPayload): StewardTokenClaims {
     ...(stagingSessionBinding ? { stagingSessionBinding } : {}),
     expiration: payload.exp ?? 0,
     issuedAt: payload.iat ?? 0,
+    ...(payload.nbf !== undefined ? { notBefore: payload.nbf } : {}),
   };
 }
 
@@ -376,6 +384,49 @@ function claimsMatchTokenClass(header: StagingTokenHeader, claims: StewardTokenC
   return header.isCandidate === Boolean(claims.stagingSessionBinding);
 }
 
+function claimsMatchTenant(env: StewardVerifyEnv, claims: StewardTokenClaims): boolean {
+  if (claims.tenantId !== undefined && typeof claims.tenantId !== "string") return false;
+  const expectedTenant = env.STEWARD_TENANT_ID;
+  return !(
+    expectedTenant &&
+    claims.tenantId &&
+    claims.tenantId !== expectedTenant &&
+    claims.tenantId !== `personal-${claims.userId}`
+  );
+}
+
+function validateStewardLifetime(claims: StewardTokenClaims): boolean {
+  const result = validateJwtLifetime(
+    { exp: claims.expiration, iat: claims.issuedAt, nbf: claims.notBefore },
+    {
+      maxTtlSeconds: MAX_STEWARD_TOKEN_TTL_SECONDS,
+      clockToleranceSeconds: STEWARD_VERIFY_CLOCK_SKEW_SECONDS,
+    },
+  );
+  if (!result.valid) {
+    logger.warn(`[StewardClient] Rejected token: ${result.reason}`);
+  }
+  return result.valid;
+}
+
+async function validateStewardClaims(
+  env: StewardVerifyEnv,
+  header: StagingTokenHeader,
+  claims: StewardTokenClaims,
+  tokenHash: string,
+): Promise<boolean> {
+  if (!validateStewardLifetime(claims)) return false;
+  if (!claims.userId || !claimsMatchTokenClass(header, claims)) return false;
+  if (!(await validateOptionalStagingBinding(env, claims))) return false;
+  if (!claimsMatchTenant(env, claims)) {
+    logger.debug("[StewardClient] Token tenant not permitted for this deployment", {
+      tokenHash: tokenHash.substring(0, 8),
+    });
+    return false;
+  }
+  return true;
+}
+
 async function verifyStewardTokenWithoutCaches(input: {
   env: StewardVerifyEnv;
   token: string;
@@ -383,23 +434,23 @@ async function verifyStewardTokenWithoutCaches(input: {
   stagingHeader: StagingTokenHeader;
   tokenHash: string;
 }): Promise<StewardTokenClaims | null> {
-  const { payload } = await jwtVerify(input.token, input.secret, {
+  const { payload, protectedHeader } = await jwtVerify(input.token, input.secret, {
     algorithms: ["HS256"],
+    clockTolerance: STEWARD_VERIFY_CLOCK_SKEW_SECONDS,
   });
 
-  if (typeof payload.exp !== "number") {
-    logger.warn("[StewardClient] Rejected token without an exp claim");
-    return null;
-  }
-  if (payload.exp * 1000 - Date.now() > MAX_STEWARD_TOKEN_TTL_SECONDS * 1000) {
-    logger.warn("[StewardClient] Rejected token whose TTL exceeds the Steward maximum");
+  if (
+    (input.stagingHeader.isCandidate && protectedHeader.typ !== STAGING_SESSION_TOKEN_TYP) ||
+    (!input.stagingHeader.isCandidate && protectedHeader.typ !== "JWT")
+  ) {
+    logger.warn("[StewardClient] Rejected token with an invalid typ header");
     return null;
   }
 
   const claims = extractClaims(payload);
 
-  if (!claims.userId) {
-    logger.warn("[StewardClient] JWT valid but missing userId/sub claim");
+  if (typeof payload.sub !== "string" || payload.sub.length === 0) {
+    logger.warn("[StewardClient] JWT valid but missing sub claim");
     return null;
   }
 
@@ -407,32 +458,9 @@ async function verifyStewardTokenWithoutCaches(input: {
   // a token selecting that path must carry the binding. This prevents a
   // normal Steward signer from manufacturing an un-revalidated QA claim or
   // a dedicated token from degrading into an ordinary session.
-  if (!claimsMatchTokenClass(input.stagingHeader, claims)) {
-    logger.debug("[StewardClient] Token class and claims do not match");
-    return null;
-  }
-
-  if (!(await validateOptionalStagingBinding(input.env, claims))) {
-    logger.debug("[StewardClient] Staging session source binding is no longer valid");
-    return null;
-  }
-
-  // Steward issues per-user personal tenants scoped inside the org tenant.
-  // Apply tenant scope before any caller can use or cache the claims.
-  const expectedTenant = input.env.STEWARD_TENANT_ID;
-  if (
-    expectedTenant &&
-    claims.tenantId &&
-    claims.tenantId !== expectedTenant &&
-    claims.tenantId !== `personal-${claims.userId}`
-  ) {
-    logger.debug("[StewardClient] Token tenant not permitted for this deployment", {
-      tokenHash: input.tokenHash.substring(0, 8),
-    });
-    return null;
-  }
-
-  return claims;
+  return (await validateStewardClaims(input.env, input.stagingHeader, claims, input.tokenHash))
+    ? claims
+    : null;
 }
 
 /**
@@ -459,6 +487,7 @@ export async function verifyStewardTokenCached(
   if (!secret) return null;
 
   const tokenHash = hashToken(token);
+  const signingKeyFingerprint = fingerprintSigningKey(secret);
   const now = Math.floor(Date.now() / 1000);
   const startTime = Date.now();
 
@@ -484,13 +513,23 @@ export async function verifyStewardTokenCached(
 
     // 0. Check in-memory cache first
     const inMemoryCached = IN_MEMORY_STEWARD_CACHE.get(tokenHash);
-    if (inMemoryCached && inMemoryCached.expiration > now) {
+    if (inMemoryCached) {
       logger.debug("[StewardClient] ✓ In-memory cache hit", {
         tokenHash: tokenHash.substring(0, 8),
         durationMs: Date.now() - startTime,
       });
-      if (!claimsMatchTokenClass(stagingHeader, inMemoryCached)) return null;
-      return (await validateOptionalStagingBinding(env, inMemoryCached)) ? inMemoryCached : null;
+      if (inMemoryCached.signingKeyFingerprint !== signingKeyFingerprint) {
+        IN_MEMORY_STEWARD_CACHE.delete(tokenHash);
+      } else {
+        const {
+          cachedAt: _cachedAt,
+          signingKeyFingerprint: _fingerprint,
+          ...claims
+        } = inMemoryCached;
+        if (await validateStewardClaims(env, stagingHeader, claims, tokenHash)) return claims;
+        IN_MEMORY_STEWARD_CACHE.delete(tokenHash);
+        return null;
+      }
     }
 
     // 1. Check the distributed memo unless the caller deliberately prefers
@@ -498,38 +537,48 @@ export async function verifyStewardTokenCached(
     const cached = options.skipDistributedCache
       ? null
       : await cache.get<CachedStewardClaims>(cacheKey);
-    if (cached && cached.expiration > now) {
+    if (cached) {
+      if (
+        typeof cached.userId !== "string" ||
+        typeof cached.expiration !== "number" ||
+        typeof cached.issuedAt !== "number" ||
+        typeof cached.signingKeyFingerprint !== "string"
+      ) {
+        await cache.del(cacheKey);
+        return null;
+      }
       logger.debug("[StewardClient] ✓ Redis cache hit", {
         tokenHash: tokenHash.substring(0, 8),
         userId: cached.userId.substring(0, 20),
         durationMs: Date.now() - startTime,
       });
 
-      const claims: StewardTokenClaims = {
-        userId: cached.userId,
-        email: cached.email,
-        address: cached.address,
-        walletAddress: cached.walletAddress,
-        walletChain: cached.walletChain,
-        tenantId: cached.tenantId,
-        ...(cached.bridged === true ? { bridged: true } : {}),
-        ...(cached.stagingSessionBinding
-          ? { stagingSessionBinding: cached.stagingSessionBinding }
-          : {}),
-        expiration: cached.expiration,
-        issuedAt: cached.issuedAt,
-      };
+      if (cached.signingKeyFingerprint !== signingKeyFingerprint) {
+        await cache.del(cacheKey);
+      } else {
+        const claims: StewardTokenClaims = {
+          userId: cached.userId,
+          email: cached.email,
+          address: cached.address,
+          walletAddress: cached.walletAddress,
+          walletChain: cached.walletChain,
+          tenantId: cached.tenantId,
+          ...(cached.bridged === true ? { bridged: true } : {}),
+          ...(cached.stagingSessionBinding
+            ? { stagingSessionBinding: cached.stagingSessionBinding }
+            : {}),
+          expiration: cached.expiration,
+          issuedAt: cached.issuedAt,
+          ...(cached.notBefore !== undefined ? { notBefore: cached.notBefore } : {}),
+        };
 
-      // Populate in-memory cache from Redis hit
-      if (!claimsMatchTokenClass(stagingHeader, claims)) return null;
-      if (!(await validateOptionalStagingBinding(env, claims))) return null;
-      IN_MEMORY_STEWARD_CACHE.set(tokenHash, claims);
-      return claims;
-    }
-
-    if (cached) {
-      // Removes expired cache entries
-      await cache.del(cacheKey);
+        if (!(await validateStewardClaims(env, stagingHeader, claims, tokenHash))) {
+          await cache.del(cacheKey);
+          return null;
+        }
+        IN_MEMORY_STEWARD_CACHE.set(tokenHash, cached);
+        return claims;
+      }
     }
 
     // 2. Cache miss: verify JWT with jose
@@ -554,6 +603,7 @@ export async function verifyStewardTokenCached(
       const cachedClaims: CachedStewardClaims = {
         ...claims,
         cachedAt: Date.now(),
+        signingKeyFingerprint,
       };
 
       const cacheWrite = cache.set(cacheKey, cachedClaims, effectiveTtl).catch((error) => {
@@ -579,7 +629,11 @@ export async function verifyStewardTokenCached(
     }
 
     // Also cache in-memory
-    IN_MEMORY_STEWARD_CACHE.set(tokenHash, claims);
+    IN_MEMORY_STEWARD_CACHE.set(tokenHash, {
+      ...claims,
+      cachedAt: Date.now(),
+      signingKeyFingerprint,
+    });
 
     return claims;
   } catch (error) {

--- a/packages/cloud/shared/src/lib/auth/steward-client.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-client.ts
@@ -124,6 +124,24 @@ export interface StewardVerifyOptions {
 
 export const STEWARD_ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
 
+/**
+ * Clock-skew allowance between the Steward issuer and this verifier. Steward
+ * mints access tokens at exactly STEWARD_ACCESS_TOKEN_TTL_SECONDS, so the
+ * acceptance ceiling below adds a small margin — a freshly minted token read
+ * against a slightly-ahead issuer clock must not be rejected, while a token
+ * claiming a materially longer lifetime still fails closed.
+ */
+const STEWARD_VERIFY_CLOCK_SKEW_SECONDS = 5 * 60;
+
+/**
+ * Maximum remaining lifetime a presented Steward token may claim. jose
+ * enforces `exp` only when the claim exists, so a token minted without one
+ * would never expire; requiring the claim and capping its horizon bounds a
+ * leaked token's usefulness. Mirrors the service-jwt verifier.
+ */
+const MAX_STEWARD_TOKEN_TTL_SECONDS =
+  STEWARD_ACCESS_TOKEN_TTL_SECONDS + STEWARD_VERIFY_CLOCK_SKEW_SECONDS;
+
 // Cache the encoded secret keyed by raw value, so repeated requests with the
 // same secret skip the TextEncoder allocation. Bounded at one entry — secrets
 // don't rotate on every request, and a stale entry just costs one re-encode.
@@ -368,6 +386,16 @@ async function verifyStewardTokenWithoutCaches(input: {
   const { payload } = await jwtVerify(input.token, input.secret, {
     algorithms: ["HS256"],
   });
+
+  if (typeof payload.exp !== "number") {
+    logger.warn("[StewardClient] Rejected token without an exp claim");
+    return null;
+  }
+  if (payload.exp * 1000 - Date.now() > MAX_STEWARD_TOKEN_TTL_SECONDS * 1000) {
+    logger.warn("[StewardClient] Rejected token whose TTL exceeds the Steward maximum");
+    return null;
+  }
+
   const claims = extractClaims(payload);
 
   if (!claims.userId) {

--- a/packages/docs/apps/dashboard.md
+++ b/packages/docs/apps/dashboard.md
@@ -174,7 +174,7 @@ The `PermissionsSection` component manages system permission grants for native p
 
 #### 9. Agent Export / Import
 
-- **Export** -- opens a modal that estimates export size (memories, entities, rooms, worlds, tasks), requires an encryption password (minimum 4 characters), and optionally includes logs. Downloads as a single encrypted file.
+- **Export** -- opens a modal that estimates export size (memories, entities, rooms, worlds, tasks), requires an encryption password (minimum 12 characters), and optionally includes logs. Downloads as a single encrypted file.
 - **Import** -- opens a modal to select an `.eliza-agent` file and enter the decryption password used during export.
 
 <Warning>

--- a/packages/elizaos/src/cli.ts
+++ b/packages/elizaos/src/cli.ts
@@ -115,7 +115,7 @@ program
   .requiredOption("--from <home>", "OpenClaw agent home, e.g. ~/.moltbot")
   .requiredOption("--agent-id <slug>", "Agent slug, e.g. sol")
   .option("--out <file>", "Write an encrypted .eliza-agent archive")
-  .option("--password <pw>", "Archive encryption password (min 8 chars)")
+  .option("--password <pw>", "Archive encryption password (min 12 chars)")
   .option(
     "--memory-days <n>",
     "Days of daily logs to seed verbatim (default 14)",

--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -17,6 +17,7 @@ import {
   archiveFromPlan,
   buildMigrationPlan,
   emitSovereignArtifacts,
+  MIN_PASSWORD_LENGTH,
   type MigratePlan,
 } from "../migrate/index.js";
 
@@ -160,9 +161,9 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
   // ---- portable encrypted archive ----
   if (opts.out) {
     const password = opts.password?.trim();
-    if (!password || password.length < 8) {
+    if (!password || password.length < MIN_PASSWORD_LENGTH) {
       fail(
-        "--password (min 8 chars) is required to write an encrypted --out archive.",
+        `--password (min ${MIN_PASSWORD_LENGTH} chars) is required to write an encrypted --out archive.`,
       );
     }
     const archivePassword = password;

--- a/packages/elizaos/src/migrate/archive-format.ts
+++ b/packages/elizaos/src/migrate/archive-format.ts
@@ -26,7 +26,7 @@ const PBKDF2_ITERATIONS = 600_000; // OWASP 2024 recommendation for SHA-256
 const SALT_LEN = 32;
 const IV_LEN = 12; // AES-256-GCM standard nonce
 const KEY_LEN = 32; // AES-256
-const MIN_PASSWORD_LENGTH = 12;
+export const MIN_PASSWORD_LENGTH = 12;
 
 function deriveKey(password: string, salt: Buffer, iterations: number): Buffer {
   return crypto.pbkdf2Sync(password, salt, iterations, KEY_LEN, "sha256");

--- a/packages/elizaos/src/migrate/index.ts
+++ b/packages/elizaos/src/migrate/index.ts
@@ -152,6 +152,7 @@ export function emitSovereignArtifacts(plan: MigratePlan): {
 }
 
 // Re-export the building blocks for direct use + testing.
+export { MIN_PASSWORD_LENGTH } from "./archive-format.js";
 export { assemblePayload } from "./archive-writer.js";
 export { mapToCharacter } from "./character-mapper.js";
 export { tierMemories } from "./memory-tiering.js";


### PR DESCRIPTION
# Relates to

Wave-10 security remediation, group **w10-crypto-docs**. This remains draft until exact-head CI and independent review complete.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `moonshot-ai/kimi-k3`, `OpenAI Codex`
<!-- attribution-row:client -->
- Agent tooling: `kimi-code`, `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

- Steward and service JWT verification now require finite integer `iat` and `exp`, reject inverted/expired claims, bound future issuance skew, and enforce the **issued** lifetime (`exp - iat`) rather than the remaining horizon.
- Steward in-memory and Redis cache hits are revalidated for lifecycle and tenant policy. Cache keys are bound to a signing-key fingerprint, preventing reuse after rotation.
- Ordinary Steward tokens require the in-repo `typ=JWT` class. Issuer/audience are not newly pinned because the external Steward issuer contract is not versioned in this repository; that requires a coordinated rollout.
- The archive-password CLI and documentation use the canonical 12-character minimum.
- A stale logout-marker fixture now moves `iat` without accidentally minting a 3,610-second token.

This closes the original remaining-horizon bypass: a 24-hour token presented in its final hour is rejected, a token without `iat` is rejected, and pre-deploy overlong cached claims are evicted and reverified.

# Validation

Exact head: `08cc8fc32e2a9472dccb3fa41e7fb44a981a4a92`, rebased on `origin/develop@82393875cc8467a4d6449cb759674986c366e4e6`.

- Pinned Bun `1.3.14`, Node `24.15.0`.
- Cloud Shared auth directory: **100 pass, 1 live-only skip**.
- Four Steward Cloud API flows: **68/68 pass** after the fixture correction.
- Focused service/Steward lifecycle suite re-run after the final rebase: **23/23 pass**.
- `packages/cloud/shared` typecheck: pass on the prior identical correction tree; final root verify reached the current-develop Cloud API baseline failures described below with no changed-file diagnostic.
- Cloud Shared and Cloud API package-wide Biome: pass; final changed-file Biome: **10/10**; `git diff --check`: pass.
- `packages/elizaos`: typecheck pass; **127 pass, 1 skip**.
- docs: **27/27 pass**.
- `bun run verify` reached **208/210 Turbo tasks**, then stopped only on unchanged current-develop Cloud API test typing defects (migration-journal readonly tuple, invalid backup `pending` state, and two `never.every`/implicit-any pairs). None is in this diff.

# Risks

Fail-closed authentication hardening. Any upstream Steward token that omits `iat`, exceeds the documented one-hour issued lifetime, or uses a non-`JWT` ordinary token type now requires reauthentication. Every observed in-repo remint emits the required class and one-hour lifetime.

# Evidence Gate

<!-- evidence-head:08cc8fc32e2a9472dccb3fa41e7fb44a981a4a92 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend JWT validation, CLI text, and documentation only; no rendered UI changed.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered UI changed.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - deterministic cryptographic and cache-path tests are the relevant behavioral evidence.`
<!-- evidence-row:backend-logs -->
- [x] Exact-head transcripts: 23 focused real-jose lifecycle tests pass; the prior full auth lane passed 100 tests with one live-only skip; the four Cloud API Steward flows passed 68/68.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model, prompt, action, or provider behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Cryptographic artifacts are exercised with real signed JWTs, cache-hit/rotation fixtures, expiry boundaries, and route-level session tests; no persistent domain row is produced.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no visual surface changed.`

# Known baseline

Root verify is not claimed green: current `develop` contains unrelated Cloud API test type errors. Exact-head CI is being dispatched and this PR must not merge until its result is classified and an independent reviewer approves it.