### PR TITLE
test(cloud): remove stale provider receipt normalizer use

### DIFF
--- a/packages/cloud/test-mocks/test/provider-contract/action-boundary-adversarial.test.ts
+++ b/packages/cloud/test-mocks/test/provider-contract/action-boundary-adversarial.test.ts
@@ -1,10 +1,7 @@
 /** Attacks receipt fabrication, replay, tenant isolation, and denial at the real fake-upstream boundary. */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import {
-  normalizeCapabilityActionReceipt,
-  normalizeEffectReceipt,
-} from "@elizaos/core";
+import { normalizeEffectReceipt } from "@elizaos/core";
 import {
   type RunningFakeProvider,
   startFakeProvider,
@@ -171,19 +168,6 @@ describe("provider action authorization/effect boundary", () => {
     expect(receipt && normalizeEffectReceipt(receipt.effect)).toEqual(
       receipt?.effect,
     );
-    expect(
-      receipt &&
-        normalizeCapabilityActionReceipt({
-          accountId: receipt.accountId,
-          capabilityId: receipt.capabilityId,
-          policyDecisionId: receipt.policyDecisionId,
-          effect: receipt.effect,
-        }),
-    ).toMatchObject({
-      accountId: "acct-owner",
-      capabilityId: "items.write",
-      effect: { outcome: "applied" },
-    });
     expect(provider.effects).toHaveLength(1);
     expect(response.headers.get("x-provider-receipt-id")).toBe(receipt?.id);
     if (receipt) receipt.outcome = "denied";


### PR DESCRIPTION
Closes #21829.

## Summary

- remove the stale cloud test import of the provider receipt normalizer deleted by #21696
- remove the obsolete projection assertion while preserving the stronger provider-owned receipt, policy, idempotency, and effect checks

## Validation

- `bun test packages/cloud/test-mocks/test/provider-contract/action-boundary-adversarial.test.ts` — 5/5 pass, 30 assertions
- `bunx @biomejs/biome check packages/cloud/test-mocks/test/provider-contract/action-boundary-adversarial.test.ts` — pass
- repository-wide removed-symbol search — no remaining consumers
- `git diff --check origin/develop...HEAD` — pass

## Evidence Gate

<!-- evidence-head:5cc5fcbcbef3af432fdd0a569bf3131c58663caf -->

- Before/after screenshots: N/A — deterministic backend test cleanup only.
- Walkthrough video: N/A — no runtime or UI behavior changes.
- Backend/frontend logs: N/A — no production path changes.
- LLM trajectory: N/A — no model, planner, provider adapter, or action behavior changes.
- Domain artifact: the exact-head adversarial provider-boundary suite passes 5/5 while retaining its canonical effect-receipt validation.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f260c4b4798fae2ad465905a6885b9e7252ce09d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@f260c4b4798fae2ad465905a6885b9e7252ce09d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pr-wave-lalalune]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@f260c4b4798fae2ad465905a6885b9e7252ce09d:packages/skills/skills/contribute-to-eliza"} -->
