### PR TITLE
fix(plugin-bluebubbles): bound client JSON and attachment fetches

### DIFF
--- a/plugins/plugin-bluebubbles/src/client-timeout.test.ts
+++ b/plugins/plugin-bluebubbles/src/client-timeout.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Behavioral BlueBubbles client deadlines. Executes JSON request and
+ * attachment POSTs under abort — not a source-grep of client.ts.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	BLUEBUBBLES_ATTACHMENT_TIMEOUT_MS,
+	BLUEBUBBLES_REQUEST_TIMEOUT_MS,
+	blueBubblesRequestWithFetch,
+	blueBubblesSendAttachmentWithFetch,
+} from "./client.js";
+
+const REQUEST_URL = "http://127.0.0.1:9/api/v1/message/text?password=pw";
+const ATTACH_URL = "http://127.0.0.1:9/api/v1/message/attachment?password=pw";
+
+function stallUntilAborted(): typeof fetch {
+	return ((_input, init) =>
+		new Promise<Response>((_resolve, reject) => {
+			const signal = init?.signal;
+			if (!signal) throw new Error("expected bluebubbles abort signal");
+			const onAbort = () => reject(signal.reason);
+			if (signal.aborted) {
+				onAbort();
+				return;
+			}
+			signal.addEventListener("abort", onAbort, { once: true });
+		})) as typeof fetch;
+}
+
+describe("BlueBubbles client request deadlines", () => {
+	it("keeps documented JSON and attachment budgets", () => {
+		expect(BLUEBUBBLES_REQUEST_TIMEOUT_MS).toBe(15_000);
+		expect(BLUEBUBBLES_ATTACHMENT_TIMEOUT_MS).toBe(30_000);
+	});
+
+	it("aborts a stalled JSON request at the injected deadline", async () => {
+		await expect(
+			blueBubblesRequestWithFetch(REQUEST_URL, {}, stallUntilAborted(), 10),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+	});
+
+	it("surfaces a provider error from a completed JSON request", async () => {
+		const fetchImpl: typeof fetch = async () =>
+			new Response("unauthorized", {
+				status: 401,
+				statusText: "Unauthorized",
+			});
+
+		await expect(
+			blueBubblesRequestWithFetch(REQUEST_URL, {}, fetchImpl, 1_000),
+		).rejects.toThrow("401");
+	});
+
+	it("uses the injected fetch for a successful JSON request", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchImpl: typeof fetch = async (_input, init) => {
+			if (init?.signal) signals.push(init.signal);
+			return Response.json({ data: { guid: "msg-1", text: "hi" } });
+		};
+
+		const payload = await blueBubblesRequestWithFetch<{
+			data: { guid: string; text: string };
+		}>(REQUEST_URL, { method: "POST" }, fetchImpl, 1_000);
+
+		expect(signals).toHaveLength(1);
+		expect(signals[0]?.aborted).toBe(false);
+		expect(payload.data.guid).toBe("msg-1");
+	});
+
+	it("preserves a caller-supplied cancellation signal", async () => {
+		const controller = new AbortController();
+		const fetchImpl: typeof fetch = async (_input, init) => {
+			expect(init?.signal).toBe(controller.signal);
+			return Response.json({ data: { guid: "caller" } });
+		};
+
+		await blueBubblesRequestWithFetch(
+			REQUEST_URL,
+			{ signal: controller.signal },
+			fetchImpl,
+			10,
+		);
+	});
+
+	it("honors caller abort without waiting for the request deadline", async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(
+			blueBubblesRequestWithFetch(
+				REQUEST_URL,
+				{ signal: controller.signal },
+				stallUntilAborted(),
+				5_000,
+			),
+		).rejects.toMatchObject({ name: "AbortError" });
+	});
+
+	it("aborts a stalled attachment POST at the injected deadline", async () => {
+		await expect(
+			blueBubblesSendAttachmentWithFetch(
+				ATTACH_URL,
+				new FormData(),
+				stallUntilAborted(),
+				10,
+			),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+	});
+
+	it("surfaces a provider error from a completed attachment POST", async () => {
+		const fetchImpl: typeof fetch = async () =>
+			new Response("too large", {
+				status: 413,
+				statusText: "Payload Too Large",
+			});
+
+		await expect(
+			blueBubblesSendAttachmentWithFetch(
+				ATTACH_URL,
+				new FormData(),
+				fetchImpl,
+				1_000,
+			),
+		).rejects.toThrow("Failed to send attachment");
+	});
+
+	it("uses the injected fetch for a successful attachment POST", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchImpl: typeof fetch = async (_input, init) => {
+			if (init?.signal) signals.push(init.signal);
+			return Response.json({
+				data: { guid: "att-1", dateCreated: 1, text: "file" },
+			});
+		};
+
+		const result = await blueBubblesSendAttachmentWithFetch(
+			ATTACH_URL,
+			new FormData(),
+			fetchImpl,
+			1_000,
+		);
+
+		expect(signals).toHaveLength(1);
+		expect(signals[0]?.aborted).toBe(false);
+		expect(result.data.guid).toBe("att-1");
+	});
+});

--- a/plugins/plugin-bluebubbles/src/client.ts
+++ b/plugins/plugin-bluebubbles/src/client.ts
@@ -17,6 +17,65 @@ import type {
 	SendMessageResult,
 } from "./types";
 
+/** JSON API hops share the documented 15s sibling budget from GitHub/Google connector OAuth. */
+export const BLUEBUBBLES_REQUEST_TIMEOUT_MS = 15_000;
+
+/** Binary attachment POSTs share the documented 30s blob-upload sibling budget. */
+export const BLUEBUBBLES_ATTACHMENT_TIMEOUT_MS = 30_000;
+
+interface BlueBubblesFetchResponse {
+	ok: boolean;
+	status: number;
+	text(): Promise<string>;
+	json(): Promise<unknown>;
+}
+
+export async function blueBubblesRequestWithFetch<T>(
+	urlWithPassword: string,
+	options: RequestInit = {},
+	fetchImpl: typeof fetch = globalThis.fetch,
+	timeoutMs: number = BLUEBUBBLES_REQUEST_TIMEOUT_MS,
+): Promise<T> {
+	const signal = options.signal ?? AbortSignal.timeout(timeoutMs);
+	const response = (await fetchImpl(urlWithPassword, {
+		...options,
+		headers: {
+			"Content-Type": "application/json",
+			...options.headers,
+		},
+		signal,
+	})) as BlueBubblesFetchResponse;
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(
+			`BlueBubbles API error (${response.status}): ${errorText}`,
+		);
+	}
+
+	return response.json() as Promise<T>;
+}
+
+export async function blueBubblesSendAttachmentWithFetch(
+	url: string,
+	formData: FormData,
+	fetchImpl: typeof fetch = globalThis.fetch,
+	timeoutMs: number = BLUEBUBBLES_ATTACHMENT_TIMEOUT_MS,
+): Promise<{ data: BlueBubblesMessage }> {
+	const response = (await fetchImpl(url, {
+		method: "POST",
+		body: formData,
+		signal: AbortSignal.timeout(timeoutMs),
+	})) as BlueBubblesFetchResponse;
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(`Failed to send attachment: ${errorText}`);
+	}
+
+	return (await response.json()) as { data: BlueBubblesMessage };
+}
+
 export class BlueBubblesClient {
 	private baseUrl: string;
 	private password: string;
@@ -34,22 +93,7 @@ export class BlueBubblesClient {
 		const separator = endpoint.includes("?") ? "&" : "?";
 		const urlWithPassword = `${url}${separator}password=${encodeURIComponent(this.password)}`;
 
-		const response = await fetch(urlWithPassword, {
-			...options,
-			headers: {
-				"Content-Type": "application/json",
-				...options.headers,
-			},
-		});
-
-		if (!response.ok) {
-			const errorText = await response.text();
-			throw new Error(
-				`BlueBubbles API error (${response.status}): ${errorText}`,
-			);
-		}
-
-		return response.json() as Promise<T>;
+		return blueBubblesRequestWithFetch<T>(urlWithPassword, options);
 	}
 
 	/**
@@ -151,17 +195,7 @@ export class BlueBubblesClient {
 		}
 
 		const url = `${this.baseUrl}${API_ENDPOINTS.SEND_ATTACHMENT}?password=${encodeURIComponent(this.password)}`;
-		const response = await fetch(url, {
-			method: "POST",
-			body: formData,
-		});
-
-		if (!response.ok) {
-			const errorText = await response.text();
-			throw new Error(`Failed to send attachment: ${errorText}`);
-		}
-
-		const result = (await response.json()) as { data: BlueBubblesMessage };
+		const result = await blueBubblesSendAttachmentWithFetch(url, formData);
 
 		return {
 			guid: result.data.guid,
@@ -195,17 +229,7 @@ export class BlueBubblesClient {
 		}
 
 		const url = `${this.baseUrl}${API_ENDPOINTS.SEND_ATTACHMENT}?password=${encodeURIComponent(this.password)}`;
-		const response = await fetch(url, {
-			method: "POST",
-			body: formData,
-		});
-
-		if (!response.ok) {
-			const errorText = await response.text();
-			throw new Error(`Failed to send attachment: ${errorText}`);
-		}
-
-		const result = (await response.json()) as { data: BlueBubblesMessage };
+		const result = await blueBubblesSendAttachmentWithFetch(url, formData);
 
 		return {
 			guid: result.data.guid,

--- a/plugins/plugin-bluebubbles/src/client.ts
+++ b/plugins/plugin-bluebubbles/src/client.ts
@@ -48,9 +48,7 @@ export async function blueBubblesRequestWithFetch<T>(
 
 	if (!response.ok) {
 		const errorText = await response.text();
-		throw new Error(
-			`BlueBubbles API error (${response.status}): ${errorText}`,
-		);
+		throw new Error(`BlueBubbles API error (${response.status}): ${errorText}`);
 	}
 
 	return response.json() as Promise<T>;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). BlueBubbles `request()` and both attachment POSTs used unbounded `fetch`, so a stalled server hangs `sendMessage` / `sendAttachment`. `#21423` closed as grep-only. This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, caller-supplied cancellation, and the attachment error boundary, with documented 15s JSON / 30s attachment deadlines. Tests execute both hops under abort. GitHub OAuth already shipped (`#21765`). Not extra-decode. Not list-limit. Not payment. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Not Twilio. Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Public `BlueBubblesClient` constructor unchanged. `probe()` still supplies its 5s caller signal. Unfixed head: JSON `request()` and attachment `fetch` had **no signal** and a hung fetch never settled (80ms race → `HUNG`). After: 10ms deadline → `TimeoutError`. JSON budget is 15s; attachment budget is 30s.

# Background

## What does this PR do?

`request()`, `sendAttachment`, and `sendAttachmentBuffer` called `fetch` with no `signal`. A stalled BlueBubbles server never returns. This PR injects `*WithFetch` (Fal `#21205` shape) and adds `AbortSignal.timeout`, preserving a caller-supplied signal on JSON hops.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Chat/message list-limit paths untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-bluebubbles/src/client-timeout.test.ts` — JSON request and attachment timeout, provider-error, success, plus caller cancellation.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-bluebubbles && bunx vitest run --config ./vitest.config.ts src/client-timeout.test.ts
```

Unfixed head `2210ad8da9`: both hops' `signal` was undefined and the call hung. After the fix: 9 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:7b45d7dfe6339c708d752d091f53692d38bc3545 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Connector fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, success, and caller cancellation.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live BlueBubbles server. vitest asserts TimeoutError, provider 401/413, caller AbortError, and success payloads.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - BlueBubbles transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live BlueBubbles. Unfixed `%` hang: no signal, 80ms race `HUNG` on `sendMessage` and `sendAttachment`. After the fix, vitest asserts TimeoutError on both hops, `401`/`413` on provider error, caller-signal identity plus AbortError, and successful JSON/attachment payloads.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

## Audio / voice walkthrough

N/A - connector HTTP only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`9 pass` plus existing plugin tests). Root verify is an unrelated full-repo cost. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
