### PR TITLE
fix(agent-skills): reserve suffix in truncateEvidence

### DIFF
--- a/plugins/plugin-agent-skills/src/security/truncateEvidence.suffix.test.ts
+++ b/plugins/plugin-agent-skills/src/security/truncateEvidence.suffix.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Skill truncateEvidence suffix-reserve — inclusive cap via scanner path.
+ */
+import { describe, expect, it } from "vitest";
+import { truncateEvidence } from "./types.ts";
+
+describe("truncateEvidence suffix-reserve", () => {
+  it("never exceeds max and handles max<=0", () => {
+    const long = "a".repeat(200);
+    expect(truncateEvidence(long, 120).length).toBeLessThanOrEqual(120);
+    expect(truncateEvidence(long, 120).endsWith("…")).toBe(true);
+    expect(truncateEvidence(long, 1)).toBe("…");
+    expect(truncateEvidence(long, 0)).toBe("");
+    expect(truncateEvidence(long, -5)).toBe("");
+    expect(truncateEvidence("short", 120)).toBe("short");
+    expect(truncateEvidence("a".repeat(120), 120).length).toBe(120);
+    expect(truncateEvidence("a".repeat(121), 120).length).toBe(120);
+  });
+
+  it("scanner consumer respects cap", async () => {
+    // Simulate scanner's usage: evidence from a long line
+    const longLine = "x".repeat(500);
+    const evidence = truncateEvidence(`field: ${JSON.stringify(longLine)}`, 120);
+    expect(evidence.length).toBeLessThanOrEqual(120);
+    expect(evidence.endsWith("…")).toBe(true);
+  });
+
+  it("max=1 edge returns single ellipsis", () => {
+    expect(truncateEvidence("hello world", 1)).toBe("…");
+    expect(truncateEvidence("hello world", 1).length).toBe(1);
+  });
+});

--- a/plugins/plugin-agent-skills/src/security/types.ts
+++ b/plugins/plugin-agent-skills/src/security/types.ts
@@ -50,7 +50,9 @@ export interface SkillScanOptions {
 
 export function truncateEvidence(evidence: string, maxLen = 120): string {
 	if (evidence.length <= maxLen) return evidence;
-	return `${evidence.slice(0, maxLen)}…`;
+	if (maxLen <= 0) return "";
+	if (maxLen === 1) return "…";
+	return `${evidence.slice(0, maxLen - 1)}…`;
 }
 
 /** Line-level rule: matches per-line, fires at most once per file. */


### PR DESCRIPTION
# Relates to

Fixes skill truncate cap violation on `develop` @ `2cb7cc7b1c`. `truncateEvidence(evidence,120)` did `slice(0,120)+"…"` =121 exceeding the documented `maxLen`, and `max<=0` returned `…` (1) contradicting inclusive cap. Mirrors calendar/google preview fixes.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2cb7cc7b1c9ba1f8574f1d9e7b236480d8169324:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `2cb7cc7b1c` (`2cb7cc7b1c9ba1f8574f1d9e7b236480d8169324`); zero conflicts.
- [x] `bun install` completed; `bun run verify` stepwise: `check:agents-claude` PASS, `check:biome-version` PASS, `check:i18n` OK, `ci-bun-version-contract` PASS, `ci-turbo-cache-contract` PASS, `fix-deps:check` OK, `ensure-plugin-test-conventions:check` PASS, `audit:alias-read-guard` PASS, `audit:tsconfig-workspace-resolution` PASS; focused `vitest`+`biome` PASS.

# Risks

Low. Changes `truncateEvidence` to `slice(0,max-1)` with explicit `max<=0→""` and `max==1→"…"`. No API change except inclusive cap now holds for all max. Scanner evidence now correctly bounded.

# Background

## What does this PR do?

Reserves suffix length in `truncateEvidence`: `a.repeat(121)` with `max=120` now returns `119+"…"` =120 instead of 121. Defines `max<=0` contract as `""` and `max==1` as `"…"` so scanner never exceeds limit.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-agent-skills/src/security/types.ts:51`
- `plugins/plugin-agent-skills/src/security/truncateEvidence.suffix.test.ts`

## Detailed testing steps

1. `bunx vitest run plugins/plugin-agent-skills/src/security/truncateEvidence.suffix.test.ts` — verifies `never exceeds 120`, `0→""`, `-5→""`, `1→"…"`, `121→120`, and scanner consumer `field: JSON` path.
2. `bunx @biomejs/biome check` clean.

```
truncateEvidence.suffix.test.ts (3 tests) passed
Checked 2 files in 4ms. No fixes applied.
git diff --check: clean
```

# Evidence Gate

<!-- evidence-head:79ec0f4783fc5b59f43bbe3532657b8f3921440a -->
<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only helper, no rendered UI`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only helper, no rendered UI`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - deterministic truncation, no interactive flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not N/A, logs pasted in Testing`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - no domain artifact beyond test mock`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/model change, pure truncation.`

## Backend + frontend logs

Backend: `truncateEvidence.suffix.test.ts` 3 pass. Frontend: `N/A`.

## Screenshots (before / after) + video walkthrough

`N/A - backend-only change.`

## Audio / voice walkthrough

`N/A - no voice change.`

## Known gaps / failures

None.

AI provider/model: openai / gpt-5.6
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@2cb7cc7b1c9ba1f8574f1d9e7b236480d8169324:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [byt61]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6","client":"Codex","skill_revision":"elizaOS/eliza@2cb7cc7b1c9ba1f8574f1d9e7b236480d8169324:packages/skills/skills/contribute-to-eliza"} -->
