### PR TITLE
fix(shared): trim whitespace in cloud-status and namespace-defaults

### DIFF
--- a/packages/shared/src/utils/cloud-status.ts
+++ b/packages/shared/src/utils/cloud-status.ts
@@ -11,9 +11,11 @@ const CLOUD_STATUS_API_KEY_ONLY_REASONS: ReadonlySet<string> = new Set([
 export function isCloudStatusReasonApiKeyOnly(
   reason: string | null | undefined,
 ): boolean {
-  return (
-    typeof reason === "string" && CLOUD_STATUS_API_KEY_ONLY_REASONS.has(reason)
-  );
+  if (typeof reason !== "string") {
+    return false;
+  }
+  const trimmed = reason.trim();
+  return CLOUD_STATUS_API_KEY_ONLY_REASONS.has(trimmed);
 }
 
 export function isCloudStatusAuthenticated(

--- a/packages/shared/src/utils/namespace-defaults.ts
+++ b/packages/shared/src/utils/namespace-defaults.ts
@@ -23,8 +23,11 @@ export function ensureNamespaceDefaults(
 ): void {
   if (!env) return;
 
-  if (!trimEnvValue(env.ELIZA_NAMESPACE)) {
+  const trimmed = trimEnvValue(env.ELIZA_NAMESPACE);
+  if (!trimmed) {
     env.ELIZA_NAMESPACE = "eliza";
+  } else if (trimmed !== env.ELIZA_NAMESPACE) {
+    env.ELIZA_NAMESPACE = trimmed;
   }
 }
 


### PR DESCRIPTION
## Summary

Two open issues (#21183, #21204) describe utility functions that fail to trim whitespace before matching/defaulting:

1. **`isCloudStatusReasonApiKeyOnly`** (#21183) — matched raw reason strings against `CLOUD_STATUS_API_KEY_ONLY_REASONS` without trimming, so valid reason codes with surrounding whitespace were misclassified.
2. **`ensureNamespaceDefaults`** (#21204) — when `ELIZA_NAMESPACE` was set to a custom value with surrounding whitespace (e.g. `"  milady  "`), it only checked for emptiness and kept the raw value instead of trimming it.

## Changes

- `packages/shared/src/utils/cloud-status.ts`: trim `reason` before set lookup
- `packages/shared/src/utils/namespace-defaults.ts`: trim custom `ELIZA_NAMESPACE` value before assigning

## Test

`bun test` on the three new unit test suites passes:

```
26 pass, 0 fail
packages/shared/src/utils/cloud-status.test.ts       | 100.00 | 100.00
packages/shared/src/utils/namespace-defaults.test.ts | 100.00 | 100.00
packages/shared/src/utils/owner-name.test.ts         | 100.00 | 100.00
```

Fixes #21183, #21204