### PR TITLE
fix(previews): keep truncation diagnostics bounded and truthful

### DIFF
--- a/plugins/plugin-calendar/src/internal/format.ts
+++ b/plugins/plugin-calendar/src/internal/format.ts
@@ -9,6 +9,20 @@ import type {
   LifeOpsNextCalendarEventContext,
 } from "@elizaos/shared";
 
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+function sliceGraphemePrefix(value: string, maxCodeUnits: number): string {
+  let end = 0;
+  for (const segment of graphemeSegmenter.segment(value)) {
+    const nextEnd = segment.index + segment.segment.length;
+    if (nextEnd > maxCodeUnits) break;
+    end = nextEnd;
+  }
+  return value.slice(0, end);
+}
+
 function truncateForPreview(value: string, maxLength: number): string {
   const limit = Number.isFinite(maxLength)
     ? Math.max(0, Math.floor(maxLength))
@@ -18,7 +32,7 @@ function truncateForPreview(value: string, maxLength: number): string {
   }
   if (limit === 0) return "";
   if (limit === 1) return "…";
-  return `${value.slice(0, limit - 1).trimEnd()}…`;
+  return `${sliceGraphemePrefix(value, limit - 1).trimEnd()}…`;
 }
 
 function formatCalendarDatePart(

--- a/plugins/plugin-calendar/src/internal/format.ts
+++ b/plugins/plugin-calendar/src/internal/format.ts
@@ -10,10 +10,15 @@ import type {
 } from "@elizaos/shared";
 
 function truncateForPreview(value: string, maxLength: number): string {
-  if (value.length <= maxLength) {
+  const limit = Number.isFinite(maxLength)
+    ? Math.max(0, Math.floor(maxLength))
+    : 0;
+  if (value.length <= limit) {
     return value;
   }
-  return `${value.slice(0, maxLength).trimEnd()}…`;
+  if (limit === 0) return "";
+  if (limit === 1) return "…";
+  return `${value.slice(0, limit - 1).trimEnd()}…`;
 }
 
 function formatCalendarDatePart(

--- a/plugins/plugin-calendar/src/internal/truncate-suffix-reserve.test.ts
+++ b/plugins/plugin-calendar/src/internal/truncate-suffix-reserve.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Exercises calendar preview truncation through the exported next-event
+ * formatter so the configured 60-character contract includes its ellipsis.
+ */
+import type { LifeOpsNextCalendarEventContext } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import { formatNextEventContext } from "./format.ts";
+
+describe("calendar preview truncation", () => {
+  it("keeps the linked-mail snippet and marker within 60 characters", () => {
+    const now = new Date("2026-08-18T12:00:00.000Z");
+    const context: LifeOpsNextCalendarEventContext = {
+      event: {
+        id: "event-1",
+        externalId: "external-1",
+        agentId: "agent-1",
+        provider: "google",
+        side: "personal",
+        calendarId: "calendar-1",
+        title: "Review",
+        description: "",
+        location: "",
+        status: "confirmed",
+        startAt: now.toISOString(),
+        endAt: new Date(now.getTime() + 3_600_000).toISOString(),
+        isAllDay: false,
+        timezone: "UTC",
+        htmlLink: null,
+        conferenceLink: null,
+        organizer: null,
+        attendees: [],
+        metadata: {},
+        syncedAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      },
+      calendarFeedState: "complete",
+      calendarSources: [],
+      startsAt: now.toISOString(),
+      startsInMinutes: 60,
+      attendeeCount: 0,
+      attendeeNames: [],
+      location: null,
+      conferenceLink: null,
+      preparationChecklist: [],
+      linkedMailState: "cache",
+      linkedMailError: null,
+      linkedMail: [
+        {
+          id: "mail-1",
+          subject: "Agenda",
+          from: "sender",
+          receivedAt: now.toISOString(),
+          snippet: "a".repeat(200),
+          htmlLink: null,
+        },
+      ],
+    };
+
+    const relatedLine = formatNextEventContext(context)
+      .split("\n")
+      .find((line) => line.startsWith('- "Agenda"'));
+    const snippet = relatedLine?.match(/\(([^()]*)\)$/)?.[1];
+
+    expect(snippet).toBe(`${"a".repeat(59)}…`);
+    expect(snippet).toHaveLength(60);
+  });
+});

--- a/plugins/plugin-calendar/src/internal/truncate-suffix-reserve.test.ts
+++ b/plugins/plugin-calendar/src/internal/truncate-suffix-reserve.test.ts
@@ -64,4 +64,77 @@ describe("calendar preview truncation", () => {
     expect(snippet).toBe(`${"a".repeat(59)}…`);
     expect(snippet).toHaveLength(60);
   });
+
+  it("does not split a surrogate pair at the preview boundary", () => {
+    const now = new Date("2026-08-18T12:00:00.000Z");
+    const context: LifeOpsNextCalendarEventContext = {
+      event: {
+        id: "event-1",
+        externalId: "external-1",
+        agentId: "agent-1",
+        provider: "google",
+        side: "personal",
+        calendarId: "calendar-1",
+        title: "Review",
+        description: "",
+        location: "",
+        status: "confirmed",
+        startAt: now.toISOString(),
+        endAt: new Date(now.getTime() + 3_600_000).toISOString(),
+        isAllDay: false,
+        timezone: "UTC",
+        htmlLink: null,
+        conferenceLink: null,
+        organizer: null,
+        attendees: [],
+        metadata: {},
+        syncedAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      },
+      calendarFeedState: "complete",
+      calendarSources: [],
+      startsAt: now.toISOString(),
+      startsInMinutes: 60,
+      attendeeCount: 0,
+      attendeeNames: [],
+      location: null,
+      conferenceLink: null,
+      preparationChecklist: [],
+      linkedMailState: "cache",
+      linkedMailError: null,
+      linkedMail: [
+        {
+          id: "mail-1",
+          subject: "Agenda",
+          from: "sender",
+          receivedAt: now.toISOString(),
+          snippet: `${"a".repeat(58)}🙂tail`,
+          htmlLink: null,
+        },
+      ],
+    };
+
+    const relatedLine = formatNextEventContext(context)
+      .split("\n")
+      .find((line) => line.startsWith('- "Agenda"'));
+    const snippet = relatedLine?.match(/\(([^()]*)\)$/)?.[1];
+
+    expect(snippet).toBe(`${"a".repeat(58)}…`);
+    expect(snippet?.isWellFormed()).toBe(true);
+    expect(snippet?.length).toBeLessThanOrEqual(60);
+
+    for (const grapheme of ["e\u0301", "👨‍👩‍👧‍👦"]) {
+      const mail = context.linkedMail[0];
+      if (!mail) throw new Error("expected linked-mail fixture");
+      mail.snippet = `${"a".repeat(58)}${grapheme}tail`;
+      const bounded = formatNextEventContext(context)
+        .split("\n")
+        .find((line) => line.startsWith('- "Agenda"'))
+        ?.match(/\(([^()]*)\)$/)?.[1];
+
+      expect(bounded).toBe(`${"a".repeat(58)}…`);
+      expect(bounded?.isWellFormed()).toBe(true);
+      expect(bounded?.length).toBeLessThanOrEqual(60);
+    }
+  });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/google/format-helpers.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/google/format-helpers.ts
@@ -27,10 +27,15 @@ import { getLocalDateKey, getZonedDateParts } from "../time.js";
 // Without the marker the slice looks like a sentence the sender wrote, which
 // confuses readers when content gets clipped mid-word.
 function truncateForPreview(value: string, maxLength: number): string {
-  if (value.length <= maxLength) {
+  const limit = Number.isFinite(maxLength)
+    ? Math.max(0, Math.floor(maxLength))
+    : 0;
+  if (value.length <= limit) {
     return value;
   }
-  return `${value.slice(0, maxLength).trimEnd()}…`;
+  if (limit === 0) return "";
+  if (limit === 1) return "…";
+  return `${value.slice(0, limit - 1).trimEnd()}…`;
 }
 
 // Build a "Display Name <email@host>" string when both are available, or

--- a/plugins/plugin-personal-assistant/src/lifeops/google/format-helpers.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/google/format-helpers.ts
@@ -23,6 +23,20 @@ import type {
 } from "../../contracts/index.js";
 import { getLocalDateKey, getZonedDateParts } from "../time.js";
 
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+function sliceGraphemePrefix(value: string, maxCodeUnits: number): string {
+  let end = 0;
+  for (const segment of graphemeSegmenter.segment(value)) {
+    const nextEnd = segment.index + segment.segment.length;
+    if (nextEnd > maxCodeUnits) break;
+    end = nextEnd;
+  }
+  return value.slice(0, end);
+}
+
 // Truncate snippet/preview text and append an ellipsis when we actually cut.
 // Without the marker the slice looks like a sentence the sender wrote, which
 // confuses readers when content gets clipped mid-word.
@@ -35,7 +49,7 @@ function truncateForPreview(value: string, maxLength: number): string {
   }
   if (limit === 0) return "";
   if (limit === 1) return "…";
-  return `${value.slice(0, limit - 1).trimEnd()}…`;
+  return `${sliceGraphemePrefix(value, limit - 1).trimEnd()}…`;
 }
 
 // Build a "Display Name <email@host>" string when both are available, or

--- a/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts
@@ -63,12 +63,26 @@ function isFullRedactKey(normalizedKey: string): boolean {
   return false;
 }
 
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+function safePrefix(value: string, maxCodeUnits: number): string {
+  let end = 0;
+  for (const segment of graphemeSegmenter.segment(value)) {
+    const nextEnd = segment.index + segment.segment.length;
+    if (nextEnd > maxCodeUnits) break;
+    end = nextEnd;
+  }
+  return value.slice(0, end);
+}
+
 function shortenSubject(value: string, max: number): string {
   const limit = Number.isFinite(max) ? Math.max(0, Math.floor(max)) : 0;
   if (value.length <= limit) return value;
   if (limit === 0) return "";
   if (limit === 1) return "…";
-  return `${value.slice(0, limit - 1).trimEnd()}…`;
+  return `${safePrefix(value, limit - 1).trimEnd()}…`;
 }
 
 function shortenBody(value: string, max: number): string {
@@ -76,11 +90,11 @@ function shortenBody(value: string, max: number): string {
   if (value.length <= limit) return value;
   if (limit === 0) return "";
 
-  // The omitted count must describe the actual retained prefix, not the
-  // nominal limit. Its digit width changes the space available to that prefix,
-  // so choose the longest prefix whose complete diagnostic still fits.
+  // The omitted count is the actual number of omitted UTF-16 code units, which
+  // matches JavaScript's length/cap contract. Its digit width changes the space
+  // available, so choose the longest complete grapheme prefix that still fits.
   for (let prefixLimit = limit - 1; prefixLimit >= 0; prefixLimit -= 1) {
-    const prefix = value.slice(0, prefixLimit).trimEnd();
+    const prefix = safePrefix(value, prefixLimit).trimEnd();
     const suffix = `… [+${value.length - prefix.length} chars]`;
     if (prefix.length + suffix.length <= limit) {
       return `${prefix}${suffix}`;

--- a/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts
@@ -64,13 +64,32 @@ function isFullRedactKey(normalizedKey: string): boolean {
 }
 
 function shortenSubject(value: string, max: number): string {
-  if (value.length <= max) return value;
-  return `${value.slice(0, max).trimEnd()}…`;
+  const limit = Number.isFinite(max) ? Math.max(0, Math.floor(max)) : 0;
+  if (value.length <= limit) return value;
+  if (limit === 0) return "";
+  if (limit === 1) return "…";
+  return `${value.slice(0, limit - 1).trimEnd()}…`;
 }
 
 function shortenBody(value: string, max: number): string {
-  if (value.length <= max) return value;
-  return `${value.slice(0, max).trimEnd()}… [+${value.length - max} chars]`;
+  const limit = Number.isFinite(max) ? Math.max(0, Math.floor(max)) : 0;
+  if (value.length <= limit) return value;
+  if (limit === 0) return "";
+
+  // The omitted count must describe the actual retained prefix, not the
+  // nominal limit. Its digit width changes the space available to that prefix,
+  // so choose the longest prefix whose complete diagnostic still fits.
+  for (let prefixLimit = limit - 1; prefixLimit >= 0; prefixLimit -= 1) {
+    const prefix = value.slice(0, prefixLimit).trimEnd();
+    const suffix = `… [+${value.length - prefix.length} chars]`;
+    if (prefix.length + suffix.length <= limit) {
+      return `${prefix}${suffix}`;
+    }
+  }
+
+  // A chopped diagnostic is misleading. For very small caps, retain only the
+  // truthful truncation marker.
+  return "…";
 }
 
 function redactEmailAddresses(value: string): string {

--- a/plugins/plugin-personal-assistant/src/lifeops/truncate-suffix-reserve.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/truncate-suffix-reserve.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Exercises bounded preview output through the exported Gmail formatter and
+ * audit redactor, including truthful omission diagnostics at small caps.
+ */
+import type { LifeOpsGmailTriageFeed } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import { formatEmailTriage } from "./google/format-helpers.ts";
+import { redactSensitiveData } from "./redact-sensitive-data.ts";
+
+describe("preview suffix reservation", () => {
+  it("bounds the real Gmail triage snippet including its ellipsis", () => {
+    const now = "2026-08-18T12:00:00.000Z";
+    const feed: LifeOpsGmailTriageFeed = {
+      source: "cache",
+      syncedAt: now,
+      summary: {
+        unreadCount: 1,
+        importantNewCount: 0,
+        likelyReplyNeededCount: 0,
+      },
+      messages: [
+        {
+          id: "mail-1",
+          externalId: "external-1",
+          agentId: "agent-1",
+          provider: "google",
+          side: "personal",
+          threadId: "thread-1",
+          subject: "Subject",
+          from: "Sender",
+          fromEmail: "sender@example.com",
+          replyTo: null,
+          to: [],
+          cc: [],
+          snippet: "g".repeat(140),
+          receivedAt: now,
+          isUnread: true,
+          isImportant: false,
+          likelyReplyNeeded: false,
+          triageScore: 0,
+          triageReason: "",
+          labels: [],
+          htmlLink: null,
+          metadata: {},
+          syncedAt: now,
+          updatedAt: now,
+        },
+      ],
+    };
+
+    const snippetLine = formatEmailTriage(feed)
+      .split("\n")
+      .find((line) => line.startsWith("  g"));
+    const snippet = snippetLine?.slice(2);
+
+    expect(snippet).toBe(`${"g".repeat(99)}…`);
+    expect(snippet).toHaveLength(100);
+  });
+
+  it("bounds subject previews at zero, one, fractional, and normal caps", () => {
+    const subject = "s".repeat(100);
+
+    expect(
+      redactSensitiveData({ subject }, { subjectPreview: 0 }).subject,
+    ).toBe("");
+    expect(
+      redactSensitiveData({ subject }, { subjectPreview: 1 }).subject,
+    ).toBe("…");
+    expect(
+      redactSensitiveData({ subject }, { subjectPreview: 5.9 }).subject,
+    ).toBe("ssss…");
+    expect(
+      redactSensitiveData({ subject }, { subjectPreview: 20 }).subject,
+    ).toBe(`${"s".repeat(19)}…`);
+  });
+
+  it("reports the actual omitted body characters within the cap", () => {
+    const source = "b".repeat(100);
+    const body = redactSensitiveData(
+      { body: source },
+      { bodyPreview: 30 },
+    ).body;
+    const match = body.match(/^(.*)… \[\+(\d+) chars\]$/s);
+
+    expect(body.length).toBeLessThanOrEqual(30);
+    expect(match).not.toBeNull();
+    expect(Number(match?.[2])).toBe(source.length - (match?.[1].length ?? 0));
+  });
+
+  it("uses an honest marker when a complete omission diagnostic cannot fit", () => {
+    const source = "b".repeat(100);
+
+    expect(redactSensitiveData({ body: source }, { bodyPreview: 0 }).body).toBe(
+      "",
+    );
+    expect(redactSensitiveData({ body: source }, { bodyPreview: 1 }).body).toBe(
+      "…",
+    );
+    expect(
+      redactSensitiveData({ body: source }, { bodyPreview: 10 }).body,
+    ).toBe("…");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/truncate-suffix-reserve.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/truncate-suffix-reserve.test.ts
@@ -55,6 +55,20 @@ describe("preview suffix reservation", () => {
 
     expect(snippet).toBe(`${"g".repeat(99)}…`);
     expect(snippet).toHaveLength(100);
+
+    for (const grapheme of ["🙂", "e\u0301", "👨‍👩‍👧‍👦"]) {
+      const message = feed.messages[0];
+      if (!message) throw new Error("expected triage fixture message");
+      message.snippet = `${"g".repeat(98)}${grapheme}tail`;
+      const bounded = formatEmailTriage(feed)
+        .split("\n")
+        .find((line) => line.startsWith("  g"))
+        ?.slice(2);
+
+      expect(bounded).toBe(`${"g".repeat(98)}…`);
+      expect(bounded?.isWellFormed()).toBe(true);
+      expect(bounded?.length).toBeLessThanOrEqual(100);
+    }
   });
 
   it("bounds subject previews at zero, one, fractional, and normal caps", () => {
@@ -72,6 +86,34 @@ describe("preview suffix reservation", () => {
     expect(
       redactSensitiveData({ subject }, { subjectPreview: 20 }).subject,
     ).toBe(`${"s".repeat(19)}…`);
+  });
+
+  it("keeps astral, combining, and ZWJ graphemes intact", () => {
+    const cases = ["🙂", "e\u0301", "👨‍👩‍👧‍👦"];
+
+    for (const grapheme of cases) {
+      const source = grapheme.repeat(100);
+      const bodyCap = grapheme.length + `… [+${source.length} chars]`.length;
+      const subject = redactSensitiveData(
+        { subject: source },
+        { subjectPreview: grapheme.length },
+      ).subject;
+      const body = redactSensitiveData(
+        { body: source },
+        { bodyPreview: bodyCap },
+      ).body;
+
+      expect(subject).toBe("…");
+      expect(subject.isWellFormed()).toBe(true);
+      expect(subject.length).toBeLessThanOrEqual(grapheme.length);
+      expect(body.isWellFormed()).toBe(true);
+      expect(body.length).toBeLessThanOrEqual(bodyCap);
+      const match = body.match(/^(.*)… \[\+(\d+) chars\]$/su);
+      expect(match).not.toBeNull();
+      const prefix = match?.[1] ?? "";
+      expect(prefix === "" || prefix === grapheme).toBe(true);
+      expect(Number(match?.[2])).toBe(source.length - prefix.length);
+    }
   });
 
   it("reports the actual omitted body characters within the cap", () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/truncate-suffix-reserve.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/truncate-suffix-reserve.test.ts
@@ -100,4 +100,44 @@ describe("preview suffix reservation", () => {
       redactSensitiveData({ body: source }, { bodyPreview: 10 }).body,
     ).toBe("…");
   });
+
+  it("stays truthful and maximal across omitted-count digit boundaries", () => {
+    for (const sourceLength of [9, 10, 11, 99, 100, 101, 999, 1_000]) {
+      const source = "b".repeat(sourceLength);
+      for (let cap = 0; cap <= 60; cap += 1) {
+        const body = redactSensitiveData(
+          { body: source },
+          { bodyPreview: cap },
+        ).body;
+
+        expect(body.length).toBeLessThanOrEqual(cap);
+        if (sourceLength <= cap) {
+          expect(body).toBe(source);
+          continue;
+        }
+        if (cap === 0) {
+          expect(body).toBe("");
+          continue;
+        }
+
+        const match = body.match(/^(.*)… \[\+(\d+) chars\]$/s);
+        if (!match) {
+          expect(body).toBe("…");
+          expect(`… [+${sourceLength} chars]`.length).toBeGreaterThan(cap);
+          continue;
+        }
+
+        const prefix = match[1] ?? "";
+        const omitted = Number(match[2]);
+        expect(source.startsWith(prefix)).toBe(true);
+        expect(omitted).toBe(sourceLength - prefix.length);
+
+        const nextPrefixLength = prefix.length + 1;
+        if (nextPrefixLength < sourceLength) {
+          const candidate = `${source.slice(0, nextPrefixLength)}… [+${sourceLength - nextPrefixLength} chars]`;
+          expect(candidate.length).toBeGreaterThan(cap);
+        }
+      }
+    }
+  });
 });

--- a/plugins/plugin-personal-assistant/test/lifeops-redact-sensitive-data.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-redact-sensitive-data.test.ts
@@ -71,8 +71,10 @@ describe("redactSensitiveData", () => {
       { subject: "abcdefghij", body: "0123456789" },
       { subjectPreview: 3, bodyPreview: 4 },
     );
-    expect(out.subject).toBe("abc…");
-    expect(out.body).toBe("0123… [+6 chars]");
+    expect(out.subject).toBe("ab…");
+    expect(out.subject).toHaveLength(3);
+    expect(out.body).toBe("…");
+    expect(out.body).toHaveLength(1);
   });
 
   it("recurses into nested objects and arrays", () => {


### PR DESCRIPTION
# Relates to

Supersedes #21811. The earlier fix bounded preview strings but under-counted omitted body characters and could emit chopped diagnostics at small caps.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

Rebased onto exact `develop` SHA `3e56d090e1988f9b856a293c7cf7394d462cf545` before final validation.

# Risks

Low. The change affects preview truncation only. Full values remain unchanged, subject/snippet previews reserve the ellipsis inside their cap, and body diagnostics report the actual omitted count. Caps too small for a complete diagnostic return only an honest ellipsis. Non-finite caps fail closed.

# Background

Calendar, Google, and audit-redaction preview helpers appended markers after slicing to the full cap. #21811 bounded the result but calculated `+N chars` from the nominal cap rather than the retained prefix, and it could slice incomplete diagnostics. This replacement chooses the longest retained prefix for which the complete truthful diagnostic fits.

Independent review found one additional issue: the existing PA redaction regression still asserted the old over-cap outputs. This head updates that owning test and adds property coverage across caps 0–60 and omitted-count digit boundaries from 9 through 1,000 characters.

# Testing

- Calendar production consumer: 2/2 passing.
- PA production consumer plus existing redaction suite: 14/14 passing.
- Total focused: 3 files, 16 tests passing at exact head.
- Astral emoji, combining marks, and family-ZWJ sequences remain whole in all
  three owning consumers. Caps and `chars` omission counts are UTF-16 code
  units, matching JavaScript string length, and the suffix math uses the actual
  retained prefix length.
- Calendar owning-package `tsc --noEmit`: exit 0.
- Biome on all six changed files and `git diff --check`: pass.
- PA aggregate typecheck: attempted; sparse checkout lacks unrelated sibling package exports and emits no changed-file diagnostic.

# Evidence Gate

<!-- evidence-head:cbf03936a4bbed3d806272fa30ea86994413ac90 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/model-context formatting only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/model-context formatting only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic string boundary with no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head validation transcript:
```text
Calendar consumer: Test Files 1 passed; Tests 2 passed
PA consumer + existing redaction suite: Test Files 2 passed; Tests 14 passed
Calendar tsc --noEmit: exit 0; Biome and diff checks: pass
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or rendered state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, action selection, or provider call changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered interface changed.

## Known gaps / failures

The personal-assistant aggregate typecheck stops on absent unrelated sibling workspaces in the sparse review checkout (`agent`, `plugin-blocker`, `plugin-finances`, `plugin-health`, `plugin-inbox`, UI subpaths, and others). It emits no diagnostic in the six changed files. The calendar owning-package typecheck passes.

---

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza"} -->
