### PR TITLE
fix(ios): stabilize native chat overlay layouts

### DIFF
--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -520,10 +520,12 @@ describe("ChatOverlay", () => {
         tintColor: "#16090DD9",
       }),
     );
-    // Native material: fill + blur drop (the OS paints them); border, bevel,
-    // and sheen stay — the branded edge survives on every tier.
-    expect(surface.style.backgroundColor).toBe("transparent");
+    // The native material remains attached below the WebView, but the open
+    // conversation owns an opaque DOM fill. Underlying launcher/view controls
+    // must never remain visible through the chat surface on iPad.
+    expect(surface.style.backgroundColor).toBe("var(--bg)");
     expect(surface.style.backdropFilter).toBe("");
+    expect(screen.getByTestId("chat-overlay").className).toContain("isolate");
     expect(screen.getByTestId("chat-glass-tier-probe").textContent).toContain(
       "chat-glass-tier:native",
     );

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -80,6 +80,7 @@ import {
 } from "../../os-intent/host";
 import { isIOS, isNative, isStandalonePwa } from "../../platform/init";
 import {
+  getPhysicalScreenVerticalExtent,
   KEYBOARD_INTRUSION_THRESHOLD_PX,
   STANDALONE_BOTTOM_RECLAIM_OFFSET,
   shouldInstallStandaloneBottomReclaim,
@@ -2687,10 +2688,7 @@ export function ChatOverlay({
       );
       let screenKeyboard = 0;
       if (SCREEN_KEYBOARD_SIGNAL_ACTIVE) {
-        const screenHeight =
-          typeof window.screen?.height === "number" && window.screen.height > 0
-            ? window.screen.height
-            : 0;
+        const screenHeight = getPhysicalScreenVerticalExtent();
         const insetFromScreen =
           screenHeight > 0
             ? Math.max(0, screenHeight - vv.height - vv.offsetTop)

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -2,6 +2,7 @@
  * Renders the chat overlay that keeps the composer and transcript
  * available across views.
  */
+import { MESSAGE_SOURCE_AGENT_GREETING } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
 import { MAX_CHAT_MEDIA_RAW_BYTES } from "@elizaos/shared";
 import { transcriptPlainText } from "@elizaos/shared/transcripts";
@@ -1923,8 +1924,17 @@ export function ChatOverlay({
       filterRenderableShellMessages(
         messages,
         responding ? "responding" : phase,
+        // The native iOS overlay is an always-available utility surface, not a
+        // social feed. The greeting endpoint currently picks a random
+        // `character.postExamples` entry, so a brand-new conversation could
+        // open with unrelated copy such as "close 40 tabs." Suppress that
+        // source on this surface: first-run choice turns are separate messages,
+        // and real user/assistant conversation remains untouched.
+        isNative && isIOS && !firstRunOpen
+          ? { excludeSources: [MESSAGE_SOURCE_AGENT_GREETING] }
+          : undefined,
       ),
-    [messages, phase, responding],
+    [firstRunOpen, messages, phase, responding],
   );
   // Mirror the active id so an async older-page result is dropped after a
   // mid-flight conversation switch: a page fetched for the previous thread must

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -5458,7 +5458,7 @@ export function ChatOverlay({
     <motion.div
       ref={overlayRef}
       className={cn(
-        "pointer-events-none fixed inset-x-0 bottom-0 flex w-full min-w-0 flex-col",
+        "pointer-events-none fixed inset-x-0 bottom-0 isolate flex w-full min-w-0 flex-col",
         // Resting on a landscape phone, the compact composer hugs the trailing
         // (inline-end) bottom corner — the conventional compose slot views leave
         // free — instead of centering a wide band over their controls (#14173).
@@ -5697,9 +5697,12 @@ export function ChatOverlay({
         >
           {/* SURFACE — absolute fill; the frosted-glass bg/border + the live
               corner radius. Crossfades in by openProgress (compositor opacity).
-              On the native tier the fill + blur drop and the OS material shows
-              through from below the WebView; border, bevel, and sheen stay —
-              they are the branded edge on every tier (GlassSurface contract). */}
+              An open native-tier conversation keeps an opaque DOM fill above
+              the OS material. Native glass used to replace that fill with
+              transparency, which allowed launcher/view controls to remain
+              visibly legible through the chat on iPad. The overlay already owns
+              the shell's highest application layer; the opaque fill makes that
+              paint-order contract visually true as well. */}
           <motion.div
             ref={glassSurfaceRef}
             aria-hidden="true"
@@ -5724,9 +5727,10 @@ export function ChatOverlay({
               // the orange app theme behind. Full-bleed stays fully opaque (it
               // covers the whole screen — there is nothing to see through, and
               // the blur would be wasted battery).
-              backgroundColor:
-                firstRunOpen || nativeInsetSheet
-                  ? "transparent"
+              backgroundColor: firstRunOpen
+                ? "transparent"
+                : nativeInsetSheet
+                  ? "var(--bg)"
                   : surfaceBackgroundColor,
               backdropFilter: cssSheetBackdropActive
                 ? GLASS_SHEET_BACKDROP_FILTER

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -2,7 +2,6 @@
  * Renders the chat overlay that keeps the composer and transcript
  * available across views.
  */
-import { MESSAGE_SOURCE_AGENT_GREETING } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
 import { MAX_CHAT_MEDIA_RAW_BYTES } from "@elizaos/shared";
 import { transcriptPlainText } from "@elizaos/shared/transcripts";
@@ -1924,17 +1923,8 @@ export function ChatOverlay({
       filterRenderableShellMessages(
         messages,
         responding ? "responding" : phase,
-        // The native iOS overlay is an always-available utility surface, not a
-        // social feed. The greeting endpoint currently picks a random
-        // `character.postExamples` entry, so a brand-new conversation could
-        // open with unrelated copy such as "close 40 tabs." Suppress that
-        // source on this surface: first-run choice turns are separate messages,
-        // and real user/assistant conversation remains untouched.
-        isNative && isIOS && !firstRunOpen
-          ? { excludeSources: [MESSAGE_SOURCE_AGENT_GREETING] }
-          : undefined,
       ),
-    [firstRunOpen, messages, phase, responding],
+    [messages, phase, responding],
   );
   // Mirror the active id so an async older-page result is dropped after a
   // mid-flight conversation switch: a page fetched for the previous thread must

--- a/packages/ui/src/components/shell/shell-state.test.ts
+++ b/packages/ui/src/components/shell/shell-state.test.ts
@@ -203,6 +203,21 @@ describe("selectVisibleShellMessages (#9141 gap 4 windowing)", () => {
 });
 
 describe("filterRenderableShellMessages", () => {
+  it("can suppress unsolicited agent-greeting copy for the native iOS overlay", () => {
+    const greeting: ShellMessage = {
+      ...msg("greeting", "assistant", "You need to close 40 tabs."),
+      source: "agent_greeting",
+    };
+    const user = msg("user", "user", "hello");
+    const reply = msg("reply", "assistant", "Hi.");
+
+    expect(
+      filterRenderableShellMessages([greeting, user, reply], "idle", {
+        excludeSources: ["agent_greeting"],
+      }).map((message) => message.id),
+    ).toEqual(["user", "reply"]);
+  });
+
   it("returns the same renderable set selectVisibleShellMessages keeps, uncapped", () => {
     const thread = Array.from({ length: 300 }, (_, i) =>
       i % 5 === 0

--- a/packages/ui/src/components/shell/shell-state.test.ts
+++ b/packages/ui/src/components/shell/shell-state.test.ts
@@ -203,19 +203,15 @@ describe("selectVisibleShellMessages (#9141 gap 4 windowing)", () => {
 });
 
 describe("filterRenderableShellMessages", () => {
-  it("can suppress unsolicited agent-greeting copy for the native iOS overlay", () => {
+  it("keeps persisted persona greetings in the canonical transcript", () => {
     const greeting: ShellMessage = {
-      ...msg("greeting", "assistant", "You need to close 40 tabs."),
+      ...msg("greeting", "assistant", "Welcome back. What should we build?"),
       source: "agent_greeting",
     };
-    const user = msg("user", "user", "hello");
-    const reply = msg("reply", "assistant", "Hi.");
 
-    expect(
-      filterRenderableShellMessages([greeting, user, reply], "idle", {
-        excludeSources: ["agent_greeting"],
-      }).map((message) => message.id),
-    ).toEqual(["user", "reply"]);
+    expect(filterRenderableShellMessages([greeting], "idle")).toEqual([
+      greeting,
+    ]);
   });
 
   it("returns the same renderable set selectVisibleShellMessages keeps, uncapped", () => {

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -118,14 +118,17 @@ export const SHELL_RENDER_WINDOW_STEP = 50;
 export function filterRenderableShellMessages(
   messages: readonly ShellMessage[],
   phase: ShellPhase,
+  options?: { excludeSources?: readonly string[] },
 ): ShellMessage[] {
+  const excludedSources = options?.excludeSources;
   return messages.filter(
     (m) =>
-      m.content.trim() ||
-      (m.attachments?.length ?? 0) > 0 ||
-      m.secretRequest !== undefined ||
-      m.failureKind !== undefined ||
-      (m.role === "assistant" && phase === "responding"),
+      !(m.source && excludedSources?.includes(m.source)) &&
+      (m.content.trim() ||
+        (m.attachments?.length ?? 0) > 0 ||
+        m.secretRequest !== undefined ||
+        m.failureKind !== undefined ||
+        (m.role === "assistant" && phase === "responding")),
   );
 }
 

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -118,17 +118,14 @@ export const SHELL_RENDER_WINDOW_STEP = 50;
 export function filterRenderableShellMessages(
   messages: readonly ShellMessage[],
   phase: ShellPhase,
-  options?: { excludeSources?: readonly string[] },
 ): ShellMessage[] {
-  const excludedSources = options?.excludeSources;
   return messages.filter(
     (m) =>
-      !(m.source && excludedSources?.includes(m.source)) &&
-      (m.content.trim() ||
-        (m.attachments?.length ?? 0) > 0 ||
-        m.secretRequest !== undefined ||
-        m.failureKind !== undefined ||
-        (m.role === "assistant" && phase === "responding")),
+      m.content.trim() ||
+      (m.attachments?.length ?? 0) > 0 ||
+      m.secretRequest !== undefined ||
+      m.failureKind !== undefined ||
+      (m.role === "assistant" && phase === "responding"),
   );
 }
 

--- a/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
@@ -33,6 +33,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   applyStandaloneBottomReclaim,
   clearStandaloneBottomReclaim,
+  getPhysicalScreenVerticalExtent,
   installStandaloneBottomReclaim,
   measureStandaloneBottomGap,
   STANDALONE_BOTTOM_RECLAIM_OFFSET,
@@ -60,6 +61,8 @@ function stubViewport(opts: {
   visualHeight?: number;
   visualOffsetTop?: number;
   orientation?: "portrait" | "landscape";
+  screenOrientation?: "portrait" | "landscape";
+  legacyOrientation?: number;
 }): void {
   Object.defineProperty(document.documentElement, "clientHeight", {
     configurable: true,
@@ -83,7 +86,15 @@ function stubViewport(opts: {
     value: {
       height: opts.screenHeight ?? opts.layoutHeight,
       width: opts.screenWidth ?? opts.layoutHeight,
+      ...(opts.screenOrientation
+        ? { orientation: { type: `${opts.screenOrientation}-primary` } }
+        : {}),
     },
+  });
+  Object.defineProperty(window, "orientation", {
+    configurable: true,
+    writable: true,
+    value: opts.legacyOrientation,
   });
   Object.defineProperty(window, "matchMedia", {
     configurable: true,
@@ -134,6 +145,11 @@ afterEach(() => {
     configurable: true,
     writable: true,
     value: { height: 0, width: 0 },
+  });
+  Object.defineProperty(window, "orientation", {
+    configurable: true,
+    writable: true,
+    value: undefined,
   });
   Object.defineProperty(window, "matchMedia", {
     configurable: true,
@@ -232,6 +248,39 @@ describe("measureStandaloneBottomGap: the screen.height cure for the collapsed-I
       orientation: "landscape",
     });
     expect(measureStandaloneBottomGap()).toBe(0);
+  });
+
+  it("uses physical screen orientation when an iPad split viewport is portrait-shaped", () => {
+    // CSS `(orientation)` describes the viewport. In iPad Split View that
+    // viewport can be tall while the output screen remains landscape. The
+    // Screen Orientation signal owns the physical axis selection, so the
+    // 1366px screen width is never mistaken for its vertical extent.
+    stubViewport({
+      layoutHeight: 1024,
+      innerHeight: 1024,
+      innerWidth: 700,
+      visualHeight: 1024,
+      screenHeight: 1024,
+      screenWidth: 1366,
+      orientation: "portrait",
+      screenOrientation: "landscape",
+    });
+    expect(getPhysicalScreenVerticalExtent()).toBe(1024);
+    expect(measureStandaloneBottomGap()).toBe(0);
+  });
+
+  it("falls back to legacy physical rotation before viewport orientation", () => {
+    stubViewport({
+      layoutHeight: 1024,
+      innerHeight: 1024,
+      innerWidth: 700,
+      visualHeight: 1024,
+      screenHeight: 1024,
+      screenWidth: 1366,
+      orientation: "portrait",
+      legacyOrientation: 90,
+    });
+    expect(getPhysicalScreenVerticalExtent()).toBe(1024);
   });
 
   it("is 0 (never negative) when the layout box exceeds screen.height (defensive)", () => {

--- a/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
@@ -217,6 +217,23 @@ describe("measureStandaloneBottomGap: the screen.height cure for the collapsed-I
     expect(measureStandaloneBottomGap()).toBe(0);
   });
 
+  it("uses the short physical axis when screen dimensions rotate in landscape", () => {
+    // Current Capacitor Simulator swaps Screen.width/height with orientation.
+    // The landscape vertical extent is still the 430px short axis; blindly
+    // reading screen.width would see 932px, clamp a false 502px reclaim to
+    // 160px, and translate the bottom composer completely off-screen.
+    stubViewport({
+      layoutHeight: 430,
+      innerHeight: 430,
+      innerWidth: 932,
+      visualHeight: 430,
+      screenHeight: 430,
+      screenWidth: 932,
+      orientation: "landscape",
+    });
+    expect(measureStandaloneBottomGap()).toBe(0);
+  });
+
   it("is 0 (never negative) when the layout box exceeds screen.height (defensive)", () => {
     // Should not happen physically, but a layout box taller than the physical
     // screen must reclaim nothing, never a negative translate off-screen.

--- a/packages/ui/src/platform/standalone-bottom-reclaim.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.ts
@@ -97,12 +97,21 @@ function isPortraitScreenOrientation(): boolean {
   return true;
 }
 
-function getPhysicalScreenExtent(): number {
+export function getPhysicalScreenVerticalExtent(): number {
   const portrait = isPortraitScreenOrientation();
-  const primary = portrait ? window.screen?.height : window.screen?.width;
-  if (typeof primary === "number" && primary > 0) return primary;
-  const fallback = portrait ? window.screen?.width : window.screen?.height;
-  return typeof fallback === "number" && fallback > 0 ? fallback : 0;
+  const width = window.screen?.width;
+  const height = window.screen?.height;
+  const dimensions = [width, height].filter(
+    (value): value is number => typeof value === "number" && value > 0,
+  );
+  if (dimensions.length === 0) return 0;
+
+  // WebKit is inconsistent about whether Screen.width/height rotate with the
+  // device. Some releases keep portrait dimensions in landscape (932x430),
+  // while Capacitor on current Simulator reports the rotated pair (430x932).
+  // The physical vertical extent is the long axis in portrait and the short
+  // axis in landscape regardless of which property currently owns that axis.
+  return portrait ? Math.max(...dimensions) : Math.min(...dimensions);
 }
 
 /**
@@ -160,11 +169,10 @@ export function measureStandaloneBottomGap(): number {
       : (document.documentElement?.clientHeight ?? 0);
   if (layoutHeight <= 0) return 0;
 
-  // The TRUE physical screen extent for the current orientation. iOS can keep
-  // `screen.height` as the portrait long side in landscape, so use
-  // `screen.width` there; otherwise a normal landscape viewport looks like a
-  // giant keyboard shortfall and freezes a stale portrait reclaim.
-  const screenExtent = getPhysicalScreenExtent();
+  // The TRUE physical screen extent for the current orientation. iOS may keep
+  // portrait screen dimensions in landscape or swap width/height as it rotates,
+  // so select the physical long/short axis rather than a named property.
+  const screenExtent = getPhysicalScreenVerticalExtent();
   if (screenExtent <= 0) return 0;
 
   // KEYBOARD-OPEN GUARD (the r-kbd regression): the resting reclaim measures

--- a/packages/ui/src/platform/standalone-bottom-reclaim.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.ts
@@ -85,6 +85,20 @@ export const KEYBOARD_INTRUSION_THRESHOLD_PX = 140;
 let lastRestingGap = 0;
 
 function isPortraitScreenOrientation(): boolean {
+  const screenOrientationType = window.screen?.orientation?.type;
+  if (screenOrientationType?.startsWith("portrait")) return true;
+  if (screenOrientationType?.startsWith("landscape")) return false;
+
+  // Older iOS WebViews expose the physical rotation only through the legacy
+  // Window.orientation angle. Prefer it over a media query: CSS orientation is
+  // the viewport's aspect ratio, which can be portrait-shaped in iPad Split
+  // View while the physical screen remains landscape. Using that viewport
+  // shape to pick the screen axis fabricates a keyboard-sized shortfall.
+  const legacyAngle = (window as Window & { orientation?: number }).orientation;
+  if (typeof legacyAngle === "number" && Number.isFinite(legacyAngle)) {
+    return Math.abs(legacyAngle) % 180 === 0;
+  }
+
   const matchMedia = window.matchMedia;
   if (typeof matchMedia === "function") {
     return matchMedia("(orientation: portrait)").matches;


### PR DESCRIPTION
# Relates to

Fixes #22076.

# Review repair

- Exact reviewed head: `81171259bfac0e5c0b70f270a34077097f82da6c`.
- The four author commits are preserved. A reviewer follow-up removes the native-only blanket `agent_greeting` render filter and adds a regression proving persisted persona greetings remain visible.
- The repaired head contains `develop` through `7e761fc3d9ed36076fd77c078fe1422841801dc2`. At final evidence capture, live `develop` had advanced to `3cb88fb1bfb438e5a4c03ab0c8ba656630d56b98`; the eight intervening commits were path-disjoint from all five PR files and the merge-tree was conflict-free.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used for the review repair
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What this PR does

1. Keeps the chat composer visible after iOS rotation and iPad multitasking size changes by selecting the physical screen axis from physical-orientation signals before viewport shape.
2. Makes the native open chat overlay opaque and isolates its stacking context so launcher content cannot bleed through.
3. Preserves the canonical transcript: persisted character/persona greetings remain renderable on iOS, matching other clients.

# Risks

Low and iOS-scoped. Orientation selection changes only the standalone bottom-reclaim calculation. The overlay styling changes only the native open surface. The review repair deliberately avoids changing greeting creation or transcript semantics.

# Exact-head validation

- Focused UI suite: 4 files, 256/256 passed at `81171259bfac0e5c0b70f270a34077097f82da6c` (existing React `act(...)` warnings only).
- Biome on all five changed source/test files: passed.
- `git diff --check origin/develop...HEAD`: passed.
- `bun run --cwd packages/app build:ios:cloud:sim`: `BUILD SUCCEEDED`; cloud artifact audit passed with renderer build ID `2ec0238b8cc13ce033e860818d432b8b12f51b9726f4356bbeca94e0136aa870` and app binary SHA-256 `d2a762e4955ea854fe18a8d4476058dad36d75a910d59d9ce26a2866daaf489d`.
- Installed the exact app on iOS 26.4 iPhone simulator `03E116C9-86DE-47D1-BDAD-93AD3358F101` and iOS 18.1 iPad simulator `B6A5F377-AE7E-4743-9857-FBE254FCAE98`. Both installed containers report exact head `81171259bfac0e5c0b70f270a34077097f82da6c`, and installed `App` binaries byte-match the audited build.
- Native captures confirm the opaque overlay and visible composer in portrait and landscape. They also confirm the repaired behavior: `Hi, I'm Eliza.` remains visible in the canonical transcript.

## Known upstream gate

`bun run --cwd packages/ui typecheck` is currently blocked by unrelated files introduced on `develop`: `BuildBadge-timeout.test.ts` and `load-pack-timeout.test.ts` import helpers that their source modules do not export. None of those files are touched by this PR. This is recorded rather than misreported as a pass.

# Evidence Gate

<!-- evidence-head:81171259bfac0e5c0b70f270a34077097f82da6c -->

<!-- evidence-row:before-screenshots -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-00-before-landscape-composer-hidden.png
<!-- evidence-row:after-screenshots -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-811712-ipad-landscape-upright.png
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-ipad-expanded-overlay-opaque-rotation-94543.mp4 (predecessor-head behavioral walkthrough; exact repaired-head state is shown in the screenshots and installed-revision artifacts below)
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend behavior changed
<!-- evidence-row:frontend-logs -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-attestation-811712.json
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-811712-installed-B6A5F377-AE7E-4743-9857-FBE254FCAE98.json
<!-- evidence-row:ocr-review -->
- [x] [21819-ocr-review-811712.jsonl](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-ocr-review-811712.jsonl)

# Exact-head artifacts

- [iPhone portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-811712-03E116C9-86DE-47D1-BDAD-93AD3358F101.png)
- [iPad portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-811712-ipad-landscape-upright.png)
- [iPad landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-811712-ipad-landscape-upright.png)
- [iPhone installed revision](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-811712-installed-03E116C9-86DE-47D1-BDAD-93AD3358F101.json)
- [iPad installed revision](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-811712-installed-B6A5F377-AE7E-4743-9857-FBE254FCAE98.json)
- [Audited app attestation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21819-attestation-811712.json)

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex Desktop  
Contribution skill revision: N/A - no contribution skill used  
Attribution status: self-reported  
— [nubs-review-drafts-delta]
