### PR TITLE
fix(personal-assistant): reserve suffix length in shortenSubject/Body

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts
@@ -63,14 +63,14 @@ function isFullRedactKey(normalizedKey: string): boolean {
   return false;
 }
 
-function shortenSubject(value: string, max: number): string {
+export function shortenSubject(value: string, max: number): string {
   if (value.length <= max) return value;
-  return `${value.slice(0, max).trimEnd()}…`;
+  return `${value.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
 }
 
-function shortenBody(value: string, max: number): string {
+export function shortenBody(value: string, max: number): string {
   if (value.length <= max) return value;
-  return `${value.slice(0, max).trimEnd()}… [+${value.length - max} chars]`;
+  return `${value.slice(0, Math.max(0, max - 1)).trimEnd()}… [+${value.length - max} chars]`;
 }
 
 function redactEmailAddresses(value: string): string {

--- a/plugins/plugin-personal-assistant/src/lifeops/redact-trunc2.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/redact-trunc2.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Exercises shortenSubject/shortenBody suffix reservation: truncated payload must not exceed advertised max before suffix.
+ */
+import { describe, expect, it } from "vitest";
+import { shortenBody, shortenSubject } from "./redact-sensitive-data";
+
+describe("shortenSubject", () => {
+  it("never exceeds max inclusive of suffix", () => {
+    const out = shortenSubject("a".repeat(100), 10);
+    expect(out.length).toBe(10);
+    expect(out.endsWith("…")).toBe(true);
+  });
+  it("returns original when under cap", () => {
+    expect(shortenSubject("hello", 10)).toBe("hello");
+  });
+  it("handles max=1 edge", () => {
+    const out = shortenSubject("hello", 1);
+    expect(out).toBe("…");
+    expect(out.length).toBe(1);
+  });
+});
+
+describe("shortenBody", () => {
+  it("never exceeds max for prefix before suffix", () => {
+    const body = "a".repeat(100);
+    const out = shortenBody(body, 10);
+    expect(out.startsWith("a".repeat(9) + "… [+")).toBe(true);
+    const prefix = out.split(" [+")[0] ?? "";
+    expect(prefix.length).toBe(10);
+  });
+  it("returns original when under cap", () => {
+    expect(shortenBody("hello body", 20)).toBe("hello body");
+  });
+  it("handles max=1 edge", () => {
+    const out = shortenBody("hello world body text", 1);
+    expect(out.startsWith("… [+")).toBe(true);
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes `shortenSubject`/`shortenBody` off-by-one on `develop` @ `5929de21`. Both helpers returned `max+1` (`slice(0, max)+"…"`) overflowing the advertised preview cap. Mirrors merged sibling `resolve-request.ts:280` and open `21665`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `5929de21` (`5929de2162ecffa1fff069faabca65779d7dcb0f`); zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` completed; `bun run verify` stepwise: `check:agents-claude` PASS, `check:biome-version` PASS, `check:i18n` OK (4675 keys), `ci-bun-version-contract` PASS, `ci-turbo-cache-contract` PASS, `fix-deps:check` OK, `ensure-plugin-test-conventions:check` PASS, `audit:alias-read-guard` PASS, `audit:tsconfig-workspace-resolution` inspected 135 projects PASS; focused `vitest`+`biome`+`typecheck` for affected package PASS (see Testing). Full `typecheck lint:check --concurrency=8` is heavy (8GB×8) — CI will confirm; locally ran with `--concurrency=2` for core.

# Risks

Low. Two expressions `value.slice(0, Math.max(0, max - 1)).trimEnd()+"…"` replace `value.slice(0, max).trimEnd()+"…"`. Adds `export` for testability. Isolated to preview helpers; no storage or API change.

# Background

## What does this PR do?

Reserves suffix length in `shortenSubject`/`shortenBody` so preview truncation at `max` never returns `max+1`. Exports helpers for direct boundary execution in tests.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts:68`
- `plugins/plugin-personal-assistant/src/lifeops/redact-trunc2.test.ts`

## Detailed testing steps

1. `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/redact-trunc2.test.ts` — 6 tests:
   - `shortenSubject never exceeds max inclusive of suffix` — `a*100` at `10` → `10` + `…`
   - `returns original when under cap`
   - `handles max=1 edge` → `…`
   - `shortenBody never exceeds max for prefix before suffix` — prefix `9+"…"` = `10` before ` [+…]`
   - `shortenBody returns original when under cap`
   - `shortenBody handles max=1 edge`
2. `bunx @biomejs/biome check` clean; `git diff --check` clean.

```
redact-trunc2.test.ts (6 tests) passed
Checked 2 files in 7ms. No fixes applied.
git diff --check: clean
```

# Evidence Gate

<!-- evidence-head:3f799792b6adc6b35e8f529b16d3c20416597878 -->
<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only preview truncation, no rendered UI`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only preview truncation, no rendered UI`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - deterministic preview truncation, no interactive flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not N/A, logs pasted in Testing`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - no domain artifact beyond test truncation`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/model change, pure truncation fix.`

## Backend + frontend logs

Backend: `redact-trunc2.test.ts` 6 passes. Frontend: `N/A`.

## Screenshots (before / after) + video walkthrough

`N/A - backend-only change.`

## Audio / voice walkthrough

`N/A - no voice change.`

## Known gaps / failures

None.

AI provider/model: openai / gpt-5.6
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [byt61]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6","client":"Codex","skill_revision":"elizaOS/eliza@5929de2162ecffa1fff069faabca65779d7dcb0f:packages/skills/skills/contribute-to-eliza"} -->
