### PR TITLE
fix(imessage): reject non-finite IMESSAGE_BACKFILL instead of rewinding to origin

### DIFF
--- a/plugins/plugin-imessage/src/heartbeat-config.test.ts
+++ b/plugins/plugin-imessage/src/heartbeat-config.test.ts
@@ -4,7 +4,7 @@
 
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { IMessageService, resolveHeartbeatIntervalMs } from "./service";
+import { IMessageService, resolveBackfillRows, resolveHeartbeatIntervalMs } from "./service";
 import { IMessageConfigurationError, type IMessageSettings } from "./types";
 
 const originalHeartbeatEnv = process.env.IMESSAGE_HEARTBEAT_INTERVAL_MS;
@@ -71,4 +71,15 @@ describe("resolveHeartbeatIntervalMs", () => {
       }
     }
   );
+});
+
+describe("resolveBackfillRows", () => {
+  it("rejects non-finite values instead of rewinding the cursor to the database origin", () => {
+    expect(resolveBackfillRows("Infinity")).toBe(0);
+    expect(resolveBackfillRows("1e9")).toBe(0);
+  });
+
+  it("accepts a safe non-negative integer", () => {
+    expect(resolveBackfillRows(" 42 ")).toBe(42);
+  });
 });

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -109,6 +109,14 @@ export function resolveHeartbeatIntervalMs(raw: string | undefined): number {
   return intervalMs;
 }
 
+export function resolveBackfillRows(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === "") return 0;
+  const normalized = raw.trim();
+  if (!/^\d+$/.test(normalized)) return 0;
+  const backfill = Number(normalized);
+  return Number.isSafeInteger(backfill) ? backfill : 0;
+}
+
 function resolveInteractionAppBaseUrl(runtime: IAgentRuntime): string | undefined {
   const rawAppUrl =
     runtime.getSetting?.("ELIZA_APP_URL") || runtime.getSetting?.("ELIZA_CLOUD_URL");
@@ -541,7 +549,7 @@ export class IMessageService extends Service implements IIMessageService {
       const settingFromEnv = process.env.IMESSAGE_BACKFILL;
       const resolvedRaw =
         (typeof settingFromRuntime === "string" && settingFromRuntime) || settingFromEnv || "";
-      const backfill = Math.max(0, Number(resolvedRaw) || 0);
+      const backfill = resolveBackfillRows(resolvedRaw);
       service.lastRowId = Math.max(0, tip - backfill);
 
       logger.debug(


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->
AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: reproduced the `Infinity` cursor-rewind myself, ran the full mutation check myself against a precise mutation (reverted just the function body to the old `Math.max(0, Number(raw ?? "") || 0)` expression, keeping the export intact, confirming the exact single-assertion failure) then restored and reconfirmed green, reran typecheck/lint myself with real captured output (exit 0), and re-traced reachability myself through `IMessageService.start()`.

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low. Tightens an already-narrow parser; every previously-valid integer backfill value is preserved exactly, only non-canonical values (`Infinity`, exponential notation, negative, non-integer) now resolve to the safe default of `0` instead of corrupting the cursor.

# Background

## What does this PR do?

`IMessageService.start()` computed the startup backfill count with `Math.max(0, Number(raw) || 0)`. `Number("Infinity")` evaluates to `Infinity`, a truthy value, so setting `IMESSAGE_BACKFILL=Infinity` produced `lastRowId = Math.max(0, tip - Infinity) = 0` — rewinding the inbound polling cursor to the very start of the chat database and replaying the entire message history on startup instead of resuming from the current tip.

Before fix: `IMESSAGE_BACKFILL=Infinity` with a database tip of `987654` resolves to `{ backfill: Infinity, lastRowId: 0 }`.

After fix: the same input resolves to `{ backfill: 0, lastRowId: 987654 }` — no backfill, resumes from the tip as intended.

## What kind of change is this?

Bug fix — no new capability, no schema change.

# Documentation changes needed?

No.

# Testing

New `resolveBackfillRows` describe block in `plugins/plugin-imessage/src/heartbeat-config.test.ts`: rejects `"Infinity"` and `"1e9"` (both resolve to `0`), accepts a valid integer (`" 42 "` → `42`).

# Evidence Gate

<!-- evidence-head:a96cbf5155d2ada08a1d719a4ebab97d839b969b -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend logic fix, no UI surface
- <!-- evidence-row:walkthrough-video --> N/A - not applicable to a backend logic fix
- <!-- evidence-row:backend-logs -->
  Precise mutation check: reverted only `resolveBackfillRows`'s body to the old `Math.max(0, Number(raw ?? "") || 0)` expression, keeping the export intact:
  ```text
  expect(resolveBackfillRows("Infinity")).toBe(0)
  Expected: 0
  Received: Infinity
  12 pass, 1 fail
  ```
  Restored: `13 pass, 0 fail`. `tsc --noEmit -p tsconfig.json` re-run directly: exit 0. `biome check` clean on both touched files.
- <!-- evidence-row:frontend-logs --> N/A - no frontend
- <!-- evidence-row:llm-trajectory --> N/A - deterministic numeric-parsing logic, no LLM in the loop
- <!-- evidence-row:domain-artifacts --> N/A
- <!-- evidence-row:ocr-review --> N/A

## Known gaps / failures

None in the touched files. The package's full test lane hung past 90s with no output on an unrelated worker/spawn issue in this sandbox — the focused, deterministic regression suite (13/13) is the relevant lane and is clean.

## Reachability

`IMessageService.start()` (`plugins/plugin-imessage/src/service.ts:518`) reads `IMESSAGE_BACKFILL` from `runtime.getSetting()` or `process.env` — real, operator-controlled configuration, not hardcoded-safe test input — and uses it to seed the polling cursor on every service startup.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported
