### PR TITLE
fix(ui): bound BuildBadge build-info JSON fetch

### DIFF
--- a/packages/ui/src/components/shell/BuildBadge-timeout.test.ts
+++ b/packages/ui/src/components/shell/BuildBadge-timeout.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Behavioral BuildBadge build-info JSON deadline. Executes
+ * getBuildInfoJsonWithFetch under abort — not a source-grep of BuildBadge.tsx.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("lucide-react", () => ({
+  X: () => null,
+}));
+
+vi.mock("../../lib/floating-layers", () => ({
+  Z_BUILD_BADGE: 1,
+}));
+
+vi.mock("../../platform/standalone-bottom-reclaim", () => ({
+  getStandaloneBottomReclaimState: () => ({ reclaimPx: 0 }),
+}));
+
+import {
+  BUILD_BADGE_JSON_TIMEOUT_MS,
+  BUILD_INFO_URL,
+  getBuildInfoJsonWithFetch,
+} from "./BuildBadge";
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected build-badge abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+describe("BuildBadge build-info JSON deadline", () => {
+  it("keeps a documented UI JSON budget", () => {
+    expect(BUILD_BADGE_JSON_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("aborts a stalled build-info GET at the injected deadline", async () => {
+    await expect(
+      getBuildInfoJsonWithFetch(BUILD_INFO_URL, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed build-info GET", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 503, statusText: "Service Unavailable" });
+
+    await expect(
+      getBuildInfoJsonWithFetch(BUILD_INFO_URL, fetchImpl, 1_000),
+    ).rejects.toThrow("503");
+  });
+
+  it("uses the injected fetch for a successful build-info GET", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({ commit: "58f6bb3beb", label: "stamp" });
+    };
+
+    const body = await getBuildInfoJsonWithFetch<{
+      commit: string;
+      label: string;
+    }>(BUILD_INFO_URL, fetchImpl, 1_000);
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(body).toEqual({ commit: "58f6bb3beb", label: "stamp" });
+  });
+});

--- a/packages/ui/src/components/shell/BuildBadge.tsx
+++ b/packages/ui/src/components/shell/BuildBadge.tsx
@@ -23,8 +23,27 @@ import { useCallback, useEffect, useState } from "react";
 import { Z_BUILD_BADGE } from "../../lib/floating-layers";
 import { getStandaloneBottomReclaimState } from "../../platform/standalone-bottom-reclaim";
 
-const BUILD_INFO_URL = "/build-info.json";
+export const BUILD_INFO_URL = "/build-info.json";
 const DISMISS_KEY = "eliza.buildBadge.dismissed";
+
+/** Build-info GET is a short UI read — same 15s family as useWeather. */
+export const BUILD_BADGE_JSON_TIMEOUT_MS = 15_000;
+
+export async function getBuildInfoJsonWithFetch<T>(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = BUILD_BADGE_JSON_TIMEOUT_MS,
+): Promise<T> {
+  const response = await fetchImpl(url, {
+    method: "GET",
+    cache: "no-store",
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`Build info request failed (${response.status})`);
+  }
+  return (await response.json()) as T;
+}
 
 interface BuildInfo {
   commit?: string;
@@ -293,9 +312,10 @@ export function BuildBadge() {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(BUILD_INFO_URL, { cache: "no-store" });
-        if (!res.ok) return;
-        const info = (await res.json()) as BuildInfo;
+        const info = await getBuildInfoJsonWithFetch<BuildInfo>(
+          BUILD_INFO_URL,
+          globalThis.fetch,
+        );
         if (!cancelled) setLabel(toLabel(info));
       } catch {
         // Best-effort: no build info available (production builds without the


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). BuildBadge used unbounded `fetch` for `GET /build-info.json`, so a stalled stamp hop hangs the tester pill. This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, with a documented 15s UI JSON deadline — same family as useWeather `#21804`. Tests execute the production helper under abort, and the stamped BuildBadge flow is captured through the real renderer at desktop and mobile sizes.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Public `BuildBadge` render unchanged. Unfixed head: `fetch(BUILD_INFO_URL)` had **no signal** and a hung fetch never settled (80ms race → `HUNG` / `sawSignal: false`). After: 10ms deadline → `TimeoutError`. UI JSON budget is 15s. Missing/malformed stamp still hides the pill.

# Background

## What does this PR do?

BuildBadge called `fetch` with no `signal`. A stalled `/build-info.json` hop never returns. This PR injects `getBuildInfoJsonWithFetch` (Fal `#21205` / useWeather `#21804` shape) and adds `AbortSignal.timeout`, keeping `cache: "no-store"`.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Build-stamp generation untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/shell/BuildBadge-timeout.test.ts` — build-info GET timeout, provider-error, and success.

## Detailed testing steps

Run the focused component suites and inspect the stamped real-renderer evidence below.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/components/shell/BuildBadge-timeout.test.ts \
  src/components/shell/BuildBadge.test.tsx
```

Unfixed head `c902191137e`: `fetch` `signal` was undefined and the call hung (`HUNG` / `sawSignal: false`). Exact rebased head: 11/11 focused tests passed, UI typecheck passed, touched Biome passed, and the publishable UI build verified all 46 runtime exports.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] Pre-fix/reference shell at develop head `e9f8a9a` (no BuildBadge diff): ![before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21805-before-shell-desktop.jpg) ![before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21805-before-shell-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] Repaired patch capture at pre-rebase head `1105681` (stable patch ID `1fb6166` is identical at current head): ![after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21805-after-build-badge-desktop.jpg) ![after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21805-after-build-badge-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21805-after-build-badge-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - same-origin static /build-info.json read; no backend route is exercised.
<!-- evidence-row:frontend-logs -->
- [x] Playwright stamped-BuildBadge flow passed 1/1 with console/network diagnostics guards clean: [frontend log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21805-build-badge-frontend.log), [trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21805-build-badge-playwright-trace.zip)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - renderer fetch deadline only; no agent, prompt, model, provider, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, wallet, scheduler, or domain artifact changes.
<!-- evidence-row:ocr-review -->
- [x] Packaged OCR triage reviewed all 216 captures (194 verified): [OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21805-ocr-triage.json)

# Evidence Details

## Real LLM-call trajectory

N/A - BuildBadge transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

No backend route fires: `/build-info.json` is a same-origin static renderer asset. The Playwright trace records the real stamped renderer flow with its console/network guards. Separately, a real local HTTP server sent JSON headers and a partial body then stalled; the production helper rejected with `TimeoutError` in 56 ms under an injected 50 ms budget, proving the deadline covers body reads as well as request setup.

## Screenshots (before / after) + video walkthrough

The rendered design is intentionally unchanged. The after captures show the stamped badge at desktop and mobile widths, and the MP4 walks the real launcher flow. Packaged OCR reviewed the full app capture set.

## Audio / voice walkthrough

N/A - UI JSON GET only.

## Known gaps / failures

The mandatory app capture completed 218/219 with zero broken views. Its only aggregate failure exactly matched the independent develop audit: three pre-existing mobile-landscape minimalism ratchets (`builtin-plugins`, `builtin-runtime`, `builtin-background`) and nine pre-existing hover probe timeouts. Packaged OCR likewise reproduced the independent develop finding that `plugin-health-gui` mobile-landscape is missing the title `Health`; neither surface is touched by this two-file BuildBadge diff. The built-in action ratchet also has the unrelated current-develop baseline drift (25 actions observed vs baseline 24). Root `bun run verify` was not repeated under the host's final ~1 GiB disk condition; the owning UI gates, real HTTP body-stall proof, full app capture/OCR, and real-renderer recording were run instead.

<!-- evidence-head:162cd9a60588074cb766376929fbbe4dd89067c9 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
