### PR TITLE
fix(ui): bound diarization status through local-agent client

### DIFF
--- a/packages/ui/src/voice/audio-frame-diarization-harness-timeout.test.ts
+++ b/packages/ui/src/voice/audio-frame-diarization-harness-timeout.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Exercises the production diarization status control through its dedicated
+ * local-agent ElizaClient while native capture collaborators are mocked.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clientBase: undefined as string | undefined,
+  clientFetch: vi.fn(),
+}));
+
+vi.mock("../api", () => ({
+  ElizaClient: class {
+    fetch = mocks.clientFetch;
+
+    constructor(baseUrl?: string) {
+      mocks.clientBase = baseUrl;
+    }
+  },
+}));
+
+vi.mock("../bridge/native-plugins", () => ({
+  getTalkModePlugin: () => ({}),
+}));
+
+vi.mock("../first-run/mobile-runtime-mode", () => ({
+  MOBILE_LOCAL_AGENT_API_BASE: "http://127.0.0.1:3000",
+}));
+
+vi.mock("./audio-frame-pump", () => ({
+  AudioFramePump: class {},
+}));
+
+import { installDiarizationPumpHarness } from "./audio-frame-diarization-harness";
+
+describe("diarization-harness status request deadline", () => {
+  beforeEach(() => {
+    mocks.clientFetch.mockReset();
+  });
+
+  it("pins the production status control to the bounded local-agent client", async () => {
+    mocks.clientFetch.mockResolvedValue({ ok: true, framesReceived: 3 });
+
+    await expect(
+      installDiarizationPumpHarness().status(),
+    ).resolves.toMatchObject({ framesReceived: 3 });
+
+    expect(mocks.clientBase).toBe("http://127.0.0.1:3000");
+    expect(mocks.clientFetch).toHaveBeenCalledWith(
+      "/api/voice/audio-frames/status",
+      { method: "GET", headers: { accept: "application/json" } },
+      { timeoutMs: 15_000 },
+    );
+  });
+
+  it("surfaces a bounded-client failure to the diagnostic caller", async () => {
+    const timeout = new Error("Request timed out after 15000ms");
+    mocks.clientFetch.mockRejectedValue(timeout);
+
+    await expect(installDiarizationPumpHarness().status()).rejects.toBe(
+      timeout,
+    );
+  });
+});

--- a/packages/ui/src/voice/audio-frame-diarization-harness.ts
+++ b/packages/ui/src/voice/audio-frame-diarization-harness.ts
@@ -18,6 +18,7 @@
  * drivable + observable on a real device.
  */
 
+import { ElizaClient } from "../api";
 import { getTalkModePlugin } from "../bridge/native-plugins";
 import { MOBILE_LOCAL_AGENT_API_BASE } from "../first-run/mobile-runtime-mode";
 import { AudioFramePump } from "./audio-frame-pump";
@@ -29,6 +30,10 @@ declare global {
 }
 
 const STATUS_PATH = "/api/voice/audio-frames/status";
+
+/** Diarization status GET is a short local-agent diagnostic hop. */
+const DIARIZATION_STATUS_TIMEOUT_MS = 15_000;
+const localAgentClient = new ElizaClient(MOBILE_LOCAL_AGENT_API_BASE);
 
 export interface DiarizationPumpControl {
   start(): Promise<{
@@ -50,11 +55,11 @@ function getPump(): AudioFramePump {
 }
 
 async function fetchStatus(): Promise<unknown> {
-  const res = await fetch(`${MOBILE_LOCAL_AGENT_API_BASE}${STATUS_PATH}`, {
-    method: "GET",
-    headers: { accept: "application/json" },
-  });
-  return res.json();
+  return localAgentClient.fetch(
+    STATUS_PATH,
+    { method: "GET", headers: { accept: "application/json" } },
+    { timeoutMs: DIARIZATION_STATUS_TIMEOUT_MS },
+  );
 }
 
 /**


### PR DESCRIPTION
# Relates to

Bounded-fetch follow-up for the on-device diarization status diagnostic.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] Focused production tests, shared client timeout tests, UI typecheck, formatting, and diff validation pass.
- [x] Exact-head evidence is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` at `ad68010c47040d9b0e4a5684243d328e2997df58`; zero conflicts.
- [x] Owning-package focused gates pass. The required app audit is serialized and remains recorded below.

# Risks

Low and isolated to the device-evidence status control. The harness deliberately targets the on-device loopback agent even if the app's active singleton points elsewhere, so this repair uses a dedicated `ElizaClient(MOBILE_LOCAL_AGENT_API_BASE)`. That preserves the existing target while adding Android/iOS/desktop transport selection, local token hydration, typed errors, and the same 15-second budget for request establishment and response-body consumption.

# Background

## What does this PR do?

Bounds `window.__diarizationPump.status()` by routing `/api/voice/audio-frames/status` through the canonical client. It removes the submitted raw-fetch/test-only exported helper and tests the actual installed control.

## What kind of change is this?

Bug fix (non-breaking diagnostic transport bound).

# Documentation changes needed?

No. The diagnostic control and response contract are unchanged.

# Testing

## Where should a reviewer start?

`packages/ui/src/voice/audio-frame-diarization-harness-timeout.test.ts` invokes the production installed status control and proves the dedicated loopback base, internal route, GET request, 15-second canonical budget, successful result, and surfaced transport failure.

## Detailed testing steps

Pinned Bun 1.3.14 and Node 24.15.0:

```bash
cd packages/ui
bun x vitest run --config ./vitest.config.ts src/voice/audio-frame-diarization-harness-timeout.test.ts src/api/client-base-timeout.test.ts
bun run typecheck
bun x biome check src/voice/audio-frame-diarization-harness.ts src/voice/audio-frame-diarization-harness-timeout.test.ts
git diff --check origin/develop...HEAD
```

Results at `c33031eac129c530fa2e1f50366b81d5cf17760f`:

- Vitest: 2 files passed, 6 tests passed.
- UI TypeScript: exit 0.
- Biome: 2 files checked, no diagnostics after formatting.
- `git diff --check`: clean.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered output; the previous diagnostic status request was unbounded.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered output; the diagnostic status request is now bounded.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no product interaction or visual-state change.
<!-- evidence-row:backend-logs -->
- [x] N/A — no backend implementation changed; the client contract is exercised directly.
<!-- evidence-row:frontend-logs -->
- [x] Production-control Vitest proves target/path/deadline wiring; shared client tests prove request and body timeout behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, prompt, provider, model, or trajectory change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no database, memory, wallet, or persisted-domain change.
<!-- evidence-row:ocr-review -->
- [x] N/A — no pixels or rendered copy changed.

# Evidence Details

## Real LLM-call trajectory

N/A — local diagnostic transport only.

## Backend + frontend logs

The production control is verified to construct its client with `http://127.0.0.1:3000` and call:

```text
/api/voice/audio-frames/status
GET, accept: application/json
options: { timeoutMs: 15000 }
```

The shared client suite verifies request timeout and stalled response-body timeout behavior.

## Screenshots (before / after) + video walkthrough

N/A — no rendered output changed.

## Audio / voice walkthrough

N/A — the change bounds a JSON diagnostic read; PCM capture and audio behavior are untouched.

## Known gaps / failures

`bun run --cwd packages/app audit:app` is required because this touches shared UI. It must run in the repository's serialized app-audit slot before merge. No focused-gate failures remain.

<!-- evidence-head:c33031eac129c530fa2e1f50366b81d5cf17760f -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza"} -->
