### PR TITLE
fix(voice): close Cartesia transport only on teardown

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -620,6 +620,10 @@ describe("voice-session WS lifecycle", () => {
     expect(cartesia.sentText().replaceAll(" ", "")).toContain(
       "Notmuch.Goodtohearfromyou.",
     );
+
+    client.clientSend(JSON.stringify({ t: "bye" }));
+    await flush();
+    expect(cartesia.closed).toBe(true);
   });
 
   test("generates the call opener as a stable canonical system turn", async () => {
@@ -1675,7 +1679,7 @@ describe("voice-session WS lifecycle", () => {
     client.clientSend(JSON.stringify({ t: "barge_in" }));
     await flush();
     expect(client.controlTypes()).toContain("interrupted");
-    expect(cartesia.closed).toBe(true);
+    expect(cartesia.closed).toBe(false);
     // The interrupted turn reports usage (accounting stays accurate on barge-in),
     // emitted BEFORE the interrupted frame.
     const types = client.controlTypes();
@@ -1725,13 +1729,13 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlFrames).toContainEqual(
       expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
     );
-    expect(cartesia.closed).toBe(true);
+    expect(cartesia.closed).toBe(false);
     expect(client.audioFrames).toHaveLength(audioBeforeInterruption);
 
     ink.emitTurn("turn.end", "wait");
     await flush();
     await flush();
-    expect(FakeCartesiaSocket.instances.at(-1)).not.toBe(cartesia);
+    expect(FakeCartesiaSocket.instances.at(-1)).toBe(cartesia);
     expect(client.audioFrames.length).toBeGreaterThan(audioBeforeInterruption);
   });
 
@@ -1789,7 +1793,7 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlFrames).toContainEqual(
       expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
     );
-    expect(activeCartesia.closed).toBe(true);
+    expect(activeCartesia.closed).toBe(false);
   });
 
   test("interruption aborts the in-flight Eliza SSE fetch", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -1189,9 +1189,6 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       this.ttsStream.cancel(`interrupted:${reason}`);
       this.ttsStream = null;
     }
-    // Context completion and barge-in intentionally keep the call-scoped
-    // Cartesia transport warm; only session teardown closes the shared socket.
-    this.cartesiaAdapter.close(`session:${reason}`);
     // 3. Abort the Eliza SSE fetch — cancels the upstream provider stream.
     if (this.llmAbort) {
       this.llmAbort.abort();
@@ -1324,6 +1321,9 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       }
       this.ttsStream = null;
     }
+    // Context completion and barge-in keep the call-scoped Cartesia transport
+    // warm. Session teardown is the sole owner of shared socket closure.
+    this.cartesiaAdapter.close(`session:${reason}`);
     if (this.llmAbort) {
       this.llmAbort.abort();
       this.llmAbort = null;


### PR DESCRIPTION
Closes #21838. Corrective follow-up to merged #21785.

`VoiceSession.interrupt()` was closing the per-call Cartesia transport immediately after documenting that barge-in must keep it warm, while normal `teardown()` never closed it. This moves close ownership to teardown: interruption remains reusable and end-of-session cleanup closes the socket.

Validation on pinned Bun 1.3.14 / Node 24.15.0:

- Full voice WebSocket lifecycle suite: 60/60 before the final mechanical rebase.
- Four directly affected reuse/teardown regressions: pass after rebase.
- Changed-file Biome and `git diff --check`: pass.
- Exact-head CI is queued. Do not merge without an independent review.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI Codex`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:c442a0e991bdde8e6bde48a25463a5cc720518fd -->
<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend voice transport lifecycle only.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered UI changed.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - deterministic WebSocket lifecycle tests are the relevant evidence.`
<!-- evidence-row:backend-logs -->
- [x] Pinned lifecycle test results are summarized above; exact-head CI is queued.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code changed.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model or prompt behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Transport reuse/close call observations in the lifecycle tests are the relevant artifacts.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no visual surface changed.`
