### PR TITLE
fix(coding-tools): reject surrogate HTML numeric entities

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
@@ -284,9 +284,9 @@ describe("coding-tools WEB_FETCH", () => {
     expect(htmlToReadableText("<p>&quot;&apos;&nbsp;x</p>")).toBe("\"' x");
   });
 
-  it("degrades out-of-range numeric entities without throwing and keeps surrounding text", () => {
-    // String.fromCodePoint throws RangeError above 0x10FFFF; the decoder must
-    // leave the malformed reference literal instead of hard-failing the fetch.
+  it("degrades invalid numeric entities without throwing and keeps surrounding text", () => {
+    // Invalid scalar values must remain literal instead of hard-failing the
+    // fetch or introducing an unpaired UTF-16 surrogate into readable text.
     const hex = htmlToReadableText("<p>hello &#x110000; world</p>");
     expect(hex).toContain("hello");
     expect(hex).toContain("world");
@@ -296,6 +296,13 @@ describe("coding-tools WEB_FETCH", () => {
     expect(dec).toContain("hi");
     expect(dec).toContain("there");
     expect(dec).toContain("&#1114112;");
+
+    expect(htmlToReadableText("<p>&#xD800; &#55296;</p>")).toBe(
+      "&#xD800; &#55296;",
+    );
+    expect(htmlToReadableText("<p>&#xDFFF; &#57343;</p>")).toBe(
+      "&#xDFFF; &#57343;",
+    );
   });
 
   it("degrades a malformed numeric entity to readable text through the handler instead of io_error", async () => {

--- a/plugins/plugin-coding-tools/src/actions/web-fetch.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.ts
@@ -46,19 +46,14 @@ function decodeHtmlEntity(entity: string): string {
     const code = entity.startsWith("#x")
       ? Number.parseInt(entity.slice(2), 16)
       : Number.parseInt(entity.slice(1), 10);
-    // String.fromCodePoint throws RangeError for negatives and any value above
-    // the Unicode ceiling (0x10FFFF), cases Number.isFinite does not reject.
-    // A single malformed reference must degrade to its literal source, never
-    // hard-fail the best-effort fetch. The try/catch is belt-and-suspenders.
-    if (Number.isInteger(code) && code >= 0 && code <= 0x10ffff) {
-      try {
-        return String.fromCodePoint(code);
-      } catch {
-        // error-policy:J4 malformed entity degrades to its literal source text
-        return `&${entity};`;
-      }
-    }
-    return `&${entity};`;
+    // Exclude the UTF-16 surrogate range as well as values outside Unicode.
+    // Once this scalar-value guard passes, String.fromCodePoint cannot throw.
+    const isUnicodeScalarValue =
+      Number.isInteger(code) &&
+      code >= 0 &&
+      code <= 0x10ffff &&
+      (code < 0xd800 || code > 0xdfff);
+    return isUnicodeScalarValue ? String.fromCodePoint(code) : `&${entity};`;
   }
   return named[entity] ?? `&${entity};`;
 }


### PR DESCRIPTION
# Relates to

Follow-up to #21718 and #21694.

# Summary

The merged range guard still accepted UTF-16 surrogate code points (`D800` through `DFFF`) even though they are not Unicode scalar values, and its `try/catch` was unreachable after the integer/range guard. This follow-up excludes surrogates, removes the catch so unexpected failures remain fail-fast, and adds hexadecimal and decimal surrogate regressions.

# Risk

Low. The change is confined to the private HTML entity decoder and its existing focused tests. Valid scalar values and named entities are unchanged; malformed numeric references continue to degrade to their literal source.

# Verification

Exact evidence head: `0d317ef954281f71ba7289825f618d356ea7ab12`

- `web-fetch.test.ts`: 15/15 passed after rebase onto `93efdd5789e350ec99a53463b39827e7b95ae52d`
- `bun run --cwd plugins/plugin-coding-tools typecheck`: passed on the preceding identical patch lineage
- `bun run --cwd plugins/plugin-coding-tools lint:check`: 104 files clean on the preceding identical patch lineage
- `git diff --check`: passed
- direct runtime assertions covered valid entities, values above `10FFFF`, and both surrogate boundaries
- Full package test run was stopped after approximately 90 seconds without output during severe concurrent Vitest contention; no failure was observed. The focused suite covers the changed contract.

UI, screenshots, video, frontend logs, OCR, audio, and live-model trajectories: N/A — deterministic headless text decoding only.

# Contribution provenance

- AI assistance: yes
- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Attribution status: self-reported

— [codex-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@93efdd5789e350ec99a53463b39827e7b95ae52d:packages/skills/skills/contribute-to-eliza"} -->
