### PR TITLE
test(cloud): type domain search registrar mock

### DIFF
--- a/packages/cloud/api/v1/domains/search/route.json-body.test.ts
+++ b/packages/cloud/api/v1/domains/search/route.json-body.test.ts
@@ -1,5 +1,6 @@
 /** Verifies syntax and schema failures at the domain-search JSON request boundary. */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AvailabilityResult } from "@/lib/services/cloudflare-registrar";
 
 const USER_ID = "00000000-0000-4000-8000-0000000000aa";
 const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
@@ -9,9 +10,11 @@ const requireUserOrApiKeyWithOrg = mock(async () => ({
   organization_id: ORG_ID,
 }));
 
-const searchDomains = mock(async () => {
-  throw new Error("cloudflareRegistrarService.searchDomains must not run");
-});
+const searchDomains = mock(
+  async (_query: string, _limit: number): Promise<AvailabilityResult[]> => {
+    throw new Error("cloudflareRegistrarService.searchDomains must not run");
+  },
+);
 const computeDomainPrice = mock((cents: number) => cents);
 const failureResponse = mock(
   (c: { json: (body: unknown, status: number) => unknown }) =>
@@ -108,7 +111,6 @@ describe("POST /api/v1/domains/search JSON body", () => {
       {
         domain: "eliza.ai",
         available: true,
-        reason: null,
         currency: "USD",
         years: 1,
         priceUsdCents: 1200,


### PR DESCRIPTION
## Summary

Follow-up to #21720. Give the domain-search registrar mock its real argument and result types so the new success-path fixture does not introduce TypeScript errors. The fixture now also matches the real optional `reason` contract.

## Evidence

- `bun test packages/cloud/api/v1/domains/search/route.json-body.test.ts`: 10 passed, 0 failed (53 assertions)
- Biome check: passed
- Cloud API typecheck no longer reports this test; the package gate remains red only on six pre-existing errors in cloud/shared backup/migration tests

## Contribution provenance

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@720152c7f19ab842073613306f9274b81cc1db81:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@720152c7f19ab842073613306f9274b81cc1db81:packages/skills/skills/contribute-to-eliza"} -->
<!-- codex-review -->