### PR TITLE
fix(plugin-github): bound GitHub OAuth token and userinfo fetches

### DIFF
--- a/plugins/plugin-github/src/connector-account-provider.ts
+++ b/plugins/plugin-github/src/connector-account-provider.ts
@@ -132,13 +132,20 @@ function roleFromMetadata(
   return defaultRoleFromAccountId(accountId);
 }
 
-async function exchangeCodeForToken(args: {
-  clientId: string;
-  clientSecret: string;
-  redirectUri: string;
-  code: string;
-}): Promise<GitHubTokenResponse> {
-  const response = (await fetch(GITHUB_TOKEN_ENDPOINT, {
+/** GitHub OAuth hops share the documented 15s sibling budget from Google connector OAuth. */
+export const GITHUB_OAUTH_TIMEOUT_MS = 15_000;
+
+export async function exchangeCodeForTokenWithFetch(
+  args: {
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+    code: string;
+  },
+  fetchImpl: typeof fetch,
+  timeoutMs: number = GITHUB_OAUTH_TIMEOUT_MS,
+): Promise<GitHubTokenResponse> {
+  const response = (await fetchImpl(GITHUB_TOKEN_ENDPOINT, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -150,6 +157,7 @@ async function exchangeCodeForToken(args: {
       code: args.code,
       redirect_uri: args.redirectUri,
     }).toString(),
+    signal: AbortSignal.timeout(timeoutMs),
   })) as GitHubFetchResponse;
   if (!response.ok) {
     const body = await response.text();
@@ -169,15 +177,18 @@ async function exchangeCodeForToken(args: {
   return parsed;
 }
 
-async function fetchGitHubUser(
+export async function fetchGitHubUserWithFetch(
   accessToken: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = GITHUB_OAUTH_TIMEOUT_MS,
 ): Promise<GitHubUserPayload> {
-  const response = (await fetch(GITHUB_USER_ENDPOINT, {
+  const response = (await fetchImpl(GITHUB_USER_ENDPOINT, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
     },
+    signal: AbortSignal.timeout(timeoutMs),
   })) as GitHubFetchResponse;
   if (!response.ok) {
     throw new Error(`GitHub /user request failed with ${response.status}`);
@@ -187,6 +198,21 @@ async function fetchGitHubUser(
     throw new Error("GitHub /user returned an invalid payload.");
   }
   return parsed;
+}
+
+async function exchangeCodeForToken(args: {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  code: string;
+}): Promise<GitHubTokenResponse> {
+  return exchangeCodeForTokenWithFetch(args, globalThis.fetch);
+}
+
+async function fetchGitHubUser(
+  accessToken: string,
+): Promise<GitHubUserPayload> {
+  return fetchGitHubUserWithFetch(accessToken, globalThis.fetch);
 }
 
 function synthesizeEnvAccounts(runtime: IAgentRuntime): ConnectorAccount[] {

--- a/plugins/plugin-github/src/connector-oauth-timeout.test.ts
+++ b/plugins/plugin-github/src/connector-oauth-timeout.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Behavioral GitHub OAuth deadlines. Executes token-exchange and userinfo
+ * under abort — not a source-grep of connector-account-provider.ts.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  GITHUB_OAUTH_TIMEOUT_MS,
+  exchangeCodeForTokenWithFetch,
+  fetchGitHubUserWithFetch,
+} from "./connector-account-provider.js";
+
+const TOKEN_ARGS = {
+  clientId: "github-client",
+  clientSecret: "github-secret",
+  redirectUri: "http://localhost/oauth/github/callback",
+  code: "oauth-code",
+};
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected github oauth abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+describe("GitHub OAuth request deadlines", () => {
+  it("keeps a documented OAuth budget", () => {
+    expect(GITHUB_OAUTH_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("aborts a stalled token exchange at the injected deadline", async () => {
+    await expect(
+      exchangeCodeForTokenWithFetch(TOKEN_ARGS, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed token exchange", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("bad_verification_code", {
+        status: 400,
+        statusText: "Bad Request",
+      });
+
+    await expect(
+      exchangeCodeForTokenWithFetch(TOKEN_ARGS, fetchImpl, 1_000),
+    ).rejects.toThrow("400");
+  });
+
+  it("uses the injected fetch for a successful token exchange", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({
+        access_token: "tok",
+        token_type: "bearer",
+        scope: "repo",
+      });
+    };
+
+    const tokens = await exchangeCodeForTokenWithFetch(
+      TOKEN_ARGS,
+      fetchImpl,
+      1_000,
+    );
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(tokens.access_token).toBe("tok");
+    expect(tokens.scope).toBe("repo");
+  });
+
+  it("aborts a stalled userinfo request at the injected deadline", async () => {
+    await expect(
+      fetchGitHubUserWithFetch("access-token", stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed userinfo request", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("", { status: 401, statusText: "Unauthorized" });
+
+    await expect(
+      fetchGitHubUserWithFetch("access-token", fetchImpl, 1_000),
+    ).rejects.toThrow("401");
+  });
+
+  it("uses the injected fetch for a successful userinfo request", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({
+        login: "ada",
+        id: 123,
+        name: "Ada",
+      });
+    };
+
+    const user = await fetchGitHubUserWithFetch("access-token", fetchImpl, 1_000);
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(user.login).toBe("ada");
+    expect(user.id).toBe(123);
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). GitHub connector **token-exchange** and **userinfo** `fetch` have no `AbortSignal`, so a stalled OAuth hop hangs `completeOAuth`. Sibling of Google OAuth `#21740` (different file). This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, with a documented 15s OAuth deadline. Tests execute both hops under abort. InboxView already shipped (`#21762`). Not extra-decode. Not list-limit. Not payment. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Not Twilio. Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Public `createGitHubConnectorAccountProvider` signature unchanged. Unfixed head: token-exchange `fetch` had **no signal** and a hung fetch never settled (80ms race → `HUNG`). After: 10ms deadline → `TimeoutError`. OAuth budget is 15s.

# Background

## What does this PR do?

`exchangeCodeForToken` and `fetchGitHubUser` called `fetch` with no `signal`. A stalled GitHub OAuth hop never returns. This PR injects `*WithFetch` (Fal `#21205` shape) and adds `AbortSignal.timeout`.

## What kind of change is this?

Bug fix (non-breaking I/O bound). PAT/env account paths untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-github/src/connector-oauth-timeout.test.ts` — token-exchange and userinfo timeout, provider-error, success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-github && bunx vitest run --config ./vitest.config.ts src/connector-oauth-timeout.test.ts
```

Unfixed head `5929de2162`: token-exchange `signal` was undefined and the call hung. After the fix: 7 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:022835955d27dc1765f96d0e349466328b0c1aec -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Provider fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live GitHub OAuth path. vitest asserts TimeoutError, provider 400/401, and success payloads.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - GitHub OAuth transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live GitHub. Unfixed `%` hang: no signal, 80ms race `HUNG`. After the fix, vitest asserts TimeoutError on token-exchange and userinfo, `400`/`401` on provider error, and successful token/identity payloads.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

## Audio / voice walkthrough

N/A - OAuth provider HTTP only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`7 pass` plus existing account/OAuth callback tests). Root verify is an unrelated full-repo cost. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
