### PR TITLE
fix(cloud): preserve legacy JSON decoder failures

### DIFF
--- a/packages/cloud/api/affiliate/create-character/route.ts
+++ b/packages/cloud/api/affiliate/create-character/route.ts
@@ -25,6 +25,7 @@ import { organizationsService } from "@/lib/services/organizations";
 import { usersService } from "@/lib/services/users";
 import type { ElizaCharacter } from "@/lib/types";
 import { getCorsHeaders } from "@/lib/utils/cors";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -212,14 +213,13 @@ app.post("/", async (c) => {
   try {
     const apiKey = await authenticateAffiliate(c);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 untrusted request body; malformed JSON becomes a typed
       // 400 ValidationError, never a silently-accepted empty/default body.
       throw ValidationError("Invalid JSON body");
     }
+    const body = decodedBody.value;
 
     const parsed = CreateCharacterSchema.safeParse(body);
     if (!parsed.success) {

--- a/packages/cloud/api/eliza-app/cli-auth/complete/route.ts
+++ b/packages/cloud/api/eliza-app/cli-auth/complete/route.ts
@@ -11,6 +11,7 @@ import { Hono } from "hono";
 import { db } from "@/db/client";
 import { cliAuthSessions } from "@/db/schemas/cli-auth-sessions";
 import { elizaAppSessionService } from "@/lib/services/eliza-app";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -29,14 +30,13 @@ app.post("/", async (c) => {
       return c.json({ success: false, error: "Invalid session" }, 401);
     }
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       // error-policy:J3 untrusted CLI-auth complete body; syntax errors are
       // caller garbage, not a server fault that completes CLI login.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     if (!body || typeof body !== "object" || Array.isArray(body)) {
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }

--- a/packages/cloud/api/eliza-app/onboarding/chat/route.ts
+++ b/packages/cloud/api/eliza-app/onboarding/chat/route.ts
@@ -26,6 +26,7 @@ import {
   runOnboardingChat,
 } from "@/lib/services/eliza-app/onboarding-chat";
 import { publicElizaAppProvisioningPayload } from "@/lib/services/eliza-app/provisioning";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../internal/_auth";
@@ -240,9 +241,11 @@ async function resolvePlatformAccount(identity: {
 
 app.post("/", async (c) => {
   try {
-    const body = await c.req.json().catch(() => {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
       throw ValidationError("Invalid JSON body");
-    });
+    }
+    const body = decodedBody.value;
     const parsed = chatSchema.safeParse(body);
     if (!parsed.success) {
       throw ValidationError("Invalid request data", {

--- a/packages/cloud/api/eliza-app/provisioning-agent/chat/route.ts
+++ b/packages/cloud/api/eliza-app/provisioning-agent/chat/route.ts
@@ -9,6 +9,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { elizaAppSessionService } from "@/lib/services/eliza-app";
 import { provisioningAgentChat } from "@/lib/services/provisioning-agent-chat";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -36,12 +37,12 @@ app.post("/", async (c) => {
     );
   }
 
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
+  const decodedBody = await decodeRequestJson(c.req);
+  if (!decodedBody.ok) {
+    // error-policy:J3 malformed JSON is invalid request input.
     return c.json({ error: "Invalid JSON body" }, 400);
   }
+  const body = decodedBody.value;
 
   const parsed = chatSchema.safeParse(body);
   if (!parsed.success) {

--- a/packages/cloud/api/eliza/rooms/[roomId]/welcome/route.ts
+++ b/packages/cloud/api/eliza/rooms/[roomId]/welcome/route.ts
@@ -14,6 +14,7 @@ import { requireUserOrApiKey } from "@/lib/auth/workers-hono-auth";
 import { roomsService } from "@/lib/services/agents/rooms";
 import { anonymousSessionsService } from "@/lib/services/anonymous-sessions";
 import { usersService } from "@/lib/services/users";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -39,15 +40,12 @@ const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   const roomId = c.req.param("roomId") ?? "";
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
-    // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
-    // bare JSON.parse. SyntaxError must be a caller 400, not an uncaught
-    // 500, before auth or the first-agent memory write.
+  const decodedBody = await decodeRequestJson(c.req);
+  if (!decodedBody.ok) {
+    // error-policy:J3 malformed JSON is invalid request input.
     return c.json({ error: "Invalid JSON body" }, 400);
   }
+  const body = decodedBody.value;
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return c.json({ error: "Invalid JSON body" }, 400);
   }

--- a/packages/cloud/api/internal/identity/resolve/route.ts
+++ b/packages/cloud/api/internal/identity/resolve/route.ts
@@ -12,6 +12,7 @@ import { agentSandboxes } from "@/db/schemas/agent-sandboxes";
 import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
 import { findActivePersonalDedicatedTarget } from "@/lib/services/agent-tier-upgrade-target";
 import { personalSharedAgentId } from "@/lib/services/shared-runtime/personal-shared-agent";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../_auth";
 
@@ -42,12 +43,12 @@ app.post("/", async (c) => {
     const auth = await requireInternalAuth(c);
     if (auth instanceof Response) return auth;
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return jsonError(c, 400, "Invalid JSON body", "validation_error");
     }
+    const rawBody = decodedBody.value;
 
     const parsed = resolveIdentitySchema.parse(rawBody);
     const identifier = parsed.platformId ?? parsed.identifier;

--- a/packages/cloud/api/invites/accept/route.ts
+++ b/packages/cloud/api/invites/accept/route.ts
@@ -12,6 +12,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { invitesService } from "@/lib/services/invites";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const acceptInviteSchema = z.object({
@@ -25,15 +26,12 @@ app.use("*", rateLimit(RateLimitPresets.STRICT));
 app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKey(c);
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
-      // bare JSON.parse. SyntaxError must be a caller 400, not the
-      // failureResponse 500 that treats it as an unexpected server fault.
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const validated = acceptInviteSchema.parse(body);
 
     const acceptedInvite = await invitesService.acceptInvite(

--- a/packages/cloud/api/organizations/credentials/route.ts
+++ b/packages/cloud/api/organizations/credentials/route.ts
@@ -23,6 +23,7 @@ import {
   listPooledCredentials,
   TeamCredentialPoolError,
 } from "@/lib/services/team-credential-pool/service";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const contributeSchema = z.object({
@@ -47,16 +48,12 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
 app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
-      // bare JSON.parse. SyntaxError must be a caller 400, not the
-      // failureResponse 500 that treats it as an unexpected server fault.
-      // Pooled credential probe/write must not run on garbage.
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     if (!body || typeof body !== "object" || Array.isArray(body)) {
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }

--- a/packages/cloud/api/set-anonymous-session/route.ts
+++ b/packages/cloud/api/set-anonymous-session/route.ts
@@ -26,6 +26,7 @@ import {
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { anonymousSessionsService } from "@/lib/services/anonymous-sessions";
 import { usersService } from "@/lib/services/users";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -55,13 +56,12 @@ app.post("/", async (c) => {
     return c.json({ error: "Forbidden", code: "csrf_marker_required" }, 403);
   }
 
-  let body: { sessionToken?: string };
-  try {
-    body = await c.req.json();
-  } catch (err) {
-    logger.error("[Set Session] Failed to parse request body:", err);
+  const decodedBody = await decodeRequestJson(c.req);
+  if (!decodedBody.ok) {
+    // error-policy:J3 malformed JSON is invalid request input.
     return c.json({ error: "Invalid JSON body" }, 400);
   }
+  const body = decodedBody.value as { sessionToken?: string };
 
   const { sessionToken } = body;
   if (!sessionToken || typeof sessionToken !== "string") {

--- a/packages/cloud/api/v1/admin/docker-nodes/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/route.ts
@@ -17,6 +17,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireAdmin } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
 import { resolveNodeCapacity } from "@/lib/services/docker-node-manager";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -126,12 +127,12 @@ app.post("/", async (c) => {
       );
     }
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
 
     const parsed = createNodeSchema.safeParse(body);
     if (!parsed.success) {

--- a/packages/cloud/api/v1/agents/route.ts
+++ b/packages/cloud/api/v1/agents/route.ts
@@ -37,6 +37,7 @@ import {
 import { findOrCreateUserByWalletAddress } from "@/lib/services/wallet-signup";
 import { SIGNUP_CREDIT_POLICY } from "@/lib/signup-credits";
 import { isUniqueConstraintError } from "@/lib/utils/db-errors";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import { normalizeTokenAddress } from "@/lib/utils/token-address";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -181,8 +182,9 @@ app.post("/", async (c) => {
     }
     const sync = requestedSync === "true";
 
-    const body = await c.req.json().catch(() => null);
-    if (!body) throw ValidationError("Invalid JSON body");
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) throw ValidationError("Invalid JSON body");
+    const body = decodedBody.value;
 
     const parsed = provisionSchema.safeParse(body);
     if (!parsed.success) {

--- a/packages/cloud/api/v1/api-keys/route.ts
+++ b/packages/cloud/api/v1/api-keys/route.ts
@@ -15,6 +15,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { apiKeysService } from "@/lib/services/api-keys";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -62,7 +63,18 @@ app.post("/", async (c) => {
     const user = await requireUserWithOrg(c);
     // Guard a malformed/empty body to a 400 instead of a 500 — the ZodError
     // branch in the catch only handles bad FIELDS, not an unparseable body.
-    const body = await c.req.json().catch(() => null);
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
+      return c.json(
+        {
+          error: "Invalid JSON body",
+          details: "Request body must be a valid JSON object",
+        },
+        400,
+      );
+    }
+    const body = decodedBody.value;
     if (!body || typeof body !== "object") {
       return c.json(
         {

--- a/packages/cloud/api/v1/apps/[id]/database/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/database/route.ts
@@ -23,6 +23,7 @@ import {
   resolveAppDatabaseMode,
 } from "@/lib/services/app-database-mode";
 import { appsService } from "@/lib/services/apps";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
@@ -77,12 +78,12 @@ app.put("/", async (c) => {
     return c.json({ success: false, error: loaded.error }, loaded.status);
   }
 
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
+  const decodedBody = await decodeRequestJson(c.req);
+  if (!decodedBody.ok) {
+    // error-policy:J3 malformed JSON is invalid request input.
     return c.json({ success: false, error: "Invalid JSON body" }, 400);
   }
+  const body = decodedBody.value;
   const parsed = PutSchema.safeParse(body);
   if (!parsed.success) {
     return c.json(

--- a/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
@@ -42,6 +42,7 @@ import { creditsService } from "@/lib/services/credits";
 import { computeDomainPrice } from "@/lib/services/domain-pricing";
 import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { domainBodySchema as BuySchema } from "../schemas";
@@ -77,16 +78,12 @@ app.post("/", domainBuyRateLimit, async (c) => {
     const appId = c.req.param("id");
     if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch (error) {
-      // error-policy:J3 Only JSON syntax failures are invalid client input.
-      if (error instanceof SyntaxError) {
-        return c.json({ success: false, error: "Invalid JSON body" }, 400);
-      }
-      throw error;
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
+      return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedBody.value;
     const parsed = BuySchema.safeParse(rawBody);
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/blooio/connect/route.ts
+++ b/packages/cloud/api/v1/blooio/connect/route.ts
@@ -11,6 +11,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { blooioAutomationService } from "@/lib/services/blooio-automation";
 import { invalidateOAuthState } from "@/lib/services/oauth/invalidation";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -26,12 +27,12 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
 
     if (!body || typeof body !== "object" || Array.isArray(body)) {
       return c.json({ error: "Request body must be a JSON object" }, 400);

--- a/packages/cloud/api/v1/browser/sessions/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.ts
@@ -16,6 +16,7 @@ import {
   listHostedBrowserSessions,
   logHostedBrowserFailure,
 } from "@/lib/services/browser-tools";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const createSessionSchema = z.object({
@@ -49,15 +50,12 @@ app.get("/", async (c) => {
 app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch (error) {
-      // error-policy:J3 SyntaxError is caller garbage. Stream/decoder
-      // failures stay 500 — do not reprint leftover-tax #21685/#21690.
-      if (!(error instanceof SyntaxError)) throw error;
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const rawBody = decodedBody.value;
     const bodyResult = createSessionSchema.safeParse(rawBody);
     if (!bodyResult.success) {
       return c.json(

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -66,6 +66,7 @@ import { isKnownUnacceptedProviderError } from "@/lib/services/inference-provide
 import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
 import { usageService } from "@/lib/services/usage";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
 import { settleOffResponsePath } from "@/lib/utils/settle-off-response-path";
@@ -338,12 +339,12 @@ app.post("/", async (c) => {
       if (orgRateLimited) return orgRateLimited;
     }
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     if (!body || typeof body !== "object") {
       return c.json({ error: "Invalid JSON body" }, 400);
     }

--- a/packages/cloud/api/v1/discord/connections/route.ts
+++ b/packages/cloud/api/v1/discord/connections/route.ts
@@ -17,6 +17,7 @@ import {
 } from "@/db/schemas/discord-connections";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -87,12 +88,12 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
 
     const validation = CreateConnectionSchema.safeParse(body);
     if (!validation.success) {

--- a/packages/cloud/api/v1/domains/search/route.ts
+++ b/packages/cloud/api/v1/domains/search/route.ts
@@ -18,6 +18,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { cloudflareRegistrarService } from "@/lib/services/cloudflare-registrar";
 import { computeDomainPrice } from "@/lib/services/domain-pricing";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const SearchSchema = z.object({
@@ -31,15 +32,12 @@ app.post("/", async (c) => {
   try {
     await requireUserOrApiKeyWithOrg(c);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch (error) {
-      // error-policy:J3 SyntaxError is caller garbage. Stream/decoder
-      // failures stay 500 — do not reprint leftover-tax #21685/#21690.
-      if (!(error instanceof SyntaxError)) throw error;
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const parsed = SearchSchema.safeParse(body);
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/identity/register/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/identity/register/route.ts
@@ -4,6 +4,7 @@ import { type Address, isAddress } from "viem";
 import { dbWrite } from "@/db/helpers";
 import { agentIdentities } from "@/db/schemas/agent-identities";
 import { nextStyleParams } from "@/lib/api/hono-next-style-params";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import {
   defaultRegistry,
@@ -48,7 +49,13 @@ export async function handleRegisterIdentity(
       });
     }
 
-    const body = (await c.req.json().catch(() => null)) as unknown;
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok)
+      return json(
+        { success: false, error: "Invalid JSON body" },
+        { status: 400 },
+      );
+    const body = decodedBody.value;
     if (!isObject(body))
       return json(
         { success: false, error: "Invalid JSON body" },

--- a/packages/cloud/api/v1/extract/route.ts
+++ b/packages/cloud/api/v1/extract/route.ts
@@ -15,6 +15,7 @@ import {
   extractHostedPage,
   logHostedBrowserFailure,
 } from "@/lib/services/browser-tools";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const extractRequestSchema = z.object({
@@ -35,15 +36,12 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch (error) {
-      // error-policy:J3 SyntaxError is caller garbage. Stream/decoder
-      // failures stay 500 — do not reprint leftover-tax #21685/#21690.
-      if (!(error instanceof SyntaxError)) throw error;
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const bodyResult = extractRequestSchema.safeParse(body);
 
     if (!bodyResult.success) {

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -92,6 +92,7 @@ import {
 } from "@/lib/services/inference-provider-outcome";
 import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
 import { settleOffResponsePath } from "@/lib/utils/settle-off-response-path";
@@ -731,12 +732,12 @@ app.post("/", async (c) => {
     useAppCredits = Boolean(monetizedApp?.monetization_enabled);
   }
 
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
+  const decodedBody = await decodeRequestJson(c.req);
+  if (!decodedBody.ok) {
+    // error-policy:J3 malformed JSON is invalid request input.
     return anthropicError("invalid_request_error", "Invalid JSON body", 400);
   }
+  const body = decodedBody.value;
 
   if (!body || typeof body !== "object") {
     return anthropicError("invalid_request_error", "Invalid JSON body", 400);

--- a/packages/cloud/api/v1/models/status/route.ts
+++ b/packages/cloud/api/v1/models/status/route.ts
@@ -15,6 +15,7 @@ import {
   hasGatewayProviderConfigured,
 } from "@/lib/providers/language-model";
 import { getCachedMergedModelCatalog } from "@/lib/services/model-catalog";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -62,15 +63,12 @@ app.post("/", async (c) => {
   try {
     await getCurrentUser(c).catch(() => null);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch (error) {
-      // error-policy:J3 SyntaxError is caller garbage. Stream/decoder
-      // failures stay 500 — do not reprint leftover-tax #21685/#21690.
-      if (!(error instanceof SyntaxError)) throw error;
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     const modelIds =
       body && typeof body === "object" && !Array.isArray(body)
         ? (body as { modelIds?: unknown }).modelIds

--- a/packages/cloud/api/v1/oauth/connect/route.ts
+++ b/packages/cloud/api/v1/oauth/connect/route.ts
@@ -18,6 +18,7 @@ import {
   oauthService,
   validationErrorResponse,
 } from "@/lib/services/oauth";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -41,12 +42,12 @@ app.post("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     organizationId = user.organization_id;
 
-    let body: ConnectRequestBody;
-    try {
-      body = (await c.req.json()) as ConnectRequestBody;
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json(validationErrorResponse("Invalid JSON body"), 400);
     }
+    const body = decodedBody.value as ConnectRequestBody;
 
     if (!isValidString(body.platform)) {
       return c.json(

--- a/packages/cloud/api/v1/redemptions/route.ts
+++ b/packages/cloud/api/v1/redemptions/route.ts
@@ -20,6 +20,7 @@ import {
   secureTokenRedemptionService,
 } from "@/lib/services/token-redemption-secure";
 import { parseClampedLimit } from "@/lib/utils/clamp-limit";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -86,12 +87,12 @@ app.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
 
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
 
     const validation = CreateRedemptionSchema.safeParse(body);
 

--- a/packages/cloud/api/v1/referrals/apply/route.ts
+++ b/packages/cloud/api/v1/referrals/apply/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { referralsService } from "@/lib/services/referrals";
 import { getCorsHeaders } from "@/lib/utils/cors";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -37,16 +38,12 @@ app.post("/", async (c) => {
       return c.json({ error: "Organization not found" }, 400, corsHeaders);
     }
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
-      // bare JSON.parse. SyntaxError must be a caller 400, not the
-      // failureResponse 500 that treats it as an unexpected server fault.
-      // Referral apply must not write an affiliate binding on garbage.
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400, corsHeaders);
     }
+    const body = decodedBody.value;
     if (!body || typeof body !== "object" || Array.isArray(body)) {
       return c.json({ error: "Invalid JSON body" }, 400, corsHeaders);
     }

--- a/packages/cloud/api/v1/twilio/connect/route.ts
+++ b/packages/cloud/api/v1/twilio/connect/route.ts
@@ -10,6 +10,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { invalidateOAuthState } from "@/lib/services/oauth/invalidation";
 import { twilioAutomationService } from "@/lib/services/twilio-automation";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import { isE164PhoneNumber } from "@/lib/utils/twilio-api";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -26,12 +27,12 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
 
     if (!body || typeof body !== "object" || Array.isArray(body)) {
       return c.json({ error: "Request body must be a JSON object" }, 400);

--- a/packages/cloud/api/v1/twilio/voice/calls/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/route.ts
@@ -15,6 +15,7 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import {
   isValidE164,
@@ -77,13 +78,12 @@ app.post("/", async (c) => {
     );
   }
 
-  let rawBody: unknown;
-  try {
-    rawBody = await c.req.json();
-  } catch {
+  const decodedBody = await decodeRequestJson(c.req);
+  if (!decodedBody.ok) {
     // error-policy:J3 malformed JSON is rejected instead of becoming an empty call request.
     return c.json({ error: "Invalid JSON body", code: "invalid_request" }, 400);
   }
+  const rawBody = decodedBody.value;
   const parsed = StartCallBody.safeParse(rawBody);
   if (!parsed.success) {
     return c.json(

--- a/packages/cloud/api/v1/user/wallets/provision/route.ts
+++ b/packages/cloud/api/v1/user/wallets/provision/route.ts
@@ -16,6 +16,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { provisionServerWallet } from "@/lib/services/server-wallets";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -50,15 +51,12 @@ app.post("/", async (c) => {
 
   try {
     user = await requireUserOrApiKey(c);
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch (error) {
-      // error-policy:J3 SyntaxError is caller garbage. Stream/decoder
-      // failures stay 500 — do not reprint leftover-tax #21685/#21690.
-      if (!(error instanceof SyntaxError)) throw error;
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const body = decodedBody.value;
     validated = provisionWalletSchema.parse(body);
     const clientAddress = validated.clientAddress.toLowerCase();
 


### PR DESCRIPTION
Closes #21758.

## Summary

- migrate all 24 legacy broad request-JSON catches named in #21758 to the shared `decodeRequestJson` boundary
- migrate the five later narrow duplicates too, leaving zero `Invalid JSON body` routes that still call `c.req.json()` directly
- preserve every existing route envelope, auth ordering, CORS headers, schema validation, and caller-facing 400 status while allowing stream, decoder, abort, and runtime failures to reach the existing 5xx boundary

## Exact-head validation

- `evidence-head:59cc66158cd484926812bdf7a41265e653024013`
- 74 focused route tests pass across 11 independently run suites
- representative internal request-stream `TypeError` reaches the route 500 boundary in `v1/apps/[id]/domains/buy/route.json.test.ts`
- changed-file Biome passes for all 29 routes
- repository audit for `Invalid JSON body` plus direct `c.req.json()` is empty
- `git diff --check` passes
- cloud-api typecheck and the production Worker dry-run pass on the exact head.

## Evidence matrix

- Screenshots/video: N/A — server request-boundary migration with no UI.
- Live integration: N/A — no external provider or production state mutation; the changed contract is deterministic request parsing and failure translation.
- Domain artifact: malformed bodies retain the exact 400 envelopes; a synthetic broken request stream reaches 500; canonical bodies preserve route behavior.

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Contribution skill revision: elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza
- Attribution status: verified
— [codex-issue-wave]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza"} -->

Independent final-head review: all 29 changes are mechanical uses of the shared syntax-only JSON decoder; auth/order/envelopes are preserved. Eleven representative route suites passed independently after rebase (including the real internal stream TypeError 500 boundary), the production audit finds zero Invalid-JSON routes still directly calling c.req.json, Biome passed all 29 files, and diff check passed. Exact-head CI and a non-author approval remain required before merge.