### PR TITLE
fix(ui): bound ApiKeyConfig reveal through canonical client

### DIFF
--- a/packages/ui/src/components/settings/ApiKeyConfig-timeout.test.ts
+++ b/packages/ui/src/components/settings/ApiKeyConfig-timeout.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Exercises the production credential-reveal callback through ApiKeyConfig's
+ * real ConfigRenderer boundary with only the shared API client mocked.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { createElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clientFetch: vi.fn(),
+  revealSecret: undefined as
+    | ((pluginId: string, key: string) => Promise<string | null>)
+    | undefined,
+}));
+
+vi.mock("../../api", () => ({
+  client: { fetch: mocks.clientFetch, fetchModels: vi.fn() },
+}));
+
+vi.mock("../../agent-surface", () => ({
+  useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+}));
+
+vi.mock("../../state", () => ({
+  useAppSelector: (fn: (s: { t: (k: string) => string }) => unknown) =>
+    fn({ t: (k: string) => k }),
+}));
+
+vi.mock("../../hooks/useTimeout", () => ({
+  useTimeout: () => ({ setTimeout: (fn: () => void) => fn() }),
+}));
+
+vi.mock("../RoleGate", () => ({
+  RoleGate: ({ children }: { children: unknown }) => children,
+  OwnerOnlyNotice: () => null,
+}));
+
+vi.mock("./settings-agent-rows", () => ({
+  SettingsActionButton: () => null,
+}));
+
+vi.mock("./settings-control-primitives", () => ({
+  AdvancedSettingsDisclosure: () => null,
+}));
+
+vi.mock("../../components/config-ui/config-renderer.helpers", () => ({
+  defaultRegistry: {},
+  useConfigValidation: () => ({
+    configRef: { current: null },
+    validateAll: () => true,
+  }),
+}));
+
+vi.mock("../../components/config-ui/config-renderer", () => ({
+  ConfigRenderer: (props: {
+    revealSecret?: (pluginId: string, key: string) => Promise<string | null>;
+  }) => {
+    mocks.revealSecret = props.revealSecret;
+    return null;
+  },
+}));
+
+vi.mock("../../config/api-key-prefix-hints", () => ({
+  API_KEY_PREFIX_HINTS: {},
+}));
+
+vi.mock("../../config/config-catalog", () => ({}));
+
+vi.mock("../../utils/labels", () => ({
+  autoLabel: (key: string) => key,
+}));
+
+import { ApiKeyConfig, type ApiKeyConfigProps } from "./ApiKeyConfig";
+
+const props: ApiKeyConfigProps = {
+  selectedProvider: {
+    id: "provider/one",
+    name: "Provider One",
+    parameters: [
+      {
+        key: "PROVIDER_API_KEY",
+        type: "string",
+        description: "Provider API key",
+        required: true,
+        sensitive: true,
+        currentValue: null,
+        isSet: true,
+      },
+    ],
+    configured: true,
+    enabled: true,
+    category: "model-provider",
+  },
+  pluginSaving: new Set(),
+  pluginSaveSuccess: new Set(),
+  handlePluginConfigSave: vi.fn(),
+  loadPlugins: vi.fn(async () => {}),
+};
+
+function getProductionReveal(): (
+  pluginId: string,
+  key: string,
+) => Promise<string | null> {
+  render(createElement(ApiKeyConfig, props));
+  if (!mocks.revealSecret) {
+    throw new Error("ConfigRenderer did not receive revealSecret");
+  }
+  return mocks.revealSecret;
+}
+
+describe("ApiKeyConfig reveal deadline", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mocks.revealSecret = undefined;
+  });
+
+  it("routes the production reveal through the canonical bounded client", async () => {
+    mocks.clientFetch.mockResolvedValue({ value: "sk-test" });
+
+    await expect(
+      getProductionReveal()("provider/one", "PROVIDER_API_KEY"),
+    ).resolves.toBe("sk-test");
+
+    expect(mocks.clientFetch).toHaveBeenCalledWith(
+      "/api/plugins/provider%2Fone/reveal",
+      {
+        method: "POST",
+        body: JSON.stringify({ key: "PROVIDER_API_KEY" }),
+      },
+      { timeoutMs: 15_000 },
+    );
+  });
+
+  it("keeps the credential masked when the bounded client rejects", async () => {
+    mocks.clientFetch.mockRejectedValue(new Error("request timed out"));
+
+    await expect(
+      getProductionReveal()("provider/one", "PROVIDER_API_KEY"),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects malformed reveal payloads without fabricating a value", async () => {
+    mocks.clientFetch.mockResolvedValue({ value: 42 });
+
+    await expect(
+      getProductionReveal()("provider/one", "PROVIDER_API_KEY"),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/ui/src/components/settings/ApiKeyConfig.tsx
+++ b/packages/ui/src/components/settings/ApiKeyConfig.tsx
@@ -132,22 +132,23 @@ function buildSchemaForParams(
   return { schema, hints, values, setKeys };
 }
 
+/** Credential reveal is a short UI POST — same 15s family as BuildBadge. */
+const API_KEY_REVEAL_TIMEOUT_MS = 15_000;
+
 async function revealSecret(
   pluginId: string,
   key: string,
 ): Promise<string | null> {
   try {
-    const res = await fetch(
+    const json = await client.fetch<{ value?: unknown }>(
       `/api/plugins/${encodeURIComponent(pluginId)}/reveal`,
       {
         method: "POST",
-        headers: { "content-type": "application/json" },
         body: JSON.stringify({ key }),
       },
+      { timeoutMs: API_KEY_REVEAL_TIMEOUT_MS },
     );
-    if (!res.ok) return null;
-    const json = (await res.json()) as { value?: string | null };
-    return typeof json.value === "string" ? json.value : null;
+    return typeof json?.value === "string" ? json.value : null;
   } catch {
     // error-policy:J4 null is the typed "cannot reveal" signal — the masked
     // field stays masked and the user can retry; never fabricate a value.


### PR DESCRIPTION
# Relates to

Bounded-fetch follow-up for the credential reveal route used by `ApiKeyConfig`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package tests, typecheck, formatting, and diff validation pass at the evidence head below.
- [x] A reviewer can confirm the changed production boundary from the tests and evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@4b64b82fe36954377e618e6d2e44e86baf95df02:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` at `4b64b82fe36954377e618e6d2e44e86baf95df02`; zero conflicts.
- [x] Owning-package focused gates pass. The required app capture and packaged OCR were completed and manually inspected as recorded below.

# Risks

Low and contained to credential reveal transport. The implementation now uses the existing `ElizaClient.fetch` boundary instead of a raw global fetch. This preserves authentication, base-URL selection, browser/native/desktop transports, typed non-OK handling, and applies the same 15-second deadline to both request establishment and response-body consumption. Failures retain the existing explicit `null` result, so the sensitive field stays masked and can be retried.

# Background

## What does this PR do?

Routes `POST /api/plugins/:id/reveal` through `client.fetch(..., { timeoutMs: 15_000 })`. The repair removes the submitted test-only exported fetch helper and exercises the private production callback passed to `ConfigRenderer` instead.

## What kind of change is this?

Bug fix (non-breaking internal I/O bound).

# Documentation changes needed?

No. This changes no public product contract or user workflow.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/settings/ApiKeyConfig-timeout.test.ts` renders `ApiKeyConfig`, captures the real `ConfigRenderer` reveal callback, and proves the exact encoded route, request body, canonical timeout option, success result, failure masking, and malformed-payload rejection.

## Detailed testing steps

Pinned Bun 1.3.14 and Node 24.15.0:

```bash
cd packages/ui
bun x vitest run --config ./vitest.config.ts src/api/client-base-timeout.test.ts src/components/settings/ApiKeyConfig-timeout.test.ts
bun run typecheck
bun x biome check src/components/settings/ApiKeyConfig.tsx src/components/settings/ApiKeyConfig-timeout.test.ts
git diff --check origin/develop...HEAD
```

Results at `290a5881befd859632fbd591dc90459158fa5388`:

- Vitest: 2 files passed, 7 tests passed.
- UI TypeScript: exit 0.
- Biome: 2 files checked, no diagnostics.
- `git diff --check`: clean.
- App capture: 218/219 passed, zero broken views; only the established three unrelated minimalism ratchets and nine hover-probe timeouts failed the strict aggregate.
- Packaged OCR: 194/216 verified, 19 needs-eyeball, 3 baseline-broken; the sole new flag was the unrelated Health mobile-landscape title crop, visually confirmed outside this PR's imports and rendered surface.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered UI or layout change; the previous field used an unbounded raw request.
<!-- evidence-row:after-screenshots -->
- [x] Full app capture completed despite no rendered UI change: 218/219 passed and zero views were broken.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no interaction or visual-state change.
<!-- evidence-row:backend-logs -->
- [x] N/A — no backend change; the UI client contract is covered directly.
<!-- evidence-row:frontend-logs -->
- [x] Production-boundary Vitest proves the request and masked failure result; shared client tests prove request/body deadline behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, prompt, model, provider, or trajectory change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no database, memory, wallet, or persisted-domain change.
<!-- evidence-row:ocr-review -->
- [x] Packaged OCR completed: 194/216 verified. The only new flag was an unrelated existing Health mobile-landscape crop; settings/API-key captures were clean.

# Evidence Details

## Real LLM-call trajectory

N/A — credential settings transport only.

## Backend + frontend logs

The production callback test verifies the canonical call:

```text
/api/plugins/provider%2Fone/reveal
POST {"key":"PROVIDER_API_KEY"}
options: { timeoutMs: 15000 }
```

Rejection from the bounded client and a non-string response both resolve to `null`, leaving the credential masked.

## Screenshots (before / after) + video walkthrough

N/A — no rendered output changed.

## Audio / voice walkthrough

N/A — no audio or voice surface.

## Known gaps / failures

`bun run --cwd packages/app audit:app` captured 218/219 passing tests with zero broken views. The strict aggregate reproduced the same unrelated minimalism ratchets for `builtin-plugins`, `builtin-runtime`, and `builtin-background`, plus nine unrelated hover-probe timeouts, so the shell exited before its chained OCR step. Packaged OCR was then run explicitly: 194 verified, 19 needs-eyeball, 3 baseline-broken; its sole new flag was `plugin-health-gui` mobile-landscape missing the clipped `Health` title. Manual screenshot inspection confirmed that crop is unrelated to this transport-only `ApiKeyConfig` diff. No touched-view or focused-gate failure remains.

<!-- evidence-head:290a5881befd859632fbd591dc90459158fa5388 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@4b64b82fe36954377e618e6d2e44e86baf95df02:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@4b64b82fe36954377e618e6d2e44e86baf95df02:packages/skills/skills/contribute-to-eliza"} -->
