### PR TITLE
fix(ui): bound screen-capture vision fetches

### DIFF
--- a/packages/ui/src/state/screen-capture-bridge-timeout.test.ts
+++ b/packages/ui/src/state/screen-capture-bridge-timeout.test.ts
@@ -1,96 +1,116 @@
 /**
- * Behavioral screen-capture-bridge deadlines. Executes the poll GET and
- * screen-frame POST helpers under abort — not a source-grep.
- * Independent hops, separate 15s budgets. Not #21385. Not Twilio.
+ * Verifies screen-capture deadlines through the canonical ElizaClient and its
+ * native-agent transport context rather than a signal-aware fetch test double.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createAndroidNativeAgentTransport } from "../api/android-native-agent-transport";
+import { ElizaClient } from "../api/client-base";
 import {
-	SCREEN_CAPTURE_POLL_TIMEOUT_MS,
-	SCREEN_FRAME_POST_TIMEOUT_MS,
-	getCaptureRequestsWithFetch,
-	postScreenFrameWithFetch,
+  getCaptureRequestsWithClient,
+  postScreenFrameWithClient,
+  SCREEN_CAPTURE_POLL_TIMEOUT_MS,
+  SCREEN_FRAME_POST_TIMEOUT_MS,
 } from "./screen-capture-bridge";
 
-function stallUntilAborted(): typeof fetch {
-	return ((_input, init) =>
-		new Promise<Response>((_resolve, reject) => {
-			const signal = init?.signal;
-			if (!signal) throw new Error("expected screen-capture abort signal");
-			signal.addEventListener("abort", () => reject(signal.reason), {
-				once: true,
-			});
-		})) as typeof fetch;
+interface NativeRequestOptions {
+  method?: string;
+  path: string;
+  headers?: Record<string, string>;
+  body?: string | null;
+  timeoutMs?: number;
 }
 
-describe("screen-capture-bridge poll GET deadline", () => {
-	it("keeps a documented UI fetch budget", () => {
-		expect(SCREEN_CAPTURE_POLL_TIMEOUT_MS).toBe(15_000);
-	});
+interface NativeRequestResult {
+  status: number;
+  statusText?: string;
+  headers?: Record<string, string>;
+  body?: string | null;
+}
 
-	it("aborts a stalled capture-requests GET at the injected deadline", async () => {
-		await expect(
-			getCaptureRequestsWithFetch(stallUntilAborted(), 10),
-		).rejects.toMatchObject({ name: "TimeoutError" });
-	});
+function clientWithNativeRequest(
+  request: (options: NativeRequestOptions) => Promise<NativeRequestResult>,
+): ElizaClient {
+  const apiClient = new ElizaClient("eliza-local-agent://ipc", "token");
+  apiClient.setRequestTransport(createAndroidNativeAgentTransport({ request }));
+  return apiClient;
+}
 
-	it("surfaces a provider error from a completed capture-requests GET", async () => {
-		const fetchImpl: typeof fetch = async () =>
-			new Response("nope", { status: 503, statusText: "Service Unavailable" });
+describe("screen-capture native transport deadlines", () => {
+  it("keeps documented independent budgets", () => {
+    expect(SCREEN_CAPTURE_POLL_TIMEOUT_MS).toBe(15_000);
+    expect(SCREEN_FRAME_POST_TIMEOUT_MS).toBe(15_000);
+  });
 
-		const response = await getCaptureRequestsWithFetch(fetchImpl, 1_000);
-		expect(response.ok).toBe(false);
-		expect(response.status).toBe(503);
-	});
+  it("forwards the capture-request deadline to the native request", async () => {
+    const request = vi.fn(async (options: NativeRequestOptions) => {
+      throw new Error(`native timeout ${options.timeoutMs}`);
+    });
+    const apiClient = clientWithNativeRequest(request);
 
-	it("uses the injected fetch for a successful capture-requests GET", async () => {
-		const signals: AbortSignal[] = [];
-		const fetchImpl: typeof fetch = async (_input, init) => {
-			if (init?.signal) signals.push(init.signal);
-			return new Response(JSON.stringify({ requests: [] }), { status: 200 });
-		};
+    await expect(getCaptureRequestsWithClient(apiClient, 3210)).rejects.toThrow(
+      "native timeout 3210",
+    );
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/vision/capture-requests",
+        timeoutMs: 3210,
+      }),
+    );
+  });
 
-		const response = await getCaptureRequestsWithFetch(fetchImpl, 1_000);
-		expect(signals).toHaveLength(1);
-		expect(signals[0]?.aborted).toBe(false);
-		expect(response.ok).toBe(true);
-		expect(await response.json()).toEqual({ requests: [] });
-	});
-});
+  it("forwards the screen-frame deadline and JSON body to native", async () => {
+    const request = vi.fn(async () => ({
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true }),
+    }));
+    const apiClient = clientWithNativeRequest(request);
 
-describe("screen-capture-bridge screen-frame POST deadline", () => {
-	it("keeps a documented UI fetch budget", () => {
-		expect(SCREEN_FRAME_POST_TIMEOUT_MS).toBe(15_000);
-	});
+    await postScreenFrameWithClient(
+      { requestId: "r1", base64: "frame" },
+      apiClient,
+      4321,
+    );
 
-	it("aborts a stalled screen-frame POST at the injected deadline", async () => {
-		await expect(
-			postScreenFrameWithFetch({ requestId: "r1" }, stallUntilAborted(), 10),
-		).rejects.toMatchObject({ name: "TimeoutError" });
-	});
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/vision/screen-frame",
+        timeoutMs: 4321,
+        body: JSON.stringify({ requestId: "r1", base64: "frame" }),
+      }),
+    );
+  });
 
-	it("surfaces a provider error from a completed screen-frame POST", async () => {
-		const fetchImpl: typeof fetch = async () =>
-			new Response("nope", { status: 503, statusText: "Service Unavailable" });
+  it("parses successful capture requests through the client", async () => {
+    const request = vi.fn(async () => ({
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ requests: [{ requestId: "r1" }] }),
+    }));
 
-		await expect(
-			postScreenFrameWithFetch({ requestId: "r1" }, fetchImpl, 1_000),
-		).rejects.toThrow("503");
-	});
+    await expect(
+      getCaptureRequestsWithClient(clientWithNativeRequest(request), 5000),
+    ).resolves.toEqual({ requests: [{ requestId: "r1" }] });
+  });
 
-	it("uses the injected fetch for a successful screen-frame POST", async () => {
-		const signals: AbortSignal[] = [];
-		const fetchImpl: typeof fetch = async (_input, init) => {
-			if (init?.signal) signals.push(init.signal);
-			return new Response("ok", { status: 200 });
-		};
+  it("surfaces non-ok screen-frame responses", async () => {
+    const request = vi.fn(async () => ({
+      status: 503,
+      statusText: "Service Unavailable",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ error: "unavailable" }),
+    }));
 
-		const response = await postScreenFrameWithFetch(
-			{ requestId: "r1" },
-			fetchImpl,
-			1_000,
-		);
-		expect(signals).toHaveLength(1);
-		expect(signals[0]?.aborted).toBe(false);
-		expect(response.ok).toBe(true);
-	});
+    await expect(
+      postScreenFrameWithClient(
+        { requestId: "r1" },
+        clientWithNativeRequest(request),
+        5000,
+      ),
+    ).rejects.toMatchObject({ status: 503 });
+  });
 });

--- a/packages/ui/src/state/screen-capture-bridge-timeout.test.ts
+++ b/packages/ui/src/state/screen-capture-bridge-timeout.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Behavioral screen-capture-bridge deadlines. Executes the poll GET and
+ * screen-frame POST helpers under abort — not a source-grep.
+ * Independent hops, separate 15s budgets. Not #21385. Not Twilio.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	SCREEN_CAPTURE_POLL_TIMEOUT_MS,
+	SCREEN_FRAME_POST_TIMEOUT_MS,
+	getCaptureRequestsWithFetch,
+	postScreenFrameWithFetch,
+} from "./screen-capture-bridge";
+
+function stallUntilAborted(): typeof fetch {
+	return ((_input, init) =>
+		new Promise<Response>((_resolve, reject) => {
+			const signal = init?.signal;
+			if (!signal) throw new Error("expected screen-capture abort signal");
+			signal.addEventListener("abort", () => reject(signal.reason), {
+				once: true,
+			});
+		})) as typeof fetch;
+}
+
+describe("screen-capture-bridge poll GET deadline", () => {
+	it("keeps a documented UI fetch budget", () => {
+		expect(SCREEN_CAPTURE_POLL_TIMEOUT_MS).toBe(15_000);
+	});
+
+	it("aborts a stalled capture-requests GET at the injected deadline", async () => {
+		await expect(
+			getCaptureRequestsWithFetch(stallUntilAborted(), 10),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+	});
+
+	it("surfaces a provider error from a completed capture-requests GET", async () => {
+		const fetchImpl: typeof fetch = async () =>
+			new Response("nope", { status: 503, statusText: "Service Unavailable" });
+
+		const response = await getCaptureRequestsWithFetch(fetchImpl, 1_000);
+		expect(response.ok).toBe(false);
+		expect(response.status).toBe(503);
+	});
+
+	it("uses the injected fetch for a successful capture-requests GET", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchImpl: typeof fetch = async (_input, init) => {
+			if (init?.signal) signals.push(init.signal);
+			return new Response(JSON.stringify({ requests: [] }), { status: 200 });
+		};
+
+		const response = await getCaptureRequestsWithFetch(fetchImpl, 1_000);
+		expect(signals).toHaveLength(1);
+		expect(signals[0]?.aborted).toBe(false);
+		expect(response.ok).toBe(true);
+		expect(await response.json()).toEqual({ requests: [] });
+	});
+});
+
+describe("screen-capture-bridge screen-frame POST deadline", () => {
+	it("keeps a documented UI fetch budget", () => {
+		expect(SCREEN_FRAME_POST_TIMEOUT_MS).toBe(15_000);
+	});
+
+	it("aborts a stalled screen-frame POST at the injected deadline", async () => {
+		await expect(
+			postScreenFrameWithFetch({ requestId: "r1" }, stallUntilAborted(), 10),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+	});
+
+	it("surfaces a provider error from a completed screen-frame POST", async () => {
+		const fetchImpl: typeof fetch = async () =>
+			new Response("nope", { status: 503, statusText: "Service Unavailable" });
+
+		await expect(
+			postScreenFrameWithFetch({ requestId: "r1" }, fetchImpl, 1_000),
+		).rejects.toThrow("503");
+	});
+
+	it("uses the injected fetch for a successful screen-frame POST", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchImpl: typeof fetch = async (_input, init) => {
+			if (init?.signal) signals.push(init.signal);
+			return new Response("ok", { status: 200 });
+		};
+
+		const response = await postScreenFrameWithFetch(
+			{ requestId: "r1" },
+			fetchImpl,
+			1_000,
+		);
+		expect(signals).toHaveLength(1);
+		expect(signals[0]?.aborted).toBe(false);
+		expect(response.ok).toBe(true);
+	});
+});

--- a/packages/ui/src/state/screen-capture-bridge.test.ts
+++ b/packages/ui/src/state/screen-capture-bridge.test.ts
@@ -4,12 +4,17 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const clientFetchMock = vi.hoisted(() => vi.fn());
+
 // Make isNativeMobile() true and the capture plugin present so the poller runs.
 vi.mock("@capacitor/core", () => ({
   Capacitor: { getPlatform: () => "android" },
 }));
 vi.mock("../bridge/native-plugins", () => ({
   getScreenCapturePlugin: () => ({}),
+}));
+vi.mock("../api", () => ({
+  client: { fetch: clientFetchMock },
 }));
 
 import {
@@ -39,22 +44,18 @@ describe("computePollDelayMs — vision-poll backoff curve", () => {
 });
 
 describe("screen-capture bridge poller — a 404 route is not hammered forever", () => {
-  const fetchMock = vi.fn();
-
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.stubGlobal("fetch", fetchMock);
-    fetchMock.mockReset();
+    clientFetchMock.mockReset();
     __resetScreenCaptureBridgeForTests();
   });
   afterEach(() => {
     __resetScreenCaptureBridgeForTests();
     vi.useRealTimers();
-    vi.unstubAllGlobals();
   });
 
   it("backs off under sustained 404s instead of polling every 1500ms", async () => {
-    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+    clientFetchMock.mockRejectedValue(new Error("HTTP 404"));
     initScreenCaptureBridge();
 
     // Over a 120s horizon, a fixed 1500ms poller would fire ~80 times. With the
@@ -62,17 +63,17 @@ describe("screen-capture bridge poller — a 404 route is not hammered forever",
     // an order of magnitude less.
     await vi.advanceTimersByTimeAsync(120_000);
 
-    expect(fetchMock.mock.calls.length).toBeGreaterThan(0);
-    expect(fetchMock.mock.calls.length).toBeLessThan(20);
+    expect(clientFetchMock.mock.calls.length).toBeGreaterThan(0);
+    expect(clientFetchMock.mock.calls.length).toBeLessThan(20);
   });
 
   it("does not schedule further polls after reset (no leaked timer)", async () => {
-    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+    clientFetchMock.mockRejectedValue(new Error("HTTP 404"));
     initScreenCaptureBridge();
     await vi.advanceTimersByTimeAsync(5000);
     __resetScreenCaptureBridgeForTests();
-    const callsAtReset = fetchMock.mock.calls.length;
+    const callsAtReset = clientFetchMock.mock.calls.length;
     await vi.advanceTimersByTimeAsync(120_000);
-    expect(fetchMock.mock.calls.length).toBe(callsAtReset);
+    expect(clientFetchMock.mock.calls.length).toBe(callsAtReset);
   });
 });

--- a/packages/ui/src/state/screen-capture-bridge.ts
+++ b/packages/ui/src/state/screen-capture-bridge.ts
@@ -4,6 +4,7 @@
  * agent→renderer push channel. See the block below for the full protocol.
  */
 import { Capacitor } from "@capacitor/core";
+import { client } from "../api";
 import { getScreenCapturePlugin } from "../bridge/native-plugins";
 
 /**
@@ -11,45 +12,55 @@ import { getScreenCapturePlugin } from "../bridge/native-plugins";
  *
  * On Android the agent (musl bun) has no Capacitor and there is no
  * agent->renderer push channel, so capture is renderer-PULLED: this module
- * interval-polls `GET /api/vision/capture-requests` (routed to the agent by the
- * installed Android fetch bridge), and for each queued request captures a frame
+ * interval-polls `GET /api/vision/capture-requests` through the canonical
+ * client's native-agent transport, and for each queued request captures a frame
  * via the Capacitor ScreenCapture plugin (MediaProjection) and POSTs the PNG
  * back to `POST /api/vision/screen-frame`. A short interval (not long-poll)
- * keeps the agent's 30s capture timeout decoupled from the 10s JNI
- * fetch-timeout.
+ * keeps the agent's 30s capture timeout decoupled from each request deadline.
  */
 
 const POLL_INTERVAL_MS = 1500;
 
-/** Independent UI hops — same 15s family as BuildBadge, separate deadlines. */
+/** Independent UI hops with separate native-transport deadlines. */
 export const SCREEN_CAPTURE_POLL_TIMEOUT_MS = 15_000;
 export const SCREEN_FRAME_POST_TIMEOUT_MS = 15_000;
 
-export async function getCaptureRequestsWithFetch(
-  fetchImpl: typeof fetch,
-  timeoutMs: number = SCREEN_CAPTURE_POLL_TIMEOUT_MS,
-): Promise<Response> {
-  return fetchImpl("/api/vision/capture-requests", {
-    method: "GET",
-    signal: AbortSignal.timeout(timeoutMs),
-  });
+interface ScreenCaptureApiClient {
+  fetch<T>(
+    path: string,
+    init?: RequestInit,
+    options?: { timeoutMs?: number },
+  ): Promise<T>;
 }
 
-export async function postScreenFrameWithFetch(
+interface CaptureRequestsResponse {
+  requests?: unknown;
+}
+
+export async function getCaptureRequestsWithClient(
+  apiClient: ScreenCaptureApiClient,
+  timeoutMs: number = SCREEN_CAPTURE_POLL_TIMEOUT_MS,
+): Promise<CaptureRequestsResponse> {
+  return apiClient.fetch<CaptureRequestsResponse>(
+    "/api/vision/capture-requests",
+    undefined,
+    { timeoutMs },
+  );
+}
+
+export async function postScreenFrameWithClient(
   body: Record<string, unknown>,
-  fetchImpl: typeof fetch,
+  apiClient: ScreenCaptureApiClient,
   timeoutMs: number = SCREEN_FRAME_POST_TIMEOUT_MS,
-): Promise<Response> {
-  const response = await fetchImpl("/api/vision/screen-frame", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-  if (!response.ok) {
-    throw new Error(`Screen-frame request failed (${response.status})`);
-  }
-  return response;
+): Promise<void> {
+  await apiClient.fetch<{ ok: boolean }>(
+    "/api/vision/screen-frame",
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+    },
+    { timeoutMs },
+  );
 }
 
 /**
@@ -119,7 +130,7 @@ function isCaptureRequest(value: unknown): value is CaptureRequest {
 }
 
 async function postScreenFrame(body: Record<string, unknown>): Promise<void> {
-  await postScreenFrameWithFetch(body, globalThis.fetch);
+  await postScreenFrameWithClient(body, client);
 }
 
 async function serveRequest(request: CaptureRequest): Promise<void> {
@@ -163,15 +174,8 @@ async function serveRequest(request: CaptureRequest): Promise<void> {
 async function poll(): Promise<void> {
   let requests: CaptureRequest[];
   try {
-    const res = await getCaptureRequestsWithFetch(globalThis.fetch);
-    if (!res.ok) {
-      // 404 = the vision route isn't registered in this config; other non-ok is
-      // transient. Either way, count toward backoff so we don't spin at 1500ms.
-      consecutiveFailures += 1;
-      return;
-    }
+    const data = await getCaptureRequestsWithClient(client);
     consecutiveFailures = 0;
-    const data = (await res.json()) as { requests?: unknown };
     const list = Array.isArray(data.requests) ? data.requests : [];
     requests = list.filter(isCaptureRequest);
   } catch {

--- a/packages/ui/src/state/screen-capture-bridge.ts
+++ b/packages/ui/src/state/screen-capture-bridge.ts
@@ -21,6 +21,37 @@ import { getScreenCapturePlugin } from "../bridge/native-plugins";
 
 const POLL_INTERVAL_MS = 1500;
 
+/** Independent UI hops — same 15s family as BuildBadge, separate deadlines. */
+export const SCREEN_CAPTURE_POLL_TIMEOUT_MS = 15_000;
+export const SCREEN_FRAME_POST_TIMEOUT_MS = 15_000;
+
+export async function getCaptureRequestsWithFetch(
+  fetchImpl: typeof fetch,
+  timeoutMs: number = SCREEN_CAPTURE_POLL_TIMEOUT_MS,
+): Promise<Response> {
+  return fetchImpl("/api/vision/capture-requests", {
+    method: "GET",
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+}
+
+export async function postScreenFrameWithFetch(
+  body: Record<string, unknown>,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = SCREEN_FRAME_POST_TIMEOUT_MS,
+): Promise<Response> {
+  const response = await fetchImpl("/api/vision/screen-frame", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`Screen-frame request failed (${response.status})`);
+  }
+  return response;
+}
+
 /**
  * Once this many polls fail in a row, stop hammering the route every 1500ms and
  * back off exponentially. The common cause is a `404` — the vision plugin isn't
@@ -88,11 +119,7 @@ function isCaptureRequest(value: unknown): value is CaptureRequest {
 }
 
 async function postScreenFrame(body: Record<string, unknown>): Promise<void> {
-  await fetch("/api/vision/screen-frame", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  await postScreenFrameWithFetch(body, globalThis.fetch);
 }
 
 async function serveRequest(request: CaptureRequest): Promise<void> {
@@ -136,7 +163,7 @@ async function serveRequest(request: CaptureRequest): Promise<void> {
 async function poll(): Promise<void> {
   let requests: CaptureRequest[];
   try {
-    const res = await fetch("/api/vision/capture-requests");
+    const res = await getCaptureRequestsWithFetch(globalThis.fetch);
     if (!res.ok) {
       // 404 = the vision route isn't registered in this config; other non-ok is
       // transient. Either way, count toward backoff so we don't spin at 1500ms.


### PR DESCRIPTION
# Relates to

Fixes the stalled screen-capture poll/frame transport path described by the fetch-timeout review family. The submitted head attempted to add `AbortSignal.timeout`, but the Android and iOS global fetch bridges do not forward that signal into their native request dispatch.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

Rebased onto exact `develop` SHA `ad68010c47040d9b0e4a5684243d328e2997df58` before final validation.

# Risks

Low after repair. Both internal vision routes now use the canonical `ElizaClient`, preserving active-target routing, local-agent authentication, typed HTTP failures, and bounded response-body parsing. The explicit 15-second budget is passed as native transport context on Android and iOS instead of being attached as a signal that those bridges discard. Poll backoff and capture behavior are unchanged.

# Background

The original production path called relative `fetch`. On Android, `installAndroidNativeAgentFetchBridge` invokes `transport.request` without a context object; `createAndroidNativeAgentTransport` ignores `RequestInit.signal` and passes only `context?.timeoutMs` to `Agent.request`. iOS similarly builds a native request without propagating the bridged request signal. Therefore the submitted signal-aware mock tests passed while the claimed native deadline was never delivered.

The repaired head routes the GET and POST through `client.fetch(..., { timeoutMs })`. Its test instantiates a real `ElizaClient` with the Android native transport and observes the exact timeout, path, method, and JSON body received by the native request layer.

# Testing

- Screen-capture timeout/native-transport suite plus existing backoff suite: 2 files, 10/10 passing.
- Full `packages/ui` TypeScript check: exit 0.
- Biome on all three changed files and `git diff --check`: pass.
- App audit: pending the shared audit slot; no rendered component or styling changed.

# Evidence Gate

<!-- evidence-head:a2a60075dcf97b669323fd94dd587b24706c24f5 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - transport-only TypeScript state module; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - transport-only TypeScript state module; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head validation transcript:
```text
screen-capture native transport + backoff: Test Files 2 passed; Tests 10 passed
packages/ui tsc --noEmit: exit 0 after exact-head repair
Biome changed files: clean; git diff --check: clean; PR mergeability: clean
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console or network surface; native transport options are asserted directly.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistence, memory, database, wallet, or media artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered interface or visual text changed.

## Known gaps / failures

The required app audit has not yet run because the shared audit slot is occupied by other parallel PR reviews. This PR will not merge until that gate is released and completed. The changed module has no rendered output.

---

AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol  
Client / agent tooling: Cursor; Codex desktop / multi-agent  
Contribution skill revision: elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza"} -->
