### PR TITLE
fix(ui): drop the duplicated invoiceDetail i18n key

### DIFF
--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -7461,7 +7461,6 @@
   "cloud.invoiceDetail.type": "Type",
   "cloud.invoiceDetail.oneTimePurchase": "One-Time Purchase",
   "cloud.invoiceDetail.paymentIntentId": "Payment Intent ID",
-  "cloud.invoiceDetail.invalidInvoiceUrl": "Invoice link is not a valid URL",
   "cloud.membersList.noMembers": "No members found",
   "cloud.membersList.unknown": "Unknown",
   "cloud.membersList.you": "You",


### PR DESCRIPTION
Two concurrent i18n additions landed the same cloud.invoiceDetail.invalidInvoiceUrl entry twice, tripping biome noDuplicateObjectKeys in ui lint:check inside the release candidate's verify gate (run 32099644310 — the only red). ui lint and check:i18n both clean.