### PR TITLE
fix(security): close wave-10 logger redaction gaps

### DIFF
--- a/packages/agent/src/config/sensitive-keys.test.ts
+++ b/packages/agent/src/config/sensitive-keys.test.ts
@@ -197,9 +197,9 @@ describe("passwd/passphrase credential names (W5-027)", () => {
 /**
  * W10: concatenated all-caps `*KEY` names (MASTERKEY/SIGNINGKEY/SSHKEY/
  * ENCRYPTIONKEY) have no separator for the boundary rules and no lowercase
- * predecessor for the camelCase rule, and bare `AUTH` is itself a credential
- * name. Both are covered by closed rules so key-suffix and auth-prefix
- * lookalikes stay non-sensitive.
+ * predecessor for the camelCase rule. An exact uppercase `AUTH` environment
+ * key is a credential, while canonical lowercase auth containers and mode
+ * discriminators must remain visible.
  */
 describe("concatenated KEY names and bare AUTH (W10)", () => {
   it("classifies concatenated all-caps *KEY names as sensitive", () => {
@@ -215,10 +215,11 @@ describe("concatenated KEY names and bare AUTH (W10)", () => {
     }
   });
 
-  it("classifies bare AUTH as sensitive without touching auth lookalikes", () => {
+  it("classifies uppercase AUTH without erasing structural lowercase auth", () => {
     expect(isSensitiveConfigKey("AUTH")).toBe(true);
-    expect(isSensitiveConfigKey("auth")).toBe(true);
-    expect(isSensitiveConfigKey("service.auth")).toBe(true);
+    expect(isSensitiveConfigKey("service.AUTH")).toBe(true);
+    expect(isSensitiveConfigKey("auth")).toBe(false);
+    expect(isSensitiveConfigKey("service.auth")).toBe(false);
     for (const key of ["OAUTH", "oauth", "author", "AUTHORITY"]) {
       expect(isSensitiveConfigKey(key), key).toBe(false);
     }
@@ -233,5 +234,57 @@ describe("concatenated KEY names and bare AUTH (W10)", () => {
     }) as { env: Record<string, unknown> };
     expect(redacted.env.MASTERKEY).toBe("[REDACTED]");
     expect(redacted.env.LOG_LEVEL).toBe("info");
+  });
+
+  it("preserves canonical auth metadata while redacting credential children", () => {
+    expect(
+      redactConfigSecrets({
+        auth: {
+          profiles: {
+            work: {
+              provider: "openai",
+              mode: "oauth",
+              email: "a@example.test",
+            },
+          },
+          order: ["work"],
+        },
+        gateway: {
+          auth: {
+            mode: "token",
+            token: "gateway-token-secret",
+            password: "gateway-password-secret",
+            allowTailscale: true,
+          },
+        },
+        models: {
+          providers: {
+            local: { auth: "api-key", apiKey: "provider-secret" },
+          },
+        },
+        env: { AUTH: "legacy-auth-secret" },
+      }),
+    ).toEqual({
+      auth: {
+        profiles: {
+          work: { provider: "openai", mode: "oauth", email: "a@example.test" },
+        },
+        order: ["work"],
+      },
+      gateway: {
+        auth: {
+          mode: "token",
+          token: "[REDACTED]",
+          password: "[REDACTED]",
+          allowTailscale: true,
+        },
+      },
+      models: {
+        providers: {
+          local: { auth: "api-key", apiKey: "[REDACTED]" },
+        },
+      },
+      env: { AUTH: "[REDACTED]" },
+    });
   });
 });

--- a/packages/agent/src/config/sensitive-keys.test.ts
+++ b/packages/agent/src/config/sensitive-keys.test.ts
@@ -193,3 +193,45 @@ describe("passwd/passphrase credential names (W5-027)", () => {
     expect(redacted.env.LOG_LEVEL).toBe("info");
   });
 });
+
+/**
+ * W10: concatenated all-caps `*KEY` names (MASTERKEY/SIGNINGKEY/SSHKEY/
+ * ENCRYPTIONKEY) have no separator for the boundary rules and no lowercase
+ * predecessor for the camelCase rule, and bare `AUTH` is itself a credential
+ * name. Both are covered by closed rules so key-suffix and auth-prefix
+ * lookalikes stay non-sensitive.
+ */
+describe("concatenated KEY names and bare AUTH (W10)", () => {
+  it("classifies concatenated all-caps *KEY names as sensitive", () => {
+    for (const key of [
+      "MASTERKEY",
+      "SIGNINGKEY",
+      "SSHKEY",
+      "ENCRYPTIONKEY",
+      "masterkey",
+      "wallet.SIGNINGKEY",
+    ]) {
+      expect(isSensitiveConfigKey(key), key).toBe(true);
+    }
+  });
+
+  it("classifies bare AUTH as sensitive without touching auth lookalikes", () => {
+    expect(isSensitiveConfigKey("AUTH")).toBe(true);
+    expect(isSensitiveConfigKey("auth")).toBe(true);
+    expect(isSensitiveConfigKey("service.auth")).toBe(true);
+    for (const key of ["OAUTH", "oauth", "author", "AUTHORITY"]) {
+      expect(isSensitiveConfigKey(key), key).toBe(false);
+    }
+  });
+
+  it("redacts a stored MASTERKEY through GET /api/config", () => {
+    const redacted = redactConfigSecrets({
+      env: {
+        MASTERKEY: "concatenated-master-secret",
+        LOG_LEVEL: "info",
+      },
+    }) as { env: Record<string, unknown> };
+    expect(redacted.env.MASTERKEY).toBe("[REDACTED]");
+    expect(redacted.env.LOG_LEVEL).toBe("info");
+  });
+});

--- a/packages/agent/src/config/sensitive-keys.ts
+++ b/packages/agent/src/config/sensitive-keys.ts
@@ -23,8 +23,11 @@ const SENSITIVE_CAMEL_KEY_RE =
  * ENCRYPTIONKEY) have no word boundary for the rules above, and the camelCase
  * rule requires a lowercase predecessor — so a closed suffix set on the
  * normalized name catches them without opening `key$` to lookalikes
- * (`monkey`, `turnkey`, `KEYBOARD`). Bare `auth` is matched exactly: looser
- * forms would fold `oauth`/`author` into the credential set.
+ * (`monkey`, `turnkey`, `KEYBOARD`). Lowercase `auth` is deliberately not a
+ * generic secret key: the canonical config uses it for profile containers and
+ * provider mode discriminators. An exact SCREAMING_SNAKE `AUTH` environment
+ * key remains classified, while credential children inside structural auth
+ * containers are redacted individually.
  */
 const SENSITIVE_CONCAT_KEY_RE = /(?:master|signing|ssh|encryption)key$/i;
 
@@ -36,6 +39,6 @@ export function isSensitiveConfigKey(key: string): boolean {
     SENSITIVE_CONFIG_KEY_RE.test(key) ||
     SENSITIVE_CAMEL_KEY_RE.test(lastSegment) ||
     SENSITIVE_CONCAT_KEY_RE.test(normalized) ||
-    normalized === "auth"
+    lastSegment === "AUTH"
   );
 }

--- a/packages/agent/src/config/sensitive-keys.ts
+++ b/packages/agent/src/config/sensitive-keys.ts
@@ -18,12 +18,24 @@ const SENSITIVE_CONFIG_KEY_RE =
 const SENSITIVE_CAMEL_KEY_RE =
   /[a-z](?:Key|Url|Uri|Jwt|Bearer|Cookie|Mnemonic|Webhook)$/;
 
+/**
+ * Separator-free concatenated `*KEY` names (MASTERKEY, SIGNINGKEY, SSHKEY,
+ * ENCRYPTIONKEY) have no word boundary for the rules above, and the camelCase
+ * rule requires a lowercase predecessor — so a closed suffix set on the
+ * normalized name catches them without opening `key$` to lookalikes
+ * (`monkey`, `turnkey`, `KEYBOARD`). Bare `auth` is matched exactly: looser
+ * forms would fold `oauth`/`author` into the credential set.
+ */
+const SENSITIVE_CONCAT_KEY_RE = /(?:master|signing|ssh|encryption)key$/i;
+
 export function isSensitiveConfigKey(key: string): boolean {
   const lastSegment = key.split(".").at(-1) ?? key;
   const normalized = lastSegment.replace(/[-_\s]/g, "").toLowerCase();
   if (/^maxtokens?$/.test(normalized)) return false;
   return (
     SENSITIVE_CONFIG_KEY_RE.test(key) ||
-    SENSITIVE_CAMEL_KEY_RE.test(lastSegment)
+    SENSITIVE_CAMEL_KEY_RE.test(lastSegment) ||
+    SENSITIVE_CONCAT_KEY_RE.test(normalized) ||
+    normalized === "auth"
   );
 }

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -58,10 +58,15 @@ describe("redactSensitiveText (pattern detection)", () => {
 		// matching does not bridge the underscore.
 		for (const [key, value] of [
 			["clientSecret", "client-secret-value-123"],
+			["client_secret", "client-snake-secret-value-123"],
 			["sessionKey", "session-secret-value-123"],
+			["session_key", "session-snake-secret-value-123"],
 			["authToken", "auth-secret-value-123"],
+			["auth_token", "auth-snake-secret-value-123"],
 			["botToken", "bot-secret-value-123"],
+			["bot_token", "bot-snake-secret-value-123"],
 			["connectionString", "Server=db;Pwd=hunter2w10"],
+			["connection_string", "Server=db;Pwd=hunter2snake"],
 			["access_token", "access-secret-value-123"],
 			["refresh_token", "refresh-secret-value-123"],
 			["webhookUrl", "https://discord.test/api/webhooks/9/hook-secret-a"],
@@ -75,7 +80,8 @@ describe("redactSensitiveText (pattern detection)", () => {
 	it("does not mask plural or lookalike JSON keys", () => {
 		// The closing quote after the alternation is the boundary: a pluralized
 		// or merely similar key must not fold into the credential set.
-		const benign = '{"sessionKeys":"ab-cd","monkey":"see","authored":"by-me"}';
+		const benign =
+			'{"sessionKeys":"ab-cd","session_keys":"ef-gh","monkey":"see","authored":"by-me","connection_strings":"docs"}';
 		expect(redactSensitiveText(benign)).toBe(benign);
 	});
 

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -52,6 +52,33 @@ describe("redactSensitiveText (pattern detection)", () => {
 		);
 	});
 
+	it("masks the common JSON credential spellings (W10 pattern-library sync)", () => {
+		// Both implementations compile this same JSON-fields alternation; the
+		// snake_case forms are separate alternatives because case-insensitive
+		// matching does not bridge the underscore.
+		for (const [key, value] of [
+			["clientSecret", "client-secret-value-123"],
+			["sessionKey", "session-secret-value-123"],
+			["authToken", "auth-secret-value-123"],
+			["botToken", "bot-secret-value-123"],
+			["connectionString", "Server=db;Pwd=hunter2w10"],
+			["access_token", "access-secret-value-123"],
+			["refresh_token", "refresh-secret-value-123"],
+			["webhookUrl", "https://discord.test/api/webhooks/9/hook-secret-a"],
+			["webhook_url", "https://discord.test/api/webhooks/9/hook-secret-b"],
+		]) {
+			const out = redactSensitiveText(`{"${key}":"${value}"}`);
+			expect(out, key).not.toContain(value);
+		}
+	});
+
+	it("does not mask plural or lookalike JSON keys", () => {
+		// The closing quote after the alternation is the boundary: a pluralized
+		// or merely similar key must not fold into the credential set.
+		const benign = '{"sessionKeys":"ab-cd","monkey":"see","authored":"by-me"}';
+		expect(redactSensitiveText(benign)).toBe(benign);
+	});
+
 	it("redacts credentials embedded in URI userinfo", () => {
 		const httpsUrl = "https://admin:hunter2hunter2@host.example.com/private";
 		const postgresUrl =

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -34,7 +34,7 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	// ENV-style assignments (incl. seed/mnemonic/passphrase/credential names).
 	String.raw`\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1`,
 	// JSON fields.
-	String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|access_token|refreshToken|refresh_token|mnemonic|seedPhrase|passphrase|privateKey|credential|clientSecret|sessionKey|authToken|botToken|connectionString|webhookUrl|webhook_url)"\s*:\s*"([^"]+)"`,
+	String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|access_token|refreshToken|refresh_token|mnemonic|seedPhrase|passphrase|privateKey|credential|clientSecret|client_secret|sessionKey|session_key|authToken|auth_token|botToken|bot_token|connectionString|connection_string|webhookUrl|webhook_url)"\s*:\s*"([^"]+)"`,
 	// CLI flags (space-separated and --flag=value forms).
 	String.raw`--(?:api[-_]?key|token|secret|password|passwd)(?:\s+|=)(["']?)([^\s"']+)\1`,
 	// Authorization credentials are either one token68 value or a complete

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -34,7 +34,7 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	// ENV-style assignments (incl. seed/mnemonic/passphrase/credential names).
 	String.raw`\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1`,
 	// JSON fields.
-	String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|mnemonic|seedPhrase|passphrase|privateKey|credential)"\s*:\s*"([^"]+)"`,
+	String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|access_token|refreshToken|refresh_token|mnemonic|seedPhrase|passphrase|privateKey|credential|clientSecret|sessionKey|authToken|botToken|connectionString|webhookUrl|webhook_url)"\s*:\s*"([^"]+)"`,
 	// CLI flags (space-separated and --flag=value forms).
 	String.raw`--(?:api[-_]?key|token|secret|password|passwd)(?:\s+|=)(["']?)([^\s"']+)\1`,
 	// Authorization credentials are either one token68 value or a complete

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -581,17 +581,22 @@ describe("secret redaction", () => {
     logger.info(
       {
         payload:
-          '{"clientSecret":"client-secret-value-123","sessionKey":"session-secret-value-123","authToken":"auth-secret-value-123","botToken":"123456:bot-secret-value-abc","connectionString":"Server=db;Pwd=hunter2w10","access_token":"access-secret-value-123","refresh_token":"refresh-secret-value-123","webhookUrl":"https://discord.test/api/webhooks/9/hook-secret-a","webhook_url":"https://discord.test/api/webhooks/9/hook-secret-b"}',
+          '{"clientSecret":"client-secret-value-123","client_secret":"client-snake-secret-value-123","sessionKey":"session-secret-value-123","session_key":"session-snake-secret-value-123","authToken":"auth-secret-value-123","auth_token":"auth-snake-secret-value-123","botToken":"123456:bot-secret-value-abc","bot_token":"123456:bot-snake-secret-value-abc","connectionString":"Server=db;Pwd=hunter2w10","connection_string":"Server=db;Pwd=hunter2snake","access_token":"access-secret-value-123","refresh_token":"refresh-secret-value-123","webhookUrl":"https://discord.test/api/webhooks/9/hook-secret-a","webhook_url":"https://discord.test/api/webhooks/9/hook-secret-b"}',
       },
       "ctx",
     );
     const logs = recentLogs();
     for (const secret of [
       "client-secret-value-123",
+      "client-snake-secret-value-123",
       "session-secret-value-123",
+      "session-snake-secret-value-123",
       "auth-secret-value-123",
+      "auth-snake-secret-value-123",
       "bot-secret-value-abc",
+      "bot-snake-secret-value-abc",
       "hunter2w10",
+      "hunter2snake",
       "access-secret-value-123",
       "refresh-secret-value-123",
       "hook-secret-a",
@@ -740,6 +745,52 @@ describe("JSON mode sink hygiene", () => {
     });
   });
 
+  it("detaches hostile built-ins, functions, map/set contents, and clone keys", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    await withJsonMode((fresh) => {
+      const secrets = {
+        date: "sk-date-hook-secret",
+        map: "sk-map-value-secret",
+        set: "sk-set-hook-secret",
+        promise: "sk-promise-hook-secret",
+        fn: "sk-function-hook-secret",
+        proto: "sk-proto-hook-secret",
+      };
+      const hostileDate = new Date("2026-01-02T03:04:05.000Z");
+      hostileDate.toJSON = () => secrets.date;
+      const hostileSetValue = { toJSON: () => secrets.set };
+      const hostilePromise = Object.assign(Promise.resolve(), {
+        toJSON: () => secrets.promise,
+      });
+      const hostileFunction = Object.assign(() => {}, {
+        toJSON: () => secrets.fn,
+      });
+      const protoValue = { toJSON: () => secrets.proto };
+      const payload: Record<string, unknown> = {
+        when: hostileDate,
+        map: new Map([["apiKey", secrets.map]]),
+        set: new Set([hostileSetValue]),
+        pending: hostilePromise,
+      };
+      Object.defineProperty(payload, "__proto__", {
+        value: protoValue,
+        enumerable: true,
+      });
+
+      fresh
+        .createLogger({ level: "trace" })
+        .info(payload, "ctx", hostileFunction);
+
+      const outputs = `${fresh.recentLogs()} ${infoSpy.mock.calls.flat().join(" ")}`;
+      for (const secret of Object.values(secrets)) {
+        expect(outputs).not.toContain(secret);
+      }
+      expect(outputs).toContain("2026-01-02T03:04:05.000Z");
+      expect(outputs).toContain("[Promise]");
+      expect(outputs).toContain("[REDACTED]");
+    });
+  });
+
   it("redacts creation and child bindings before they become Adze meta", async () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     await withJsonMode((fresh) => {
@@ -753,6 +804,26 @@ describe("JSON mode sink hygiene", () => {
       expect(printed).toContain("[REDACTED]");
       // Non-secret bindings survive onto the JSON lines.
       expect(printed).toContain("r-1");
+    });
+  });
+
+  it("detaches hostile Date hooks in creation and child bindings", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    await withJsonMode((fresh) => {
+      const parentSecret = "sk-parent-date-hook-secret";
+      const childSecret = "sk-child-date-hook-secret";
+      const parentDate = new Date("2026-02-03T04:05:06.000Z");
+      const childDate = new Date("2026-03-04T05:06:07.000Z");
+      parentDate.toJSON = () => parentSecret;
+      childDate.toJSON = () => childSecret;
+
+      const logger = fresh.createLogger({ level: "trace", when: parentDate });
+      logger.child({ when: childDate }).info("child-line");
+
+      const printed = infoSpy.mock.calls.flat().join(" ");
+      expect(printed).not.toContain(parentSecret);
+      expect(printed).not.toContain(childSecret);
+      expect(printed).toContain("2026-03-04T05:06:07.000Z");
     });
   });
 });
@@ -810,6 +881,26 @@ describe("binary payload redaction", () => {
     expect(out).toContain("[BUFFER REDACTED 14 bytes]");
     expect(out).not.toContain('"type":"Buffer"');
   });
+
+  it("detaches hostile built-ins and functions in the browser path", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const dateSecret = "sk-browser-date-hook-secret";
+    const functionSecret = "sk-browser-function-hook-secret";
+    const date = new Date("2026-04-05T06:07:08.000Z");
+    date.toJSON = () => dateSecret;
+    const fn = Object.assign(() => {}, { toJSON: () => functionSecret });
+
+    createLogger({ level: "trace", __forceType: "browser" }).info(
+      { date, values: new Set([fn]) },
+      "ctx",
+      fn,
+    );
+
+    const out = infoSpy.mock.calls.flat().join(" ");
+    expect(out).not.toContain(dateSecret);
+    expect(out).not.toContain(functionSecret);
+    expect(out).toContain("2026-04-05T06:07:08.000Z");
+  });
 });
 
 /**
@@ -838,6 +929,10 @@ describe("file sink permissions", () => {
         vi.resetModules();
         const fresh = await import("./logger");
         fresh.logger.info("perm-test-entry");
+        const sinkSecret = "sk-file-date-hook-secret";
+        const hostileDate = new Date("2026-05-06T07:08:09.000Z");
+        hostileDate.toJSON = () => sinkSecret;
+        fresh.logger.info({ when: hostileDate }, "file-redaction-entry");
         fresh.logPrompt("text", "prompt-body");
         fresh.logChatIn({
           agentName: "Eliza",
@@ -855,6 +950,9 @@ describe("file sink permissions", () => {
         // The legacy content survives the heal (append-only sink).
         expect(await fs.readFile(logPath, "utf8")).toContain("old line");
         expect(await fs.readFile(logPath, "utf8")).toContain("perm-test-entry");
+        const fileContents = await fs.readFile(logPath, "utf8");
+        expect(fileContents).not.toContain(sinkSecret);
+        expect(fileContents).toContain("2026-05-06T07:08:09.000Z");
       } finally {
         if (previous === undefined) delete process.env.LOG_FILE;
         else process.env.LOG_FILE = previous;

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -576,6 +576,31 @@ describe("secret redaction", () => {
     expect(logs).toContain("postgres://***@db.internal:5432/app");
   });
 
+  it("scrubs the common JSON credential spellings from string values (W10)", () => {
+    const logger = redactLogger();
+    logger.info(
+      {
+        payload:
+          '{"clientSecret":"client-secret-value-123","sessionKey":"session-secret-value-123","authToken":"auth-secret-value-123","botToken":"123456:bot-secret-value-abc","connectionString":"Server=db;Pwd=hunter2w10","access_token":"access-secret-value-123","refresh_token":"refresh-secret-value-123","webhookUrl":"https://discord.test/api/webhooks/9/hook-secret-a","webhook_url":"https://discord.test/api/webhooks/9/hook-secret-b"}',
+      },
+      "ctx",
+    );
+    const logs = recentLogs();
+    for (const secret of [
+      "client-secret-value-123",
+      "session-secret-value-123",
+      "auth-secret-value-123",
+      "bot-secret-value-abc",
+      "hunter2w10",
+      "access-secret-value-123",
+      "refresh-secret-value-123",
+      "hook-secret-a",
+      "hook-secret-b",
+    ]) {
+      expect(logs).not.toContain(secret);
+    }
+  });
+
   it("scrubs credential patterns from the Error headline message (W5-026)", () => {
     const logger = redactLogger();
     logger.error(
@@ -635,6 +660,100 @@ describe("secret redaction", () => {
     const logs = recentLogs();
     expect(logs).not.toContain("sk-proxy-hidden-secret");
     expect(logs).toContain("[REDACTED: redaction failed]");
+  });
+});
+
+/**
+ * JSON-mode sink hygiene (W10 logger group): the redacted clone must carry no
+ * executable serializer hooks — a hostile own-property toJSON re-runs when a
+ * sink JSON-stringifies the clone and would reconstitute the very secrets the
+ * walk just masked — and creation/child bindings must be redacted before they
+ * become Adze meta, which Adze emits verbatim on every JSON line.
+ * LOG_JSON_FORMAT is read at module load, so each case boots a fresh module
+ * instance and restores the variable afterwards; observable surfaces are the
+ * ring buffer and Adze's own JSON console lines.
+ */
+describe("JSON mode sink hygiene", () => {
+  const withJsonMode = async (
+    run: (fresh: typeof import("./logger")) => void,
+  ): Promise<void> => {
+    const previous = process.env.LOG_JSON_FORMAT;
+    process.env.LOG_JSON_FORMAT = "true";
+    try {
+      vi.resetModules();
+      run(await import("./logger"));
+    } finally {
+      if (previous === undefined) delete process.env.LOG_JSON_FORMAT;
+      else process.env.LOG_JSON_FORMAT = previous;
+      vi.resetModules();
+      // Re-seat Adze's global setup in the default pretty format so the
+      // JSON-mode module instance cannot contaminate later tests.
+      await import("./logger");
+    }
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("drops a hostile toJSON so serialization cannot reconstitute secrets", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    await withJsonMode((fresh) => {
+      const secret = "sk-tojson-resurrected-secret";
+      const hostile = {
+        apiKey: secret,
+        note: "kept",
+        toJSON: () => ({ apiKey: secret, marker: "resurrected" }),
+      };
+      fresh.createLogger({ level: "trace" }).info(hostile, "ctx");
+
+      const logs = fresh.recentLogs();
+      expect(logs).not.toContain(secret);
+      expect(logs).not.toContain("resurrected");
+      // The non-hook remainder of the payload still serializes.
+      expect(logs).toContain('"note":"kept"');
+      // Adze's own JSON console line is clean as well.
+      const printed = infoSpy.mock.calls.flat().join(" ");
+      expect(printed).not.toContain(secret);
+      expect(printed).not.toContain("resurrected");
+    });
+  });
+
+  it("drops serializer hooks in nested objects and array elements", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    await withJsonMode((fresh) => {
+      const secret = "sk-nested-hook-secret";
+      const hookedFn = Object.assign(() => {}, { toJSON: () => secret });
+      fresh.createLogger({ level: "trace" }).info(
+        {
+          nested: { hook: { toJSON: () => secret }, ok: 1 },
+          list: [{ toJSON: () => secret }, hookedFn],
+        },
+        "ctx",
+      );
+
+      const logs = fresh.recentLogs();
+      expect(logs).not.toContain(secret);
+      expect(logs).toContain('"ok":1');
+      // Bare function array elements collapse to null, matching JSON.stringify.
+      expect(logs).toContain("null");
+    });
+  });
+
+  it("redacts creation and child bindings before they become Adze meta", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    await withJsonMode((fresh) => {
+      const secret = "sk-child-binding-secret";
+      const logger = fresh.createLogger({ level: "trace", token: secret });
+      logger.info("parent-line");
+      logger.child({ apiKey: secret, requestId: "r-1" }).info("child-line");
+
+      const printed = infoSpy.mock.calls.flat().join(" ");
+      expect(printed).not.toContain(secret);
+      expect(printed).toContain("[REDACTED]");
+      // Non-secret bindings survive onto the JSON lines.
+      expect(printed).toContain("r-1");
+    });
   });
 });
 

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -413,6 +413,7 @@ describe("secret redaction", () => {
 
   afterEach(() => {
     redactLogger().clear();
+    vi.restoreAllMocks();
   });
 
   it("masks top-level credential keys", () => {
@@ -665,6 +666,32 @@ describe("secret redaction", () => {
     const logs = recentLogs();
     expect(logs).not.toContain("sk-proxy-hidden-secret");
     expect(logs).toContain("[REDACTED: redaction failed]");
+  });
+
+  it("drops a bare function context without losing the message", () => {
+    const logger = redactLogger();
+    expect(() =>
+      logger.info(
+        (() => "never-invoked") as unknown as Record<string, unknown>,
+        "fn-context-message-survives",
+      ),
+    ).not.toThrow();
+    const logs = recentLogs();
+    expect(logs).toContain("fn-context-message-survives");
+    expect(logs).not.toContain("never-invoked");
+  });
+
+  it("scrubs credential-shaped namespace bindings", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const nsSecret = "sk-namespace-binding-secret-1234";
+    createLogger({ level: "trace", namespace: nsSecret }).info(
+      "namespace-scrub-entry",
+    );
+    const out = `${recentLogs()} ${infoSpy.mock.calls.flat().join(" ")}`;
+    expect(out).not.toContain(nsSecret);
+    // The scrubbed affix form, not the raw value, tags the line.
+    expect(out).toContain("sk-nam…1234");
+    expect(out).toContain("namespace-scrub-entry");
   });
 });
 

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1432,6 +1432,18 @@ function extractBindingsConfig(bindings: LoggerBindings | boolean): {
     base = rest;
   }
 
+  // Namespace bindings bypass the per-call redaction like meta does: Adze
+  // prints the ns tag and invoke() prefixes the ring-buffer message with the
+  // raw value. Scrub credential shapes once here, where both consumers read.
+  if (typeof base.namespace === "string") {
+    base.namespace = redactSensitiveLogText(base.namespace);
+  }
+  if (Array.isArray(base.namespaces)) {
+    base.namespaces = base.namespaces.map((ns) =>
+      typeof ns === "string" ? redactSensitiveLogText(ns) : ns,
+    );
+  }
+
   return { level, base, maxMemoryLogs };
 }
 
@@ -1531,6 +1543,12 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
       if (typeof obj === "string") {
         const rest = cleanMsg !== undefined ? [cleanMsg, ...args] : args;
         return [redactSensitiveLogText(obj), ...redactTrailingArgs(rest)];
+      }
+      // A bare function in the context slot collapses like a function-valued
+      // property: drop it and keep the message (see the node path).
+      if (typeof obj === "function") {
+        const rest = cleanMsg !== undefined ? [cleanMsg, ...args] : args;
+        return redactTrailingArgs(rest);
       }
       if (obj instanceof Error) {
         const rest = cleanMsg !== undefined ? [cleanMsg, ...args] : args;
@@ -1703,6 +1721,13 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
     if (typeof obj === "string") {
       const rest = cleanMsg !== undefined ? [cleanMsg, ...args] : args;
       return [redactSensitiveLogText(obj), ...redactTrailingArgs(rest)];
+    }
+    // A bare function in the context slot collapses like a function-valued
+    // property: drop it and keep the message rather than handing the pretty
+    // formatter the redactor's null stand-in.
+    if (typeof obj === "function") {
+      const rest = cleanMsg !== undefined ? [cleanMsg, ...args] : args;
+      return redactTrailingArgs(rest);
     }
     // Error object - the wrapper must be redacted too: error instances can
     // carry credentials on enumerable properties (request config, headers),

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -448,7 +448,7 @@ const SENSITIVE_TEXT_PATTERNS: readonly string[] = [
   // ENV-style assignments (incl. seed/mnemonic/passphrase/credential names).
   String.raw`\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1`,
   // JSON fields.
-  String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|access_token|refreshToken|refresh_token|mnemonic|seedPhrase|passphrase|privateKey|credential|clientSecret|sessionKey|authToken|botToken|connectionString|webhookUrl|webhook_url)"\s*:\s*"([^"]+)"`,
+  String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|access_token|refreshToken|refresh_token|mnemonic|seedPhrase|passphrase|privateKey|credential|clientSecret|client_secret|sessionKey|session_key|authToken|auth_token|botToken|bot_token|connectionString|connection_string|webhookUrl|webhook_url)"\s*:\s*"([^"]+)"`,
   // CLI flags (space-separated and --flag=value forms).
   String.raw`--(?:api[-_]?key|token|secret|password|passwd)(?:\s+|=)(["']?)([^\s"']+)\1`,
   // Authorization headers (see core for the full grammar rationale: Basic
@@ -592,6 +592,10 @@ function redactLogValue(
   depth: number,
 ): unknown {
   if (typeof value === "string") return redactSensitiveLogText(value);
+  // Functions are executable values even when they are passed directly or as
+  // trailing arguments. Never let a caller-owned function (and its toJSON)
+  // survive into a sink.
+  if (typeof value === "function") return null;
   if (value === null || typeof value !== "object") return value;
   if (seen.has(value)) return "[Circular]";
   if (depth >= MAX_REDACT_DEPTH) return REDACTED_VALUE;
@@ -599,7 +603,7 @@ function redactLogValue(
 
   if (value instanceof Error) {
     const clone = new Error(redactSensitiveLogText(value.message));
-    clone.name = value.name;
+    clone.name = redactSensitiveLogText(value.name);
     if (value.stack) clone.stack = redactSensitiveLogText(value.stack);
     if (value.cause !== undefined) {
       clone.cause = redactLogValue(value.cause, seen, depth + 1);
@@ -610,12 +614,12 @@ function redactLogValue(
   }
 
   if (Array.isArray(value)) {
-    // Function elements collapse to null (matching JSON.stringify semantics)
-    // so no executable serializer hook survives the clone — see
-    // redactOwnPropertiesInto for why hooks must never be copied.
-    return value.map((item) =>
-      typeof item === "function" ? null : redactLogValue(item, seen, depth + 1),
-    );
+    // Avoid the caller's potentially overridden `map` and species constructor.
+    const result = new Array<unknown>(value.length);
+    for (let index = 0; index < value.length; index += 1) {
+      result[index] = redactLogValue(value[index], seen, depth + 1);
+    }
+    return result;
   }
 
   // Binary payloads carry raw bytes that JSON serializes verbatim
@@ -626,26 +630,71 @@ function redactLogValue(
     return `[BUFFER REDACTED ${value.byteLength} bytes]`;
   }
 
-  // Opaque built-ins have no enumerable credential keys to mask and are never
-  // mutated by the walker, so returning them by reference is safe.
-  if (
-    value instanceof Date ||
-    value instanceof RegExp ||
-    value instanceof Map ||
-    value instanceof Set ||
-    value instanceof WeakMap ||
-    value instanceof WeakSet ||
-    value instanceof Promise
-  ) {
-    return value;
+  // Built-ins must also be detached from the caller. JSON.stringify invokes a
+  // caller-owned Date/toJSON before its replacer, and pretty sinks may inspect
+  // Map/Set contents directly.
+  if (value instanceof Date) {
+    try {
+      return Date.prototype.toISOString.call(value);
+    } catch {
+      return "[Invalid Date]";
+    }
   }
+  if (value instanceof RegExp) {
+    return `[RegExp ${redactSensitiveLogText(RegExp.prototype.toString.call(value))}]`;
+  }
+  if (value instanceof Map) {
+    const entries: unknown[] = [];
+    Map.prototype.forEach.call(
+      value,
+      (entryValue: unknown, entryKey: unknown) => {
+        const safeKey = redactLogValue(entryKey, seen, depth + 1);
+        const safeValue =
+          typeof entryKey === "string" && isSensitiveLogKey(entryKey)
+            ? REDACTED_VALUE
+            : redactLogValue(entryValue, seen, depth + 1);
+        entries.push([safeKey, safeValue]);
+      },
+    );
+    const result = Object.create(null) as Record<string, unknown>;
+    defineSafeProperty(result, "type", "Map");
+    defineSafeProperty(result, "entries", entries);
+    return result;
+  }
+  if (value instanceof Set) {
+    const values: unknown[] = [];
+    Set.prototype.forEach.call(value, (entryValue: unknown) => {
+      values.push(redactLogValue(entryValue, seen, depth + 1));
+    });
+    const result = Object.create(null) as Record<string, unknown>;
+    defineSafeProperty(result, "type", "Set");
+    defineSafeProperty(result, "values", values);
+    return result;
+  }
+  if (value instanceof WeakMap) return "[WeakMap]";
+  if (value instanceof WeakSet) return "[WeakSet]";
+  if (value instanceof Promise) return "[Promise]";
 
   // Class instances are cloned into plain objects: JSON serialization only
   // ever emits own enumerable properties anyway, and walking them here masks
   // credentials stashed on config/response wrappers (axios-style).
-  const result: Record<string, unknown> = {};
+  const result = Object.create(null) as Record<string, unknown>;
   redactOwnPropertiesInto(value, result, seen, depth + 1);
   return result;
+}
+
+/** Define a clone key without invoking Object.prototype's `__proto__` setter. */
+function defineSafeProperty(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
 }
 
 /**
@@ -664,7 +713,7 @@ function redactOwnPropertiesInto(
 ): void {
   for (const key of Object.keys(source)) {
     if (isSensitiveLogKey(key)) {
-      target[key] = REDACTED_VALUE;
+      defineSafeProperty(target, key, REDACTED_VALUE);
       continue;
     }
     try {
@@ -674,11 +723,11 @@ function redactOwnPropertiesInto(
       // can reconstitute the very secrets the walk just masked. JSON.stringify
       // omits function props anyway, so the clone drops them outright.
       if (typeof entry === "function") continue;
-      target[key] = redactLogValue(entry, seen, depth);
+      defineSafeProperty(target, key, redactLogValue(entry, seen, depth));
     } catch {
       // error-policy:J7 logging must never break the runtime; a throwing
       // getter fails closed on this one key, never emits the raw value.
-      target[key] = REDACTION_FAILED_VALUE;
+      defineSafeProperty(target, key, REDACTION_FAILED_VALUE);
     }
   }
 }
@@ -691,7 +740,8 @@ function redactOwnPropertiesInto(
 function redactTrailingArgs(args: readonly unknown[]): unknown[] {
   return args.map((arg) => {
     if (typeof arg === "string") return redactSensitiveLogText(arg);
-    if (arg === null || typeof arg !== "object") return arg;
+    if (arg === null || (typeof arg !== "object" && typeof arg !== "function"))
+      return arg;
     try {
       return redactLogValue(arg, new WeakSet<object>(), 0);
     } catch {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -448,7 +448,7 @@ const SENSITIVE_TEXT_PATTERNS: readonly string[] = [
   // ENV-style assignments (incl. seed/mnemonic/passphrase/credential names).
   String.raw`\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1`,
   // JSON fields.
-  String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|mnemonic|seedPhrase|passphrase|privateKey|credential)"\s*:\s*"([^"]+)"`,
+  String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|access_token|refreshToken|refresh_token|mnemonic|seedPhrase|passphrase|privateKey|credential|clientSecret|sessionKey|authToken|botToken|connectionString|webhookUrl|webhook_url)"\s*:\s*"([^"]+)"`,
   // CLI flags (space-separated and --flag=value forms).
   String.raw`--(?:api[-_]?key|token|secret|password|passwd)(?:\s+|=)(["']?)([^\s"']+)\1`,
   // Authorization headers (see core for the full grammar rationale: Basic
@@ -572,9 +572,14 @@ function redactSensitiveLogText(text: string): string {
  * caller's live objects (previously a shallow copy let the redactor overwrite
  * nested credentials in place, corrupting e.g. a provider config mid-use).
  * String values are pattern-scrubbed for credential shapes at every depth.
- * Cycles and over-depth payloads collapse to a marker instead of recursing
- * forever. Buffer/TypedArray/DataView/ArrayBuffer values collapse to a
- * size-only marker — JSON would otherwise serialize the raw bytes verbatim
+ * Function-valued properties are dropped from the clone: they are executable
+ * serializer hooks (toJSON/valueOf/toString), and a copied hook re-runs when a
+ * sink JSON-stringifies the clone, able to reconstitute the very secrets the
+ * walk just masked — JSON.stringify drops function props anyway, so omission
+ * matches serialization semantics. Cycles and over-depth payloads collapse
+ * to a marker instead of recursing forever. Buffer/TypedArray/DataView/
+ * ArrayBuffer values collapse to a size-only marker — JSON would otherwise
+ * serialize the raw bytes verbatim
  * (`{"type":"Buffer","data":[...]}`) under an innocent-looking key. Error
  * instances keep their name/message/stack shape (Adze renders
  * it) with message and stack scrubbed — thrown errors routinely interpolate
@@ -605,7 +610,12 @@ function redactLogValue(
   }
 
   if (Array.isArray(value)) {
-    return value.map((item) => redactLogValue(item, seen, depth + 1));
+    // Function elements collapse to null (matching JSON.stringify semantics)
+    // so no executable serializer hook survives the clone — see
+    // redactOwnPropertiesInto for why hooks must never be copied.
+    return value.map((item) =>
+      typeof item === "function" ? null : redactLogValue(item, seen, depth + 1),
+    );
   }
 
   // Binary payloads carry raw bytes that JSON serializes verbatim
@@ -658,11 +668,13 @@ function redactOwnPropertiesInto(
       continue;
     }
     try {
-      target[key] = redactLogValue(
-        (source as Record<string, unknown>)[key],
-        seen,
-        depth,
-      );
+      const entry = (source as Record<string, unknown>)[key];
+      // Function-valued properties are executable serializer hooks: a copied
+      // toJSON/valueOf/toString re-runs when a sink serializes the clone and
+      // can reconstitute the very secrets the walk just masked. JSON.stringify
+      // omits function props anyway, so the clone drops them outright.
+      if (typeof entry === "function") continue;
+      target[key] = redactLogValue(entry, seen, depth);
     } catch {
       // error-policy:J7 logging must never break the runtime; a throwing
       // getter fails closed on this one key, never emits the raw value.
@@ -1324,7 +1336,22 @@ function sealAdze(base: Record<string, unknown>): ReturnType<typeof adze.seal> {
     levels: customLevelConfig,
   };
 
-  return chain.meta(metaBase).seal(globalConfig);
+  // Creation/child bindings bypass the per-call redaction in adaptArgs — Adze
+  // emits the merged meta verbatim on every line — so scrub the bindings here:
+  // logger.child({ apiKey }) must not print the key on each subsequent line.
+  let safeMeta: Record<string, unknown>;
+  try {
+    safeMeta = redactLogValue(metaBase, new WeakSet<object>(), 0) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    // error-policy:J7 logging must never break the runtime; an unwalkable
+    // bindings payload degrades to a marker, never emits unredacted (W5-028).
+    safeMeta = { redactionError: REDACTION_FAILED_VALUE };
+  }
+
+  return chain.meta(safeMeta).seal(globalConfig);
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the remaining Wave-10 logger/config redaction gaps while preserving legitimate configuration structure. This is remediation from the private security review; public evidence is limited to adversarial sentinel behavior and contains no real credentials.

### Redaction boundary

- Logger redaction returns no caller-owned object or function reference that a downstream JSON, pretty, browser, ring-buffer, child-binding, or file sink could execute later.
- Direct/trailing functions become inert; arrays are cloned without caller species/hooks; Date uses the intrinsic ISO conversion; RegExp, weak collections, and Promise become inert markers; Map/Set are recursively redacted safe records.
- Plain/class instances are copied into null-prototype objects with defined own properties, so a `__proto__` key cannot alter the clone.
- Logger creation and child bindings pass through the same redactor before becoming sink metadata.

### Credential patterns and config compatibility

- Logger/core serialized-text patterns remain mechanically identical and cover common camelCase plus snake_case credential names, including `client_secret`, `session_key`, `auth_token`, `bot_token`, and `connection_string`.
- Closed lookalike tests keep plural/non-secret names visible.
- Generic lowercase bare `auth` is intentionally not classified as a secret: real top-level auth profiles, gateway auth metadata, and provider auth discriminators remain structurally visible while their nested token/password/key values are redacted. Exact uppercase environment `AUTH` remains sensitive.

## Validation

Exact head `4189544d7cfa4183e6c014cec5d26f8a206f3b8d`, rebased on `develop@51d348d51b21231f826d4d05b1ee4b0bf7b4d3e6`, pinned Bun 1.3.14 / Node 24.15.0:

- logger suite: 46/46 passed
- core security redaction suite: 46/46 passed
- agent sensitive-config suite: 16/16 passed
- logger typecheck: passed
- core typecheck: passed
- Biome on all six changed files: passed
- `git diff --check`: passed
- agent package-wide typecheck remains blocked only by unrelated missing/generated workspace export prerequisites (capacitor-bridge, wallet diagnostic, optional media/notes, todos edge, cloud routing); the focused agent suite compiles and passes.

## Risk and rollback

The change intentionally makes log serialization more inert. Map/Set and opaque runtime objects now render safe normalized data/markers rather than retaining identity. Legitimate auth configuration containers remain intact. Rollback would reopen credential-sink execution paths and is not recommended.

## Evidence Gate

<!-- evidence-head:4189544d7cfa4183e6c014cec5d26f8a206f3b8d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend logger/config security behavior only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend logger/config security behavior only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - real secrets were deliberately not emitted; deterministic sentinel sink tests are the safe boundary proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/state behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head adversarial sink transcript:

<details><summary>Redaction boundary artifact</summary>

~~~text
Pinned Bun 1.3.14: logger 46/46, core redaction 46/46, agent sensitive-config 16/16.
Hostile Date/function/toJSON, Map/Set, Promise, child/creation binding, browser, ring-buffer, and file-sink sentinels were absent from every captured output.
Logger/core patterns stayed exact-parity; real schema-shaped auth profiles and gateway/provider auth metadata survived while nested credentials were masked.
~~~

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [shaw-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->