### PR TITLE
fix(plugin-whatsapp): bound Cloud API request fetch

### DIFF
--- a/plugins/plugin-whatsapp/src/client-timeout.test.ts
+++ b/plugins/plugin-whatsapp/src/client-timeout.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Behavioral WhatsApp Cloud API deadlines. Executes request() under abort —
+ * not a source-grep of client.ts.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  WHATSAPP_REQUEST_TIMEOUT_MS,
+  whatsAppRequestWithFetch,
+} from "./client.ts";
+
+const REQUEST_URL = "https://graph.facebook.com/v24.0/123/messages";
+const AUTH_HEADERS = {
+  Authorization: "Bearer tok",
+  "Content-Type": "application/json",
+};
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected whatsapp abort signal");
+      const onAbort = () => reject(signal.reason);
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    })) as typeof fetch;
+}
+
+describe("WhatsApp Cloud API request deadlines", () => {
+  it("keeps a documented Cloud API budget", () => {
+    expect(WHATSAPP_REQUEST_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("aborts a stalled request at the injected deadline", async () => {
+    await expect(
+      whatsAppRequestWithFetch(
+        REQUEST_URL,
+        AUTH_HEADERS,
+        { method: "POST" },
+        stallUntilAborted(),
+        10
+      )
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed request", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify({ error: { message: "invalid token" } }), {
+        status: 401,
+        statusText: "Unauthorized",
+      });
+
+    await expect(
+      whatsAppRequestWithFetch(REQUEST_URL, AUTH_HEADERS, { method: "POST" }, fetchImpl, 1_000)
+    ).rejects.toThrow("WhatsApp Cloud API request failed (401 Unauthorized)");
+  });
+
+  it("uses the injected fetch for a successful request", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({ messages: [{ id: "wamid.1" }] });
+    };
+
+    const result = await whatsAppRequestWithFetch<{ messages: Array<{ id: string }> }>(
+      REQUEST_URL,
+      AUTH_HEADERS,
+      { method: "POST" },
+      fetchImpl,
+      1_000
+    );
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(result.status).toBe(200);
+    expect(result.data.messages[0]?.id).toBe("wamid.1");
+  });
+
+  it("preserves a caller-supplied cancellation signal", async () => {
+    const controller = new AbortController();
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      expect(init?.signal).toBe(controller.signal);
+      return Response.json({ messages: [{ id: "caller" }] });
+    };
+
+    await whatsAppRequestWithFetch(
+      REQUEST_URL,
+      AUTH_HEADERS,
+      { method: "POST", signal: controller.signal },
+      fetchImpl,
+      10
+    );
+  });
+});

--- a/plugins/plugin-whatsapp/src/client.ts
+++ b/plugins/plugin-whatsapp/src/client.ts
@@ -23,11 +23,66 @@ import type {
 
 const DEFAULT_API_VERSION = "v24.0";
 
+/** Cloud API hops share the documented 15s sibling budget from GitHub/Google/Discord OAuth. */
+export const WHATSAPP_REQUEST_TIMEOUT_MS = 15_000;
+
 interface WhatsAppApiResponse<T> {
   data: T;
   status: number;
   statusText: string;
   headers: Headers;
+}
+
+interface WhatsAppFetchResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Headers;
+  text(): Promise<string>;
+}
+
+function parseWhatsAppResponseBody(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export async function whatsAppRequestWithFetch<T>(
+  url: string,
+  headers: HeadersInit,
+  init: RequestInit,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs: number = WHATSAPP_REQUEST_TIMEOUT_MS
+): Promise<WhatsAppApiResponse<T>> {
+  const signal = init.signal ?? AbortSignal.timeout(timeoutMs);
+  const response = (await fetchImpl(url, {
+    ...init,
+    headers: {
+      ...headers,
+      ...init.headers,
+    },
+    signal,
+  })) as WhatsAppFetchResponse;
+
+  const text = await response.text();
+  const data = text ? parseWhatsAppResponseBody(text) : undefined;
+
+  if (!response.ok) {
+    const detail =
+      typeof data === "string" ? data : data ? JSON.stringify(data) : response.statusText;
+    throw new Error(
+      `WhatsApp Cloud API request failed (${response.status} ${response.statusText}): ${detail}`
+    );
+  }
+
+  return {
+    data: data as T,
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  };
 }
 
 export class WhatsAppClient extends EventEmitter implements IWhatsAppClient {
@@ -356,39 +411,11 @@ export class WhatsAppClient extends EventEmitter implements IWhatsAppClient {
 
   private async request<T>(endpoint: string, init: RequestInit): Promise<WhatsAppApiResponse<T>> {
     const normalizedEndpoint = endpoint.startsWith("/") ? endpoint.slice(1) : endpoint;
-    const response = await fetch(`${this.baseUrl}/${normalizedEndpoint}`, {
-      ...init,
-      headers: {
-        ...this.headers,
-        ...init.headers,
-      },
-    });
-
-    const text = await response.text();
-    const data = text ? this.parseResponseBody(text) : undefined;
-
-    if (!response.ok) {
-      const detail =
-        typeof data === "string" ? data : data ? JSON.stringify(data) : response.statusText;
-      throw new Error(
-        `WhatsApp Cloud API request failed (${response.status} ${response.statusText}): ${detail}`
-      );
-    }
-
-    return {
-      data: data as T,
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-    };
-  }
-
-  private parseResponseBody(text: string): unknown {
-    try {
-      return JSON.parse(text);
-    } catch {
-      return text;
-    }
+    return whatsAppRequestWithFetch<T>(
+      `${this.baseUrl}/${normalizedEndpoint}`,
+      this.headers,
+      init
+    );
   }
 
   /**


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). WhatsApp Cloud API `request()` used unbounded `fetch`, so a stalled Graph hop hangs `sendTextMessage` and every other Cloud API call. This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, and caller-signal identity, with a documented 15s Cloud API deadline. Tests execute `whatsAppRequestWithFetch` under abort. Discord local OAuth already shipped (`#21768`). Telegram account-auth already bounded. Not extra-decode. Not list-limit. Not payment. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Not Twilio. Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Public `WhatsAppClient` constructor unchanged. Unfixed head: `request()` `fetch` had **no signal** and a hung fetch never settled (80ms race → `HUNG`). After: 10ms deadline → `TimeoutError`. Cloud API budget is 15s. Caller-supplied `init.signal` is preserved.

# Background

## What does this PR do?

`request()` called `fetch` with no `signal`. A stalled Meta Graph hop never returns. This PR injects `whatsAppRequestWithFetch` (Fal `#21205` shape) and adds `AbortSignal.timeout`.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Baileys transport untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-whatsapp/src/client-timeout.test.ts` — request timeout, provider-error, success, and caller cancellation.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-whatsapp && bunx vitest run --config ./vitest.config.ts src/client-timeout.test.ts
```

Unfixed head `51d348d51b`: `request()` `signal` was undefined and the call hung. After the fix: 5 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:d299dea74ef0f2d7cf186aa2cb76d7b602d99eb0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Cloud API fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, success, and caller cancellation.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live WhatsApp Graph path. vitest asserts TimeoutError, provider 401, and success payload.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - WhatsApp Cloud API transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live Graph. Unfixed `%` hang: no signal, 80ms race `HUNG` on `sendTextMessage`. After the fix, vitest asserts TimeoutError, `401 Unauthorized` provider error, caller-signal identity, and a successful `wamid` payload.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

## Audio / voice walkthrough

N/A - Cloud API HTTP only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`5 pass` plus existing media-validation). Root verify is an unrelated full-repo cost. No `bun install`.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
