### PR TITLE
feat(cloud): converge Shared turns on AgentRuntime channels

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -1,5 +1,6 @@
 /** Runs a trusted messaging delivery through one rowless personal Shared turn. */
 
+import { ChannelType } from "@elizaos/core/edge";
 import { Hono } from "hono";
 import { z } from "zod";
 import { resolvePersonalDeliveryProjection } from "@/api-app/personal-delivery-projection";
@@ -634,6 +635,8 @@ app.post("/", async (c) => {
       parsed.data.messageId,
       "platform",
       trustedDelivery,
+      undefined,
+      { source: parsed.data.platform, channelType: ChannelType.DM },
     );
     c.header(
       "Server-Timing",

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1064,7 +1064,7 @@ describe("cloud-api worker entrypoint", () => {
     expect(productionRoutes).toContain("*.cloud.eliza.app/*");
   });
 
-  test("publishes the genuine Shared runtime in staging and production", async () => {
+  test("does not retain the retired Shared runtime transition gate", async () => {
     const config = Bun.TOML.parse(
       await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
     ) as {
@@ -1075,11 +1075,13 @@ describe("cloud-api worker entrypoint", () => {
       };
     };
 
-    expect(config.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe("false");
-    expect(config.env?.staging?.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe("true");
-    expect(config.env?.production?.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe(
-      "true",
-    );
+    expect(config.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBeUndefined();
+    expect(
+      config.env?.staging?.vars?.SHARED_ELIZA_AGENT_RUNTIME,
+    ).toBeUndefined();
+    expect(
+      config.env?.production?.vars?.SHARED_ELIZA_AGENT_RUNTIME,
+    ).toBeUndefined();
   });
 
   test("keeps the legacy edge guard false and reserves the replacement names for the cutover secrets", async () => {

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -39,6 +39,7 @@ let rehydrateCalls = 0;
 let bridgeFunding: unknown;
 let recoveredCutoverTargetId: string | null = null;
 let lastBridgeAgent: unknown;
+let lastBridgeTrustedChannel: unknown;
 let apnsOutcome: { outcome: string; reason?: string; status?: number } = {
   outcome: "accepted",
 };
@@ -65,6 +66,7 @@ mock.module("@/db/client", () => ({
   runWithDbCacheAsync: async <T>(fn: () => Promise<T>) => await fn(),
 }));
 mock.module("@/lib/runtime/cloud-bindings", () => ({
+  getCloudAwareEnv: () => ({}),
   runWithCloudBindingsAsync: async <T>(_env: unknown, fn: () => Promise<T>) =>
     await fn(),
 }));
@@ -132,6 +134,7 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
       },
       options: {
         funding?: unknown;
+        trustedChannel?: unknown;
         mobilePushDispatch?: (message: {
           title: string;
           body?: string;
@@ -157,6 +160,7 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
     ) => {
       bridgeFunding = options.funding;
       lastBridgeAgent = agent;
+      lastBridgeTrustedChannel = options.trustedChannel;
       if (rpc.id === "push-event") {
         await options.mobilePushDispatch?.({
           title: "Reminder",
@@ -255,7 +259,7 @@ mock.module("@/lib/mobile-push/apns-provider", () => ({
   },
 }));
 mock.module("@/lib/utils/logger", () => ({
-  logger: { warn: loggerWarn },
+  logger: { info: mock(() => undefined), warn: loggerWarn },
 }));
 
 const { SharedRuntimeConversation } = await import(
@@ -278,6 +282,7 @@ beforeEach(() => {
   bridgeFunding = undefined;
   recoveredCutoverTargetId = null;
   lastBridgeAgent = undefined;
+  lastBridgeTrustedChannel = undefined;
   apnsOutcome = { outcome: "accepted" };
   apnsSentTokens.length = 0;
   apnsOutcomes.clear();
@@ -379,6 +384,71 @@ function makeInvoke(object: { fetch(request: Request): Promise<Response> }) {
     return await response.json();
   };
 }
+
+test("validates server-owned channel provenance outside JSON-RPC params", async () => {
+  const data = new Map<string, unknown>([
+    [
+      "conversation",
+      {
+        agentId: AGENT_FIXTURE.id,
+        channelId: "room-1",
+        history: [],
+        dirty: false,
+        version: 0,
+      },
+    ],
+  ]);
+  const object = new SharedRuntimeConversation(
+    makeState(data, []) as never,
+    {} as never,
+  );
+  const request = (body: Record<string, unknown>) =>
+    object.fetch(
+      new Request("https://shared-runtime.internal/bridge", {
+        method: "POST",
+        body: JSON.stringify({
+          operation: "bridge",
+          agent: AGENT_FIXTURE,
+          rpc: {
+            jsonrpc: "2.0",
+            id: "channel-boundary",
+            method: "message.send",
+            params: {
+              text: "hi",
+              roomId: "room-1",
+              source: "client_chat",
+              channelType: "VOICE_DM",
+            },
+          },
+          ...body,
+        }),
+      }),
+    );
+
+  const withoutEnvelope = await request({});
+  expect(withoutEnvelope.status).toBe(200);
+  await withoutEnvelope.arrayBuffer();
+  expect(lastBridgeTrustedChannel).toBeUndefined();
+
+  const withEnvelope = await request({
+    trustedChannel: { source: "discord", channelType: "GROUP" },
+  });
+  expect(withEnvelope.status).toBe(200);
+  await withEnvelope.arrayBuffer();
+  expect(lastBridgeTrustedChannel).toEqual({
+    source: "discord",
+    channelType: "GROUP",
+  });
+
+  const invalidEnvelope = await request({
+    trustedChannel: { source: "discord", channelType: "API" },
+  });
+  expect(invalidEnvelope.status).toBe(400);
+  expect((await invalidEnvelope.json()) as unknown).toEqual({
+    success: false,
+    error: "Invalid trusted channel envelope",
+  });
+});
 
 async function pushOperation(
   object: { fetch(request: Request): Promise<Response> },

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -30,6 +30,10 @@ import {
   mergeSharedRuntimeHistoryMessages,
   selectSharedRuntimeContext,
 } from "@/lib/services/shared-runtime/shared-runtime-history-policy";
+import {
+  parseTrustedSharedChannelEnvelope,
+  type TrustedSharedChannelEnvelope,
+} from "@/lib/services/shared-runtime/trusted-shared-channel";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 // The agent row crosses the Durable Object boundary as JSON, so its Drizzle
@@ -42,6 +46,7 @@ type ConversationRequest =
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
+      trustedChannel?: TrustedSharedChannelEnvelope;
     }
   | {
       operation: "personal-bridge";
@@ -49,6 +54,7 @@ type ConversationRequest =
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
+      trustedChannel?: TrustedSharedChannelEnvelope;
     }
   | {
       operation: "stream";
@@ -56,6 +62,7 @@ type ConversationRequest =
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
+      trustedChannel?: TrustedSharedChannelEnvelope;
     }
   | {
       operation: "personal-stream";
@@ -63,6 +70,7 @@ type ConversationRequest =
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
       trustedUserUtterance?: string;
+      trustedChannel?: TrustedSharedChannelEnvelope;
     }
   | {
       operation: "prewarm";
@@ -443,14 +451,10 @@ export class SharedRuntimeConversation {
       const imports: Promise<unknown>[] = [
         import("@/lib/services/shared-runtime/shared-runtime-chat"),
         import("@/lib/services/shared-runtime/cached-agent-dates"),
+        import("@/lib/services/shared-runtime/shared-eliza-runtime").then(
+          ({ prewarmSharedElizaRuntime }) => prewarmSharedElizaRuntime(),
+        ),
       ];
-      if (this.env.SHARED_ELIZA_AGENT_RUNTIME === "true") {
-        imports.push(
-          import("@/lib/services/shared-runtime/shared-eliza-runtime").then(
-            ({ prewarmSharedElizaRuntime }) => prewarmSharedElizaRuntime(),
-          ),
-        );
-      }
       await Promise.all(imports);
     });
   }
@@ -1623,10 +1627,15 @@ export class SharedRuntimeConversation {
       const executionCtx = {
         waitUntil: (promise: Promise<unknown>) => this.state.waitUntil(promise),
       };
-      const executionEngine =
-        this.env.SHARED_ELIZA_AGENT_RUNTIME === "true"
-          ? ("eliza-runtime" as const)
-          : ("direct-model" as const);
+      const trustedChannel = parseTrustedSharedChannelEnvelope(
+        payload.trustedChannel,
+      );
+      if (payload.trustedChannel !== undefined && !trustedChannel) {
+        return Response.json(
+          { success: false, error: "Invalid trusted channel envelope" },
+          { status: 400 },
+        );
+      }
       if (
         payload.operation === "stream" ||
         payload.operation === "personal-stream"
@@ -1639,7 +1648,7 @@ export class SharedRuntimeConversation {
           funding: personal ? "platform" : "organization-credits",
           trustedMessageRole: payload.trustedMessageRole,
           trustedUserUtterance: payload.trustedUserUtterance,
-          executionEngine,
+          trustedChannel,
           mobilePushDispatch: personal
             ? async (message: MobilePushMessage) => {
                 this.enqueueMobilePush(message);
@@ -1654,7 +1663,7 @@ export class SharedRuntimeConversation {
         funding: personal ? "platform" : "organization-credits",
         trustedMessageRole: payload.trustedMessageRole,
         trustedUserUtterance: payload.trustedUserUtterance,
-        executionEngine,
+        trustedChannel,
         mobilePushDispatch: personal
           ? async (message: MobilePushMessage) => {
               this.enqueueMobilePush(message);

--- a/packages/cloud/api/v1/cron/shared-agent-keepwarm/route.test.ts
+++ b/packages/cloud/api/v1/cron/shared-agent-keepwarm/route.test.ts
@@ -33,7 +33,7 @@ const { default: app } = await import("./route");
 const PERSONAL_AGENT_ID = "personal:9610511b-dff2-5ca3-989a-8e1004ff44b1";
 const SANDBOX_AGENT_ID = "9610511b-dff2-4ca3-889a-8e1004ff44b2";
 
-function hitCron(sharedRuntimeEnabled = true) {
+function hitCron() {
   return app.fetch(
     new Request("https://api.example.test/", {
       method: "POST",
@@ -41,7 +41,6 @@ function hitCron(sharedRuntimeEnabled = true) {
     }),
     {
       CRON_SECRET: "cron-secret",
-      SHARED_ELIZA_AGENT_RUNTIME: sharedRuntimeEnabled ? "true" : "false",
       SHARED_RUNTIME_CONVERSATIONS: {},
     },
   );
@@ -121,16 +120,6 @@ describe("shared-agent keepwarm cron", () => {
     });
     expect(prewarmSharedAgentTurnCaches).not.toHaveBeenCalled();
     expect(prewarmSharedElizaRuntime).toHaveBeenCalledTimes(1);
-  });
-
-  test("does not prewarm the process-wide runtime when the feature is disabled", async () => {
-    listRecentlyActiveAgentIds.mockResolvedValueOnce([PERSONAL_AGENT_ID]);
-
-    const response = await hitCron(false);
-
-    expect(response.status).toBe(200);
-    expect(prewarmSharedElizaRuntime).not.toHaveBeenCalled();
-    expect(findById).not.toHaveBeenCalled();
   });
 
   test("rejects an invalid cron secret before querying history", async () => {

--- a/packages/cloud/api/v1/cron/shared-agent-keepwarm/route.ts
+++ b/packages/cloud/api/v1/cron/shared-agent-keepwarm/route.ts
@@ -63,9 +63,7 @@ async function runKeepwarm(c: AppContext) {
       warmed++;
     }
 
-    if (c.env.SHARED_ELIZA_AGENT_RUNTIME === "true") {
-      await prewarmSharedElizaRuntime();
-    }
+    await prewarmSharedElizaRuntime();
 
     logger.info("[SharedKeepwarm Cron] swept recently active shared agents", {
       candidates: agentIds.length,

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
@@ -4,6 +4,7 @@
  * Scope authorization and conversation execution are cache-only through the
  * shared Durable Object; cold hydration returns retryable unavailability.
  */
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import { Hono } from "hono";
 import { InsufficientCreditsError, RateLimitError } from "@/lib/api/errors";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
@@ -181,6 +182,9 @@ app.post("/", async (c) => {
       worker.namespace,
       sharedTurnClientMessageId(raw),
       "agentKind" in r ? "platform" : "organization-credits",
+      undefined,
+      undefined,
+      { source: MESSAGE_SOURCE_CLIENT_CHAT, channelType: ChannelType.DM },
     );
   } catch (error) {
     // error-policy:J1 route boundary translates bridge/billing failures to HTTP responses.

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -4,6 +4,7 @@
  * Scope authorization and turn execution are cache-only on the response path;
  * cold hydration is scheduled under waitUntil and surfaced as retryable 503.
  */
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import { Hono } from "hono";
 import type { AgentSandbox } from "@/db/repositories/agent-sandboxes";
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
@@ -268,6 +269,10 @@ app.post("/", async (c) => {
     origin,
     namespace: worker.namespace,
     agentKind: "agentKind" in r ? r.agentKind : "sandbox",
+    trustedChannel: {
+      source: MESSAGE_SOURCE_CLIENT_CHAT,
+      channelType: ChannelType.DM,
+    },
     // The Worker context carries both cold hydration and the shared turn's
     // deferred billing tail without putting either on the response path.
     executionCtx: worker.executionCtx,

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts
@@ -6,6 +6,7 @@
  * to its own container bridge. Losing that second branch is what 404'd every
  * dedicated agent between 2026-07-23 and #18062.
  */
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -82,6 +83,10 @@ async function __hono_POST(
       executionCtx: resolved.executionCtx,
       namespace: resolved.namespace,
       agentKind: resolved.agentKind,
+      trustedChannel: {
+        source: MESSAGE_SOURCE_CLIENT_CHAT,
+        channelType: ChannelType.DM,
+      },
     });
 
     return applyCorsHeaders(Response.json(response), CORS_METHODS);

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
@@ -4,6 +4,7 @@
  * Worker bindings and cache-authorized agent scope are mandatory; the route
  * never falls through to a repository-backed sandbox stream.
  */
+import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import { Hono } from "hono";
 import { z } from "zod";
 import { errorToResponse, ValidationError } from "@/lib/api/errors";
@@ -100,6 +101,10 @@ async function __hono_POST(
         executionCtx: resolved.executionCtx,
         namespace: resolved.namespace,
         agentKind: resolved.agentKind,
+        trustedChannel: {
+          source: MESSAGE_SOURCE_CLIENT_CHAT,
+          channelType: ChannelType.DM,
+        },
       },
     );
 

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -8,6 +8,7 @@
  * contract cannot select the legacy database-backed bridge.
  */
 
+import { ChannelType } from "@elizaos/core/edge";
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys } from "@/lib/cache/keys";
@@ -344,6 +345,7 @@ async function dispatchInternalElizaConversationFetch(
       (body as { messageRole?: unknown }).messageRole === "system"
         ? "system"
         : undefined,
+    trustedChannel: { source: "voice", channelType: ChannelType.VOICE_DM },
     body,
     origin: headers.get("origin"),
     namespace: runtime.namespace,

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -204,9 +204,7 @@ new_sqlite_classes = ["InferenceRateLimitV2RollbackFloor"]
 # transition the database control durable -> paused, then remove/false this
 # secondary switch; keep the durable binary deployed so recovery can converge.
 [vars]
-# Local/default deployments retain the direct-model control unless explicitly opted in.
 NODE_ENV = "production"
-SHARED_ELIZA_AGENT_RUNTIME = "false"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
 PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
 # PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED and
@@ -488,9 +486,7 @@ __dirname = '"/"'
 __filename = '"/worker.js"'
 
 [env.staging.vars]
-# Protected staging proves the genuine Workerd AgentRuntime before production promotion.
 NODE_ENV = "production"
-SHARED_ELIZA_AGENT_RUNTIME = "true"
 # Staging exercises the strongly invalidated sender projection while default
 # and production stay on canonical resolution until the live latency matrix passes.
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "true"
@@ -774,9 +770,7 @@ __dirname = '"/"'
 __filename = '"/worker.js"'
 
 [env.production.vars]
-# Production uses the genuine Shared Workerd runtime for personal voice.
 NODE_ENV = "production"
-SHARED_ELIZA_AGENT_RUNTIME = "true"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
 PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
 # The protected production cutover owns

--- a/packages/cloud/shared/src/db/repositories/shared-agent-memories.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-agent-memories.integration.test.ts
@@ -285,6 +285,13 @@ describe("SharedAgentMemoriesReader.searchByEmbedding (real PGlite + pgvector)",
       content: { text: "orthogonal" },
       embedding: [0, 1, 0],
     });
+    await sharedAgentMemoriesWriter.insertMemory({
+      scope: scopeA,
+      roomId: ROOM_B,
+      type: "messages",
+      content: { text: "other room exact match" },
+      embedding: [1, 0, 0],
+    });
     // Dimension mismatch: must be filtered out, not fail the whole query.
     await sharedAgentMemoriesWriter.insertMemory({
       scope: scopeA,
@@ -302,7 +309,7 @@ describe("SharedAgentMemoriesReader.searchByEmbedding (real PGlite + pgvector)",
       embedding: [1, 0, 0],
     });
 
-    const hits = await sharedAgentMemoriesReader.searchByEmbedding(scopeA, [1, 0, 0], 5);
+    const hits = await sharedAgentMemoriesReader.searchByEmbedding(scopeA, [1, 0, 0], 5, ROOM_A);
     expect(hits.map((hit) => hit.content.text)).toEqual([
       "exact match",
       "near match",

--- a/packages/cloud/shared/src/db/repositories/shared-agent-memories.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-agent-memories.test.ts
@@ -155,6 +155,7 @@ describe("SharedAgentMemoriesReader.searchByEmbedding", () => {
         scope,
         [0.25, 0.5, 0.25],
         7,
+        ROOM_A,
       );
       expect(result).toEqual(hits as never);
       expect(capturedWindow).toBe(SHARED_AGENT_MEMORY_SEARCH_WINDOW);
@@ -164,6 +165,8 @@ describe("SharedAgentMemoriesReader.searchByEmbedding", () => {
       expect(rendered.sql).toContain("embedding");
       expect(rendered.sql).toContain("cardinality");
       expect(rendered.params).toContain(3);
+      expect(rendered.sql).toContain("room_id");
+      expect(rendered.params).toContain(ROOM_A);
       const order = new PgDialect().sqlToQuery(capturedOuterOrder as SQL);
       expect(order.sql).toContain("distance");
       expect(order.sql).toContain("asc");
@@ -181,6 +184,9 @@ describe("SharedAgentMemoriesReader.searchByEmbedding", () => {
     );
     await expect(reader.searchByEmbedding(scope, new Array(5000).fill(0.1), 5)).rejects.toThrow(
       "finite vector",
+    );
+    await expect(reader.searchByEmbedding(scope, [1], 5, " ")).rejects.toThrow(
+      "roomId is required",
     );
   });
 });

--- a/packages/cloud/shared/src/db/repositories/shared-agent-memories.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-agent-memories.ts
@@ -273,19 +273,26 @@ export class SharedAgentMemoriesReader {
   }
 
   /**
-   * Exact cosine-distance search over the tenant's most recent embedded rows
-   * (bounded window; see module header). Only rows whose stored vector has the
-   * query's dimensionality participate, so mixed-model histories cannot fail
-   * the whole query.
+   * Exact cosine-distance search over the tenant's most recent embedded rows,
+   * optionally narrowed to one server-resolved room. Only rows whose stored
+   * vector has the query's dimensionality participate, so mixed-model
+   * histories cannot fail the whole query.
    */
   async searchByEmbedding(
     scope: SharedAgentMemoryScope,
     embedding: number[],
     limit: number,
+    roomId?: string,
   ): Promise<SharedAgentMemorySearchHit[]> {
     requiredScope(scope);
     assertLimit(limit);
     assertEmbedding(embedding);
+    if (roomId !== undefined && roomId.trim().length === 0) {
+      throw new ElizaError("Shared agent memory roomId is required", {
+        code: SHARED_AGENT_MEMORY_INVALID_INPUT,
+        context: { field: "roomId" },
+      });
+    }
     const distance = sql<number>`(${sharedAgentMemories.embedding}::vector <=> ${vectorParam(
       embedding,
     )})`.as("distance");
@@ -309,6 +316,7 @@ export class SharedAgentMemoriesReader {
       .where(
         and(
           ...tenantPins(scope),
+          ...(roomId !== undefined ? [eq(sharedAgentMemories.room_id, roomId)] : []),
           isNotNull(sharedAgentMemories.embedding),
           sql`cardinality(${sharedAgentMemories.embedding}) = ${embedding.length}`,
         ),

--- a/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
+++ b/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
@@ -1,4 +1,5 @@
 // Defines the shared runtime history Drizzle table shape used by cloud repositories and services.
+import type { ChannelType } from "@elizaos/core/edge";
 import { jsonb, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core";
 
 /** One persisted turn in a shared-runtime conversation. Mirrors `SharedTurnMessage`. */
@@ -7,6 +8,9 @@ export type SharedRuntimeHistoryMessage = {
   id?: string;
   role: "system" | "user" | "assistant";
   content: string;
+  /** Original transport provenance; absent only on legacy rows. */
+  source?: string;
+  channelType?: ChannelType;
   /** Epoch-ms timestamp; used to order turns merged from concurrent writers. */
   createdAt?: number;
   /** True when an assistant message is a partial interrupted response. */

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -119,6 +119,7 @@ import {
 import { purgeSharedConversationRooms } from "./shared-runtime/conversation-coordinator";
 import { isDedicatedBootstrapWindow } from "./shared-runtime/dedicated-bootstrap";
 import {
+  appendSharedTurn,
   type RunSharedAgentTurnResult,
   resolveSharedAgentTurnModel,
   runSharedAgentTurn,
@@ -126,6 +127,7 @@ import {
   type SharedAgentCharacter,
   type SharedAgentTurnUsage,
   type SharedTurnMessage,
+  sharedTurnProvenance,
 } from "./shared-runtime/run-shared-agent-turn";
 import { applyPooledCredentialsToBootstrapEnv } from "./team-credential-pool/bootstrap-env";
 import {
@@ -4294,6 +4296,7 @@ export class ElizaSandboxService {
         character,
         history,
         message: text,
+        execution: { engine: "eliza-runtime", agentKey: rec.id, roomKey: channelId },
       });
       if (turn.degraded) {
         // A failed/degraded turn isn't persisted or billed — just refund the hold.
@@ -4452,10 +4455,16 @@ export class ElizaSandboxService {
     }
 
     try {
+      const execution = {
+        engine: "eliza-runtime" as const,
+        agentKey: rec.id,
+        roomKey: channelId,
+      };
       const turn = await runSharedAgentTurnStream({
         character,
         history,
         message: text,
+        execution,
       });
       if (turn.degraded) {
         await settleReservation(0);
@@ -4501,12 +4510,14 @@ export class ElizaSandboxService {
 
               finished = true;
               const finalReply = part.text.trim() || reply.trim() || "…";
-              const sentAt = Date.now();
-              const nextHistory: SharedTurnMessage[] = [
-                ...history,
-                { role: "user", content: text.trim(), createdAt: sentAt },
-                { role: "assistant", content: finalReply, createdAt: sentAt + 1 },
-              ];
+              const nextHistory = appendSharedTurn(
+                history,
+                text.trim(),
+                finalReply,
+                undefined,
+                "user",
+                sharedTurnProvenance({ execution }),
+              );
               await this.saveSharedRuntimeHistory(rec.id, channelId, nextHistory);
               if (billingContext) {
                 // The reply is final once the last token arrived and history

--- a/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
+++ b/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
@@ -2,6 +2,7 @@
  * Authorizes and executes managed Discord guild text and voice turns against
  * personal Shared Eliza while isolating public guild history from private transports.
  */
+import { ChannelType } from "@elizaos/core/edge";
 import { ElevenLabsService } from "./elevenlabs";
 import { elizaAppUserService } from "./eliza-app";
 import {
@@ -85,6 +86,7 @@ export async function runManagedDiscordGuildTextTurn(
     "platform",
     undefined,
     input.message,
+    { source: "discord", channelType: ChannelType.GROUP },
   );
   return {
     replyText: reply.text.trim(),
@@ -193,6 +195,7 @@ export async function runManagedDiscordGuildVoiceTurn(
     "platform",
     undefined,
     transcript,
+    { source: "discord", channelType: ChannelType.VOICE_GROUP },
   );
   const replyText = reply.text.trim();
   if (!replyText) throw new Error("Shared Eliza returned no guild voice reply");

--- a/packages/cloud/shared/src/lib/services/personal-message-delivery.ts
+++ b/packages/cloud/shared/src/lib/services/personal-message-delivery.ts
@@ -2,6 +2,7 @@
  * Routes a normalized personal connector turn to the user's active Dedicated
  * runtime when present, otherwise to their rowless personal Shared runtime.
  */
+import { ChannelType } from "@elizaos/core/edge";
 import type { Organization } from "../../db/schemas/organizations";
 import type { User } from "../../db/schemas/users";
 import type { AppEnv, RuntimeDurableObjectNamespace } from "../../types/cloud-worker-env";
@@ -188,6 +189,8 @@ export async function deliverPersonalTextMessage(params: {
     params.messageId,
     "platform",
     undefined,
+    undefined,
+    { source: params.platform, channelType: ChannelType.DM },
   );
   return {
     success: true,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -112,6 +112,27 @@ describe("handleCanonicalScopedAgentStream", () => {
     expect(options.trustedMessageRole).toBeUndefined();
   });
 
+  test("does not trust channel provenance supplied in the ordinary request body", async () => {
+    await handleCanonicalScopedAgentStream({
+      ...BASE,
+      trustedChannel: { source: "voice", channelType: "VOICE_DM" },
+      body: {
+        text: "hello",
+        source: "discord",
+        channelType: "VOICE_GROUP",
+      },
+    });
+
+    const [, rpc, options] = coordinateSharedStream.mock.calls[0] as unknown as [
+      unknown,
+      { params: Record<string, unknown> },
+      Record<string, unknown>,
+    ];
+    expect(rpc.params).not.toHaveProperty("source");
+    expect(rpc.params).not.toHaveProperty("channelType");
+    expect(options.trustedChannel).toEqual({ source: "voice", channelType: "VOICE_DM" });
+  });
+
   test("passes an authenticated in-process role outside untrusted RPC params", async () => {
     await handleCanonicalScopedAgentStream({
       ...BASE,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -15,6 +15,7 @@ import { coordinateSharedStream } from "./conversation-coordinator";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import type { BridgeExecutionContext } from "./shared-runtime-chat";
 import { sharedTurnClientMessageId } from "./shared-turn-client-message-id";
+import type { TrustedSharedChannelEnvelope } from "./trusted-shared-channel";
 
 const CORS_METHODS = "POST, OPTIONS";
 const STREAM_HEADERS = {
@@ -38,6 +39,8 @@ export interface CanonicalScopedStreamRequest {
   agentKind?: "sandbox" | "personal";
   /** Set only by the authenticated in-process voice adapter for lifecycle turns. */
   trustedMessageRole?: "system";
+  /** Server-owned transport provenance; body fields cannot override it. */
+  trustedChannel?: TrustedSharedChannelEnvelope;
   namespace: RuntimeDurableObjectNamespace;
   executionCtx: BridgeExecutionContext;
   abortSignal?: AbortSignal;
@@ -103,7 +106,7 @@ export async function handleCanonicalScopedAgentStream(
       text,
       roomId: request.conversationId,
       ...(clientMessageId ? { clientMessageId } : {}),
-      ...(request.userId ? { userId: request.userId, source: "voice" } : {}),
+      ...(request.userId ? { userId: request.userId } : {}),
     },
   };
 
@@ -116,6 +119,7 @@ export async function handleCanonicalScopedAgentStream(
       executionCtx: request.executionCtx,
       agentKind: request.agentKind,
       trustedMessageRole: request.trustedMessageRole,
+      trustedChannel: request.trustedChannel,
     });
     timings.bridge = elapsedMs(bridgeStartedAt);
   } catch (error) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -151,6 +151,7 @@ describe("shared conversation coordinator", () => {
       agentKind: "personal",
       trustedMessageRole: "system",
       trustedUserUtterance: "email Bob now",
+      trustedChannel: { source: "voice", channelType: "VOICE_DM" },
     });
     await coordinateSharedLifecycleEvent(
       agent.id,
@@ -166,6 +167,7 @@ describe("shared conversation coordinator", () => {
         rpc,
         trustedMessageRole: "system",
         trustedUserUtterance: "email Bob now",
+        trustedChannel: { source: "voice", channelType: "VOICE_DM" },
       },
       {
         operation: "lifecycle",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -19,6 +19,7 @@ import type { SharedTurnMessage } from "./run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import type { BridgeExecutionContext } from "./shared-runtime-chat";
 import { SharedRuntimeCacheWarmingError, SharedTurnConflictError } from "./shared-runtime-errors";
+import type { TrustedSharedChannelEnvelope } from "./trusted-shared-channel";
 
 export interface SharedConversationCoordinatorOptions {
   namespace: RuntimeDurableObjectNamespace;
@@ -30,6 +31,8 @@ export interface SharedConversationCoordinatorOptions {
   trustedMessageRole?: "system";
   /** Authenticated raw utterance when RPC text also contains server-composed context. */
   trustedUserUtterance?: string;
+  /** Server-owned channel provenance, serialized outside the JSON-RPC request. */
+  trustedChannel?: TrustedSharedChannelEnvelope;
 }
 
 export interface SharedConversationHistoryCoordinatorOptions {
@@ -296,6 +299,7 @@ export async function coordinateSharedBridge(
         ...(options.trustedUserUtterance
           ? { trustedUserUtterance: options.trustedUserUtterance }
           : {}),
+        ...(options.trustedChannel ? { trustedChannel: options.trustedChannel } : {}),
       }),
     });
   await requireCoordinatorResponse(response, "conversation");
@@ -321,6 +325,7 @@ export async function coordinateSharedStream(
         ...(options.trustedUserUtterance
           ? { trustedUserUtterance: options.trustedUserUtterance }
           : {}),
+        ...(options.trustedChannel ? { trustedChannel: options.trustedChannel } : {}),
       }),
       ...(options.abortSignal ? { signal: options.abortSignal } : {}),
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.memory-commit.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.memory-commit.test.ts
@@ -98,7 +98,13 @@ describe("runSharedAgentTurn memory commit", () => {
         userMessage: "remember this",
         assistantReply: "landed reply",
         messageIds,
+        source: "shared-runtime",
+        channelType: "DM",
       },
+    ]);
+    expect(result.history.slice(-2)).toEqual([
+      expect.objectContaining({ source: "shared-runtime", channelType: "DM" }),
+      expect.objectContaining({ source: "shared-runtime", channelType: "DM" }),
     ]);
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -22,6 +22,9 @@
 
 import {
   type ActionResult,
+  ChannelType,
+  type ChannelType as ChannelTypeValue,
+  MESSAGE_SOURCE_CLIENT_CHAT,
   type MediaGenerationRequest,
   type MediaGenerationResponse,
   replaceNameTokens,
@@ -42,12 +45,18 @@ import {
   type SharedCapabilityWall,
 } from "./shared-capability-wall";
 import type { SharedMemoryStore } from "./shared-memory-store";
+import type { TrustedSharedChannelEnvelope } from "./trusted-shared-channel";
+import { LEGACY_SHARED_HISTORY_CHANNEL, SHARED_SYSTEM_CHANNEL } from "./trusted-shared-channel";
 
 export interface SharedTurnMessage {
   /** Stable message id used by SSE, REST history, and storage merge paths. */
   id?: string;
   role: "system" | "user" | "assistant";
   content: string;
+  /** Original transport source. Optional only for pre-provenance persisted rows. */
+  source?: string;
+  /** Original transport mode. Optional only for pre-provenance persisted rows. */
+  channelType?: ChannelTypeValue;
   /** Epoch-ms timestamp used by REST chat clients to reconcile persisted turns. */
   createdAt?: number;
   /**
@@ -101,30 +110,32 @@ export interface RunSharedAgentTurnInput {
    * Flag-gated durable mirror of the landed user/assistant pair into the
    * tenant-scoped `shared_agent_memories` table (P2 edge memory store).
    * Attached by the caller only while `SHARED_MEMORY_TABLES_ENABLED === "true"`;
-   * both the direct-model and eliza-runtime engines commit through it.
+   * the runtime engine commits through it.
    */
   memory?: SharedMemoryStore;
   /**
    * Pre-rendered semantic-recall block (P3, `buildSharedRecallContext`) the
    * caller computed from the tenant memory store when the recall flag is on
    * and the recent window missed. Appended verbatim to the system prompt on
-   * every engine path; absent means recall contributed nothing this turn.
+   * every runtime turn; absent means recall contributed nothing this turn.
    */
   recallContext?: string;
   /**
-   * Transition-only selector for the genuine Workerd AgentRuntime path. The
-   * direct model path remains the control until the runtime path has passed
-   * live model and connector proof.
+   * Selects the canonical Workerd AgentRuntime path and its stable identity.
    */
   execution?: {
     engine: "eliza-runtime";
     agentKey: string;
+    /** Server-resolved conversation identity used for runtime room/world isolation. */
+    roomKey?: string;
     /**
      * Server-only attestation that the hosting boundary resolved this turn to an
      * authenticated Personal Shared tenant/account. Transport payload fields
      * must never populate this grant.
      */
     authenticatedPersonalSharedUser?: true;
+    /** Server-owned transport provenance; RPC/body fields never populate it. */
+    trustedChannel?: TrustedSharedChannelEnvelope;
     todos?: {
       scope: { agentId: UUID; entityId: UUID };
       store: TodoStore;
@@ -314,13 +325,45 @@ export function appendSharedTurn(
   reply: string,
   messageIds?: RunSharedAgentTurnInput["messageIds"],
   messageRole: "system" | "user" = "user",
+  provenance: TrustedSharedChannelEnvelope = messageRole === "system"
+    ? SHARED_SYSTEM_CHANNEL
+    : LEGACY_SHARED_HISTORY_CHANNEL,
 ): SharedTurnMessage[] {
   const sentAt = Date.now();
   return [
     ...history,
-    { id: messageIds?.user, role: messageRole, content: userMessage, createdAt: sentAt },
-    { id: messageIds?.assistant, role: "assistant", content: reply, createdAt: sentAt + 1 },
+    {
+      id: messageIds?.user,
+      role: messageRole,
+      content: userMessage,
+      source: provenance.source,
+      channelType: provenance.channelType,
+      createdAt: sentAt,
+    },
+    {
+      id: messageIds?.assistant,
+      role: "assistant",
+      content: reply,
+      source: provenance.source,
+      channelType: provenance.channelType,
+      createdAt: sentAt + 1,
+    },
   ];
+}
+
+/** Resolve the exact provenance stored for the newly landed turn pair. */
+export function sharedTurnProvenance(
+  input: Pick<RunSharedAgentTurnInput, "execution" | "messageRole">,
+): TrustedSharedChannelEnvelope {
+  if (input.messageRole === "system") return SHARED_SYSTEM_CHANNEL;
+  if (input.execution?.trustedChannel) return input.execution.trustedChannel;
+  return {
+    source:
+      input.execution?.authenticatedPersonalSharedUser === true
+        ? MESSAGE_SOURCE_CLIENT_CHAT
+        : "shared-runtime",
+    channelType: ChannelType.DM,
+  };
 }
 
 /**
@@ -343,11 +386,14 @@ async function commitSharedTurnMemory(
 ): Promise<void> {
   const memory = input.memory;
   if (!memory) return;
+  const provenance = sharedTurnProvenance(input);
   await memory.recordTurnPair({
     userMessage: input.message.trim(),
     assistantReply: reply,
     ...(input.messageIds ? { messageIds: input.messageIds } : {}),
     ...(input.messageRole ? { messageRole: input.messageRole } : {}),
+    source: provenance.source,
+    channelType: provenance.channelType,
   });
 }
 
@@ -391,6 +437,7 @@ function withBlockedSecondaryCapabilities(
       reply,
       input.messageIds,
       input.messageRole,
+      sharedTurnProvenance(input),
     ),
     blockedSecondaryCapabilities: blocked,
   };
@@ -448,6 +495,7 @@ export async function runSharedAgentTurn(
         capabilityWall.reply,
         input.messageIds,
         input.messageRole,
+        sharedTurnProvenance(input),
       ),
       model: "capability-wall",
       degraded: false,
@@ -461,7 +509,14 @@ export async function runSharedAgentTurn(
     const reply = `${input.character.name} is temporarily unavailable (no shared model configured).`;
     return {
       reply,
-      history: appendSharedTurn(input.history, message, reply, input.messageIds, input.messageRole),
+      history: appendSharedTurn(
+        input.history,
+        message,
+        reply,
+        input.messageIds,
+        input.messageRole,
+        sharedTurnProvenance(input),
+      ),
       model: "none",
       degraded: true,
     };
@@ -530,6 +585,7 @@ export async function runSharedAgentTurn(
           reply,
           input.messageIds,
           input.messageRole,
+          sharedTurnProvenance(input),
         ),
         model: modelId,
         degraded: false,
@@ -590,7 +646,14 @@ export async function runSharedAgentTurnStream(
       model: "capability-wall",
       degraded: false,
       reply,
-      history: appendSharedTurn(input.history, message, reply, input.messageIds, input.messageRole),
+      history: appendSharedTurn(
+        input.history,
+        message,
+        reply,
+        input.messageIds,
+        input.messageRole,
+        sharedTurnProvenance(input),
+      ),
       parts,
       capabilityWall,
     };
@@ -602,7 +665,14 @@ export async function runSharedAgentTurnStream(
     const reply = `${input.character.name} is temporarily unavailable (no shared model configured).`;
     return {
       reply,
-      history: appendSharedTurn(input.history, message, reply, input.messageIds, input.messageRole),
+      history: appendSharedTurn(
+        input.history,
+        message,
+        reply,
+        input.messageIds,
+        input.messageRole,
+        sharedTurnProvenance(input),
+      ),
       model: "none",
       degraded: true,
     };

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -4,10 +4,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { AgentRuntime } from "@elizaos/core/edge";
+import { AgentRuntime, ChannelType, InMemoryDatabaseAdapter } from "@elizaos/core/edge";
 import { NotificationService } from "@elizaos/core/services/notification";
 import type { ScheduledTask, ScheduledTaskRunner } from "@elizaos/plugin-scheduling/edge";
 import type { CreateTodoInput, TodoMutationRecord, TodoStore } from "@elizaos/plugin-todos/edge";
+import { sharedRuntimeConversationRoomId } from "./shared-runtime-storage-identity";
 
 const scheduledInputs: Array<Record<string, unknown>> = [];
 type StoredTodo = Awaited<ReturnType<TodoStore["create"]>>;
@@ -383,6 +384,8 @@ describe("Shared Eliza Workerd runtime", () => {
   });
 
   test("runs HANDLE_RESPONSE through AgentRuntime and preserves native usage", async () => {
+    const connectionSpy = spyOn(AgentRuntime.prototype, "ensureConnection");
+    const historySpy = spyOn(InMemoryDatabaseAdapter.prototype, "createMemories");
     const requests: Array<Record<string, unknown>> = [];
     globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
       requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
@@ -441,7 +444,27 @@ describe("Shared Eliza Workerd runtime", () => {
         system: "You are Eliza.",
         model: "gemma-4-31b",
       },
-      history: [],
+      history: [
+        {
+          id: "telegram-user",
+          role: "user",
+          content: "telegram text",
+          source: "telegram",
+          channelType: ChannelType.DM,
+        },
+        {
+          id: "telegram-assistant",
+          role: "assistant",
+          content: "telegram reply",
+          source: "telegram",
+          channelType: ChannelType.DM,
+        },
+        {
+          id: "legacy-user",
+          role: "user",
+          content: "legacy text without provenance",
+        },
+      ],
       message: "say hello",
       messageIds: {
         user: "c92f5aaa-59ce-40a6-994b-e9e16dc85198",
@@ -453,6 +476,11 @@ describe("Shared Eliza Workerd runtime", () => {
       execution: {
         engine: "eliza-runtime",
         agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
+        roomKey: "discord:guild-1:channel-7",
+        trustedChannel: {
+          source: "discord",
+          channelType: ChannelType.VOICE_GROUP,
+        },
       },
     });
 
@@ -467,10 +495,52 @@ describe("Shared Eliza Workerd runtime", () => {
       outputTokens: 17,
     });
     expect(result.history.map((message) => message.content)).toEqual([
+      "telegram text",
+      "telegram reply",
+      "legacy text without provenance",
       "say hello",
       "hello from the genuine Shared runtime",
     ]);
+    expect(result.history.slice(-2)).toEqual([
+      expect.objectContaining({ source: "discord", channelType: ChannelType.VOICE_GROUP }),
+      expect.objectContaining({ source: "discord", channelType: ChannelType.VOICE_GROUP }),
+    ]);
+    const projectedHistory = historySpy.mock.calls
+      .flatMap(([entries]) => entries)
+      .filter(
+        (entry) =>
+          entry.tableName === "messages" &&
+          ["telegram text", "telegram reply", "legacy text without provenance"].includes(
+            entry.memory.content.text ?? "",
+          ),
+      );
+    expect(projectedHistory.map((entry) => entry.memory.content)).toEqual([
+      expect.objectContaining({
+        text: "telegram text",
+        source: "telegram",
+        channelType: ChannelType.DM,
+      }),
+      expect.objectContaining({
+        text: "telegram reply",
+        source: "telegram",
+        channelType: ChannelType.DM,
+      }),
+      expect.objectContaining({
+        text: "legacy text without provenance",
+        source: "shared-runtime-history",
+        channelType: ChannelType.DM,
+      }),
+    ]);
     expect(dispatches).toBe(1);
+    expect(connectionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: sharedRuntimeConversationRoomId("discord:guild-1:channel-7"),
+        source: "discord",
+        type: ChannelType.VOICE_GROUP,
+      }),
+    );
+    connectionSpy.mockRestore();
+    historySpy.mockRestore();
     expect(requests).toHaveLength(1);
     expect(
       (requests[0].tools as Array<{ function?: { name?: string } }>).some(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -57,11 +57,16 @@ import type {
   SharedMediaGenerationPort,
   SharedTurnMessage,
 } from "./run-shared-agent-turn";
-import { appendSharedTurn } from "./run-shared-agent-turn";
+import { appendSharedTurn, sharedTurnProvenance } from "./run-shared-agent-turn";
 import {
   sharedRuntimeConversationRoomId,
   sharedRuntimeWorldId,
 } from "./shared-runtime-storage-identity";
+import {
+  LEGACY_SHARED_HISTORY_CHANNEL,
+  parseTrustedSharedChannelEnvelope,
+  SHARED_SYSTEM_CHANNEL,
+} from "./trusted-shared-channel";
 
 type NativeTextModelResult = string & {
   text: string;
@@ -375,6 +380,15 @@ function runtimeMemoryId(message: SharedTurnMessage, index: number) {
   );
 }
 
+function persistedMessageChannel(message: SharedTurnMessage) {
+  const persisted = parseTrustedSharedChannelEnvelope({
+    source: message.source,
+    channelType: message.channelType,
+  });
+  if (persisted) return persisted;
+  return message.role === "system" ? SHARED_SYSTEM_CHANNEL : LEGACY_SHARED_HISTORY_CHANNEL;
+}
+
 function projectedHistoryTimestamps(history: SharedTurnMessage[]): number[] {
   const anchors: Array<{ index: number; timestamp: number }> = [];
   for (const [index, message] of history.entries()) {
@@ -624,15 +638,22 @@ async function executeSharedElizaRuntimeTurn(
         throw new Error("Eliza Shared runtime initialized without its GENERATE_MEDIA action");
       }
     }
-    const roomId = sharedRuntimeConversationRoomId(input.agentKey);
+    const roomKey = input.execution?.roomKey ?? input.agentKey;
+    const roomId = sharedRuntimeConversationRoomId(roomKey);
+    const channel = !actionsEnabled
+      ? { source: "shared-runtime-system", channelType: ChannelType.DM }
+      : (input.execution?.trustedChannel ?? {
+          source: authenticatedPersonalSharedUser ? MESSAGE_SOURCE_CLIENT_CHAT : "shared-runtime",
+          channelType: ChannelType.DM,
+        });
     const connectionStartedAt = performance.now();
     await runtime.ensureConnection({
       entityId: incomingEntityId,
       roomId,
-      worldId: sharedRuntimeWorldId(input.agentKey),
+      worldId: sharedRuntimeWorldId(roomKey),
       userName: actionsEnabled ? "Shared user" : "Shared lifecycle",
-      source: actionsEnabled ? "shared-runtime" : "shared-runtime-system",
-      type: ChannelType.DM,
+      source: channel.source,
+      type: channel.channelType,
       ...(authenticatedPersonalSharedUser
         ? {
             metadata: {
@@ -649,6 +670,7 @@ async function executeSharedElizaRuntimeTurn(
       await adapter.createMemories(
         input.history.map((message, index) => {
           const createdAt = historyTimestamps[index];
+          const historyChannel = persistedMessageChannel(message);
           const memory = createMessageMemory({
             id: runtimeMemoryId(message, index),
             entityId:
@@ -661,8 +683,8 @@ async function executeSharedElizaRuntimeTurn(
             roomId,
             content: {
               text: message.content,
-              source: message.role === "system" ? "shared-runtime-system" : "shared-runtime",
-              channelType: ChannelType.DM,
+              source: historyChannel.source,
+              channelType: historyChannel.channelType,
             },
           });
           memory.createdAt = createdAt;
@@ -693,15 +715,10 @@ async function executeSharedElizaRuntimeTurn(
         roomId,
         content: {
           text: input.message.trim(),
-          // Only the server-owned execution attestation may translate a Shared
-          // turn to authenticated client-chat provenance. Connector payloads and
-          // direct runtime callers remain on the fail-closed Shared source.
-          source: !actionsEnabled
-            ? "shared-runtime-system"
-            : authenticatedPersonalSharedUser
-              ? MESSAGE_SOURCE_CLIENT_CHAT
-              : "shared-runtime",
-          channelType: ChannelType.DM,
+          // Only the server-owned execution envelope may set transport
+          // provenance. Direct callers retain the fail-closed Shared DM.
+          source: channel.source,
+          channelType: channel.channelType,
           ...(input.originClientMessageId
             ? {
                 chatIdempotency: {
@@ -775,6 +792,7 @@ async function executeSharedElizaRuntimeTurn(
         reply,
         input.messageIds,
         input.messageRole,
+        sharedTurnProvenance(input),
       ),
       model: input.model,
       degraded: false,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.test.ts
@@ -10,6 +10,7 @@ import { stringToUuid } from "@elizaos/core/edge";
 import type {
   InsertSharedAgentMemoryInput,
   MergeSharedAgentMessageMemoryInput,
+  SharedAgentMemoriesReader,
   SharedAgentMemoriesWriter,
 } from "../../../db/repositories/shared-agent-memories";
 import {
@@ -26,6 +27,7 @@ import {
 const ORG = "5a5c62c4-51b6-4e94-8c4e-a41d62b85e2f";
 const USER = "9a3d9f2e-97ab-46be-a687-3a4f2f6bfa53";
 const AGENT_KEY = "agent-shared-42";
+const ROOM_KEY = "discord:guild-1:channel-7";
 
 function scriptedWriter(behavior?: { failOn?: number }): {
   writer: SharedAgentMemoriesWriter;
@@ -86,7 +88,13 @@ describe("SharedMemoryStore.recordTurnPair", () => {
     const { writer, inserts } = scriptedWriter();
     const storage = sharedTodoStorageScope({ sourceAgentId: AGENT_KEY, ownerId: USER });
     const store = new SharedMemoryStore(
-      { organizationId: ORG, userId: USER, agentKey: AGENT_KEY, storage },
+      {
+        organizationId: ORG,
+        userId: USER,
+        agentKey: AGENT_KEY,
+        roomKey: ROOM_KEY,
+        storage,
+      },
       writer,
     );
     const messageIds = {
@@ -109,8 +117,8 @@ describe("SharedMemoryStore.recordTurnPair", () => {
         userId: USER,
         agentId: storage.agentId,
       });
-      expect(row?.roomId).toBe(sharedRuntimeConversationRoomId(AGENT_KEY));
-      expect(row?.worldId).toBe(sharedRuntimeWorldId(AGENT_KEY));
+      expect(row?.roomId).toBe(sharedRuntimeConversationRoomId(ROOM_KEY));
+      expect(row?.worldId).toBe(sharedRuntimeWorldId(ROOM_KEY));
       expect(row?.type).toBe("messages");
     }
     expect(userRow?.id).toBe(messageIds.user);
@@ -129,6 +137,41 @@ describe("SharedMemoryStore.recordTurnPair", () => {
     });
     expect(userRow?.createdAt).toBeInstanceOf(Date);
     expect(assistantRow?.createdAt?.getTime()).toBe((userRow?.createdAt?.getTime() ?? 0) + 1);
+  });
+
+  test("pins semantic recall to the same conversation room as runtime writes", async () => {
+    const searches: unknown[][] = [];
+    const reader = {
+      searchByEmbedding: async (...args: unknown[]) => {
+        searches.push(args);
+        return [];
+      },
+    } as unknown as SharedAgentMemoriesReader;
+    const store = new SharedMemoryStore(
+      {
+        organizationId: ORG,
+        userId: USER,
+        agentKey: AGENT_KEY,
+        roomKey: ROOM_KEY,
+      },
+      scriptedWriter().writer,
+      reader,
+    );
+
+    await store.searchByEmbedding([1, 0, 0], 5);
+
+    expect(searches).toEqual([
+      [
+        {
+          organizationId: ORG,
+          userId: USER,
+          agentId: stringToUuid(AGENT_KEY),
+        },
+        [1, 0, 0],
+        5,
+        sharedRuntimeConversationRoomId(ROOM_KEY),
+      ],
+    ]);
   });
 
   test("derives deterministic fallback identities without a Todo storage scope", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.test.ts
@@ -97,6 +97,8 @@ describe("SharedMemoryStore.recordTurnPair", () => {
       userMessage: "remember the launch date",
       assistantReply: "noted — the launch is on Friday",
       messageIds,
+      source: "telegram",
+      channelType: "VOICE_DM",
     });
 
     expect(inserts).toHaveLength(2);
@@ -115,15 +117,15 @@ describe("SharedMemoryStore.recordTurnPair", () => {
     expect(userRow?.entityId).toBe(storage.entityId);
     expect(userRow?.content).toEqual({
       text: "remember the launch date",
-      source: "shared-runtime",
-      channelType: "DM",
+      source: "telegram",
+      channelType: "VOICE_DM",
     });
     expect(assistantRow?.id).toBe(messageIds.assistant);
     expect(assistantRow?.entityId).toBe(storage.agentId);
     expect(assistantRow?.content).toEqual({
       text: "noted — the launch is on Friday",
-      source: "shared-runtime",
-      channelType: "DM",
+      source: "telegram",
+      channelType: "VOICE_DM",
     });
     expect(userRow?.createdAt).toBeInstanceOf(Date);
     expect(assistantRow?.createdAt?.getTime()).toBe((userRow?.createdAt?.getTime() ?? 0) + 1);

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
@@ -9,7 +9,12 @@
  * never constructed and the turn path is byte-identical to before.
  */
 
-import { stringToUuid, validateUuid } from "@elizaos/core/edge";
+import {
+  ChannelType,
+  type ChannelType as ChannelTypeValue,
+  stringToUuid,
+  validateUuid,
+} from "@elizaos/core/edge";
 import {
   type SharedAgentMemoriesReader,
   type SharedAgentMemoriesWriter,
@@ -49,6 +54,9 @@ export interface SharedMemoryTurnPair {
   /** Transport-stable ids; reused as row ids so a claim replay cannot double-write. */
   messageIds?: { user: string; assistant: string };
   messageRole?: "system" | "user";
+  /** Exact server-authenticated transport provenance for both landed messages. */
+  source?: string;
+  channelType?: ChannelTypeValue;
   /** Mirrors the canonical history marker for a client-cancelled partial reply. */
   interrupted?: boolean;
 }
@@ -114,6 +122,8 @@ export class SharedMemoryStore {
       agentId,
     };
     const landedAt = Date.now();
+    const source = pair.source?.trim() || "shared-runtime";
+    const channelType = pair.channelType ?? ChannelType.DM;
     // One batched sidecar round-trip for both texts; an embedding failure
     // degrades to vector-less rows (recall coverage shrinks) but never loses
     // the memory write itself.
@@ -146,8 +156,8 @@ export class SharedMemoryStore {
       type: SHARED_MEMORY_TYPE,
       content: {
         text: pair.userMessage,
-        source: "shared-runtime",
-        channelType: "DM",
+        source,
+        channelType,
         ...(pair.messageRole === "system" ? { role: "system" } : {}),
       },
       ...embeddingFields(0),
@@ -165,8 +175,8 @@ export class SharedMemoryStore {
       type: SHARED_MEMORY_TYPE,
       content: {
         text: assistantReply,
-        source: "shared-runtime",
-        channelType: "DM",
+        source,
+        channelType,
       },
       createdAt: new Date(landedAt + 1),
     };

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
@@ -4,9 +4,9 @@
  * is mirrored into the tenant-scoped `shared_agent_memories` table with the
  * SAME storage identities the ephemeral Workerd runtime projects (agent/entity
  * uuids from the Todo storage scope when present, room/world derived from the
- * agent key) — so a later Dedicated cutover or retrieval pass reads rows that
- * line up with what the runtime actually saw. Off (the default), the store is
- * never constructed and the turn path is byte-identical to before.
+ * canonical conversation key) — so public/group recall cannot cross into a
+ * private room and a later Dedicated cutover reads the runtime's exact rows.
+ * Off (the default), the store is never constructed.
  */
 
 import {
@@ -44,6 +44,8 @@ export interface SharedMemoryStoreScope {
   userId: string;
   /** Logical Shared agent id (`agent.id`), the seed for storage identities. */
   agentKey: string;
+  /** Canonical conversation key used by AgentRuntime for room/world isolation. */
+  roomKey?: string;
   /** Storage uuids shared with the runtime's Todo scope, when Todos are wired. */
   storage?: SharedTodoStorageScope;
 }
@@ -86,15 +88,16 @@ export class SharedMemoryStore {
   ) {}
 
   /**
-   * Tenant-scoped vector search over this store's transcript rows (P3 recall's
-   * store leg). Scope pinning mirrors recordTurnPair exactly — the same
-   * organization/user/agent triple — so recall can never read across tenants.
+   * Tenant- and room-scoped vector search over this store's transcript rows.
+   * Scope pinning mirrors recordTurnPair exactly so recall cannot cross either
+   * a tenant boundary or a private/public conversation boundary.
    */
   async searchByEmbedding(
     embedding: number[],
     limit: number,
   ): Promise<SharedAgentMemorySearchHit[]> {
     const agentId = this.scope.storage?.agentId ?? stringToUuid(this.scope.agentKey);
+    const roomId = sharedRuntimeConversationRoomId(this.scope.roomKey ?? this.scope.agentKey);
     return this.reader.searchByEmbedding(
       {
         organizationId: this.scope.organizationId,
@@ -103,6 +106,7 @@ export class SharedMemoryStore {
       },
       embedding,
       limit,
+      roomId,
     );
   }
 
@@ -114,8 +118,9 @@ export class SharedMemoryStore {
   async recordTurnPair(pair: SharedMemoryTurnPair): Promise<void> {
     const agentId = this.scope.storage?.agentId ?? stringToUuid(this.scope.agentKey);
     const entityId = this.scope.storage?.entityId ?? stringToUuid(`${this.scope.agentKey}:owner`);
-    const roomId = sharedRuntimeConversationRoomId(this.scope.agentKey);
-    const worldId = sharedRuntimeWorldId(this.scope.agentKey);
+    const roomKey = this.scope.roomKey ?? this.scope.agentKey;
+    const roomId = sharedRuntimeConversationRoomId(roomKey);
+    const worldId = sharedRuntimeWorldId(roomKey);
     const scope = {
       organizationId: this.scope.organizationId,
       userId: this.scope.userId,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -24,6 +24,7 @@ import { coordinateSharedBridge, coordinateSharedHistory } from "./conversation-
 import type { SharedAgentCharacter } from "./run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import { type BridgeExecutionContext, sharedRuntimeChatService } from "./shared-runtime-chat";
+import type { TrustedSharedChannelEnvelope } from "./trusted-shared-channel";
 
 const BRIDGE_INSUFFICIENT_CREDITS_CODE = -32002;
 
@@ -541,6 +542,7 @@ export async function sharedRestMessageSend(
   funding: "organization-credits" | "platform" = "organization-credits",
   trustedDelivery?: SharedReminderDelivery,
   trustedUserUtterance?: string,
+  trustedChannel?: TrustedSharedChannelEnvelope,
 ): Promise<{ text: string; agentName: string }> {
   const rpc: BridgeRequest = {
     jsonrpc: "2.0",
@@ -562,6 +564,7 @@ export async function sharedRestMessageSend(
     namespace,
     ...(funding === "platform" ? { agentKind: "personal" as const } : {}),
     ...(trustedUserUtterance ? { trustedUserUtterance } : {}),
+    ...(trustedChannel ? { trustedChannel } : {}),
   });
   if (response.error) {
     // A credit-reserve rejection is a permanent add-credits condition, not a

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -160,6 +160,25 @@ mock.module("../../../db/repositories/characters", () => ({
 }));
 mock.module("./run-shared-agent-turn", () => ({
   resolveSharedAgentTurnModel: () => "openai/gpt-oss-120b",
+  sharedTurnProvenance: (input: {
+    execution?: {
+      authenticatedPersonalSharedUser?: boolean;
+      trustedChannel?: { source: string; channelType: string };
+    };
+    messageRole?: "system" | "user";
+  }) => {
+    if (input.messageRole === "system") {
+      return { source: "shared-runtime-system", channelType: "DM" };
+    }
+    if (input.execution?.trustedChannel) return input.execution.trustedChannel;
+    return {
+      source:
+        input.execution?.authenticatedPersonalSharedUser === true
+          ? "client_chat"
+          : "shared-runtime",
+      channelType: "DM",
+    };
+  },
   runSharedAgentTurn: async (input: {
     messageIds?: { user: string; assistant: string };
     messageRole?: "system" | "user";
@@ -228,6 +247,8 @@ type TestMemoryPair = {
   assistantReply: string;
   messageIds?: { user: string; assistant: string };
   messageRole?: "system" | "user";
+  source?: string;
+  channelType?: string;
   interrupted?: boolean;
 };
 const memoryPairs: TestMemoryPair[] = [];
@@ -346,12 +367,14 @@ type TestMessage = {
   id?: string;
   role: "user" | "assistant";
   content: string;
+  source?: string;
+  channelType?: string;
   createdAt?: number;
   interrupted?: boolean;
 };
 
-function harness() {
-  let history: TestMessage[] = [{ role: "assistant", content: "prior" }];
+function harness(initialHistory: TestMessage[] = [{ role: "assistant", content: "prior" }]) {
+  let history: TestMessage[] = initialHistory;
   const background: Promise<unknown>[] = [];
   const merge = (messages: TestMessage[]): TestMessage[] => {
     const byId = new Map<string, TestMessage>();
@@ -545,21 +568,27 @@ describe("SharedRuntimeChatService", () => {
     expect(h.history()).toHaveLength(3);
   });
 
-  test("passes the explicit AgentRuntime transition gate without changing identity", async () => {
+  test("always uses AgentRuntime and only accepts server-owned channel provenance", async () => {
     const service = new SharedRuntimeChatService();
     const h = harness();
     turn.actionResults = [expectedTodoActionResult];
+    const hostileRpc = {
+      ...rpc,
+      params: { ...rpc.params, source: "telegram", channelType: "DM" },
+    };
 
-    const response = await service.bridge(agent, rpc, {
+    const response = await service.bridge(agent, hostileRpc, {
       ...h,
       funding: "platform",
-      executionEngine: "eliza-runtime",
+      trustedChannel: { source: "discord", channelType: "GROUP" },
     });
 
     expect(lastTurnInput?.execution).toEqual({
       engine: "eliza-runtime",
       agentKey: agent.id,
+      roomKey: expect.any(String),
       authenticatedPersonalSharedUser: true,
+      trustedChannel: { source: "discord", channelType: "GROUP" },
       todos: expectedTodoExecution,
     });
     expect(sharedTodoStorageScope).toHaveBeenCalledWith({
@@ -588,12 +617,12 @@ describe("SharedRuntimeChatService", () => {
     await service.bridge(forgedAgent, forgedRpc, {
       ...harness(),
       funding: "platform",
-      executionEngine: "eliza-runtime",
     });
 
     expect(lastTurnInput?.execution).toEqual({
       engine: "eliza-runtime",
       agentKey: forgedAgent.id,
+      roomKey: expect.any(String),
       todos: expectedTodoExecution,
     });
   });
@@ -613,7 +642,6 @@ describe("SharedRuntimeChatService", () => {
     const response = await new SharedRuntimeChatService().stream(agent, rpc, {
       ...harness(),
       funding: "platform",
-      executionEngine: "eliza-runtime",
     });
 
     expect(response.status).toBe(200);
@@ -623,6 +651,7 @@ describe("SharedRuntimeChatService", () => {
     expect(lastStreamTurnInput?.execution).toEqual({
       engine: "eliza-runtime",
       agentKey: agent.id,
+      roomKey: expect.any(String),
       authenticatedPersonalSharedUser: true,
       todos: expectedTodoExecution,
     });
@@ -654,7 +683,6 @@ describe("SharedRuntimeChatService", () => {
     const response = await new SharedRuntimeChatService().stream(agent, rpc, {
       ...harness(),
       funding: "platform",
-      executionEngine: "eliza-runtime",
     });
 
     const body = await response.text();
@@ -686,11 +714,11 @@ describe("SharedRuntimeChatService", () => {
     await service.bridge(agent, trustedRpc, {
       ...harness(),
       funding: "platform",
-      executionEngine: "eliza-runtime",
     });
     expect(lastTurnInput?.execution).toEqual({
       engine: "eliza-runtime",
       agentKey: agent.id,
+      roomKey: expect.any(String),
       authenticatedPersonalSharedUser: true,
       todos: expectedTodoExecution,
       reminders: {
@@ -706,11 +734,11 @@ describe("SharedRuntimeChatService", () => {
     await service.bridge(agent, trustedRpc, {
       ...harness(),
       funding: "organization-credits",
-      executionEngine: "eliza-runtime",
     });
     expect(lastTurnInput?.execution).toEqual({
       engine: "eliza-runtime",
       agentKey: agent.id,
+      roomKey: expect.any(String),
       todos: expectedTodoExecution,
     });
 
@@ -734,7 +762,6 @@ describe("SharedRuntimeChatService", () => {
         {
           ...harness(),
           funding: "platform",
-          executionEngine: "eliza-runtime",
         },
       );
       expect(lastTurnInput?.execution).toMatchObject({
@@ -886,6 +913,44 @@ describe("SharedRuntimeChatService", () => {
     ]);
     await Promise.all(h.background);
     expect(settleCalls).toEqual([0.004]);
+  });
+
+  test("preserves Telegram text provenance when the next turn lands on Discord voice", async () => {
+    process.env.SHARED_MEMORY_TABLES_ENABLED = "true";
+    const h = harness([
+      {
+        id: "telegram-user",
+        role: "user",
+        content: "sent as Telegram text",
+        source: "telegram",
+        channelType: "DM",
+      },
+      {
+        id: "telegram-assistant",
+        role: "assistant",
+        content: "replied as Telegram text",
+        source: "telegram",
+        channelType: "DM",
+      },
+    ]);
+    const response = await new SharedRuntimeChatService().stream(agent, rpc, {
+      ...h,
+      trustedChannel: { source: "discord", channelType: "VOICE_GROUP" },
+    });
+
+    expect(response.status).toBe(200);
+    await response.text();
+    expect(h.history().slice(0, 2)).toEqual([
+      expect.objectContaining({ source: "telegram", channelType: "DM" }),
+      expect.objectContaining({ source: "telegram", channelType: "DM" }),
+    ]);
+    expect(h.history().slice(-2)).toEqual([
+      expect.objectContaining({ source: "discord", channelType: "VOICE_GROUP" }),
+      expect.objectContaining({ source: "discord", channelType: "VOICE_GROUP" }),
+    ]);
+    expect(memoryPairs).toEqual([
+      expect.objectContaining({ source: "discord", channelType: "VOICE_GROUP" }),
+    ]);
   });
 
   test("no-model degradation remains a complete canonical SSE turn", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -65,6 +65,7 @@ import {
   type SharedAgentTurnUsage,
   type SharedMediaGenerationPort,
   type SharedTurnMessage,
+  sharedTurnProvenance,
 } from "./run-shared-agent-turn";
 import { projectSharedAgentCharacter } from "./shared-agent-character";
 import { capabilityWallActionResult } from "./shared-capability-wall";
@@ -87,6 +88,7 @@ import {
   recordSharedTurnTrace,
   type SharedTurnSummaryResult,
 } from "./shared-turn-trace-recorder";
+import type { TrustedSharedChannelEnvelope } from "./trusted-shared-channel";
 
 export { MAX_HISTORY_MESSAGES } from "./shared-runtime-history-policy";
 export { sharedTurnClientMessageId } from "./shared-turn-client-message-id";
@@ -225,8 +227,8 @@ export interface SharedRuntimeChatOptions {
   trustedMessageRole?: "system";
   /** Server-authenticated raw utterance when the model message includes connector context. */
   trustedUserUtterance?: string;
-  /** Local/transition gate for proving the genuine Workerd AgentRuntime path. */
-  executionEngine?: "direct-model" | "eliza-runtime";
+  /** Server-owned transport provenance, never derived from bridge params. */
+  trustedChannel?: TrustedSharedChannelEnvelope;
   mobilePushDispatch?: NonNullable<
     NonNullable<RunSharedAgentTurnInput["execution"]>["mobilePush"]
   >["dispatch"];
@@ -399,6 +401,7 @@ function sharedElizaRuntimeExecution(
   funding: SharedRuntimeChatOptions["funding"],
   executionCtx: BridgeExecutionContext | undefined,
   mobilePushDispatch?: SharedRuntimeChatOptions["mobilePushDispatch"],
+  trustedChannel?: TrustedSharedChannelEnvelope,
 ): NonNullable<RunSharedAgentTurnInput["execution"]> {
   const personalShared = funding === "platform" && isCanonicalPersonalSharedAgent(agent);
   const reminderDelivery = personalShared ? trustedReminderDelivery(params) : undefined;
@@ -408,9 +411,11 @@ function sharedElizaRuntimeExecution(
   return {
     engine: "eliza-runtime",
     agentKey: agent.id,
+    roomKey: roomId,
     // Personal funding is selected by the server-owned coordinator only after
     // account/tenant resolution; RPC params cannot grant this attestation.
     ...(personalShared ? { authenticatedPersonalSharedUser: true as const } : {}),
+    ...(trustedChannel ? { trustedChannel } : {}),
     todos: {
       scope: sharedTodoStorageScope({
         sourceAgentId: agent.id,
@@ -1139,19 +1144,16 @@ export class SharedRuntimeChatService {
         ...(claimKey ? { originClientMessageId: claimKey } : {}),
         onProviderDispatch: billing?.markProviderDispatched,
         ...(memoryStore ? { memory: memoryStore } : {}),
-        ...(options.executionEngine === "eliza-runtime"
-          ? {
-              execution: sharedElizaRuntimeExecution(
-                agent,
-                roomId,
-                claimKey,
-                params,
-                options.funding,
-                options.executionCtx,
-                options.mobilePushDispatch,
-              ),
-            }
-          : {}),
+        execution: sharedElizaRuntimeExecution(
+          agent,
+          roomId,
+          claimKey,
+          params,
+          options.funding,
+          options.executionCtx,
+          options.mobilePushDispatch,
+          options.trustedChannel,
+        ),
       });
     } catch (error) {
       await settleFailedProviderWorkOffPath(
@@ -1329,6 +1331,17 @@ export class SharedRuntimeChatService {
     const streamRecallContext = await sharedTurnRecallContext(streamMemoryStore, text, history);
     const streamTurnStartedAtEpochMs = Date.now();
     const providerSetupStartedAt = performance.now();
+    const execution = sharedElizaRuntimeExecution(
+      agent,
+      roomId,
+      claimKey,
+      params,
+      options.funding,
+      options.executionCtx,
+      options.mobilePushDispatch,
+      options.trustedChannel,
+    );
+    const turnProvenance = sharedTurnProvenance({ messageRole, execution });
     try {
       turn = await runSharedAgentTurnStream({
         abortSignal: generationAbort.signal,
@@ -1341,19 +1354,7 @@ export class SharedRuntimeChatService {
         messageIds,
         ...(claimKey ? { originClientMessageId: claimKey } : {}),
         onProviderDispatch: billing?.markProviderDispatched,
-        ...(options.executionEngine === "eliza-runtime"
-          ? {
-              execution: sharedElizaRuntimeExecution(
-                agent,
-                roomId,
-                claimKey,
-                params,
-                options.funding,
-                options.executionCtx,
-                options.mobilePushDispatch,
-              ),
-            }
-          : {}),
+        execution,
       });
     } catch (error) {
       detachRequestAbort();
@@ -1410,7 +1411,14 @@ export class SharedRuntimeChatService {
     const makeTurnMessages = (reply: string, interrupted: boolean): SharedTurnMessage[] => {
       const sentAt = Date.now();
       const messages: SharedTurnMessage[] = [
-        { id: messageIds.user, role: messageRole, content: text, createdAt: sentAt },
+        {
+          id: messageIds.user,
+          role: messageRole,
+          content: text,
+          source: turnProvenance.source,
+          channelType: turnProvenance.channelType,
+          createdAt: sentAt,
+        },
       ];
       const assistantText = reply.trim();
       if (assistantText) {
@@ -1418,6 +1426,8 @@ export class SharedRuntimeChatService {
           id: messageIds.assistant,
           role: "assistant",
           content: assistantText,
+          source: turnProvenance.source,
+          channelType: turnProvenance.channelType,
           createdAt: sentAt + 1,
           interrupted,
         });
@@ -1458,6 +1468,8 @@ export class SharedRuntimeChatService {
             assistantReply: reply,
             messageIds,
             messageRole,
+            source: turnProvenance.source,
+            channelType: turnProvenance.channelType,
             interrupted,
           });
         }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -449,7 +449,7 @@ function sharedElizaRuntimeExecution(
  * uuids reuse the Todo scope so memory rows line up with the runtime's
  * projected identities.
  */
-function sharedTurnMemoryStore(agent: SharedRuntimeAgent) {
+function sharedTurnMemoryStore(agent: SharedRuntimeAgent, roomKey: string) {
   const embedBase = process.env.LOCAL_EMBEDDINGS_BASE_URL;
   const embed =
     sharedRecallEnabled() && embedBase
@@ -464,6 +464,7 @@ function sharedTurnMemoryStore(agent: SharedRuntimeAgent) {
       organizationId: agent.organization_id,
       userId: agent.user_id,
       agentKey: agent.id,
+      roomKey,
       storage: sharedTodoStorageScope({
         sourceAgentId: agent.id,
         ownerId: agent.user_id,
@@ -1128,7 +1129,7 @@ export class SharedRuntimeChatService {
     }
 
     const messageIds = turnMessageIds(agent.id, roomId, claimKey);
-    const memoryStore = sharedTurnMemoryStore(agent);
+    const memoryStore = sharedTurnMemoryStore(agent, roomId);
     const recallContext = await sharedTurnRecallContext(memoryStore, text, history);
     const turnStartedAtEpochMs = Date.now();
     let turn: RunSharedAgentTurnResult;
@@ -1327,7 +1328,7 @@ export class SharedRuntimeChatService {
     const detachRequestAbort = () =>
       options.abortSignal?.removeEventListener("abort", abortFromRequest);
     let turn: Awaited<ReturnType<typeof runSharedAgentTurnStream>>;
-    const streamMemoryStore = sharedTurnMemoryStore(agent);
+    const streamMemoryStore = sharedTurnMemoryStore(agent, roomId);
     const streamRecallContext = await sharedTurnRecallContext(streamMemoryStore, text, history);
     const streamTurnStartedAtEpochMs = Date.now();
     const providerSetupStartedAt = performance.now();

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
@@ -50,6 +50,8 @@ export interface SharedRuntimeHistoryMessageLike {
   id?: string;
   role: "system" | "user" | "assistant";
   content: string;
+  source?: string;
+  channelType?: string;
   createdAt?: number;
   interrupted?: boolean;
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/trusted-shared-channel.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/trusted-shared-channel.test.ts
@@ -1,0 +1,28 @@
+/** Validates the narrow server-owned channel envelope accepted across the DO boundary. */
+
+import { describe, expect, test } from "bun:test";
+import { ChannelType } from "@elizaos/core/edge";
+import { parseTrustedSharedChannelEnvelope } from "./trusted-shared-channel";
+
+describe("trusted Shared channel envelope", () => {
+  test("accepts messaging and voice room semantics", () => {
+    expect(
+      parseTrustedSharedChannelEnvelope({ source: "discord", channelType: ChannelType.GROUP }),
+    ).toEqual({ source: "discord", channelType: ChannelType.GROUP });
+    expect(
+      parseTrustedSharedChannelEnvelope({ source: "voice", channelType: ChannelType.VOICE_DM }),
+    ).toEqual({ source: "voice", channelType: ChannelType.VOICE_DM });
+  });
+
+  test("rejects unsupported, empty, and structurally forged envelopes", () => {
+    expect(parseTrustedSharedChannelEnvelope({ source: "discord", channelType: "API" })).toBe(
+      undefined,
+    );
+    expect(parseTrustedSharedChannelEnvelope({ source: " ", channelType: ChannelType.DM })).toBe(
+      undefined,
+    );
+    expect(
+      parseTrustedSharedChannelEnvelope({ source: { value: "voice" }, channelType: "DM" }),
+    ).toBe(undefined);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/trusted-shared-channel.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/trusted-shared-channel.ts
@@ -1,0 +1,54 @@
+/**
+ * Defines and validates the server-owned transport provenance carried into a
+ * Shared AgentRuntime turn. Request bodies and JSON-RPC params are never read
+ * as channel authority.
+ */
+
+import { ChannelType, type ChannelType as ChannelTypeValue } from "@elizaos/core/edge";
+
+const SHARED_CHANNEL_TYPES = new Set<ChannelTypeValue>([
+  ChannelType.DM,
+  ChannelType.GROUP,
+  ChannelType.VOICE_DM,
+  ChannelType.VOICE_GROUP,
+]);
+
+export interface TrustedSharedChannelEnvelope {
+  source: string;
+  channelType: ChannelTypeValue;
+}
+
+/**
+ * Neutral provenance for history written before per-message channel metadata
+ * existed. Never substitute the current request channel: doing so would turn a
+ * Telegram or text turn into Discord or voice merely because it was replayed
+ * there later.
+ */
+export const LEGACY_SHARED_HISTORY_CHANNEL: TrustedSharedChannelEnvelope = {
+  source: "shared-runtime-history",
+  channelType: ChannelType.DM,
+};
+
+export const SHARED_SYSTEM_CHANNEL: TrustedSharedChannelEnvelope = {
+  source: "shared-runtime-system",
+  channelType: ChannelType.DM,
+};
+
+/** Validate the envelope after it crosses the coordinator's JSON boundary. */
+export function parseTrustedSharedChannelEnvelope(
+  value: unknown,
+): TrustedSharedChannelEnvelope | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const source = (value as { source?: unknown }).source;
+  const channelType = (value as { channelType?: unknown }).channelType;
+  if (
+    typeof source !== "string" ||
+    !source.trim() ||
+    source.length > 80 ||
+    typeof channelType !== "string" ||
+    !SHARED_CHANNEL_TYPES.has(channelType as ChannelTypeValue)
+  ) {
+    return undefined;
+  }
+  return { source: source.trim(), channelType: channelType as ChannelTypeValue };
+}

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -525,8 +525,6 @@ export interface Bindings {
   INFERENCE_PASSTHROUGH_STREAMING?: string;
   RATE_LIMIT_DISABLED?: string;
   RATE_LIMIT_MULTIPLIER?: string;
-  /** Transition gate for the genuine AgentRuntime-backed Shared turn. */
-  SHARED_ELIZA_AGENT_RUNTIME?: string;
   PLAYWRIGHT_TEST_AUTH?: string;
   PLAYWRIGHT_TEST_AUTH_SECRET?: string;
   TWILIO_SMS_COST_PER_SEGMENT_USD?: string;

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -137,17 +137,13 @@ describe("canonical cloud deployment environment contract", () => {
     expect(deploy.with?.envs).toContain("TARGET_SHA");
     expect(deploy.with?.script).toContain("apps-worker-deployed-sha");
     expect(deploy.with?.script).toContain("skipping redundant queued build");
-    expect(deploy.with?.script).toContain(
-      'deployed_head" = "$TARGET_SHA"',
-    );
+    expect(deploy.with?.script).toContain('deployed_head" = "$TARGET_SHA"');
     expect(deploy.with?.script).toContain('origin "$TARGET_SHA"');
     expect(health.with?.envs).toContain("TARGET_SHA");
     expect(health.with?.script).toContain(
       "sudo tee /var/lib/eliza/apps-worker-deployed-sha",
     );
-    expect(health.with?.script).toContain(
-      'deployed_head" != "$TARGET_SHA"',
-    );
+    expect(health.with?.script).toContain('deployed_head" != "$TARGET_SHA"');
   });
 
   test("does not retain the retired Shared runtime transition gate", () => {

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -150,17 +150,8 @@ describe("canonical cloud deployment environment contract", () => {
     );
   });
 
-  test("runs genuine Shared Eliza in staging and production", () => {
-    const staging = cloudApiWranglerSource.slice(
-      cloudApiWranglerSource.indexOf("[env.staging.vars]"),
-      cloudApiWranglerSource.indexOf("[env.production.vars]"),
-    );
-    const production = cloudApiWranglerSource.slice(
-      cloudApiWranglerSource.indexOf("[env.production.vars]"),
-    );
-
-    expect(staging).toContain('SHARED_ELIZA_AGENT_RUNTIME = "true"');
-    expect(production).toContain('SHARED_ELIZA_AGENT_RUNTIME = "true"');
+  test("does not retain the retired Shared runtime transition gate", () => {
+    expect(cloudApiWranglerSource).not.toContain("SHARED_ELIZA_AGENT_RUNTIME");
   });
 
   test("enables Shared semantic memory only in the staging prove-out", () => {


### PR DESCRIPTION
## Scope

Implements the claimed runtime-only execution and trusted channel-envelope slice of #21794.

- makes `SharedRuntimeChatService` always execute turns through the canonical Workerd `AgentRuntime`
- makes the legacy shared sandbox bridge attach the same runtime execution descriptor instead of selecting the direct-model path
- removes the production `SHARED_ELIZA_AGENT_RUNTIME` downgrade at conversation dispatch and always prewarms the runtime module
- carries a server-owned, validated `{ source, channelType }` envelope outside request-body/JSON-RPC params
- binds web/REST/bridge to `client_chat` DM, in-process voice to voice DM, Discord guild text to group, Discord guild voice to voice group, and personal connectors to their server-resolved source
- carries the server-resolved room key into runtime room/world derivation, preserving public/private room isolation

This is deliberately a partial tracker slice. It does not claim cross-repository device convergence, production rollout, or real-channel proof, so it uses `Refs #21794` and leaves the issue open.

## Security and adversarial behavior

- request-body and JSON-RPC `source`, `channelType`, execution, and authentication fields cannot populate the trusted envelope
- the Durable Object validates the envelope after its JSON boundary and rejects unsupported/invalid channel types
- authenticated Personal Shared user role attestation remains a separate server-owned grant; channel provenance cannot grant it
- lifecycle system turns retain their action-free system source/DM semantics

## Exact-head evidence

<!-- evidence-head:b2cc870e3eeca55d414280530ce82e375581f519 -->

Rebased head: b2cc870e3eeca55d414280530ce82e375581f519

Rebase parent: 1daf0cb646c076d40ae38e430634a6e4b1023285

- trusted channel parser: PASS, 2 tests;
- room-scoped semantic memory: PASS, 6 tests;
- runtime memory commit: PASS, 6 tests;
- genuine Shared Eliza Workerd runtime: PASS, 17 tests;
- SharedRuntimeChat: PASS, 32 tests;
- changed-file Biome: PASS with one pre-existing shell-template warning in the deployment-contract test;
- complete PR-range diff check: PASS;
- Cloud Shared typecheck reached only unrelated missing optional dependency declarations in plugin-elizacloud/plugin-sql; no changed-file diagnostic was emitted;
- the standard core prerequisite built core successfully, then the wider 22-package build stopped because tsup is absent for plugin-web-search. Neither dependency-install limitation is represented as a green repository gate.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend runtime/channel contract with no rendered UI diff.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend runtime/channel contract with no rendered UI diff.
<!-- evidence-row:walkthrough-video -->
- [ ] Pending - exact-head deployed Shared web/voice/Discord or personal-connector walkthrough.
<!-- evidence-row:backend-logs -->
- [ ] Pending - exact-head deployed Durable Object/model/channel/billing/memory logs.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed; transport proof belongs in backend/channel logs.
<!-- evidence-row:llm-trajectory -->
- [ ] Pending - exact-head configured real-model turn and inspected trajectory.
<!-- evidence-row:domain-artifacts -->
- [ ] Pending - exact-head room-isolated memory rows and billing receipts from the deployed path.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Evidence still required before merge

- real configured model turn through the deployed Shared Durable Object at this exact head
- authenticated web/voice/Discord or connector traces proving source, `ChannelType`, room isolation, reply delivery, billing, and memory behavior
- independent second-wave review completed on exact head; see https://github.com/elizaOS/eliza/pull/21824#issuecomment-5324634501

Refs #21794

---
OpenAI / gpt-5.6-sol; Codex Desktop / multi-agent; skill revision `b2cc870e3eeca55d414280530ce82e375581f519`