### PR TITLE
fix(plugin-anthropic-proxy): frame reverse mapping by SSE event

### DIFF
--- a/plugins/plugin-anthropic-proxy/__tests__/sse-rewrite.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/sse-rewrite.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "vitest";
 import { ELIZA_TOOL_RENAMES } from "../src/proxy/eliza-fingerprint.js";
 import { reverseMap } from "../src/proxy/reverse-map.js";
+import { applyReplacements } from "../src/proxy/sanitize.js";
 import { createSseStream } from "../src/proxy/sse-rewrite.js";
 
 describe("createSseStream", () => {
@@ -147,16 +148,14 @@ describe("createSseStream", () => {
     }
   });
 
-  it("does not double-transform an already-mapped retained tail (idempotence)", () => {
+  it("maps a default tool rename once when input arrives byte by byte", () => {
     const config = {
       toolRenames: ELIZA_TOOL_RENAMES,
       propRenames: [] as ReadonlyArray<readonly [string, string]>,
       reverseMap: [] as ReadonlyArray<readonly [string, string]>,
     };
     const reverse = (text: string) => reverseMap(text, config);
-    // Drip the token in one-byte chunks so its mapped form sits in the retained
-    // tail across many rounds; the eliza output token "write_file" must not be
-    // re-triggered by any reverse key.
+    // Drip the token in one-byte chunks to exercise decoder/event buffering.
     const payload = `${"c".repeat(80)}"name":"Write"${"d".repeat(80)}`;
     const emitted: string[] = [];
     const stream = createSseStream(
@@ -171,6 +170,64 @@ describe("createSseStream", () => {
     const joined = emitted.join("");
     expect(joined).toBe(`${"c".repeat(80)}"name":"write_file"${"d".repeat(80)}`);
   });
+
+  it("applies a non-idempotent custom reverse map exactly once", () => {
+    const pairs = [
+      ["B", "C"],
+      ["A", "B"],
+    ] as const;
+    const emitted: string[] = [];
+    const stream = createSseStream(
+      (text) => applyReplacements(text, pairs),
+      (text) => emitted.push(text),
+      () => undefined
+    );
+    const firstEvent = `data: ${"x".repeat(70)}A\n\n`;
+    const secondEvent = "data: done\n\n";
+
+    stream.write(Buffer.from(firstEvent));
+    stream.write(Buffer.from(secondEvent));
+    stream.end();
+
+    expect(emitted.join("")).toBe(applyReplacements(firstEvent + secondEvent, pairs));
+    expect(emitted.join("")).toContain("B\n\n");
+    expect(emitted.join("")).not.toContain("C\n\n");
+  });
+
+  it("buffers custom reverse-map keys longer than 64 characters", () => {
+    const pattern = "K".repeat(80);
+    const emitted: string[] = [];
+    const stream = createSseStream(
+      (text) => text.replaceAll(pattern, "mapped"),
+      (text) => emitted.push(text),
+      () => undefined
+    );
+
+    stream.write(Buffer.from(`data: ${"x".repeat(70)}${pattern.slice(0, 70)}`));
+    stream.write(Buffer.from(`${pattern.slice(70)}\n\n`));
+    stream.end();
+
+    expect(emitted.join("")).toBe(`data: ${"x".repeat(70)}mapped\n\n`);
+  });
+
+  it.each(["\n", "\r", "\r\n"])(
+    "emits an event with %j line endings before the upstream stream ends",
+    (lineEnd) => {
+      const emitted: string[] = [];
+      const stream = createSseStream(
+        (text) => text.replaceAll("Write", "write_file"),
+        (text) => emitted.push(text),
+        () => undefined
+      );
+      const event = `event: content_block_start${lineEnd}data: {"name":"Write"}${lineEnd}${lineEnd}`;
+
+      stream.write(Buffer.from(`${event}partial`));
+
+      expect(emitted).toEqual([event.replace("Write", "write_file")]);
+      stream.end();
+      expect(emitted.join("")).toContain("partial");
+    }
+  );
 
   it("calls finish even for empty streams", () => {
     const emitted: string[] = [];

--- a/plugins/plugin-anthropic-proxy/src/proxy/sse-rewrite.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/sse-rewrite.ts
@@ -1,46 +1,36 @@
 /**
  * SSE response transformation.
  *
- * Tail-buffer reverseMap to handle patterns split across TCP chunk boundaries.
- * Without this, "ocplatform" can split as "ocp"+"latform" and leak through.
- * TAIL_SIZE >= longest reverseMap pattern.
- *
- * The reverse map is applied to the WHOLE accumulated buffer before any bytes
- * leave, then only the mapped output beyond the retained tail is emitted. This
- * matters because a token can straddle the internal tail cut: it starts in the
- * flushable prefix and ends inside the retained tail. Transforming the prefix
- * in isolation would emit its head un-mapped and map its tail separately next
- * round, so the full token would never reverse-map and would leak verbatim
- * (e.g. `"Write"` reaching the framework instead of `"write_file"`). Mapping
- * the whole buffer first resolves any such straddling token before its head is
- * committed.
- *
- * The retained tail is the already-mapped suffix, not raw bytes. reverseFn must
- * be idempotent — its eliza-side output tokens (snake_case tool names, identity
- * replacements) do not re-trigger the quoted-PascalCase reverse keys — so a
- * settled tail is never double-transformed on the next round, while an
- * incomplete key at a real chunk boundary (kept literal because it did not
- * match) still completes and maps once its continuation arrives. TAIL_SIZE >=
- * longest quoted/escaped reverse key guarantees such an incomplete key is
- * always fully within the retained tail.
+ * Buffers complete SSE events before applying the reverse map. An SSE consumer
+ * cannot dispatch an event before its blank-line terminator, so this preserves
+ * streaming behavior while ensuring every event is transformed exactly once.
+ * It also allows custom dictionaries to contain length-changing, non-idempotent,
+ * or longer-than-fixed-tail replacements without leaking or double-mapping
+ * tokens split across TCP chunks.
  *
  * Also uses StringDecoder to buffer partial UTF-8 sequences across TCP
  * chunks. chunk.toString() would emit U+FFFD whenever a multi-byte char
  * (中文, emoji, etc.) lands on a chunk boundary.
  *
- * Defends against splitting a UTF-16 surrogate pair (4-byte UTF-8 chars like
- * emoji).
+ * Event boundaries accept CRLF, LF, and CR line endings as required by the SSE
+ * wire format. A replacement spanning separate SSE events is intentionally not
+ * supported because events are independent protocol messages.
  */
 
 import { StringDecoder } from "node:string_decoder";
-
-const SSE_TAIL_SIZE = 64;
 
 export type ReverseFn = (text: string) => string;
 
 export interface SseStream {
   write: (chunk: Buffer) => void;
   end: () => void;
+}
+
+function firstCompletedEventEnd(text: string): number {
+  // Spell out the pairs so one CRLF line ending cannot backtrack into a
+  // separate CR + LF blank line.
+  const match = /\r\n(?:\r\n|\r|\n)|\n(?:\r\n|\r|\n)|\r\r/.exec(text);
+  return match ? match.index + match[0].length : 0;
 }
 
 export function createSseStream(
@@ -54,19 +44,11 @@ export function createSseStream(
   return {
     write(chunk: Buffer): void {
       pending += decoder.write(chunk);
-      // Map the whole buffer so a token straddling the internal tail cut is
-      // resolved before its head is emitted; retain the mapped tail (not raw)
-      // for the next round.
-      const mapped = reverseFn(pending);
-      if (mapped.length > SSE_TAIL_SIZE) {
-        let sliceIdx = mapped.length - SSE_TAIL_SIZE;
-        // Don't cut between a UTF-16 surrogate pair
-        const prev = mapped.charCodeAt(sliceIdx - 1);
-        if (prev >= 0xd800 && prev <= 0xdbff) sliceIdx -= 1;
-        emit(mapped.slice(0, sliceIdx));
-        pending = mapped.slice(sliceIdx);
-      } else {
-        pending = mapped;
+      for (let eventEnd = firstCompletedEventEnd(pending); eventEnd > 0; ) {
+        const completeEvent = pending.slice(0, eventEnd);
+        pending = pending.slice(eventEnd);
+        emit(reverseFn(completeEvent));
+        eventEnd = firstCompletedEventEnd(pending);
       }
     },
     end(): void {


### PR DESCRIPTION
# Relates to

Follow-up to #21274 and #21257.

# Summary

The merged mapped-tail implementation assumes the reverse function is idempotent and every replacement key fits inside a fixed 64-character tail. Both assumptions are false for the package's supported custom dictionaries: a non-idempotent map can transform retained output twice, and a key longer than 64 characters can still leak across a chunk boundary.

This follow-up buffers raw UTF-8 through each complete SSE event boundary, applies the reverse map exactly once per completed event, and emits it immediately. SSE consumers cannot dispatch an event before its blank-line terminator, so the implementation preserves protocol-level streaming while supporting CRLF, LF, and CR framing, length-changing/non-idempotent maps, and keys of arbitrary event-bounded length. See the [WHATWG SSE parsing model](https://html.spec.whatwg.org/dev/server-sent-events.html).

# Verification

Exact evidence head: `a285627192d1d54880eafa1b3c56560a83c4f4f1`

- Focused SSE suite: 13/13 passed after rebase onto `f92f84628085f6fa079e106afc655de1e41c5aca`
- Full plugin suite: 11 files / 75 tests passed on the preceding identical patch lineage
- Package typecheck: passed on the preceding identical patch lineage
- Package Biome: 33 files clean on the preceding identical patch lineage
- `git diff --check`: passed
- Regression coverage includes non-idempotent custom maps, a key longer than 64 characters, all SSE line-ending forms, immediate emission at a completed event, byte-wise input, and UTF-8 chunk boundaries

UI, screenshots, video, frontend logs, OCR, audio, and live-model trajectories: N/A — backend deterministic SSE transformation only.

# Risk

Bounded to the SSE transform and its tests. A malformed upstream stream with no blank-line event terminator is retained until end-of-stream, matching the fact that an SSE client could not dispatch that incomplete event earlier.

# Contribution provenance

- AI assistance: yes
- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Attribution status: self-reported

— [codex-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@f92f84628085f6fa079e106afc655de1e41c5aca:packages/skills/skills/contribute-to-eliza"} -->
