### PR TITLE
perf(voice): reuse Cartesia transport per call

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/revoke-and-metering.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/revoke-and-metering.test.ts
@@ -90,6 +90,9 @@ class FakeCartesiaSocket implements CartesiaWebSocketLike {
     if (!this.listeners.has(type)) this.listeners.set(type, new Set());
     this.listeners.get(type)!.add(l as (e: unknown) => void);
   }
+  removeEventListener(type: string, l: (e: never) => void) {
+    this.listeners.get(type)?.delete(l as (e: unknown) => void);
+  }
   private fire(t: string, p: unknown) {
     for (const l of this.listeners.get(t) ?? []) l(p);
   }

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -153,6 +153,9 @@ class FakeCartesiaSocket implements CartesiaWebSocketLike {
     if (!this.listeners.has(type)) this.listeners.set(type, new Set());
     this.listeners.get(type)!.add(listener as (e: unknown) => void);
   }
+  removeEventListener(type: string, listener: (e: never) => void) {
+    this.listeners.get(type)?.delete(listener as (e: unknown) => void);
+  }
   emitDone() {
     this.fire("message", {
       data: JSON.stringify({ type: "done", done: true }),
@@ -591,6 +594,32 @@ describe("voice-session WS lifecycle", () => {
     cartesia.emitDone();
     await flush();
     expect(client.controlTypes()).toContain("speaking_end");
+  });
+
+  test("reuses the opening greeting socket for the first caller response", async () => {
+    const beforeSockets = FakeCartesiaSocket.instances.length;
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      openingGreeting: "hey, what's up?",
+      fetchImpl: makeSseFetch(["Not much. Good to hear from you."]),
+    });
+    await flush();
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    cartesia.emitDone();
+    await flush();
+
+    const ink = FakeInkSocket.instances.at(-1)!;
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "not much");
+    await flush();
+    await flush();
+
+    expect(FakeCartesiaSocket.instances).toHaveLength(beforeSockets + 1);
+    expect(cartesia.sentText()).toContain("hey, what's up?");
+    expect(cartesia.sentText().replaceAll(" ", "")).toContain(
+      "Notmuch.Goodtohearfromyou.",
+    );
   });
 
   test("generates the call opener as a stable canonical system turn", async () => {
@@ -1092,11 +1121,14 @@ describe("voice-session WS lifecycle", () => {
     await flush();
     await flush();
 
-    // The socket was opened speculatively at turn start; with no speakable
-    // output it must be cancelled (closed) rather than leaked, and the turn
-    // still closes out with a usage frame.
+    // The context was opened speculatively at turn start; with no speakable
+    // output it must be cancelled without closing the call-scoped transport,
+    // and the turn still closes out with a usage frame.
     const cartesia = FakeCartesiaSocket.instances.at(-1)!;
-    expect(cartesia.closed).toBe(true);
+    expect(cartesia.closed).toBe(false);
+    expect(cartesia.sent.map((frame) => JSON.parse(frame))).toContainEqual(
+      expect.objectContaining({ cancel: true }),
+    );
     expect(client.controlTypes()).toContain("usage");
     expect(client.controlTypes()).not.toContain("speaking_start");
   });

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -1189,6 +1189,9 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       this.ttsStream.cancel(`interrupted:${reason}`);
       this.ttsStream = null;
     }
+    // Context completion and barge-in intentionally keep the call-scoped
+    // Cartesia transport warm; only session teardown closes the shared socket.
+    this.cartesiaAdapter.close(`session:${reason}`);
     // 3. Abort the Eliza SSE fetch — cancels the upstream provider stream.
     if (this.llmAbort) {
       this.llmAbort.abort();

--- a/packages/cloud/api/v1/voice/tts/cartesia-synthesis.ts
+++ b/packages/cloud/api/v1/voice/tts/cartesia-synthesis.ts
@@ -212,6 +212,16 @@ export function makeWorkersCartesiaWebSocketFactory(): CartesiaWebSocketFactory 
             }) => void,
           );
       },
+      removeEventListener(type: string, listener: unknown) {
+        const remove = <T>(listeners: T[], target: unknown): void => {
+          const index = listeners.indexOf(target as T);
+          if (index !== -1) listeners.splice(index, 1);
+        };
+        if (type === "open") remove(openListeners, listener);
+        else if (type === "message") remove(messageListeners, listener);
+        else if (type === "error") remove(errorListeners, listener);
+        else if (type === "close") remove(closeListeners, listener);
+      },
     } as CartesiaWebSocketLike;
     return wrapper;
   };

--- a/packages/cloud/shared/src/lib/services/__tests__/cartesia-sonic-tts.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/cartesia-sonic-tts.test.ts
@@ -81,6 +81,34 @@ class FakeCartesiaWebSocket implements CartesiaWebSocketLike {
     }
   }
 
+  removeEventListener(
+    type: "open" | "message" | "error" | "close",
+    listener:
+      | (() => void)
+      | ((event: { readonly data: unknown }) => void)
+      | ((event: { readonly message?: string; readonly error?: unknown }) => void)
+      | ((event: { readonly code?: number; readonly reason?: string }) => void),
+  ): void {
+    if (type === "open") this.listeners.open.delete(listener as () => void);
+    if (type === "message") {
+      this.listeners.message.delete(listener as (event: { readonly data: unknown }) => void);
+    }
+    if (type === "error") {
+      this.listeners.error.delete(
+        listener as (event: { readonly message?: string; readonly error?: unknown }) => void,
+      );
+    }
+    if (type === "close") {
+      this.listeners.close.delete(
+        listener as (event: { readonly code?: number; readonly reason?: string }) => void,
+      );
+    }
+  }
+
+  listenerCount(type: "open" | "message" | "error" | "close"): number {
+    return this.listeners[type].size;
+  }
+
   emitOpen(): void {
     this.readyState = FakeCartesiaWebSocket.OPEN;
     for (const listener of this.listeners.open) listener();
@@ -118,7 +146,7 @@ function makeHarness() {
     websocketFactory: factory,
     metrics: (event) => metrics.push(event.name),
   });
-  return { adapter, calls, metrics, socket: () => sockets[0] };
+  return { adapter, calls, metrics, socket: () => sockets[0], sockets };
 }
 
 function chunk(data: Uint8Array, sequenceExtras?: Record<string, unknown>) {
@@ -184,10 +212,7 @@ describe("CartesiaSonicTtsAdapter", () => {
     expect(openError).toBeInstanceOf(Error);
     expect(openError.message).toBe("Cartesia WebSocket closed during cancellation");
     expect(socket().sent).toEqual([]);
-    expect(socket().closes.at(-1)).toEqual({
-      code: 1000,
-      reason: "barge-in-before-open",
-    });
+    expect(socket().closes).toEqual([]);
   });
 
   test("discards queued synthesis when the provider fails before open", async () => {
@@ -366,7 +391,7 @@ describe("CartesiaSonicTtsAdapter", () => {
     expect(metrics.filter((name) => name === "cartesia_tts_provider_error")).toHaveLength(1);
   });
 
-  test("emits completion after done and closes the provider socket", () => {
+  test("emits completion after done and keeps the call-scoped socket warm", () => {
     const { adapter, socket } = makeHarness();
     const completions: number[] = [];
     adapter
@@ -388,10 +413,57 @@ describe("CartesiaSonicTtsAdapter", () => {
     );
 
     expect(completions).toEqual([1]);
-    expect(socket().closes.at(-1)).toEqual({
-      code: 1000,
-      reason: "Cartesia context complete",
-    });
+    expect(socket().closes).toEqual([]);
+  });
+
+  test("reuses one socket across contexts and routes frames only to their owner", () => {
+    const { adapter, calls, metrics, socket, sockets } = makeHarness();
+    const firstFrames: number[] = [];
+    const secondFrames: number[] = [];
+    const secondErrors: string[] = [];
+    const first = adapter.createStream(
+      { contextId: "ctx-1" },
+      { onAudioFrame: (event) => firstFrames.push(event.sequence) },
+    );
+    socket().emitOpen();
+    first.sendPhrase({ text: "first", continueContext: false });
+    socket().emitMessage(JSON.stringify({ type: "done", done: true, context_id: "ctx-1" }));
+
+    expect(socket().listenerCount("open")).toBe(0);
+    expect(socket().listenerCount("message")).toBe(0);
+    expect(socket().listenerCount("error")).toBe(0);
+    // The adapter retains one close listener so it can discard a dead shared socket.
+    expect(socket().listenerCount("close")).toBe(1);
+
+    const second = adapter.createStream(
+      { contextId: "ctx-2" },
+      {
+        onAudioFrame: (event) => secondFrames.push(event.sequence),
+        onProviderError: (event) => secondErrors.push(event.code ?? "unknown"),
+      },
+    );
+    second.sendPhrase({ text: "second", continueContext: false });
+    socket().emitMessage(
+      JSON.stringify({ type: "chunk", data: "stale-invalid-audio", context_id: "ctx-1" }),
+    );
+    socket().emitMessage(
+      JSON.stringify({
+        type: "chunk",
+        data: encodeBase64(new Uint8Array([2])),
+        context_id: "ctx-2",
+      }),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(sockets).toHaveLength(1);
+    expect(firstFrames).toEqual([]);
+    expect(secondFrames).toEqual([1]);
+    expect(secondErrors).toEqual([]);
+    expect(socket().closes).toEqual([]);
+    expect(metrics.filter((name) => name === "cartesia_tts_ws_open")).toHaveLength(1);
+    expect(metrics.filter((name) => name === "cartesia_tts_ws_reused")).toHaveLength(1);
+    adapter.close("call ended");
+    expect(socket().closes.at(-1)).toEqual({ code: 1000, reason: "call ended" });
   });
 
   test("emits provider errors without fabricating completion", () => {
@@ -423,10 +495,7 @@ describe("CartesiaSonicTtsAdapter", () => {
     expect(errors).toEqual(["voice_not_found:Voice not found"]);
     expect(completions).toEqual([]);
     expect(metrics).toContain("cartesia_tts_provider_error");
-    expect(socket().closes.at(-1)).toEqual({
-      code: 1011,
-      reason: "Cartesia provider error",
-    });
+    expect(socket().closes).toEqual([]);
   });
 
   test("rejects malformed chunk frames inside message handling and closes the socket", () => {
@@ -488,7 +557,7 @@ describe("CartesiaSonicTtsAdapter", () => {
     expect(cancellations).toEqual(["barge-in"]);
     expect(frames).toEqual([]);
     expect(metrics).toContain("cartesia_tts_cancelled");
-    expect(socket().closes.at(-1)).toEqual({ code: 1000, reason: "barge-in" });
+    expect(socket().closes).toEqual([]);
   });
 
   test("rejects missing server key and invalid Cartesia voice IDs", () => {

--- a/packages/cloud/shared/src/lib/services/cartesia-sonic-tts.ts
+++ b/packages/cloud/shared/src/lib/services/cartesia-sonic-tts.ts
@@ -1,10 +1,9 @@
 /**
  * Server-side Cartesia Sonic streaming TTS adapter.
  *
- * The module owns only Cartesia's WebSocket protocol mapping: validation,
- * request framing, PCM chunk decoding, cancellation, and provider metadata.
- * Callers remain responsible for phrase chunking, playback, billing, and HTTP
- * route translation.
+ * The module owns Cartesia's WebSocket protocol mapping and multiplexes
+ * utterance contexts over one call-scoped transport. Callers remain responsible
+ * for phrase chunking, playback, billing, and HTTP route translation.
  */
 
 export const CARTESIA_SONIC_PROVIDER_ID = "cartesia-sonic";
@@ -49,6 +48,7 @@ export interface CartesiaSonicAdapterConfig {
 export interface CartesiaSonicMetricEvent {
   readonly name:
     | "cartesia_tts_ws_open"
+    | "cartesia_tts_ws_reused"
     | "cartesia_tts_first_audio"
     | "cartesia_tts_audio_frame"
     | "cartesia_tts_complete"
@@ -156,6 +156,18 @@ export interface CartesiaWebSocketLike {
     type: "close",
     listener: (event: { readonly code?: number; readonly reason?: string }) => void,
   ): void;
+  removeEventListener: {
+    (type: "open", listener: () => void): void;
+    (type: "message", listener: (event: { readonly data: unknown }) => void): void;
+    (
+      type: "error",
+      listener: (event: { readonly message?: string; readonly error?: unknown }) => void,
+    ): void;
+    (
+      type: "close",
+      listener: (event: { readonly code?: number; readonly reason?: string }) => void,
+    ): void;
+  };
 }
 
 interface CartesiaGenerationRequest {
@@ -241,6 +253,7 @@ export class CartesiaSonicTtsAdapter {
   private readonly websocketUrl: string;
   private readonly language: string;
   private readonly metrics?: CartesiaSonicMetricsHook;
+  private socket: CartesiaWebSocketLike | undefined;
 
   constructor(config: CartesiaSonicAdapterConfig) {
     const normalized = validateCartesiaSonicConfig(config);
@@ -268,11 +281,11 @@ export class CartesiaSonicTtsAdapter {
     options: CartesiaSonicStreamOptions,
     callbacks: CartesiaSonicStreamCallbacks,
   ): CartesiaSonicTtsStream {
+    const { socket, reused } = this.sharedSocket();
     return new CartesiaSonicTtsStream({
-      apiKey: this.apiKey,
       voiceId: this.voiceId,
-      websocketFactory: this.websocketFactory,
-      websocketUrl: this.websocketUrl,
+      socket,
+      reusedConnection: reused,
       language: options.language ?? this.language,
       metadata: this.metadata,
       contextId: options.contextId ?? crypto.randomUUID(),
@@ -281,6 +294,33 @@ export class CartesiaSonicTtsAdapter {
       callbacks,
       metrics: this.metrics,
     });
+  }
+
+  /** Close the call-scoped transport after every context has been cancelled. */
+  close(reason = "Cartesia adapter closed"): void {
+    const socket = this.socket;
+    this.socket = undefined;
+    if (socket && (socket.readyState === 0 || socket.readyState === 1)) {
+      socket.close(1000, reason);
+    }
+  }
+
+  private sharedSocket(): { socket: CartesiaWebSocketLike; reused: boolean } {
+    const current = this.socket;
+    if (current && current.readyState !== 2 && current.readyState !== 3) {
+      return { socket: current, reused: true };
+    }
+    const socket = this.websocketFactory(buildCartesiaWebSocketUrl(this.websocketUrl), {
+      headers: {
+        "Cartesia-Version": CARTESIA_API_VERSION,
+        "X-API-Key": this.apiKey,
+      },
+    });
+    this.socket = socket;
+    socket.addEventListener("close", () => {
+      if (this.socket === socket) this.socket = undefined;
+    });
+    return { socket, reused: false };
   }
 }
 
@@ -357,10 +397,9 @@ function validateCartesiaSonicConfig(config: CartesiaSonicAdapterConfig): Normal
 }
 
 interface StreamConstructorInput {
-  readonly apiKey: string;
   readonly voiceId: string;
-  readonly websocketFactory: CartesiaWebSocketFactory;
-  readonly websocketUrl: string;
+  readonly socket: CartesiaWebSocketLike;
+  readonly reusedConnection: boolean;
   readonly language: string;
   readonly metadata: CartesiaSonicProviderMetadata;
   readonly contextId: string;
@@ -390,6 +429,83 @@ export class CartesiaSonicTtsStream {
   private resolveOpened!: () => void;
   private rejectOpened!: (error: unknown) => void;
   private resolveClosed!: () => void;
+  private closedSettled = false;
+  private readonly onSocketOpen = (): void => {
+    if (this.openedSettled || this.cancelled || this.providerErrorEmitted) {
+      this.discardQueuedOutbound();
+      return;
+    }
+    this.markSocketOpened();
+  };
+  private readonly onSocketMessage = (event: { readonly data: unknown }): void => {
+    this.handleMessage(event.data);
+  };
+  private readonly onSocketError = (event: {
+    readonly message?: string;
+    readonly error?: unknown;
+  }): void => {
+    if (this.cancelled || this.completed) return;
+    this.discardQueuedOutbound();
+    const errorEvent = {
+      contextId: this.contextId,
+      traceId: this.traceId,
+      title: "Cartesia WebSocket error",
+      message:
+        event.message ?? (event.error instanceof Error ? event.error.message : "WebSocket error"),
+      code: "websocket_error",
+    };
+    this.emitProviderError(errorEvent);
+    this.rejectOpenedOnce(new CartesiaSonicTtsError(errorEvent.message, errorEvent.code));
+  };
+  private readonly onSocketClose = (event: {
+    readonly code?: number;
+    readonly reason?: string;
+  }): void => {
+    if (this.completed || this.cancelled) {
+      this.resolveClosedOnce();
+      return;
+    }
+    if (!this.socketOpened && !this.openedSettled) {
+      this.discardQueuedOutbound();
+      if (this.cancelled) {
+        this.rejectOpenedOnce(
+          new CartesiaSonicTtsError(
+            "Cartesia WebSocket closed during cancellation",
+            "STREAM_CANCELLED",
+            { contextId: this.contextId },
+          ),
+        );
+      } else {
+        const code = "websocket_closed_before_open";
+        const message = event.reason
+          ? `Cartesia WebSocket closed before opening: ${event.reason}`
+          : "Cartesia WebSocket closed before opening";
+        this.emitProviderError({
+          contextId: this.contextId,
+          traceId: this.traceId,
+          title: "Cartesia WebSocket closed before opening",
+          message,
+          code,
+          statusCode: event.code,
+        });
+        this.rejectOpenedOnce(new CartesiaSonicTtsError(message, code));
+      }
+    } else if (!this.providerErrorEmitted) {
+      const code = "websocket_closed";
+      const message = event.reason
+        ? `Cartesia WebSocket closed: ${event.reason}`
+        : "Cartesia WebSocket closed unexpectedly";
+      this.emitProviderError({
+        contextId: this.contextId,
+        traceId: this.traceId,
+        title: "Cartesia WebSocket closed",
+        message,
+        code,
+        statusCode: event.code,
+      });
+    }
+    this.resolveClosedOnce();
+  };
 
   constructor(input: StreamConstructorInput) {
     this.input = input;
@@ -402,13 +518,9 @@ export class CartesiaSonicTtsStream {
     this.closed = new Promise<void>((resolve) => {
       this.resolveClosed = resolve;
     });
-    this.socket = input.websocketFactory(buildCartesiaWebSocketUrl(input.websocketUrl), {
-      headers: {
-        "Cartesia-Version": CARTESIA_API_VERSION,
-        "X-API-Key": input.apiKey,
-      },
-    });
+    this.socket = input.socket;
     this.attachSocketListeners();
+    if (this.socket.readyState === 1) this.markSocketOpened();
   }
 
   sendPhrase(phrase: CartesiaSonicPhraseInput): void {
@@ -479,69 +591,40 @@ export class CartesiaSonicTtsStream {
         });
       }
     }
-    this.socket.close(1000, reason);
+    this.rejectOpenedOnce(
+      new CartesiaSonicTtsError(
+        "Cartesia WebSocket closed during cancellation",
+        "STREAM_CANCELLED",
+        { contextId: this.contextId },
+      ),
+    );
+    this.resolveClosedOnce();
   }
 
   private attachSocketListeners(): void {
-    this.socket.addEventListener("open", () => {
-      if (this.openedSettled || this.cancelled || this.providerErrorEmitted) {
-        this.discardQueuedOutbound();
-        return;
-      }
-      this.socketOpened = true;
-      this.openedSettled = true;
-      this.resolveOpened();
-      this.flushQueuedOutbound();
-      this.emitMetric("cartesia_tts_ws_open", {
-        contextId: this.contextId,
-      });
-    });
-    this.socket.addEventListener("message", (event) => {
-      this.handleMessage(event.data);
-    });
-    this.socket.addEventListener("error", (event) => {
-      if (this.cancelled) return;
-      this.discardQueuedOutbound();
-      const errorEvent = {
-        contextId: this.contextId,
-        traceId: this.traceId,
-        title: "Cartesia WebSocket error",
-        message:
-          event.message ?? (event.error instanceof Error ? event.error.message : "WebSocket error"),
-        code: "websocket_error",
-      };
-      this.emitProviderError(errorEvent);
-      this.rejectOpenedOnce(new CartesiaSonicTtsError(errorEvent.message, errorEvent.code));
-    });
-    this.socket.addEventListener("close", (event) => {
-      if (!this.socketOpened && !this.openedSettled) {
-        this.discardQueuedOutbound();
-        if (this.cancelled) {
-          this.rejectOpenedOnce(
-            new CartesiaSonicTtsError(
-              "Cartesia WebSocket closed during cancellation",
-              "STREAM_CANCELLED",
-              { contextId: this.contextId },
-            ),
-          );
-        } else {
-          const code = "websocket_closed_before_open";
-          const message = event.reason
-            ? `Cartesia WebSocket closed before opening: ${event.reason}`
-            : "Cartesia WebSocket closed before opening";
-          this.emitProviderError({
-            contextId: this.contextId,
-            traceId: this.traceId,
-            title: "Cartesia WebSocket closed before opening",
-            message,
-            code,
-            statusCode: event.code,
-          });
-          this.rejectOpenedOnce(new CartesiaSonicTtsError(message, code));
-        }
-      }
-      this.resolveClosed();
-    });
+    this.socket.addEventListener("open", this.onSocketOpen);
+    this.socket.addEventListener("message", this.onSocketMessage);
+    this.socket.addEventListener("error", this.onSocketError);
+    this.socket.addEventListener("close", this.onSocketClose);
+  }
+
+  private detachSocketListeners(): void {
+    this.socket.removeEventListener("open", this.onSocketOpen);
+    this.socket.removeEventListener("message", this.onSocketMessage);
+    this.socket.removeEventListener("error", this.onSocketError);
+    this.socket.removeEventListener("close", this.onSocketClose);
+  }
+
+  private markSocketOpened(): void {
+    if (this.openedSettled) return;
+    this.socketOpened = true;
+    this.openedSettled = true;
+    this.resolveOpened();
+    this.flushQueuedOutbound();
+    this.emitMetric(
+      this.input.reusedConnection ? "cartesia_tts_ws_reused" : "cartesia_tts_ws_open",
+      { contextId: this.contextId },
+    );
   }
 
   private sendOrQueue(data: string): void {
@@ -569,9 +652,9 @@ export class CartesiaSonicTtsStream {
   }
 
   private handleMessage(data: unknown): void {
-    if (this.cancelled) return;
+    if (this.cancelled || this.completed) return;
 
-    let message: CartesiaIncomingMessage;
+    let message: CartesiaIncomingMessage | undefined;
     try {
       message = parseCartesiaIncomingMessage(data, this.contextId);
     } catch (error) {
@@ -587,6 +670,7 @@ export class CartesiaSonicTtsStream {
       this.socket.close(1011, "Invalid Cartesia provider message");
       return;
     }
+    if (!message) return;
 
     if (message.type === "chunk") {
       this.handleChunk(message);
@@ -647,7 +731,7 @@ export class CartesiaSonicTtsStream {
       frameCount: this.frameSequence,
       statusCode: message.status_code,
     });
-    this.socket.close(1000, "Cartesia context complete");
+    this.resolveClosedOnce();
   }
 
   private handleProviderError(message: Extract<CartesiaIncomingMessage, { type: "error" }>): void {
@@ -662,7 +746,7 @@ export class CartesiaSonicTtsStream {
       docUrl: message.doc_url,
     };
     this.emitProviderError(event);
-    this.socket.close(1011, "Cartesia provider error");
+    this.resolveClosedOnce();
   }
 
   private emitProviderError(event: CartesiaSonicProviderErrorEvent): void {
@@ -681,6 +765,13 @@ export class CartesiaSonicTtsStream {
     if (this.openedSettled) return;
     this.openedSettled = true;
     this.rejectOpened(error);
+  }
+
+  private resolveClosedOnce(): void {
+    if (this.closedSettled) return;
+    this.closedSettled = true;
+    this.detachSocketListeners();
+    this.resolveClosed();
   }
 
   private emitMetric(
@@ -708,7 +799,10 @@ function buildCartesiaWebSocketUrl(baseUrl: string): string {
   return url.toString();
 }
 
-function parseCartesiaIncomingMessage(data: unknown, contextId: string): CartesiaIncomingMessage {
+function parseCartesiaIncomingMessage(
+  data: unknown,
+  contextId: string,
+): CartesiaIncomingMessage | undefined {
   if (typeof data !== "string") {
     throw new CartesiaSonicTtsError(
       "Cartesia WebSocket message must be JSON text",
@@ -724,6 +818,12 @@ function parseCartesiaIncomingMessage(data: unknown, contextId: string): Cartesi
         "PROVIDER_MESSAGE_INVALID",
         { contextId },
       );
+    }
+    // A shared call transport can deliver the tail of a cancelled context
+    // after the next context has started. Ignore it before validating payload
+    // details so an irrelevant stale frame cannot poison the active utterance.
+    if (typeof parsed.context_id === "string" && parsed.context_id !== contextId) {
+      return undefined;
     }
     return validateCartesiaIncomingMessage(parsed, contextId);
   } catch (error) {


### PR DESCRIPTION
Closes #21779

## Outcome

Reuses the Cartesia Sonic WebSocket established by the opening greeting for subsequent utterances in the same phone call. Each utterance still receives an isolated `context_id`; barge-in cancels only that context, while session teardown owns transport closure. This removes a redundant connection/auth handshake from the first caller response.

## Safety

- Routes frames by `context_id` and ignores stale cancelled-context frames before payload validation.
- Detaches all per-context listeners on completion/cancellation so long calls do not accumulate handlers.
- Keeps the adapter close listener so dead transports are discarded and subsequent turns reconnect.
- Adds `cartesia_tts_ws_reused` separately from new-connection telemetry.
- Updates the Workers synthesis wrapper to honor listener removal.

## Exact-head verification

Head: `a61f1b896930fa1edcd8965f3fb3d5fe1f8ada16`

- PASS: 82 focused adapter/session/revocation tests, 0 failures, 305 assertions.
- PASS: `bun run --cwd packages/cloud/shared typecheck`.
- PASS: Biome on all six changed files.
- PASS: `git diff --check origin/develop...HEAD`.
- Known unrelated blocker: full Cloud API typecheck currently reports existing agent-backup/migration test typing errors; no voice file is present in the diagnostic set.

## Live evidence boundary

The protocol and lifecycle behavior is proven locally. PSTN latency improvement still requires staging deployment plus a cold-call trace before production claims.