### PR TITLE
feat(cloud): make OAuth grants capability-based

### DIFF
--- a/packages/cloud/api/v1/oauth/connect/route.ts
+++ b/packages/cloud/api/v1/oauth/connect/route.ts
@@ -27,6 +27,7 @@ interface ConnectRequestBody {
   redirectUrl?: string;
   scopes?: string[];
   capabilities?: string[];
+  capabilityRequest?: unknown;
   connectionId?: string;
 }
 
@@ -97,6 +98,17 @@ app.post("/", async (c) => {
       );
     }
     if (
+      body.capabilityRequest !== undefined &&
+      body.capabilities === undefined
+    ) {
+      return c.json(
+        validationErrorResponse(
+          "capabilityRequest requires named capabilities",
+        ),
+        400,
+      );
+    }
+    if (
       body.connectionId !== undefined &&
       (!isValidString(body.connectionId) ||
         !UUID_PATTERN.test(body.connectionId) ||
@@ -128,6 +140,7 @@ app.post("/", async (c) => {
       redirectUrl: body.redirectUrl,
       scopes: body.scopes,
       capabilities: body.capabilities,
+      capabilityRequest: body.capabilityRequest,
       connectionId: body.connectionId,
     });
 

--- a/packages/cloud/api/v1/oauth/connect/route.ts
+++ b/packages/cloud/api/v1/oauth/connect/route.ts
@@ -26,10 +26,23 @@ interface ConnectRequestBody {
   platform: string;
   redirectUrl?: string;
   scopes?: string[];
+  capabilities?: string[];
+  connectionId?: string;
 }
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function isValidString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
+}
+
+function isNonEmptyStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((entry) => typeof entry === "string" && entry.trim().length > 0)
+  );
 }
 
 const app = new Hono<AppEnv>();
@@ -58,6 +71,45 @@ app.post("/", async (c) => {
       );
     }
 
+    if (body.scopes !== undefined && !isNonEmptyStringArray(body.scopes)) {
+      return c.json(
+        validationErrorResponse("scopes must be a non-empty string array"),
+        400,
+      );
+    }
+    if (
+      body.capabilities !== undefined &&
+      !isNonEmptyStringArray(body.capabilities)
+    ) {
+      return c.json(
+        validationErrorResponse(
+          "capabilities must be a non-empty string array",
+        ),
+        400,
+      );
+    }
+    if (body.scopes !== undefined && body.capabilities !== undefined) {
+      return c.json(
+        validationErrorResponse(
+          "Request either named capabilities or raw scopes, not both",
+        ),
+        400,
+      );
+    }
+    if (
+      body.connectionId !== undefined &&
+      (!isValidString(body.connectionId) ||
+        !UUID_PATTERN.test(body.connectionId) ||
+        body.capabilities === undefined)
+    ) {
+      return c.json(
+        validationErrorResponse(
+          "connectionId is only valid with named capabilities",
+        ),
+        400,
+      );
+    }
+
     // Sanitize platform — lowercase and max 50 chars.
     body.platform = body.platform.toLowerCase().slice(0, 50);
     platform = body.platform;
@@ -66,6 +118,7 @@ app.post("/", async (c) => {
       organizationId,
       platform,
       hasScopes: !!body.scopes,
+      capabilityCount: body.capabilities?.length,
     });
 
     const result = await oauthService.initiateAuth({
@@ -74,6 +127,8 @@ app.post("/", async (c) => {
       platform,
       redirectUrl: body.redirectUrl,
       scopes: body.scopes,
+      capabilities: body.capabilities,
+      connectionId: body.connectionId,
     });
 
     return c.json(result);

--- a/packages/cloud/api/v1/oauth/generic-callback.ts
+++ b/packages/cloud/api/v1/oauth/generic-callback.ts
@@ -138,6 +138,7 @@ export async function handleGenericOAuthCallback(
         connectionId: result.connectionId,
         organizationId: result.organizationId,
         userId: result.userId,
+        capabilityContinuation: result.capabilityContinuation,
       });
       if (proof) {
         redirectTarget.searchParams.set("proof", proof);

--- a/packages/cloud/api/v1/oauth/generic-initiate.capabilities.test.ts
+++ b/packages/cloud/api/v1/oauth/generic-initiate.capabilities.test.ts
@@ -50,15 +50,18 @@ const initiateAuth = mock(
     scopes?: string[];
     redirectUrl?: string;
     connectionId?: string;
+    capabilityRequest?: unknown;
   }) => ({
     authUrl: "https://accounts.example/authorize",
     state: "state-1",
     capabilityAccess: params.capabilities?.map((capabilityId) => ({
       capabilityId,
+      riskLevel: "R1" as const,
       status: "needs_scope" as const,
       missingScopes: ["calendar.read"],
       missingUserScopes: [],
     })),
+    retryAfterConsent: params.capabilityRequest !== undefined,
   }),
 );
 mock.module("@/lib/services/oauth", () => ({
@@ -87,7 +90,7 @@ describe("generic OAuth capability initiation (#19879)", () => {
 
   test("returns the consent state and preserves the retry redirect", async () => {
     const response = await request({
-      capabilities: ["google.calendar.read"],
+      capabilities: ["calendar.events.read"],
       redirectUrl: "/cloud/calendar?retry=intent-1",
     });
 
@@ -95,7 +98,7 @@ describe("generic OAuth capability initiation (#19879)", () => {
     expect(initiateAuth).toHaveBeenCalledWith(
       expect.objectContaining({
         platform: "google",
-        capabilities: ["google.calendar.read"],
+        capabilities: ["calendar.events.read"],
         scopes: undefined,
         redirectUrl: "/cloud/calendar?retry=intent-1",
       }),
@@ -103,17 +106,17 @@ describe("generic OAuth capability initiation (#19879)", () => {
     expect(await response.json()).toMatchObject({
       capabilityAccess: [
         {
-          capabilityId: "google.calendar.read",
+          capabilityId: "calendar.events.read",
           status: "needs_scope",
         },
       ],
-      retryAfterConsent: true,
+      retryAfterConsent: false,
     });
   });
 
   test("passes the explicit connection binding used to inspect existing grants", async () => {
     const response = await request({
-      capabilities: ["google.calendar.read"],
+      capabilities: ["calendar.events.read"],
       connectionId: "11111111-1111-4111-8111-111111111111",
     });
 
@@ -127,7 +130,7 @@ describe("generic OAuth capability initiation (#19879)", () => {
 
   test.each([
     { capabilities: [] },
-    { capabilities: "google.calendar.read" },
+    { capabilities: "calendar.events.read" },
     { capabilities: [" "] },
   ])("rejects malformed capability input %#", async (body) => {
     const response = await request(body);
@@ -138,7 +141,7 @@ describe("generic OAuth capability initiation (#19879)", () => {
   test("rejects ambiguous raw-scope and capability requests", async () => {
     const response = await request({
       scopes: ["calendar.read"],
-      capabilities: ["google.calendar.read"],
+      capabilities: ["calendar.events.read"],
     });
     expect(response.status).toBe(400);
     expect(initiateAuth).not.toHaveBeenCalled();
@@ -154,7 +157,7 @@ describe("generic OAuth capability initiation (#19879)", () => {
 
   test("rejects a malformed connection binding before tenant lookup", async () => {
     const response = await request({
-      capabilities: ["google.calendar.read"],
+      capabilities: ["calendar.events.read"],
       connectionId: "not-a-uuid",
     });
     expect(response.status).toBe(400);
@@ -171,5 +174,30 @@ describe("generic OAuth capability initiation (#19879)", () => {
       }),
     );
     expect(await response.json()).toMatchObject({ retryAfterConsent: false });
+  });
+
+  test("forwards an exact request only through the authenticated continuation", async () => {
+    const capabilityRequest = {
+      contractVersion: 2,
+      requestId: "req_calendar_1",
+      capabilityId: "calendar.events.read",
+      operation: "calendar.events.list",
+      riskLevel: "R1",
+      accountId: null,
+      inputDigest: "a".repeat(64),
+    };
+    const response = await request({
+      capabilities: ["calendar.events.read"],
+      capabilityRequest,
+    });
+
+    expect(response.status).toBe(200);
+    expect(initiateAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capabilityRequest,
+        redirectUrl: "/auth/success",
+      }),
+    );
+    expect(await response.json()).toMatchObject({ retryAfterConsent: true });
   });
 });

--- a/packages/cloud/api/v1/oauth/generic-initiate.capabilities.test.ts
+++ b/packages/cloud/api/v1/oauth/generic-initiate.capabilities.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Exercises capability-based generic OAuth initiation through the HTTP
+ * boundary with deterministic auth and provider adapters.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_c: unknown, error: unknown) => {
+    throw error;
+  },
+  ApiError: class ApiError extends Error {},
+}));
+mock.module("@/lib/api/errors", () => ({
+  ApiError: class ApiError extends Error {},
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: mock(async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  })),
+}));
+
+const provider = {
+  id: "google",
+  name: "Google",
+  description: "Google",
+  type: "oauth2",
+  envVars: [],
+  useGenericRoutes: true,
+  defaultScopes: ["identity"],
+  storage: "platform_credentials",
+} as const;
+mock.module("@/lib/services/oauth/provider-registry", () => ({
+  getProvider: (id: string) => (id === "google" ? provider : null),
+  isProviderConfigured: () => true,
+}));
+
+const initiateAuth = mock(
+  async (params: {
+    capabilities?: string[];
+    scopes?: string[];
+    redirectUrl?: string;
+    connectionId?: string;
+  }) => ({
+    authUrl: "https://accounts.example/authorize",
+    state: "state-1",
+    capabilityAccess: params.capabilities?.map((capabilityId) => ({
+      capabilityId,
+      status: "needs_scope" as const,
+      missingScopes: ["calendar.read"],
+      missingUserScopes: [],
+    })),
+  }),
+);
+mock.module("@/lib/services/oauth", () => ({
+  OAuthError: class OAuthError extends Error {},
+  oauthService: { initiateAuth },
+}));
+
+const { handleGenericOAuthInitiate } = await import("./generic-initiate");
+
+function request(body: unknown): Promise<Response> {
+  const app = new Hono<AppEnv>();
+  app.post("/api/v1/oauth/google/initiate", (c) =>
+    handleGenericOAuthInitiate(c, "google"),
+  );
+  return Promise.resolve(
+    app.request("/api/v1/oauth/google/initiate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("generic OAuth capability initiation (#19879)", () => {
+  beforeEach(() => initiateAuth.mockClear());
+
+  test("returns the consent state and preserves the retry redirect", async () => {
+    const response = await request({
+      capabilities: ["google.calendar.read"],
+      redirectUrl: "/cloud/calendar?retry=intent-1",
+    });
+
+    expect(response.status).toBe(200);
+    expect(initiateAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platform: "google",
+        capabilities: ["google.calendar.read"],
+        scopes: undefined,
+        redirectUrl: "/cloud/calendar?retry=intent-1",
+      }),
+    );
+    expect(await response.json()).toMatchObject({
+      capabilityAccess: [
+        {
+          capabilityId: "google.calendar.read",
+          status: "needs_scope",
+        },
+      ],
+      retryAfterConsent: true,
+    });
+  });
+
+  test("passes the explicit connection binding used to inspect existing grants", async () => {
+    const response = await request({
+      capabilities: ["google.calendar.read"],
+      connectionId: "11111111-1111-4111-8111-111111111111",
+    });
+
+    expect(response.status).toBe(200);
+    expect(initiateAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: "11111111-1111-4111-8111-111111111111",
+      }),
+    );
+  });
+
+  test.each([
+    { capabilities: [] },
+    { capabilities: "google.calendar.read" },
+    { capabilities: [" "] },
+  ])("rejects malformed capability input %#", async (body) => {
+    const response = await request(body);
+    expect(response.status).toBe(400);
+    expect(initiateAuth).not.toHaveBeenCalled();
+  });
+
+  test("rejects ambiguous raw-scope and capability requests", async () => {
+    const response = await request({
+      scopes: ["calendar.read"],
+      capabilities: ["google.calendar.read"],
+    });
+    expect(response.status).toBe(400);
+    expect(initiateAuth).not.toHaveBeenCalled();
+  });
+
+  test("rejects a connection binding without named capabilities", async () => {
+    const response = await request({
+      connectionId: "11111111-1111-4111-8111-111111111111",
+    });
+    expect(response.status).toBe(400);
+    expect(initiateAuth).not.toHaveBeenCalled();
+  });
+
+  test("rejects a malformed connection binding before tenant lookup", async () => {
+    const response = await request({
+      capabilities: ["google.calendar.read"],
+      connectionId: "not-a-uuid",
+    });
+    expect(response.status).toBe(400);
+    expect(initiateAuth).not.toHaveBeenCalled();
+  });
+
+  test("preserves the legacy raw-scope request path", async () => {
+    const response = await request({ scopes: ["identity"] });
+    expect(response.status).toBe(200);
+    expect(initiateAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopes: ["identity"],
+        capabilities: undefined,
+      }),
+    );
+    expect(await response.json()).toMatchObject({ retryAfterConsent: false });
+  });
+});

--- a/packages/cloud/api/v1/oauth/generic-initiate.ts
+++ b/packages/cloud/api/v1/oauth/generic-initiate.ts
@@ -36,6 +36,7 @@ interface InitiateRequestBody {
   redirectUrl?: string;
   scopes?: string[];
   capabilities?: string[];
+  capabilityRequest?: unknown;
   connectionId?: string;
   connectionRole?: "owner" | "agent";
 }
@@ -115,7 +116,11 @@ export async function handleGenericOAuthInitiate(
       // Empty body is fine — defaults apply.
     }
 
-    const redirectUrl = body.redirectUrl || "/cloud/settings?tab=connections";
+    const redirectUrl =
+      body.redirectUrl ||
+      (body.capabilityRequest
+        ? "/auth/success"
+        : "/cloud/settings?tab=connections");
     if (redirectUrl.startsWith("http")) {
       const allowedAbsoluteOrigins = [
         ...getDefaultPlatformRedirectOrigins(),
@@ -172,6 +177,18 @@ export async function handleGenericOAuthInitiate(
       );
     }
     if (
+      body.capabilityRequest !== undefined &&
+      body.capabilities === undefined
+    ) {
+      return c.json(
+        {
+          error: "INVALID_CAPABILITY_REQUEST",
+          message: "capabilityRequest requires named capabilities",
+        },
+        400,
+      );
+    }
+    if (
       body.connectionId !== undefined &&
       (typeof body.connectionId !== "string" ||
         body.connectionId.trim().length === 0 ||
@@ -218,6 +235,7 @@ export async function handleGenericOAuthInitiate(
       redirectUrl,
       scopes,
       capabilities,
+      capabilityRequest: body.capabilityRequest,
       connectionId: body.connectionId,
       connectionRole,
     });
@@ -230,10 +248,7 @@ export async function handleGenericOAuthInitiate(
         name: provider.name,
       },
       capabilityAccess: result.capabilityAccess,
-      retryAfterConsent:
-        result.capabilityAccess?.some(
-          (capability) => capability.status !== "available",
-        ) ?? false,
+      retryAfterConsent: result.retryAfterConsent ?? false,
     });
   } catch (error) {
     logger.error(`[OAuth ${platform}] Failed to initiate auth`, {

--- a/packages/cloud/api/v1/oauth/generic-initiate.ts
+++ b/packages/cloud/api/v1/oauth/generic-initiate.ts
@@ -24,19 +24,31 @@ import {
   isSafeRelativeRedirectPath,
   LOOPBACK_REDIRECT_ORIGINS,
 } from "@/lib/security/redirect-validation";
-import { OAuthError } from "@/lib/services/oauth";
+import { OAuthError, oauthService } from "@/lib/services/oauth";
 import {
   getProvider,
   isProviderConfigured,
 } from "@/lib/services/oauth/provider-registry";
-import { initiateOAuth2 } from "@/lib/services/oauth/providers";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 interface InitiateRequestBody {
   redirectUrl?: string;
   scopes?: string[];
+  capabilities?: string[];
+  connectionId?: string;
   connectionRole?: "owner" | "agent";
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isNonEmptyStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((entry) => typeof entry === "string" && entry.trim().length > 0)
+  );
 }
 
 export async function handleGenericOAuthInitiate(
@@ -129,7 +141,53 @@ export async function handleGenericOAuthInitiate(
       );
     }
 
-    const scopes = body.scopes || provider.defaultScopes || [];
+    if (body.scopes !== undefined && !isNonEmptyStringArray(body.scopes)) {
+      return c.json(
+        {
+          error: "INVALID_SCOPES",
+          message: "scopes must be a non-empty string array",
+        },
+        400,
+      );
+    }
+    if (
+      body.capabilities !== undefined &&
+      !isNonEmptyStringArray(body.capabilities)
+    ) {
+      return c.json(
+        {
+          error: "INVALID_CAPABILITIES",
+          message: "capabilities must be a non-empty string array",
+        },
+        400,
+      );
+    }
+    if (body.scopes !== undefined && body.capabilities !== undefined) {
+      return c.json(
+        {
+          error: "AMBIGUOUS_OAUTH_REQUEST",
+          message: "Request either named capabilities or raw scopes, not both",
+        },
+        400,
+      );
+    }
+    if (
+      body.connectionId !== undefined &&
+      (typeof body.connectionId !== "string" ||
+        body.connectionId.trim().length === 0 ||
+        !UUID_PATTERN.test(body.connectionId) ||
+        body.capabilities === undefined)
+    ) {
+      return c.json(
+        {
+          error: "INVALID_CONNECTION_ID",
+          message: "connectionId is only valid with named capabilities",
+        },
+        400,
+      );
+    }
+    const scopes = body.scopes;
+    const capabilities = body.capabilities;
     const connectionRole =
       body.connectionRole === "owner" || body.connectionRole === "agent"
         ? body.connectionRole
@@ -148,15 +206,19 @@ export async function handleGenericOAuthInitiate(
     logger.info(`[OAuth ${platform}] Initiating auth`, {
       organizationId,
       userId: user.id,
-      scopeCount: scopes.length,
+      scopeCount: scopes?.length,
+      capabilityCount: capabilities?.length,
       connectionRole,
     });
 
-    const result = await initiateOAuth2(provider, {
+    const result = await oauthService.initiateAuth({
       organizationId,
       userId: user.id,
+      platform: provider.id,
       redirectUrl,
       scopes,
+      capabilities,
+      connectionId: body.connectionId,
       connectionRole,
     });
 
@@ -167,6 +229,11 @@ export async function handleGenericOAuthInitiate(
         id: provider.id,
         name: provider.name,
       },
+      capabilityAccess: result.capabilityAccess,
+      retryAfterConsent:
+        result.capabilityAccess?.some(
+          (capability) => capability.status !== "available",
+        ) ?? false,
     });
   } catch (error) {
     logger.error(`[OAuth ${platform}] Failed to initiate auth`, {

--- a/packages/cloud/api/v1/oauth/success-proof/verify/route.ts
+++ b/packages/cloud/api/v1/oauth/success-proof/verify/route.ts
@@ -53,6 +53,7 @@ app.get("/", async (c) => {
     ok: true,
     platform: result.payload.platform,
     connectionId: result.payload.connectionId,
+    capabilityContinuation: result.payload.capabilityContinuation,
     exp: result.payload.exp,
   });
 });

--- a/packages/cloud/shared/src/db/schemas/platform-credentials.ts
+++ b/packages/cloud/shared/src/db/schemas/platform-credentials.ts
@@ -128,6 +128,7 @@ export const platformCredentials = pgTable(
       referrer?: string;
       agentGoogleSide?: "owner" | "agent";
       connectionRole?: "OWNER" | "AGENT" | "TEAM";
+      oauthUserScopes?: string[];
     }>(),
 
     // Raw profile data from OAuth provider

--- a/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.capabilities.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.capabilities.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Exercises the real OAUTH action's incremental-consent handoff while the
+ * tenant lookup and OAuth service are deterministic boundary doubles.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import * as realOAuthModule from "../../../services/oauth";
+import * as realUtils from "../utils";
+
+const realOAuthExports = { ...realOAuthModule };
+const realUtilsExports = { ...realUtils };
+const initiateAuth = mock(async (_input: unknown) => ({
+  authUrl: "https://accounts.example/authorize",
+  state: "state-1",
+  capabilityAccess: [
+    {
+      capabilityId: "google.calendar.write",
+      status: "needs_review" as const,
+      missingScopes: ["calendar.write"],
+      missingUserScopes: [],
+    },
+  ],
+  retryAfterConsent: true,
+}));
+
+mock.module("../../../services/oauth", () => ({
+  oauthService: {
+    isPlatformConnected: async () => true,
+    listConnections: async () => [
+      {
+        id: "11111111-1111-4111-8111-111111111111",
+        status: "active",
+        platform: "google",
+        platformUserId: "google-user-1",
+        userId: "user-1",
+        connectionRole: "owner",
+        scopes: ["identity"],
+        linkedAt: new Date("2026-01-01T00:00:00.000Z"),
+        source: "platform_credentials",
+      },
+    ],
+    initiateAuth,
+  },
+}));
+
+mock.module("../utils", () => ({
+  ...realUtilsExports,
+  getSupportedPlatforms: () => ["google"],
+  isSupportedPlatform: (platform: string) => platform === "google",
+  lookupUser: async () => ({
+    organizationId: "org-1",
+    user: { id: "user-1", organization_id: "org-1" },
+  }),
+}));
+
+const { oauthAction } = await import("./oauth");
+
+afterAll(() => {
+  mock.module("../../../services/oauth", () => realOAuthExports);
+  mock.module("../utils", () => realUtilsExports);
+});
+
+function message(): Memory {
+  return {
+    agentId: "agent-1",
+    entityId: "user-1",
+    roomId: "room-1",
+    content: {
+      text: "I need calendar write access",
+      actionParams: {
+        op: "connect",
+        platform: "google",
+        capabilities: ["google.calendar.write"],
+        redirectUrl: "/calendar?retry=intent-1",
+      },
+    },
+  } as Memory;
+}
+
+describe("OAUTH incremental capability handoff (#19879)", () => {
+  beforeEach(() => initiateAuth.mockClear());
+
+  test("extends the active account and returns machine-readable retry state", async () => {
+    const result = await oauthAction.handler({} as IAgentRuntime, message());
+
+    expect(initiateAuth).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      userId: "user-1",
+      platform: "google",
+      redirectUrl: "/calendar?retry=intent-1",
+      scopes: undefined,
+      capabilities: ["google.calendar.write"],
+      connectionId: "11111111-1111-4111-8111-111111111111",
+      connectionRole: "owner",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      actionName: "OAUTH",
+      op: "connect",
+      connectionId: "11111111-1111-4111-8111-111111111111",
+      retryAfterConsent: true,
+      capabilityAccess: [
+        {
+          capabilityId: "google.calendar.write",
+          status: "needs_review",
+        },
+      ],
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.capabilities.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.capabilities.test.ts
@@ -23,23 +23,26 @@ const initiateAuth = mock(async (_input: unknown) => ({
   ],
   retryAfterConsent: true,
 }));
+let connections: Array<Record<string, unknown>> = [];
+
+function connection(id: string, platformUserId: string): Record<string, unknown> {
+  return {
+    id,
+    status: "active",
+    platform: "google",
+    platformUserId,
+    userId: "user-1",
+    connectionRole: "owner",
+    scopes: ["identity"],
+    linkedAt: new Date("2026-01-01T00:00:00.000Z"),
+    source: "platform_credentials",
+  };
+}
 
 mock.module("../../../services/oauth", () => ({
   oauthService: {
     isPlatformConnected: async () => true,
-    listConnections: async () => [
-      {
-        id: "11111111-1111-4111-8111-111111111111",
-        status: "active",
-        platform: "google",
-        platformUserId: "google-user-1",
-        userId: "user-1",
-        connectionRole: "owner",
-        scopes: ["identity"],
-        linkedAt: new Date("2026-01-01T00:00:00.000Z"),
-        source: "platform_credentials",
-      },
-    ],
+    listConnections: async () => connections,
     initiateAuth,
   },
 }));
@@ -61,7 +64,7 @@ afterAll(() => {
   mock.module("../utils", () => realUtilsExports);
 });
 
-function message(): Memory {
+function message(actionParams: Record<string, unknown> = {}): Memory {
   return {
     agentId: "agent-1",
     entityId: "user-1",
@@ -73,13 +76,17 @@ function message(): Memory {
         platform: "google",
         capabilities: ["google.calendar.write"],
         redirectUrl: "/calendar?retry=intent-1",
+        ...actionParams,
       },
     },
   } as Memory;
 }
 
 describe("OAUTH incremental capability handoff (#19879)", () => {
-  beforeEach(() => initiateAuth.mockClear());
+  beforeEach(() => {
+    initiateAuth.mockClear();
+    connections = [connection("11111111-1111-4111-8111-111111111111", "google-user-1")];
+  });
 
   test("extends the active account and returns machine-readable retry state", async () => {
     const result = await oauthAction.handler({} as IAgentRuntime, message());
@@ -107,5 +114,33 @@ describe("OAUTH incremental capability handoff (#19879)", () => {
         },
       ],
     });
+  });
+
+  test("requires an explicit account when multiple active connections exist", async () => {
+    connections.push(connection("22222222-2222-4222-8222-222222222222", "google-user-2"));
+
+    const result = await oauthAction.handler({} as IAgentRuntime, message());
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "AMBIGUOUS_CONNECTION",
+    });
+    expect(initiateAuth).not.toHaveBeenCalled();
+  });
+
+  test("binds the explicitly selected account when multiple are active", async () => {
+    connections.push(connection("22222222-2222-4222-8222-222222222222", "google-user-2"));
+
+    const result = await oauthAction.handler(
+      {} as IAgentRuntime,
+      message({ connectionId: "22222222-2222-4222-8222-222222222222" }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(initiateAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: "22222222-2222-4222-8222-222222222222",
+      }),
+    );
   });
 });

--- a/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.ts
@@ -149,36 +149,42 @@ async function runConnect(
 
   const { organizationId, user } = userResult;
   const platformName = capitalize(platform);
+  const capabilities = normalizeScopes(params.capabilities);
+  const connectionRole = normalizeRole(params.connectionRole) ?? "owner";
 
   try {
     const alreadyConnected = await oauthService.isPlatformConnected(
       organizationId,
       platform,
       user.id,
-      normalizeRole(params.connectionRole),
+      connectionRole,
     );
 
+    let activeConnectionId: string | undefined;
     if (alreadyConnected) {
       const connections = await oauthService.listConnections({
         organizationId,
         userId: user.id,
         platform,
-        connectionRole: normalizeRole(params.connectionRole),
+        connectionRole,
       });
       const active = connections.find((c) => c.status === "active");
+      activeConnectionId = active?.id;
       const identifier = active ? formatConnectionIdentifier(active) : "";
-      const text = `Your ${platformName} account is already connected${identifier ? ` (${identifier})` : ""}.`;
-      if (callback) await callback({ text, actions: ["OAUTH"] });
-      return {
-        text,
-        success: true,
-        data: {
-          actionName: "OAUTH",
-          op: "connect",
-          alreadyConnected: true,
-          platform,
-        },
-      };
+      if (!capabilities) {
+        const text = `Your ${platformName} account is already connected${identifier ? ` (${identifier})` : ""}.`;
+        if (callback) await callback({ text, actions: ["OAUTH"] });
+        return {
+          text,
+          success: true,
+          data: {
+            actionName: "OAUTH",
+            op: "connect",
+            alreadyConnected: true,
+            platform,
+          },
+        };
+      }
     }
 
     const result = await oauthService.initiateAuth({
@@ -187,7 +193,9 @@ async function runConnect(
       platform,
       redirectUrl: typeof params.redirectUrl === "string" ? params.redirectUrl : undefined,
       scopes: normalizeScopes(params.scopes),
-      connectionRole: normalizeRole(params.connectionRole),
+      capabilities,
+      connectionId: capabilities ? activeConnectionId : undefined,
+      connectionRole,
     });
 
     if (!result.authUrl) {
@@ -209,6 +217,9 @@ async function runConnect(
         platform,
         authUrl: result.authUrl,
         state: result.state,
+        connectionId: activeConnectionId,
+        capabilityAccess: result.capabilityAccess,
+        retryAfterConsent: result.retryAfterConsent ?? false,
       },
     };
   } catch (error) {
@@ -530,7 +541,14 @@ export const oauthAction: ActionWithParams = {
     },
     scopes: {
       type: "array",
-      description: "For op=connect: optional OAuth scopes to request.",
+      description:
+        "For op=connect: legacy raw OAuth scopes. Prefer named capabilities; do not combine both fields.",
+      required: false,
+    },
+    capabilities: {
+      type: "array",
+      description:
+        "For op=connect: stable named capabilities to authorize incrementally. An existing active account is bound automatically and the returned state tells the caller whether consent, review, or admin approval is needed before retrying the blocked action.",
       required: false,
     },
   }),

--- a/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.ts
@@ -236,6 +236,10 @@ async function runConnect(
       redirectUrl: typeof params.redirectUrl === "string" ? params.redirectUrl : undefined,
       scopes: normalizeScopes(params.scopes),
       capabilities,
+      capabilityRequest:
+        params.capabilityRequest && typeof params.capabilityRequest === "object"
+          ? params.capabilityRequest
+          : undefined,
       connectionId: capabilities ? activeConnectionId : undefined,
       connectionRole,
     });

--- a/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.ts
@@ -151,6 +151,24 @@ async function runConnect(
   const platformName = capitalize(platform);
   const capabilities = normalizeScopes(params.capabilities);
   const connectionRole = normalizeRole(params.connectionRole) ?? "owner";
+  const requestedConnectionId =
+    typeof params.connectionId === "string" && params.connectionId.trim().length > 0
+      ? params.connectionId.trim()
+      : undefined;
+
+  if (params.connectionId !== undefined && requestedConnectionId === undefined) {
+    return failureResult("Choose a valid connected account.", "INVALID_CONNECTION_ID", {
+      op: "connect",
+      platform,
+    });
+  }
+  if (requestedConnectionId && !capabilities) {
+    return failureResult(
+      "A connected account can only be selected when requesting named capabilities.",
+      "INVALID_CONNECTION_ID",
+      { op: "connect", platform },
+    );
+  }
 
   try {
     const alreadyConnected = await oauthService.isPlatformConnected(
@@ -161,14 +179,38 @@ async function runConnect(
     );
 
     let activeConnectionId: string | undefined;
-    if (alreadyConnected) {
+    if (alreadyConnected || capabilities) {
       const connections = await oauthService.listConnections({
         organizationId,
         userId: user.id,
         platform,
         connectionRole,
       });
-      const active = connections.find((c) => c.status === "active");
+      const activeConnections = connections.filter((connection) => connection.status === "active");
+      const active = requestedConnectionId
+        ? activeConnections.find((connection) => connection.id === requestedConnectionId)
+        : activeConnections.length === 1
+          ? activeConnections[0]
+          : undefined;
+
+      if (requestedConnectionId && !active) {
+        return failureResult(
+          `The selected ${platformName} account is unavailable or does not belong to you.`,
+          "CONNECTION_NOT_FOUND",
+          { op: "connect", platform },
+        );
+      }
+      if (capabilities && !requestedConnectionId && activeConnections.length > 1) {
+        return failureResult(
+          `Choose which ${platformName} account should receive the additional access.`,
+          "AMBIGUOUS_CONNECTION",
+          {
+            op: "connect",
+            platform,
+            connectionIds: activeConnections.map((connection) => connection.id),
+          },
+        );
+      }
       activeConnectionId = active?.id;
       const identifier = active ? formatConnectionIdentifier(active) : "";
       if (!capabilities) {
@@ -549,6 +591,12 @@ export const oauthAction: ActionWithParams = {
       type: "array",
       description:
         "For op=connect: stable named capabilities to authorize incrementally. An existing active account is bound automatically and the returned state tells the caller whether consent, review, or admin approval is needed before retrying the blocked action.",
+      required: false,
+    },
+    connectionId: {
+      type: "string",
+      description:
+        "For capability-based connect: the existing connected account to extend. Required when more than one active account exists.",
       required: false,
     },
   }),

--- a/packages/cloud/shared/src/lib/services/oauth/connection-adapters/generic-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/connection-adapters/generic-adapter.ts
@@ -24,6 +24,13 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 // Buffer before token expiry to trigger refresh (5 minutes)
 const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 
+function readOAuthUserScopes(sourceContext: unknown): string[] | undefined {
+  if (!sourceContext || typeof sourceContext !== "object") return undefined;
+  const value = (sourceContext as Record<string, unknown>).oauthUserScopes;
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((scope): scope is string => typeof scope === "string");
+}
+
 /**
  * Create a generic adapter for a specific platform.
  * This allows the adapter to be used for any platform that stores in platform_credentials.
@@ -125,6 +132,7 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
         avatarUrl: cred.platform_avatar_url || undefined,
         status: cred.status,
         scopes: (cred.scopes as string[]) || [],
+        userScopes: readOAuthUserScopes(cred.source_context),
         linkedAt: cred.linked_at || cred.created_at,
         lastUsedAt: cred.last_used_at || undefined,
         tokenExpired: cred.token_expires_at ? new Date(cred.token_expires_at) < new Date() : false,

--- a/packages/cloud/shared/src/lib/services/oauth/connection-adapters/generic-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/connection-adapters/generic-adapter.ts
@@ -13,10 +13,14 @@ import { secretsService } from "../../secrets";
 import { DecryptionError } from "../../secrets/encryption";
 import { incrementOAuthVersion } from "../cache-version";
 import { Errors } from "../errors";
-import { getProvider } from "../provider-registry";
-import { refreshOAuth2Token } from "../providers";
+import { getAllowedScopes, getProvider } from "../provider-registry";
+import {
+  OAuthRefreshRejectedError,
+  refreshOAuth2Token,
+  revokeOAuth2Credential,
+} from "../providers";
 import type { OAuthConnection, TokenResult } from "../types";
-import { formatOAuthConnectionRole } from "../types";
+import { formatOAuthConnectionRole, normalizeOAuthConnectionRole } from "../types";
 import type { ConnectionAdapter } from "./types";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -158,6 +162,18 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
       let accessToken: string;
       let expiresAt: Date | undefined = cred.token_expires_at || undefined;
       let wasRefreshed = false;
+      const storedUserScopes = readOAuthUserScopes(cred.source_context) ?? [];
+      const storedRole =
+        cred.source_context && typeof cred.source_context === "object"
+          ? normalizeOAuthConnectionRole(
+              (cred.source_context as Record<string, unknown>).connectionRole ??
+                (cred.source_context as Record<string, unknown>).agentGoogleSide,
+            )
+          : "OWNER";
+      let effectiveScopes =
+        storedRole === "OWNER" && storedUserScopes.length > 0
+          ? storedUserScopes
+          : ((cred.scopes as string[]) ?? []);
 
       if (tokenExpired && cred.refresh_token_secret_id) {
         // Attempt to refresh the token
@@ -237,10 +253,34 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
           const newExpiresAt = refreshResult.expiresIn
             ? new Date(Date.now() + refreshResult.expiresIn * 1000)
             : undefined;
+          const allowedScopes = new Set(getAllowedScopes(provider));
+          const allowedUserScopes = new Set(
+            provider.allowedUserScopes ?? provider.userScopes ?? [],
+          );
+          const confirmedScopes = refreshResult.grantedScopes?.filter((scope) =>
+            allowedScopes.has(scope),
+          );
+          const confirmedUserScopes = refreshResult.grantedUserScopes?.filter((scope) =>
+            allowedUserScopes.has(scope),
+          );
+          if (storedRole === "OWNER" && confirmedUserScopes !== undefined) {
+            effectiveScopes = confirmedUserScopes;
+          } else if (confirmedScopes !== undefined) {
+            effectiveScopes = confirmedScopes;
+          }
+          const sourceContext =
+            cred.source_context && typeof cred.source_context === "object"
+              ? { ...(cred.source_context as Record<string, unknown>) }
+              : {};
+          if (confirmedUserScopes !== undefined) {
+            sourceContext.oauthUserScopes = confirmedUserScopes;
+          }
           await dbWrite
             .update(platformCredentials)
             .set({
               token_expires_at: newExpiresAt,
+              ...(confirmedScopes !== undefined ? { scopes: confirmedScopes } : {}),
+              ...(confirmedUserScopes !== undefined ? { source_context: sourceContext } : {}),
               last_refreshed_at: new Date(),
               last_used_at: new Date(),
               updated_at: new Date(),
@@ -262,6 +302,13 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
           // failure into the typed tokenRefreshFailed domain error carrying the
           // underlying reason; the failure is never swallowed.
         } catch (error) {
+          if (error instanceof OAuthRefreshRejectedError && error.reauthRequired) {
+            await dbWrite
+              .update(platformCredentials)
+              .set({ status: "expired", updated_at: new Date() })
+              .where(eq(platformCredentials.id, connectionId));
+            await incrementOAuthVersion(organizationId, platform);
+          }
           logger.error(`[GenericAdapter] Token refresh failed for ${platform}`, {
             connectionId,
             organizationId,
@@ -290,7 +337,7 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
       return {
         accessToken,
         expiresAt,
-        scopes: (cred.scopes as string[]) || [],
+        scopes: effectiveScopes,
         refreshed: wasRefreshed,
         fromCache: false,
       };
@@ -305,6 +352,31 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
         actorId: "oauth-service",
         source: "revoke-connection",
       };
+
+      const provider = getProvider(platform);
+      if (!provider) throw Errors.platformNotSupported(platform);
+      const accessToken =
+        provider.revocation?.token === "access" && cred.access_token_secret_id
+          ? await decryptTokenSecret(
+              cred.access_token_secret_id,
+              organizationId,
+              connectionId,
+              "access_token",
+            )
+          : undefined;
+      const refreshToken =
+        provider.revocation?.token === "refresh" && cred.refresh_token_secret_id
+          ? await decryptTokenSecret(
+              cred.refresh_token_secret_id,
+              organizationId,
+              connectionId,
+              "refresh_token",
+            )
+          : undefined;
+      const revocation = await revokeOAuth2Credential(provider, {
+        accessToken,
+        refreshToken,
+      });
 
       const deleteSecret = async (id: string | null, tokenType: string) => {
         if (!id) return;
@@ -340,6 +412,7 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
       logger.info(`[GenericAdapter] Connection revoked for ${platform}`, {
         connectionId,
         organizationId,
+        remoteRevoked: revocation.remoteRevoked,
       });
     },
 

--- a/packages/cloud/shared/src/lib/services/oauth/errors.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/errors.ts
@@ -15,6 +15,7 @@ export enum OAuthErrorCode {
   PLATFORM_NOT_CONFIGURED = "PLATFORM_NOT_CONFIGURED",
   PLATFORM_NOT_SUPPORTED = "PLATFORM_NOT_SUPPORTED",
   INVALID_SCOPE_REQUEST = "INVALID_SCOPE_REQUEST",
+  INVALID_CAPABILITY_REQUEST = "INVALID_CAPABILITY_REQUEST",
 
   // Token errors
   TOKEN_REFRESH_FAILED = "TOKEN_REFRESH_FAILED",
@@ -44,6 +45,7 @@ export const ERROR_STATUS_MAP: Record<OAuthErrorCode, number> = {
   [OAuthErrorCode.PLATFORM_NOT_CONFIGURED]: 400,
   [OAuthErrorCode.PLATFORM_NOT_SUPPORTED]: 400,
   [OAuthErrorCode.INVALID_SCOPE_REQUEST]: 400,
+  [OAuthErrorCode.INVALID_CAPABILITY_REQUEST]: 400,
   [OAuthErrorCode.UNAUTHORIZED]: 401,
   [OAuthErrorCode.FORBIDDEN]: 403,
   [OAuthErrorCode.RATE_LIMITED]: 429,
@@ -169,6 +171,13 @@ export const Errors = {
     new OAuthError(
       OAuthErrorCode.INVALID_SCOPE_REQUEST,
       `Requested scopes are not allowed for ${platform}: ${invalidScopes.join(", ")}`,
+      false,
+    ),
+
+  invalidCapabilityRequest: (platform: string, invalidCapabilities: string[]) =>
+    new OAuthError(
+      OAuthErrorCode.INVALID_CAPABILITY_REQUEST,
+      `Requested capabilities are not registered for ${platform}: ${invalidCapabilities.join(", ")}`,
       false,
     ),
 

--- a/packages/cloud/shared/src/lib/services/oauth/oauth-service.capabilities.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/oauth-service.capabilities.test.ts
@@ -45,6 +45,21 @@ describe("existing OAuth capability grant binding (#19879)", () => {
     });
   });
 
+  test("does not infer user-token authority from an overlapping bot scope", () => {
+    const candidate = connection({ scopes: ["chat:write"] });
+    const grant = resolveExistingCapabilityGrant(candidate, {
+      connectionId: CONNECTION_ID,
+      platform: "google",
+      userId: "user-1",
+      connectionRole: "OWNER",
+      allowedScopes: ["chat:write"],
+      allowedUserScopes: ["chat:write"],
+    });
+
+    expect(grant.grantedScopes).toEqual(["chat:write"]);
+    expect(grant.grantedUserScopes).toEqual([]);
+  });
+
   test.each([
     null,
     connection({ userId: "other-user" }),
@@ -58,5 +73,21 @@ describe("existing OAuth capability grant binding (#19879)", () => {
     } catch (error) {
       expect(error).toMatchObject({ code: OAuthErrorCode.CONNECTION_NOT_FOUND });
     }
+  });
+
+  test("accepts an organization-shared TEAM connection without fabricating user ownership", () => {
+    const grant = resolveExistingCapabilityGrant(
+      connection({ connectionRole: "team", userId: undefined }),
+      {
+        connectionId: CONNECTION_ID,
+        platform: "google",
+        userId: "user-1",
+        connectionRole: "TEAM",
+        allowedScopes: ["identity", "calendar.read"],
+        allowedUserScopes: [],
+      },
+    );
+
+    expect(grant.expectedPlatformUserId).toBe("google-user-1");
   });
 });

--- a/packages/cloud/shared/src/lib/services/oauth/oauth-service.capabilities.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/oauth-service.capabilities.test.ts
@@ -5,7 +5,10 @@
 
 import { describe, expect, test } from "bun:test";
 import { OAuthErrorCode } from "./errors";
-import { resolveExistingCapabilityGrant } from "./oauth-service";
+import {
+  resolveExistingCapabilityGrant,
+  selectImplicitIncrementalOAuthConnection,
+} from "./oauth-service";
 import type { OAuthConnection } from "./types";
 
 const CONNECTION_ID = "11111111-1111-4111-8111-111111111111";
@@ -37,6 +40,21 @@ function resolve(candidate: OAuthConnection | null) {
 }
 
 describe("existing OAuth capability grant binding (#19879)", () => {
+  test("requires explicit selection when multiple active accounts exist", () => {
+    const first = connection();
+    const second = {
+      ...first,
+      id: "22222222-2222-4222-8222-222222222222",
+      platformUserId: "provider-user-2",
+    };
+    expect(() => selectImplicitIncrementalOAuthConnection("test", [first, second])).toThrow(
+      "multiple active accounts",
+    );
+    expect(selectImplicitIncrementalOAuthConnection("test", [first])).toBe(first.id);
+    expect(
+      selectImplicitIncrementalOAuthConnection("test", [{ ...first, status: "expired" }]),
+    ).toBeUndefined();
+  });
   test("projects only allowlisted grants and binds the provider account", () => {
     expect(resolve(connection())).toEqual({
       grantedScopes: ["identity", "calendar.read"],

--- a/packages/cloud/shared/src/lib/services/oauth/oauth-service.capabilities.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/oauth-service.capabilities.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Exercises tenant, actor, role, and scope projection for an existing OAuth
+ * connection before capability-based incremental consent begins.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { OAuthErrorCode } from "./errors";
+import { resolveExistingCapabilityGrant } from "./oauth-service";
+import type { OAuthConnection } from "./types";
+
+const CONNECTION_ID = "11111111-1111-4111-8111-111111111111";
+
+function connection(overrides: Partial<OAuthConnection> = {}): OAuthConnection {
+  return {
+    id: CONNECTION_ID,
+    userId: "user-1",
+    connectionRole: "owner",
+    platform: "google",
+    platformUserId: "google-user-1",
+    status: "active",
+    scopes: ["identity", "calendar.read", "provider:unexpected"],
+    linkedAt: new Date("2026-01-01T00:00:00.000Z"),
+    source: "platform_credentials",
+    ...overrides,
+  };
+}
+
+function resolve(candidate: OAuthConnection | null) {
+  return resolveExistingCapabilityGrant(candidate, {
+    connectionId: CONNECTION_ID,
+    platform: "google",
+    userId: "user-1",
+    connectionRole: "OWNER",
+    allowedScopes: ["identity", "calendar.read"],
+    allowedUserScopes: ["profile.read"],
+  });
+}
+
+describe("existing OAuth capability grant binding (#19879)", () => {
+  test("projects only allowlisted grants and binds the provider account", () => {
+    expect(resolve(connection())).toEqual({
+      grantedScopes: ["identity", "calendar.read"],
+      grantedUserScopes: [],
+      expectedPlatformUserId: "google-user-1",
+    });
+  });
+
+  test.each([
+    null,
+    connection({ userId: "other-user" }),
+    connection({ platform: "microsoft" }),
+    connection({ status: "revoked" }),
+    connection({ connectionRole: "agent", userId: undefined }),
+  ])("fails closed for an inaccessible or mismatched connection %#", (candidate) => {
+    try {
+      resolve(candidate);
+      throw new Error("expected connection binding to fail");
+    } catch (error) {
+      expect(error).toMatchObject({ code: OAuthErrorCode.CONNECTION_NOT_FOUND });
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/oauth-service.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/oauth-service.ts
@@ -14,7 +14,12 @@ import { logger } from "../../utils/logger";
 import { getOAuthVersion, incrementOAuthVersion } from "./cache-version";
 import { getAdapter, getAllAdapters } from "./connection-adapters";
 import { Errors } from "./errors";
-import { getProvider, isProviderConfigured, OAUTH_PROVIDERS } from "./provider-registry";
+import {
+  getAllowedScopes,
+  getProvider,
+  isProviderConfigured,
+  OAUTH_PROVIDERS,
+} from "./provider-registry";
 import { initiateOAuth2 } from "./providers";
 import { tokenCache } from "./token-cache";
 import type {
@@ -35,6 +40,45 @@ const DEFAULT_REDIRECT = "/cloud/settings?tab=connections";
 const STATE_TTL = 600; // 10 minutes
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 type PlatformCredential = typeof platformCredentials.$inferSelect;
+
+interface ExistingCapabilityGrant {
+  grantedScopes: string[];
+  grantedUserScopes: string[];
+  expectedPlatformUserId: string;
+}
+
+/** Validate and project one explicit existing connection for incremental consent. */
+export function resolveExistingCapabilityGrant(
+  connection: OAuthConnection | null,
+  input: {
+    connectionId: string;
+    platform: string;
+    userId: string;
+    connectionRole: OAuthStandardConnectionRole;
+    allowedScopes: readonly string[];
+    allowedUserScopes: readonly string[];
+  },
+): ExistingCapabilityGrant {
+  const ownsConnection =
+    connection !== null &&
+    connection.platform === input.platform &&
+    connection.status === "active" &&
+    normalizeOAuthConnectionRole(connection.connectionRole) === input.connectionRole &&
+    (input.connectionRole === "AGENT"
+      ? connection.userId === undefined
+      : connection.userId === input.userId);
+  if (!ownsConnection || !connection) {
+    throw Errors.connectionNotFound(input.connectionId);
+  }
+
+  const allowedScopes = new Set(input.allowedScopes);
+  const allowedUserScopes = new Set(input.allowedUserScopes);
+  return {
+    grantedScopes: connection.scopes.filter((scope) => allowedScopes.has(scope)),
+    grantedUserScopes: connection.scopes.filter((scope) => allowedUserScopes.has(scope)),
+    expectedPlatformUserId: connection.platformUserId,
+  };
+}
 
 export function sortConnectionsByRecency(connections: OAuthConnection[]): OAuthConnection[] {
   return [...connections].sort((a, b) => {
@@ -155,12 +199,24 @@ class OAuthService {
 
   /** Initiate OAuth flow for a platform */
   async initiateAuth(params: InitiateAuthParams): Promise<InitiateAuthResult> {
-    const { organizationId, userId, platform, redirectUrl, scopes, connectionRole } = params;
+    const {
+      organizationId,
+      userId,
+      platform,
+      redirectUrl,
+      scopes,
+      capabilities,
+      connectionId,
+      connectionRole,
+    } = params;
     const role = normalizeOAuthConnectionRole(connectionRole);
 
     const provider = getProvider(platform);
     if (!provider) throw Errors.platformNotSupported(platform);
     if (!isProviderConfigured(provider)) throw Errors.platformNotConfigured(platform);
+    if (connectionId !== undefined && capabilities === undefined) {
+      throw Errors.invalidCapabilityRequest(platform, ["connectionId requires named capabilities"]);
+    }
 
     // API key providers return a form URL
     if (provider.type === "api_key") {
@@ -172,14 +228,42 @@ class OAuthService {
 
     // Use generic OAuth2 flow for providers that opt-in
     if (provider.useGenericRoutes && provider.type === "oauth2") {
+      let grantedScopes: string[] | undefined;
+      let grantedUserScopes: string[] | undefined;
+      let expectedPlatformUserId: string | undefined;
+      if (connectionId !== undefined) {
+        const connection = await this.getConnection({ organizationId, connectionId });
+        const grant = resolveExistingCapabilityGrant(connection, {
+          connectionId,
+          platform,
+          userId,
+          connectionRole: role,
+          allowedScopes: getAllowedScopes(provider),
+          allowedUserScopes: provider.allowedUserScopes ?? provider.userScopes ?? [],
+        });
+        grantedScopes = grant.grantedScopes;
+        grantedUserScopes = grant.grantedUserScopes;
+        expectedPlatformUserId = grant.expectedPlatformUserId;
+      }
+
       const result = await initiateOAuth2(provider, {
         organizationId,
         userId,
         redirectUrl,
         scopes,
+        capabilities,
+        grantedScopes,
+        grantedUserScopes,
+        expectedPlatformUserId,
         connectionRole: role,
       });
-      return { authUrl: result.authUrl, state: result.state };
+      return {
+        authUrl: result.authUrl,
+        state: result.state,
+        capabilityAccess: result.capabilityAccess,
+        retryAfterConsent:
+          result.capabilityAccess?.some((capability) => capability.status !== "available") ?? false,
+      };
     }
 
     // Provider-specific compatibility handlers remain for OAuth 1.0a Twitter

--- a/packages/cloud/shared/src/lib/services/oauth/oauth-service.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/oauth-service.ts
@@ -64,9 +64,9 @@ export function resolveExistingCapabilityGrant(
     connection.platform === input.platform &&
     connection.status === "active" &&
     normalizeOAuthConnectionRole(connection.connectionRole) === input.connectionRole &&
-    (input.connectionRole === "AGENT"
-      ? connection.userId === undefined
-      : connection.userId === input.userId);
+    (input.connectionRole === "OWNER"
+      ? connection.userId === input.userId
+      : connection.userId === undefined);
   if (!ownsConnection || !connection) {
     throw Errors.connectionNotFound(input.connectionId);
   }
@@ -75,7 +75,9 @@ export function resolveExistingCapabilityGrant(
   const allowedUserScopes = new Set(input.allowedUserScopes);
   return {
     grantedScopes: connection.scopes.filter((scope) => allowedScopes.has(scope)),
-    grantedUserScopes: connection.scopes.filter((scope) => allowedUserScopes.has(scope)),
+    grantedUserScopes: (connection.userScopes ?? []).filter((scope) =>
+      allowedUserScopes.has(scope),
+    ),
     expectedPlatformUserId: connection.platformUserId,
   };
 }
@@ -169,6 +171,7 @@ function connectionFromPlatformCredential(cred: PlatformCredential): OAuthConnec
     avatarUrl: cred.platform_avatar_url || undefined,
     status: cred.status,
     scopes: (cred.scopes as string[]) || [],
+    userScopes: getStoredOAuthUserScopes(cred.source_context),
     linkedAt: cred.linked_at || cred.created_at,
     lastUsedAt: cred.last_used_at || undefined,
     tokenExpired: cred.token_expires_at ? new Date(cred.token_expires_at) < new Date() : false,
@@ -182,6 +185,13 @@ function getStoredConnectionRole(sourceContext: unknown): OAuthStandardConnectio
   }
   const context = sourceContext as Record<string, unknown>;
   return normalizeOAuthConnectionRole(context.connectionRole ?? context.agentGoogleSide);
+}
+
+function getStoredOAuthUserScopes(sourceContext: unknown): string[] | undefined {
+  if (!sourceContext || typeof sourceContext !== "object") return undefined;
+  const value = (sourceContext as Record<string, unknown>).oauthUserScopes;
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((scope): scope is string => typeof scope === "string");
 }
 
 class OAuthService {

--- a/packages/cloud/shared/src/lib/services/oauth/oauth-service.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/oauth-service.ts
@@ -5,6 +5,10 @@
  * across multiple platforms (Google, Twitter, Twilio, Blooio).
  */
 
+import {
+  type CapabilityRequest,
+  normalizeCapabilityRequest,
+} from "@elizaos/core/types/provider-integrations";
 import { and, eq } from "drizzle-orm";
 import { dbRead } from "../../../db/client";
 import { platformCredentials } from "../../../db/schemas/platform-credentials";
@@ -100,6 +104,20 @@ export function getMostRecentActiveConnection(
     const connTime = conn.lastUsedAt?.getTime() || conn.linkedAt.getTime();
     return connTime > mostTime ? conn : most;
   });
+}
+
+/** Select an account only when consent cannot be confused with another active account. */
+export function selectImplicitIncrementalOAuthConnection(
+  platform: string,
+  connections: readonly OAuthConnection[],
+): string | undefined {
+  const activeConnections = connections.filter((connection) => connection.status === "active");
+  if (activeConnections.length > 1) {
+    throw Errors.invalidCapabilityRequest(platform, [
+      "connectionId is required when multiple active accounts are available",
+    ]);
+  }
+  return activeConnections[0]?.id;
 }
 
 export function getPreferredActiveConnection(
@@ -216,6 +234,7 @@ class OAuthService {
       redirectUrl,
       scopes,
       capabilities,
+      capabilityRequest,
       connectionId,
       connectionRole,
     } = params;
@@ -226,6 +245,17 @@ class OAuthService {
     if (!isProviderConfigured(provider)) throw Errors.platformNotConfigured(platform);
     if (connectionId !== undefined && capabilities === undefined) {
       throw Errors.invalidCapabilityRequest(platform, ["connectionId requires named capabilities"]);
+    }
+    const normalizedCapabilityRequest: CapabilityRequest | undefined = capabilityRequest
+      ? normalizeCapabilityRequest(capabilityRequest)
+      : undefined;
+    if (
+      normalizedCapabilityRequest &&
+      (!capabilities || !capabilities.includes(normalizedCapabilityRequest.capabilityId))
+    ) {
+      throw Errors.invalidCapabilityRequest(platform, [
+        "capabilityRequest.capabilityId must be included in capabilities",
+      ]);
     }
 
     // API key providers return a form URL
@@ -241,10 +271,25 @@ class OAuthService {
       let grantedScopes: string[] | undefined;
       let grantedUserScopes: string[] | undefined;
       let expectedPlatformUserId: string | undefined;
-      if (connectionId !== undefined) {
-        const connection = await this.getConnection({ organizationId, connectionId });
+      let selectedConnectionId = connectionId;
+      if (capabilities !== undefined && selectedConnectionId === undefined) {
+        selectedConnectionId = selectImplicitIncrementalOAuthConnection(
+          platform,
+          await this.listConnections({
+            organizationId,
+            userId,
+            platform,
+            connectionRole: role,
+          }),
+        );
+      }
+      if (selectedConnectionId !== undefined) {
+        const connection = await this.getConnection({
+          organizationId,
+          connectionId: selectedConnectionId,
+        });
         const grant = resolveExistingCapabilityGrant(connection, {
-          connectionId,
+          connectionId: selectedConnectionId,
           platform,
           userId,
           connectionRole: role,
@@ -254,6 +299,15 @@ class OAuthService {
         grantedScopes = grant.grantedScopes;
         grantedUserScopes = grant.grantedUserScopes;
         expectedPlatformUserId = grant.expectedPlatformUserId;
+        if (
+          normalizedCapabilityRequest?.accountId &&
+          normalizedCapabilityRequest.accountId !== selectedConnectionId
+        ) {
+          throw Errors.connectionNotFound(normalizedCapabilityRequest.accountId);
+        }
+      }
+      if (normalizedCapabilityRequest?.accountId && selectedConnectionId === undefined) {
+        throw Errors.connectionNotFound(normalizedCapabilityRequest.accountId);
       }
 
       const result = await initiateOAuth2(provider, {
@@ -262,6 +316,7 @@ class OAuthService {
         redirectUrl,
         scopes,
         capabilities,
+        capabilityRequest: normalizedCapabilityRequest,
         grantedScopes,
         grantedUserScopes,
         expectedPlatformUserId,
@@ -272,7 +327,9 @@ class OAuthService {
         state: result.state,
         capabilityAccess: result.capabilityAccess,
         retryAfterConsent:
-          result.capabilityAccess?.some((capability) => capability.status !== "available") ?? false,
+          normalizedCapabilityRequest !== undefined &&
+          (result.capabilityAccess?.some((capability) => capability.status !== "available") ??
+            false),
       };
     }
 

--- a/packages/cloud/shared/src/lib/services/oauth/provider-registry.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/provider-registry.test.ts
@@ -152,8 +152,12 @@ describe("incremental capability scope bundles (#19879)", () => {
 
     const request = resolveOAuthCapabilityRequest(slack, ["messages.send", "files.read"]);
 
-    expect(request.scopes).toEqual(["users:read"]);
-    expect(request.userScopes).toEqual(["identity.basic", "chat:write", "files:read"]);
+    expect(request.scopes).toEqual([]);
+    expect(request.userScopes).toEqual(["users:read", "chat:write", "files:read"]);
+    expect(request.userScopes.some((scope) => scope.startsWith("identity."))).toBe(false);
+    expect(
+      resolveOAuthCapabilityRequest(slack, Object.keys(slack.capabilityScopes ?? {})).scopes,
+    ).toEqual([]);
 
     const agentRequest = resolveOAuthCapabilityRequest(
       slack,
@@ -163,7 +167,7 @@ describe("incremental capability scope bundles (#19879)", () => {
       "AGENT",
     );
     expect(agentRequest.scopes).toEqual(["users:read", "chat:write", "files:read"]);
-    expect(agentRequest.userScopes).toEqual(["identity.basic"]);
+    expect(agentRequest.userScopes).toEqual([]);
   });
 
   test("deduplicates repeated capabilities and fails closed for unknown names", () => {

--- a/packages/cloud/shared/src/lib/services/oauth/provider-registry.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/provider-registry.test.ts
@@ -14,6 +14,7 @@ import {
   isProviderConfigured,
   isValidProvider,
   type OAuthProviderConfig,
+  projectOAuthConnectedAccount,
   resolveOAuthCapabilityRequest,
   resolveRequestedScopes,
 } from "./provider-registry";
@@ -87,7 +88,7 @@ describe("incremental capability scope bundles (#19879)", () => {
     const google = getProvider("google");
     if (!google) throw new Error("google provider must exist");
 
-    const request = resolveOAuthCapabilityRequest(google, ["google.calendar.read"]);
+    const request = resolveOAuthCapabilityRequest(google, ["calendar.events.read"]);
 
     expect(request.scopes).toEqual([
       "https://www.googleapis.com/auth/userinfo.email",
@@ -97,7 +98,8 @@ describe("incremental capability scope bundles (#19879)", () => {
     expect(request.scopes).not.toContain("https://www.googleapis.com/auth/gmail.send");
     expect(request.capabilities).toEqual([
       {
-        capabilityId: "google.calendar.read",
+        capabilityId: "calendar.events.read",
+        riskLevel: "R1",
         status: "needs_scope",
         missingScopes: ["https://www.googleapis.com/auth/calendar.readonly"],
         missingUserScopes: [],
@@ -113,15 +115,15 @@ describe("incremental capability scope bundles (#19879)", () => {
     expect(
       resolveOAuthCapabilityRequest(
         google,
-        ["google.calendar.read"],
+        ["calendar.events.read"],
         ["https://www.googleapis.com/auth/calendar.readonly"],
       ).capabilities[0]?.status,
     ).toBe("available");
     expect(
-      resolveOAuthCapabilityRequest(google, ["google.gmail.send"]).capabilities[0]?.status,
+      resolveOAuthCapabilityRequest(google, ["email.messages.send"]).capabilities[0]?.status,
     ).toBe("needs_review");
     expect(
-      resolveOAuthCapabilityRequest(salesforce, ["salesforce.full"]).capabilities[0]?.status,
+      resolveOAuthCapabilityRequest(salesforce, ["crm.full_control"]).capabilities[0]?.status,
     ).toBe("needs_admin");
   });
 
@@ -131,7 +133,7 @@ describe("incremental capability scope bundles (#19879)", () => {
 
     const request = resolveOAuthCapabilityRequest(
       google,
-      ["google.calendar.read"],
+      ["calendar.events.read"],
       ["https://www.googleapis.com/auth/gmail.readonly"],
     );
 
@@ -148,28 +150,86 @@ describe("incremental capability scope bundles (#19879)", () => {
     const slack = getProvider("slack");
     if (!slack) throw new Error("slack provider must exist");
 
-    const request = resolveOAuthCapabilityRequest(slack, [
-      "slack.message.send",
-      "slack.files.read",
-    ]);
+    const request = resolveOAuthCapabilityRequest(slack, ["messages.send", "files.read"]);
 
-    expect(request.scopes).toEqual(["users:read", "chat:write"]);
+    expect(request.scopes).toEqual(["users:read"]);
     expect(request.userScopes).toEqual(["identity.basic", "chat:write", "files:read"]);
+
+    const agentRequest = resolveOAuthCapabilityRequest(
+      slack,
+      ["messages.send", "files.read"],
+      [],
+      [],
+      "AGENT",
+    );
+    expect(agentRequest.scopes).toEqual(["users:read", "chat:write", "files:read"]);
+    expect(agentRequest.userScopes).toEqual(["identity.basic"]);
   });
 
   test("deduplicates repeated capabilities and fails closed for unknown names", () => {
     const airtable = getProvider("airtable");
     if (!airtable) throw new Error("airtable provider must exist");
 
-    const request = resolveOAuthCapabilityRequest(airtable, [
-      "airtable.records.read",
-      "airtable.records.read",
-    ]);
+    const request = resolveOAuthCapabilityRequest(airtable, ["records.read", "records.read"]);
     expect(request.capabilities).toHaveLength(1);
     expect(request.scopes).toEqual(["user.email:read", "data.records:read"]);
-    expect(() => resolveOAuthCapabilityRequest(airtable, ["airtable.not-real"])).toThrow(
+    expect(() => resolveOAuthCapabilityRequest(airtable, ["not-real"])).toThrow(
       "Requested capabilities are not registered",
     );
+  });
+
+  test("uses one provider-neutral vocabulary for equivalent Google and Microsoft grants", () => {
+    const google = getProvider("google");
+    const microsoft = getProvider("microsoft");
+    if (!google || !microsoft) throw new Error("calendar providers must exist");
+
+    for (const capabilityId of ["calendar.events.read", "calendar.events.write"]) {
+      expect(google.capabilityScopes?.[capabilityId]).toBeDefined();
+      expect(microsoft.capabilityScopes?.[capabilityId]).toBeDefined();
+    }
+    expect(getProvider("github")?.capabilityScopes?.["repositories.full_control"]).toMatchObject({
+      scopes: ["repo"],
+      riskLevel: "R3",
+    });
+  });
+
+  test("projects an opaque canonical account and invalidates capabilities with lifecycle state", () => {
+    const google = getProvider("google");
+    if (!google) throw new Error("google provider must exist");
+    const baseConnection = {
+      id: "11111111-1111-4111-8111-111111111111",
+      userId: "cloud-user-private",
+      connectionRole: "owner" as const,
+      platform: "google",
+      platformUserId: "provider-user-private",
+      email: "private@example.test",
+      displayName: "Work calendar",
+      status: "active" as const,
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+      linkedAt: new Date("2026-08-19T00:00:00.000Z"),
+      tokenExpired: false,
+      source: "platform_credentials" as const,
+    };
+
+    const connected = projectOAuthConnectedAccount(google, baseConnection);
+    expect(JSON.stringify(connected)).not.toMatch(/provider-user-private|private@example/);
+    expect(connected).toMatchObject({
+      contractVersion: 2,
+      accountId: baseConnection.id,
+      providerId: "google",
+      mode: "cloud",
+      status: "connected",
+    });
+    expect(
+      connected.capabilities.find(({ capabilityId }) => capabilityId === "calendar.events.write"),
+    ).toMatchObject({ riskLevel: "R2", status: "available" });
+
+    const revoked = projectOAuthConnectedAccount(google, {
+      ...baseConnection,
+      status: "revoked",
+    });
+    expect(revoked.status).toBe("revoked");
+    expect(revoked.capabilities.every(({ status }) => status === "account_revoked")).toBe(true);
   });
 
   test("validates every registered bundle against its provider allowlists", () => {

--- a/packages/cloud/shared/src/lib/services/oauth/provider-registry.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/provider-registry.test.ts
@@ -14,6 +14,7 @@ import {
   isProviderConfigured,
   isValidProvider,
   type OAuthProviderConfig,
+  resolveOAuthCapabilityRequest,
   resolveRequestedScopes,
 } from "./provider-registry";
 
@@ -53,6 +54,142 @@ describe("getAllowedScopes / resolveRequestedScopes", () => {
     expect(resolveRequestedScopes(p, ["read", " write "])).toEqual(["read", "write"]);
     // 'admin' is not in the allowlist → scope-escalation attempt must throw.
     expect(() => resolveRequestedScopes(p, ["read", "admin"])).toThrow();
+  });
+});
+
+describe("incremental capability scope bundles (#19879)", () => {
+  test("the seven promoted providers use minimal baselines while retaining legacy scope allowlists", () => {
+    const expectedBaselines: Record<string, string[]> = {
+      google: [
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/userinfo.profile",
+      ],
+      microsoft: ["openid", "profile", "email", "offline_access", "User.Read"],
+      github: ["read:user", "user:email"],
+      linear: ["read"],
+      slack: ["users:read"],
+      salesforce: ["id", "refresh_token"],
+      airtable: ["user.email:read"],
+    };
+
+    for (const [providerId, baseline] of Object.entries(expectedBaselines)) {
+      const registered = getProvider(providerId);
+      expect(registered?.defaultScopes).toEqual(baseline);
+      expect(registered?.capabilityScopes).toBeDefined();
+      expect(registered?.allowedScopes?.length).toBeGreaterThan(baseline.length);
+      for (const scope of baseline) {
+        expect(registered?.allowedScopes).toContain(scope);
+      }
+    }
+  });
+
+  test("derives only baseline plus the requested named capability", () => {
+    const google = getProvider("google");
+    if (!google) throw new Error("google provider must exist");
+
+    const request = resolveOAuthCapabilityRequest(google, ["google.calendar.read"]);
+
+    expect(request.scopes).toEqual([
+      "https://www.googleapis.com/auth/userinfo.email",
+      "https://www.googleapis.com/auth/userinfo.profile",
+      "https://www.googleapis.com/auth/calendar.readonly",
+    ]);
+    expect(request.scopes).not.toContain("https://www.googleapis.com/auth/gmail.send");
+    expect(request.capabilities).toEqual([
+      {
+        capabilityId: "google.calendar.read",
+        status: "needs_scope",
+        missingScopes: ["https://www.googleapis.com/auth/calendar.readonly"],
+        missingUserScopes: [],
+      },
+    ]);
+  });
+
+  test("projects available, review, and admin states from actual grants", () => {
+    const google = getProvider("google");
+    const salesforce = getProvider("salesforce");
+    if (!google || !salesforce) throw new Error("promoted providers must exist");
+
+    expect(
+      resolveOAuthCapabilityRequest(
+        google,
+        ["google.calendar.read"],
+        ["https://www.googleapis.com/auth/calendar.readonly"],
+      ).capabilities[0]?.status,
+    ).toBe("available");
+    expect(
+      resolveOAuthCapabilityRequest(google, ["google.gmail.send"]).capabilities[0]?.status,
+    ).toBe("needs_review");
+    expect(
+      resolveOAuthCapabilityRequest(salesforce, ["salesforce.full"]).capabilities[0]?.status,
+    ).toBe("needs_admin");
+  });
+
+  test("preserves an existing allowed grant while adding one capability", () => {
+    const google = getProvider("google");
+    if (!google) throw new Error("google provider must exist");
+
+    const request = resolveOAuthCapabilityRequest(
+      google,
+      ["google.calendar.read"],
+      ["https://www.googleapis.com/auth/gmail.readonly"],
+    );
+
+    expect(request.scopes).toEqual([
+      "https://www.googleapis.com/auth/userinfo.email",
+      "https://www.googleapis.com/auth/userinfo.profile",
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/calendar.readonly",
+    ]);
+    expect(request.capabilities[0]?.status).toBe("needs_scope");
+  });
+
+  test("splits Slack bot and user scopes without restoring the old broad default", () => {
+    const slack = getProvider("slack");
+    if (!slack) throw new Error("slack provider must exist");
+
+    const request = resolveOAuthCapabilityRequest(slack, [
+      "slack.message.send",
+      "slack.files.read",
+    ]);
+
+    expect(request.scopes).toEqual(["users:read", "chat:write"]);
+    expect(request.userScopes).toEqual(["identity.basic", "chat:write", "files:read"]);
+  });
+
+  test("deduplicates repeated capabilities and fails closed for unknown names", () => {
+    const airtable = getProvider("airtable");
+    if (!airtable) throw new Error("airtable provider must exist");
+
+    const request = resolveOAuthCapabilityRequest(airtable, [
+      "airtable.records.read",
+      "airtable.records.read",
+    ]);
+    expect(request.capabilities).toHaveLength(1);
+    expect(request.scopes).toEqual(["user.email:read", "data.records:read"]);
+    expect(() => resolveOAuthCapabilityRequest(airtable, ["airtable.not-real"])).toThrow(
+      "Requested capabilities are not registered",
+    );
+  });
+
+  test("validates every registered bundle against its provider allowlists", () => {
+    for (const providerId of [
+      "google",
+      "microsoft",
+      "github",
+      "linear",
+      "slack",
+      "salesforce",
+      "airtable",
+    ]) {
+      const registered = getProvider(providerId);
+      if (!registered?.capabilityScopes) {
+        throw new Error(`${providerId} capability registry must exist`);
+      }
+      expect(() =>
+        resolveOAuthCapabilityRequest(registered, Object.keys(registered.capabilityScopes)),
+      ).not.toThrow();
+    }
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/oauth/provider-registry.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/provider-registry.ts
@@ -16,6 +16,31 @@ import { getCloudAwareEnv } from "../../runtime/cloud-bindings";
 import { Errors } from "./errors";
 import type { OAuthProviderType } from "./types";
 
+/** Approval boundary for a named OAuth capability bundle. */
+export type OAuthCapabilityConsent = "consent" | "review" | "admin";
+
+/** Provider-owned scope mapping for one stable product capability. */
+export interface OAuthCapabilityScopeBundle {
+  scopes: string[];
+  userScopes?: string[];
+  consent?: OAuthCapabilityConsent;
+}
+
+/** Capability availability projected without exposing provider credentials. */
+export interface OAuthCapabilityAccess {
+  capabilityId: string;
+  status: "available" | "needs_scope" | "needs_review" | "needs_admin";
+  missingScopes: string[];
+  missingUserScopes: string[];
+}
+
+/** Canonical scope request derived from named capabilities. */
+export interface ResolvedOAuthCapabilityRequest {
+  scopes: string[];
+  userScopes: string[];
+  capabilities: OAuthCapabilityAccess[];
+}
+
 /**
  * OAuth endpoint URLs for the authorization flow.
  */
@@ -129,6 +154,12 @@ export interface OAuthProviderConfig {
 
   /** Superset of scopes this app will allow callers to request for the provider. */
   allowedScopes?: string[];
+
+  /** Stable product capabilities that may incrementally extend the baseline grant. */
+  capabilityScopes?: Record<string, OAuthCapabilityScopeBundle>;
+
+  /** Superset of user-level scopes accepted across named capability bundles. */
+  allowedUserScopes?: string[];
 
   /**
    * Default user-level OAuth scopes for providers that distinguish between
@@ -250,12 +281,35 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     defaultScopes: [
       "https://www.googleapis.com/auth/userinfo.email",
       "https://www.googleapis.com/auth/userinfo.profile",
+    ],
+    allowedScopes: [
+      "https://www.googleapis.com/auth/userinfo.email",
+      "https://www.googleapis.com/auth/userinfo.profile",
       "https://www.googleapis.com/auth/gmail.send",
       "https://www.googleapis.com/auth/gmail.readonly",
       "https://www.googleapis.com/auth/calendar.events",
       "https://www.googleapis.com/auth/calendar.readonly",
       "https://www.googleapis.com/auth/contacts.readonly",
     ],
+    capabilityScopes: {
+      "google.gmail.read": {
+        scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      },
+      "google.gmail.send": {
+        scopes: ["https://www.googleapis.com/auth/gmail.send"],
+        consent: "review",
+      },
+      "google.calendar.read": {
+        scopes: ["https://www.googleapis.com/auth/calendar.readonly"],
+      },
+      "google.calendar.write": {
+        scopes: ["https://www.googleapis.com/auth/calendar.events"],
+        consent: "review",
+      },
+      "google.contacts.read": {
+        scopes: ["https://www.googleapis.com/auth/contacts.readonly"],
+      },
+    },
     userInfoMapping: {
       id: "id",
       email: "email",
@@ -264,6 +318,7 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     },
     authParams: {
       access_type: "offline",
+      include_granted_scopes: "true",
       prompt: "consent",
     },
     storage: "platform_credentials",
@@ -284,7 +339,8 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       token: "https://login.microsoftonline.com/consumers/oauth2/v2.0/token",
       userInfo: "https://graph.microsoft.com/v1.0/me",
     },
-    defaultScopes: [
+    defaultScopes: ["openid", "profile", "email", "offline_access", "User.Read"],
+    allowedScopes: [
       "openid",
       "profile",
       "email",
@@ -296,6 +352,22 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       "Mail.ReadWrite",
       "Mail.Send",
     ],
+    capabilityScopes: {
+      "microsoft.calendar.read": { scopes: ["Calendars.Read"] },
+      "microsoft.calendar.write": {
+        scopes: ["Calendars.ReadWrite"],
+        consent: "review",
+      },
+      "microsoft.mail.read": { scopes: ["Mail.Read"] },
+      "microsoft.mail.write": {
+        scopes: ["Mail.ReadWrite"],
+        consent: "review",
+      },
+      "microsoft.mail.send": {
+        scopes: ["Mail.Send"],
+        consent: "review",
+      },
+    },
     userInfoMapping: {
       id: "id",
       email: "mail",
@@ -323,7 +395,15 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       userInfoGraphQLQuery: "query { viewer { id email name avatarUrl } }",
       revoke: "https://api.linear.app/oauth/revoke",
     },
-    defaultScopes: ["read", "write", "issues:create"],
+    defaultScopes: ["read"],
+    allowedScopes: ["read", "write", "issues:create"],
+    capabilityScopes: {
+      "linear.issue.write": { scopes: ["write"], consent: "review" },
+      "linear.issue.create": {
+        scopes: ["issues:create"],
+        consent: "review",
+      },
+    },
     userInfoMapping: {
       id: "data.viewer.id",
       email: "data.viewer.email",
@@ -375,7 +455,11 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       token: "https://github.com/login/oauth/access_token",
       userInfo: "https://api.github.com/user",
     },
-    defaultScopes: ["read:user", "user:email", "repo"],
+    defaultScopes: ["read:user", "user:email"],
+    allowedScopes: ["read:user", "user:email", "repo"],
+    capabilityScopes: {
+      "github.repository": { scopes: ["repo"], consent: "review" },
+    },
     userInfoMapping: {
       id: "id",
       email: "email",
@@ -402,7 +486,25 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       userInfo: "https://slack.com/api/users.identity",
       revoke: "https://slack.com/api/auth.revoke",
     },
-    defaultScopes: ["identity.basic", "users:read", "chat:write", "channels:read"],
+    defaultScopes: ["users:read"],
+    allowedScopes: ["identity.basic", "users:read", "chat:write", "channels:read"],
+    capabilityScopes: {
+      "slack.channels.read": { scopes: ["channels:read"] },
+      "slack.users.read": {
+        scopes: [],
+        userScopes: ["users:read"],
+      },
+      "slack.message.send": {
+        scopes: ["chat:write"],
+        userScopes: ["chat:write"],
+        consent: "review",
+      },
+      "slack.message.search": {
+        scopes: [],
+        userScopes: ["search:read"],
+      },
+      "slack.files.read": { scopes: [], userScopes: ["files:read"] },
+    },
     // User-level scopes requested for the OWNER role so the user's own
     // Slack identity (authed_user.access_token, `xoxp-...`) can act on
     // the user's behalf — read their channels, write as them, search
@@ -411,7 +513,8 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     // (the userInfo URL above) — without it the OWNER callback's
     // userInfo fetch fails with `missing_scope` and `extractUserInfo`
     // cannot resolve `user_id`.
-    userScopes: ["identity.basic", "chat:write", "search:read", "users:read", "files:read"],
+    userScopes: ["identity.basic"],
+    allowedUserScopes: ["identity.basic", "chat:write", "search:read", "users:read", "files:read"],
     userInfoMapping: {
       id: "user_id",
       displayName: "user",
@@ -529,7 +632,16 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       userInfo: "https://login.salesforce.com/services/oauth2/userinfo",
       revoke: "https://login.salesforce.com/services/oauth2/revoke",
     },
-    defaultScopes: ["full", "api", "id", "refresh_token", "chatter_api"],
+    defaultScopes: ["id", "refresh_token"],
+    allowedScopes: ["full", "api", "id", "refresh_token", "chatter_api"],
+    capabilityScopes: {
+      "salesforce.api": { scopes: ["api"], consent: "review" },
+      "salesforce.chatter": {
+        scopes: ["chatter_api"],
+        consent: "review",
+      },
+      "salesforce.full": { scopes: ["full"], consent: "admin" },
+    },
     userInfoMapping: {
       id: "user_id",
       email: "email",
@@ -555,7 +667,8 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       token: "https://airtable.com/oauth2/v1/token",
       userInfo: "https://api.airtable.com/v0/meta/whoami",
     },
-    defaultScopes: [
+    defaultScopes: ["user.email:read"],
+    allowedScopes: [
       "data.records:read",
       "data.records:write",
       "data.recordComments:read",
@@ -565,6 +678,29 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       "user.email:read",
       "webhook:manage",
     ],
+    capabilityScopes: {
+      "airtable.records.read": { scopes: ["data.records:read"] },
+      "airtable.records.write": {
+        scopes: ["data.records:write"],
+        consent: "review",
+      },
+      "airtable.comments.read": {
+        scopes: ["data.recordComments:read"],
+      },
+      "airtable.comments.write": {
+        scopes: ["data.recordComments:write"],
+        consent: "review",
+      },
+      "airtable.schema.read": { scopes: ["schema.bases:read"] },
+      "airtable.schema.write": {
+        scopes: ["schema.bases:write"],
+        consent: "admin",
+      },
+      "airtable.webhook.manage": {
+        scopes: ["webhook:manage"],
+        consent: "admin",
+      },
+    },
     userInfoMapping: {
       id: "id",
       email: "email",
@@ -867,6 +1003,20 @@ function normalizeScopes(scopes: string[] | undefined): string[] {
   return [...new Set(scopes.map((scope) => scope.trim()).filter(Boolean))];
 }
 
+function missingScopes(required: string[], granted: ReadonlySet<string>): string[] {
+  return required.filter((scope) => !granted.has(scope));
+}
+
+function capabilityStatus(
+  bundle: OAuthCapabilityScopeBundle,
+  missing: boolean,
+): OAuthCapabilityAccess["status"] {
+  if (!missing) return "available";
+  if (bundle.consent === "admin") return "needs_admin";
+  if (bundle.consent === "review") return "needs_review";
+  return "needs_scope";
+}
+
 export function getAllowedScopes(provider: OAuthProviderConfig): string[] {
   return normalizeScopes(provider.allowedScopes ?? provider.defaultScopes ?? []);
 }
@@ -887,6 +1037,75 @@ export function resolveRequestedScopes(
   }
 
   return normalizedRequested;
+}
+
+/**
+ * Resolve a capability request into the least-privilege provider scope set.
+ * Existing raw-scope callers continue to use `resolveRequestedScopes`; new
+ * callers use stable capability IDs so provider spellings remain server-owned.
+ */
+export function resolveOAuthCapabilityRequest(
+  provider: OAuthProviderConfig,
+  requestedCapabilities: string[],
+  grantedScopes: readonly string[] = [],
+  grantedUserScopes: readonly string[] = [],
+): ResolvedOAuthCapabilityRequest {
+  const capabilityIds = normalizeScopes(requestedCapabilities);
+  const bundles = provider.capabilityScopes ?? {};
+  const invalidCapabilities = capabilityIds.filter((id) => bundles[id] === undefined);
+  if (invalidCapabilities.length > 0) {
+    throw Errors.invalidCapabilityRequest(provider.id, invalidCapabilities);
+  }
+
+  const normalizedGrantedScopes = normalizeScopes([...grantedScopes]);
+  const normalizedGrantedUserScopes = normalizeScopes([...grantedUserScopes]);
+  const scopes = normalizeScopes([...(provider.defaultScopes ?? []), ...normalizedGrantedScopes]);
+  const userScopes = normalizeScopes([
+    ...(provider.userScopes ?? []),
+    ...normalizedGrantedUserScopes,
+  ]);
+  const grantedScopeSet = new Set(normalizedGrantedScopes);
+  const grantedUserScopeSet = new Set(normalizedGrantedUserScopes);
+  const capabilities = capabilityIds.map((capabilityId) => {
+    const bundle = bundles[capabilityId];
+    if (!bundle) {
+      throw Errors.invalidCapabilityRequest(provider.id, [capabilityId]);
+    }
+    const requiredScopes = normalizeScopes(bundle.scopes);
+    const requiredUserScopes = normalizeScopes(bundle.userScopes);
+    const capabilityMissingScopes = missingScopes(requiredScopes, grantedScopeSet);
+    const capabilityMissingUserScopes = missingScopes(requiredUserScopes, grantedUserScopeSet);
+    scopes.push(...requiredScopes);
+    userScopes.push(...requiredUserScopes);
+    return {
+      capabilityId,
+      status: capabilityStatus(
+        bundle,
+        capabilityMissingScopes.length > 0 || capabilityMissingUserScopes.length > 0,
+      ),
+      missingScopes: capabilityMissingScopes,
+      missingUserScopes: capabilityMissingUserScopes,
+    } satisfies OAuthCapabilityAccess;
+  });
+
+  const resolvedScopes = normalizeScopes(scopes);
+  const invalidScopes = resolvedScopes.filter(
+    (scope) => !getAllowedScopes(provider).includes(scope),
+  );
+  const resolvedUserScopes = normalizeScopes(userScopes);
+  const allowedUserScopes = normalizeScopes(provider.allowedUserScopes ?? provider.userScopes);
+  const invalidUserScopes = resolvedUserScopes.filter(
+    (scope) => !allowedUserScopes.includes(scope),
+  );
+  if (invalidScopes.length > 0 || invalidUserScopes.length > 0) {
+    throw Errors.invalidScopeRequest(provider.id, [...invalidScopes, ...invalidUserScopes]);
+  }
+
+  return {
+    scopes: resolvedScopes,
+    userScopes: resolvedUserScopes,
+    capabilities,
+  };
 }
 
 /** Get all provider IDs. */

--- a/packages/cloud/shared/src/lib/services/oauth/provider-registry.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/provider-registry.ts
@@ -12,27 +12,62 @@
  * - API Key (Twilio, Blooio - user provides credentials)
  */
 
+import {
+  type CapabilityRiskLevel,
+  type CapabilityUnavailableCode,
+  type ConnectedAccount,
+  normalizeConnectedAccount,
+  PROVIDER_INTEGRATION_CONTRACT_VERSION,
+} from "@elizaos/core/types/provider-integrations";
 import { getCloudAwareEnv } from "../../runtime/cloud-bindings";
 import { Errors } from "./errors";
-import type { OAuthProviderType } from "./types";
-
-/** Approval boundary for a named OAuth capability bundle. */
-export type OAuthCapabilityConsent = "consent" | "review" | "admin";
+import {
+  normalizeOAuthConnectionRole,
+  type OAuthConnection,
+  type OAuthProviderType,
+  type OAuthStandardConnectionRole,
+} from "./types";
 
 /** Provider-owned scope mapping for one stable product capability. */
 export interface OAuthCapabilityScopeBundle {
   scopes: string[];
   userScopes?: string[];
-  consent?: OAuthCapabilityConsent;
+  riskLevel: CapabilityRiskLevel;
 }
 
 /** Capability availability projected without exposing provider credentials. */
 export interface OAuthCapabilityAccess {
   capabilityId: string;
-  status: "available" | "needs_scope" | "needs_review" | "needs_admin";
+  riskLevel: CapabilityRiskLevel;
+  status: "available" | CapabilityUnavailableCode;
   missingScopes: string[];
   missingUserScopes: string[];
 }
+
+/** Provider-specific source of the grant set confirmed after authorization. */
+export interface OAuthGrantedScopeAuthority {
+  source: "user_info_header";
+  header: string;
+}
+
+/** Protocol required to revoke the provider-side grant, not merely local storage. */
+export type OAuthRevocationConfig =
+  | {
+      transport: "form";
+      token: "access" | "refresh";
+      includeClientCredentials?: boolean;
+      response: "http_ok" | "slack_json";
+    }
+  | {
+      transport: "bearer";
+      token: "access" | "refresh";
+      response: "http_ok" | "slack_json";
+    }
+  | {
+      transport: "github_token";
+      token: "access";
+      response: "http_ok";
+    };
 
 /** Canonical scope request derived from named capabilities. */
 export interface ResolvedOAuthCapabilityRequest {
@@ -160,6 +195,12 @@ export interface OAuthProviderConfig {
 
   /** Superset of user-level scopes accepted across named capability bundles. */
   allowedUserScopes?: string[];
+
+  /** Authoritative post-exchange scope source when the token body is insufficient. */
+  grantedScopeAuthority?: OAuthGrantedScopeAuthority;
+
+  /** Exact provider-side token/grant revocation protocol. */
+  revocation?: OAuthRevocationConfig;
 
   /**
    * Default user-level OAuth scopes for providers that distinguish between
@@ -292,24 +333,28 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       "https://www.googleapis.com/auth/contacts.readonly",
     ],
     capabilityScopes: {
-      "google.gmail.read": {
+      "email.messages.read": {
         scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+        riskLevel: "R1",
       },
-      "google.gmail.send": {
+      "email.messages.send": {
         scopes: ["https://www.googleapis.com/auth/gmail.send"],
-        consent: "review",
+        riskLevel: "R2",
       },
-      "google.calendar.read": {
+      "calendar.events.read": {
         scopes: ["https://www.googleapis.com/auth/calendar.readonly"],
+        riskLevel: "R1",
       },
-      "google.calendar.write": {
+      "calendar.events.write": {
         scopes: ["https://www.googleapis.com/auth/calendar.events"],
-        consent: "review",
+        riskLevel: "R2",
       },
-      "google.contacts.read": {
+      "contacts.read": {
         scopes: ["https://www.googleapis.com/auth/contacts.readonly"],
+        riskLevel: "R1",
       },
     },
+    revocation: { transport: "form", token: "access", response: "http_ok" },
     userInfoMapping: {
       id: "id",
       email: "email",
@@ -353,19 +398,19 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       "Mail.Send",
     ],
     capabilityScopes: {
-      "microsoft.calendar.read": { scopes: ["Calendars.Read"] },
-      "microsoft.calendar.write": {
+      "calendar.events.read": { scopes: ["Calendars.Read"], riskLevel: "R1" },
+      "calendar.events.write": {
         scopes: ["Calendars.ReadWrite"],
-        consent: "review",
+        riskLevel: "R2",
       },
-      "microsoft.mail.read": { scopes: ["Mail.Read"] },
-      "microsoft.mail.write": {
+      "email.messages.read": { scopes: ["Mail.Read"], riskLevel: "R1" },
+      "email.messages.write": {
         scopes: ["Mail.ReadWrite"],
-        consent: "review",
+        riskLevel: "R2",
       },
-      "microsoft.mail.send": {
+      "email.messages.send": {
         scopes: ["Mail.Send"],
-        consent: "review",
+        riskLevel: "R2",
       },
     },
     userInfoMapping: {
@@ -398,10 +443,10 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     defaultScopes: ["read"],
     allowedScopes: ["read", "write", "issues:create"],
     capabilityScopes: {
-      "linear.issue.write": { scopes: ["write"], consent: "review" },
-      "linear.issue.create": {
+      "issues.write": { scopes: ["write"], riskLevel: "R2" },
+      "issues.create": {
         scopes: ["issues:create"],
-        consent: "review",
+        riskLevel: "R2",
       },
     },
     userInfoMapping: {
@@ -458,7 +503,16 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     defaultScopes: ["read:user", "user:email"],
     allowedScopes: ["read:user", "user:email", "repo"],
     capabilityScopes: {
-      "github.repository": { scopes: ["repo"], consent: "review" },
+      "repositories.full_control": { scopes: ["repo"], riskLevel: "R3" },
+    },
+    grantedScopeAuthority: {
+      source: "user_info_header",
+      header: "x-oauth-scopes",
+    },
+    revocation: {
+      transport: "github_token",
+      token: "access",
+      response: "http_ok",
     },
     userInfoMapping: {
       id: "id",
@@ -487,24 +541,31 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       revoke: "https://slack.com/api/auth.revoke",
     },
     defaultScopes: ["users:read"],
-    allowedScopes: ["identity.basic", "users:read", "chat:write", "channels:read"],
+    allowedScopes: ["identity.basic", "users:read", "chat:write", "channels:read", "files:read"],
     capabilityScopes: {
-      "slack.channels.read": { scopes: ["channels:read"] },
-      "slack.users.read": {
-        scopes: [],
+      "channels.read": { scopes: ["channels:read"], riskLevel: "R1" },
+      "directory.users.read": {
+        scopes: ["users:read"],
         userScopes: ["users:read"],
+        riskLevel: "R1",
       },
-      "slack.message.send": {
+      "messages.send": {
         scopes: ["chat:write"],
         userScopes: ["chat:write"],
-        consent: "review",
+        riskLevel: "R2",
       },
-      "slack.message.search": {
+      "messages.search": {
         scopes: [],
         userScopes: ["search:read"],
+        riskLevel: "R1",
       },
-      "slack.files.read": { scopes: [], userScopes: ["files:read"] },
+      "files.read": {
+        scopes: ["files:read"],
+        userScopes: ["files:read"],
+        riskLevel: "R1",
+      },
     },
+    revocation: { transport: "bearer", token: "access", response: "slack_json" },
     // User-level scopes requested for the OWNER role so the user's own
     // Slack identity (authed_user.access_token, `xoxp-...`) can act on
     // the user's behalf — read their channels, write as them, search
@@ -635,13 +696,14 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     defaultScopes: ["id", "refresh_token"],
     allowedScopes: ["full", "api", "id", "refresh_token", "chatter_api"],
     capabilityScopes: {
-      "salesforce.api": { scopes: ["api"], consent: "review" },
-      "salesforce.chatter": {
+      "crm.api": { scopes: ["api"], riskLevel: "R2" },
+      "crm.chatter": {
         scopes: ["chatter_api"],
-        consent: "review",
+        riskLevel: "R2",
       },
-      "salesforce.full": { scopes: ["full"], consent: "admin" },
+      "crm.full_control": { scopes: ["full"], riskLevel: "R3" },
     },
+    revocation: { transport: "form", token: "refresh", response: "http_ok" },
     userInfoMapping: {
       id: "user_id",
       email: "email",
@@ -679,26 +741,27 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       "webhook:manage",
     ],
     capabilityScopes: {
-      "airtable.records.read": { scopes: ["data.records:read"] },
-      "airtable.records.write": {
+      "records.read": { scopes: ["data.records:read"], riskLevel: "R1" },
+      "records.write": {
         scopes: ["data.records:write"],
-        consent: "review",
+        riskLevel: "R2",
       },
-      "airtable.comments.read": {
+      "record_comments.read": {
         scopes: ["data.recordComments:read"],
+        riskLevel: "R1",
       },
-      "airtable.comments.write": {
+      "record_comments.write": {
         scopes: ["data.recordComments:write"],
-        consent: "review",
+        riskLevel: "R2",
       },
-      "airtable.schema.read": { scopes: ["schema.bases:read"] },
-      "airtable.schema.write": {
+      "schemas.read": { scopes: ["schema.bases:read"], riskLevel: "R1" },
+      "schemas.write": {
         scopes: ["schema.bases:write"],
-        consent: "admin",
+        riskLevel: "R3",
       },
-      "airtable.webhook.manage": {
+      "webhooks.manage": {
         scopes: ["webhook:manage"],
-        consent: "admin",
+        riskLevel: "R3",
       },
     },
     userInfoMapping: {
@@ -1012,9 +1075,78 @@ function capabilityStatus(
   missing: boolean,
 ): OAuthCapabilityAccess["status"] {
   if (!missing) return "available";
-  if (bundle.consent === "admin") return "needs_admin";
-  if (bundle.consent === "review") return "needs_review";
+  if (bundle.riskLevel === "R3") return "needs_admin";
+  if (bundle.riskLevel === "R2") return "needs_review";
   return "needs_scope";
+}
+
+function unavailableForConnection(connection: OAuthConnection): CapabilityUnavailableCode | null {
+  switch (connection.status) {
+    case "active":
+      return null;
+    case "revoked":
+      return "account_revoked";
+    case "error":
+      return "account_error";
+    case "expired":
+      return "needs_scope";
+    case "pending":
+      return "provider_unavailable";
+  }
+}
+
+/**
+ * Project Cloud's credential row into the canonical opaque connected-account
+ * authority. Provider identities, raw scopes, and credential row internals do
+ * not cross this boundary.
+ */
+export function projectOAuthConnectedAccount(
+  provider: OAuthProviderConfig,
+  connection: OAuthConnection,
+): ConnectedAccount {
+  if (connection.platform !== provider.id) {
+    throw Errors.connectionNotFound(connection.id);
+  }
+  const scopes = new Set(normalizeScopes(connection.scopes));
+  const userScopes = new Set(normalizeScopes(connection.userScopes));
+  const accountUnavailable = unavailableForConnection(connection);
+  const capabilities = Object.entries(provider.capabilityScopes ?? {}).map(
+    ([capabilityId, bundle]) => {
+      const ownerUsesUserGrant =
+        normalizeOAuthConnectionRole(connection.connectionRole) === "OWNER" &&
+        normalizeScopes(bundle.userScopes).length > 0;
+      const hasAllScopes = ownerUsesUserGrant
+        ? true
+        : normalizeScopes(bundle.scopes).every((scope) => scopes.has(scope));
+      const hasAllUserScopes = ownerUsesUserGrant
+        ? normalizeScopes(bundle.userScopes).every((scope) => userScopes.has(scope))
+        : true;
+      return {
+        capabilityId,
+        riskLevel: bundle.riskLevel,
+        status: accountUnavailable ?? capabilityStatus(bundle, !hasAllScopes || !hasAllUserScopes),
+      };
+    },
+  );
+  const accountStatus =
+    connection.status === "active"
+      ? "connected"
+      : connection.status === "expired"
+        ? "reauth_required"
+        : connection.status === "pending"
+          ? "unavailable"
+          : connection.status;
+
+  return normalizeConnectedAccount({
+    contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+    accountId: connection.id,
+    providerId: provider.id,
+    mode: "cloud",
+    status: accountStatus,
+    displayName: connection.displayName ?? connection.username ?? null,
+    capabilities,
+    lastUsedAt: connection.lastUsedAt?.toISOString() ?? null,
+  });
 }
 
 export function getAllowedScopes(provider: OAuthProviderConfig): string[] {
@@ -1049,6 +1181,7 @@ export function resolveOAuthCapabilityRequest(
   requestedCapabilities: string[],
   grantedScopes: readonly string[] = [],
   grantedUserScopes: readonly string[] = [],
+  connectionRole: OAuthStandardConnectionRole = "OWNER",
 ): ResolvedOAuthCapabilityRequest {
   const capabilityIds = normalizeScopes(requestedCapabilities);
   const bundles = provider.capabilityScopes ?? {};
@@ -1071,14 +1204,17 @@ export function resolveOAuthCapabilityRequest(
     if (!bundle) {
       throw Errors.invalidCapabilityRequest(provider.id, [capabilityId]);
     }
-    const requiredScopes = normalizeScopes(bundle.scopes);
-    const requiredUserScopes = normalizeScopes(bundle.userScopes);
+    const ownerUsesUserGrant =
+      connectionRole === "OWNER" && normalizeScopes(bundle.userScopes).length > 0;
+    const requiredScopes = ownerUsesUserGrant ? [] : normalizeScopes(bundle.scopes);
+    const requiredUserScopes = ownerUsesUserGrant ? normalizeScopes(bundle.userScopes) : [];
     const capabilityMissingScopes = missingScopes(requiredScopes, grantedScopeSet);
     const capabilityMissingUserScopes = missingScopes(requiredUserScopes, grantedUserScopeSet);
     scopes.push(...requiredScopes);
     userScopes.push(...requiredUserScopes);
     return {
       capabilityId,
+      riskLevel: bundle.riskLevel,
       status: capabilityStatus(
         bundle,
         capabilityMissingScopes.length > 0 || capabilityMissingUserScopes.length > 0,

--- a/packages/cloud/shared/src/lib/services/oauth/provider-registry.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/provider-registry.ts
@@ -35,6 +35,12 @@ export interface OAuthCapabilityScopeBundle {
   riskLevel: CapabilityRiskLevel;
 }
 
+/** Provider baseline grants when credential authority differs by connection role. */
+export interface OAuthRoleScopeDefaults {
+  scopes: string[];
+  userScopes: string[];
+}
+
 /** Capability availability projected without exposing provider credentials. */
 export interface OAuthCapabilityAccess {
   capabilityId: string;
@@ -118,6 +124,19 @@ export interface UserInfoMapping {
 }
 
 /**
+ * Identity fields carried by a provider's signed/token-endpoint response.
+ * `idParts` are joined so tenant/workspace-scoped subject IDs never collide
+ * when the same Cloud organization connects more than one provider tenant.
+ */
+export interface TokenIdentityMapping {
+  idParts: string[];
+  email?: string;
+  username?: string;
+  displayName?: string;
+  avatarUrl?: string;
+}
+
+/**
  * Mapping for non-standard token response fields.
  * Most OAuth2 providers use standard field names, but some differ.
  */
@@ -193,6 +212,9 @@ export interface OAuthProviderConfig {
   /** Stable product capabilities that may incrementally extend the baseline grant. */
   capabilityScopes?: Record<string, OAuthCapabilityScopeBundle>;
 
+  /** Role-specific least-privilege baselines for split user/app token providers. */
+  roleScopeDefaults?: Partial<Record<OAuthStandardConnectionRole, OAuthRoleScopeDefaults>>;
+
   /** Superset of user-level scopes accepted across named capability bundles. */
   allowedUserScopes?: string[];
 
@@ -221,6 +243,9 @@ export interface OAuthProviderConfig {
    * If not provided, uses standard OAuth2 claims.
    */
   userInfoMapping?: UserInfoMapping;
+
+  /** Role-specific identity authority in the token response. */
+  tokenIdentityMappings?: Partial<Record<OAuthStandardConnectionRole, TokenIdentityMapping>>;
 
   /**
    * How to map token response fields if non-standard.
@@ -537,13 +562,16 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     endpoints: {
       authorization: "https://slack.com/oauth/v2/authorize",
       token: "https://slack.com/api/oauth.v2.access",
-      userInfo: "https://slack.com/api/users.identity",
       revoke: "https://slack.com/api/auth.revoke",
     },
     defaultScopes: ["users:read"],
-    allowedScopes: ["identity.basic", "users:read", "chat:write", "channels:read", "files:read"],
+    allowedScopes: ["users:read", "chat:write", "channels:read", "files:read"],
     capabilityScopes: {
-      "channels.read": { scopes: ["channels:read"], riskLevel: "R1" },
+      "channels.read": {
+        scopes: ["channels:read"],
+        userScopes: ["channels:read"],
+        riskLevel: "R1",
+      },
       "directory.users.read": {
         scopes: ["users:read"],
         userScopes: ["users:read"],
@@ -566,20 +594,28 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       },
     },
     revocation: { transport: "bearer", token: "access", response: "slack_json" },
-    // User-level scopes requested for the OWNER role so the user's own
-    // Slack identity (authed_user.access_token, `xoxp-...`) can act on
-    // the user's behalf — read their channels, write as them, search
-    // their messages, and read files they have access to.
-    // `identity.basic` is required by Slack's `users.identity` endpoint
-    // (the userInfo URL above) — without it the OWNER callback's
-    // userInfo fetch fails with `missing_scope` and `extractUserInfo`
-    // cannot resolve `user_id`.
-    userScopes: ["identity.basic"],
-    allowedUserScopes: ["identity.basic", "chat:write", "search:read", "users:read", "files:read"],
-    userInfoMapping: {
-      id: "user_id",
-      displayName: "user",
-      // Bot tokens don't return email from auth.test - email is optional for bot auth
+    allowedUserScopes: ["channels:read", "chat:write", "search:read", "users:read", "files:read"],
+    roleScopeDefaults: {
+      OWNER: { scopes: [], userScopes: ["users:read"] },
+      AGENT: { scopes: ["users:read"], userScopes: [] },
+      TEAM: { scopes: ["users:read"], userScopes: [] },
+    },
+    // Slack forbids combining identity.* Sign-in-with-Slack scopes with
+    // ordinary app/user scopes. OAuth v2 already returns the authorizing user,
+    // bot, and workspace identities, so bind those instead of calling the
+    // legacy users.identity endpoint or requesting identity.basic.
+    tokenIdentityMappings: {
+      OWNER: {
+        idParts: ["team.id", "authed_user.id"],
+      },
+      AGENT: {
+        idParts: ["team.id", "bot_user_id"],
+        displayName: "team.name",
+      },
+      TEAM: {
+        idParts: ["team.id", "bot_user_id"],
+        displayName: "team.name",
+      },
     },
     storage: "platform_credentials",
     useGenericRoutes: true,
@@ -1192,9 +1228,13 @@ export function resolveOAuthCapabilityRequest(
 
   const normalizedGrantedScopes = normalizeScopes([...grantedScopes]);
   const normalizedGrantedUserScopes = normalizeScopes([...grantedUserScopes]);
-  const scopes = normalizeScopes([...(provider.defaultScopes ?? []), ...normalizedGrantedScopes]);
+  const roleDefaults = provider.roleScopeDefaults?.[connectionRole];
+  const scopes = normalizeScopes([
+    ...(roleDefaults?.scopes ?? provider.defaultScopes ?? []),
+    ...normalizedGrantedScopes,
+  ]);
   const userScopes = normalizeScopes([
-    ...(provider.userScopes ?? []),
+    ...(roleDefaults?.userScopes ?? provider.userScopes ?? []),
     ...normalizedGrantedUserScopes,
   ]);
   const grantedScopeSet = new Set(normalizedGrantedScopes);

--- a/packages/cloud/shared/src/lib/services/oauth/providers/index.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/index.ts
@@ -9,5 +9,7 @@ export {
   type InitiateOAuth2Result,
   initiateOAuth2,
   type OAuth2CallbackResult,
+  OAuthRefreshRejectedError,
   refreshOAuth2Token,
+  revokeOAuth2Credential,
 } from "./oauth2";

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
@@ -350,6 +350,128 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
     expect(insertReturning).not.toHaveBeenCalled();
   });
 
+  it("binds Slack OWNER identity to workspace plus authorizing user without identity scopes", async () => {
+    const { handleOAuth2Callback } = await import("./oauth2");
+    const slackProvider = {
+      ...provider,
+      id: "slack",
+      endpoints: {
+        authorization: "https://slack.com/oauth/v2/authorize",
+        token: "https://test.example/token",
+      },
+      defaultScopes: ["users:read"],
+      allowedScopes: ["users:read", "chat:write"],
+      userScopes: undefined,
+      allowedUserScopes: ["users:read", "chat:write"],
+      tokenIdentityMappings: {
+        OWNER: { idParts: ["team.id", "authed_user.id"] },
+      },
+    } as never;
+    stateData = {
+      organizationId: "org-1",
+      userId: "user-1",
+      providerId: "slack",
+      redirectUrl: "/done",
+      scopes: [],
+      userScopes: ["users:read", "chat:write"],
+      connectionRole: "OWNER",
+      createdAt: Date.now(),
+    };
+    tokenBody = {
+      ok: true,
+      team: { id: "T123", name: "Workspace" },
+      authed_user: {
+        id: "U456",
+        access_token: "user-secret-must-not-reach-profile",
+        refresh_token: "refresh-secret-must-not-reach-profile",
+        expires_in: 43_200,
+        scope: "users:read,chat:write",
+      },
+    };
+
+    const result = await handleOAuth2Callback(slackProvider, "auth-code", "state-token");
+
+    expect(result.platformUserId).toBe("T123:U456");
+    expect(storedConnection?.platform_user_id).toBe("T123:U456");
+    expect(storedConnection?.source_context).toEqual({
+      connectionRole: "OWNER",
+      oauthUserScopes: ["users:read", "chat:write"],
+    });
+    expect(JSON.stringify(storedConnection?.profile_data)).not.toContain("secret-must-not");
+  });
+
+  it("fails closed when Slack omits the workspace component of its role-bound identity", async () => {
+    const { handleOAuth2Callback } = await import("./oauth2");
+    const slackProvider = {
+      ...provider,
+      id: "slack",
+      endpoints: {
+        authorization: "https://slack.com/oauth/v2/authorize",
+        token: "https://test.example/token",
+      },
+      userScopes: undefined,
+      allowedUserScopes: [],
+      tokenIdentityMappings: {
+        OWNER: { idParts: ["team.id", "authed_user.id"] },
+      },
+    } as never;
+    stateData = {
+      organizationId: "org-1",
+      userId: "user-1",
+      providerId: "slack",
+      redirectUrl: "/done",
+      scopes: ["a"],
+      userScopes: [],
+      connectionRole: "OWNER",
+      createdAt: Date.now(),
+    };
+    tokenBody = {
+      access_token: "bot-at-123",
+      authed_user: { id: "U456" },
+    };
+
+    await expect(handleOAuth2Callback(slackProvider, "auth-code", "state-token")).rejects.toThrow(
+      "role-bound identity",
+    );
+    expect(secretsCreateCalls).toHaveLength(0);
+    expect(insertReturning).not.toHaveBeenCalled();
+  });
+
+  it("redacts nested token material from token-response profile metadata", async () => {
+    const { handleOAuth2Callback } = await import("./oauth2");
+    const tokenIdentityProvider = {
+      ...provider,
+      userScopes: undefined,
+      allowedUserScopes: undefined,
+      tokenIdentityMappings: {
+        OWNER: { idParts: ["owner.id"] },
+      },
+    } as never;
+    stateData = {
+      organizationId: "org-1",
+      userId: "user-1",
+      providerId: "testprov",
+      redirectUrl: "/done",
+      scopes: ["a"],
+      userScopes: [],
+      connectionRole: "OWNER",
+      createdAt: Date.now(),
+    };
+    tokenBody = {
+      access_token: "top-level-secret",
+      refresh_token: "refresh-secret",
+      id_token: "identity-secret",
+      owner: {
+        id: "owner-1",
+        accessToken: "nested-secret",
+      },
+    };
+
+    await handleOAuth2Callback(tokenIdentityProvider, "auth-code", "state-token");
+
+    expect(storedConnection?.profile_data).toEqual({ owner: { id: "owner-1" } });
+  });
+
   it("uses GitHub's confirmed grant header and never continues on a merely requested repo scope", async () => {
     const { handleOAuth2Callback } = await import("./oauth2");
     const githubProvider = {
@@ -438,11 +560,68 @@ describe("initiateOAuth2 — incremental capability protocol (#19879)", () => {
       expectedPlatformUserId: "platform-user-1",
     });
   });
+
+  it("keeps Slack OWNER and bot grants in separate OAuth installations", async () => {
+    const { initiateOAuth2 } = await import("./oauth2");
+    const slackProvider = {
+      ...provider,
+      id: "slack",
+      defaultScopes: ["users:read"],
+      allowedScopes: ["users:read", "chat:write"],
+      userScopes: undefined,
+      allowedUserScopes: ["users:read", "chat:write"],
+      roleScopeDefaults: {
+        OWNER: { scopes: [], userScopes: ["users:read"] },
+        AGENT: { scopes: ["users:read"], userScopes: [] },
+      },
+    } as never;
+
+    const owner = await initiateOAuth2(slackProvider, {
+      organizationId: "org-1",
+      userId: "user-1",
+      connectionRole: "OWNER",
+    });
+    const ownerUrl = new URL(owner.authUrl);
+    expect(ownerUrl.searchParams.has("scope")).toBe(false);
+    expect(ownerUrl.searchParams.get("user_scope")).toBe("users:read");
+
+    const agent = await initiateOAuth2(slackProvider, {
+      organizationId: "org-1",
+      userId: "user-1",
+      connectionRole: "AGENT",
+    });
+    const agentUrl = new URL(agent.authUrl);
+    expect(agentUrl.searchParams.get("scope")).toBe("users:read");
+    expect(agentUrl.searchParams.has("user_scope")).toBe(false);
+  });
 });
 
 describe("OAuth2 provider credential lifecycle (#19879)", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
+  });
+
+  it("refreshes a Slack user grant from the nested authed_user response", async () => {
+    const { refreshOAuth2Token } = await import("./oauth2");
+    globalThis.fetch = mock(async () =>
+      jsonResponse({
+        ok: true,
+        authed_user: {
+          access_token: "rotated-user-token",
+          refresh_token: "rotated-user-refresh",
+          expires_in: 43_200,
+          scope: "users:read,chat:write",
+        },
+      }),
+    ) as unknown as typeof globalThis.fetch;
+
+    await expect(refreshOAuth2Token(provider as never, "old-user-refresh")).resolves.toEqual({
+      accessToken: "rotated-user-token",
+      expiresIn: 43_200,
+      newRefreshToken: "rotated-user-refresh",
+      grantedScopes: undefined,
+      grantedUserScopes: ["users:read", "chat:write"],
+    });
   });
 
   it("revokes only the selected GitHub token with authenticated app credentials", async () => {

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
@@ -59,6 +59,7 @@ mock.module("../provider-registry", () => ({
   resolveOAuthCapabilityRequest: realProviderRegistry.resolveOAuthCapabilityRequest,
   resolveRequestedScopes: realProviderRegistry.resolveRequestedScopes,
   getNestedValue: realProviderRegistry.getNestedValue,
+  projectOAuthConnectedAccount: realProviderRegistry.projectOAuthConnectedAccount,
 }));
 
 mock.module("../../secrets", () => ({
@@ -108,12 +109,13 @@ afterAll(() => {
   mock.module("../../../../db/helpers", () => realDbHelpersExports);
 });
 
-function jsonResponse(body: unknown) {
+function jsonResponse(body: unknown, headers?: HeadersInit) {
   return {
     ok: true,
     status: 200,
     json: async () => body,
     text: async () => JSON.stringify(body),
+    headers: new Headers(headers),
   } as unknown as Response;
 }
 
@@ -128,7 +130,7 @@ const provider = {
   defaultScopes: ["a"],
   allowedScopes: ["a", "b"],
   capabilityScopes: {
-    "test.write": { scopes: ["b"], consent: "review" },
+    "test.write": { scopes: ["b"], riskLevel: "R2" },
   },
   userScopes: ["user:read"],
   allowedUserScopes: ["user:read"],
@@ -148,7 +150,11 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
       connectionRole: "OWNER",
       createdAt: Date.now(),
     };
-    tokenBody = { access_token: "at-123", token_type: "Bearer" };
+    tokenBody = {
+      access_token: "at-123",
+      token_type: "Bearer",
+      authed_user: { access_token: "user-at-123" },
+    };
     storedConnection = null;
     cachedState = null;
     originalFetch = globalThis.fetch;
@@ -222,7 +228,11 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
       fetchedSignals.push(init?.signal);
       const u = String(url);
       if (u.includes("/token")) {
-        return jsonResponse({ access_token: "at-123", token_type: "Bearer" });
+        return jsonResponse({
+          access_token: "at-123",
+          token_type: "Bearer",
+          authed_user: { access_token: "user-at-123" },
+        });
       }
       if (u.includes("/userinfo")) {
         return jsonResponse(userInfoBody);
@@ -292,7 +302,10 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
       access_token: "at-123",
       token_type: "Bearer",
       scope: "a provider:unexpected",
-      authed_user: { scope: "user:read rogue:scope" },
+      authed_user: {
+        access_token: "user-at-123",
+        scope: "user:read rogue:scope",
+      },
     };
 
     await handleOAuth2Callback(provider, "auth-code", "state-token");
@@ -324,6 +337,69 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
     );
     expect(insertReturning).not.toHaveBeenCalled();
   });
+
+  it("rejects an OWNER grant when the provider omits the user-authority token", async () => {
+    const { handleOAuth2Callback } = await import("./oauth2");
+    userInfoBody = { id: "real-user-42" };
+    tokenBody = { access_token: "bot-at-123", token_type: "Bearer" };
+
+    await expect(handleOAuth2Callback(provider, "auth-code", "state-token")).rejects.toThrow(
+      "permission",
+    );
+    expect(secretsCreateCalls).toHaveLength(0);
+    expect(insertReturning).not.toHaveBeenCalled();
+  });
+
+  it("uses GitHub's confirmed grant header and never continues on a merely requested repo scope", async () => {
+    const { handleOAuth2Callback } = await import("./oauth2");
+    const githubProvider = {
+      ...provider,
+      id: "github",
+      userScopes: undefined,
+      allowedUserScopes: undefined,
+      defaultScopes: ["read:user"],
+      allowedScopes: ["read:user", "repo"],
+      capabilityScopes: {
+        "repositories.full_control": { scopes: ["repo"], riskLevel: "R3" },
+      },
+      grantedScopeAuthority: { source: "user_info_header", header: "x-oauth-scopes" },
+    } as never;
+    stateData = {
+      organizationId: "org-1",
+      userId: "user-1",
+      providerId: "github",
+      redirectUrl: "/auth/success",
+      scopes: ["read:user", "repo"],
+      capabilities: ["repositories.full_control"],
+      capabilityRequest: {
+        contractVersion: 2,
+        requestId: "req_repo_1",
+        capabilityId: "repositories.full_control",
+        operation: "repository.write",
+        riskLevel: "R3",
+        accountId: null,
+        inputDigest: "a".repeat(64),
+      },
+      connectionRole: "OWNER",
+      createdAt: Date.now(),
+    };
+    tokenBody = { access_token: "github-at", token_type: "Bearer", scope: "repo" };
+    globalThis.fetch = mock(async (url: unknown) => {
+      if (String(url).includes("/token")) return jsonResponse(tokenBody);
+      if (String(url).includes("/userinfo")) {
+        return jsonResponse({ id: "github-user" }, { "x-oauth-scopes": "read:user" });
+      }
+      throw new Error(`unexpected fetch ${String(url)}`);
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await handleOAuth2Callback(githubProvider, "auth-code", "state-token");
+
+    expect(storedConnection?.scopes).toEqual(["read:user"]);
+    expect(result.capabilityAccess).toMatchObject([
+      { capabilityId: "repositories.full_control", riskLevel: "R3", status: "needs_admin" },
+    ]);
+    expect(result.capabilityContinuation).toBeUndefined();
+  });
 });
 
 describe("initiateOAuth2 — incremental capability protocol (#19879)", () => {
@@ -348,6 +424,7 @@ describe("initiateOAuth2 — incremental capability protocol (#19879)", () => {
     expect(result.capabilityAccess).toEqual([
       {
         capabilityId: "test.write",
+        riskLevel: "R2",
         status: "needs_review",
         missingScopes: ["b"],
         missingUserScopes: [],
@@ -360,5 +437,58 @@ describe("initiateOAuth2 — incremental capability protocol (#19879)", () => {
       userScopes: ["user:read"],
       expectedPlatformUserId: "platform-user-1",
     });
+  });
+});
+
+describe("OAuth2 provider credential lifecycle (#19879)", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("revokes only the selected GitHub token with authenticated app credentials", async () => {
+    const { revokeOAuth2Credential } = await import("./oauth2");
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+    globalThis.fetch = mock(async (url: unknown, init?: RequestInit) => {
+      capturedUrl = String(url);
+      capturedInit = init;
+      return jsonResponse({});
+    }) as unknown as typeof globalThis.fetch;
+
+    await expect(
+      revokeOAuth2Credential(
+        {
+          ...provider,
+          id: "github",
+          revocation: { transport: "github_token", token: "access", response: "http_ok" },
+        } as never,
+        { accessToken: "selected-token" },
+      ),
+    ).resolves.toEqual({ remoteRevoked: true });
+
+    expect(capturedUrl).toBe("https://api.github.com/applications/client-id/token");
+    expect(capturedInit?.method).toBe("DELETE");
+    expect(capturedInit?.body).toBe(JSON.stringify({ access_token: "selected-token" }));
+    expect(new Headers(capturedInit?.headers).get("authorization")).toBe(
+      `Basic ${Buffer.from("client-id:client-secret").toString("base64")}`,
+    );
+  });
+
+  it("does not treat Slack HTTP 200 as revocation without an affirmative body", async () => {
+    const { revokeOAuth2Credential } = await import("./oauth2");
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ ok: false, error: "not_authed" }),
+    ) as unknown as typeof globalThis.fetch;
+
+    await expect(
+      revokeOAuth2Credential(
+        {
+          ...provider,
+          endpoints: { ...provider.endpoints, revoke: "https://slack.com/api/auth.revoke" },
+          revocation: { transport: "bearer", token: "access", response: "slack_json" },
+        } as never,
+        { accessToken: "slack-token" },
+      ),
+    ).rejects.toThrow("did not confirm");
   });
 });

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
@@ -32,13 +32,18 @@ const insertReturning = mock(async () => [{ id: "conn-1" }]);
 
 let stateData: Record<string, unknown> | null;
 let userInfoBody: Record<string, unknown>;
+let tokenBody: Record<string, unknown>;
+let storedConnection: Record<string, unknown> | null;
+let cachedState: Record<string, unknown> | null;
 let originalFetch: typeof globalThis.fetch;
 
 mock.module("../../../cache/client", () => ({
   cache: {
     get: async () => stateData,
     del: async () => {},
-    set: async () => {},
+    set: async (_key: string, value: Record<string, unknown>) => {
+      cachedState = value;
+    },
   },
 }));
 
@@ -50,8 +55,10 @@ mock.module("../provider-registry", () => ({
   getClientId: () => "client-id",
   getClientSecret: () => "client-secret",
   getCallbackUrl: () => "https://test.example/callback",
-  resolveRequestedScopes: (_p: unknown, s?: string[]) => s ?? [],
-  getNestedValue: () => undefined,
+  getAllowedScopes: realProviderRegistry.getAllowedScopes,
+  resolveOAuthCapabilityRequest: realProviderRegistry.resolveOAuthCapabilityRequest,
+  resolveRequestedScopes: realProviderRegistry.resolveRequestedScopes,
+  getNestedValue: realProviderRegistry.getNestedValue,
 }));
 
 mock.module("../../secrets", () => ({
@@ -82,9 +89,12 @@ mock.module("../../../../db/helpers", () => ({
   writeTransaction: async (fn: (tx: unknown) => Promise<unknown>) =>
     fn({
       insert: () => ({
-        values: () => ({
-          onConflictDoUpdate: () => ({ returning: insertReturning }),
-        }),
+        values: (values: Record<string, unknown>) => {
+          storedConnection = values;
+          return {
+            onConflictDoUpdate: () => ({ returning: insertReturning }),
+          };
+        },
       }),
     }),
 }));
@@ -115,6 +125,13 @@ const provider = {
     userInfo: "https://test.example/userinfo",
   },
   pkce: false,
+  defaultScopes: ["a"],
+  allowedScopes: ["a", "b"],
+  capabilityScopes: {
+    "test.write": { scopes: ["b"], consent: "review" },
+  },
+  userScopes: ["user:read"],
+  allowedUserScopes: ["user:read"],
 } as never;
 
 describe("handleOAuth2Callback — identity extraction fails closed (#13415)", () => {
@@ -127,14 +144,18 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
       providerId: "testprov",
       redirectUrl: "/done",
       scopes: ["a"],
+      userScopes: ["user:read"],
       connectionRole: "OWNER",
       createdAt: Date.now(),
     };
+    tokenBody = { access_token: "at-123", token_type: "Bearer" };
+    storedConnection = null;
+    cachedState = null;
     originalFetch = globalThis.fetch;
     globalThis.fetch = mock(async (url: unknown) => {
       const u = String(url);
       if (u.includes("/token")) {
-        return jsonResponse({ access_token: "at-123", token_type: "Bearer" });
+        return jsonResponse(tokenBody);
       }
       if (u.includes("/userinfo")) {
         return jsonResponse(userInfoBody);
@@ -258,5 +279,78 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
     } finally {
       AbortSignal.timeout = originalTimeout;
     }
+  });
+
+  it("stores provider-confirmed grants and drops malformed added scopes", async () => {
+    const { handleOAuth2Callback } = await import("./oauth2");
+    userInfoBody = { id: "real-user-42" };
+    tokenBody = {
+      access_token: "at-123",
+      token_type: "Bearer",
+      scope: "a provider:unexpected",
+      authed_user: { scope: "user:read rogue:scope" },
+    };
+
+    await handleOAuth2Callback(provider, "auth-code", "state-token");
+
+    expect(storedConnection?.scopes).toEqual(["a", "user:read"]);
+  });
+
+  it("rejects a different account returned during bound incremental consent", async () => {
+    const { handleOAuth2Callback } = await import("./oauth2");
+    stateData = {
+      organizationId: "org-1",
+      userId: "user-1",
+      providerId: "testprov",
+      redirectUrl: "/done",
+      scopes: ["a"],
+      userScopes: ["user:read"],
+      expectedPlatformUserId: "expected-user",
+      connectionRole: "OWNER",
+      createdAt: Date.now(),
+    };
+    userInfoBody = { id: "different-user" };
+
+    await expect(handleOAuth2Callback(provider, "auth-code", "state-token")).rejects.toThrow(
+      "permission",
+    );
+    expect(insertReturning).not.toHaveBeenCalled();
+  });
+});
+
+describe("initiateOAuth2 — incremental capability protocol (#19879)", () => {
+  it("preserves grants, binds the account, and emits PKCE plus capability state", async () => {
+    const { initiateOAuth2 } = await import("./oauth2");
+    cachedState = null;
+    const result = await initiateOAuth2({ ...provider, pkce: true } as never, {
+      organizationId: "org-1",
+      userId: "user-1",
+      capabilities: ["test.write"],
+      grantedScopes: ["a"],
+      expectedPlatformUserId: "platform-user-1",
+      connectionRole: "OWNER",
+    });
+
+    const url = new URL(result.authUrl);
+    expect(url.searchParams.get("scope")?.split(" ")).toEqual(["a", "b"]);
+    expect(url.searchParams.get("user_scope")).toBe("user:read");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("code_challenge")).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(url.searchParams.get("state")).toBe(result.state);
+    expect(result.capabilityAccess).toEqual([
+      {
+        capabilityId: "test.write",
+        status: "needs_review",
+        missingScopes: ["b"],
+        missingUserScopes: [],
+      },
+    ]);
+    expect(cachedState).toMatchObject({
+      organizationId: "org-1",
+      userId: "user-1",
+      scopes: ["a", "b"],
+      userScopes: ["user:read"],
+      expectedPlatformUserId: "platform-user-1",
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
@@ -198,6 +198,10 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
     expect(result.connectionId).toBe("conn-1");
     // The real id flowed through storage untouched (never coerced to "unknown").
     expect(insertReturning).toHaveBeenCalledTimes(1);
+    expect(storedConnection?.source_context).toEqual({
+      connectionRole: "OWNER",
+      oauthUserScopes: [],
+    });
   });
 
   it("applies the shared 15-second deadline to callback and refresh requests", async () => {
@@ -293,7 +297,11 @@ describe("handleOAuth2Callback — identity extraction fails closed (#13415)", (
 
     await handleOAuth2Callback(provider, "auth-code", "state-token");
 
-    expect(storedConnection?.scopes).toEqual(["a", "user:read"]);
+    expect(storedConnection?.scopes).toEqual(["a"]);
+    expect(storedConnection?.source_context).toEqual({
+      connectionRole: "OWNER",
+      oauthUserScopes: ["user:read"],
+    });
   });
 
   it("rejects a different account returned during bound incremental consent", async () => {

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
@@ -26,6 +26,7 @@ import { Errors } from "../errors";
 import type {
   OAuthCapabilityAccess,
   OAuthProviderConfig,
+  TokenIdentityMapping,
   UserInfoMapping,
 } from "../provider-registry";
 import {
@@ -110,6 +111,14 @@ function parseGrantedScopeField(value: unknown): string[] {
     : [];
 }
 
+function nonEmptyTokenField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function finiteNumberField(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
 /**
  * Prefer scopes confirmed by the token response, while preserving providers
  * that omit scope on a successful exchange. Provider-added values are dropped
@@ -175,8 +184,9 @@ function pickUserInfoToken(
   provider: OAuthProviderConfig,
   tokens: TokenResponse,
   connectionRole: OAuthStandardConnectionRole,
+  requestedUserScopes: readonly string[],
 ): string {
-  if (connectionRole !== "OWNER" || !provider.userScopes || provider.userScopes.length === 0) {
+  if (connectionRole !== "OWNER" || requestedUserScopes.length === 0) {
     return tokens.access_token;
   }
   const authedUser = tokens.authed_user;
@@ -187,6 +197,53 @@ function pickUserInfoToken(
     }
   }
   throw Errors.forbidden();
+}
+
+const SENSITIVE_PROFILE_KEYS = new Set(["accesstoken", "refreshtoken", "idtoken", "clientsecret"]);
+
+function isSensitiveProfileKey(key: string): boolean {
+  return SENSITIVE_PROFILE_KEYS.has(key.replace(/[^a-z0-9]/gi, "").toLowerCase());
+}
+
+/** Remove credential material before provider profile metadata reaches Postgres. */
+function sanitizeProfileData(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeProfileData);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => !isSensitiveProfileKey(key))
+      .map(([key, nested]) => [key, sanitizeProfileData(nested)]),
+  );
+}
+
+function extractTokenIdentity(
+  mapping: TokenIdentityMapping,
+  tokens: TokenResponse,
+): ExtractedUserInfo {
+  const idParts = mapping.idParts.map((path) => getNestedValue(tokens, path));
+  if (
+    idParts.length === 0 ||
+    idParts.some((part) => part === undefined || part === null || part === "")
+  ) {
+    throw new Error("[OAuth2] Could not extract role-bound identity from token response");
+  }
+  const profile = sanitizeProfileData(tokens) as Record<string, unknown>;
+  return {
+    id: idParts.map(String).join(":"),
+    email: mapping.email
+      ? (getNestedValue(tokens, mapping.email) as string | undefined)
+      : undefined,
+    username: mapping.username
+      ? (getNestedValue(tokens, mapping.username) as string | undefined)
+      : undefined,
+    displayName: mapping.displayName
+      ? (getNestedValue(tokens, mapping.displayName) as string | undefined)
+      : undefined,
+    avatarUrl: mapping.avatarUrl
+      ? (getNestedValue(tokens, mapping.avatarUrl) as string | undefined)
+      : undefined,
+    raw: profile,
+  };
 }
 
 function getStoredConnectionRole(sourceContext: unknown): OAuthStandardConnectionRole {
@@ -314,8 +371,15 @@ export async function initiateOAuth2(
       "capabilityRequest.riskLevel cannot downgrade catalog risk",
     ]);
   }
-  const scopes = capabilityRequest?.scopes ?? resolveRequestedScopes(provider, params.scopes);
-  const userScopes = capabilityRequest?.userScopes ?? provider.userScopes ?? [];
+  const connectionRole = normalizeOAuthConnectionRole(params.connectionRole);
+  const roleDefaults = provider.roleScopeDefaults?.[connectionRole];
+  const scopes =
+    capabilityRequest?.scopes ??
+    (params.scopes === undefined && roleDefaults
+      ? [...roleDefaults.scopes]
+      : resolveRequestedScopes(provider, params.scopes));
+  const userScopes =
+    capabilityRequest?.userScopes ?? roleDefaults?.userScopes ?? provider.userScopes ?? [];
   const redirectUrl = params.redirectUrl || "/auth/success";
   if (normalizedBlockedRequest) {
     const continuationTarget = new URL(redirectUrl, baseUrl);
@@ -350,7 +414,7 @@ export async function initiateOAuth2(
     capabilities: params.capabilities,
     capabilityRequest: normalizedBlockedRequest,
     expectedPlatformUserId: params.expectedPlatformUserId,
-    connectionRole: normalizeOAuthConnectionRole(params.connectionRole),
+    connectionRole,
     createdAt: Date.now(),
     codeVerifier,
   };
@@ -380,8 +444,7 @@ export async function initiateOAuth2(
   // lookup to resolve to the same Slack user_id (the authorizer), which
   // the `storeConnection` dedup guard rejects with
   // `OAUTH_ACCOUNT_ALREADY_LINKED_TO_DIFFERENT_ROLE` on the second click.
-  const normalizedRole = normalizeOAuthConnectionRole(params.connectionRole);
-  if (userScopes.length > 0 && normalizedRole !== "AGENT") {
+  if (userScopes.length > 0 && connectionRole !== "AGENT") {
     authUrl.searchParams.set("user_scope", userScopes.join(" "));
   }
 
@@ -460,11 +523,15 @@ export async function handleOAuth2Callback(
   // workspace admin who clicked Authorize on both buttons), and the
   // `storeConnection` dedup guard rejects the second connection with
   // `OAUTH_ACCOUNT_ALREADY_LINKED_TO_DIFFERENT_ROLE`.
-  const userInfoToken = pickUserInfoToken(provider, tokens, connectionRole);
+  const requestedUserScopes = stateData.userScopes ?? [];
+  const userInfoToken = pickUserInfoToken(provider, tokens, connectionRole, requestedUserScopes);
 
   // Fetch user info: userInfo endpoint, token metadata endpoint, or from token response
   let userInfo: ExtractedUserInfo;
-  if (provider.endpoints?.userInfo) {
+  const tokenIdentityMapping = provider.tokenIdentityMappings?.[connectionRole];
+  if (tokenIdentityMapping) {
+    userInfo = extractTokenIdentity(tokenIdentityMapping, tokens);
+  } else if (provider.endpoints?.userInfo) {
     userInfo = await fetchUserInfo(provider, userInfoToken);
   } else if (provider.endpoints?.tokenInfo) {
     userInfo = await fetchTokenInfo(provider, userInfoToken);
@@ -638,22 +705,36 @@ async function exchangeCodeForTokens(
     throw new Error(`Token exchange failed: ${response.status}`);
   }
 
-  const data = (await response.json()) as Record<string, string | number | undefined>;
+  const data = (await response.json()) as Record<string, unknown>;
+
+  const rawAuthedUser = data.authed_user;
+  const authedUser =
+    rawAuthedUser && typeof rawAuthedUser === "object" && !Array.isArray(rawAuthedUser)
+      ? (rawAuthedUser as Record<string, unknown>)
+      : null;
 
   // Map non-standard field names if configured
   const tokenMapping = provider.tokenMapping;
-  const tokens: TokenResponse = {
-    access_token: data[tokenMapping?.accessToken || "access_token"] as string,
-    refresh_token: data[tokenMapping?.refreshToken || "refresh_token"] as string | undefined,
-    expires_in: data[tokenMapping?.expiresIn || "expires_in"] as number | undefined,
-    token_type: data[tokenMapping?.tokenType || "token_type"] as string | undefined,
-    scope: data[tokenMapping?.scope || "scope"] as string | undefined,
-    ...data,
-  };
-
-  if (!tokens.access_token) {
+  const accessToken =
+    nonEmptyTokenField(data[tokenMapping?.accessToken || "access_token"]) ??
+    nonEmptyTokenField(authedUser?.access_token);
+  if (!accessToken) {
     throw new Error("Token exchange did not return access_token");
   }
+  const tokens: TokenResponse = {
+    ...data,
+    access_token: accessToken,
+    refresh_token:
+      nonEmptyTokenField(data[tokenMapping?.refreshToken || "refresh_token"]) ??
+      nonEmptyTokenField(authedUser?.refresh_token),
+    expires_in:
+      finiteNumberField(data[tokenMapping?.expiresIn || "expires_in"]) ??
+      finiteNumberField(authedUser?.expires_in),
+    token_type:
+      nonEmptyTokenField(data[tokenMapping?.tokenType || "token_type"]) ??
+      nonEmptyTokenField(authedUser?.token_type),
+    scope: nonEmptyTokenField(data[tokenMapping?.scope || "scope"]),
+  };
 
   return tokens;
 }
@@ -813,7 +894,7 @@ function extractUserInfo(mapping: UserInfoMapping | undefined, data: unknown): E
       username: obj.username as string | undefined,
       displayName: (obj.name || obj.display_name) as string | undefined,
       avatarUrl: (obj.picture || obj.avatar_url || obj.avatar) as string | undefined,
-      raw: obj,
+      raw: sanitizeProfileData(obj) as Record<string, unknown>,
     };
   }
 
@@ -830,7 +911,7 @@ function extractUserInfo(mapping: UserInfoMapping | undefined, data: unknown): E
       ? (getNestedValue(data, mapping.displayName) as string)
       : undefined,
     avatarUrl: mapping.avatarUrl ? (getNestedValue(data, mapping.avatarUrl) as string) : undefined,
-    raw: data as Record<string, unknown>,
+    raw: sanitizeProfileData(data) as Record<string, unknown>,
   };
 }
 
@@ -1264,16 +1345,26 @@ export async function refreshOAuth2Token(
 
   const data = (await response.json()) as Record<string, unknown>;
   const tokenMapping = provider.tokenMapping;
-
-  const accessToken = data[tokenMapping?.accessToken || "access_token"] as string | undefined;
+  const rawAuthedUser = data.authed_user;
+  const authedUser =
+    rawAuthedUser && typeof rawAuthedUser === "object" && !Array.isArray(rawAuthedUser)
+      ? (rawAuthedUser as Record<string, unknown>)
+      : null;
+  const accessToken =
+    nonEmptyTokenField(data[tokenMapping?.accessToken || "access_token"]) ??
+    nonEmptyTokenField(authedUser?.access_token);
   if (!accessToken) {
     throw new Error("Token refresh response missing access_token");
   }
 
   return {
     accessToken,
-    expiresIn: data[tokenMapping?.expiresIn || "expires_in"] as number | undefined,
-    newRefreshToken: data[tokenMapping?.refreshToken || "refresh_token"] as string | undefined,
+    expiresIn:
+      finiteNumberField(data[tokenMapping?.expiresIn || "expires_in"]) ??
+      finiteNumberField(authedUser?.expires_in),
+    newRefreshToken:
+      nonEmptyTokenField(data[tokenMapping?.refreshToken || "refresh_token"]) ??
+      nonEmptyTokenField(authedUser?.refresh_token),
     grantedScopes:
       typeof data[tokenMapping?.scope || "scope"] === "string"
         ? parseGrantedScopeField(data[tokenMapping?.scope || "scope"])

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
@@ -16,12 +16,19 @@ import { cache } from "../../../cache/client";
 import { getCloudAwareEnv } from "../../../runtime/cloud-bindings";
 import { logger } from "../../../utils/logger";
 import { secretsService } from "../../secrets";
-import type { OAuthProviderConfig, UserInfoMapping } from "../provider-registry";
+import { Errors } from "../errors";
+import type {
+  OAuthCapabilityAccess,
+  OAuthProviderConfig,
+  UserInfoMapping,
+} from "../provider-registry";
 import {
+  getAllowedScopes,
   getCallbackUrl,
   getClientId,
   getClientSecret,
   getNestedValue,
+  resolveOAuthCapabilityRequest,
   resolveRequestedScopes,
 } from "../provider-registry";
 import type { OAuthConnectionRole, OAuthStandardConnectionRole } from "../types";
@@ -47,6 +54,8 @@ interface OAuth2State {
   providerId: string;
   redirectUrl: string;
   scopes: string[];
+  userScopes?: string[];
+  expectedPlatformUserId?: string;
   connectionRole?: OAuthConnectionRole;
   createdAt: number;
   codeVerifier?: string;
@@ -81,6 +90,41 @@ interface TokenResponse {
   token_type?: string;
   scope?: string;
   [key: string]: unknown;
+}
+
+function parseGrantedScopeField(value: unknown): string[] {
+  return typeof value === "string"
+    ? value
+        .split(/[\s,]+/)
+        .map((scope) => scope.trim())
+        .filter(Boolean)
+    : [];
+}
+
+/**
+ * Prefer scopes confirmed by the token response, while preserving providers
+ * that omit scope on a successful exchange. Provider-added values are dropped
+ * unless they were registered in the server-owned allowlist.
+ */
+function resolveGrantedScopes(
+  provider: OAuthProviderConfig,
+  tokens: TokenResponse,
+  requestedScopes: string[],
+  requestedUserScopes: string[],
+): string[] {
+  const tokenScopes = parseGrantedScopeField(tokens.scope);
+  const authedUser = tokens.authed_user;
+  const userTokenScopes =
+    authedUser && typeof authedUser === "object" && !Array.isArray(authedUser)
+      ? parseGrantedScopeField((authedUser as Record<string, unknown>).scope)
+      : [];
+  const confirmed = [...tokenScopes, ...userTokenScopes];
+  const resolved = confirmed.length > 0 ? confirmed : [...requestedScopes, ...requestedUserScopes];
+  const allowed = new Set([
+    ...getAllowedScopes(provider),
+    ...(provider.allowedUserScopes ?? provider.userScopes ?? []),
+  ]);
+  return [...new Set(resolved.filter((scope) => allowed.has(scope)))];
 }
 
 /**
@@ -166,6 +210,7 @@ function oauthSecretName(
 export interface InitiateOAuth2Result {
   authUrl: string;
   state: string;
+  capabilityAccess?: OAuthCapabilityAccess[];
 }
 
 /**
@@ -193,6 +238,10 @@ export async function initiateOAuth2(
     userId: string;
     redirectUrl?: string;
     scopes?: string[];
+    capabilities?: string[];
+    grantedScopes?: string[];
+    grantedUserScopes?: string[];
+    expectedPlatformUserId?: string;
     connectionRole?: OAuthConnectionRole;
   },
 ): Promise<InitiateOAuth2Result> {
@@ -207,7 +256,22 @@ export async function initiateOAuth2(
 
   const baseUrl = getCloudAwareEnv().NEXT_PUBLIC_APP_URL || "https://cloud.eliza.app";
   const callbackUrl = getCallbackUrl(provider, baseUrl);
-  const scopes = resolveRequestedScopes(provider, params.scopes);
+  if (params.scopes !== undefined && params.capabilities !== undefined) {
+    throw Errors.invalidCapabilityRequest(provider.id, [
+      "capabilities cannot be combined with raw scopes",
+    ]);
+  }
+  const capabilityRequest =
+    params.capabilities === undefined
+      ? undefined
+      : resolveOAuthCapabilityRequest(
+          provider,
+          params.capabilities,
+          params.grantedScopes,
+          params.grantedUserScopes,
+        );
+  const scopes = capabilityRequest?.scopes ?? resolveRequestedScopes(provider, params.scopes);
+  const userScopes = capabilityRequest?.userScopes ?? provider.userScopes ?? [];
   const redirectUrl = params.redirectUrl || "/auth/success";
 
   // Generate cryptographically secure state
@@ -229,6 +293,8 @@ export async function initiateOAuth2(
     providerId: provider.id,
     redirectUrl,
     scopes,
+    userScopes,
+    expectedPlatformUserId: params.expectedPlatformUserId,
     connectionRole: normalizeOAuthConnectionRole(params.connectionRole),
     createdAt: Date.now(),
     codeVerifier,
@@ -260,8 +326,8 @@ export async function initiateOAuth2(
   // the `storeConnection` dedup guard rejects with
   // `OAUTH_ACCOUNT_ALREADY_LINKED_TO_DIFFERENT_ROLE` on the second click.
   const normalizedRole = normalizeOAuthConnectionRole(params.connectionRole);
-  if (provider.userScopes && provider.userScopes.length > 0 && normalizedRole !== "AGENT") {
-    authUrl.searchParams.set("user_scope", provider.userScopes.join(" "));
+  if (userScopes.length > 0 && normalizedRole !== "AGENT") {
+    authUrl.searchParams.set("user_scope", userScopes.join(" "));
   }
 
   authUrl.searchParams.set("state", state);
@@ -288,6 +354,7 @@ export async function initiateOAuth2(
   return {
     authUrl: authUrl.toString(),
     state,
+    ...(capabilityRequest ? { capabilityAccess: capabilityRequest.capabilities } : {}),
   };
 }
 
@@ -316,7 +383,15 @@ export async function handleOAuth2Callback(
   // Delete state to prevent replay attacks
   await cache.del(stateKey);
 
-  const { organizationId, userId, redirectUrl, scopes, codeVerifier } = stateData;
+  const {
+    organizationId,
+    userId,
+    redirectUrl,
+    scopes,
+    userScopes,
+    expectedPlatformUserId,
+    codeVerifier,
+  } = stateData;
   const connectionRole = normalizeOAuthConnectionRole(stateData.connectionRole);
 
   // Exchange code for tokens
@@ -341,6 +416,16 @@ export async function handleOAuth2Callback(
     userInfo = extractUserInfoFromTokens(provider, tokens);
   }
 
+  if (expectedPlatformUserId !== undefined && userInfo.id !== expectedPlatformUserId) {
+    logger.warn("[OAuth2] Incremental consent returned a different account", {
+      providerId: provider.id,
+      organizationId,
+      expectedPlatformUserId,
+      returnedPlatformUserId: userInfo.id,
+    });
+    throw Errors.forbidden();
+  }
+
   // Store connection
   const connectionId = await storeConnection(
     provider,
@@ -349,7 +434,7 @@ export async function handleOAuth2Callback(
     connectionRole,
     tokens,
     userInfo,
-    scopes,
+    resolveGrantedScopes(provider, tokens, scopes, userScopes ?? []),
   );
 
   logger.info(`[OAuth2] Callback completed for ${provider.id}`, {

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
@@ -110,21 +110,26 @@ function resolveGrantedScopes(
   provider: OAuthProviderConfig,
   tokens: TokenResponse,
   requestedScopes: string[],
-  requestedUserScopes: string[],
-): string[] {
+): { scopes: string[]; userScopes: string[] } {
   const tokenScopes = parseGrantedScopeField(tokens.scope);
+  const tokenScopesConfirmed = typeof tokens.scope === "string";
   const authedUser = tokens.authed_user;
-  const userTokenScopes =
+  const rawUserScope =
     authedUser && typeof authedUser === "object" && !Array.isArray(authedUser)
-      ? parseGrantedScopeField((authedUser as Record<string, unknown>).scope)
-      : [];
-  const confirmed = [...tokenScopes, ...userTokenScopes];
-  const resolved = confirmed.length > 0 ? confirmed : [...requestedScopes, ...requestedUserScopes];
-  const allowed = new Set([
-    ...getAllowedScopes(provider),
-    ...(provider.allowedUserScopes ?? provider.userScopes ?? []),
-  ]);
-  return [...new Set(resolved.filter((scope) => allowed.has(scope)))];
+      ? (authedUser as Record<string, unknown>).scope
+      : undefined;
+  const userTokenScopes = rawUserScope === undefined ? [] : parseGrantedScopeField(rawUserScope);
+  const resolvedScopes = tokenScopesConfirmed ? tokenScopes : requestedScopes;
+  // User-token grants must never be inferred from the request. Slack returns
+  // them under authed_user.scope; if that authority is absent or malformed,
+  // persist no user grant and require consent again.
+  const resolvedUserScopes = userTokenScopes;
+  const allowedScopes = new Set(getAllowedScopes(provider));
+  const allowedUserScopes = new Set(provider.allowedUserScopes ?? provider.userScopes ?? []);
+  return {
+    scopes: [...new Set(resolvedScopes.filter((scope) => allowedScopes.has(scope)))],
+    userScopes: [...new Set(resolvedUserScopes.filter((scope) => allowedUserScopes.has(scope)))],
+  };
 }
 
 /**
@@ -184,6 +189,7 @@ function getStoredConnectionRole(sourceContext: unknown): OAuthStandardConnectio
 
 function connectionSourceContext(
   connectionRole: OAuthStandardConnectionRole,
+  oauthUserScopes: string[],
 ): PlatformCredentialSourceContext {
   // We intentionally no longer write `agentGoogleSide`. `connectionRole`
   // is the canonical field; existing rows that only have the compatibility
@@ -192,7 +198,7 @@ function connectionSourceContext(
   // and `connection-adapters/generic-adapter.ts`. The upsert
   // setWhere clause below also COALESCEs both fields so a re-link
   // matches the original row.
-  return { connectionRole };
+  return { connectionRole, oauthUserScopes };
 }
 
 function oauthSecretName(
@@ -383,15 +389,8 @@ export async function handleOAuth2Callback(
   // Delete state to prevent replay attacks
   await cache.del(stateKey);
 
-  const {
-    organizationId,
-    userId,
-    redirectUrl,
-    scopes,
-    userScopes,
-    expectedPlatformUserId,
-    codeVerifier,
-  } = stateData;
+  const { organizationId, userId, redirectUrl, scopes, expectedPlatformUserId, codeVerifier } =
+    stateData;
   const connectionRole = normalizeOAuthConnectionRole(stateData.connectionRole);
 
   // Exchange code for tokens
@@ -427,6 +426,7 @@ export async function handleOAuth2Callback(
   }
 
   // Store connection
+  const granted = resolveGrantedScopes(provider, tokens, scopes);
   const connectionId = await storeConnection(
     provider,
     organizationId,
@@ -434,7 +434,8 @@ export async function handleOAuth2Callback(
     connectionRole,
     tokens,
     userInfo,
-    resolveGrantedScopes(provider, tokens, scopes, userScopes ?? []),
+    granted.scopes,
+    granted.userScopes,
   );
 
   logger.info(`[OAuth2] Callback completed for ${provider.id}`, {
@@ -785,6 +786,7 @@ async function storeConnection(
   tokens: TokenResponse,
   userInfo: ExtractedUserInfo,
   scopes: string[],
+  userScopes: string[],
 ): Promise<string> {
   const connectionUserId = connectionRole === "OWNER" ? userId : null;
   const audit = {
@@ -1023,7 +1025,7 @@ async function storeConnection(
           scopes,
           profile_data: userInfo.raw,
           source_type: "web",
-          source_context: connectionSourceContext(connectionRole),
+          source_context: connectionSourceContext(connectionRole, userScopes),
           linked_at: new Date(),
         })
         .onConflictDoUpdate({
@@ -1052,7 +1054,7 @@ async function storeConnection(
             token_expires_at: tokenExpiresAt,
             scopes,
             profile_data: userInfo.raw,
-            source_context: connectionSourceContext(connectionRole),
+            source_context: connectionSourceContext(connectionRole, userScopes),
             linked_at: new Date(),
             updated_at: new Date(),
           },

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
@@ -5,6 +5,12 @@
  * Works with standard OAuth 2.0 and supports provider-specific variations via config.
  */
 
+import {
+  type BoundCapabilityRequest,
+  bindCapabilityRequest,
+  type CapabilityRequest,
+  normalizeCapabilityRequest,
+} from "@elizaos/core/types/provider-integrations";
 import { and, eq, sql } from "drizzle-orm";
 import { dbWrite } from "../../../../db/client";
 import { writeTransaction } from "../../../../db/helpers";
@@ -28,11 +34,12 @@ import {
   getClientId,
   getClientSecret,
   getNestedValue,
+  projectOAuthConnectedAccount,
   resolveOAuthCapabilityRequest,
   resolveRequestedScopes,
 } from "../provider-registry";
-import type { OAuthConnectionRole, OAuthStandardConnectionRole } from "../types";
-import { normalizeOAuthConnectionRole } from "../types";
+import type { OAuthConnection, OAuthConnectionRole, OAuthStandardConnectionRole } from "../types";
+import { formatOAuthConnectionRole, normalizeOAuthConnectionRole } from "../types";
 
 const STATE_TTL_SECONDS = 600; // 10 minutes
 export const OAUTH2_REQUEST_TIMEOUT_MS = 15_000;
@@ -55,6 +62,8 @@ interface OAuth2State {
   redirectUrl: string;
   scopes: string[];
   userScopes?: string[];
+  capabilities?: string[];
+  capabilityRequest?: CapabilityRequest;
   expectedPlatformUserId?: string;
   connectionRole?: OAuthConnectionRole;
   createdAt: number;
@@ -110,6 +119,7 @@ function resolveGrantedScopes(
   provider: OAuthProviderConfig,
   tokens: TokenResponse,
   requestedScopes: string[],
+  confirmedUserInfoScopes?: readonly string[],
 ): { scopes: string[]; userScopes: string[] } {
   const tokenScopes = parseGrantedScopeField(tokens.scope);
   const tokenScopesConfirmed = typeof tokens.scope === "string";
@@ -119,7 +129,11 @@ function resolveGrantedScopes(
       ? (authedUser as Record<string, unknown>).scope
       : undefined;
   const userTokenScopes = rawUserScope === undefined ? [] : parseGrantedScopeField(rawUserScope);
-  const resolvedScopes = tokenScopesConfirmed ? tokenScopes : requestedScopes;
+  const resolvedScopes = provider.grantedScopeAuthority
+    ? [...(confirmedUserInfoScopes ?? [])]
+    : tokenScopesConfirmed
+      ? tokenScopes
+      : requestedScopes;
   // User-token grants must never be inferred from the request. Slack returns
   // them under authed_user.scope; if that authority is absent or malformed,
   // persist no user grant and require consent again.
@@ -142,6 +156,7 @@ interface ExtractedUserInfo {
   displayName?: string;
   avatarUrl?: string;
   raw: Record<string, unknown>;
+  confirmedScopes?: string[];
 }
 
 /**
@@ -171,12 +186,7 @@ function pickUserInfoToken(
       return userToken;
     }
   }
-  // Fall back to the bot token if the provider didn't return a user
-  // token (e.g. the user denied user-scope permissions on the consent
-  // screen). The caller will still hit the dedup guard, but that's the
-  // correct behavior: an OWNER connection without user-token grants
-  // isn't meaningfully distinct from an AGENT connection.
-  return tokens.access_token;
+  throw Errors.forbidden();
 }
 
 function getStoredConnectionRole(sourceContext: unknown): OAuthStandardConnectionRole {
@@ -230,6 +240,8 @@ export interface OAuth2CallbackResult {
   email?: string;
   displayName?: string;
   redirectUrl: string;
+  capabilityAccess?: OAuthCapabilityAccess[];
+  capabilityContinuation?: BoundCapabilityRequest;
 }
 
 /**
@@ -245,6 +257,7 @@ export async function initiateOAuth2(
     redirectUrl?: string;
     scopes?: string[];
     capabilities?: string[];
+    capabilityRequest?: CapabilityRequest;
     grantedScopes?: string[];
     grantedUserScopes?: string[];
     expectedPlatformUserId?: string;
@@ -275,10 +288,44 @@ export async function initiateOAuth2(
           params.capabilities,
           params.grantedScopes,
           params.grantedUserScopes,
+          normalizeOAuthConnectionRole(params.connectionRole),
         );
+  const normalizedBlockedRequest = params.capabilityRequest
+    ? normalizeCapabilityRequest(params.capabilityRequest)
+    : undefined;
+  if (
+    normalizedBlockedRequest &&
+    (!params.capabilities || !params.capabilities.includes(normalizedBlockedRequest.capabilityId))
+  ) {
+    throw Errors.invalidCapabilityRequest(provider.id, [
+      "capabilityRequest.capabilityId must be included in capabilities",
+    ]);
+  }
+  const blockedCapability = capabilityRequest?.capabilities.find(
+    (capability) => capability.capabilityId === normalizedBlockedRequest?.capabilityId,
+  );
+  if (
+    normalizedBlockedRequest &&
+    blockedCapability &&
+    ["R0", "R1", "R2", "R3"].indexOf(normalizedBlockedRequest.riskLevel) <
+      ["R0", "R1", "R2", "R3"].indexOf(blockedCapability.riskLevel)
+  ) {
+    throw Errors.invalidCapabilityRequest(provider.id, [
+      "capabilityRequest.riskLevel cannot downgrade catalog risk",
+    ]);
+  }
   const scopes = capabilityRequest?.scopes ?? resolveRequestedScopes(provider, params.scopes);
   const userScopes = capabilityRequest?.userScopes ?? provider.userScopes ?? [];
   const redirectUrl = params.redirectUrl || "/auth/success";
+  if (normalizedBlockedRequest) {
+    const continuationTarget = new URL(redirectUrl, baseUrl);
+    const normalizedPath = continuationTarget.pathname.replace(/\/+$/, "") || "/";
+    if (normalizedPath !== "/auth/success") {
+      throw Errors.invalidCapabilityRequest(provider.id, [
+        "capabilityRequest requires the authenticated /auth/success continuation",
+      ]);
+    }
+  }
 
   // Generate cryptographically secure state
   const state = crypto.randomUUID();
@@ -300,6 +347,8 @@ export async function initiateOAuth2(
     redirectUrl,
     scopes,
     userScopes,
+    capabilities: params.capabilities,
+    capabilityRequest: normalizedBlockedRequest,
     expectedPlatformUserId: params.expectedPlatformUserId,
     connectionRole: normalizeOAuthConnectionRole(params.connectionRole),
     createdAt: Date.now(),
@@ -389,8 +438,16 @@ export async function handleOAuth2Callback(
   // Delete state to prevent replay attacks
   await cache.del(stateKey);
 
-  const { organizationId, userId, redirectUrl, scopes, expectedPlatformUserId, codeVerifier } =
-    stateData;
+  const {
+    organizationId,
+    userId,
+    redirectUrl,
+    scopes,
+    capabilities,
+    capabilityRequest,
+    expectedPlatformUserId,
+    codeVerifier,
+  } = stateData;
   const connectionRole = normalizeOAuthConnectionRole(stateData.connectionRole);
 
   // Exchange code for tokens
@@ -426,17 +483,58 @@ export async function handleOAuth2Callback(
   }
 
   // Store connection
-  const granted = resolveGrantedScopes(provider, tokens, scopes);
+  const granted = resolveGrantedScopes(provider, tokens, scopes, userInfo.confirmedScopes);
   const connectionId = await storeConnection(
     provider,
     organizationId,
     userId,
     connectionRole,
-    tokens,
+    connectionRole === "OWNER" && userInfoToken !== tokens.access_token
+      ? { ...tokens, access_token: userInfoToken }
+      : tokens,
     userInfo,
     granted.scopes,
     granted.userScopes,
   );
+
+  const capabilityAccess = capabilities
+    ? resolveOAuthCapabilityRequest(
+        provider,
+        capabilities,
+        granted.scopes,
+        granted.userScopes,
+        connectionRole,
+      ).capabilities
+    : undefined;
+  let capabilityContinuation: BoundCapabilityRequest | undefined;
+  if (capabilityRequest) {
+    const connection: OAuthConnection = {
+      id: connectionId,
+      userId: connectionRole === "OWNER" ? userId : undefined,
+      connectionRole: formatOAuthConnectionRole(connectionRole),
+      platform: provider.id,
+      platformUserId: userInfo.id,
+      displayName: userInfo.displayName,
+      username: userInfo.username,
+      status: "active",
+      scopes: granted.scopes,
+      userScopes: granted.userScopes,
+      linkedAt: new Date(),
+      tokenExpired: false,
+      source: "platform_credentials",
+    };
+    const account = projectOAuthConnectedAccount(provider, connection);
+    const targetCapability = account.capabilities.find(
+      (entry) => entry.capabilityId === capabilityRequest.capabilityId,
+    );
+    if (targetCapability?.status === "available") {
+      capabilityContinuation = bindCapabilityRequest(
+        capabilityRequest,
+        account,
+        new Date().toISOString(),
+      );
+    }
+  }
 
   logger.info(`[OAuth2] Callback completed for ${provider.id}`, {
     organizationId,
@@ -452,6 +550,8 @@ export async function handleOAuth2Callback(
     email: userInfo.email,
     displayName: userInfo.displayName,
     redirectUrl,
+    capabilityAccess,
+    capabilityContinuation,
   };
 }
 
@@ -624,7 +724,14 @@ async function fetchUserInfo(
     throw new Error(`GraphQL error: ${errorMessage}`);
   }
 
-  return extractUserInfo(provider.userInfoMapping, data);
+  const extracted = extractUserInfo(provider.userInfoMapping, data);
+  const grantAuthority = provider.grantedScopeAuthority;
+  if (!grantAuthority) return extracted;
+  const rawHeader = response.headers.get(grantAuthority.header);
+  return {
+    ...extracted,
+    confirmedScopes: parseGrantedScopeField(rawHeader),
+  };
 }
 
 /**
@@ -1091,6 +1198,8 @@ export async function refreshOAuth2Token(
   accessToken: string;
   expiresIn?: number;
   newRefreshToken?: string;
+  grantedScopes?: string[];
+  grantedUserScopes?: string[];
 }> {
   const clientId = getClientId(provider);
   const clientSecret = getClientSecret(provider);
@@ -1144,15 +1253,16 @@ export async function refreshOAuth2Token(
   });
 
   if (!response.ok) {
-    const errorText = await response.text();
     logger.error(`[OAuth2] Token refresh failed for ${provider.id}`, {
       status: response.status,
-      error: errorText.substring(0, 500),
     });
-    throw new Error(`Token refresh failed: ${response.status}`);
+    throw new OAuthRefreshRejectedError(
+      `Token refresh failed: ${response.status}`,
+      response.status === 400 || response.status === 401,
+    );
   }
 
-  const data = (await response.json()) as Record<string, string | number | undefined>;
+  const data = (await response.json()) as Record<string, unknown>;
   const tokenMapping = provider.tokenMapping;
 
   const accessToken = data[tokenMapping?.accessToken || "access_token"] as string | undefined;
@@ -1164,5 +1274,106 @@ export async function refreshOAuth2Token(
     accessToken,
     expiresIn: data[tokenMapping?.expiresIn || "expires_in"] as number | undefined,
     newRefreshToken: data[tokenMapping?.refreshToken || "refresh_token"] as string | undefined,
+    grantedScopes:
+      typeof data[tokenMapping?.scope || "scope"] === "string"
+        ? parseGrantedScopeField(data[tokenMapping?.scope || "scope"])
+        : undefined,
+    grantedUserScopes:
+      data.authed_user &&
+      typeof data.authed_user === "object" &&
+      !Array.isArray(data.authed_user) &&
+      typeof (data.authed_user as Record<string, unknown>).scope === "string"
+        ? parseGrantedScopeField((data.authed_user as Record<string, unknown>).scope)
+        : undefined,
   };
+}
+
+/** Refresh rejection that distinguishes reauthorization from a transient outage. */
+export class OAuthRefreshRejectedError extends Error {
+  constructor(
+    message: string,
+    public readonly reauthRequired: boolean,
+  ) {
+    super(message);
+    this.name = "OAuthRefreshRejectedError";
+  }
+}
+
+/**
+ * Revoke the provider-side grant when the registry declares a verified
+ * protocol. A missing protocol is an explicit local-disconnect result.
+ */
+export async function revokeOAuth2Credential(
+  provider: OAuthProviderConfig,
+  credentials: { accessToken?: string; refreshToken?: string },
+): Promise<{ remoteRevoked: boolean }> {
+  const config = provider.revocation;
+  if (!config) return { remoteRevoked: false };
+  const token = config.token === "refresh" ? credentials.refreshToken : credentials.accessToken;
+  if (!token) {
+    throw new Error(`[OAuth2] ${provider.id} revocation requires a ${config.token} token`);
+  }
+
+  let url: string;
+  let init: RequestInit;
+  if (config.transport === "github_token") {
+    const clientId = getClientId(provider);
+    const clientSecret = getClientSecret(provider);
+    if (!clientId || !clientSecret) {
+      throw new Error(`[OAuth2] ${provider.id} revocation requires app credentials`);
+    }
+    url = `https://api.github.com/applications/${encodeURIComponent(clientId)}/token`;
+    init = {
+      method: "DELETE",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2026-03-10",
+      },
+      body: JSON.stringify({ access_token: token }),
+    };
+  } else {
+    if (!provider.endpoints?.revoke) {
+      throw new Error(`[OAuth2] ${provider.id} revocation endpoint is not configured`);
+    }
+    url = provider.endpoints.revoke;
+    if (config.transport === "bearer") {
+      init = {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+      };
+    } else {
+      const body = new URLSearchParams({ token });
+      if (config.includeClientCredentials) {
+        const clientId = getClientId(provider);
+        const clientSecret = getClientSecret(provider);
+        if (!clientId || !clientSecret) {
+          throw new Error(`[OAuth2] ${provider.id} revocation requires app credentials`);
+        }
+        body.set("client_id", clientId);
+        body.set("client_secret", clientSecret);
+      }
+      init = {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      };
+    }
+  }
+
+  const response = await fetchOAuth2(url, init);
+  if (!response.ok) {
+    throw new Error(`[OAuth2] ${provider.id} revocation failed with status ${response.status}`);
+  }
+  if (config.response === "slack_json") {
+    const body = (await response.json()) as Record<string, unknown>;
+    if (body.ok !== true || body.revoked !== true) {
+      throw new Error(`[OAuth2] ${provider.id} did not confirm token revocation`);
+    }
+  }
+  return { remoteRevoked: true };
 }

--- a/packages/cloud/shared/src/lib/services/oauth/success-proof.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/success-proof.test.ts
@@ -1,5 +1,6 @@
 /** Unit tests for OAuth success-proof mint/consume (HMAC + one-time ticket). */
 
+import { bindCapabilityRequest } from "@elizaos/core/types/provider-integrations";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   __setOAuthSuccessProofTicketStoreForTests,
@@ -50,6 +51,48 @@ describe("oauth success proof", () => {
     });
     const second = await consumeOAuthSuccessProof(proof, BINDING);
     expect(second).toEqual({ ok: false, reason: "already_used" });
+  });
+
+  it("returns the exact signed capability continuation only to the bound session", async () => {
+    const continuation = bindCapabilityRequest(
+      {
+        contractVersion: 2,
+        requestId: "req_repo_1",
+        capabilityId: "repositories.full_control",
+        operation: "repository.write",
+        riskLevel: "R3",
+        accountId: null,
+        inputDigest: "a".repeat(64),
+      },
+      {
+        contractVersion: 2,
+        accountId: "conn-1",
+        providerId: "github",
+        mode: "cloud",
+        status: "connected",
+        displayName: null,
+        capabilities: [
+          {
+            capabilityId: "repositories.full_control",
+            riskLevel: "R3",
+            status: "available",
+          },
+        ],
+        lastUsedAt: null,
+      },
+      "2026-08-20T00:00:00.000Z",
+    );
+    const proof = await mintOAuthSuccessProof({
+      platform: "github",
+      connectionId: "conn-1",
+      capabilityContinuation: continuation,
+      ...BINDING,
+    });
+
+    expect(await consumeOAuthSuccessProof(proof, BINDING)).toEqual({
+      ok: true,
+      payload: expect.objectContaining({ capabilityContinuation: continuation }),
+    });
   });
 
   it("mints twitter proofs without a connection id and consumes once", async () => {

--- a/packages/cloud/shared/src/lib/services/oauth/success-proof.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/success-proof.ts
@@ -9,6 +9,10 @@
  */
 
 import { createHash, createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import {
+  type BoundCapabilityRequest,
+  normalizeBoundCapabilityRequest,
+} from "@elizaos/core/types/provider-integrations";
 import { oauthSuccessProofTicketsRepository } from "../../../db/repositories/oauth-success-proof-tickets";
 import { getCloudAwareEnv } from "../../runtime/cloud-bindings";
 import { getAllProviderIds } from "./provider-registry";
@@ -68,6 +72,7 @@ export interface OAuthSuccessProofPayload {
   userId: string;
   exp: number;
   nonce: string;
+  capabilityContinuation: BoundCapabilityRequest | null;
 }
 
 /** Server-side ticket record stored under the proof nonce for one-time consume. */
@@ -209,6 +214,7 @@ export async function mintOAuthSuccessProof(args: {
   connectionId?: string | null;
   organizationId: string;
   userId: string;
+  capabilityContinuation?: BoundCapabilityRequest | null;
   ttlMs?: number;
 }): Promise<string | null> {
   const secret = resolveProofSecret();
@@ -230,6 +236,9 @@ export async function mintOAuthSuccessProof(args: {
     userId,
     exp,
     nonce,
+    capabilityContinuation: args.capabilityContinuation
+      ? normalizeBoundCapabilityRequest(args.capabilityContinuation)
+      : null,
   };
   const ticket: OAuthSuccessProofTicket = {
     platform,
@@ -318,6 +327,15 @@ export async function consumeOAuthSuccessProof(
       typeof raw.connectionId === "string" && raw.connectionId.trim()
         ? raw.connectionId.trim()
         : null;
+    let capabilityContinuation: BoundCapabilityRequest | null = null;
+    if (raw.capabilityContinuation !== undefined && raw.capabilityContinuation !== null) {
+      try {
+        capabilityContinuation = normalizeBoundCapabilityRequest(raw.capabilityContinuation);
+      } catch {
+        // error-policy:J3 a malformed signed payload is still invalid input.
+        return { ok: false, reason: "malformed" };
+      }
+    }
     payload = {
       platform: raw.platform.trim().toLowerCase(),
       connectionId,
@@ -325,6 +343,7 @@ export async function consumeOAuthSuccessProof(
       userId: raw.userId.trim(),
       exp: raw.exp,
       nonce: raw.nonce.trim(),
+      capabilityContinuation,
     };
   } catch {
     // error-policy:J3 malformed proof payload is an explicit invalid result.
@@ -416,6 +435,14 @@ export function verifyOAuthSuccessProof(
       typeof raw.connectionId === "string" && raw.connectionId.trim()
         ? raw.connectionId.trim()
         : null;
+    let capabilityContinuation: BoundCapabilityRequest | null = null;
+    if (raw.capabilityContinuation !== undefined && raw.capabilityContinuation !== null) {
+      try {
+        capabilityContinuation = normalizeBoundCapabilityRequest(raw.capabilityContinuation);
+      } catch {
+        return { ok: false, reason: "malformed" };
+      }
+    }
     return {
       ok: true,
       payload: {
@@ -425,6 +452,7 @@ export function verifyOAuthSuccessProof(
         userId: raw.userId.trim(),
         exp: raw.exp,
         nonce: raw.nonce.trim(),
+        capabilityContinuation,
       },
     };
   } catch {

--- a/packages/cloud/shared/src/lib/services/oauth/types.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/types.ts
@@ -99,6 +99,8 @@ export interface OAuthConnection {
   status: OAuthConnectionStatus;
   /** OAuth scopes granted */
   scopes: string[];
+  /** User-token OAuth scopes when the provider separates user and bot grants. */
+  userScopes?: string[];
   /** When the connection was established */
   linkedAt: Date;
   /** When the connection was last used */

--- a/packages/cloud/shared/src/lib/services/oauth/types.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/types.ts
@@ -141,6 +141,10 @@ export interface InitiateAuthParams {
   redirectUrl?: string;
   /** Specific scopes to request (overrides defaults) */
   scopes?: string[];
+  /** Stable provider capability IDs to request incrementally. */
+  capabilities?: string[];
+  /** Existing tenant-owned connection whose grants should be extended. */
+  connectionId?: string;
   /** Logical Agent-side role for the connection */
   connectionRole?: OAuthConnectionRole;
 }
@@ -153,6 +157,15 @@ export interface InitiateAuthResult {
   authUrl: string;
   /** State parameter for CSRF protection */
   state?: string;
+  /** Capability states that caused this incremental consent flow. */
+  capabilityAccess?: Array<{
+    capabilityId: string;
+    status: "available" | "needs_scope" | "needs_review" | "needs_admin";
+    missingScopes: string[];
+    missingUserScopes: string[];
+  }>;
+  /** Signals that the caller's redirect may retry its blocked action after consent. */
+  retryAfterConsent?: boolean;
   /** For API key platforms - indicates credentials form should be shown */
   requiresCredentials?: boolean;
 }

--- a/packages/cloud/shared/src/lib/services/oauth/types.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/types.ts
@@ -5,6 +5,12 @@
  * a consistent interface across multiple OAuth providers (Google, Twitter, Twilio, Blooio).
  */
 
+import type {
+  BoundCapabilityRequest,
+  ConnectedAccountCapability,
+} from "@elizaos/core/types/provider-integrations";
+import type { OAuthCapabilityAccess } from "./provider-registry";
+
 export type OAuthProviderType = "oauth2" | "oauth1a" | "api_key";
 
 export type OAuthConnectionStatus = "pending" | "active" | "expired" | "revoked" | "error";
@@ -145,6 +151,8 @@ export interface InitiateAuthParams {
   scopes?: string[];
   /** Stable provider capability IDs to request incrementally. */
   capabilities?: string[];
+  /** Exact blocked action intent to bind after the provider confirms consent. */
+  capabilityRequest?: unknown;
   /** Existing tenant-owned connection whose grants should be extended. */
   connectionId?: string;
   /** Logical Agent-side role for the connection */
@@ -160,14 +168,13 @@ export interface InitiateAuthResult {
   /** State parameter for CSRF protection */
   state?: string;
   /** Capability states that caused this incremental consent flow. */
-  capabilityAccess?: Array<{
-    capabilityId: string;
-    status: "available" | "needs_scope" | "needs_review" | "needs_admin";
-    missingScopes: string[];
-    missingUserScopes: string[];
-  }>;
+  capabilityAccess?: OAuthCapabilityAccess[];
   /** Signals that the caller's redirect may retry its blocked action after consent. */
   retryAfterConsent?: boolean;
+  /** Selected canonical account capability when incremental consent is account-bound. */
+  selectedCapability?: ConnectedAccountCapability;
+  /** Authenticated exact-action continuation, emitted only after callback verification. */
+  capabilityContinuation?: BoundCapabilityRequest;
   /** For API key platforms - indicates credentials form should be shown */
   requiresCredentials?: boolean;
 }


### PR DESCRIPTION
## Summary

- replace broad initial OAuth grants for Google, Microsoft, GitHub, Linear, Slack, Salesforce, and Airtable with minimal baselines plus server-owned capability bundles
- use the provider-neutral capability vocabulary and canonical R0-R3 risk levels introduced by #19878 instead of a second Cloud-only dialect
- bind incremental consent to an exact capability request, authenticated `/auth/success` continuation, tenant-owned account, and provider-confirmed grant
- keep credential refresh/revocation and the usable token's scope authority synchronized, including role-separated Slack owner and bot credentials plus provider-side revocation

Closes #19879

## Authority and lifecycle behavior

- Multiple active accounts fail closed until the caller supplies an explicit `connectionId`; an explicit selection is checked for tenant, actor, role, provider, and active lifecycle state.
- The signed one-time success proof carries the canonical bound capability continuation only after the provider confirms the requested authority. It is returned only after the browser's authenticated org/user binding matches and the nonce is atomically consumed.
- GitHub's classic `repo` scope is truthfully modeled as `repositories.full_control` / R3. Callback authority comes from `X-OAuth-Scopes`, never from the requested or token-exchange scope echo.
- Slack OWNER connections require and persist `authed_user.access_token`; bot scopes cannot authorize a user token and absence of the user token fails before credential storage.
- Refresh persists provider-confirmed allowlisted scopes, marks rejected refresh credentials for reauthorization, and returns scopes for the token actually handed to the caller.
- Revocation calls the provider before deleting local credentials. GitHub deletes only the selected app token, Slack requires an affirmative `{ ok: true, revoked: true }`, and provider-specific access/refresh-token protocols are registry-owned.

## Draft boundary

This PR remains draft for independent review. The isolated environment has no real Google, Microsoft, GitHub, Linear, Slack, Salesforce, or Airtable accounts, so current-head live consent, denial, refresh, revoke, reconnect, and multi-account traces are still required before merge. Deterministic transport tests and the production Worker build are not represented as real-provider evidence.

## Verification

Exact reviewed head: `01037cdb36b5f6418fc7be7b0a1651cdc15bd207`

Exact base: `7c8f9da796dc6cf89ffbb92f9df8d2e0f79d5cea`

<!-- evidence-head:01037cdb36b5f6418fc7be7b0a1651cdc15bd207 -->

- PASS: fresh `bun install --frozen-lockfile` with pinned Bun 1.3.14
- PASS: 72 exact-head focused tests across provider registry, OAuth service account selection, OAuth2 callback/refresh/revocation, one-time authenticated continuation, and HTTP initiation
- PASS: `bun run --cwd packages/cloud/shared typecheck`
- PASS: API `tsc --noEmit`
- PASS: `bun run --cwd packages/cloud/api check:worker-bundle` (24,498.91 KiB production dry-run upload)
- PASS: Cloud shared/API package lint and exact changed-surface Biome
- PASS: `git diff --check`
- PARTIAL: root `bun run verify` passed guide parity, toolchain/dependency/i18n/tsconfig audits and entered the 144-package typecheck/lint lane; it then failed only because the shared machine exhausted disk while writing unrelated core declaration artifacts (`ENOSPC`). The owning Cloud package gates above completed independently after the exact-head rebase.

### Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend OAuth protocol and action contract only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend OAuth protocol and action contract only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered surface changed; real-provider walkthrough remains required while draft.
<!-- evidence-row:backend-logs -->
- [x] Exact-head deterministic transcript:

  ```text
  72 focused tests passed.
  Adversarial coverage includes ambiguous account selection, mismatched provider identity,
  workspace-qualified Slack identity, user-vs-bot authority, nested Slack refresh, token-metadata redaction, requested-vs-confirmed GitHub grants, signed session-bound
  continuation replay, selected-token GitHub revoke, and false-positive Slack HTTP 200 revoke.
  Cloud shared/API typecheck, lint, and production Worker dry-run passed.
  ```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or rendered state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic OAuth transport/domain behavior; no prompt or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head authority transcript:

  ```text
  Provider-neutral capabilities map to provider-owned least-privilege scope bundles.
  Only provider-confirmed grants become canonical connected-account capability authority.
  Exact operations resume only through a signed, authenticated, one-time continuation.
  Credential refresh and revocation update the same account authority projected to callers.
  ```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop multi-agent orchestration
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7c8f9da796dc6cf89ffbb92f9df8d2e0f79d5cea:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@7c8f9da796dc6cf89ffbb92f9df8d2e0f79d5cea:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-pr21776]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@7c8f9da796dc6cf89ffbb92f9df8d2e0f79d5cea:packages/skills/skills/contribute-to-eliza"} -->
