### PR TITLE
fix(ui): bound audio-frame batches through agent client

### DIFF
--- a/packages/ui/src/voice/audio-frame-pump.test.ts
+++ b/packages/ui/src/voice/audio-frame-pump.test.ts
@@ -10,10 +10,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import type {
   TalkModeAudioFrameEvent,
   TalkModePluginLike,
 } from "../bridge/native-plugins";
+import { MOBILE_LOCAL_AGENT_API_BASE } from "../first-run/mobile-runtime-mode";
 import { AudioFramePump } from "./audio-frame-pump";
 
 interface SentBatch {
@@ -80,12 +82,7 @@ beforeEach(() => {
       const body = JSON.parse(String(init?.body)) as SentBatch;
       sent.push(body);
       const framesReceived = sent.reduce((n, b) => n + b.frames.length, 0);
-      return {
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        json: async () => ({ ok: true, framesReceived, turnsObserved: 0 }),
-      } as Response;
+      return Response.json({ ok: true, framesReceived, turnsObserved: 0 });
     }),
   );
 });
@@ -138,13 +135,11 @@ describe("AudioFramePump", () => {
     await pump.start();
     // 49 frames trips MAX_BATCH_FRAMES → an immediate (non-final) POST.
     for (let i = 0; i < 49; i++) emit(frame(i));
-    // Let the queued flush microtask settle.
-    await Promise.resolve();
-    await Promise.resolve();
+    // Stop waits for the already-queued cap flush before its final flush.
+    await pump.stop();
     expect(sent.length).toBeGreaterThanOrEqual(1);
     expect(sent[0].frames.length).toBe(49);
     expect(sent[0].flush).toBe(false);
-    await pump.stop();
     expect(pump.framesAcked).toBe(49);
   });
 
@@ -155,5 +150,43 @@ describe("AudioFramePump", () => {
     await pump.stop();
     emit(frame(100));
     expect(sent.flatMap((b) => b.frames).length).toBe(0);
+  });
+});
+
+describe("audio-frame-pump request deadline", () => {
+  it("aborts the production batch POST at its 15-second client deadline", async () => {
+    vi.useFakeTimers();
+    let requestUrl: string | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>((input, init) => {
+        requestUrl = String(input);
+        return new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal)
+            throw new Error("expected audio-frame-pump abort signal");
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        });
+      }),
+    );
+
+    const { plugin, emit } = makeFakePlugin();
+    const pump = new AudioFramePump(plugin);
+    await pump.start();
+    emit(frame(0));
+    const result = pump.stop().catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(14_999);
+    expect(await Promise.race([result, Promise.resolve("pending")])).toBe(
+      "pending",
+    );
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(result).resolves.toMatchObject({ kind: "timeout" });
+    expect(requestUrl).toBe(
+      `${MOBILE_LOCAL_AGENT_API_BASE}/api/voice/audio-frames`,
+    );
   });
 });

--- a/packages/ui/src/voice/audio-frame-pump.ts
+++ b/packages/ui/src/voice/audio-frame-pump.ts
@@ -15,10 +15,11 @@
  * final `flush:true` batch on stop so a trailing utterance is not lost.
  *
  * The agent base URL (loopback) is routed through the Android native-agent
- * fetch bridge (`installAndroidNativeAgentFetchBridge`), so a plain `fetch`
- * reaches the on-device agent over IPC without bespoke transport plumbing.
+ * client transport, which selects the Android native-agent bridge for the
+ * loopback URL so requests reach the on-device agent over IPC.
  */
 
+import { ElizaClient } from "../api";
 import type {
   TalkModeAudioFrameEvent,
   TalkModePluginLike,
@@ -53,6 +54,9 @@ interface AgentFramesResponse {
   turnsObserved?: number;
 }
 
+/** Audio-frame batches are short local-agent UI hops. */
+const AUDIO_FRAME_PUMP_TIMEOUT_MS = 15_000;
+
 /**
  * Drives the Android `audioFrame` → batched-POST → agent diarization pipeline.
  * One instance per capture session. Native-only: `start` no-ops cleanly on a
@@ -60,7 +64,7 @@ interface AgentFramesResponse {
  */
 export class AudioFramePump {
   private readonly plugin: TalkModePluginLike;
-  private readonly agentBaseUrl: string;
+  private readonly agentClient: ElizaClient;
   private readonly sampleRate: number;
   private readonly frameMs: number;
 
@@ -76,7 +80,9 @@ export class AudioFramePump {
 
   constructor(plugin: TalkModePluginLike, options: AudioFramePumpOptions = {}) {
     this.plugin = plugin;
-    this.agentBaseUrl = options.agentBaseUrl ?? MOBILE_LOCAL_AGENT_API_BASE;
+    this.agentClient = new ElizaClient(
+      options.agentBaseUrl ?? MOBILE_LOCAL_AGENT_API_BASE,
+    );
     this.sampleRate = options.sampleRate ?? 16_000;
     this.frameMs = options.frameMs ?? 20;
   }
@@ -156,17 +162,14 @@ export class AudioFramePump {
     final: boolean,
   ): Promise<void> {
     if (frames.length === 0 && !final) return;
-    const res = await fetch(`${this.agentBaseUrl}${AUDIO_FRAMES_PATH}`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ frames, flush: final }),
-    });
-    if (!res.ok) {
-      throw new Error(
-        `[audio-frame-pump] agent rejected batch: ${res.status} ${res.statusText}`,
-      );
-    }
-    const json = (await res.json()) as AgentFramesResponse;
+    const json = await this.agentClient.fetch<AgentFramesResponse>(
+      AUDIO_FRAMES_PATH,
+      {
+        method: "POST",
+        body: JSON.stringify({ frames, flush: final }),
+      },
+      { timeoutMs: AUDIO_FRAME_PUMP_TIMEOUT_MS },
+    );
     this.framesSent += frames.length;
     if (typeof json.framesReceived === "number") {
       this.framesAcked = json.framesReceived;


### PR DESCRIPTION
# Relates to

Bounded-fetch follow-up for the on-device PCM batch pump.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] Production-path tests, shared client timeout tests, UI typecheck, formatting, and diff validation pass.
- [x] Exact-head evidence is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@1fba16ec3ac20fb158307b7a05527fff42726832:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` at `1fba16ec3ac20fb158307b7a05527fff42726832`; zero conflicts.
- [x] Owning-package focused gates pass. The required app audit remains serialized below.

# Risks

Low and isolated to the existing PCM batch transport. Each `AudioFramePump` now owns an `ElizaClient` pinned to its configured `agentBaseUrl`, preserving custom/default targets while adding local token hydration, Android/iOS/desktop transport selection, typed HTTP failures, and the same 15-second budget for request establishment and response-body consumption. Batching order, flush cadence, and counters are unchanged.

# Background

## What does this PR do?

Bounds `POST /api/voice/audio-frames` through the canonical client. It removes the submitted raw-fetch/test-only helper and tests the real queued pump path, including the exact production deadline.

## What kind of change is this?

Bug fix (non-breaking transport bound).

# Documentation changes needed?

No. The pump API, PCM payload, and response contract are unchanged.

# Testing

## Where should a reviewer start?

`packages/ui/src/voice/audio-frame-pump.test.ts` exercises native subscription, batching, cap flush, final flush, stopped-frame handling, target resolution, and a fake-timer production timeout that remains pending at 14,999 ms and fails at 15,000 ms.

## Detailed testing steps

Pinned Bun 1.3.14 and Node 24.15.0:

```bash
cd packages/ui
bun x vitest run --config ./vitest.config.ts src/voice/audio-frame-pump.test.ts src/api/client-base-timeout.test.ts
bun run typecheck
bun x biome check src/voice/audio-frame-pump.ts src/voice/audio-frame-pump.test.ts
git diff --check origin/develop...HEAD
```

Results at `4e68426283e70ecb00d33d9a23b1b9344e16c873`:

- Vitest: 2 files passed, 10 tests passed.
- UI TypeScript: exit 0.
- Biome: 2 files checked, no diagnostics.
- `git diff --check`: clean.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered output; the previous PCM batch request was unbounded.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered output; the PCM batch request is now bounded.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no product interaction or visual-state change.
<!-- evidence-row:backend-logs -->
- [x] N/A — no backend implementation changed; the client/pump contracts are exercised directly.
<!-- evidence-row:frontend-logs -->
- [x] Production-pump Vitest proves batching and exact timeout behavior; shared client tests prove request/body bounds.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, prompt, provider, model, or trajectory change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no database, memory, wallet, or persisted-domain change.
<!-- evidence-row:ocr-review -->
- [x] N/A — no pixels or rendered copy changed.

# Evidence Details

## Real LLM-call trajectory

N/A — local PCM transport only.

## Backend + frontend logs

The real pump test proves the configured/default agent URL and JSON batch are sent through the client, and the queued `stop()` remains pending through 14,999 ms before resolving with a typed timeout at the 15,000 ms budget.

## Screenshots (before / after) + video walkthrough

N/A — no rendered output changed.

## Audio / voice walkthrough

N/A — capture and PCM contents are unchanged; this only bounds the JSON batch hop.

## Known gaps / failures

`bun run --cwd packages/app audit:app` is required because this touches shared UI. It must run in the serialized app-audit slot before merge. No focused-gate failures remain.

<!-- evidence-head:4e68426283e70ecb00d33d9a23b1b9344e16c873 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@1fba16ec3ac20fb158307b7a05527fff42726832:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@1fba16ec3ac20fb158307b7a05527fff42726832:packages/skills/skills/contribute-to-eliza"} -->
