### PR TITLE
fix(skills): harden symlink containment across platforms

### DIFF
--- a/plugins/plugin-agent-skills/src/security/index.ts
+++ b/plugins/plugin-agent-skills/src/security/index.ts
@@ -131,8 +131,12 @@ export async function scanSkillDirectory(
 	const fs = await import("node:fs/promises");
 	const path = await import("node:path");
 
-	const manifestEntries = await buildManifestEntriesFromDisk(dirPath);
-	const manifestFindings = scanManifest(manifestEntries, dirPath);
+	// Resolve the root through the same filesystem canonicalization used for
+	// symlink targets before comparing them. This avoids false escapes through
+	// aliases such as macOS `/tmp` -> `/private/tmp`.
+	const canonicalDirPath = await fs.realpath(dirPath);
+	const manifestEntries = await buildManifestEntriesFromDisk(canonicalDirPath);
+	const manifestFindings = scanManifest(manifestEntries, canonicalDirPath);
 
 	const allFindings: SkillScanFinding[] = [];
 	let scannedCount = 0;
@@ -148,7 +152,7 @@ export async function scanSkillDirectory(
 		let content: string;
 		try {
 			content = await fs.readFile(
-				path.join(dirPath, entry.relativePath),
+				path.join(canonicalDirPath, entry.relativePath),
 				"utf-8",
 			);
 		} catch {
@@ -166,7 +170,12 @@ export async function scanSkillDirectory(
 			allFindings.push(...scanFrontmatterBins(content, entry.relativePath));
 	}
 
-	return buildReport(dirPath, scannedCount, allFindings, manifestFindings);
+	return buildReport(
+		canonicalDirPath,
+		scannedCount,
+		allFindings,
+		manifestFindings,
+	);
 }
 
 export function scanSkillPackage(

--- a/plugins/plugin-agent-skills/src/security/manifest-scanner.test.ts
+++ b/plugins/plugin-agent-skills/src/security/manifest-scanner.test.ts
@@ -3,104 +3,195 @@
  * the security scanner. The builder cases prove byte lengths for text and
  * binary payloads so integrity checks do not confuse character count with UTF-8
  * size. The scanManifest cases pin the separator-aware boundary of the blocking
- * `symlink-escape` rule so a sibling directory that shares a string prefix
- * cannot masquerade as an internal (non-blocking) symlink. Deterministic; no
- * disk, no mocks — scanManifest is pure over synthetic manifest entries.
+ * `symlink-escape` rule so sibling directories sharing a string prefix cannot
+ * masquerade as internal symlinks. Synthetic cases cover POSIX and Windows
+ * path syntax; a real-filesystem case covers POSIX backslashes and canonical
+ * root resolution.
  */
 
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { scanSkillDirectory } from ".";
 import type { ManifestFileEntry } from "./manifest-scanner";
 import {
-  buildManifestEntriesFromMemory,
-  scanManifest,
+	buildManifestEntriesFromMemory,
+	scanManifest,
 } from "./manifest-scanner";
 
 describe("buildManifestEntriesFromMemory", () => {
-  it("returns an empty manifest for no files", () => {
-    expect(buildManifestEntriesFromMemory(new Map())).toEqual([]);
-  });
+	it("returns an empty manifest for no files", () => {
+		expect(buildManifestEntriesFromMemory(new Map())).toEqual([]);
+	});
 
-  it("measures text size in UTF-8 bytes, not characters", () => {
-    const files = new Map([
-      ["a.txt", { content: "hello", isText: true }], // 5 ASCII bytes
-      ["u.txt", { content: "café", isText: true }], // é = 2 bytes -> 5
-      ["e.txt", { content: "🎉", isText: true }], // 1 char, 4 bytes
-    ]);
-    const size = Object.fromEntries(
-      buildManifestEntriesFromMemory(files).map((e) => [e.relativePath, e.sizeBytes]),
-    );
-    expect(size["a.txt"]).toBe(5);
-    expect(size["u.txt"]).toBe(5);
-    expect(size["e.txt"]).toBe(4);
-  });
+	it("measures text size in UTF-8 bytes, not characters", () => {
+		const files = new Map([
+			["a.txt", { content: "hello", isText: true }], // 5 ASCII bytes
+			["u.txt", { content: "café", isText: true }], // é = 2 bytes -> 5
+			["e.txt", { content: "🎉", isText: true }], // 1 char, 4 bytes
+		]);
+		const size = Object.fromEntries(
+			buildManifestEntriesFromMemory(files).map((e) => [
+				e.relativePath,
+				e.sizeBytes,
+			]),
+		);
+		expect(size["a.txt"]).toBe(5);
+		expect(size["u.txt"]).toBe(5);
+		expect(size["e.txt"]).toBe(4);
+	});
 
-  it("uses byteLength for binary content and preserves the path", () => {
-    const files = new Map([
-      ["b.bin", { content: new Uint8Array([1, 2, 3, 4, 5, 6, 7]), isText: false }],
-    ]);
-    const [entry] = buildManifestEntriesFromMemory(files);
-    expect(entry.sizeBytes).toBe(7);
-    expect(entry.relativePath).toBe("b.bin");
-  });
+	it("uses byteLength for binary content and preserves the path", () => {
+		const files = new Map([
+			[
+				"b.bin",
+				{ content: new Uint8Array([1, 2, 3, 4, 5, 6, 7]), isText: false },
+			],
+		]);
+		const [entry] = buildManifestEntriesFromMemory(files);
+		expect(entry.sizeBytes).toBe(7);
+		expect(entry.relativePath).toBe("b.bin");
+	});
 
-  it("marks every entry as a non-symlink", () => {
-    const files = new Map([["x", { content: "y", isText: true }]]);
-    expect(buildManifestEntriesFromMemory(files).every((e) => e.isSymlink === false)).toBe(true);
-  });
+	it("marks every entry as a non-symlink", () => {
+		const files = new Map([["x", { content: "y", isText: true }]]);
+		expect(
+			buildManifestEntriesFromMemory(files).every((e) => e.isSymlink === false),
+		).toBe(true);
+	});
 });
 
 describe("scanManifest symlink-escape boundary", () => {
-  const SKILL_DIR = "/base/skills/myskill";
+	const SKILL_DIR = "/base/skills/myskill";
 
-  function symlinkFinding(target: string, skillDir = SKILL_DIR) {
-    const entries: ManifestFileEntry[] = [
-      { relativePath: "SKILL.md", sizeBytes: 10, isSymlink: false },
-      { relativePath: "link", sizeBytes: 0, isSymlink: true, symlinkTarget: target },
-    ];
-    const finding = scanManifest(entries, skillDir).find((f) =>
-      f.ruleId.startsWith("symlink-"),
-    );
-    if (!finding) throw new Error("expected a symlink finding");
-    return finding;
-  }
+	function symlinkFinding(target: string, skillDir = SKILL_DIR) {
+		const entries: ManifestFileEntry[] = [
+			{ relativePath: "SKILL.md", sizeBytes: 10, isSymlink: false },
+			{
+				relativePath: "link",
+				sizeBytes: 0,
+				isSymlink: true,
+				symlinkTarget: target,
+			},
+		];
+		const finding = scanManifest(entries, skillDir).find((f) =>
+			f.ruleId.startsWith("symlink-"),
+		);
+		if (!finding) throw new Error("expected a symlink finding");
+		return finding;
+	}
 
-  it("blocks a sibling-prefix target that only shares a string prefix", () => {
-    // Regression for #21213: /base/skills/myskill-evil resolves OUTSIDE
-    // /base/skills/myskill despite the shared prefix and must not be treated
-    // as internal.
-    const finding = symlinkFinding("/base/skills/myskill-evil/secret.env");
-    expect(finding.ruleId).toBe("symlink-escape");
-    expect(finding.severity).toBe("critical");
-  });
+	it("blocks a sibling-prefix target that only shares a string prefix", () => {
+		// Regression for #21213: /base/skills/myskill-evil resolves OUTSIDE
+		// /base/skills/myskill despite the shared prefix and must not be treated
+		// as internal.
+		const finding = symlinkFinding("/base/skills/myskill-evil/secret.env");
+		expect(finding.ruleId).toBe("symlink-escape");
+		expect(finding.severity).toBe("critical");
+	});
 
-  it("blocks a target fully outside the skill directory", () => {
-    const finding = symlinkFinding("/etc/passwd");
-    expect(finding.ruleId).toBe("symlink-escape");
-    expect(finding.severity).toBe("critical");
-  });
+	it("blocks a target fully outside the skill directory", () => {
+		const finding = symlinkFinding("/etc/passwd");
+		expect(finding.ruleId).toBe("symlink-escape");
+		expect(finding.severity).toBe("critical");
+	});
 
-  it("treats a genuinely nested target as an internal warning", () => {
-    const finding = symlinkFinding("/base/skills/myskill/sub/x");
-    expect(finding.ruleId).toBe("symlink-internal");
-    expect(finding.severity).toBe("warn");
-  });
+	it("blocks a POSIX sibling whose name begins with a backslash", () => {
+		const finding = symlinkFinding("/base/skills/myskill\\evil/secret.env");
+		expect(finding.ruleId).toBe("symlink-escape");
+		expect(finding.severity).toBe("critical");
+	});
 
-  it("treats a target equal to the skill directory as internal", () => {
-    const finding = symlinkFinding("/base/skills/myskill");
-    expect(finding.ruleId).toBe("symlink-internal");
-    expect(finding.severity).toBe("warn");
-  });
+	it("fails closed when a symlink target cannot be resolved", () => {
+		const entries: ManifestFileEntry[] = [
+			{ relativePath: "SKILL.md", sizeBytes: 10, isSymlink: false },
+			{ relativePath: "broken-link", sizeBytes: 0, isSymlink: true },
+		];
+		const finding = scanManifest(entries, SKILL_DIR).find(
+			(candidate) => candidate.file === "broken-link",
+		);
+		expect(finding?.ruleId).toBe("symlink-escape");
+		expect(finding?.severity).toBe("critical");
+	});
 
-  it("classifies identically when the skill dir carries a trailing slash", () => {
-    expect(
-      symlinkFinding("/base/skills/myskill-evil/secret.env", "/base/skills/myskill/")
-        .ruleId,
-    ).toBe("symlink-escape");
-    expect(symlinkFinding("/etc/passwd", "/base/skills/myskill/").ruleId).toBe(
-      "symlink-escape",
-    );
-    expect(
-      symlinkFinding("/base/skills/myskill/sub/x", "/base/skills/myskill/").ruleId,
-    ).toBe("symlink-internal");
-  });
+	it("treats a genuinely nested target as an internal warning", () => {
+		const finding = symlinkFinding("/base/skills/myskill/sub/x");
+		expect(finding.ruleId).toBe("symlink-internal");
+		expect(finding.severity).toBe("warn");
+	});
+
+	it("treats a target equal to the skill directory as internal", () => {
+		const finding = symlinkFinding("/base/skills/myskill");
+		expect(finding.ruleId).toBe("symlink-internal");
+		expect(finding.severity).toBe("warn");
+	});
+
+	it("classifies identically when the skill dir carries a trailing slash", () => {
+		expect(
+			symlinkFinding(
+				"/base/skills/myskill-evil/secret.env",
+				"/base/skills/myskill/",
+			).ruleId,
+		).toBe("symlink-escape");
+		expect(symlinkFinding("/etc/passwd", "/base/skills/myskill/").ruleId).toBe(
+			"symlink-escape",
+		);
+		expect(
+			symlinkFinding("/base/skills/myskill/sub/x", "/base/skills/myskill/")
+				.ruleId,
+		).toBe("symlink-internal");
+	});
+
+	it("uses Windows separators and case-insensitive path identity", () => {
+		expect(
+			symlinkFinding(
+				"C:\\base\\skills\\myskill-evil\\secret.env",
+				"C:\\base\\skills\\myskill",
+			).ruleId,
+		).toBe("symlink-escape");
+		expect(
+			symlinkFinding(
+				"c:\\BASE\\skills\\myskill\\sub\\x",
+				"C:\\base\\skills\\myskill",
+			).ruleId,
+		).toBe("symlink-internal");
+	});
+
+	it("blocks a real POSIX backslash sibling while allowing a real internal target", async () => {
+		const root = await mkdtemp(join(tmpdir(), "manifest-containment-"));
+		try {
+			const skillDir = join(root, "skill");
+			const internalDir = join(skillDir, "internal");
+			const escapedDir = join(root, "skill\\outside");
+			await mkdir(internalDir, { recursive: true });
+			await mkdir(escapedDir);
+			await writeFile(join(skillDir, "SKILL.md"), "# Test\n");
+			await writeFile(join(internalDir, "inside.txt"), "inside");
+			await writeFile(join(escapedDir, "outside.txt"), "outside");
+			await symlink(
+				join(internalDir, "inside.txt"),
+				join(skillDir, "internal-link"),
+			);
+			await symlink(
+				join(escapedDir, "outside.txt"),
+				join(skillDir, "escape-link"),
+			);
+
+			const report = await scanSkillDirectory(skillDir);
+			expect(
+				report.manifestFindings.find(
+					(finding) => finding.file === "internal-link",
+				)?.ruleId,
+			).toBe("symlink-internal");
+			expect(
+				report.manifestFindings.find(
+					(finding) => finding.file === "escape-link",
+				)?.ruleId,
+			).toBe("symlink-escape");
+			expect(report.status).toBe("blocked");
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
 });

--- a/plugins/plugin-agent-skills/src/security/manifest-scanner.ts
+++ b/plugins/plugin-agent-skills/src/security/manifest-scanner.ts
@@ -58,22 +58,37 @@ function hasHiddenComponent(filePath: string): boolean {
 }
 
 /**
- * Separator-aware containment test for the symlink-escape gate. A raw
- * `target.startsWith(dir)` check would treat a sibling directory that merely
- * shares a string prefix (e.g. `/base/skills/myskill-evil` for skill dir
- * `/base/skills/myskill`) as internal, letting an escaping symlink bypass the
- * blocking rule. Requiring an exact match or a trailing path separator closes
- * that boundary. `symlinkTarget` is a realpath-resolved, absolute, canonical
- * path, so only the skill dir needs its trailing separator stripped to accept
- * dirs passed with or without a trailing slash.
+ * Platform-aware containment test for the symlink-escape gate. POSIX permits a
+ * backslash in a filename, so accepting both slash styles as separators would
+ * let a sibling such as `skill\\outside` masquerade as a child of `skill`.
+ * Windows absolute paths are normalized to their native separator and compared
+ * case-insensitively; POSIX paths preserve backslashes as ordinary characters.
+ * Both inputs must already be absolute and canonical, as they are in the disk
+ * scanner after `realpath` resolution.
  */
 function isInsideDir(target: string, dir: string): boolean {
-	const normalizedDir = dir.replace(/[/\\]+$/, "");
-	if (normalizedDir === "") return true;
-	if (target === normalizedDir) return true;
+	const isWindowsAbsolute =
+		/^[a-zA-Z]:[/\\]/.test(dir) || dir.startsWith("\\\\");
+	const separator = isWindowsAbsolute ? "\\" : "/";
+	const normalize = (value: string): string => {
+		const withNativeSeparators = isWindowsAbsolute
+			? value.replaceAll("/", "\\")
+			: value;
+		const withoutTrailingSeparators = withNativeSeparators.replace(
+			isWindowsAbsolute ? /\\+$/ : /\/+$/,
+			"",
+		);
+		const normalized = withoutTrailingSeparators || separator;
+		return isWindowsAbsolute ? normalized.toLowerCase() : normalized;
+	};
+
+	const normalizedTarget = normalize(target);
+	const normalizedDir = normalize(dir);
 	return (
-		target.startsWith(`${normalizedDir}/`) ||
-		target.startsWith(`${normalizedDir}\\`)
+		normalizedTarget === normalizedDir ||
+		normalizedTarget.startsWith(
+			normalizedDir === separator ? separator : `${normalizedDir}${separator}`,
+		)
 	);
 }
 
@@ -108,10 +123,15 @@ export function scanManifest(
 		}
 
 		if (entry.isSymlink) {
-			if (
-				entry.symlinkTarget &&
-				!isInsideDir(entry.symlinkTarget, skillDirPath)
-			) {
+			if (!entry.symlinkTarget) {
+				findings.push({
+					ruleId: "symlink-escape",
+					severity: "critical",
+					file: entry.relativePath,
+					message:
+						"Symbolic link target could not be resolved inside the skill directory",
+				});
+			} else if (!isInsideDir(entry.symlinkTarget, skillDirPath)) {
 				findings.push({
 					ruleId: "symlink-escape",
 					severity: "critical",


### PR DESCRIPTION
# Relates to

Follow-up to #21225 and #21213.

# Summary

The merged containment helper accepts both `/` and `\\` as separators on every platform. On POSIX, backslash is a valid filename character, so a real sibling path containing `\\` can still be misclassified as internal. The disk scanner also treated an unresolved symlink target as a non-blocking internal warning and compared canonical targets against a potentially non-canonical root alias.

This follow-up makes containment platform-syntax-aware, canonicalizes the disk root with `realpath` before comparison and reads, and fails closed when a symlink target cannot be resolved. Synthetic POSIX/Windows cases and real-filesystem regressions cover internal links, ordinary siblings, and POSIX backslash siblings.

# Verification

Exact evidence head: `48509f80ead9753548f41cfa25977157fe3fd8c7`

- Manifest and skill scanner suites: 2 files / 18 tests passed after rebase onto `720152c7f19a`
- Package typecheck: passed on the preceding identical patch lineage
- Package `lint:check`: 59 files clean on the preceding identical patch lineage
- Package build: passed on the preceding identical patch lineage
- `git diff --check`: passed
- Aggregate package Vitest previously hung before reporting suites during heavy concurrent test contention and was stopped; the two owning security suites pass independently

UI, screenshots, video, frontend logs, OCR, audio, and live-model trajectories: N/A — deterministic server-side filesystem security scanning only.

# Risk

Fail-closed behavior may reject a broken symlink that was previously warned and retained; that is the intended security boundary. The scanner remains a point-in-time validator rather than a claim about later filesystem mutation.

# Contribution provenance

- AI assistance: yes
- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Attribution status: self-reported

— [codex-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@720152c7f19ab842073613306f9274b81cc1db81:packages/skills/skills/contribute-to-eliza"} -->
