### PR TITLE
fix(ui): preserve Android SMS gateway error details with timeout

### DIFF
--- a/packages/ui/src/components/pages/ElizaOsAppsView-timeout.test.ts
+++ b/packages/ui/src/components/pages/ElizaOsAppsView-timeout.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Behavioral Android SMS gateway deadline. Executes
+ * postAndroidSmsGatewayWithFetch under abort — not a source-grep.
+ * Not Twilio. Not #21385.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../bridge/plugin-bridge", () => ({
+	getPlugins: () => ({
+		messages: {
+			plugin: {
+				listMessages: async () => ({ messages: [] }),
+			},
+		},
+	}),
+}));
+
+vi.mock("../../bridge/native-plugins", () => ({}));
+
+vi.mock("../../state/TranslationContext.hooks", () => ({
+	useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("../../agent-surface", () => ({
+	useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+}));
+
+vi.mock("../views/ShellViewAgentSurface", () => ({
+	ShellViewAgentSurface: ({ children }: { children: unknown }) => children,
+}));
+
+vi.mock("../ui/button", () => ({ Button: () => null }));
+vi.mock("../ui/input", () => ({ Input: () => null }));
+vi.mock("../ui/textarea", () => ({ Textarea: () => null }));
+
+vi.mock("lucide-react", () => ({
+	Clock3: () => null,
+	ContactRound: () => null,
+	FileUp: () => null,
+	MessageSquare: () => null,
+	NotebookText: () => null,
+	PhoneCall: () => null,
+	Plus: () => null,
+	RefreshCw: () => null,
+	Search: () => null,
+	Send: () => null,
+	Settings: () => null,
+	ShieldCheck: () => null,
+	UserPlus: () => null,
+}));
+
+import {
+	ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS,
+	postAndroidSmsGatewayWithFetch,
+} from "./ElizaOsAppsView";
+
+const URL = "http://test.local/api/webhooks/android-sms";
+const BODY = JSON.stringify({ type: "new-message", data: { text: "hi" } });
+const SECRET = "test-secret";
+
+function stallUntilAborted(): typeof fetch {
+	return ((_input, init) =>
+		new Promise<Response>((_resolve, reject) => {
+			const signal = init?.signal;
+			if (!signal) throw new Error("expected android-sms-gateway abort signal");
+			signal.addEventListener("abort", () => reject(signal.reason), {
+				once: true,
+			});
+		})) as typeof fetch;
+}
+
+describe("ElizaOsAppsView Android SMS gateway deadline", () => {
+	it("keeps a documented UI fetch budget", () => {
+		expect(ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS).toBe(15_000);
+	});
+
+	it("aborts a stalled gateway POST at the injected deadline", async () => {
+		await expect(
+			postAndroidSmsGatewayWithFetch(
+				URL,
+				BODY,
+				SECRET,
+				stallUntilAborted(),
+				10,
+			),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+	});
+
+	it("surfaces a provider error from a completed gateway POST", async () => {
+		const fetchImpl: typeof fetch = async () =>
+			new Response("nope", { status: 503, statusText: "Service Unavailable" });
+
+		await expect(
+			postAndroidSmsGatewayWithFetch(URL, BODY, SECRET, fetchImpl, 1_000),
+		).rejects.toThrow("503");
+	});
+
+	it("uses the injected fetch for a successful gateway POST", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchImpl: typeof fetch = async (_input, init) => {
+			if (init?.signal) signals.push(init.signal);
+			return new Response(JSON.stringify({ replyText: "pong" }), {
+				status: 200,
+			});
+		};
+
+		const response = await postAndroidSmsGatewayWithFetch(
+			URL,
+			BODY,
+			SECRET,
+			fetchImpl,
+			1_000,
+		);
+
+		expect(signals).toHaveLength(1);
+		expect(signals[0]?.aborted).toBe(false);
+		expect(response.ok).toBe(true);
+		expect(await response.json()).toEqual({ replyText: "pong" });
+	});
+});

--- a/packages/ui/src/components/pages/ElizaOsAppsView-timeout.test.ts
+++ b/packages/ui/src/components/pages/ElizaOsAppsView-timeout.test.ts
@@ -6,27 +6,27 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../bridge/plugin-bridge", () => ({
-	getPlugins: () => ({
-		messages: {
-			plugin: {
-				listMessages: async () => ({ messages: [] }),
-			},
-		},
-	}),
+  getPlugins: () => ({
+    messages: {
+      plugin: {
+        listMessages: async () => ({ messages: [] }),
+      },
+    },
+  }),
 }));
 
 vi.mock("../../bridge/native-plugins", () => ({}));
 
 vi.mock("../../state/TranslationContext.hooks", () => ({
-	useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({ t: (key: string) => key }),
 }));
 
 vi.mock("../../agent-surface", () => ({
-	useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+  useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
 }));
 
 vi.mock("../views/ShellViewAgentSurface", () => ({
-	ShellViewAgentSurface: ({ children }: { children: unknown }) => children,
+  ShellViewAgentSurface: ({ children }: { children: unknown }) => children,
 }));
 
 vi.mock("../ui/button", () => ({ Button: () => null }));
@@ -34,24 +34,24 @@ vi.mock("../ui/input", () => ({ Input: () => null }));
 vi.mock("../ui/textarea", () => ({ Textarea: () => null }));
 
 vi.mock("lucide-react", () => ({
-	Clock3: () => null,
-	ContactRound: () => null,
-	FileUp: () => null,
-	MessageSquare: () => null,
-	NotebookText: () => null,
-	PhoneCall: () => null,
-	Plus: () => null,
-	RefreshCw: () => null,
-	Search: () => null,
-	Send: () => null,
-	Settings: () => null,
-	ShieldCheck: () => null,
-	UserPlus: () => null,
+  Clock3: () => null,
+  ContactRound: () => null,
+  FileUp: () => null,
+  MessageSquare: () => null,
+  NotebookText: () => null,
+  PhoneCall: () => null,
+  Plus: () => null,
+  RefreshCw: () => null,
+  Search: () => null,
+  Send: () => null,
+  Settings: () => null,
+  ShieldCheck: () => null,
+  UserPlus: () => null,
 }));
 
 import {
-	ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS,
-	postAndroidSmsGatewayWithFetch,
+  ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS,
+  postAndroidSmsGatewayWithFetch,
 } from "./ElizaOsAppsView";
 
 const URL = "http://test.local/api/webhooks/android-sms";
@@ -59,62 +59,69 @@ const BODY = JSON.stringify({ type: "new-message", data: { text: "hi" } });
 const SECRET = "test-secret";
 
 function stallUntilAborted(): typeof fetch {
-	return ((_input, init) =>
-		new Promise<Response>((_resolve, reject) => {
-			const signal = init?.signal;
-			if (!signal) throw new Error("expected android-sms-gateway abort signal");
-			signal.addEventListener("abort", () => reject(signal.reason), {
-				once: true,
-			});
-		})) as typeof fetch;
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected android-sms-gateway abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
 }
 
 describe("ElizaOsAppsView Android SMS gateway deadline", () => {
-	it("keeps a documented UI fetch budget", () => {
-		expect(ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS).toBe(15_000);
-	});
+  it("keeps a documented UI fetch budget", () => {
+    expect(ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS).toBe(15_000);
+  });
 
-	it("aborts a stalled gateway POST at the injected deadline", async () => {
-		await expect(
-			postAndroidSmsGatewayWithFetch(
-				URL,
-				BODY,
-				SECRET,
-				stallUntilAborted(),
-				10,
-			),
-		).rejects.toMatchObject({ name: "TimeoutError" });
-	});
+  it("aborts a stalled gateway POST at the injected deadline", async () => {
+    await expect(
+      postAndroidSmsGatewayWithFetch(
+        URL,
+        BODY,
+        SECRET,
+        stallUntilAborted(),
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
 
-	it("surfaces a provider error from a completed gateway POST", async () => {
-		const fetchImpl: typeof fetch = async () =>
-			new Response("nope", { status: 503, statusText: "Service Unavailable" });
+  it("returns a completed provider error for the caller to decode", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 503, statusText: "Service Unavailable" });
 
-		await expect(
-			postAndroidSmsGatewayWithFetch(URL, BODY, SECRET, fetchImpl, 1_000),
-		).rejects.toThrow("503");
-	});
+    const response = await postAndroidSmsGatewayWithFetch(
+      URL,
+      BODY,
+      SECRET,
+      fetchImpl,
+      1_000,
+    );
 
-	it("uses the injected fetch for a successful gateway POST", async () => {
-		const signals: AbortSignal[] = [];
-		const fetchImpl: typeof fetch = async (_input, init) => {
-			if (init?.signal) signals.push(init.signal);
-			return new Response(JSON.stringify({ replyText: "pong" }), {
-				status: 200,
-			});
-		};
+    expect(response.status).toBe(503);
+    expect(await response.text()).toBe("nope");
+  });
 
-		const response = await postAndroidSmsGatewayWithFetch(
-			URL,
-			BODY,
-			SECRET,
-			fetchImpl,
-			1_000,
-		);
+  it("uses the injected fetch for a successful gateway POST", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response(JSON.stringify({ replyText: "pong" }), {
+        status: 200,
+      });
+    };
 
-		expect(signals).toHaveLength(1);
-		expect(signals[0]?.aborted).toBe(false);
-		expect(response.ok).toBe(true);
-		expect(await response.json()).toEqual({ replyText: "pong" });
-	});
+    const response = await postAndroidSmsGatewayWithFetch(
+      URL,
+      BODY,
+      SECRET,
+      fetchImpl,
+      1_000,
+    );
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(response.ok).toBe(true);
+    expect(await response.json()).toEqual({ replyText: "pong" });
+  });
 });

--- a/packages/ui/src/components/pages/ElizaOsAppsView.tsx
+++ b/packages/ui/src/components/pages/ElizaOsAppsView.tsx
@@ -1530,9 +1530,6 @@ export async function postAndroidSmsGatewayWithFetch(
     body,
     signal: AbortSignal.timeout(timeoutMs),
   });
-  if (!response.ok) {
-    throw new Error(`Cloud gateway failed (${response.status})`);
-  }
   return response;
 }
 

--- a/packages/ui/src/components/pages/ElizaOsAppsView.tsx
+++ b/packages/ui/src/components/pages/ElizaOsAppsView.tsx
@@ -1510,6 +1510,32 @@ function initialMessageBody(params: URLSearchParams): string {
     : (params.get("body") ?? "");
 }
 
+/** Android SMS gateway POST is a short UI hop — same 15s family as BuildBadge. */
+export const ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS = 15_000;
+
+export async function postAndroidSmsGatewayWithFetch(
+  url: string,
+  body: string,
+  secret: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-eliza-bridge": "android-sms",
+      "x-eliza-gateway-secret": secret,
+    },
+    body,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`Cloud gateway failed (${response.status})`);
+  }
+  return response;
+}
+
 function androidSmsGatewayPayload(incoming: IncomingSmsContext) {
   return {
     type: "new-message",
@@ -1628,15 +1654,12 @@ export function MessagesPageView() {
     let cancelled = false;
     const forward = async () => {
       try {
-        const response = await fetch(ANDROID_SMS_GATEWAY_WEBHOOK_URL, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            "x-eliza-bridge": "android-sms",
-            "x-eliza-gateway-secret": ANDROID_SMS_GATEWAY_SECRET,
-          },
-          body: JSON.stringify(androidSmsGatewayPayload(incomingSms)),
-        });
+        const response = await postAndroidSmsGatewayWithFetch(
+          ANDROID_SMS_GATEWAY_WEBHOOK_URL,
+          JSON.stringify(androidSmsGatewayPayload(incomingSms)),
+          ANDROID_SMS_GATEWAY_SECRET,
+          globalThis.fetch,
+        );
         let cloudReply: AndroidSmsGatewayReply | Record<string, never> = {};
         try {
           cloudReply = (await response.json()) as AndroidSmsGatewayReply;


### PR DESCRIPTION
# Relates to

Fixes #21843. Replaces the closed #21816 after exact-head review found that its timeout helper discarded completed gateway error responses before the existing UI boundary could decode them.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@c1659c7a8a709224cb4177567abed53f269533c2:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` at `c1659c7a8a709224cb4177567abed53f269533c2`; zero conflicts.
- [ ] Root `bun run verify` was not run; focused exact-head evidence and the known package-typecheck setup blocker are recorded below.

# Risks

Low and localized to the existing Android SMS gateway UI path. The POST remains bounded at 15 seconds. Completed non-2xx responses now reach the existing response-decoding boundary, restoring its structured provider-error detail instead of throwing a status-only error prematurely.

# Background

## What does this PR do?

It retains #21816's bounded fetch but removes the helper-level `response.ok` throw. The caller already owns JSON decoding and translates non-2xx responses into the user-visible failure; this restores that boundary and removes an unreachable duplicate status check.

## What kind of change is this?

Bug fix and completion of #21816's timeout work.

# Documentation changes needed?

No. This changes internal transport/error semantics only.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/pages/ElizaOsAppsView-timeout.test.ts`.

## Detailed testing steps

```bash
bunx vitest run --config ./vitest.config.ts src/components/pages/ElizaOsAppsView-timeout.test.ts
bunx biome check src/components/pages/ElizaOsAppsView.tsx src/components/pages/ElizaOsAppsView-timeout.test.ts
git diff --check origin/develop...HEAD
```

Exact head `df010cd4689b33b078bccf26f24b4084eca955fa`: 4/4 tests pass; changed-file Biome and diff checks pass.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered layout or styling change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered layout or styling change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - transport/error-boundary correction exercised directly by the focused behavioral suite.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend implementation change.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no live gateway credentials are available; the injected fetch proves timeout, completed 503 response preservation, and success.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, or durable state change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual change.

# Evidence Details

## Real LLM-call trajectory

N/A - transport-only UI fetch boundary.

## Backend + frontend logs

Focused Vitest proves the request aborts at the injected deadline, a completed 503 response remains available for boundary decoding, and success responses remain unchanged.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI change.

## Audio / voice walkthrough

N/A - Android SMS gateway HTTP only.

## Known gaps / failures

`bun run --cwd packages/ui typecheck` reaches unrelated unbuilt-workspace resolution failures for `@elizaos/core/edge` and `@elizaos/cloud-routing`. The focused suite, changed-file Biome, and diff check pass after a pinned Bun 1.3.14 install.

<!-- evidence-head:df010cd4689b33b078bccf26f24b4084eca955fa -->

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@c1659c7a8a709224cb4177567abed53f269533c2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-ss251-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@c1659c7a8a709224cb4177567abed53f269533c2:packages/skills/skills/contribute-to-eliza"} -->