### PR TITLE
fix(core): honest delivery floors for toolless planner deaths and coding-work verb coverage

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -717,6 +717,59 @@ describe("live routing regressions", () => {
 		}
 	});
 
+	it("routes add-family and repository-submission work through TASKS", () => {
+		const actions: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "TASKS", similes: ["TASKS_SPAWN_AGENT"] },
+		];
+		for (const text of [
+			"add a one-line description to the readme",
+			"append the release note to the changelog",
+			"rename the repository",
+			"delete the stale commit",
+			"put up a PR for this change",
+			"submit the pull request",
+			"push the branch",
+		]) {
+			expect(inferDirectCurrentRequestCandidateActions(actions, text)).toEqual([
+				"TASKS",
+			]);
+		}
+	});
+
+	it("keeps add/open/remove requests for app, site, and page surfaces out of coding delegation", () => {
+		const actions: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "TASKS", similes: ["TASKS_SPAWN_AGENT"] },
+		];
+		for (const text of [
+			"delete the weather app",
+			"open the company site",
+			"remove this page",
+			"add a reminder to the app",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateActions(actions, text),
+			).not.toContain("TASKS");
+		}
+	});
+
+	it("recognizes the eliza-code agent name without overriding an explicit exclusion", () => {
+		const actions: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "TASKS", similes: ["TASKS_SPAWN_AGENT"] },
+		];
+		expect(
+			inferDirectCurrentRequestCandidateActions(
+				actions,
+				"use eliza-code to build the release artifact",
+			),
+		).toEqual(["TASKS"]);
+		expect(
+			inferDirectCurrentRequestCandidateActions(
+				actions,
+				"do not use eliza-code to build this app",
+			),
+		).not.toContain("TASKS");
+	});
+
 	it("fast-paths a direct shell ask to TERMINAL_SHELL in a lean-chat runtime (follow-up to #12021)", () => {
 		// PR #12021 renamed the terminal action SHELL -> TERMINAL_SHELL. In a
 		// lean-chat deployment (no plugin-coding-tools) TERMINAL_SHELL is the only

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -3882,6 +3882,129 @@ describe("runV5MessageRuntimeStage1", () => {
 		}
 	});
 
+	it("recovers an addressed toolless planner exhaustion with an honest failure", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "The addressed request needs planning.",
+				contexts: ["general"],
+				replyText: "",
+			}),
+			{ text: "", toolCalls: [] },
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "please handle this request",
+				channelType: ChannelType.DM,
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000010" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"I couldn't finish that request, so nothing was completed. Please try again.",
+			);
+		}
+	});
+
+	it("follows a stranded early acknowledgement with exactly one honest failure", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "Acknowledge before planning.",
+				contexts: ["general"],
+				replyText: "On it.",
+			}),
+			{ text: "", toolCalls: [] },
+		]);
+		const earlyReply = vi.fn(async () => undefined);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.DM }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000011" as UUID,
+			onResponseHandlerEarlyReply: earlyReply,
+			deliveredVisibleTexts: new Set(["on it."]),
+		});
+
+		expect(earlyReply).toHaveBeenCalledTimes(1);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"I couldn't finish that request, so nothing was completed. Please try again.",
+			);
+			expect(result.result.responseMessages).toHaveLength(1);
+		}
+	});
+
+	it("does not append a failure when another visible delivery already completed the turn", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "Acknowledge before planning.",
+				contexts: ["general"],
+				replyText: "On it.",
+			}),
+			{ text: "", toolCalls: [] },
+		]);
+		const earlyReply = vi.fn(async () => undefined);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.DM }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000012" as UUID,
+			onResponseHandlerEarlyReply: earlyReply,
+			deliveredVisibleTexts: new Set(["on it.", "completed elsewhere"]),
+		});
+
+		expect(earlyReply).toHaveBeenCalledTimes(1);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent).toBeNull();
+			expect(result.result.responseMessages).toEqual([]);
+		}
+	});
+
+	it("does not turn a substantive early answer into a second failure bubble", async () => {
+		const answer = "The repository uses Bun 1.3.14.";
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "The answer is useful before optional planning.",
+				contexts: ["general"],
+				replyText: answer,
+			}),
+			{ text: "", toolCalls: [] },
+		]);
+		runtime.responseHandlerEvaluators = [
+			{
+				name: "test.plan_after_substantive_answer",
+				priority: 5,
+				shouldRun: () => true,
+				evaluate: () => ({ requiresTool: true, addContexts: ["general"] }),
+			} satisfies ResponseHandlerEvaluator,
+		];
+		const earlyReply = vi.fn(async () => undefined);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.DM }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000013" as UUID,
+			onResponseHandlerEarlyReply: earlyReply,
+			deliveredVisibleTexts: new Set([answer.toLowerCase()]),
+		});
+
+		expect(earlyReply).toHaveBeenCalledTimes(1);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent).toBeNull();
+			expect(result.result.responseMessages).toEqual([]);
+		}
+	});
+
 	it("keeps RECENT_ERRORS out of the planner recompose AND its cached rendering on an ambient turn", async () => {
 		// The Stage-1 exclusion alone is not enough: the planner recompose
 		// re-adds every alwaysInResponseState provider, and composeState merges

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -10702,14 +10702,30 @@ function looksLikeDelegationExcludedAsk(text: string): boolean {
 
 const LEGACY_CODING_WORK_VERB_PATTERN =
 	/\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|update|verify)\b/giu;
+// Add-family verbs are everyday mutation words ("add a reminder", "delete the
+// weather app"), so they pair ONLY with strong code artifacts — never the
+// legacy artifact set whose app/site/page tokens belong to view and app
+// management asks. Live gap 2026-08-18: "yo can u add a lil one-line
+// description to the readme in my <name> repo and put up a pr" carried
+// repo+pr artifacts but no legacy verb; no deterministic coding candidate
+// fired and Stage-1 answered ["simple"] from stale room history, fabricating
+// "a PR is up".
+const ADD_FAMILY_CODING_VERB_PATTERN =
+	/\b(?:add|append|insert|rename|remove|delete)\b/giu;
 const LEGACY_CODING_ARTIFACT_PATTERN =
 	/\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|feature|bug|url)\b/giu;
 const CODING_OPERATION_VERB_PATTERN =
 	/\b(?:refactor|debug|deploy|patch|optimize|migrate|profile)\b/giu;
+// Repo-submission verbs pair ONLY with the strong code artifacts: "put up a
+// pr", "push a branch", "open a pull request". "open" lives here and NOT in
+// the legacy verb set because anchored to pr/repo/branch it is unambiguous,
+// while "open the app/page" is view navigation.
+const REPO_SUBMIT_VERB_PATTERN =
+	/\b(?:put\s+up|open|submit|push|raise|file)\b/giu;
 const REVIEW_WORK_VERB_PATTERN =
 	/\b(?:review|audit|investigate|analyze|inspect|test|trace|diagnose)\b/giu;
 const STRONG_CODE_ARTIFACT_PATTERN =
-	/\b(?:code|cli|script|backend|frontend|repo|repository|bug|pr|pull request|commit|branch|stack trace|pipeline|ci)\b/giu;
+	/\b(?:code|cli|script|backend|frontend|repo|repository|bug|pr|pull request|commit|branch|stack trace|pipeline|ci|readme|changelog)\b/giu;
 const EXPANDED_WORK_ARTIFACT_PATTERN =
 	/\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|repository|feature|bug|url|pr|pull request|issue|commit|branch|build|test|error|stack trace|failure|log|docs|documentation|run|pipeline|ci)\b/giu;
 const HTTP_URL_PATTERN = /\bhttps?:\/\/[^\s<>()]+/iu;
@@ -10777,6 +10793,22 @@ function looksLikeCodingWorkRequest(text: string): boolean {
 		hasNearbyTerms(
 			normalized,
 			REVIEW_WORK_VERB_PATTERN,
+			STRONG_CODE_ARTIFACT_PATTERN,
+			160,
+		) ||
+		// Submission verbs anchored to strong code artifacts: "put up a pr",
+		// "push the branch", "open a pull request".
+		hasNearbyTerms(
+			normalized,
+			REPO_SUBMIT_VERB_PATTERN,
+			STRONG_CODE_ARTIFACT_PATTERN,
+			160,
+		) ||
+		// Add-family mutations anchored to strong code artifacts: "add a line
+		// to the readme", "rename the branch", "delete the stale commit".
+		hasNearbyTerms(
+			normalized,
+			ADD_FAMILY_CODING_VERB_PATTERN,
 			STRONG_CODE_ARTIFACT_PATTERN,
 			160,
 		) ||

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9761,11 +9761,19 @@ export async function runV5MessageRuntimeStage1(args: {
 		// visible-TEXT set, and deliberate silence (suppressPlannerReply
 		// terminals, ambient IGNORE after tool work) is a contract this
 		// invariant must honor, not a failure for it to "fix" into filler.
+		// An early ack ("on it.") is a PROMISE of work. When the planner then
+		// dies toolless with nothing else delivered, leaving only the ack turns
+		// the promise into a lie by omission — the recovery below must still
+		// fire and own up (live 2026-08-17: "on it." then silence on a repo
+		// ask). Tool-ful turns keep the stricter early-reply exclusion: their
+		// ack was followed by real result delivery paths.
+		const earlyAckBrokenPromise =
+			earlyReplySent && actionResults.length === 0 && !ambientTurn;
 		if (
 			!shouldSendPlannedText &&
-			!earlyReplySent &&
+			(!earlyReplySent || earlyAckBrokenPromise) &&
 			!suppressesPlannerReply &&
-			deliveredVisibleTexts.size === 0 &&
+			(deliveredVisibleTexts.size === 0 || earlyAckBrokenPromise) &&
 			deliveredMediaUrls.length === 0 &&
 			// Toolless planner deaths on an ADDRESSED turn are the same
 			// recoverable silence: the planner exhausted its retries with no

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9767,11 +9767,22 @@ export async function runV5MessageRuntimeStage1(args: {
 			!suppressesPlannerReply &&
 			deliveredVisibleTexts.size === 0 &&
 			deliveredMediaUrls.length === 0 &&
-			actionResults.length > 0
+			// Toolless planner deaths on an ADDRESSED turn are the same
+			// recoverable silence: the planner exhausted its retries with no
+			// tool call and no usable terminal text, every fallback above
+			// rejected the ack-shaped Stage-1 reply, and the user saw nothing
+			// (live 2026-08-17: casual-phrased coding asks after the
+			// gpt-oss-120b cutover ended [messageHandler, toolSearch, planner]
+			// with zero deliveries). Ambient turns keep their silence contract.
+			(actionResults.length > 0 || !ambientTurn)
 		) {
+			// On a toolless recovery the Stage-1 ack is a false promise of work
+			// that never happened ("On it." then nothing) — skip straight to
+			// the honest line instead.
+			const recoverableAck = actionResults.length > 0 ? stageOneAck : "";
 			const recoveredText =
 				effectiveDeliveredReplyText ||
-				stageOneAck ||
+				recoverableAck ||
 				actionResults
 					.map((result) =>
 						typeof result.userFacingText === "string"

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9767,12 +9767,24 @@ export async function runV5MessageRuntimeStage1(args: {
 		// fire and own up (live 2026-08-17: "on it." then silence on a repo
 		// ask). Tool-ful turns keep the stricter early-reply exclusion: their
 		// ack was followed by real result delivery paths.
+		const normalizedEarlyReply =
+			normalizeVisibleTextForDuplicateCheck(earlyReplyText);
+		const earlyReplyWasOnlyVisibleDelivery =
+			deliveredVisibleTexts.size === 0 ||
+			(deliveredVisibleTexts.size === 1 &&
+				normalizedEarlyReply.length > 0 &&
+				deliveredVisibleTexts.has(normalizedEarlyReply));
 		const earlyAckBrokenPromise =
-			earlyReplySent && actionResults.length === 0 && !ambientTurn;
+			earlyReplySent &&
+			actionResults.length === 0 &&
+			!ambientTurn &&
+			PROGRESS_ONLY_ANSWER_REJECT.test(earlyReplyText.trim()) &&
+			earlyReplyWasOnlyVisibleDelivery;
 		if (
 			!shouldSendPlannedText &&
 			(!earlyReplySent || earlyAckBrokenPromise) &&
 			!suppressesPlannerReply &&
+			plannerResult.endedWithDeliberateSilence !== true &&
 			(deliveredVisibleTexts.size === 0 || earlyAckBrokenPromise) &&
 			deliveredMediaUrls.length === 0 &&
 			// Toolless planner deaths on an ADDRESSED turn are the same
@@ -9799,7 +9811,9 @@ export async function runV5MessageRuntimeStage1(args: {
 					)
 					.filter((ownedText) => ownedText.length > 0)
 					.at(-1) ||
-				"I finished working on that but could not compose a clean reply — ask again and I will retry.";
+				(actionResults.length === 0
+					? "I couldn't finish that request, so nothing was completed. Please try again."
+					: "I finished working on that but could not compose a clean reply — ask again and I will retry.");
 			args.runtime.logger.warn(
 				{
 					src: "service:message",
@@ -10678,7 +10692,7 @@ function looksLikeDelegationExcludedAsk(text: string): boolean {
 		return false;
 	}
 	if (
-		/\b(?:do not|don't|dont|without)\s+(?:spawn|delegate|use|start)\s+(?:a\s+)?(?:sub[- ]?agent|task[- ]?agent|coding agent|opencode|codex|claude)\b/iu.test(
+		/\b(?:do not|don't|dont|without)\s+(?:spawn|delegate|use|start)\s+(?:a\s+)?(?:sub[- ]?agent|task[- ]?agent|coding agent|eliza[- ]code|opencode|codex|claude)\b/iu.test(
 			normalized,
 		)
 	) {
@@ -10829,10 +10843,10 @@ function looksLikeCodingWorkRequest(text: string): boolean {
 function looksLikeExplicitDelegationRequest(text: string): boolean {
 	const normalized = text.toLowerCase();
 	return (
-		/\b(?:spawn|delegate|use|start|ask|have)\b[\s\S]{0,80}\b(?:sub[- ]?agent|task[- ]?agent|coding agent|opencode|codex|claude)\b/iu.test(
+		/\b(?:spawn|delegate|use|start|ask|have)\b[\s\S]{0,80}\b(?:sub[- ]?agent|task[- ]?agent|coding agent|eliza[- ]code|opencode|codex|claude)\b/iu.test(
 			normalized,
 		) ||
-		/\b(?:sub[- ]?agent|task[- ]?agent|coding agent|opencode|codex|claude)\b[\s\S]{0,80}\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|verify)\b/iu.test(
+		/\b(?:sub[- ]?agent|task[- ]?agent|coding agent|eliza[- ]code|opencode|codex|claude)\b[\s\S]{0,80}\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|verify)\b/iu.test(
 			normalized,
 		)
 	);


### PR DESCRIPTION
The delivery-floor and routing ideas from closed #21637, separately scoped as its closure invited — **without** the rejected shell-containment recovery (develop's operation-key correlation is untouched; no planner-loop changes here). cc @lalalune

## What this does (message service only, +56/−5)

- **Toolless planner deaths on an addressed turn are no longer silent.** The zero-deliveries recovery floor required `actionResults.length > 0`; when the planner exhausted its retries with no tool call and no usable terminal text, the user saw nothing at all (live, gpt-oss-120b planner, casual coding asks). Addressed turns now recover with an honest "that didn't go through" line; ambient turns keep their silence contract.
- **A broken early-ack promise is recoverable silence.** Stage-1 sent "on it." and the planner died toolless; the floor's `earlyReplySent` exclusion treated the ack as a delivery — the promise became a lie by omission. That shape now recovers, and skips the ack-shaped text on the recovery path.
- **Coding-work verb vocabulary**: add-family (add/append/insert/rename/remove/delete) and submission verbs (put up/open/submit/push/raise) count as coding work only when anchored to STRONG code artifacts (repo/pr/branch/commit/readme/…). Live gap: "add a lil one-line description to the readme in my … repo and put up a pr" carried repo+pr artifacts but no listed verb — no deterministic coding candidate fired, and Stage-1 answered ["simple"] from stale room history, fabricating "a PR is up". Weak artifacts (app/site/page) are deliberately excluded so "delete the weather app" stays an app-management ask.
- Also teaches the delegation matchers the `eliza-code` spelling alongside codex/claude.

## Evidence

- Message delegation + preserved-tool-result suites 14/14.
- Live: all three silence/fabrication classes reproduced on the reference deployment before the fixes and are absent across the subsequent nine-round live battery (which ended in the hands-free repo→PR proof, NubsCarson/eliza-code-sandbox#3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
