### PR TITLE
fix(ui): bound attachment prefetches without losing fallback

### DIFF
--- a/packages/ui/src/utils/download-share.test.ts
+++ b/packages/ui/src/utils/download-share.test.ts
@@ -201,6 +201,47 @@ describe("downloadAttachment — <a download> fallback path", () => {
     expect(anchor.download).toBe("cat.png");
     expect(clickSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("falls back to the raw url when the picker prefetch times out", async () => {
+    const timeout = new DOMException(
+      "The operation was aborted due to timeout",
+      "TimeoutError",
+    );
+    const fetchMock = vi.fn(async () => {
+      throw timeout;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("window", {
+      showSaveFilePicker: vi.fn(),
+    });
+
+    await withGlobal("Capacitor", undefined, () =>
+      downloadAttachment("https://example.com/cat.png", "cat.png"),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(anchor.href).toBe("https://example.com/cat.png");
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start an anchor download when the user cancels the picker", async () => {
+    const blob = new Blob(["hello"], { type: "image/png" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(blob)),
+    );
+    vi.stubGlobal("window", {
+      showSaveFilePicker: vi.fn(async () => {
+        throw new DOMException("The user aborted a request", "AbortError");
+      }),
+    });
+
+    await withGlobal("Capacitor", undefined, () =>
+      downloadAttachment("https://example.com/cat.png", "cat.png"),
+    );
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
 });
 
 /* ── shareAttachment ──────────────────────────────────────────────────── */
@@ -254,7 +295,7 @@ describe("shareAttachment", () => {
   });
 });
 
-/* ── blob prefetch deadline (Fal #21205) ─────────────────────────────── */
+/* ── Blob prefetch deadline ─────────────────────────────────────────── */
 
 const PREFETCH_URL = "https://example.com/cat.png";
 
@@ -278,6 +319,32 @@ describe("download-share blob prefetch deadline", () => {
     await expect(
       getDownloadShareResponseWithFetch(PREFETCH_URL, stallUntilAborted(), 10),
     ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("keeps the deadline active while the response body is read", async () => {
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected download-share abort signal");
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          signal.addEventListener(
+            "abort",
+            () => controller.error(signal.reason),
+            { once: true },
+          );
+        },
+      });
+      return new Response(body, { status: 200 });
+    };
+
+    const response = await getDownloadShareResponseWithFetch(
+      PREFETCH_URL,
+      fetchImpl,
+      10,
+    );
+    await expect(response.blob()).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
   });
 
   it("surfaces a provider error from a completed prefetch GET", async () => {
@@ -308,4 +375,3 @@ describe("download-share blob prefetch deadline", () => {
     expect(await response.text()).toBe("hello");
   });
 });
-

--- a/packages/ui/src/utils/download-share.test.ts
+++ b/packages/ui/src/utils/download-share.test.ts
@@ -3,9 +3,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   canShareFiles,
+  DOWNLOAD_SHARE_FETCH_TIMEOUT_MS,
   downloadAttachment,
   extForMime,
   filenameForMime,
+  getDownloadShareResponseWithFetch,
   shareAttachment,
 } from "./download-share";
 
@@ -164,7 +166,13 @@ describe("downloadAttachment — <a download> fallback path", () => {
       downloadAttachment("https://example.com/cat.png", "cat.png"),
     );
 
-    expect(fetchMock).toHaveBeenCalledWith("https://example.com/cat.png");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/cat.png",
+      expect.objectContaining({
+        method: "GET",
+        signal: expect.any(AbortSignal),
+      }),
+    );
     expect(
       (URL as unknown as { createObjectURL: ReturnType<typeof vi.fn> })
         .createObjectURL,
@@ -245,3 +253,59 @@ describe("shareAttachment", () => {
     expect(result).toBe(true);
   });
 });
+
+/* ── blob prefetch deadline (Fal #21205) ─────────────────────────────── */
+
+const PREFETCH_URL = "https://example.com/cat.png";
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected download-share abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+describe("download-share blob prefetch deadline", () => {
+  it("keeps a documented UI fetch budget", () => {
+    expect(DOWNLOAD_SHARE_FETCH_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("aborts a stalled prefetch GET at the injected deadline", async () => {
+    await expect(
+      getDownloadShareResponseWithFetch(PREFETCH_URL, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed prefetch GET", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 503, statusText: "Service Unavailable" });
+
+    await expect(
+      getDownloadShareResponseWithFetch(PREFETCH_URL, fetchImpl, 1_000),
+    ).rejects.toThrow("503");
+  });
+
+  it("uses the injected fetch for a successful prefetch GET", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response("hello", { status: 200 });
+    };
+
+    const response = await getDownloadShareResponseWithFetch(
+      PREFETCH_URL,
+      fetchImpl,
+      1_000,
+    );
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(response.ok).toBe(true);
+    expect(await response.text()).toBe("hello");
+  });
+});
+

--- a/packages/ui/src/utils/download-share.ts
+++ b/packages/ui/src/utils/download-share.ts
@@ -166,13 +166,16 @@ export function canShareFiles(): boolean {
 /* ── Internal helpers ─────────────────────────────────────────────────── */
 
 function isAbortError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const { name, message } = err as { name?: unknown; message?: unknown };
+  if (name === "TimeoutError") return false;
   return (
-    err instanceof Error &&
-    (err.name === "AbortError" || /abort|cancel/i.test(err.message))
+    name === "AbortError" ||
+    (typeof message === "string" && /abort|cancel/i.test(message))
   );
 }
 
-/** Attachment blob prefetch is a short UI GET — same 15s family as BuildBadge. */
+/** Attachment blob prefetch has a 15-second UI deadline. */
 export const DOWNLOAD_SHARE_FETCH_TIMEOUT_MS = 15_000;
 
 export async function getDownloadShareResponseWithFetch(
@@ -202,7 +205,10 @@ async function downloadViaAnchor(url: string, filename: string): Promise<void> {
     // Same-origin / fetchable assets: pull to a blob so the download attribute
     // is honored cross-origin and so blob:/data: sources work uniformly.
     if (typeof fetch === "function" && !url.startsWith("data:")) {
-      const res = await getDownloadShareResponseWithFetch(url, globalThis.fetch);
+      const res = await getDownloadShareResponseWithFetch(
+        url,
+        globalThis.fetch,
+      );
       const blob = await res.blob();
       if (typeof URL !== "undefined" && URL.createObjectURL) {
         objectUrl = URL.createObjectURL(blob);
@@ -320,9 +326,14 @@ export async function downloadAttachment(
     typeof fetch === "function" &&
     !url.startsWith("data:")
   ) {
+    let pickerOpened = false;
     try {
-      const res = await getDownloadShareResponseWithFetch(url, globalThis.fetch);
+      const res = await getDownloadShareResponseWithFetch(
+        url,
+        globalThis.fetch,
+      );
       const blob = await res.blob();
+      pickerOpened = true;
       const handle = await picker({ suggestedName: filename });
       const writable = await handle.createWritable();
       await writable.write(blob);
@@ -330,8 +341,9 @@ export async function downloadAttachment(
       return;
     } catch (err) {
       // error-policy:J4 user cancelled the picker → done (don't
-      // double-download); any other failure falls through to the anchor path.
-      if (isAbortError(err)) return;
+      // double-download). A prefetch abort/timeout happens before the picker is
+      // opened and must still fall through to the raw-url anchor path.
+      if (pickerOpened && isAbortError(err)) return;
     }
   }
 

--- a/packages/ui/src/utils/download-share.ts
+++ b/packages/ui/src/utils/download-share.ts
@@ -172,6 +172,24 @@ function isAbortError(err: unknown): boolean {
   );
 }
 
+/** Attachment blob prefetch is a short UI GET — same 15s family as BuildBadge. */
+export const DOWNLOAD_SHARE_FETCH_TIMEOUT_MS = 15_000;
+
+export async function getDownloadShareResponseWithFetch(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = DOWNLOAD_SHARE_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const response = await fetchImpl(url, {
+    method: "GET",
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`Download request failed (${response.status})`);
+  }
+  return response;
+}
+
 /** Web/desktop fallback: object-URL + temporary `<a download>` click. */
 async function downloadViaAnchor(url: string, filename: string): Promise<void> {
   if (typeof document === "undefined") {
@@ -184,13 +202,11 @@ async function downloadViaAnchor(url: string, filename: string): Promise<void> {
     // Same-origin / fetchable assets: pull to a blob so the download attribute
     // is honored cross-origin and so blob:/data: sources work uniformly.
     if (typeof fetch === "function" && !url.startsWith("data:")) {
-      const res = await fetch(url);
-      if (res.ok) {
-        const blob = await res.blob();
-        if (typeof URL !== "undefined" && URL.createObjectURL) {
-          objectUrl = URL.createObjectURL(blob);
-          href = objectUrl;
-        }
+      const res = await getDownloadShareResponseWithFetch(url, globalThis.fetch);
+      const blob = await res.blob();
+      if (typeof URL !== "undefined" && URL.createObjectURL) {
+        objectUrl = URL.createObjectURL(blob);
+        href = objectUrl;
       }
     }
   } catch {
@@ -242,8 +258,7 @@ async function downloadViaCapacitor(
   const fs = getCapacitorFilesystem();
   if (!fs || typeof fetch !== "function") return false;
   try {
-    const res = await fetch(url);
-    if (!res.ok) return false;
+    const res = await getDownloadShareResponseWithFetch(url, globalThis.fetch);
     const data = arrayBufferToBase64(await res.arrayBuffer());
     const written = await fs.writeFile({
       path: filename,
@@ -306,15 +321,13 @@ export async function downloadAttachment(
     !url.startsWith("data:")
   ) {
     try {
-      const res = await fetch(url);
-      if (res.ok) {
-        const blob = await res.blob();
-        const handle = await picker({ suggestedName: filename });
-        const writable = await handle.createWritable();
-        await writable.write(blob);
-        await writable.close();
-        return;
-      }
+      const res = await getDownloadShareResponseWithFetch(url, globalThis.fetch);
+      const blob = await res.blob();
+      const handle = await picker({ suggestedName: filename });
+      const writable = await handle.createWritable();
+      await writable.write(blob);
+      await writable.close();
+      return;
     } catch (err) {
       // error-policy:J4 user cancelled the picker → done (don't
       // double-download); any other failure falls through to the anchor path.


### PR DESCRIPTION
# Relates to

Attachment downloads prefetched blobs with unbounded `fetch` calls in the anchor, save-picker, and Capacitor paths. A stalled connection or response body could leave a download pending indefinitely.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] Exact-head tests cover the request deadline, response-body deadline, non-OK response, success, timeout fallback, and genuine picker cancellation.
- [x] A reviewer can verify the transport/fallback contract from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6, openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Cursor, Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@404b4a5b41bf766201606dadd07b91d796de5334:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `404b4a5b41bf766201606dadd07b91d796de5334`; zero conflicts.
- [x] Focused validation rerun at exact head `0957582e9a9f021544846033bf97d01b8e4408a3`.

# Risks

Low after repair. The submitted timeout correctly bounded the external blob fetch, but its timeout error could be misclassified as a user-cancelled picker because the message contains “aborted.” That would silently skip the documented raw-URL fallback. The repaired head only treats an abort as picker cancellation after the picker has actually opened, recognizes cross-realm `DOMException` cancellation structurally, and explicitly keeps `TimeoutError` distinct.

# Background

## What does this PR do?

Applies a 15-second `AbortSignal.timeout` to all attachment blob prefetches. The same signal remains associated with response-body consumption, so a server that sends headers and then stalls is bounded too. Non-OK, network, CORS, and timeout failures retain the existing fallback chain.

## What kind of change is this?

Bug fix; no rendered UI or public package export change.

# Documentation changes needed?

No. This is an internal download transport correction.

# Testing

## Where should a reviewer start?

`packages/ui/src/utils/download-share.test.ts` and `packages/ui/src/utils/download-share.ts`.

## Detailed testing steps

```bash
cd packages/ui
vitest run --config ./vitest.config.ts src/utils/download-share.test.ts
```

Exact-head result: 1 file passed, 24 tests passed. Biome checked both changed files and `git diff --check` passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change; download transport only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interaction layout or visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend implementation changed; deterministic transport tests are the relevant artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no new console behavior; failures retain the existing raw-URL fallback.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, or other domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - attachment transport only.

## Backend + frontend logs

The focused suite exercises a stalled request, a stalled response body, HTTP 503, success, the production anchor signal, raw-URL fallback after timeout, and picker cancellation. All 24 tests pass at the evidence head.

## Screenshots (before / after) + video walkthrough

N/A - no visual output changed.

## Audio / voice walkthrough

N/A - no audio or voice path.

## Known gaps / failures

The full app visual audit and root verify were not rerun for this non-rendering utility change. Focused exact-head tests, formatter/lint checks, diff checks, and direct fallback-path review are the validation evidence.

<!-- evidence-head:0957582e9a9f021544846033bf97d01b8e4408a3 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@404b4a5b41bf766201606dadd07b91d796de5334:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@404b4a5b41bf766201606dadd07b91d796de5334:skills/contribute-to-eliza"} -->
