### PR TITLE
test(scenario): restore zero-key active-view determinism

### DIFF
--- a/packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts
@@ -222,17 +222,26 @@ function promptHasActiveViewElements(value: string): boolean {
   ].every((needle) => value.includes(needle));
 }
 
-function evaluatorFixture({
+function postTurnEvaluatorFixture({
   capability,
   elementId,
-  thought,
+  input,
 }: {
   capability: "agent-click" | "agent-fill";
   elementId: string;
-  thought: string;
+  input: string;
 }) {
+  const expectedEvaluatorNames = [
+    "factMemory",
+    "preferences",
+    "relationships",
+    "identities",
+    "success",
+    "ftu_goal_discovery",
+    capability === "agent-fill" ? "experiencePatterns" : "skillProposal",
+  ];
   return {
-    name: `active-view-evaluator-${capability}-${elementId}`,
+    name: `active-view-post-turn-${capability}-${elementId}`,
     match: (call: DeterministicModelCall) => {
       if (call.modelType !== ModelType.TEXT_SMALL) return false;
       const promptText =
@@ -242,15 +251,37 @@ function evaluatorFixture({
               .map((m: { content?: string }) => m.content ?? "")
               .join("\n")
           : "");
+      const schema = call.params.responseSchema as
+        | { properties?: Record<string, unknown> }
+        | undefined;
+      const evaluatorNames = Object.keys(schema?.properties ?? {});
       return (
-        promptText.includes("task: Evaluate latest action") &&
-        promptText.includes(elementId)
+        promptText.includes("# Task: Post-turn evaluation") &&
+        promptText.includes(input) &&
+        promptText.includes(capability) &&
+        promptText.includes(elementId) &&
+        evaluatorNames.length === expectedEvaluatorNames.length &&
+        expectedEvaluatorNames.every((name) => evaluatorNames.includes(name))
       );
     },
     response: {
-      success: true,
-      decision: "FINISH",
-      thought,
+      factMemory: { ops: [] },
+      preferences: { ops: [] },
+      relationships: { relationships: [] },
+      identities: { identities: [] },
+      success: {
+        completed: true,
+        reason: "The requested active-view interaction completed successfully.",
+      },
+      ftu_goal_discovery: { goalFound: false, goal: "", confidence: 0 },
+      ...(capability === "agent-fill"
+        ? { experiencePatterns: { experiences: [] } }
+        : {
+            skillProposal: {
+              extract: false,
+              reason: "This one-off view interaction is not a reusable skill.",
+            },
+          }),
     },
     times: 1,
   };
@@ -431,10 +462,10 @@ export default scenario({
             messageToUser: "Filled the active ledger title.",
             value: "Close Issue 11355",
           }),
-          evaluatorFixture({
+          postTurnEvaluatorFixture({
             capability: "agent-fill",
             elementId: "ledger-title",
-            thought: "Filled the active ledger title element successfully.",
+            input: FILL_TEXT,
           }),
           stage1ResponseHandlerFixture({
             actionName: "VIEWS",
@@ -455,10 +486,10 @@ export default scenario({
             input: CLICK_TEXT,
             messageToUser: "Saved the active ledger.",
           }),
-          evaluatorFixture({
+          postTurnEvaluatorFixture({
             capability: "agent-click",
             elementId: "save-ledger",
-            thought: "Clicked the save ledger element successfully.",
+            input: CLICK_TEXT,
           }),
         );
         return undefined;

--- a/packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts
@@ -26,15 +26,14 @@ import type {
   ViewDeclaration,
 } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
-import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { stage1ResponseHandlerFixture } from "@elizaos/core/testing";
 import type { DeterministicModelCall } from "@elizaos/core/testing";
 import {
   finalMessageUserText,
-  matchesScenarioInput,
   type RuntimeWithScenarioModelFixtures,
+  stage1ResponseHandlerFixture,
 } from "@elizaos/core/testing";
+import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
 
 const VIEW_ID = "scenario-active-ledger";
 const VIEW_LABEL = "Scenario Active Ledger";
@@ -223,6 +222,40 @@ function promptHasActiveViewElements(value: string): boolean {
   ].every((needle) => value.includes(needle));
 }
 
+function evaluatorFixture({
+  capability,
+  elementId,
+  thought,
+}: {
+  capability: "agent-click" | "agent-fill";
+  elementId: string;
+  thought: string;
+}) {
+  return {
+    name: `active-view-evaluator-${capability}-${elementId}`,
+    match: (call: DeterministicModelCall) => {
+      if (call.modelType !== ModelType.TEXT_SMALL) return false;
+      const promptText =
+        call.params.prompt ??
+        (Array.isArray(call.params.messages)
+          ? call.params.messages
+              .map((m: { content?: string }) => m.content ?? "")
+              .join("\n")
+          : "");
+      return (
+        promptText.includes("task: Evaluate latest action") &&
+        promptText.includes(elementId)
+      );
+    },
+    response: {
+      success: true,
+      decision: "FINISH",
+      thought,
+    },
+    times: 1,
+  };
+}
+
 function plannerFixture({
   capability,
   elementId,
@@ -398,6 +431,11 @@ export default scenario({
             messageToUser: "Filled the active ledger title.",
             value: "Close Issue 11355",
           }),
+          evaluatorFixture({
+            capability: "agent-fill",
+            elementId: "ledger-title",
+            thought: "Filled the active ledger title element successfully.",
+          }),
           stage1ResponseHandlerFixture({
             actionName: "VIEWS",
             contextIds: ["active-view", "views"],
@@ -416,6 +454,11 @@ export default scenario({
             elementId: "save-ledger",
             input: CLICK_TEXT,
             messageToUser: "Saved the active ledger.",
+          }),
+          evaluatorFixture({
+            capability: "agent-click",
+            elementId: "save-ledger",
+            thought: "Clicked the save ledger element successfully.",
           }),
         );
         return undefined;


### PR DESCRIPTION
Fixes #21457. Supersedes #21470.

## Summary

- preserves the original strict planner fixtures for the active-view fill and click turns
- adds two turn-scoped `TEXT_SMALL` fixtures for the real merged post-turn evaluator path
- binds each evaluator fixture to the exact latest input, action capability, element id, and full expected merged schema
- returns valid no-op outputs for every active evaluator so zero-key execution completes without masking a wrong model call
- drops #21470’s Android host-port edit because current `develop` independently replaced the pinned port with the current ephemeral/override contract

## Why #21470 could not merge unchanged

The original fixtures matched the obsolete string `task: Evaluate latest action` and returned an old `{ success, decision, thought }` shape. The runtime now sends `# Task: Post-turn evaluation` through one merged evaluator schema, so neither original fixture could ever match. The PR was also conflicted, and its Android port patch was superseded on `develop`.

## Exact-head validation

- head: `f157f2b8e3bb995bef1f4894a511bdc53d270ef9`
- base: `ad68010c47040d9b0e4a5684243d328e2997df58`
- keyless deterministic active-view scenario — PASS, 1/1 scenario; fill and click assertions pass; both post-turn fixtures consumed exactly once
- touched-file Biome — PASS
- `git diff --check` — PASS
- `packages/scenario-runner` typecheck was attempted after install but resolves unrelated optional-workspace packages without built exports in this isolated worktree (`plugin-discord`, `plugin-elizacloud`, `plugin-wallet`, `capacitor-bun-runtime`, and others); the exact scenario compiles and executes the changed TypeScript path directly

## Evidence Gate

<!-- evidence-head:f157f2b8e3bb995bef1f4894a511bdc53d270ef9 -->
- Screenshots/video: N/A — deterministic scenario fixture repair; no rendered UI changes.
- Backend/frontend logs: scenario report `\/tmp\/pr21855-final-report.STddht\/matrix.json` recorded locally; inline result is 1 passed, 0 failed.
- LLM trajectory: N/A — deterministic keyless model fixture path; no live-provider behavior change.
- Domain artifact: the scenario’s fill and click executions both complete against the real active-view route/action surface, with the merged post-turn evaluator calls consumed exactly once.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pr-wave-other]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza"} -->

Independent exact-head rerun after the final rebase: the real deterministic scenario runner passed 1/1 (fill and click plus both merged post-turn evaluator fixtures), Biome passed, and diff check passed. GitHub CI and a non-author approval remain required before merge.