### PR TITLE
fix(ui): bound JNI PCM handoff through local-agent client

### DIFF
--- a/packages/ui/src/voice/jni-voice-harness-timeout.test.ts
+++ b/packages/ui/src/voice/jni-voice-harness-timeout.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Exercises the production completed-turn callback through its dedicated
+ * local-agent ElizaClient while JNI/native collaborators are mocked.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clientBase: undefined as string | undefined,
+  rawRequest: vi.fn(),
+  completedTurn: undefined as
+    | ((turn: {
+        turnId: string;
+        audio: { pcm: Float32Array; sampleRate: number };
+        signal: unknown;
+      }) => Promise<void>)
+    | undefined,
+}));
+
+vi.mock("../api", () => ({
+  ElizaClient: class {
+    rawRequest = mocks.rawRequest;
+
+    constructor(baseUrl?: string) {
+      mocks.clientBase = baseUrl;
+    }
+  },
+}));
+
+vi.mock("../bridge/native-plugins", () => ({
+  getElizaVoicePlugin: () => ({}),
+  getTalkModePlugin: () => ({}),
+}));
+
+vi.mock("../first-run/mobile-runtime-mode", () => ({
+  MOBILE_LOCAL_AGENT_API_BASE: "http://127.0.0.1:3000",
+}));
+
+vi.mock("./jni-voice-pipeline", () => ({
+  JniVoicePipeline: class {
+    framesSent = 0;
+
+    constructor(
+      _talkMode: unknown,
+      _elizaVoice: unknown,
+      options: { onCompletedPcmTurn?: typeof mocks.completedTurn },
+    ) {
+      mocks.completedTurn = options.onCompletedPcmTurn;
+    }
+
+    onTurn(): void {}
+
+    async start(): Promise<{ started: boolean }> {
+      return { started: true };
+    }
+  },
+}));
+
+import { installJniVoiceHarness } from "./jni-voice-harness";
+
+const TURN = {
+  turnId: "t1",
+  audio: { pcm: new Float32Array([0.5, -0.5]), sampleRate: 16_000 },
+  signal: { agentShouldSpeak: false, nextSpeaker: "user" },
+};
+
+async function getCompletedTurnCallback() {
+  await installJniVoiceHarness().start();
+  if (!mocks.completedTurn) {
+    throw new Error("JNI pipeline did not receive onCompletedPcmTurn");
+  }
+  return mocks.completedTurn;
+}
+
+describe("jni-voice-harness native PCM turn deadline", () => {
+  beforeEach(() => {
+    mocks.rawRequest.mockReset();
+  });
+
+  it("pins the production handoff to the bounded local-agent client", async () => {
+    mocks.rawRequest.mockResolvedValue(new Response(null, { status: 204 }));
+
+    await expect(
+      (await getCompletedTurnCallback())(TURN),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.clientBase).toBe("http://127.0.0.1:3000");
+    expect(mocks.rawRequest).toHaveBeenCalledWith(
+      "/api/voice/native-pcm-turn",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: expect.any(String),
+      },
+      { timeoutMs: 15_000 },
+    );
+    const body = JSON.parse(
+      mocks.rawRequest.mock.calls[0]?.[1]?.body as string,
+    ) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      turnId: "t1",
+      sampleRate: 16_000,
+      signal: TURN.signal,
+    });
+    expect(typeof body.pcm).toBe("string");
+  });
+
+  it("surfaces a bounded-client failure to the JNI pipeline", async () => {
+    const timeout = new Error("Request timed out after 15000ms");
+    mocks.rawRequest.mockRejectedValue(timeout);
+
+    await expect((await getCompletedTurnCallback())(TURN)).rejects.toBe(
+      timeout,
+    );
+  });
+});

--- a/packages/ui/src/voice/jni-voice-harness.ts
+++ b/packages/ui/src/voice/jni-voice-harness.ts
@@ -17,10 +17,12 @@
  * pipeline owns ASR/text/TTS while this harness remains observable on-device.
  */
 
+import { ElizaClient } from "../api";
 import {
   getElizaVoicePlugin,
   getTalkModePlugin,
 } from "../bridge/native-plugins";
+import { MOBILE_LOCAL_AGENT_API_BASE } from "../first-run/mobile-runtime-mode";
 import {
   type JniAttributedTurn,
   type JniCompletedPcmTurn,
@@ -108,26 +110,27 @@ function float32ToBase64(pcm: Float32Array): string {
   return btoa(binary);
 }
 
+/** Native PCM handoff is a short local-agent POST. */
+const JNI_VOICE_PCM_TURN_TIMEOUT_MS = 15_000;
+const localAgentClient = new ElizaClient(MOBILE_LOCAL_AGENT_API_BASE);
+
 async function forwardCompletedPcmTurnToLocalAgent(
   turn: JniCompletedPcmTurn,
 ): Promise<void> {
-  const res = await fetch("/api/voice/native-pcm-turn", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      turnId: turn.turnId,
-      pcm: float32ToBase64(turn.audio.pcm),
-      sampleRate: turn.audio.sampleRate,
-      signal: turn.signal,
-    }),
-  });
-  if (!res.ok) {
-    // error-policy:J6 best-effort error detail — the throw carries the status
-    const detail = await res.text().catch(() => "");
-    throw new Error(
-      `[JniVoiceHarness] native PCM turn handoff failed (${res.status}): ${detail}`,
-    );
-  }
+  await localAgentClient.rawRequest(
+    "/api/voice/native-pcm-turn",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        turnId: turn.turnId,
+        pcm: float32ToBase64(turn.audio.pcm),
+        sampleRate: turn.audio.sampleRate,
+        signal: turn.signal,
+      }),
+    },
+    { timeoutMs: JNI_VOICE_PCM_TURN_TIMEOUT_MS },
+  );
 }
 
 function pipelineOptionsForHarness(


### PR DESCRIPTION
# Relates to

Bounded-fetch follow-up for the Android JNI completed-PCM-turn handoff.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] Production-boundary tests, shared client timeout tests, UI typecheck, formatting, and diff validation pass.
- [x] Exact-head evidence is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@1fba16ec3ac20fb158307b7a05527fff42726832:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` at `1fba16ec3ac20fb158307b7a05527fff42726832`; zero conflicts.
- [x] Owning-package focused gates pass. The required app audit remains serialized below.

# Risks

Low and isolated to the existing native PCM handoff. The repair uses a dedicated `ElizaClient(MOBILE_LOCAL_AGENT_API_BASE)`, preserving the invariant that JNI turns always reach the on-device agent even if another runtime is selected. It adds local token hydration, Android/iOS/desktop transport selection, typed HTTP errors, and a 15-second request plus non-OK-body budget. JNI capture, PCM encoding, speaker attribution, and response handling are unchanged.

# Background

## What does this PR do?

Bounds `POST /api/voice/native-pcm-turn` through the canonical local-agent client. It removes the submitted raw-fetch/test-only helper and tests the actual private callback passed to `JniVoicePipeline`.

## What kind of change is this?

Bug fix (non-breaking diagnostic transport bound).

# Documentation changes needed?

No. The JNI harness and payload contract are unchanged.

# Testing

## Where should a reviewer start?

`packages/ui/src/voice/jni-voice-harness-timeout.test.ts` starts the production harness, captures the real completed-turn callback at the pipeline boundary, and verifies the pinned local base, route, serialized PCM payload, 15-second canonical budget, success, and surfaced failure.

## Detailed testing steps

Pinned Bun 1.3.14 and Node 24.15.0:

```bash
cd packages/ui
bun x vitest run --config ./vitest.config.ts src/voice/jni-voice-harness-timeout.test.ts src/api/client-base-timeout.test.ts
bun run typecheck
bun x biome check src/voice/jni-voice-harness.ts src/voice/jni-voice-harness-timeout.test.ts
git diff --check origin/develop...HEAD
```

Results at `e1732606be09314d1fa2862a44481379b74b3497`:

- Vitest: 2 files passed, 6 tests passed.
- UI TypeScript: exit 0.
- Biome: 2 files checked, no diagnostics.
- `git diff --check`: clean.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered output; the previous JNI handoff was unbounded.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered output; the JNI handoff is now bounded.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no product interaction or visual-state change.
<!-- evidence-row:backend-logs -->
- [x] N/A — no backend implementation changed; the client contract is exercised directly.
<!-- evidence-row:frontend-logs -->
- [x] Production pipeline-boundary Vitest proves route/payload/deadline wiring; shared client tests prove request and non-OK body bounds.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, prompt, provider, model, or trajectory change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no database, memory, wallet, or persisted-domain change.
<!-- evidence-row:ocr-review -->
- [x] N/A — no pixels or rendered copy changed.

# Evidence Details

## Real LLM-call trajectory

N/A — local native PCM transport only.

## Backend + frontend logs

The production callback is verified to create its client at `http://127.0.0.1:3000`, post the completed turn to `/api/voice/native-pcm-turn`, preserve the PCM/sample-rate/speaker signal payload, and pass `{ timeoutMs: 15000 }`.

## Screenshots (before / after) + video walkthrough

N/A — no rendered output changed.

## Audio / voice walkthrough

N/A — native capture, PCM bytes, and attribution behavior are unchanged; this only bounds the handoff.

## Known gaps / failures

`bun run --cwd packages/app audit:app` is required because this touches shared UI. It must run in the serialized app-audit slot before merge. No focused-gate failures remain.

<!-- evidence-head:e1732606be09314d1fa2862a44481379b74b3497 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@1fba16ec3ac20fb158307b7a05527fff42726832:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@1fba16ec3ac20fb158307b7a05527fff42726832:packages/skills/skills/contribute-to-eliza"} -->
