### PR TITLE
fix(cloud,ui): gate Telegram account claim behind explicit confirmation (W9-001)

### DIFF
--- a/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
@@ -656,6 +656,49 @@ describe("onboarding chat — trusted platform gateway caller", () => {
     expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();
   });
 
+  test("previews a Telegram account-claim continuation for the authenticated browser landing", async () => {
+    // Mirror the /connect DM mint: a trusted gateway turn, bound to the
+    // account that owns the attested Telegram identity, statusOnly so nothing
+    // is appended or provisioned.
+    resolveIdentity.mockResolvedValue({ user: userRow(), identity: undefined });
+    await dataOf(
+      await post({
+        sessionId: "platform:telegram-claim:test-claim-1",
+        platform: "telegram",
+        platformUserId: "9911",
+        platformDisplayName: "Ada",
+        statusOnly: true,
+      }),
+    );
+    const stored = sessionCache.get(
+      "eliza-app:onboarding:platform:telegram-claim:test-claim-1",
+    ) as { continuationToken?: string };
+    const continuation = stored?.continuationToken;
+    if (!continuation) throw new Error("Expected a claim continuation token");
+
+    // The claim session is bound to user-9/org-9, so the generic account-bound
+    // preview rejects the steward caller — the claim preview fallback answers
+    // with only the Telegram identity the landing asks the user to confirm.
+    getCurrentUser.mockResolvedValue(activeStewardUser());
+    const preview = await get(continuation, STEWARD_JWT);
+    expect(preview.status).toBe(200);
+    expect(await dataOf(preview)).toEqual({
+      platform: "telegram",
+      platformUserId: "9911",
+      platformDisplayName: "Ada",
+      returnUrl: null,
+    });
+    expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();
+
+    // An unknown continuation still fails closed on both inspection paths.
+    const invalid = await get("unknown-opaque-continuation", STEWARD_JWT);
+    expect(invalid.status).toBe(403);
+    expect(await invalid.json()).toMatchObject({
+      success: false,
+      code: "access_denied",
+    });
+  });
+
   test("a Steward caller can never mint a platform-scoped session or act as a trusted transport", async () => {
     getCurrentUser.mockResolvedValue(activeStewardUser());
 

--- a/packages/cloud/api/eliza-app/onboarding/chat/route.ts
+++ b/packages/cloud/api/eliza-app/onboarding/chat/route.ts
@@ -20,7 +20,9 @@ import { getCurrentUser } from "@/lib/auth/workers-hono-auth";
 import { elizaAppSessionService } from "@/lib/services/eliza-app";
 import {
   inspectOnboardingContinuation,
+  type OnboardingContinuationPreview,
   type OnboardingPlatform,
+  previewTelegramPersonalAccountClaimContinuation,
   runOnboardingChat,
 } from "@/lib/services/eliza-app/onboarding-chat";
 import { publicElizaAppProvisioningPayload } from "@/lib/services/eliza-app/provisioning";
@@ -72,10 +74,26 @@ app.get("/", async (c) => {
     if (!caller.authenticatedUser || caller.trustedPlatformIdentity) {
       throw ForbiddenError("Browser authentication required");
     }
-    const preview = await inspectOnboardingContinuation(
-      token,
-      caller.authenticatedUser,
-    );
+    let preview: OnboardingContinuationPreview;
+    try {
+      preview = await inspectOnboardingContinuation(
+        token,
+        caller.authenticatedUser,
+      );
+    } catch (error) {
+      // A Telegram account-claim session is bound to the DM-created account
+      // it lets the caller claim, so the account-bound preview rejects it.
+      // Fall back to the read-only claim preview so the landing can name the
+      // Telegram identity before the user confirms; any other failure — or an
+      // invalid claim continuation — keeps the original fail-closed response.
+      if (
+        !isElizaError(error) ||
+        error.code !== "ONBOARDING_TRUSTED_CONTINUATION_INVALID"
+      ) {
+        throw error;
+      }
+      preview = await previewTelegramPersonalAccountClaimContinuation(token);
+    }
     return c.json({ success: true, data: preview });
   } catch (error) {
     if (

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -94,6 +94,7 @@ mock.module("./user-service", () => ({
 const {
   inspectOnboardingContinuation,
   inspectTelegramPersonalAccountContinuation,
+  previewTelegramPersonalAccountClaimContinuation,
   runOnboardingChat,
   validateTelegramOnboardingContinuation,
 } = await import(`./onboarding-chat.ts?test=onboarding-chat-${Date.now()}`);
@@ -224,9 +225,52 @@ describe("runOnboardingChat", () => {
       telegramId: "123456789",
       userId: "telegram-user-1",
       organizationId: "telegram-org-1",
+      platformDisplayName: "Nubs",
     });
     expect(claim.session.history).toEqual([]);
     expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();
+  });
+
+  test("previews a Telegram account-claim continuation without binding or mutating it", async () => {
+    getElizaAppProvisioningStatus.mockResolvedValue({
+      status: "none",
+      agentId: null,
+      bridgeUrl: null,
+      sandbox: null,
+    });
+    const claim = await runOnboardingChat({
+      platform: "telegram",
+      platformUserId: "123456789",
+      platformDisplayName: "Nubs",
+      sessionId: "platform:telegram:123456789",
+      trustedPlatformIdentity: true,
+      authenticatedUser: {
+        userId: "telegram-user-1",
+        organizationId: "telegram-org-1",
+        telegramId: "123456789",
+      },
+      statusOnly: true,
+    });
+    const token = continuationToken(claim);
+
+    // The confirmation landing learns only the Telegram identity it names —
+    // never the bound account ids — and the session stays unclaimed.
+    await expect(previewTelegramPersonalAccountClaimContinuation(token)).resolves.toEqual({
+      platform: "telegram",
+      platformUserId: "123456789",
+      platformDisplayName: "Nubs",
+      returnUrl: null,
+    });
+    await expect(inspectTelegramPersonalAccountContinuation(token)).resolves.toMatchObject({
+      userId: "telegram-user-1",
+    });
+    expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();
+
+    await expect(
+      previewTelegramPersonalAccountClaimContinuation("unknown-opaque-continuation"),
+    ).rejects.toMatchObject({
+      code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID",
+    });
   });
 
   test("rejects an unbound Telegram continuation as account-claim authority", async () => {

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -112,6 +112,12 @@ export interface TelegramPersonalAccountContinuation {
   telegramId: string;
   userId: string;
   organizationId: string;
+  /**
+   * Gateway-attested Telegram display name. The claim decision never reads
+   * it; it exists so the browser landing can name the identity it asks the
+   * user to confirm before the claim fires.
+   */
+  platformDisplayName: string;
 }
 
 export interface OnboardingChatCta {
@@ -467,6 +473,27 @@ export async function inspectTelegramPersonalAccountContinuation(
     telegramId: session.platformUserId,
     userId: session.userId,
     organizationId: session.organizationId,
+    platformDisplayName: session.platformDisplayName?.trim() || session.platformUserId,
+  };
+}
+
+/**
+ * Browser-facing read-only preview of a Telegram personal-account claim
+ * continuation. The generic account-bound preview rejects these sessions by
+ * design — a claim session is bound to the DM-created account the caller may
+ * claim, never to the caller — so the confirmation landing inspects the claim
+ * authority directly. Only the Telegram identity being linked is disclosed;
+ * the bound account ids stay server-side.
+ */
+export async function previewTelegramPersonalAccountClaimContinuation(
+  continuationToken: string,
+): Promise<OnboardingContinuationPreview> {
+  const claim = await inspectTelegramPersonalAccountContinuation(continuationToken);
+  return {
+    platform: "telegram",
+    platformUserId: claim.telegramId,
+    platformDisplayName: claim.platformDisplayName,
+    returnUrl: null,
   };
 }
 

--- a/packages/ui/src/cloud/join/GetStartedPage.test.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.test.tsx
@@ -222,7 +222,13 @@ describe("GetStartedPage", () => {
     expect(await screen.findByText("You're connected")).toBeTruthy();
   });
 
-  it("claims through Steward sync without entering the generic preview flow", async () => {
+  it("gates the Telegram account claim behind the explicit confirmation", async () => {
+    vi.mocked(previewPendingOnboardingContinuation).mockResolvedValue({
+      platform: "telegram",
+      platformUserId: "123456789",
+      platformDisplayName: "attested-telegram-user",
+      returnUrl: null,
+    });
     const entry = `/get-started?onboardingSession=${TOKEN}&accountClaim=telegram`;
     window.history.replaceState(null, "", entry);
 
@@ -235,20 +241,35 @@ describe("GetStartedPage", () => {
       </MemoryRouter>,
     );
 
+    // Load runs the read-only preview only: the identity being linked is
+    // named, and no claim fires without a gesture.
+    expect(await screen.findByText("attested-telegram-user")).toBeTruthy();
+    expect(screen.getByText(/Telegram ID/)).toBeTruthy();
+    expect(screen.getByText(/123456789/)).toBeTruthy();
+    expect(syncStewardSessionCookie).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Connect this Telegram account/ }),
+    );
     expect(await screen.findByText("join")).toBeTruthy();
     expect(syncStewardSessionCookie).toHaveBeenCalledWith(
       "existing-steward-token",
       undefined,
       { telegramContinuation: TOKEN },
     );
-    expect(previewPendingOnboardingContinuation).not.toHaveBeenCalled();
     expect(
       peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE),
     ).toBeNull();
     expect(window.location.search).not.toContain("accountClaim");
   });
 
-  it("retries Telegram convergence without falling into generic identity linking", async () => {
+  it("retries a failed Telegram claim without re-running the preview", async () => {
+    vi.mocked(previewPendingOnboardingContinuation).mockResolvedValue({
+      platform: "telegram",
+      platformUserId: "123456789",
+      platformDisplayName: "attested-telegram-user",
+      returnUrl: null,
+    });
     syncStewardSessionCookie.mockRejectedValueOnce(
       new Error("claim temporarily unavailable"),
     );
@@ -264,13 +285,60 @@ describe("GetStartedPage", () => {
       </MemoryRouter>,
     );
 
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /Connect this Telegram account/,
+      }),
+    );
     expect(
       await screen.findByText("claim temporarily unavailable"),
     ).toBeTruthy();
     fireEvent.click(screen.getByText("Try again"));
     expect(await screen.findByText("join")).toBeTruthy();
     expect(syncStewardSessionCookie).toHaveBeenCalledTimes(2);
-    expect(previewPendingOnboardingContinuation).not.toHaveBeenCalled();
+    expect(previewPendingOnboardingContinuation).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a failed Telegram claim preview without ever firing the claim", async () => {
+    vi.mocked(previewPendingOnboardingContinuation)
+      .mockRejectedValueOnce(new Error("preview temporarily unavailable"))
+      .mockResolvedValue({
+        platform: "telegram",
+        platformUserId: "123456789",
+        platformDisplayName: "attested-telegram-user",
+        returnUrl: null,
+      });
+    const entry = `/get-started?onboardingSession=${TOKEN}&accountClaim=telegram`;
+    window.history.replaceState(null, "", entry);
+
+    render(
+      <MemoryRouter initialEntries={[entry]}>
+        <Routes>
+          <Route path="/get-started" element={<GetStartedPage />} />
+          <Route path="/join" element={<div>join</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText("preview temporarily unavailable"),
+    ).toBeTruthy();
+    expect(syncStewardSessionCookie).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("Try again"));
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /Connect this Telegram account/,
+      }),
+    );
+    expect(await screen.findByText("join")).toBeTruthy();
+    expect(previewPendingOnboardingContinuation).toHaveBeenCalledTimes(2);
+    expect(syncStewardSessionCookie).toHaveBeenCalledTimes(1);
+    expect(syncStewardSessionCookie).toHaveBeenCalledWith(
+      "existing-steward-token",
+      undefined,
+      { telegramContinuation: TOKEN },
+    );
   });
 
   it("offers a deep link back to the originating iMessage conversation", async () => {

--- a/packages/ui/src/cloud/join/GetStartedPage.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.tsx
@@ -5,10 +5,12 @@
  * A messaging onboarding funnel hands the browser
  * `?onboardingSession=<opaque token>`. This page persists the token across the
  * Steward login round trip. Ordinary identity-link continuations are previewed
- * and explicitly confirmed here. Telegram account-claim continuations are
- * consumed earlier by Steward sync so the DM-created user and organization are
- * adopted before generic signup can create duplicates; after auth this page
- * simply forwards to `/join`.
+ * and explicitly confirmed here. Telegram account-claim continuations run
+ * through the same confirm phase: the page shows the attested Telegram
+ * identity and only the explicit confirmation gesture fires the claim, which
+ * Steward sync consumes so the DM-created user and organization are adopted
+ * before generic signup can create duplicates. A signed-out visit still
+ * redirects to login, where session creation consumes the pending claim.
  *
  * Signed-out visitors bounce to `/login?returnTo=/get-started`; the token
  * survives in storage, not the URL. A visit with no pending token just
@@ -184,21 +186,17 @@ export default function GetStartedPage(): React.JSX.Element {
     if (!session.ready || !session.authenticated) return;
     if (startedRef.current) return;
     if (telegramClaimToken) {
+      // A clicked claim link must never execute the account claim on its own:
+      // run the read-only preview and let the confirmation gesture fire it.
       startedRef.current = true;
-      void claimTelegramAccount(telegramClaimToken);
+      void preview(telegramClaimToken);
       return;
     }
     const token = peekPendingOnboardingSession();
     if (!token) return;
     startedRef.current = true;
     void preview(token);
-  }, [
-    session.ready,
-    session.authenticated,
-    telegramClaimToken,
-    claimTelegramAccount,
-    preview,
-  ]);
+  }, [session.ready, session.authenticated, telegramClaimToken, preview]);
 
   if (
     session.ready &&
@@ -258,6 +256,10 @@ export default function GetStartedPage(): React.JSX.Element {
             <Button
               type="button"
               onClick={() => {
+                if (telegramClaimToken) {
+                  void claimTelegramAccount(telegramClaimToken);
+                  return;
+                }
                 const token = peekPendingOnboardingSession();
                 if (token) void redeem(token);
               }}
@@ -322,7 +324,12 @@ export default function GetStartedPage(): React.JSX.Element {
                   return;
                 }
                 if (telegramClaimToken) {
-                  void claimTelegramAccount(telegramClaimToken);
+                  // Retry only the step that failed: the mutating claim once
+                  // the preview has named the identity, otherwise the preview.
+                  // A failed preview must never escalate into the claim.
+                  if (platformIdentity)
+                    void claimTelegramAccount(telegramClaimToken);
+                  else void preview(telegramClaimToken);
                   return;
                 }
                 const token = peekPendingOnboardingSession();

--- a/packages/ui/src/cloud/join/lib/onboarding-continuation.ts
+++ b/packages/ui/src/cloud/join/lib/onboarding-continuation.ts
@@ -9,7 +9,8 @@
  * `public-pages/lib/login-return-to.ts` — and redeemed exactly once after
  * authentication by POSTing the onboarding chat endpoint with the Steward
  * bearer. Ordinary continuations are explicitly confirmed after login. A
- * Telegram personal-account claim is purpose-marked separately and consumed by
+ * Telegram personal-account claim is purpose-marked separately, confirmed
+ * against the read-only claim preview on the landing page, and consumed by
  * Steward sync before generic account creation, preserving its existing user,
  * organization, and transcript. The purpose marker is routing metadata only;
  * the server validates all authority from the opaque token.

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.telegram-claim.test.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.telegram-claim.test.ts
@@ -74,6 +74,30 @@ describe("Steward Telegram account claim handoff", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("never attaches the pending claim on a passive session recovery", async () => {
+    // The login page's stored-token recovery runs on page load with no user
+    // gesture. It must skip the pending claim entirely: not sent, not consumed.
+    storePendingOnboardingSession(TOKEN, TELEGRAM_ACCOUNT_CLAIM_PURPOSE);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await syncStewardSessionCookie("steward-token", null, {
+      skipPendingTelegramClaim: true,
+    });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      token: "steward-token",
+    });
+    expect(peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE)).toBe(
+      TOKEN,
+    );
+  });
+
   it("keeps the claim for an idempotent retry when Cloud rejects the sync", async () => {
     storePendingOnboardingSession(TOKEN, TELEGRAM_ACCOUNT_CLAIM_PURPOSE);
     vi.stubGlobal(

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.ts
@@ -67,11 +67,21 @@ async function readSessionError(response: Response): Promise<{
 /**
  * Steward JWT → HttpOnly cookie sync. Production cloud hosts post directly to
  * api.eliza.app so auth callbacks do not depend on a same-origin redirect.
+ *
+ * A pending Telegram account claim rides this sync only on an explicit
+ * gesture: an explicit `telegramContinuation`, or the pending continuation
+ * peeked for a sign-in ceremony. Passive page-load callers (session recovery)
+ * must pass `skipPendingTelegramClaim` so a stored claim can never fire
+ * without the /get-started confirmation (W9-001).
  */
 export async function syncStewardSessionCookie(
   token: string,
   refreshToken?: string | null,
-  options?: { verifiedPhone?: string; telegramContinuation?: string },
+  options?: {
+    verifiedPhone?: string;
+    telegramContinuation?: string;
+    skipPendingTelegramClaim?: boolean;
+  },
 ): Promise<void> {
   const explicitTelegramContinuation = sanitizeTelegramAccountClaimContinuation(
     options?.telegramContinuation,
@@ -84,7 +94,9 @@ export async function syncStewardSessionCookie(
   }
   const telegramContinuation =
     explicitTelegramContinuation ??
-    peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE);
+    (options?.skipPendingTelegramClaim
+      ? null
+      : peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE));
   const response = await postAuthJson(STEWARD_SESSION_ENDPOINT, {
     token,
     ...(refreshToken ? { refreshToken } : {}),

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.phone-login.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.phone-login.test.tsx
@@ -192,7 +192,11 @@ describe("StewardLoginSection phone login", () => {
     renderSection();
 
     await waitFor(() =>
-      expect(sessionSpies.sync).toHaveBeenCalledWith("existing-session-token"),
+      expect(sessionSpies.sync).toHaveBeenCalledWith(
+        "existing-session-token",
+        null,
+        { skipPendingTelegramClaim: true },
+      ),
     );
     expect(authSpies.refreshSession).not.toHaveBeenCalled();
   });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -782,7 +782,13 @@ export default function StewardLoginSection() {
         const storedToken = readStoredStewardToken();
         if (storedToken) {
           try {
-            await syncStewardSessionCookie(storedToken);
+            // Passive recovery runs on page load with no user gesture, so it
+            // must not consume a pending Telegram account claim: only the
+            // /get-started confirmation or a sign-in ceremony may fire it
+            // (W9-001). The claim stays stored for those paths.
+            await syncStewardSessionCookie(storedToken, null, {
+              skipPendingTelegramClaim: true,
+            });
             if (!cancelled) {
               setRedirectTo(resolveLoginReturnTo(searchParams));
             }

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
@@ -135,7 +135,11 @@ afterEach(() => {
 });
 
 describe("AuthTokenSync 401 handling", () => {
-  it("carries a pending Telegram account claim through background token sync", async () => {
+  it("never carries a pending Telegram account claim through the passive token sync", async () => {
+    // The passive JWT → cookie mirror runs on any authenticated page load with
+    // no user gesture, so it must not execute the account-claim merge: only
+    // the /get-started confirmation click or a sign-in ceremony may consume
+    // the pending claim (W9-001).
     const token = makeJwt({
       sub: "u1",
       exp: Math.floor(Date.now() / 1000) + 3600,
@@ -162,11 +166,10 @@ describe("AuthTokenSync 401 handling", () => {
 
     mount();
 
-    await waitFor(() => expect(peekPendingOnboardingSession()).toBeNull());
-    expect(requestBody).toEqual({
-      token,
-      telegramContinuation: "opaque-telegram-claim-token",
-    });
+    await waitFor(() => expect(requestBody).toEqual({ token }));
+    expect(peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE)).toBe(
+      "opaque-telegram-claim-token",
+    );
   });
 
   it("keeps a still-valid token when session-sync and refresh both 401 (no re-login loop), then retries the cookie sync on the next trigger", async () => {

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -36,11 +36,6 @@ import { scrubPersistedAgentProfileTokens } from "../../state/agent-profiles";
 import { scrubPersistedActiveServerToken } from "../../state/persistence";
 import { reportRendererDiagnostic } from "../../utils/renderer-diagnostics";
 import {
-  clearPendingOnboardingSession,
-  peekPendingOnboardingSession,
-  TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
-} from "../join/lib/onboarding-continuation";
-import {
   clearServerStewardSessionCookies,
   clearStaleStewardSession,
   configuredRefreshEndpoint,
@@ -122,22 +117,21 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
 
       lastSyncedToken.current = token;
       wasAuthenticated.current = true;
-      const telegramContinuation = peekPendingOnboardingSession(
-        TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
-      );
 
+      // A pending Telegram account claim is deliberately NOT attached to this
+      // passive mirror. The claim merges the DM-created account, so it must
+      // fire only on an explicit gesture: the /get-started confirmation, or a
+      // sign-in ceremony (nonce exchange, session sync, SSO exchange), each of
+      // which attaches the pending continuation itself. A clicked claim link
+      // landing on an authenticated session must never execute on page load.
       fetch(configuredSessionEndpoint(), {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          token,
-          ...(telegramContinuation ? { telegramContinuation } : {}),
-        }),
+        body: JSON.stringify({ token }),
       })
         .then(async (res) => {
           if (res.ok) {
-            if (telegramContinuation) clearPendingOnboardingSession();
             dispatchStewardSessionChange("present");
             window.dispatchEvent(
               new CustomEvent("steward-token-sync", {


### PR DESCRIPTION
## Summary

Wave-10 remediation of **W9-001 (MEDIUM)**: an authenticated browser landing on `/get-started` with a Telegram account-claim continuation executed the account-claim merge on page load — one clicked first-party link, zero user gesture.

## Fix

The claim now runs through the page's existing confirm-phase machinery, exactly like the generic platform-link path:

- **`packages/ui/src/cloud/join/GetStartedPage.tsx`** — a pending claim continuation triggers only the read-only preview; the existing confirmation screen renders the attested Telegram identity (display name + Telegram ID), and the claim fires solely from the explicit "Connect this Telegram account" click. Retry repeats only the step that failed: a failed preview re-previews and never escalates into the mutating claim (mirroring the generic path's confused-deputy guard). The signed-out redirect variant is unchanged: unauthenticated visits still bounce to login, where the sign-in ceremonies (nonce exchange, session sync, SSO exchange) attach the pending claim themselves, and a completed claim still forwards to `/join`.
- **`packages/cloud/api/eliza-app/onboarding/chat/route.ts` + `packages/cloud/shared/.../onboarding-chat.ts`** — the GET preview endpoint fell over for claim sessions because they are bound to the DM-created account, not the caller's. It now falls back (only on the fail-closed `ONBOARDING_TRUSTED_CONTINUATION_INVALID` branch) to the existing read-only claim inspection, returning just the Telegram identity being linked — bound account ids never leave the server, and invalid/expired continuations keep the same non-enumerating 403. `inspectTelegramPersonalAccountContinuation` additively returns the gateway-attested display name so the confirmation can name the identity.
- **`packages/ui/src/cloud/shell/StewardProviderRuntime.tsx`** — scope extension beyond the assigned file list, required for the fix to hold: `AuthTokenSync`'s passive JWT→cookie mirror auto-attached any pending claim continuation on every authenticated page load, which would have executed the claim even with the page gated. The mirror no longer carries it; every token-minting sign-in ceremony attaches the pending claim explicitly, so the signed-out (legacy redirect) flow is unaffected.

## Test evidence

- `GetStartedPage.test.tsx` (9/9): no claim fires on load with a claim token (sync mock never called, identity shown); claim fires after the click and forwards to `/join`; failed claim retries without re-preview; failed preview retries the preview and never fires the claim.
- `StewardProviderRuntime.test.tsx` (6/6): passive mirror sends only the token and leaves the pending claim intact (inverted the previous auto-attach pin).
- `eliza-app-onboarding-chat-platform-caller.test.ts` (22/22): authenticated steward caller previews a gateway-minted claim session (200, Telegram identity only); unknown continuation still 403s.
- `onboarding-chat.test.ts` (84/84): claim inspection returns the display name; new claim-preview mapping is read-only and rejects unknown continuations.
- Regression lanes: `onboarding-continuation` 14/14, `sso-bridge` 35/35, `steward-session.telegram-claim` pass; cloud `steward-sync-telegram-convergence` 11/11, `steward-session-phone-convergence` 7/7, `steward-nonce-exchange-telegram-claim` 3/3, `personal-shared/messages` route 28/28. Combined-run mock-leak failure between the two steward auth test files reproduces on pristine `origin/develop` (stash-verified) — the package's isolated runner is the supported lane.
- Typecheck: `packages/ui` and `packages/cloud/shared` clean; `packages/cloud/api` shows only pre-existing `agent-backup-restore-authority*` test errors, reproduced on pristine `origin/develop` via stash-rerun.
- Biome: clean on all 9 changed files.

## Notes

- The /connect DM mint (`internal/eliza-app/personal-shared/messages/route.ts`) needed no change; its link lands on the same page, which now confirms before claiming.
- UI note for reviewers: the confirm screen markup is the pre-existing audited component (same as the generic Telegram link path); no new visual elements were introduced.