### PR TITLE
feat(cloud): propagate Shared provider timing receipts

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -111,10 +111,15 @@ mock.module("@/lib/services/eliza-app", () => ({
     resolvePersonalDelivery,
   },
 }));
+// The real serializer, not a re-implementation: mocking it meant the header
+// this route exists to emit was never actually produced by the code under
+// test, so the whole route-layer claim went unexercised.
+const { sharedTurnServerTiming } = await import(
+  "@/lib/services/shared-runtime/shared-rest-adapter"
+);
 mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
   sharedRestMessageSend,
-  sharedTurnServerTiming: (timing?: { durationMs: number }) =>
-    timing ? `shared_model;dur=${timing.durationMs.toFixed(1)}` : "",
+  sharedTurnServerTiming,
 }));
 mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
   prewarmPersonalSharedAgentTurnCaches,
@@ -1218,5 +1223,36 @@ describe("personal Shared messaging deliveries", () => {
   ])("rejects malformed deliveries before account creation", async (body) => {
     expect((await request(body)).status).toBe(400);
     expect(resolvePersonalDelivery).not.toHaveBeenCalled();
+  });
+
+  // The route's headline claim is that a provider timing receipt reaches the
+  // client as a `shared_model` Server-Timing segment. Every other test here
+  // returns no `timing`, so that segment was never produced — this drives the
+  // real serializer with a real receipt.
+  test("emits the shared_model segment when the turn carries a timing receipt", async () => {
+    sharedRestMessageSend.mockResolvedValueOnce({
+      text: "hello from Eliza",
+      timing: {
+        replayed: false,
+        durationMs: 1234.5,
+        callCount: 2,
+        fallbackCount: 1,
+        selectedProvider: "openrouter",
+        callsTruncated: false,
+        clamped: false,
+        calls: [],
+      },
+    } as never);
+
+    const response = await request(valid);
+    expect(response.status).toBe(200);
+
+    const serverTiming = response.headers.get("server-timing") ?? "";
+    expect(serverTiming).toContain("shared_model;dur=1234.5");
+    expect(serverTiming).toContain("provider=openrouter");
+    expect(serverTiming).toContain("calls=2");
+    expect(serverTiming).toContain("fallbacks=1");
+    expect(serverTiming).toContain("replayed=0");
+    expect(serverTiming).toContain("clamped=0");
   });
 });

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -113,6 +113,8 @@ mock.module("@/lib/services/eliza-app", () => ({
 }));
 mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
   sharedRestMessageSend,
+  sharedTurnServerTiming: (timing?: { durationMs: number }) =>
+    timing ? `shared_model;dur=${timing.durationMs.toFixed(1)}` : "",
 }));
 mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
   prewarmPersonalSharedAgentTurnCaches,

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -649,15 +649,8 @@ app.post("/", async (c) => {
       "platform",
       trustedDelivery,
     );
-    if (result.timing) {
-      logger.info("[personal-shared-messaging] shared provider timing", {
-        selectedProvider: result.timing.selectedProvider,
-        callCount: result.timing.callCount,
-        fallbackCount: result.timing.fallbackCount,
-        replayed: result.timing.replayed,
-        durationMs: result.timing.durationMs,
-      });
-    }
+    // The same values ship on `Server-Timing` below; a second uncorrelated
+    // per-turn log on the hot path would only duplicate them.
     const providerTiming = sharedTurnServerTiming(result.timing);
     c.header(
       "Server-Timing",

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -19,7 +19,10 @@ import { coordinateSharedHistory } from "@/lib/services/shared-runtime/conversat
 import { personalSharedAgent } from "@/lib/services/shared-runtime/personal-shared-agent";
 import { prewarmPersonalSharedAgentTurnCaches } from "@/lib/services/shared-runtime/prewarm-shared-agent";
 import { resolveSharedRuntimeWorkerRequestContext } from "@/lib/services/shared-runtime/resolve-shared-agent";
-import { sharedRestMessageSend } from "@/lib/services/shared-runtime/shared-rest-adapter";
+import {
+  sharedRestMessageSend,
+  sharedTurnServerTiming,
+} from "@/lib/services/shared-runtime/shared-rest-adapter";
 import { SharedRuntimeCacheWarmingError } from "@/lib/services/shared-runtime/shared-runtime-errors";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -646,11 +649,26 @@ app.post("/", async (c) => {
       "platform",
       trustedDelivery,
     );
+    if (result.timing) {
+      logger.info("[personal-shared-messaging] shared provider timing", {
+        selectedProvider: result.timing.selectedProvider,
+        callCount: result.timing.callCount,
+        fallbackCount: result.timing.fallbackCount,
+        replayed: result.timing.replayed,
+        durationMs: result.timing.durationMs,
+      });
+    }
+    const providerTiming = sharedTurnServerTiming(result.timing);
     c.header(
       "Server-Timing",
-      `${accountTiming}, prewarm;dur=${prewarmMs.toFixed(1)}, shared;dur=${(
-        performance.now() - sharedStartedAt
-      ).toFixed(1)}`,
+      [
+        accountTiming,
+        `prewarm;dur=${prewarmMs.toFixed(1)}`,
+        `shared;dur=${(performance.now() - sharedStartedAt).toFixed(1)}`,
+        providerTiming,
+      ]
+        .filter(Boolean)
+        .join(", "),
     );
 
     return c.json({

--- a/packages/cloud/shared/src/lib/providers/language-model-interactive-cerebras-failover.test.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model-interactive-cerebras-failover.test.ts
@@ -101,22 +101,27 @@ describe("getInteractiveCerebrasLanguageModel 5xx instant failover", () => {
   });
 
   test("happy path serves directly via cerebras (no failover)", async () => {
+    const selections: unknown[] = [];
     globalThis.fetch = (async (url: RequestInfo | URL) => {
       hosts.push(hostOf(url));
       return completion("gemma-4-31b", "from-cerebras");
     }) as typeof fetch;
 
     const result = await generateText({
-      model: getInteractiveCerebrasLanguageModel("gemma-4-31b"),
+      model: getInteractiveCerebrasLanguageModel("gemma-4-31b", (selection) =>
+        selections.push(selection),
+      ),
       prompt: "hi",
       maxRetries: 0,
     });
 
     expect(result.text).toBe("from-cerebras");
     expect(hosts).toEqual(["cerebras"]);
+    expect(selections).toEqual([{ provider: "cerebras", fallback: false }]);
   });
 
   test("a transient 5xx fails over to OpenRouter WITHOUT retrying cerebras", async () => {
+    const selections: unknown[] = [];
     // The whole point of the fix: on a 5xx we do NOT sleep-then-retry the same
     // dead cerebras upstream; we fail over to a healthy provider immediately.
     // maxRetries:0 mirrors the interactive turn's config — the ONLY retry is the
@@ -133,7 +138,9 @@ describe("getInteractiveCerebrasLanguageModel 5xx instant failover", () => {
     }) as typeof fetch;
 
     const result = await generateText({
-      model: getInteractiveCerebrasLanguageModel("gemma-4-31b"),
+      model: getInteractiveCerebrasLanguageModel("gemma-4-31b", (selection) =>
+        selections.push(selection),
+      ),
       prompt: "hi",
       maxRetries: 0,
     });
@@ -142,6 +149,7 @@ describe("getInteractiveCerebrasLanguageModel 5xx instant failover", () => {
     // Exactly one cerebras attempt (no SDK backoff loop) then the failover.
     expect(hosts).toEqual(["cerebras", "openrouter"]);
     expect(models).toEqual(["gemma-4-31b", "google/gemma-4-31b-it"]);
+    expect(selections).toEqual([{ provider: "openrouter", fallback: true }]);
   });
 
   test("a decorated cerebras id (:nitro) also fails over on 5xx", async () => {

--- a/packages/cloud/shared/src/lib/providers/language-model-openrouter-fallback.test.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model-openrouter-fallback.test.ts
@@ -27,6 +27,9 @@ mock.module("@/lib/utils/logger", () => ({
 
 const { generateText } = await import("ai");
 const { getLanguageModel } = await import("./language-model");
+const { SharedRuntimeTimingCollector } = await import(
+  "../services/shared-runtime/shared-runtime-timing"
+);
 
 function hostOf(url: RequestInfo | URL): "openrouter" | "openai" | "other" {
   const u = String(url);
@@ -89,7 +92,26 @@ describe("getLanguageModel native → OpenRouter fallback (AI SDK path)", () => 
     expect(selections).toEqual([{ provider: "openrouter", fallback: true }]);
   });
 
+  test("attributes a successful native OpenAI turn to openai, not the catch-all", async () => {
+    const selections: unknown[] = [];
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      hosts.push(hostOf(url));
+      return completion("openai/gpt-4", "from-openai");
+    }) as typeof fetch;
+
+    const result = await generateText({
+      model: getLanguageModel("openai/gpt-4", undefined, (selection) => selections.push(selection)),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(result.text).toBe("from-openai");
+    expect(hosts).toEqual(["openai"]);
+    expect(selections).toEqual([{ provider: "openai", fallback: false }]);
+  });
+
   test("does not fall over on a non-retryable error (400)", async () => {
+    const selections: unknown[] = [];
     globalThis.fetch = (async (url: RequestInfo | URL) => {
       hosts.push(hostOf(url));
       return new Response(JSON.stringify({ error: { message: "bad request" } }), { status: 400 });
@@ -97,13 +119,36 @@ describe("getLanguageModel native → OpenRouter fallback (AI SDK path)", () => 
 
     await expect(
       generateText({
-        model: getLanguageModel("openai/gpt-4"),
+        model: getLanguageModel("openai/gpt-4", undefined, (selection) =>
+          selections.push(selection),
+        ),
         prompt: "hi",
         maxRetries: 0,
       }),
     ).rejects.toBeDefined();
     // OpenRouter is never reached: a 400 is a real request error, not an outage.
     expect(hosts).toEqual(["openai"]);
+    // A failed call must never be attributed to a provider that served nothing.
+    expect(selections).toEqual([]);
+  });
+
+  test("records a call whose provider never reported a selection as unobserved", async () => {
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      hosts.push(hostOf(url));
+      return new Response(JSON.stringify({ error: { message: "bad request" } }), { status: 400 });
+    }) as typeof fetch;
+
+    let now = 0;
+    const timing = new SharedRuntimeTimingCollector("failed-call", 0, () => (now += 12));
+    const call = timing.prepareModelCall();
+    const model = getLanguageModel("openai/gpt-4", undefined, call.select);
+    call.begin();
+    await expect(generateText({ model, prompt: "hi", maxRetries: 0 })).rejects.toBeDefined();
+    call.finish();
+
+    const receipt = timing.receipt("error").model;
+    expect(receipt.selectedProvider).toBe("none");
+    expect(receipt.calls).toEqual([{ provider: "unobserved", durationMs: 12, fallback: false }]);
   });
 
   test("retries OpenRouter's transient no-models 400 once after native failover", async () => {

--- a/packages/cloud/shared/src/lib/providers/language-model-openrouter-fallback.test.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model-openrouter-fallback.test.ts
@@ -71,6 +71,7 @@ describe("getLanguageModel native → OpenRouter fallback (AI SDK path)", () => 
   });
 
   test("falls over to OpenRouter when the native provider returns a retryable 503", async () => {
+    const selections: unknown[] = [];
     globalThis.fetch = (async (url: RequestInfo | URL) => {
       const host = hostOf(url);
       hosts.push(host);
@@ -78,13 +79,14 @@ describe("getLanguageModel native → OpenRouter fallback (AI SDK path)", () => 
     }) as typeof fetch;
 
     const result = await generateText({
-      model: getLanguageModel("openai/gpt-4"),
+      model: getLanguageModel("openai/gpt-4", undefined, (selection) => selections.push(selection)),
       prompt: "hi",
       maxRetries: 0,
     });
 
     expect(result.text).toBe("from-openrouter");
     expect(hosts).toEqual(["openai", "openrouter"]);
+    expect(selections).toEqual([{ provider: "openrouter", fallback: true }]);
   });
 
   test("does not fall over on a non-retryable error (400)", async () => {

--- a/packages/cloud/shared/src/lib/providers/language-model.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model.ts
@@ -10,6 +10,7 @@ import {
   isGroqNativeModel,
   isVastNativeModel,
 } from "../models";
+import type { SharedModelCallSelection } from "../services/shared-runtime/shared-runtime-timing";
 import type { PooledDirectProvider } from "../services/team-credential-pool/provider-map";
 import { logger } from "../utils/logger";
 import { RETRYABLE_UPSTREAM_STATUSES } from "./failover";
@@ -489,15 +490,20 @@ async function invokeOpenRouterFallback<T>(
  * the native call returns a retryable error. A no-op when OPENROUTER_API_KEY is
  * unset, so direct-only deployments are unchanged.
  */
+/**
+ * `nativeProvider` names the provider serving `primaryModel` so a successful
+ * native call is attributed to itself rather than to the catch-all `other`.
+ */
 function withOpenRouterFallback(
   primaryModel: Parameters<typeof wrapLanguageModel>[0]["model"],
   model: string,
+  nativeProvider: InteractiveLanguageModelSelection["provider"],
   onProviderSelected?: (selection: InteractiveLanguageModelSelection) => void,
 ) {
   if (!getOpenRouterApiKey()) {
     return withSuccessfulProviderSelection(
       primaryModel,
-      { provider: "other", fallback: false },
+      { provider: nativeProvider, fallback: false },
       onProviderSelected,
     );
   }
@@ -508,7 +514,7 @@ function withOpenRouterFallback(
     wrapGenerate: async ({ doGenerate, params }) => {
       try {
         const result = await doGenerate();
-        notifyProviderSelected(onProviderSelected, { provider: "other", fallback: false });
+        notifyProviderSelected(onProviderSelected, { provider: nativeProvider, fallback: false });
         return result;
       } catch (error) {
         if (!isRetryableAiSdkError(error)) {
@@ -529,7 +535,7 @@ function withOpenRouterFallback(
     wrapStream: async ({ doStream, params }) => {
       try {
         const result = await doStream();
-        notifyProviderSelected(onProviderSelected, { provider: "other", fallback: false });
+        notifyProviderSelected(onProviderSelected, { provider: nativeProvider, fallback: false });
         return result;
       } catch (error) {
         if (!isRetryableAiSdkError(error)) {
@@ -706,8 +712,13 @@ function withCerebrasInteractiveFailover(
   return wrapLanguageModel({ model: primaryModel, middleware });
 }
 
+/**
+ * Provider attribution reported to a timing observer once a call succeeds.
+ * `other` is the deliberate catch-all for pooled, Groq, and Vast models, whose
+ * individual identity the Shared timing receipt does not need.
+ */
 export interface InteractiveLanguageModelSelection {
-  provider: "cerebras" | "openrouter" | "other";
+  provider: SharedModelCallSelection["provider"];
   fallback: boolean;
 }
 
@@ -891,13 +902,14 @@ export function getLanguageModel(
     const primary = getProviderKey("OPENAI_BASE_URL")
       ? getOpenAIClient().chat(modelId)
       : getOpenAIClient().languageModel(modelId);
-    return withOpenRouterFallback(primary, model, onProviderSelected);
+    return withOpenRouterFallback(primary, model, "openai", onProviderSelected);
   }
 
   if (isAnthropicNativeModel(model) && getProviderKey("ANTHROPIC_API_KEY")) {
     return withOpenRouterFallback(
       getAnthropicClient().languageModel(normalizeAnthropicModelId(model)),
       model,
+      "anthropic",
       onProviderSelected,
     );
   }

--- a/packages/cloud/shared/src/lib/providers/language-model.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model.ts
@@ -492,9 +492,14 @@ async function invokeOpenRouterFallback<T>(
 function withOpenRouterFallback(
   primaryModel: Parameters<typeof wrapLanguageModel>[0]["model"],
   model: string,
+  onProviderSelected?: (selection: InteractiveLanguageModelSelection) => void,
 ) {
   if (!getOpenRouterApiKey()) {
-    return primaryModel;
+    return withSuccessfulProviderSelection(
+      primaryModel,
+      { provider: "other", fallback: false },
+      onProviderSelected,
+    );
   }
 
   const fallbackModel = getOpenRouterLanguageModel(model);
@@ -502,7 +507,9 @@ function withOpenRouterFallback(
     specificationVersion: "v3",
     wrapGenerate: async ({ doGenerate, params }) => {
       try {
-        return await doGenerate();
+        const result = await doGenerate();
+        notifyProviderSelected(onProviderSelected, { provider: "other", fallback: false });
+        return result;
       } catch (error) {
         if (!isRetryableAiSdkError(error)) {
           throw error;
@@ -512,14 +519,18 @@ function withOpenRouterFallback(
           model,
           aiSdkErrorStatus(error),
         );
-        return await invokeOpenRouterFallback(model, "generate", () =>
+        const result = await invokeOpenRouterFallback(model, "generate", () =>
           fallbackModel.doGenerate(params),
         );
+        notifyProviderSelected(onProviderSelected, { provider: "openrouter", fallback: true });
+        return result;
       }
     },
     wrapStream: async ({ doStream, params }) => {
       try {
-        return await doStream();
+        const result = await doStream();
+        notifyProviderSelected(onProviderSelected, { provider: "other", fallback: false });
+        return result;
       } catch (error) {
         if (!isRetryableAiSdkError(error)) {
           throw error;
@@ -529,14 +540,40 @@ function withOpenRouterFallback(
           model,
           aiSdkErrorStatus(error),
         );
-        return await invokeOpenRouterFallback(model, "stream", () =>
+        const result = await invokeOpenRouterFallback(model, "stream", () =>
           fallbackModel.doStream(params),
         );
+        notifyProviderSelected(onProviderSelected, { provider: "openrouter", fallback: true });
+        return result;
       }
     },
   };
 
   return wrapLanguageModel({ model: primaryModel, middleware });
+}
+
+function withSuccessfulProviderSelection(
+  model: Parameters<typeof wrapLanguageModel>[0]["model"],
+  selection: InteractiveLanguageModelSelection,
+  onProviderSelected?: (selection: InteractiveLanguageModelSelection) => void,
+) {
+  if (!onProviderSelected) return model;
+  return wrapLanguageModel({
+    model,
+    middleware: {
+      specificationVersion: "v3",
+      wrapGenerate: async ({ doGenerate }) => {
+        const result = await doGenerate();
+        notifyProviderSelected(onProviderSelected, selection);
+        return result;
+      },
+      wrapStream: async ({ doStream }) => {
+        const result = await doStream();
+        notifyProviderSelected(onProviderSelected, selection);
+        return result;
+      },
+    },
+  });
 }
 
 /**
@@ -615,16 +652,23 @@ function withRateLimitFailFast(primaryModel: Parameters<typeof wrapLanguageModel
 function withCerebrasInteractiveFailover(
   primaryModel: Parameters<typeof wrapLanguageModel>[0]["model"],
   model: string,
+  onProviderSelected?: (selection: InteractiveLanguageModelSelection) => void,
 ) {
   if (!getOpenRouterApiKey()) {
-    return primaryModel;
+    return withSuccessfulProviderSelection(
+      primaryModel,
+      { provider: "cerebras", fallback: false },
+      onProviderSelected,
+    );
   }
   const fallbackModel = getOpenRouterLanguageModel(resolveCerebrasOpenRouterFallbackModel(model));
   const middleware: LanguageModelMiddleware = {
     specificationVersion: "v3",
     wrapGenerate: async ({ doGenerate, params }) => {
       try {
-        return await doGenerate();
+        const result = await doGenerate();
+        notifyProviderSelected(onProviderSelected, { provider: "cerebras", fallback: false });
+        return result;
       } catch (error) {
         if (!isRetryableAiSdkError(error)) throw error;
         logger.warn(
@@ -632,14 +676,18 @@ function withCerebrasInteractiveFailover(
           model,
           aiSdkErrorStatus(error),
         );
-        return await invokeOpenRouterFallback(model, "generate", () =>
+        const result = await invokeOpenRouterFallback(model, "generate", () =>
           fallbackModel.doGenerate(params),
         );
+        notifyProviderSelected(onProviderSelected, { provider: "openrouter", fallback: true });
+        return result;
       }
     },
     wrapStream: async ({ doStream, params }) => {
       try {
-        return await doStream();
+        const result = await doStream();
+        notifyProviderSelected(onProviderSelected, { provider: "cerebras", fallback: false });
+        return result;
       } catch (error) {
         if (!isRetryableAiSdkError(error)) throw error;
         logger.warn(
@@ -647,13 +695,35 @@ function withCerebrasInteractiveFailover(
           model,
           aiSdkErrorStatus(error),
         );
-        return await invokeOpenRouterFallback(model, "stream", () =>
+        const result = await invokeOpenRouterFallback(model, "stream", () =>
           fallbackModel.doStream(params),
         );
+        notifyProviderSelected(onProviderSelected, { provider: "openrouter", fallback: true });
+        return result;
       }
     },
   };
   return wrapLanguageModel({ model: primaryModel, middleware });
+}
+
+export interface InteractiveLanguageModelSelection {
+  provider: "cerebras" | "openrouter" | "other";
+  fallback: boolean;
+}
+
+function notifyProviderSelected(
+  observer: ((selection: InteractiveLanguageModelSelection) => void) | undefined,
+  selection: InteractiveLanguageModelSelection,
+): void {
+  if (!observer) return;
+  try {
+    observer(selection);
+  } catch (error) {
+    // error-policy:J7 timing must never change a successful inference outcome.
+    logger.warn("[language-model] Provider-selection observer failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 /**
@@ -664,14 +734,18 @@ function withCerebrasInteractiveFailover(
  * normal router. Interactive callers (shared-runtime chat/voice turn) pair this
  * with `maxRetries: 0` so the only retry is the instant cross-provider failover.
  */
-export function getInteractiveCerebrasLanguageModel(model: string) {
+export function getInteractiveCerebrasLanguageModel(
+  model: string,
+  onProviderSelected?: (selection: InteractiveLanguageModelSelection) => void,
+) {
   if (isCerebrasNativeModel(model) && getProviderKey("CEREBRAS_API_KEY")) {
     return withCerebrasInteractiveFailover(
       withRateLimitFailFast(getCerebrasClient().chat(normalizeCerebrasModelId(model))),
       model,
+      onProviderSelected,
     );
   }
-  return getLanguageModel(model);
+  return getLanguageModel(model, undefined, onProviderSelected);
 }
 
 /**
@@ -750,19 +824,37 @@ export function hasTextEmbeddingProviderConfigured(model?: string): boolean {
   return Boolean(getProviderKey("OPENAI_API_KEY"));
 }
 
-export function getLanguageModel(model: string, credential?: PooledLanguageModelCredential) {
+export function getLanguageModel(
+  model: string,
+  credential?: PooledLanguageModelCredential,
+  onProviderSelected?: (selection: InteractiveLanguageModelSelection) => void,
+) {
   if (credential) {
     const pooledModel = getPooledLanguageModel(model, credential);
-    if (pooledModel) return pooledModel;
+    if (pooledModel) {
+      return withSuccessfulProviderSelection(
+        pooledModel,
+        { provider: "other", fallback: false },
+        onProviderSelected,
+      );
+    }
   }
 
   if (isGroqNativeModel(model)) {
-    return getGroqClient().languageModel(getGroqApiModelId(model));
+    return withSuccessfulProviderSelection(
+      getGroqClient().languageModel(getGroqApiModelId(model)),
+      { provider: "other", fallback: false },
+      onProviderSelected,
+    );
   }
 
   if (isVastNativeModel(model)) {
     const { client, apiModelId } = getVastClient(model);
-    return client.languageModel(apiModelId);
+    return withSuccessfulProviderSelection(
+      client.languageModel(apiModelId),
+      { provider: "other", fallback: false },
+      onProviderSelected,
+    );
   }
 
   // Cerebras-native bare IDs (gemma-4-31b, gpt-oss-120b, zai-glm-4.7) → Cerebras direct.
@@ -772,14 +864,22 @@ export function getLanguageModel(model: string, credential?: PooledLanguageModel
   // so that 429 surfaces in ~one round-trip instead of after the AI SDK's default
   // ~50s 3-attempt backoff (which turned a throttled turn into a 50s hang).
   if (isCerebrasNativeModel(model) && getProviderKey("CEREBRAS_API_KEY")) {
-    return withRateLimitFailFast(getCerebrasClient().chat(normalizeCerebrasModelId(model)));
+    return withSuccessfulProviderSelection(
+      withRateLimitFailFast(getCerebrasClient().chat(normalizeCerebrasModelId(model))),
+      { provider: "cerebras", fallback: false },
+      onProviderSelected,
+    );
   }
 
   // OpenRouter-catalog ids no native provider can serve (`:nitro`/`:floor`,
   // `openai/gpt-oss-120b` as an OpenRouter id) → OpenRouter backup.
   if (requiresGatewayRouting(model)) {
     if (getOpenRouterApiKey()) {
-      return getOpenRouterLanguageModel(model);
+      return withSuccessfulProviderSelection(
+        getOpenRouterLanguageModel(model),
+        { provider: "openrouter", fallback: false },
+        onProviderSelected,
+      );
     }
     throw new ProviderConfigurationError("OPENROUTER_API_KEY is required for this model");
   }
@@ -791,19 +891,24 @@ export function getLanguageModel(model: string, credential?: PooledLanguageModel
     const primary = getProviderKey("OPENAI_BASE_URL")
       ? getOpenAIClient().chat(modelId)
       : getOpenAIClient().languageModel(modelId);
-    return withOpenRouterFallback(primary, model);
+    return withOpenRouterFallback(primary, model, onProviderSelected);
   }
 
   if (isAnthropicNativeModel(model) && getProviderKey("ANTHROPIC_API_KEY")) {
     return withOpenRouterFallback(
       getAnthropicClient().languageModel(normalizeAnthropicModelId(model)),
       model,
+      onProviderSelected,
     );
   }
 
   // Backup: OpenRouter (BYOK) serves any model we have no native key for.
   if (getOpenRouterApiKey()) {
-    return getOpenRouterLanguageModel(model);
+    return withSuccessfulProviderSelection(
+      getOpenRouterLanguageModel(model),
+      { provider: "openrouter", fallback: false },
+      onProviderSelected,
+    );
   }
 
   throw new ProviderConfigurationError(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -46,7 +46,10 @@ import {
 } from "./shared-capability-wall";
 import type { SharedMemoryStore } from "./shared-memory-store";
 import type { SharedRuntimeChannel } from "./shared-runtime-channel";
-import type { SharedRuntimeTimingReceipt } from "./shared-runtime-timing";
+import type {
+  SharedProviderTimingReceipt,
+  SharedRuntimeTimingReceipt,
+} from "./shared-runtime-timing";
 
 export type { SharedRuntimeChannel } from "./shared-runtime-channel";
 export {
@@ -197,6 +200,8 @@ export interface RunSharedAgentTurnResult {
   actionResults?: ActionResult[];
   /** Typed refusal for a tool or device action Shared cannot execute. */
   capabilityWall?: SharedCapabilityWall;
+  /** Privacy-bounded provider timing exposed to Shared transports. */
+  timing?: SharedProviderTimingReceipt;
   /** Unsupported clauses that follow an enabled primary reminder or Todo. */
   blockedSecondaryCapabilities?: SharedCapabilityWall[];
 }
@@ -210,6 +215,8 @@ export type SharedAgentTurnStreamPart =
       usage?: SharedAgentTurnUsage;
       /** Applied plugin effects that must land with the terminal turn. */
       actionResults?: ActionResult[];
+      /** Privacy-bounded provider timing exposed on the terminal stream frame. */
+      timing?: SharedProviderTimingReceipt;
     };
 
 export interface RunSharedAgentTurnStreamResult {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -604,6 +604,7 @@ describe("Shared Eliza Workerd runtime", () => {
 
     const { runSharedAgentTurn } = await import("./run-shared-agent-turn");
     let dispatches = 0;
+    const startedAt = performance.now();
     const result = await runSharedAgentTurn({
       character: {
         name: "Shared Eliza",
@@ -618,6 +619,7 @@ describe("Shared Eliza Workerd runtime", () => {
       },
       onProviderDispatch: async () => {
         dispatches += 1;
+        await new Promise((resolve) => setTimeout(resolve, 50));
       },
       execution: {
         channel: { type: ChannelType.DM, source: "shared-runtime" },
@@ -641,6 +643,15 @@ describe("Shared Eliza Workerd runtime", () => {
       "hello from the genuine Shared runtime",
     ]);
     expect(dispatches).toBe(1);
+    expect(performance.now() - startedAt).toBeGreaterThanOrEqual(40);
+    expect(result.timing).toMatchObject({
+      replayed: false,
+      callCount: 1,
+      fallbackCount: 0,
+      selectedProvider: "cerebras",
+      callsTruncated: false,
+    });
+    expect(result.timing?.durationMs).toBeLessThan(30);
     expect(requests).toHaveLength(1);
     expect(
       (requests[0].tools as Array<{ function?: { name?: string } }>).some(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -447,6 +447,7 @@ describe("Shared Eliza Workerd runtime", () => {
     const { runSharedAgentTurnStream } = await import("./run-shared-agent-turn");
     const reportSpy = spyOn(AgentRuntime.prototype, "reportError");
     let dispatches = 0;
+    const startedAt = performance.now();
     const result = await runSharedAgentTurnStream({
       character: {
         name: "Shared Eliza",
@@ -461,6 +462,7 @@ describe("Shared Eliza Workerd runtime", () => {
       },
       onProviderDispatch: async () => {
         dispatches += 1;
+        await new Promise((resolve) => setTimeout(resolve, 50));
       },
       traceId: "trace-observer-nonfatal",
       onRuntimeTiming: () => {
@@ -474,6 +476,7 @@ describe("Shared Eliza Workerd runtime", () => {
     });
     const parts = [];
     for await (const part of result.parts ?? []) parts.push(part);
+    const elapsedMs = performance.now() - startedAt;
 
     expect(
       parts
@@ -481,10 +484,22 @@ describe("Shared Eliza Workerd runtime", () => {
         .map((part) => part.text)
         .join(""),
     ).toBe("Take one slow breath, then choose the smallest next step.");
-    expect(parts.at(-1)).toMatchObject({
+    const terminalPart = parts.at(-1);
+    expect(terminalPart).toMatchObject({
       type: "finish",
       text: "Take one slow breath, then choose the smallest next step.",
+      timing: {
+        replayed: false,
+        callCount: 1,
+        selectedProvider: "cerebras",
+      },
     });
+    if (!terminalPart || terminalPart.type !== "finish") {
+      throw new Error("Expected a terminal streamed Shared runtime result");
+    }
+    const providerDurationMs = terminalPart.timing?.durationMs;
+    expect(typeof providerDurationMs).toBe("number");
+    expect(elapsedMs - (providerDurationMs ?? elapsedMs)).toBeGreaterThanOrEqual(40);
     expect(dispatches).toBe(1);
     expect(requests).toHaveLength(1);
     expect(requests[0]).toMatchObject({ stream: true });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -599,6 +599,9 @@ async function executeMeasuredSharedElizaRuntimeTurn(
         modelCall.begin();
         result = streamText(generation);
       } catch (error) {
+        // error-policy:J6 best-effort teardown — close the timing span so a
+        // synchronous streamText failure cannot leave the call recorded as
+        // still running, then let the original error propagate untouched.
         modelCall.finish();
         throw error;
       }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -74,6 +74,7 @@ import {
 import {
   SharedRuntimeTimingCollector,
   type SharedRuntimeTimingOutcome,
+  type SharedRuntimeTimingReceipt,
 } from "./shared-runtime-timing";
 import { SHARED_TURN_MAX_RETRIES } from "./shared-turn-retry-budget";
 
@@ -500,9 +501,10 @@ async function executeSharedElizaRuntimeTurn(
     input.history.length,
   );
   let runtimeReporter: IAgentRuntime | undefined;
-  const emitTiming = (outcome: SharedRuntimeTimingOutcome): void => {
+  const emitTiming = (outcome: SharedRuntimeTimingOutcome): SharedRuntimeTimingReceipt => {
+    const receipt = timing.receipt(outcome);
     try {
-      input.onRuntimeTiming?.(timing.receipt(outcome));
+      input.onRuntimeTiming?.(receipt);
     } catch (error) {
       // error-policy:J7 diagnostics must not kill the loop. Once the genuine
       // runtime exists, report through its canonical error surface; setup
@@ -524,6 +526,7 @@ async function executeSharedElizaRuntimeTurn(
         error: error instanceof Error ? error.message : String(error),
       });
     }
+    return receipt;
   };
   try {
     const result = await executeMeasuredSharedElizaRuntimeTurn(
@@ -534,8 +537,8 @@ async function executeSharedElizaRuntimeTurn(
         runtimeReporter = runtime;
       },
     );
-    emitTiming("success");
-    return result;
+    const receipt = emitTiming("success");
+    return { ...result, timing: receipt.model };
   } catch (error) {
     emitTiming(input.abortSignal?.aborted ? "aborted" : "error");
     throw error;
@@ -564,12 +567,13 @@ async function executeMeasuredSharedElizaRuntimeTurn(
   let providerDispatched = false;
   const inferenceTelemetry: { summary?: InferenceTurnSummary } = {};
   let usage: SharedAgentTurnUsage | undefined;
-  const model = getInteractiveCerebrasLanguageModel(input.model);
 
   const modelHandler = async (
     _runtime: IAgentRuntime,
     params: GenerateTextParams,
   ): Promise<string | NativeTextModelResult | TextStreamResult> => {
+    const modelCall = timing.prepareModelCall();
+    const model = getInteractiveCerebrasLanguageModel(input.model, modelCall.select);
     if (!providerDispatched) {
       providerDispatched = true;
       await input.onProviderDispatch?.();
@@ -589,6 +593,7 @@ async function executeMeasuredSharedElizaRuntimeTurn(
       ...(typeof params.topP === "number" ? { topP: params.topP } : {}),
       ...(params.signal ? { abortSignal: params.signal } : {}),
     };
+    modelCall.begin();
     if (onStreamChunk && params.stream === true) {
       const result = streamText(generation);
       const text = Promise.resolve(result.text);
@@ -626,11 +631,13 @@ async function executeMeasuredSharedElizaRuntimeTurn(
           yield chunk;
         }
       })();
-      const streamUsage = totalUsage.then((value) => {
-        const normalized = normalizeUsage(value);
-        usage = addUsage(usage, normalized);
-        return normalized;
-      });
+      const streamUsage = totalUsage
+        .then((value) => {
+          const normalized = normalizeUsage(value);
+          usage = addUsage(usage, normalized);
+          return normalized;
+        })
+        .finally(() => modelCall.finish());
       const normalizedToolCalls = toolCalls.then((calls) =>
         calls.map((call) => ({
           id: call.toolCallId,
@@ -651,9 +658,12 @@ async function executeMeasuredSharedElizaRuntimeTurn(
         providerMetadata: { modelName: input.model },
       } as TextStreamResult;
     }
-    const result = await generateText({
-      ...generation,
-    });
+    let result: Awaited<ReturnType<typeof generateText>>;
+    try {
+      result = await generateText({ ...generation });
+    } finally {
+      modelCall.finish();
+    }
     if (result.text.trim()) timing.markProviderFirstText();
     usage = addUsage(usage, normalizeUsage(result.usage));
     if (result.toolCalls.length === 0) {
@@ -1038,6 +1048,7 @@ export async function runSharedElizaRuntimeTurnStream(
         text: result.reply,
         ...(result.responded === false ? { responded: false } : {}),
         usage: result.usage,
+        ...(result.timing ? { timing: result.timing } : {}),
         ...(result.actionResults?.length ? { actionResults: result.actionResults } : {}),
       });
       terminal = true;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -593,9 +593,15 @@ async function executeMeasuredSharedElizaRuntimeTurn(
       ...(typeof params.topP === "number" ? { topP: params.topP } : {}),
       ...(params.signal ? { abortSignal: params.signal } : {}),
     };
-    modelCall.begin();
     if (onStreamChunk && params.stream === true) {
-      const result = streamText(generation);
+      let result: ReturnType<typeof streamText>;
+      try {
+        modelCall.begin();
+        result = streamText(generation);
+      } catch (error) {
+        modelCall.finish();
+        throw error;
+      }
       const text = Promise.resolve(result.text);
       const toolCalls = Promise.resolve(result.toolCalls);
       const finishReason = Promise.resolve(result.finishReason);
@@ -660,6 +666,7 @@ async function executeMeasuredSharedElizaRuntimeTurn(
     }
     let result: Awaited<ReturnType<typeof generateText>>;
     try {
+      modelCall.begin();
       result = await generateText({ ...generation });
     } finally {
       modelCall.finish();

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -49,6 +49,7 @@ const {
   sharedRestFirstRunStatus,
   sharedRestHealth,
   sharedRestMessageSend,
+  sharedTurnServerTiming,
   sharedRestMessagesGet,
   sharedRestStatus,
   sharedRestViews,
@@ -305,6 +306,61 @@ describe("shared-rest-adapter — messages", () => {
       namespace: NAMESPACE,
       channel: { type: ChannelType.DM, source: MESSAGE_SOURCE_CLIENT_CHAT },
     });
+  });
+
+  test("POST preserves a consistent provider receipt and formats Server-Timing", async () => {
+    const timing = {
+      replayed: false,
+      durationMs: 8.1,
+      callCount: 2,
+      fallbackCount: 1,
+      selectedProvider: "mixed" as const,
+      callsTruncated: false,
+      calls: [
+        { provider: "cerebras" as const, durationMs: 3, fallback: false },
+        { provider: "openrouter" as const, durationMs: 5.1, fallback: true },
+      ],
+    };
+    coordinateSharedBridge.mockResolvedValueOnce({
+      jsonrpc: "2.0",
+      id: "timed",
+      result: { text: "four", timing },
+    });
+
+    const out = await sharedRestMessageSend(
+      SHARED_AGENT,
+      AGENT,
+      "2+2?",
+      "Eliza",
+      EXECUTION_CTX,
+      NAMESPACE,
+    );
+    expect(out.timing).toEqual(timing);
+    expect(sharedTurnServerTiming(out.timing)).toBe(
+      'shared_model;dur=8.1;desc="provider=mixed calls=2 fallbacks=1 replayed=0"',
+    );
+  });
+
+  test("POST rejects impossible provider timing from the untrusted bridge", async () => {
+    coordinateSharedBridge.mockResolvedValueOnce({
+      jsonrpc: "2.0",
+      id: "timed",
+      result: {
+        text: "four",
+        timing: {
+          replayed: false,
+          durationMs: 1,
+          callCount: 1,
+          fallbackCount: 1,
+          selectedProvider: "mixed",
+          callsTruncated: false,
+          calls: [{ provider: "cerebras", durationMs: 1, fallback: false }],
+        },
+      },
+    });
+    expect(
+      await sharedRestMessageSend(SHARED_AGENT, AGENT, "2+2?", "Eliza", EXECUTION_CTX, NAMESPACE),
+    ).toEqual({ text: "four", agentName: "Eliza" });
   });
 
   test("POST rides a caller-supplied clientMessageId as the bridge RPC id (retry idempotency, #18045)", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -317,9 +317,15 @@ describe("shared-rest-adapter — messages", () => {
       selectedProvider: "mixed" as const,
       callsTruncated: false,
       calls: [
-        { provider: "cerebras" as const, durationMs: 3, fallback: false },
+        {
+          provider: "cerebras" as const,
+          durationMs: 3,
+          fallback: false,
+          privateProviderMetadata: "must-not-cross-the-bridge",
+        },
         { provider: "openrouter" as const, durationMs: 5.1, fallback: true },
       ],
+      privateTrace: "must-not-cross-the-bridge",
     };
     coordinateSharedBridge.mockResolvedValueOnce({
       jsonrpc: "2.0",
@@ -335,32 +341,112 @@ describe("shared-rest-adapter — messages", () => {
       EXECUTION_CTX,
       NAMESPACE,
     );
-    expect(out.timing).toEqual(timing);
+    expect(out.timing).toEqual({
+      replayed: false,
+      durationMs: 8.1,
+      callCount: 2,
+      fallbackCount: 1,
+      selectedProvider: "mixed",
+      callsTruncated: false,
+      calls: [
+        { provider: "cerebras", durationMs: 3, fallback: false },
+        { provider: "openrouter", durationMs: 5.1, fallback: true },
+      ],
+    });
     expect(sharedTurnServerTiming(out.timing)).toBe(
       'shared_model;dur=8.1;desc="provider=mixed calls=2 fallbacks=1 replayed=0"',
     );
   });
 
   test("POST rejects impossible provider timing from the untrusted bridge", async () => {
+    const impossibleReceipts = [
+      {
+        replayed: false,
+        durationMs: 1,
+        callCount: 1,
+        fallbackCount: 1,
+        selectedProvider: "mixed",
+        callsTruncated: false,
+        calls: [{ provider: "cerebras", durationMs: 1, fallback: false }],
+      },
+      {
+        replayed: false,
+        durationMs: 1,
+        callCount: 1,
+        fallbackCount: 1,
+        selectedProvider: "cerebras",
+        callsTruncated: false,
+        calls: [{ provider: "cerebras", durationMs: 1, fallback: true }],
+      },
+      {
+        replayed: false,
+        durationMs: 2,
+        callCount: 1,
+        fallbackCount: 0,
+        selectedProvider: "cerebras",
+        callsTruncated: false,
+        calls: [{ provider: "cerebras", durationMs: 1, fallback: false }],
+      },
+      {
+        replayed: false,
+        durationMs: 0,
+        callCount: 0,
+        fallbackCount: 0,
+        selectedProvider: "openrouter",
+        callsTruncated: false,
+        calls: [],
+      },
+    ];
+    for (const timing of impossibleReceipts) {
+      coordinateSharedBridge.mockResolvedValueOnce({
+        jsonrpc: "2.0",
+        id: "timed",
+        result: { text: "four", timing },
+      });
+      expect(
+        await sharedRestMessageSend(SHARED_AGENT, AGENT, "2+2?", "Eliza", EXECUTION_CTX, NAMESPACE),
+      ).toEqual({ text: "four", agentName: "Eliza" });
+    }
+  });
+
+  test("POST accepts the explicit first-16 call truncation contract", async () => {
+    const calls = Array.from({ length: 16 }, () => ({
+      provider: "cerebras" as const,
+      durationMs: 1,
+      fallback: false,
+    }));
     coordinateSharedBridge.mockResolvedValueOnce({
       jsonrpc: "2.0",
-      id: "timed",
+      id: "timed-truncated",
       result: {
         text: "four",
         timing: {
           replayed: false,
-          durationMs: 1,
-          callCount: 1,
+          durationMs: 17,
+          callCount: 17,
           fallbackCount: 1,
           selectedProvider: "mixed",
-          callsTruncated: false,
-          calls: [{ provider: "cerebras", durationMs: 1, fallback: false }],
+          callsTruncated: true,
+          calls,
         },
       },
     });
-    expect(
-      await sharedRestMessageSend(SHARED_AGENT, AGENT, "2+2?", "Eliza", EXECUTION_CTX, NAMESPACE),
-    ).toEqual({ text: "four", agentName: "Eliza" });
+
+    const out = await sharedRestMessageSend(
+      SHARED_AGENT,
+      AGENT,
+      "2+2?",
+      "Eliza",
+      EXECUTION_CTX,
+      NAMESPACE,
+    );
+    expect(out.timing).toMatchObject({
+      callCount: 17,
+      fallbackCount: 1,
+      selectedProvider: "mixed",
+      callsTruncated: true,
+      calls,
+    });
   });
 
   test("POST rides a caller-supplied clientMessageId as the bridge RPC id (retry idempotency, #18045)", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -49,11 +49,12 @@ const {
   sharedRestFirstRunStatus,
   sharedRestHealth,
   sharedRestMessageSend,
-  sharedTurnServerTiming,
   sharedRestMessagesGet,
   sharedRestStatus,
   sharedRestViews,
+  sharedTurnServerTiming,
 } = await import("./shared-rest-adapter");
+const { MAX_SHARED_PROVIDER_TIMING_MS } = await import("./shared-runtime-timing");
 
 // Restore the real module so this file's process-global mock doesn't strand
 // later test files that use the full elizaSandboxService surface.
@@ -312,6 +313,7 @@ describe("shared-rest-adapter — messages", () => {
     const timing = {
       replayed: false,
       durationMs: 8.1,
+      clamped: false,
       callCount: 2,
       fallbackCount: 1,
       selectedProvider: "mixed" as const,
@@ -344,6 +346,7 @@ describe("shared-rest-adapter — messages", () => {
     expect(out.timing).toEqual({
       replayed: false,
       durationMs: 8.1,
+      clamped: false,
       callCount: 2,
       fallbackCount: 1,
       selectedProvider: "mixed",
@@ -354,7 +357,7 @@ describe("shared-rest-adapter — messages", () => {
       ],
     });
     expect(sharedTurnServerTiming(out.timing)).toBe(
-      'shared_model;dur=8.1;desc="provider=mixed calls=2 fallbacks=1 replayed=0"',
+      'shared_model;dur=8.1;desc="provider=mixed calls=2 fallbacks=1 replayed=0 clamped=0"',
     );
   });
 
@@ -363,6 +366,7 @@ describe("shared-rest-adapter — messages", () => {
       {
         replayed: false,
         durationMs: 1,
+        clamped: false,
         callCount: 1,
         fallbackCount: 1,
         selectedProvider: "mixed",
@@ -372,6 +376,7 @@ describe("shared-rest-adapter — messages", () => {
       {
         replayed: false,
         durationMs: 1,
+        clamped: false,
         callCount: 1,
         fallbackCount: 1,
         selectedProvider: "cerebras",
@@ -381,6 +386,7 @@ describe("shared-rest-adapter — messages", () => {
       {
         replayed: false,
         durationMs: 2,
+        clamped: false,
         callCount: 1,
         fallbackCount: 0,
         selectedProvider: "cerebras",
@@ -390,11 +396,34 @@ describe("shared-rest-adapter — messages", () => {
       {
         replayed: false,
         durationMs: 0,
+        clamped: false,
         callCount: 0,
         fallbackCount: 0,
         selectedProvider: "openrouter",
         callsTruncated: false,
         calls: [],
+      },
+      // A receipt with no `clamped` field cannot be told apart from a clamped
+      // one, so the boundary rejects it rather than guessing.
+      {
+        replayed: false,
+        durationMs: 1,
+        callCount: 1,
+        fallbackCount: 0,
+        selectedProvider: "cerebras",
+        callsTruncated: false,
+        calls: [{ provider: "cerebras", durationMs: 1, fallback: false }],
+      },
+      // `unobserved` describes a call, never the provider that served the turn.
+      {
+        replayed: false,
+        durationMs: 1,
+        clamped: false,
+        callCount: 1,
+        fallbackCount: 0,
+        selectedProvider: "unobserved",
+        callsTruncated: false,
+        calls: [{ provider: "unobserved", durationMs: 1, fallback: false }],
       },
     ];
     for (const timing of impossibleReceipts) {
@@ -423,6 +452,7 @@ describe("shared-rest-adapter — messages", () => {
         timing: {
           replayed: false,
           durationMs: 17,
+          clamped: false,
           callCount: 17,
           fallbackCount: 1,
           selectedProvider: "mixed",
@@ -447,6 +477,42 @@ describe("shared-rest-adapter — messages", () => {
       callsTruncated: true,
       calls,
     });
+  });
+
+  test("POST keeps a clamped over-bound receipt instead of discarding it", async () => {
+    coordinateSharedBridge.mockResolvedValueOnce({
+      jsonrpc: "2.0",
+      id: "timed-clamped",
+      result: {
+        text: "four",
+        timing: {
+          replayed: false,
+          durationMs: MAX_SHARED_PROVIDER_TIMING_MS,
+          clamped: true,
+          callCount: 2,
+          fallbackCount: 0,
+          selectedProvider: "cerebras",
+          callsTruncated: false,
+          calls: [
+            { provider: "cerebras", durationMs: MAX_SHARED_PROVIDER_TIMING_MS, fallback: false },
+            { provider: "cerebras", durationMs: 12, fallback: false },
+          ],
+        },
+      },
+    });
+
+    const out = await sharedRestMessageSend(
+      SHARED_AGENT,
+      AGENT,
+      "2+2?",
+      "Eliza",
+      EXECUTION_CTX,
+      NAMESPACE,
+    );
+    // The summed call durations exceed the bound; the old exact-sum rule would
+    // have dropped the whole receipt for the very turn it exists to diagnose.
+    expect(out.timing).toMatchObject({ clamped: true, durationMs: MAX_SHARED_PROVIDER_TIMING_MS });
+    expect(sharedTurnServerTiming(out.timing)).toContain("clamped=1");
   });
 
   test("POST rides a caller-supplied clientMessageId as the bridge RPC id (retry idempotency, #18045)", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -14,8 +14,9 @@
  * from this adapter would be a production database-path regression.
  */
 
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
+import { logger } from "../../utils/logger";
 
 class InsufficientCreditsError extends Error {}
 
@@ -362,6 +363,7 @@ describe("shared-rest-adapter — messages", () => {
   });
 
   test("POST rejects impossible provider timing from the untrusted bridge", async () => {
+    const warn = spyOn(logger, "warn").mockImplementation(() => undefined);
     const impossibleReceipts = [
       {
         replayed: false,
@@ -436,6 +438,12 @@ describe("shared-rest-adapter — messages", () => {
         await sharedRestMessageSend(SHARED_AGENT, AGENT, "2+2?", "Eliza", EXECUTION_CTX, NAMESPACE),
       ).toEqual({ text: "four", agentName: "Eliza" });
     }
+    expect(warn).toHaveBeenCalledTimes(impossibleReceipts.length);
+    expect(warn).toHaveBeenLastCalledWith(
+      "[shared-runtime REST] message.send returned an invalid timing receipt",
+      { agentId: AGENT, conversationId: AGENT },
+    );
+    warn.mockRestore();
   });
 
   test("POST accepts the explicit first-16 call truncation contract", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -26,8 +26,87 @@ import type { SharedAgentCharacter } from "./run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import type { SharedRuntimeChannel } from "./shared-runtime-channel";
 import { type BridgeExecutionContext, sharedRuntimeChatService } from "./shared-runtime-chat";
+import type { SharedProviderTimingReceipt } from "./shared-runtime-timing";
 
 const BRIDGE_INSUFFICIENT_CREDITS_CODE = -32002;
+
+function isSharedProviderTimingReceipt(value: unknown): value is SharedProviderTimingReceipt {
+  if (!value || typeof value !== "object") return false;
+  const receipt = value as Record<string, unknown>;
+  const callCount = receipt.callCount;
+  const calls = receipt.calls;
+  if (
+    typeof callCount !== "number" ||
+    !Number.isInteger(callCount) ||
+    callCount < 0 ||
+    callCount > 1_000 ||
+    typeof receipt.callsTruncated !== "boolean" ||
+    !Array.isArray(calls) ||
+    calls.length !== Math.min(callCount, 16) ||
+    receipt.callsTruncated !== callCount > calls.length
+  ) {
+    return false;
+  }
+  const safeCalls = calls.every((call) => {
+    if (!call || typeof call !== "object") return false;
+    const entry = call as Record<string, unknown>;
+    return (
+      (entry.provider === "cerebras" ||
+        entry.provider === "openrouter" ||
+        entry.provider === "other") &&
+      typeof entry.durationMs === "number" &&
+      Number.isFinite(entry.durationMs) &&
+      entry.durationMs >= 0 &&
+      entry.durationMs <= 600_000 &&
+      typeof entry.fallback === "boolean"
+    );
+  });
+  if (!safeCalls) return false;
+  const selectedProvider = receipt.selectedProvider;
+  if (
+    selectedProvider !== "cerebras" &&
+    selectedProvider !== "openrouter" &&
+    selectedProvider !== "other" &&
+    selectedProvider !== "mixed" &&
+    selectedProvider !== "none"
+  ) {
+    return false;
+  }
+  const recordedFallbacks = calls.filter((call) => (call as { fallback: boolean }).fallback).length;
+  const fallbackCount = receipt.fallbackCount;
+  const hiddenCalls = callCount - calls.length;
+  const providers = new Set(calls.map((call) => (call as { provider: string }).provider));
+  const providerIsPossible =
+    callCount === 0
+      ? selectedProvider === "none"
+      : selectedProvider === "mixed"
+        ? providers.size > 1 || (receipt.callsTruncated && providers.size === 1)
+        : selectedProvider !== "none" && providers.size === 1 && providers.has(selectedProvider);
+  return (
+    typeof receipt.replayed === "boolean" &&
+    typeof receipt.durationMs === "number" &&
+    Number.isFinite(receipt.durationMs) &&
+    receipt.durationMs >= 0 &&
+    receipt.durationMs <= 600_000 &&
+    typeof fallbackCount === "number" &&
+    Number.isInteger(fallbackCount) &&
+    fallbackCount >= recordedFallbacks &&
+    fallbackCount <= recordedFallbacks + hiddenCalls &&
+    providerIsPossible &&
+    (!receipt.replayed ||
+      (receipt.durationMs === 0 &&
+        callCount === 0 &&
+        fallbackCount === 0 &&
+        selectedProvider === "none" &&
+        receipt.callsTruncated === false))
+  );
+}
+
+/** Serialize the privacy-bounded provider receipt into finite Server-Timing metrics. */
+export function sharedTurnServerTiming(receipt: SharedProviderTimingReceipt | undefined): string {
+  if (!receipt) return "";
+  return `shared_model;dur=${receipt.durationMs.toFixed(1)};desc="provider=${receipt.selectedProvider} calls=${receipt.callCount} fallbacks=${receipt.fallbackCount} replayed=${receipt.replayed ? 1 : 0}"`;
+}
 
 /** Minimal subset of the agent-server REST `Conversation` the chat client reads. */
 export interface SharedRestConversation {
@@ -544,7 +623,7 @@ export async function sharedRestMessageSend(
   trustedDelivery?: SharedReminderDelivery,
   trustedUserUtterance?: string,
   trustedChannel?: SharedRuntimeChannel,
-): Promise<{ text: string; agentName: string }> {
+): Promise<{ text: string; agentName: string; timing?: SharedProviderTimingReceipt }> {
   const rpc: BridgeRequest = {
     jsonrpc: "2.0",
     id: clientMessageId ?? crypto.randomUUID(),
@@ -579,7 +658,11 @@ export async function sharedRestMessageSend(
     }
     throw new Error(response.error.message || "shared message.send failed");
   }
-  const result = (response.result ?? {}) as { text?: unknown };
+  const result = (response.result ?? {}) as { text?: unknown; timing?: unknown };
   const replyText = typeof result.text === "string" ? result.text : "";
-  return { text: replyText, agentName: agentName || "Eliza" };
+  return {
+    text: replyText,
+    agentName: agentName || "Eliza",
+    ...(isSharedProviderTimingReceipt(result.timing) ? { timing: result.timing } : {}),
+  };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -36,7 +36,7 @@ const BRIDGE_INSUFFICIENT_CREDITS_CODE = -32002;
 /** Serialize the privacy-bounded provider receipt into finite Server-Timing metrics. */
 export function sharedTurnServerTiming(receipt: SharedProviderTimingReceipt | undefined): string {
   if (!receipt) return "";
-  return `shared_model;dur=${receipt.durationMs.toFixed(1)};desc="provider=${receipt.selectedProvider} calls=${receipt.callCount} fallbacks=${receipt.fallbackCount} replayed=${receipt.replayed ? 1 : 0}"`;
+  return `shared_model;dur=${receipt.durationMs.toFixed(1)};desc="provider=${receipt.selectedProvider} calls=${receipt.callCount} fallbacks=${receipt.fallbackCount} replayed=${receipt.replayed ? 1 : 0} clamped=${receipt.clamped ? 1 : 0}"`;
 }
 
 /** Minimal subset of the agent-server REST `Conversation` the chat client reads. */

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -20,6 +20,7 @@ import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
 import type { SharedReminderDelivery } from "@elizaos/plugin-scheduling/edge";
 import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
 import { InsufficientCreditsError } from "../../api/errors";
+import { logger } from "../../utils/logger";
 import type { BridgeRequest } from "../eliza-sandbox-bridge";
 import { coordinateSharedBridge, coordinateSharedHistory } from "./conversation-coordinator";
 import type { SharedAgentCharacter } from "./run-shared-agent-turn";
@@ -592,6 +593,12 @@ export async function sharedRestMessageSend(
   const result = (response.result ?? {}) as { text?: unknown; timing?: unknown };
   const replyText = typeof result.text === "string" ? result.text : "";
   const timing = parseSharedProviderTimingReceipt(result.timing);
+  if (result.timing !== undefined && timing === undefined) {
+    logger.warn("[shared-runtime REST] message.send returned an invalid timing receipt", {
+      agentId: agent.id,
+      conversationId,
+    });
+  }
   return {
     text: replyText,
     agentName: agentName || "Eliza",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -26,81 +26,12 @@ import type { SharedAgentCharacter } from "./run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import type { SharedRuntimeChannel } from "./shared-runtime-channel";
 import { type BridgeExecutionContext, sharedRuntimeChatService } from "./shared-runtime-chat";
-import type { SharedProviderTimingReceipt } from "./shared-runtime-timing";
+import {
+  parseSharedProviderTimingReceipt,
+  type SharedProviderTimingReceipt,
+} from "./shared-runtime-timing";
 
 const BRIDGE_INSUFFICIENT_CREDITS_CODE = -32002;
-
-function isSharedProviderTimingReceipt(value: unknown): value is SharedProviderTimingReceipt {
-  if (!value || typeof value !== "object") return false;
-  const receipt = value as Record<string, unknown>;
-  const callCount = receipt.callCount;
-  const calls = receipt.calls;
-  if (
-    typeof callCount !== "number" ||
-    !Number.isInteger(callCount) ||
-    callCount < 0 ||
-    callCount > 1_000 ||
-    typeof receipt.callsTruncated !== "boolean" ||
-    !Array.isArray(calls) ||
-    calls.length !== Math.min(callCount, 16) ||
-    receipt.callsTruncated !== callCount > calls.length
-  ) {
-    return false;
-  }
-  const safeCalls = calls.every((call) => {
-    if (!call || typeof call !== "object") return false;
-    const entry = call as Record<string, unknown>;
-    return (
-      (entry.provider === "cerebras" ||
-        entry.provider === "openrouter" ||
-        entry.provider === "other") &&
-      typeof entry.durationMs === "number" &&
-      Number.isFinite(entry.durationMs) &&
-      entry.durationMs >= 0 &&
-      entry.durationMs <= 600_000 &&
-      typeof entry.fallback === "boolean"
-    );
-  });
-  if (!safeCalls) return false;
-  const selectedProvider = receipt.selectedProvider;
-  if (
-    selectedProvider !== "cerebras" &&
-    selectedProvider !== "openrouter" &&
-    selectedProvider !== "other" &&
-    selectedProvider !== "mixed" &&
-    selectedProvider !== "none"
-  ) {
-    return false;
-  }
-  const recordedFallbacks = calls.filter((call) => (call as { fallback: boolean }).fallback).length;
-  const fallbackCount = receipt.fallbackCount;
-  const hiddenCalls = callCount - calls.length;
-  const providers = new Set(calls.map((call) => (call as { provider: string }).provider));
-  const providerIsPossible =
-    callCount === 0
-      ? selectedProvider === "none"
-      : selectedProvider === "mixed"
-        ? providers.size > 1 || (receipt.callsTruncated && providers.size === 1)
-        : selectedProvider !== "none" && providers.size === 1 && providers.has(selectedProvider);
-  return (
-    typeof receipt.replayed === "boolean" &&
-    typeof receipt.durationMs === "number" &&
-    Number.isFinite(receipt.durationMs) &&
-    receipt.durationMs >= 0 &&
-    receipt.durationMs <= 600_000 &&
-    typeof fallbackCount === "number" &&
-    Number.isInteger(fallbackCount) &&
-    fallbackCount >= recordedFallbacks &&
-    fallbackCount <= recordedFallbacks + hiddenCalls &&
-    providerIsPossible &&
-    (!receipt.replayed ||
-      (receipt.durationMs === 0 &&
-        callCount === 0 &&
-        fallbackCount === 0 &&
-        selectedProvider === "none" &&
-        receipt.callsTruncated === false))
-  );
-}
 
 /** Serialize the privacy-bounded provider receipt into finite Server-Timing metrics. */
 export function sharedTurnServerTiming(receipt: SharedProviderTimingReceipt | undefined): string {
@@ -660,9 +591,10 @@ export async function sharedRestMessageSend(
   }
   const result = (response.result ?? {}) as { text?: unknown; timing?: unknown };
   const replyText = typeof result.text === "string" ? result.text : "";
+  const timing = parseSharedProviderTimingReceipt(result.timing);
   return {
     text: replyText,
     agentName: agentName || "Eliza",
-    ...(isSharedProviderTimingReceipt(result.timing) ? { timing: result.timing } : {}),
+    ...(timing ? { timing } : {}),
   };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -1538,7 +1538,18 @@ describe("SharedRuntimeChatService", () => {
     expect(admitOrganizationInference).toHaveBeenCalledTimes(1);
     expect(billCalls).toHaveLength(1);
     expect(settleCalls).toEqual([0.004]);
-    expect(second.result).toEqual(first.result);
+    expect(second.result).toEqual({
+      ...first.result,
+      timing: {
+        replayed: true,
+        durationMs: 0,
+        callCount: 0,
+        fallbackCount: 0,
+        selectedProvider: "none",
+        callsTruncated: false,
+        calls: [],
+      },
+    });
     expect(second.id).toBe("client-key-1");
     expect(h.history()).toHaveLength(historyAfterFirst);
   });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -69,6 +69,15 @@ function timingReceipt(
       providerTotalDurationMs: 10,
       slowestProviderDurationMs: 10,
     },
+    model: {
+      replayed: false,
+      durationMs: 0,
+      callCount: 0,
+      fallbackCount: 0,
+      selectedProvider: "none" as const,
+      callsTruncated: false,
+      calls: [],
+    },
     routing: { decision: "respond" as const, contextIds: ["room"] },
   };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -1556,6 +1556,10 @@ describe("SharedRuntimeChatService", () => {
         fallbackCount: 0,
         selectedProvider: "none",
         callsTruncated: false,
+        // A replay never ran a provider call, so nothing was clamped. The
+        // field is required on the receipt, so asserting it here keeps a
+        // replayed receipt structurally identical to a live one.
+        clamped: false,
         calls: [],
       },
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -88,7 +88,11 @@ import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import { SharedRuntimeCacheWarmingError, SharedTurnConflictError } from "./shared-runtime-errors";
 import { MAX_HISTORY_MESSAGES } from "./shared-runtime-history-policy";
 import { normalizeSharedRuntimeRoom } from "./shared-runtime-room-identity";
-import type { SharedRuntimeTimingReceipt } from "./shared-runtime-timing";
+import {
+  replayedSharedProviderTiming,
+  type SharedProviderTimingReceipt,
+  type SharedRuntimeTimingReceipt,
+} from "./shared-runtime-timing";
 import { createSharedScheduledTaskRunner } from "./shared-scheduling";
 import { createSharedTodoStore, sharedTodoStorageScope } from "./shared-todos";
 import { sharedTurnClientMessageId } from "./shared-turn-client-message-id";
@@ -245,6 +249,7 @@ export interface SharedTurnTerminalResult {
   runtime: "shared";
   transport: "shared-runtime";
   actionResults?: unknown[];
+  timing?: SharedProviderTimingReceipt;
 }
 
 export type SharedTurnClaimDecision =
@@ -1275,7 +1280,10 @@ export class SharedRuntimeChatService {
         return {
           jsonrpc: "2.0",
           id: rpc.id,
-          result: replay as unknown as Record<string, unknown>,
+          result: {
+            ...replay,
+            timing: replayedSharedProviderTiming(),
+          } as unknown as Record<string, unknown>,
         };
       }
     }
@@ -1403,6 +1411,7 @@ export class SharedRuntimeChatService {
         runtime: "shared",
         transport: "shared-runtime",
         ...(actionResults ? { actionResults } : {}),
+        ...(turn.timing ? { timing: turn.timing } : {}),
       };
       if (turn.degraded) {
         await billing?.settle(0);
@@ -1488,6 +1497,7 @@ export class SharedRuntimeChatService {
                 text: replay.text,
                 fullText: replay.text,
                 ...(replay.actionResults ? { actionResults: replay.actionResults } : {}),
+                timing: replayedSharedProviderTiming(),
               }),
             { headers: { "Content-Type": "text/event-stream; charset=utf-8" } },
           ),
@@ -1759,6 +1769,7 @@ export class SharedRuntimeChatService {
                     degraded: false,
                     runtime: "shared",
                     transport: "shared-runtime",
+                    ...(part.timing ? { timing: part.timing } : {}),
                   });
                 }
                 terminalSettlementStarted = true;
@@ -1777,6 +1788,7 @@ export class SharedRuntimeChatService {
                     text: "",
                     fullText: "",
                     responded: false,
+                    ...(part.timing ? { timing: part.timing } : {}),
                   }),
                 ),
               );
@@ -1827,6 +1839,7 @@ export class SharedRuntimeChatService {
                   degraded: false,
                   runtime: "shared",
                   transport: "shared-runtime",
+                  ...(part.timing ? { timing: part.timing } : {}),
                   ...(actionResults ? { actionResults } : {}),
                 });
               }
@@ -1847,12 +1860,14 @@ export class SharedRuntimeChatService {
                   text: finalReply,
                   fullText: finalReply,
                   actionResults,
+                  ...(part.timing ? { timing: part.timing } : {}),
                 }
               : {
                   messageId: messageIds.assistant,
                   userMessageId: messageIds.user,
                   text: finalReply,
                   fullText: finalReply,
+                  ...(part.timing ? { timing: part.timing } : {}),
                 };
             controller.enqueue(encoder.encode(chatSseFrame("done", done)));
           }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.test.ts
@@ -50,10 +50,37 @@ describe("SharedRuntimeTimingCollector", () => {
         providerTotalDurationMs: 0,
         slowestProviderDurationMs: null,
       },
+      model: {
+        replayed: false,
+        durationMs: 0,
+        callCount: 0,
+        fallbackCount: 0,
+        selectedProvider: "none",
+        callsTruncated: false,
+        calls: [],
+      },
       routing: {
         decision: "unknown",
         contextIds: [],
       },
+    });
+  });
+
+  test("measures model work after admission and records selected fallback authority", () => {
+    const timing = new SharedRuntimeTimingCollector("provider", 0, clock([0, 100, 145, 200]));
+    const call = timing.prepareModelCall();
+    call.select({ provider: "openrouter", fallback: true });
+    call.begin();
+    call.finish();
+
+    expect(timing.receipt("success").model).toEqual({
+      replayed: false,
+      durationMs: 45,
+      callCount: 1,
+      fallbackCount: 1,
+      selectedProvider: "openrouter",
+      callsTruncated: false,
+      calls: [{ provider: "openrouter", durationMs: 45, fallback: true }],
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.test.ts
@@ -4,7 +4,10 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { SharedRuntimeTimingCollector } from "./shared-runtime-timing";
+import {
+  parseSharedProviderTimingReceipt,
+  SharedRuntimeTimingCollector,
+} from "./shared-runtime-timing";
 
 function clock(values: number[]): () => number {
   let index = 0;
@@ -66,8 +69,9 @@ describe("SharedRuntimeTimingCollector", () => {
     });
   });
 
-  test("measures model work after admission and records selected fallback authority", () => {
-    const timing = new SharedRuntimeTimingCollector("provider", 0, clock([0, 100, 145, 200]));
+  test("excludes dispatch and setup before the SDK invocation begins", () => {
+    const timing = new SharedRuntimeTimingCollector("provider", 0, clock([0, 100, 145, 200, 220]));
+    timing.markProviderDispatched();
     const call = timing.prepareModelCall();
     call.select({ provider: "openrouter", fallback: true });
     call.begin();
@@ -75,12 +79,128 @@ describe("SharedRuntimeTimingCollector", () => {
 
     expect(timing.receipt("success").model).toEqual({
       replayed: false,
-      durationMs: 45,
+      durationMs: 55,
       callCount: 1,
       fallbackCount: 1,
       selectedProvider: "openrouter",
       callsTruncated: false,
-      calls: [{ provider: "openrouter", durationMs: 45, fallback: true }],
+      calls: [{ provider: "openrouter", durationMs: 55, fallback: true }],
+    });
+  });
+
+  test("keeps exact aggregate counts while truncating only the first-16 call list", () => {
+    let now = 0;
+    const timing = new SharedRuntimeTimingCollector("many-provider-calls", 0, () => now++);
+    for (let index = 0; index < 17; index += 1) {
+      const call = timing.prepareModelCall();
+      call.select(
+        index === 16
+          ? { provider: "openrouter", fallback: true }
+          : { provider: "cerebras", fallback: false },
+      );
+      call.begin();
+      call.finish();
+    }
+
+    expect(timing.receipt("success").model).toMatchObject({
+      durationMs: 17,
+      callCount: 17,
+      fallbackCount: 1,
+      selectedProvider: "mixed",
+      callsTruncated: true,
+    });
+    expect(timing.receipt("success").model.calls).toHaveLength(16);
+  });
+
+  test("canonicalizes a valid receipt and strips undeclared transport fields", () => {
+    expect(
+      parseSharedProviderTimingReceipt({
+        replayed: false,
+        durationMs: 8.1,
+        callCount: 2,
+        fallbackCount: 1,
+        selectedProvider: "mixed",
+        callsTruncated: false,
+        privateTrace: "drop-me",
+        calls: [
+          {
+            provider: "cerebras",
+            durationMs: 3,
+            fallback: false,
+            privateProviderMetadata: "drop-me",
+          },
+          { provider: "openrouter", durationMs: 5.1, fallback: true },
+        ],
+      }),
+    ).toEqual({
+      replayed: false,
+      durationMs: 8.1,
+      callCount: 2,
+      fallbackCount: 1,
+      selectedProvider: "mixed",
+      callsTruncated: false,
+      calls: [
+        { provider: "cerebras", durationMs: 3, fallback: false },
+        { provider: "openrouter", durationMs: 5.1, fallback: true },
+      ],
+    });
+  });
+
+  test("rejects internally impossible untrusted receipts", () => {
+    const base = {
+      replayed: false,
+      durationMs: 1,
+      callCount: 1,
+      fallbackCount: 0,
+      selectedProvider: "cerebras",
+      callsTruncated: false,
+      calls: [{ provider: "cerebras", durationMs: 1, fallback: false }],
+    };
+    expect(parseSharedProviderTimingReceipt(base)).toBeDefined();
+    expect(parseSharedProviderTimingReceipt({ ...base, fallbackCount: 1 })).toBeUndefined();
+    expect(
+      parseSharedProviderTimingReceipt({ ...base, selectedProvider: "mixed" }),
+    ).toBeUndefined();
+    expect(parseSharedProviderTimingReceipt({ ...base, durationMs: 2 })).toBeUndefined();
+    expect(
+      parseSharedProviderTimingReceipt({
+        ...base,
+        calls: [{ provider: "cerebras", durationMs: 1, fallback: true }],
+      }),
+    ).toBeUndefined();
+    expect(
+      parseSharedProviderTimingReceipt({
+        ...base,
+        callCount: 0,
+        durationMs: 0,
+        calls: [],
+        selectedProvider: "openrouter",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("accepts an internally possible first-16 truncated receipt", () => {
+    const calls = Array.from({ length: 16 }, () => ({
+      provider: "cerebras",
+      durationMs: 1,
+      fallback: false,
+    }));
+    expect(
+      parseSharedProviderTimingReceipt({
+        replayed: false,
+        durationMs: 17,
+        callCount: 17,
+        fallbackCount: 1,
+        selectedProvider: "mixed",
+        callsTruncated: true,
+        calls,
+      }),
+    ).toMatchObject({
+      callCount: 17,
+      fallbackCount: 1,
+      selectedProvider: "mixed",
+      callsTruncated: true,
+      calls,
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  MAX_SHARED_PROVIDER_TIMING_MS,
   parseSharedProviderTimingReceipt,
   SharedRuntimeTimingCollector,
 } from "./shared-runtime-timing";
@@ -56,6 +57,7 @@ describe("SharedRuntimeTimingCollector", () => {
       model: {
         replayed: false,
         durationMs: 0,
+        clamped: false,
         callCount: 0,
         fallbackCount: 0,
         selectedProvider: "none",
@@ -80,12 +82,134 @@ describe("SharedRuntimeTimingCollector", () => {
     expect(timing.receipt("success").model).toEqual({
       replayed: false,
       durationMs: 55,
+      clamped: false,
       callCount: 1,
       fallbackCount: 1,
       selectedProvider: "openrouter",
       callsTruncated: false,
       calls: [{ provider: "openrouter", durationMs: 55, fallback: true }],
     });
+  });
+
+  test("records a call whose provider selection never fired as unobserved", () => {
+    const timing = new SharedRuntimeTimingCollector("unobserved", 0, clock([0, 10, 40, 60]));
+    const call = timing.prepareModelCall();
+    call.begin();
+    // The provider threw before any wrapper reported a successful selection.
+    call.finish();
+
+    expect(timing.receipt("error").model).toEqual({
+      replayed: false,
+      durationMs: 30,
+      clamped: false,
+      callCount: 1,
+      fallbackCount: 0,
+      selectedProvider: "none",
+      callsTruncated: false,
+      calls: [{ provider: "unobserved", durationMs: 30, fallback: false }],
+    });
+  });
+
+  test("keeps an unobserved failed call from forcing mixed attribution", () => {
+    let now = 0;
+    const timing = new SharedRuntimeTimingCollector("failed-then-served", 0, () => (now += 5));
+    const failed = timing.prepareModelCall();
+    failed.begin();
+    failed.finish();
+    const served = timing.prepareModelCall();
+    served.select({ provider: "cerebras", fallback: false });
+    served.begin();
+    served.finish();
+
+    const model = timing.receipt("success").model;
+    expect(model.selectedProvider).toBe("cerebras");
+    expect(model.callCount).toBe(2);
+    expect(model.calls.map((call) => call.provider)).toEqual(["unobserved", "cerebras"]);
+  });
+
+  test("attributes a native OpenAI selection to itself instead of the catch-all", () => {
+    const timing = new SharedRuntimeTimingCollector("native", 0, clock([0, 5, 25]));
+    const call = timing.prepareModelCall();
+    call.select({ provider: "openai", fallback: false });
+    call.begin();
+    call.finish();
+
+    expect(timing.receipt("success").model).toMatchObject({
+      selectedProvider: "openai",
+      calls: [{ provider: "openai", durationMs: 20, fallback: false }],
+    });
+  });
+
+  test("reports an over-bound single call at the bound and marks it clamped", () => {
+    const timing = new SharedRuntimeTimingCollector(
+      "slow",
+      0,
+      clock([0, 1, MAX_SHARED_PROVIDER_TIMING_MS + 5_000]),
+    );
+    const call = timing.prepareModelCall();
+    call.select({ provider: "cerebras", fallback: false });
+    call.begin();
+    call.finish();
+
+    expect(timing.receipt("success").model).toMatchObject({
+      durationMs: MAX_SHARED_PROVIDER_TIMING_MS,
+      clamped: true,
+      callCount: 1,
+      selectedProvider: "cerebras",
+      calls: [{ provider: "cerebras", durationMs: MAX_SHARED_PROVIDER_TIMING_MS, fallback: false }],
+    });
+  });
+
+  test("survives the transport boundary when the summed total is clamped", () => {
+    const perCall = MAX_SHARED_PROVIDER_TIMING_MS * 0.6;
+    let now = 0;
+    const timing = new SharedRuntimeTimingCollector("clamped-total", 0, () => {
+      const value = now;
+      now += perCall;
+      return value;
+    });
+    for (let index = 0; index < 2; index += 1) {
+      const call = timing.prepareModelCall();
+      call.select({ provider: "cerebras", fallback: false });
+      call.begin();
+      call.finish();
+    }
+
+    const model = timing.receipt("success").model;
+    expect(model.clamped).toBe(true);
+    expect(model.durationMs).toBe(MAX_SHARED_PROVIDER_TIMING_MS);
+    // The exact-sum rule would otherwise discard the whole receipt here.
+    expect(parseSharedProviderTimingReceipt(model)).toEqual(model);
+  });
+
+  test("rejects a clamped receipt whose duration is not the bound", () => {
+    expect(
+      parseSharedProviderTimingReceipt({
+        replayed: false,
+        durationMs: 12,
+        clamped: true,
+        callCount: 1,
+        fallbackCount: 0,
+        selectedProvider: "cerebras",
+        callsTruncated: false,
+        calls: [{ provider: "cerebras", durationMs: 12, fallback: false }],
+      }),
+    ).toBeUndefined();
+  });
+
+  test("rejects a receipt that claims an unobserved call as the selected provider", () => {
+    expect(
+      parseSharedProviderTimingReceipt({
+        replayed: false,
+        durationMs: 4,
+        clamped: false,
+        callCount: 1,
+        fallbackCount: 0,
+        selectedProvider: "unobserved",
+        callsTruncated: false,
+        calls: [{ provider: "unobserved", durationMs: 4, fallback: false }],
+      }),
+    ).toBeUndefined();
   });
 
   test("keeps exact aggregate counts while truncating only the first-16 call list", () => {
@@ -117,6 +241,7 @@ describe("SharedRuntimeTimingCollector", () => {
       parseSharedProviderTimingReceipt({
         replayed: false,
         durationMs: 8.1,
+        clamped: false,
         callCount: 2,
         fallbackCount: 1,
         selectedProvider: "mixed",
@@ -135,6 +260,7 @@ describe("SharedRuntimeTimingCollector", () => {
     ).toEqual({
       replayed: false,
       durationMs: 8.1,
+      clamped: false,
       callCount: 2,
       fallbackCount: 1,
       selectedProvider: "mixed",
@@ -150,6 +276,7 @@ describe("SharedRuntimeTimingCollector", () => {
     const base = {
       replayed: false,
       durationMs: 1,
+      clamped: false,
       callCount: 1,
       fallbackCount: 0,
       selectedProvider: "cerebras",
@@ -189,6 +316,7 @@ describe("SharedRuntimeTimingCollector", () => {
       parseSharedProviderTimingReceipt({
         replayed: false,
         durationMs: 17,
+        clamped: false,
         callCount: 17,
         fallbackCount: 1,
         selectedProvider: "mixed",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
@@ -14,6 +14,25 @@ export interface SharedRuntimeInferenceSpan {
   durationMs: number;
 }
 
+export type SharedModelProvider = "cerebras" | "openrouter" | "other";
+
+export interface SharedModelCallTiming {
+  provider: SharedModelProvider;
+  durationMs: number;
+  fallback: boolean;
+}
+
+/** Privacy-bounded model timing safe for Shared REST and SSE clients. */
+export interface SharedProviderTimingReceipt {
+  replayed: boolean;
+  durationMs: number;
+  callCount: number;
+  fallbackCount: number;
+  selectedProvider: SharedModelProvider | "mixed" | "none";
+  callsTruncated: boolean;
+  calls: SharedModelCallTiming[];
+}
+
 export interface SharedRuntimeTimingReceipt {
   traceId: string;
   outcome: SharedRuntimeTimingOutcome;
@@ -36,6 +55,7 @@ export interface SharedRuntimeTimingReceipt {
     providerTotalDurationMs: number | null;
     slowestProviderDurationMs: number | null;
   };
+  model: SharedProviderTimingReceipt;
   routing: {
     decision: SharedRuntimeRoutingDecision;
     contextIds: string[];
@@ -78,6 +98,11 @@ export class SharedRuntimeTimingCollector {
   #slowestProviderDurationMs: number | null = null;
   #routingDecision: SharedRuntimeRoutingDecision = "unknown";
   #contextIds: string[] = [];
+  #modelDurationMs = 0;
+  #modelCallCount = 0;
+  #modelFallbackCount = 0;
+  #modelProviders = new Set<SharedModelProvider>();
+  #modelCalls: SharedModelCallTiming[] = [];
 
   constructor(
     readonly traceId: string,
@@ -114,6 +139,44 @@ export class SharedRuntimeTimingCollector {
   }
   markProviderFirstText(): void {
     this.#providerFirstTextAt ??= this.#now();
+  }
+
+  prepareModelCall(): {
+    select: (selection: { provider: SharedModelProvider; fallback: boolean }) => void;
+    begin: () => void;
+    finish: () => void;
+  } {
+    let selection: { provider: SharedModelProvider; fallback: boolean } = {
+      provider: "other",
+      fallback: false,
+    };
+    let startedAt: number | null = null;
+    let finished = false;
+    return {
+      select: (selected) => {
+        selection = selected;
+      },
+      begin: () => {
+        startedAt ??= this.#now();
+      },
+      finish: () => {
+        if (finished || startedAt === null) return;
+        finished = true;
+        const durationMs = boundedDuration(startedAt, this.#now()) ?? 0;
+        this.#modelCallCount = Math.min(this.#modelCallCount + 1, 1_000);
+        if (selection.fallback) {
+          this.#modelFallbackCount = Math.min(this.#modelFallbackCount + 1, 1_000);
+        }
+        this.#modelDurationMs = Math.min(
+          Math.round((this.#modelDurationMs + durationMs) * 10) / 10,
+          MAX_RUNTIME_TIMING_MS,
+        );
+        this.#modelProviders.add(selection.provider);
+        if (this.#modelCalls.length < 16) {
+          this.#modelCalls.push({ ...selection, durationMs });
+        }
+      },
+    };
   }
 
   markInferenceSpans(spans: readonly SharedRuntimeInferenceSpan[]): void {
@@ -175,10 +238,37 @@ export class SharedRuntimeTimingCollector {
         providerTotalDurationMs: this.#providerTotalDurationMs,
         slowestProviderDurationMs: this.#slowestProviderDurationMs,
       },
+      model: {
+        replayed: false,
+        durationMs: this.#modelDurationMs,
+        callCount: this.#modelCallCount,
+        fallbackCount: this.#modelFallbackCount,
+        selectedProvider:
+          this.#modelProviders.size === 0
+            ? "none"
+            : this.#modelProviders.size === 1
+              ? (this.#modelProviders.values().next().value ?? "none")
+              : "mixed",
+        callsTruncated: this.#modelCallCount > this.#modelCalls.length,
+        calls: this.#modelCalls.map((call) => ({ ...call })),
+      },
       routing: {
         decision: this.#routingDecision,
         contextIds: [...this.#contextIds],
       },
     };
   }
+}
+
+/** A replay performed no fresh provider work. */
+export function replayedSharedProviderTiming(): SharedProviderTimingReceipt {
+  return {
+    replayed: true,
+    durationMs: 0,
+    callCount: 0,
+    fallbackCount: 0,
+    selectedProvider: "none",
+    callsTruncated: false,
+    calls: [],
+  };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
@@ -47,6 +47,17 @@ function isSharedModelCallProvider(value: unknown): value is SharedModelCallProv
   return value === "unobserved" || isSharedModelProvider(value);
 }
 
+function summarizeSelectedProviders(
+  providers: ReadonlySet<SharedModelProvider>,
+): SharedModelProvider | "mixed" | "none" {
+  let selected: SharedModelProvider | "none" = "none";
+  for (const provider of providers) {
+    if (selected !== "none") return "mixed";
+    selected = provider;
+  }
+  return selected;
+}
+
 /** Provider attribution supplied by the AI SDK wrapper once a call succeeds. */
 export interface SharedModelCallSelection {
   provider: SharedModelProvider;
@@ -449,12 +460,7 @@ export class SharedRuntimeTimingCollector {
         clamped: this.#modelClamped,
         callCount: this.#modelCallCount,
         fallbackCount: this.#modelFallbackCount,
-        selectedProvider:
-          this.#modelProviders.size === 0
-            ? "none"
-            : this.#modelProviders.size === 1
-              ? (this.#modelProviders.values().next().value ?? "none")
-              : "mixed",
+        selectedProvider: summarizeSelectedProviders(this.#modelProviders),
         callsTruncated: this.#modelCallCount > this.#modelCalls.length,
         calls: this.#modelCalls.map((call) => ({ ...call })),
       },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
@@ -4,7 +4,9 @@
  * cannot accidentally compare unlike measurements.
  */
 
-const MAX_RUNTIME_TIMING_MS = 10 * 60 * 1_000;
+export const MAX_SHARED_PROVIDER_TIMING_MS = 10 * 60 * 1_000;
+export const MAX_SHARED_PROVIDER_TIMING_CALL_COUNT = 1_000;
+export const MAX_SHARED_PROVIDER_TIMING_RECORDED_CALLS = 16;
 
 export type SharedRuntimeTimingOutcome = "success" | "aborted" | "error";
 export type SharedRuntimeRoutingDecision = "respond" | "silent" | "unknown";
@@ -22,7 +24,12 @@ export interface SharedModelCallTiming {
   fallback: boolean;
 }
 
-/** Privacy-bounded model timing safe for Shared REST and SSE clients. */
+/**
+ * Privacy-bounded model timing safe for Shared REST and SSE clients.
+ * `callCount` and `fallbackCount` describe every call. `calls` contains the
+ * first 16 calls only, and `callsTruncated` is true exactly when later calls
+ * were omitted.
+ */
 export interface SharedProviderTimingReceipt {
   replayed: boolean;
   durationMs: number;
@@ -31,6 +38,119 @@ export interface SharedProviderTimingReceipt {
   selectedProvider: SharedModelProvider | "mixed" | "none";
   callsTruncated: boolean;
   calls: SharedModelCallTiming[];
+}
+
+/** Validate and canonicalize an untrusted provider receipt at a transport boundary. */
+export function parseSharedProviderTimingReceipt(
+  value: unknown,
+): SharedProviderTimingReceipt | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const receipt = value as Record<string, unknown>;
+  const callCount = receipt.callCount;
+  const calls = receipt.calls;
+  if (
+    typeof callCount !== "number" ||
+    !Number.isInteger(callCount) ||
+    callCount < 0 ||
+    callCount > MAX_SHARED_PROVIDER_TIMING_CALL_COUNT ||
+    typeof receipt.callsTruncated !== "boolean" ||
+    !Array.isArray(calls) ||
+    calls.length !== Math.min(callCount, MAX_SHARED_PROVIDER_TIMING_RECORDED_CALLS) ||
+    receipt.callsTruncated !== callCount > calls.length
+  ) {
+    return undefined;
+  }
+  const safeCalls = calls.every((call) => {
+    if (!call || typeof call !== "object") return false;
+    const entry = call as Record<string, unknown>;
+    return (
+      (entry.provider === "cerebras" ||
+        entry.provider === "openrouter" ||
+        entry.provider === "other") &&
+      typeof entry.durationMs === "number" &&
+      Number.isFinite(entry.durationMs) &&
+      entry.durationMs >= 0 &&
+      entry.durationMs <= MAX_SHARED_PROVIDER_TIMING_MS &&
+      typeof entry.fallback === "boolean" &&
+      (!entry.fallback || entry.provider === "openrouter")
+    );
+  });
+  if (!safeCalls) return undefined;
+  const modelCalls = calls as SharedModelCallTiming[];
+  const selectedProvider = receipt.selectedProvider;
+  if (
+    selectedProvider !== "cerebras" &&
+    selectedProvider !== "openrouter" &&
+    selectedProvider !== "other" &&
+    selectedProvider !== "mixed" &&
+    selectedProvider !== "none"
+  ) {
+    return undefined;
+  }
+  const recordedFallbacks = modelCalls.filter((call) => call.fallback).length;
+  const fallbackCount = receipt.fallbackCount;
+  const hiddenCalls = callCount - calls.length;
+  const providers = new Set(modelCalls.map((call) => call.provider));
+  const providerIsPossible =
+    callCount === 0
+      ? selectedProvider === "none"
+      : selectedProvider === "mixed"
+        ? providers.size > 1 || (hiddenCalls > 0 && providers.size === 1)
+        : selectedProvider !== "none" && providers.size === 1 && providers.has(selectedProvider);
+  const fallbackCountIsPossible =
+    typeof fallbackCount === "number" &&
+    Number.isInteger(fallbackCount) &&
+    fallbackCount >= recordedFallbacks &&
+    fallbackCount <= recordedFallbacks + hiddenCalls &&
+    (selectedProvider === "openrouter" || selectedProvider === "mixed" || fallbackCount === 0);
+  const recordedDurationMs =
+    Math.round(modelCalls.reduce((total, call) => total + call.durationMs, 0) * 10) / 10;
+  const durationMs = receipt.durationMs;
+  const durationIsConsistent =
+    typeof durationMs === "number" &&
+    Number.isFinite(durationMs) &&
+    durationMs >= 0 &&
+    durationMs <= MAX_SHARED_PROVIDER_TIMING_MS &&
+    (receipt.callsTruncated ? durationMs >= recordedDurationMs : durationMs === recordedDurationMs);
+  const replayed = receipt.replayed;
+  const emptyReceiptIsConsistent =
+    callCount !== 0 ||
+    (durationMs === 0 &&
+      fallbackCount === 0 &&
+      selectedProvider === "none" &&
+      receipt.callsTruncated === false);
+  const replayIsConsistent =
+    replayed === false ||
+    (durationMs === 0 &&
+      callCount === 0 &&
+      fallbackCount === 0 &&
+      selectedProvider === "none" &&
+      receipt.callsTruncated === false);
+  if (
+    !(
+      typeof replayed === "boolean" &&
+      providerIsPossible &&
+      fallbackCountIsPossible &&
+      durationIsConsistent &&
+      emptyReceiptIsConsistent &&
+      replayIsConsistent
+    )
+  ) {
+    return undefined;
+  }
+  return {
+    replayed,
+    durationMs,
+    callCount,
+    fallbackCount,
+    selectedProvider,
+    callsTruncated: receipt.callsTruncated,
+    calls: modelCalls.map((call) => ({
+      provider: call.provider,
+      durationMs: call.durationMs,
+      fallback: call.fallback,
+    })),
+  };
 }
 
 export interface SharedRuntimeTimingReceipt {
@@ -68,13 +188,13 @@ function boundedDuration(startedAt: number | null, completedAt: number | null): 
   if (startedAt === null || completedAt === null) return null;
   const value = completedAt - startedAt;
   if (!Number.isFinite(value) || value < 0) return null;
-  if (value > MAX_RUNTIME_TIMING_MS) return null;
+  if (value > MAX_SHARED_PROVIDER_TIMING_MS) return null;
   return Math.round(value * 10) / 10;
 }
 
 function boundedMeasuredDuration(value: number): number | null {
   if (!Number.isFinite(value) || value < 0) return null;
-  if (value > MAX_RUNTIME_TIMING_MS) return null;
+  if (value > MAX_SHARED_PROVIDER_TIMING_MS) return null;
   return Math.round(value * 10) / 10;
 }
 
@@ -163,16 +283,16 @@ export class SharedRuntimeTimingCollector {
         if (finished || startedAt === null) return;
         finished = true;
         const durationMs = boundedDuration(startedAt, this.#now()) ?? 0;
-        this.#modelCallCount = Math.min(this.#modelCallCount + 1, 1_000);
+        this.#modelCallCount += 1;
         if (selection.fallback) {
-          this.#modelFallbackCount = Math.min(this.#modelFallbackCount + 1, 1_000);
+          this.#modelFallbackCount += 1;
         }
         this.#modelDurationMs = Math.min(
           Math.round((this.#modelDurationMs + durationMs) * 10) / 10,
-          MAX_RUNTIME_TIMING_MS,
+          MAX_SHARED_PROVIDER_TIMING_MS,
         );
         this.#modelProviders.add(selection.provider);
-        if (this.#modelCalls.length < 16) {
+        if (this.#modelCalls.length < MAX_SHARED_PROVIDER_TIMING_RECORDED_CALLS) {
           this.#modelCalls.push({ ...selection, durationMs });
         }
       },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-timing.ts
@@ -16,10 +16,45 @@ export interface SharedRuntimeInferenceSpan {
   durationMs: number;
 }
 
-export type SharedModelProvider = "cerebras" | "openrouter" | "other";
+/**
+ * Provider that actually served a model call. `other` is deliberately coarse:
+ * it means a pooled credential, Groq, or Vast model, none of which the Shared
+ * turn needs to attribute individually.
+ */
+export type SharedModelProvider = "cerebras" | "openrouter" | "openai" | "anthropic" | "other";
+
+/**
+ * `unobserved` marks a call whose provider selection never fired — the model
+ * threw before any provider succeeded, or provider resolution itself failed.
+ * It is never a `selectedProvider`, so a failed turn can never be read as a
+ * healthy call against a real provider.
+ */
+export type SharedModelCallProvider = SharedModelProvider | "unobserved";
+
+const SHARED_MODEL_PROVIDERS: readonly SharedModelProvider[] = [
+  "cerebras",
+  "openrouter",
+  "openai",
+  "anthropic",
+  "other",
+];
+
+function isSharedModelProvider(value: unknown): value is SharedModelProvider {
+  return SHARED_MODEL_PROVIDERS.includes(value as SharedModelProvider);
+}
+
+function isSharedModelCallProvider(value: unknown): value is SharedModelCallProvider {
+  return value === "unobserved" || isSharedModelProvider(value);
+}
+
+/** Provider attribution supplied by the AI SDK wrapper once a call succeeds. */
+export interface SharedModelCallSelection {
+  provider: SharedModelProvider;
+  fallback: boolean;
+}
 
 export interface SharedModelCallTiming {
-  provider: SharedModelProvider;
+  provider: SharedModelCallProvider;
   durationMs: number;
   fallback: boolean;
 }
@@ -28,11 +63,15 @@ export interface SharedModelCallTiming {
  * Privacy-bounded model timing safe for Shared REST and SSE clients.
  * `callCount` and `fallbackCount` describe every call. `calls` contains the
  * first 16 calls only, and `callsTruncated` is true exactly when later calls
- * were omitted.
+ * were omitted. `clamped` is true when a single call or the running total
+ * exceeded `MAX_SHARED_PROVIDER_TIMING_MS`, in which case `durationMs` is the
+ * bound rather than the measured value — a pathologically slow turn must stay
+ * visible instead of collapsing to zero or being discarded.
  */
 export interface SharedProviderTimingReceipt {
   replayed: boolean;
   durationMs: number;
+  clamped: boolean;
   callCount: number;
   fallbackCount: number;
   selectedProvider: SharedModelProvider | "mixed" | "none";
@@ -40,7 +79,12 @@ export interface SharedProviderTimingReceipt {
   calls: SharedModelCallTiming[];
 }
 
-/** Validate and canonicalize an untrusted provider receipt at a transport boundary. */
+/**
+ * Validate and canonicalize an untrusted provider receipt at a transport
+ * boundary. Every aggregate is re-derived from `calls` and rejected when it
+ * cannot describe any real turn, and the returned object is rebuilt field by
+ * field so undeclared keys never reach a public response.
+ */
 export function parseSharedProviderTimingReceipt(
   value: unknown,
 ): SharedProviderTimingReceipt | undefined {
@@ -54,19 +98,19 @@ export function parseSharedProviderTimingReceipt(
     callCount < 0 ||
     callCount > MAX_SHARED_PROVIDER_TIMING_CALL_COUNT ||
     typeof receipt.callsTruncated !== "boolean" ||
+    typeof receipt.clamped !== "boolean" ||
     !Array.isArray(calls) ||
     calls.length !== Math.min(callCount, MAX_SHARED_PROVIDER_TIMING_RECORDED_CALLS) ||
     receipt.callsTruncated !== callCount > calls.length
   ) {
     return undefined;
   }
+  const clamped = receipt.clamped;
   const safeCalls = calls.every((call) => {
     if (!call || typeof call !== "object") return false;
     const entry = call as Record<string, unknown>;
     return (
-      (entry.provider === "cerebras" ||
-        entry.provider === "openrouter" ||
-        entry.provider === "other") &&
+      isSharedModelCallProvider(entry.provider) &&
       typeof entry.durationMs === "number" &&
       Number.isFinite(entry.durationMs) &&
       entry.durationMs >= 0 &&
@@ -79,9 +123,7 @@ export function parseSharedProviderTimingReceipt(
   const modelCalls = calls as SharedModelCallTiming[];
   const selectedProvider = receipt.selectedProvider;
   if (
-    selectedProvider !== "cerebras" &&
-    selectedProvider !== "openrouter" &&
-    selectedProvider !== "other" &&
+    !isSharedModelProvider(selectedProvider) &&
     selectedProvider !== "mixed" &&
     selectedProvider !== "none"
   ) {
@@ -90,13 +132,27 @@ export function parseSharedProviderTimingReceipt(
   const recordedFallbacks = modelCalls.filter((call) => call.fallback).length;
   const fallbackCount = receipt.fallbackCount;
   const hiddenCalls = callCount - calls.length;
-  const providers = new Set(modelCalls.map((call) => call.provider));
+  // Unobserved calls carry duration but never attribution, so they must not
+  // decide `selectedProvider` nor force `mixed`.
+  const observedProviders = new Set(
+    modelCalls
+      .map((call) => call.provider)
+      .filter((provider): provider is SharedModelProvider => provider !== "unobserved"),
+  );
   const providerIsPossible =
     callCount === 0
       ? selectedProvider === "none"
-      : selectedProvider === "mixed"
-        ? providers.size > 1 || (hiddenCalls > 0 && providers.size === 1)
-        : selectedProvider !== "none" && providers.size === 1 && providers.has(selectedProvider);
+      : hiddenCalls > 0
+        ? selectedProvider === "mixed" ||
+          observedProviders.size === 0 ||
+          (observedProviders.size === 1 &&
+            isSharedModelProvider(selectedProvider) &&
+            observedProviders.has(selectedProvider))
+        : observedProviders.size === 0
+          ? selectedProvider === "none"
+          : observedProviders.size > 1
+            ? selectedProvider === "mixed"
+            : isSharedModelProvider(selectedProvider) && observedProviders.has(selectedProvider);
   const fallbackCountIsPossible =
     typeof fallbackCount === "number" &&
     Number.isInteger(fallbackCount) &&
@@ -111,21 +167,27 @@ export function parseSharedProviderTimingReceipt(
     Number.isFinite(durationMs) &&
     durationMs >= 0 &&
     durationMs <= MAX_SHARED_PROVIDER_TIMING_MS &&
-    (receipt.callsTruncated ? durationMs >= recordedDurationMs : durationMs === recordedDurationMs);
+    (clamped
+      ? durationMs === MAX_SHARED_PROVIDER_TIMING_MS
+      : receipt.callsTruncated
+        ? durationMs >= recordedDurationMs
+        : durationMs === recordedDurationMs);
   const replayed = receipt.replayed;
   const emptyReceiptIsConsistent =
     callCount !== 0 ||
     (durationMs === 0 &&
       fallbackCount === 0 &&
       selectedProvider === "none" &&
-      receipt.callsTruncated === false);
+      receipt.callsTruncated === false &&
+      clamped === false);
   const replayIsConsistent =
     replayed === false ||
     (durationMs === 0 &&
       callCount === 0 &&
       fallbackCount === 0 &&
       selectedProvider === "none" &&
-      receipt.callsTruncated === false);
+      receipt.callsTruncated === false &&
+      clamped === false);
   if (
     !(
       typeof replayed === "boolean" &&
@@ -141,6 +203,7 @@ export function parseSharedProviderTimingReceipt(
   return {
     replayed,
     durationMs,
+    clamped,
     callCount,
     fallbackCount,
     selectedProvider,
@@ -192,6 +255,20 @@ function boundedDuration(startedAt: number | null, completedAt: number | null): 
   return Math.round(value * 10) / 10;
 }
 
+/**
+ * Bound a single model-call duration without losing the pathological case: an
+ * over-bound call reports the bound and marks the receipt clamped rather than
+ * collapsing to zero, because a call slower than the bound is exactly what the
+ * receipt exists to expose.
+ */
+function clampedCallDuration(measured: number): { value: number; clamped: boolean } | null {
+  if (!Number.isFinite(measured) || measured < 0) return null;
+  if (measured > MAX_SHARED_PROVIDER_TIMING_MS) {
+    return { value: MAX_SHARED_PROVIDER_TIMING_MS, clamped: true };
+  }
+  return { value: Math.round(measured * 10) / 10, clamped: false };
+}
+
 function boundedMeasuredDuration(value: number): number | null {
   if (!Number.isFinite(value) || value < 0) return null;
   if (value > MAX_SHARED_PROVIDER_TIMING_MS) return null;
@@ -223,6 +300,7 @@ export class SharedRuntimeTimingCollector {
   #modelFallbackCount = 0;
   #modelProviders = new Set<SharedModelProvider>();
   #modelCalls: SharedModelCallTiming[] = [];
+  #modelClamped = false;
 
   constructor(
     readonly traceId: string,
@@ -261,15 +339,18 @@ export class SharedRuntimeTimingCollector {
     this.#providerFirstTextAt ??= this.#now();
   }
 
+  /**
+   * Track one model call. `select` is invoked by the provider wrapper only when
+   * a provider actually served the call; a call that finishes without it is
+   * recorded as `unobserved` so a failed or unattributed call is never reported
+   * as a healthy call against a real provider.
+   */
   prepareModelCall(): {
-    select: (selection: { provider: SharedModelProvider; fallback: boolean }) => void;
+    select: (selection: SharedModelCallSelection) => void;
     begin: () => void;
     finish: () => void;
   } {
-    let selection: { provider: SharedModelProvider; fallback: boolean } = {
-      provider: "other",
-      fallback: false,
-    };
+    let selection: SharedModelCallSelection | null = null;
     let startedAt: number | null = null;
     let finished = false;
     return {
@@ -282,18 +363,22 @@ export class SharedRuntimeTimingCollector {
       finish: () => {
         if (finished || startedAt === null) return;
         finished = true;
-        const durationMs = boundedDuration(startedAt, this.#now()) ?? 0;
+        const measured = clampedCallDuration(this.#now() - startedAt);
+        if (measured === null) return;
+        if (measured.clamped) this.#modelClamped = true;
         this.#modelCallCount += 1;
-        if (selection.fallback) {
+        const call: SharedModelCallTiming = selection
+          ? { ...selection, durationMs: measured.value }
+          : { provider: "unobserved", fallback: false, durationMs: measured.value };
+        if (call.fallback) {
           this.#modelFallbackCount += 1;
         }
-        this.#modelDurationMs = Math.min(
-          Math.round((this.#modelDurationMs + durationMs) * 10) / 10,
-          MAX_SHARED_PROVIDER_TIMING_MS,
-        );
-        this.#modelProviders.add(selection.provider);
+        const total = Math.round((this.#modelDurationMs + measured.value) * 10) / 10;
+        if (total > MAX_SHARED_PROVIDER_TIMING_MS) this.#modelClamped = true;
+        this.#modelDurationMs = Math.min(total, MAX_SHARED_PROVIDER_TIMING_MS);
+        if (call.provider !== "unobserved") this.#modelProviders.add(call.provider);
         if (this.#modelCalls.length < MAX_SHARED_PROVIDER_TIMING_RECORDED_CALLS) {
-          this.#modelCalls.push({ ...selection, durationMs });
+          this.#modelCalls.push(call);
         }
       },
     };
@@ -361,6 +446,7 @@ export class SharedRuntimeTimingCollector {
       model: {
         replayed: false,
         durationMs: this.#modelDurationMs,
+        clamped: this.#modelClamped,
         callCount: this.#modelCallCount,
         fallbackCount: this.#modelFallbackCount,
         selectedProvider:
@@ -385,6 +471,7 @@ export function replayedSharedProviderTiming(): SharedProviderTimingReceipt {
   return {
     replayed: true,
     durationMs: 0,
+    clamped: false,
     callCount: 0,
     fallbackCount: 0,
     selectedProvider: "none",


### PR DESCRIPTION
# Relates to

Fixes #20127.

- [x] Targets `develop` and was rebased onto latest observed `origin/develop` with zero conflicts.
- [x] Focused provider, timing, REST, chat, history, and genuine-runtime suites plus affected-package typecheck and Biome pass on the repaired tree.
- [x] Deterministic timing receipts are reviewer-visible; live staging evidence remains explicit below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e4b0af6a49c1464d734e0805073e5a866c5ebce5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest observed `origin/develop`; zero conflicts.
- [ ] Root verify must be rerun after final sync; the prior baseline Cloud type blocker is handled by #21815.

# Risks

Medium. This extends timing metadata across provider, genuine Shared runtime, REST/SSE, and Personal Shared proxy boundaries. Values are coarse, bounded duration/enum receipts and contain no prompts, responses, tokens, account identifiers, or provider secrets.

# Background

## What does this PR do?

Propagates provider selection, fallback, result, header, and response-path timing receipts through Personal Shared without placing raw provider payloads or content in logs. It preserves receipt identity through retry/failover and exposes the same contract on direct Shared, REST, and streamed completion paths.

## What kind of change is this?

Observability improvement and bug fix.

# Documentation changes needed?

No external documentation change; the typed contract and route tests define the surface.

# Independent correction

The actual resolver/fallback wrapper now emits provider success observations. Native OpenAI/Anthropic 503 to OpenRouter fallback is correctly recorded for both generate and stream instead of other / fallback false. The repaired tree passes provider/timing/REST 52/52, Shared timing 21/21, chat/durable-row 34/34, history policy 20/20, and the genuine authority regression 1/1. Cloud Shared typecheck, Biome, and diff integrity pass.

Required live staging evidence remains pending and merge-blocking. #21799 is complementary but overlaps these runtime collectors and must be rebased/consolidated deliberately after this contract stabilizes.

# Testing

## Where should a reviewer start?

Start with `shared-turn-timing.ts`, then inspect provider failover, Shared runtime, REST adapter, chat streaming, and Personal Shared route tests.

## Detailed testing steps

Run the nine owning test files independently, then:

```bash
bun run --cwd packages/cloud/shared typecheck
bunx biome check <the fifteen changed files>
git diff --check
```

Repaired-head results at `3247fe7f2e4dc8acc43d4598e2caa8a9b7197bf1`: provider/timing/REST 52/52; Shared timing 21/21; chat/durable-row semantics 34/34; history policy 20/20; genuine authority regression 1/1. The model clock begins immediately before the SDK call after dispatch/setup; untrusted receipts enforce count/fallback/provider/truncation consistency and strip undeclared fields. Cloud Shared typecheck, targeted Biome, and diff check pass. Exact hosted Quality succeeded: https://github.com/elizaOS/eliza/actions/runs/32355872996. A source-light final-worktree rerun lacked package-local `ai`/`uuid` links; the byte-identical fully installed tree produced the passing behavioral results above.

# Evidence Gate

<!-- evidence-head:ab38790dfa52887f420a3e553298acaff7c8ee3a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend timing-contract change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend timing-contract change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [ ] Pending - staging cold/warm/fallback Personal Shared and REST/SSE receipt logs are required before merge.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changes.
<!-- evidence-row:llm-trajectory -->
- [ ] Pending - real-provider staging turns are required before merge.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/schema/domain artifact changes; the output is transport metadata.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

Pending staging cold/warm/fallback real-provider turns before merge.

## Backend + frontend logs

Pending staging REST/SSE and Personal Shared timing receipts. Unit and integration tests verify the exact privacy-bounded envelope and retry/fallback behavior.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio or voice change.

## Known gaps / failures

- Staging cold/warm/fallback provider and transport evidence remains a merge blocker.
- A prior root verify reached 206/210 Turbo tasks before unrelated Cloud backup test type failures; those are addressed separately in #21815. Final-sync verify remains required.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@e4b0af6a49c1464d734e0805073e5a866c5ebce5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

— [codex-root/nubs-issue-closeout]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@e4b0af6a49c1464d734e0805073e5a866c5ebce5:packages/skills/skills/contribute-to-eliza"} -->