### PR TITLE
fix(app): publish the bound device-host port consistently

### DIFF
--- a/packages/app-core/scripts/lib/device-e2e-port-advertisement.test.ts
+++ b/packages/app-core/scripts/lib/device-e2e-port-advertisement.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Integration coverage for publishing a real kernel-assigned device-e2e port
+ * through the runtime environment, CORS cache, self-report route, and file.
+ */
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveDevStackFromEnv } from "../../src/api/dev-stack.ts";
+import {
+  getCorsAllowedPorts,
+  invalidateCorsAllowedPorts,
+  isAllowedOrigin,
+} from "../../src/api/server-cors.ts";
+import { publishBoundDeviceE2ePort } from "./device-e2e-port-advertisement.ts";
+
+const ENV_KEYS = ["ELIZA_API_PORT", "ELIZA_UI_PORT", "ELIZA_PORT"] as const;
+const originalEnv = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  for (const key of ENV_KEYS) {
+    const original = originalEnv[key];
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+  invalidateCorsAllowedPorts();
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("device-e2e bound-port publication", () => {
+  it("rejects an invalid bound port before mutating runtime state", () => {
+    process.env.ELIZA_API_PORT = "43137";
+    process.env.ELIZA_UI_PORT = "43138";
+    process.env.ELIZA_PORT = "43139";
+
+    expect(() => publishBoundDeviceE2ePort(0)).toThrow(
+      "Invalid bound device-e2e port: 0",
+    );
+    expect(process.env.ELIZA_API_PORT).toBe("43137");
+    expect(process.env.ELIZA_UI_PORT).toBe("43138");
+    expect(process.env.ELIZA_PORT).toBe("43139");
+  });
+
+  it("synchronizes env and cache before advertising the self-reported route", async () => {
+    process.env.ELIZA_API_PORT = "43137";
+    process.env.ELIZA_UI_PORT = "43138";
+    process.env.ELIZA_PORT = "43139";
+    expect(getCorsAllowedPorts().has("43137")).toBe(true);
+    process.env.ELIZA_API_PORT = "0";
+    process.env.ELIZA_UI_PORT = "0";
+    process.env.ELIZA_PORT = "0";
+
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          envPort: process.env.ELIZA_API_PORT,
+          stack: resolveDevStackFromEnv(process.env),
+          corsAllowsSelf: isAllowedOrigin(
+            `http://127.0.0.1:${process.env.ELIZA_API_PORT}`,
+          ),
+        }),
+      );
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Test server did not bind a TCP port.");
+      }
+      const directory = await mkdtemp(join(tmpdir(), "eliza-port-publish-"));
+      temporaryDirectories.push(directory);
+      const portFile = join(directory, "port");
+
+      publishBoundDeviceE2ePort(address.port, portFile);
+
+      expect(process.env.ELIZA_API_PORT).toBe(String(address.port));
+      expect(process.env.ELIZA_UI_PORT).toBe(String(address.port));
+      expect(process.env.ELIZA_PORT).toBe(String(address.port));
+      expect(await readFile(portFile, "utf8")).toBe(`${address.port}\n`);
+
+      const response = await fetch(`http://127.0.0.1:${address.port}/self`);
+      expect(await response.json()).toMatchObject({
+        envPort: String(address.port),
+        stack: {
+          api: {
+            listenPort: address.port,
+            baseUrl: `http://127.0.0.1:${address.port}`,
+          },
+        },
+        corsAllowsSelf: true,
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+});

--- a/packages/app-core/scripts/lib/device-e2e-port-advertisement.ts
+++ b/packages/app-core/scripts/lib/device-e2e-port-advertisement.ts
@@ -1,0 +1,22 @@
+/**
+ * Publishes a device-e2e host's kernel-assigned port only after synchronizing
+ * the child runtime's environment and invalidating port-derived CORS caches.
+ */
+
+import { syncResolvedApiPort } from "@elizaos/shared/runtime-env";
+import { advertisePort } from "../../../scripts/e2e-ports.mjs";
+import { invalidateCorsAllowedPorts } from "../../src/api/server-cors.ts";
+
+export function publishBoundDeviceE2ePort(
+  port: number,
+  portFile?: string,
+): void {
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`Invalid bound device-e2e port: ${port}`);
+  }
+
+  syncResolvedApiPort(process.env, port, { overwriteUiPort: true });
+  invalidateCorsAllowedPorts();
+
+  if (portFile) advertisePort(portFile, port);
+}

--- a/packages/app-core/scripts/serve-real-local-agent.ts
+++ b/packages/app-core/scripts/serve-real-local-agent.ts
@@ -13,10 +13,10 @@ import { readFile } from "node:fs/promises";
 import { ModelType, type Plugin, type Route } from "@elizaos/core";
 import { createDeterministicModelPlugin } from "@elizaos/core/testing";
 import { backgroundUploadImageRoute } from "../../agent/src/api/background-routes.ts";
-import { advertisePort } from "../../scripts/e2e-ports.mjs";
 import { startApiServer } from "../src/api/server.ts";
 import { useIsolatedConfigEnv } from "../test/helpers/isolated-config.ts";
 import { createRealTestRuntime } from "../test/helpers/real-runtime.ts";
+import { publishBoundDeviceE2ePort } from "./lib/device-e2e-port-advertisement.ts";
 
 const deviceE2eUploadImageRoute = {
   ...backgroundUploadImageRoute,
@@ -267,7 +267,7 @@ async function main(): Promise<void> {
   });
 
   const portFile = process.env.ELIZA_E2E_PORT_FILE?.trim();
-  if (portFile) advertisePort(portFile, server.port);
+  publishBoundDeviceE2ePort(server.port, portFile);
 
   console.log(
     `[device-e2e-host-agent] real API up on :${server.port} in ${Date.now() - t0}ms`,

--- a/packages/app/scripts/lib/host-agent.mjs
+++ b/packages/app/scripts/lib/host-agent.mjs
@@ -5,6 +5,7 @@
  * the stop handle used by iOS/Android device lanes.
  */
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { waitForAdvertisedPort } from "../../../scripts/e2e-ports.mjs";
@@ -18,6 +19,38 @@ export const DEFAULT_ADVERTISEMENT_POLL_INTERVAL_MS = 100;
 export const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 const SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
+const activeSignalStops = new Set();
+const sharedSignalHandlers = new Map();
+
+function signalExitCode(signal) {
+  return 128 + (signal === "SIGHUP" ? 1 : signal === "SIGINT" ? 2 : 15);
+}
+
+/** Coordinate all live children before honoring a parent termination signal. */
+function registerSignalStop(stop) {
+  activeSignalStops.add(stop);
+  if (sharedSignalHandlers.size === 0) {
+    for (const signal of SIGNALS) {
+      const handler = () => {
+        const stops = [...activeSignalStops];
+        void Promise.allSettled(
+          stops.map((activeStop) => activeStop()),
+        ).finally(() => process.exit(signalExitCode(signal)));
+      };
+      sharedSignalHandlers.set(signal, handler);
+      process.once(signal, handler);
+    }
+  }
+
+  return () => {
+    activeSignalStops.delete(stop);
+    if (activeSignalStops.size > 0) return;
+    for (const [signal, handler] of sharedSignalHandlers) {
+      process.off(signal, handler);
+    }
+    sharedSignalHandlers.clear();
+  };
+}
 
 export function parsePort(value, label = "port") {
   const raw = String(value ?? "").trim();
@@ -258,7 +291,7 @@ export async function startDeviceE2eHostAgent({
   const logPath = path.join(artifactDir, "host-agent.log");
   const portFile = path.join(
     artifactDir,
-    `.host-agent-port-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    `.host-agent-port-${process.pid}-${randomUUID()}`,
   );
   fs.rmSync(portFile, { force: true });
   const logFd = fs.openSync(logPath, "w");
@@ -323,23 +356,7 @@ export async function startDeviceE2eHostAgent({
     return stopPromise;
   };
 
-  const signalHandlers = new Map();
-  for (const signal of SIGNALS) {
-    const handler = () => {
-      void stop().finally(() =>
-        process.exit(
-          128 + (signal === "SIGHUP" ? 1 : signal === "SIGINT" ? 2 : 15),
-        ),
-      );
-    };
-    signalHandlers.set(signal, handler);
-    process.once(signal, handler);
-  }
-  const removeSignalHandlers = () => {
-    for (const [signal, handler] of signalHandlers) {
-      process.off(signal, handler);
-    }
-  };
+  const unregisterSignalStop = registerSignalStop(stop);
 
   try {
     const port = await Promise.race([
@@ -370,14 +387,14 @@ export async function startDeviceE2eHostAgent({
       logPath,
       pid: child.pid,
       async stop() {
-        removeSignalHandlers();
+        unregisterSignalStop();
         await stop();
         log?.(`stopped host agent at ${apiBase}`);
       },
     };
   } catch (error) {
     // error-policy:J2 stop child then rethrow readiness/spawn failure
-    removeSignalHandlers();
+    unregisterSignalStop();
     await stop();
     throw error;
   }

--- a/packages/app/scripts/lib/host-agent.mjs
+++ b/packages/app/scripts/lib/host-agent.mjs
@@ -13,6 +13,7 @@ export const DEFAULT_HOST_AGENT_HOST = "127.0.0.1";
 export const DEFAULT_HOST_AGENT_HEALTH_PATH = "/api/health";
 export const DEFAULT_READY_ATTEMPTS = 90;
 export const DEFAULT_READY_DELAY_MS = 2000;
+export const DEFAULT_ADVERTISEMENT_POLL_INTERVAL_MS = 100;
 /** Node clamps setTimeout delays above this value to 1 ms. */
 export const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
@@ -114,6 +115,27 @@ export function resolveReadyOptions(options = {}) {
       "host-agent readyDelayMs",
       { max: MAX_TIMER_DELAY_MS },
     ),
+  };
+}
+
+/**
+ * Give port advertisement the same validated wall-clock budget as readiness.
+ * A zero-delay readiness loop still receives one millisecond per attempt so
+ * process startup is not converted into an immediate timeout.
+ */
+export function resolveAdvertisementWaitOptions({
+  readyAttempts,
+  readyDelayMs,
+}) {
+  const timeoutMs = readyAttempts * Math.max(readyDelayMs, 1);
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1) {
+    throw new Error(
+      "Invalid host-agent readiness budget: readyAttempts * readyDelayMs must be a positive safe integer duration.",
+    );
+  }
+  return {
+    timeoutMs,
+    pollIntervalMs: Math.min(DEFAULT_ADVERTISEMENT_POLL_INTERVAL_MS, timeoutMs),
   };
 }
 
@@ -226,6 +248,7 @@ export async function startDeviceE2eHostAgent({
     readyDelayMs,
     env: process.env,
   });
+  const advertisementWait = resolveAdvertisementWaitOptions(resolvedReady);
 
   const explicitPort =
     requestedPort === null || requestedPort === undefined
@@ -320,7 +343,7 @@ export async function startDeviceE2eHostAgent({
 
   try {
     const port = await Promise.race([
-      waitForAdvertisedPort(portFile, { child }),
+      waitForAdvertisedPort(portFile, { child, ...advertisementWait }),
       new Promise((_, reject) => {
         child.once("error", reject);
       }),

--- a/packages/app/scripts/lib/host-agent.test.mjs
+++ b/packages/app/scripts/lib/host-agent.test.mjs
@@ -10,6 +10,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  DEFAULT_ADVERTISEMENT_POLL_INTERVAL_MS,
   DEFAULT_READY_ATTEMPTS,
   DEFAULT_READY_DELAY_MS,
   hostAgentApiBase,
@@ -17,6 +18,7 @@ import {
   parseNonNegativeSafeInteger,
   parsePort,
   parsePositiveSafeInteger,
+  resolveAdvertisementWaitOptions,
   resolveReadyOptions,
   startDeviceE2eHostAgent,
 } from "./host-agent.mjs";
@@ -213,6 +215,54 @@ describe("host-agent helper", () => {
     ).toThrow(`no greater than ${MAX_TIMER_DELAY_MS}`);
   });
 
+  it("derives short and extended advertisement timeouts from readiness", () => {
+    expect(
+      resolveAdvertisementWaitOptions({
+        readyAttempts: 2,
+        readyDelayMs: 20,
+      }),
+    ).toEqual({ timeoutMs: 40, pollIntervalMs: 40 });
+    expect(
+      resolveAdvertisementWaitOptions({
+        readyAttempts: DEFAULT_READY_ATTEMPTS,
+        readyDelayMs: DEFAULT_READY_DELAY_MS,
+      }),
+    ).toEqual({
+      timeoutMs: 180_000,
+      pollIntervalMs: DEFAULT_ADVERTISEMENT_POLL_INTERVAL_MS,
+    });
+    expect(
+      resolveAdvertisementWaitOptions({
+        readyAttempts: 3,
+        readyDelayMs: 0,
+      }),
+    ).toEqual({ timeoutMs: 3, pollIntervalMs: 3 });
+    expect(() =>
+      resolveAdvertisementWaitOptions({
+        readyAttempts: Number.MAX_SAFE_INTEGER,
+        readyDelayMs: 2,
+      }),
+    ).toThrow(/readiness budget/);
+  });
+
+  it("uses a short readiness budget when a live child never advertises", async () => {
+    const artifactDir = makeTmpDir();
+    const startedAt = Date.now();
+    await expect(
+      startDeviceE2eHostAgent({
+        repoRoot: process.cwd(),
+        artifactDir,
+        readyAttempts: 2,
+        readyDelayMs: 20,
+        command: process.execPath,
+        args: ["-e", "setInterval(() => {}, 1_000)"],
+        env: {},
+      }),
+    ).rejects.toThrow(/timed out after 40ms/);
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    fs.rmSync(path.join(artifactDir, "host-agent.log"));
+  });
+
   it("rejects invalid readyAttempts before spawning a host agent child", async () => {
     const artifactDir = makeTmpDir();
     await expect(
@@ -299,8 +349,8 @@ describe("host-agent helper", () => {
           repoRoot: process.cwd(),
           artifactDir: makeTmpDir(),
           requestedPort: port,
-          readyAttempts: 5,
-          readyDelayMs: 10,
+          readyAttempts: 50,
+          readyDelayMs: 20,
           command: process.execPath,
           args: ["-e", fakeHostAgentScript()],
           env: {},

--- a/packages/app/scripts/lib/host-agent.test.mjs
+++ b/packages/app/scripts/lib/host-agent.test.mjs
@@ -260,7 +260,48 @@ describe("host-agent helper", () => {
       }),
     ).rejects.toThrow(/timed out after 40ms/);
     expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(
+      fs
+        .readdirSync(artifactDir)
+        .filter((entry) => entry.startsWith(".host-agent-port-")),
+    ).toEqual([]);
     fs.rmSync(path.join(artifactDir, "host-agent.log"));
+  });
+
+  it("shares one signal coordinator while concurrent children are starting", async () => {
+    const signalCounts = new Map(
+      ["SIGINT", "SIGTERM", "SIGHUP"].map((signal) => [
+        signal,
+        process.listenerCount(signal),
+      ]),
+    );
+    const starts = Array.from({ length: 12 }, (_, index) =>
+      startDeviceE2eHostAgent({
+        repoRoot: process.cwd(),
+        artifactDir: path.join(makeTmpDir(), String(index)),
+        readyAttempts: 10,
+        readyDelayMs: 20,
+        command: process.execPath,
+        args: ["-e", "setInterval(() => {}, 1_000)"],
+        env: {},
+      }),
+    );
+
+    for (const [signal, count] of signalCounts) {
+      expect(process.listenerCount(signal)).toBe(count + 1);
+    }
+    const results = await Promise.allSettled(starts);
+    expect(results).toHaveLength(12);
+    expect(
+      results.every(
+        (result) =>
+          result.status === "rejected" &&
+          /timed out after 200ms/.test(String(result.reason)),
+      ),
+    ).toBe(true);
+    for (const [signal, count] of signalCounts) {
+      expect(process.listenerCount(signal)).toBe(count);
+    }
   });
 
   it("rejects invalid readyAttempts before spawning a host agent child", async () => {
@@ -386,6 +427,11 @@ describe("host-agent helper", () => {
     });
 
     await agent.stop();
+    expect(
+      fs
+        .readdirSync(artifactDir)
+        .filter((entry) => entry.startsWith(".host-agent-port-")),
+    ).toEqual([]);
     expect(fs.readFileSync(agent.logPath, "utf8")).toContain(
       "fake host agent up on :0",
     );
@@ -402,6 +448,12 @@ describe("host-agent helper", () => {
   });
 
   it("starts concurrent children on distinct bound ports without probe races", async () => {
+    const signalCounts = new Map(
+      ["SIGINT", "SIGTERM", "SIGHUP"].map((signal) => [
+        signal,
+        process.listenerCount(signal),
+      ]),
+    );
     const agents = await Promise.all(
       Array.from({ length: 12 }, (_, index) =>
         startDeviceE2eHostAgent({
@@ -416,6 +468,9 @@ describe("host-agent helper", () => {
       ),
     );
     try {
+      for (const [signal, count] of signalCounts) {
+        expect(process.listenerCount(signal)).toBe(count + 1);
+      }
       expect(new Set(agents.map((agent) => agent.port)).size).toBe(12);
       const responses = await Promise.all(
         agents.map((agent) => fetch(`${agent.apiBase}/api/health`)),
@@ -423,6 +478,9 @@ describe("host-agent helper", () => {
       expect(responses.every((response) => response.ok)).toBe(true);
     } finally {
       await Promise.all(agents.map((agent) => agent.stop()));
+    }
+    for (const [signal, count] of signalCounts) {
+      expect(process.listenerCount(signal)).toBe(count);
     }
   });
 

--- a/packages/app/scripts/lib/host-agent.test.mjs
+++ b/packages/app/scripts/lib/host-agent.test.mjs
@@ -410,7 +410,7 @@ describe("host-agent helper", () => {
     const agent = await startDeviceE2eHostAgent({
       repoRoot: process.cwd(),
       artifactDir,
-      readyAttempts: 50,
+      readyAttempts: 250,
       readyDelayMs: 20,
       command: process.execPath,
       args: ["-e", fakeHostAgentScript()],
@@ -459,7 +459,7 @@ describe("host-agent helper", () => {
         startDeviceE2eHostAgent({
           repoRoot: process.cwd(),
           artifactDir: path.join(makeTmpDir(), String(index)),
-          readyAttempts: 50,
+          readyAttempts: 500,
           readyDelayMs: 10,
           command: process.execPath,
           args: ["-e", fakeHostAgentScript()],

--- a/packages/scripts/__tests__/e2e-ports.test.ts
+++ b/packages/scripts/__tests__/e2e-ports.test.ts
@@ -7,7 +7,15 @@
  */
 
 import { spawn } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -22,7 +30,32 @@ describe("advertisePort / waitForAdvertisedPort", () => {
     const portFile = path.join(dir, "round-trip.port");
     advertisePort(portFile, 43210);
     expect(readFileSync(portFile, "utf8")).toBe("43210\n");
+    if (process.platform !== "win32") {
+      expect(statSync(portFile).mode & 0o777).toBe(0o600);
+    }
     await expect(waitForAdvertisedPort(portFile)).resolves.toBe(43210);
+  });
+
+  it("cleans its temporary file when atomic publication fails", () => {
+    const portFile = path.join(dir, "blocked.port");
+    mkdirSync(portFile);
+
+    expect(() => advertisePort(portFile, 43210)).toThrow();
+    expect(
+      readdirSync(dir).filter((entry) => entry.startsWith("blocked.port.")),
+    ).toEqual([]);
+  });
+
+  it("surfaces port-file I/O failures without waiting for timeout", async () => {
+    const portFile = path.join(dir, "unreadable.port");
+    mkdirSync(portFile);
+
+    await expect(
+      waitForAdvertisedPort(portFile, {
+        timeoutMs: 10_000,
+        pollIntervalMs: 1_000,
+      }),
+    ).rejects.toThrow(/failed to read/);
   });
 
   it("polls until a slow child advertises", async () => {

--- a/packages/scripts/e2e-ports.mjs
+++ b/packages/scripts/e2e-ports.mjs
@@ -17,7 +17,8 @@
  * packages/homepage/scripts/e2e-port.mjs.
  */
 
-import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 
 /**
  * Child side: publish the port this process actually bound. The write goes to
@@ -31,9 +32,19 @@ export function advertisePort(portFile, port) {
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
     throw new Error(`advertisePort: not a bound TCP port: ${port}`);
   }
-  const tmp = `${portFile}.${process.pid}.tmp`;
-  writeFileSync(tmp, `${port}\n`, "utf8");
-  renameSync(tmp, portFile);
+  const tmp = `${portFile}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(tmp, `${port}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(tmp, portFile);
+  } finally {
+    // error-policy:J6 a failed atomic rename must not leave a stale temporary
+    // advertisement that can confuse later diagnostics or process runs.
+    rmSync(tmp, { force: true });
+  }
 }
 
 /**
@@ -64,10 +75,22 @@ export async function waitForAdvertisedPort(
     let raw = null;
     try {
       raw = readFileSync(portFile, "utf8");
-    } catch {
-      // error-policy:J3 an absent port file is the expected pre-advertisement
-      // state while the child boots; only parsed file content below is
-      // treated as a result, and timeout/child-exit surface as errors.
+    } catch (error) {
+      // error-policy:J3 only absence is the expected pre-advertisement state;
+      // permission, descriptor, and filesystem failures are not equivalent to
+      // a child that has not advertised yet.
+      if (
+        !error ||
+        typeof error !== "object" ||
+        !("code" in error) ||
+        error.code !== "ENOENT"
+      ) {
+        // error-policy:J2 preserve the underlying filesystem failure while
+        // adding the advertisement path the orchestrator needs to diagnose it.
+        throw new Error(`waitForAdvertisedPort: failed to read ${portFile}`, {
+          cause: error,
+        });
+      }
     }
     if (raw !== null) {
       const value = raw.trim();


### PR DESCRIPTION
Closes #21846. Corrective follow-up to merged #21657.

The child now validates its kernel-assigned port, synchronizes the canonical API/UI/runtime env and invalidates the derived CORS port cache before atomically advertising readiness. The parent advertisement deadline is derived from the configured readiness attempts × delay instead of an unrelated fixed 120-second ceiling, with bounded polling and overflow validation.

Pinned Bun 1.3.14 / Node 24.15.0 exact-head evidence (`be7fd8ff6c7a08ca4e41b4ff22cb0ec07a4230c8`):

- host-agent and shared port coordination: 23/23.
- app-core publication regression: 2/2.
- Real bound HTTP server verifies API/UI/PORT env, port file, dev-stack self-report, and stale CORS-cache invalidation.
- Real non-advertising child verifies short configured timeout; default extended 180-second derivation and overflow/zero-delay cases are covered deterministically. Independent review also widened only the successful-child test budgets after a contended exact-head run exposed false 500–1000 ms startup assumptions.
- app-core typecheck/build, targeted strict TypeScript, Biome, and diff-check: pass.
- app package typecheck is environment-blocked by duplicate Drizzle installations in the shared main checkout; no changed-file diagnostic.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@aad515ff7407a79ff0a0bf854aba2bb6c5d990a1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:be7fd8ff6c7a08ca4e41b4ff22cb0ec07a4230c8 -->
<!-- evidence-row:before-screenshots -->
- [x] `N/A - host startup/runtime state only.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered UI changed.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - real child/server process tests are the relevant evidence.`
<!-- evidence-row:backend-logs -->
- [x] [21847-be7fd8ff-process-log.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21847-be7fd8ff-process-log.txt)
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend rendering changed.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model or agent behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - host orchestration changes produce no persistent business-domain artifact; the bound-port and environment observations are captured in backend logs.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no visual surface changed.`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@aad515ff7407a79ff0a0bf854aba2bb6c5d990a1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-pr-21847]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@aad515ff7407a79ff0a0bf854aba2bb6c5d990a1:packages/skills/skills/contribute-to-eliza"} -->



