### PR TITLE
fix(ui): bound Android SMS gateway fetch

### DIFF
--- a/packages/ui/src/components/pages/ElizaOsAppsView-timeout.test.ts
+++ b/packages/ui/src/components/pages/ElizaOsAppsView-timeout.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Behavioral Android SMS gateway deadline. Executes
+ * postAndroidSmsGatewayWithFetch under abort — not a source-grep.
+ * Not Twilio. Not #21385.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../bridge/plugin-bridge", () => ({
+	getPlugins: () => ({
+		messages: {
+			plugin: {
+				listMessages: async () => ({ messages: [] }),
+			},
+		},
+	}),
+}));
+
+vi.mock("../../bridge/native-plugins", () => ({}));
+
+vi.mock("../../state/TranslationContext.hooks", () => ({
+	useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("../../agent-surface", () => ({
+	useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+}));
+
+vi.mock("../views/ShellViewAgentSurface", () => ({
+	ShellViewAgentSurface: ({ children }: { children: unknown }) => children,
+}));
+
+vi.mock("../ui/button", () => ({ Button: () => null }));
+vi.mock("../ui/input", () => ({ Input: () => null }));
+vi.mock("../ui/textarea", () => ({ Textarea: () => null }));
+
+vi.mock("lucide-react", () => ({
+	Clock3: () => null,
+	ContactRound: () => null,
+	FileUp: () => null,
+	MessageSquare: () => null,
+	NotebookText: () => null,
+	PhoneCall: () => null,
+	Plus: () => null,
+	RefreshCw: () => null,
+	Search: () => null,
+	Send: () => null,
+	Settings: () => null,
+	ShieldCheck: () => null,
+	UserPlus: () => null,
+}));
+
+import {
+	ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS,
+	postAndroidSmsGatewayWithFetch,
+} from "./ElizaOsAppsView";
+
+const URL = "http://test.local/api/webhooks/android-sms";
+const BODY = JSON.stringify({ type: "new-message", data: { text: "hi" } });
+const SECRET = "test-secret";
+
+function stallUntilAborted(): typeof fetch {
+	return ((_input, init) =>
+		new Promise<Response>((_resolve, reject) => {
+			const signal = init?.signal;
+			if (!signal) throw new Error("expected android-sms-gateway abort signal");
+			signal.addEventListener("abort", () => reject(signal.reason), {
+				once: true,
+			});
+		})) as typeof fetch;
+}
+
+describe("ElizaOsAppsView Android SMS gateway deadline", () => {
+	it("keeps a documented UI fetch budget", () => {
+		expect(ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS).toBe(15_000);
+	});
+
+	it("aborts a stalled gateway POST at the injected deadline", async () => {
+		await expect(
+			postAndroidSmsGatewayWithFetch(
+				URL,
+				BODY,
+				SECRET,
+				stallUntilAborted(),
+				10,
+			),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+	});
+
+	it("surfaces a provider error from a completed gateway POST", async () => {
+		const fetchImpl: typeof fetch = async () =>
+			new Response("nope", { status: 503, statusText: "Service Unavailable" });
+
+		await expect(
+			postAndroidSmsGatewayWithFetch(URL, BODY, SECRET, fetchImpl, 1_000),
+		).rejects.toThrow("503");
+	});
+
+	it("uses the injected fetch for a successful gateway POST", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchImpl: typeof fetch = async (_input, init) => {
+			if (init?.signal) signals.push(init.signal);
+			return new Response(JSON.stringify({ replyText: "pong" }), {
+				status: 200,
+			});
+		};
+
+		const response = await postAndroidSmsGatewayWithFetch(
+			URL,
+			BODY,
+			SECRET,
+			fetchImpl,
+			1_000,
+		);
+
+		expect(signals).toHaveLength(1);
+		expect(signals[0]?.aborted).toBe(false);
+		expect(response.ok).toBe(true);
+		expect(await response.json()).toEqual({ replyText: "pong" });
+	});
+});

--- a/packages/ui/src/components/pages/ElizaOsAppsView.tsx
+++ b/packages/ui/src/components/pages/ElizaOsAppsView.tsx
@@ -1510,6 +1510,32 @@ function initialMessageBody(params: URLSearchParams): string {
     : (params.get("body") ?? "");
 }
 
+/** Android SMS gateway POST is a short UI hop — same 15s family as BuildBadge. */
+export const ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS = 15_000;
+
+export async function postAndroidSmsGatewayWithFetch(
+  url: string,
+  body: string,
+  secret: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-eliza-bridge": "android-sms",
+      "x-eliza-gateway-secret": secret,
+    },
+    body,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`Cloud gateway failed (${response.status})`);
+  }
+  return response;
+}
+
 function androidSmsGatewayPayload(incoming: IncomingSmsContext) {
   return {
     type: "new-message",
@@ -1628,15 +1654,12 @@ export function MessagesPageView() {
     let cancelled = false;
     const forward = async () => {
       try {
-        const response = await fetch(ANDROID_SMS_GATEWAY_WEBHOOK_URL, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            "x-eliza-bridge": "android-sms",
-            "x-eliza-gateway-secret": ANDROID_SMS_GATEWAY_SECRET,
-          },
-          body: JSON.stringify(androidSmsGatewayPayload(incomingSms)),
-        });
+        const response = await postAndroidSmsGatewayWithFetch(
+          ANDROID_SMS_GATEWAY_WEBHOOK_URL,
+          JSON.stringify(androidSmsGatewayPayload(incomingSms)),
+          ANDROID_SMS_GATEWAY_SECRET,
+          globalThis.fetch,
+        );
         let cloudReply: AndroidSmsGatewayReply | Record<string, never> = {};
         try {
           cloudReply = (await response.json()) as AndroidSmsGatewayReply;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). MessagesPageView used unbounded `fetch(ANDROID_SMS_GATEWAY_WEBHOOK_URL)` so a stalled Android SMS gateway POST hangs the Messages app. This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, with a documented 15s UI POST deadline — same family as ApiKeyConfig `#21813` / TranscriptViewerOverlay `#21810`. Tests execute `postAndroidSmsGatewayWithFetch` under abort. Not extra-decode. Not list-limit. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Not Twilio. Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Messages UI unchanged. Unfixed head: gateway `fetch` had **no signal** and a hung POST never settled (80ms race → `HUNG` / `sawSignal: false`). After: 10ms deadline → `TimeoutError`. UI POST budget is 15s. Failed/stalled hops still surface through the existing `setError` catch.

# Background

## What does this PR do?

MessagesPageView called `fetch` with no `signal` when forwarding an incoming SMS to the Android SMS gateway. A stalled webhook hop never returns. This PR injects `postAndroidSmsGatewayWithFetch` (Fal `#21205` / `#21813` shape) and adds `AbortSignal.timeout`. Method, headers, and JSON body stay POST.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Gateway secret storage and Twilio untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/pages/ElizaOsAppsView-timeout.test.ts` — gateway POST timeout, provider-error, and success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts src/components/pages/ElizaOsAppsView-timeout.test.ts
```

Unfixed head `09d1311b750`: `fetch` `signal` was undefined and the call hung (`HUNG` / `sawSignal: false`). After the fix: 4 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Android SMS gateway POST timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live gateway path. vitest asserts TimeoutError, provider 503, and success payload.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console change beyond the existing setError catch.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no new rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - ElizaOsAppsView transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no live gateway hop. Unfixed hang: no signal, 80ms race `HUNG` / `sawSignal: false` on `MessagesPageView`. After the fix, vitest asserts TimeoutError, `503` provider error, and a successful reply payload.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface change.

## Audio / voice walkthrough

N/A - UI gateway POST only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`4 pass`). Root verify is an unrelated full-repo cost. No `bun install`.

<!-- evidence-head:d887afdbdd3de9e58586cdbb3e4f2f667a1c698a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
