### PR TITLE
fix(desktop): open canonical workspace from tray and palette

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -327,6 +327,7 @@
         "@elizaos/agent": "workspace:*",
         "@elizaos/auth": "workspace:*",
         "@elizaos/core": "workspace:*",
+        "@elizaos/logger": "workspace:*",
         "@elizaos/plugin-anthropic": "workspace:*",
         "@elizaos/plugin-browser": "workspace:*",
         "@elizaos/plugin-elizacloud": "workspace:*",

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -282,6 +282,7 @@
     "@clack/prompts": "^1.0.0",
     "@elizaos/agent": "workspace:*",
     "@elizaos/core": "workspace:*",
+    "@elizaos/logger": "workspace:*",
     "@elizaos/plugin-anthropic": "workspace:*",
     "@elizaos/plugin-browser": "workspace:*",
     "@elizaos/plugin-elizacloud": "workspace:*",

--- a/packages/app-core/platforms/electrobun/src/application-menu.test.ts
+++ b/packages/app-core/platforms/electrobun/src/application-menu.test.ts
@@ -6,7 +6,9 @@ import {
   findViewMenuEntryById,
   getViewMenuEntries,
   NEW_VIEW_WINDOW_ACTION_PREFIX,
+  OPEN_DESKTOP_WORKSPACE_ACTION,
   parseViewWindowAction,
+  resolveDesktopWorkspaceWindowOptions,
 } from "./application-menu";
 import { overrideBrandConfig, resetBrandConfigForTests } from "./brand-config";
 import type { ManagedWindowSnapshot } from "./surface-windows";
@@ -167,5 +169,29 @@ describe("buildApplicationMenu", () => {
     expect(
       desktop?.submenu?.some((item) => item.action === "desktop-notify"),
     ).toBe(true);
+  });
+
+  it("routes Desktop Workspace to the complete managed shell", () => {
+    const menu = buildApplicationMenu({
+      isMac: true,
+      browserEnabled: true,
+      detachedWindows: noWindows,
+    });
+    const desktop = menu.find((item) => item.label === "Desktop");
+    const workspace = desktop?.submenu?.find(
+      (item) => item.label === "Desktop Workspace",
+    );
+
+    expect(workspace?.action).toBe(OPEN_DESKTOP_WORKSPACE_ACTION);
+    expect(workspace?.action).not.toBe("open-settings-desktop");
+    expect(resolveDesktopWorkspaceWindowOptions(workspace?.action)).toEqual({
+      slug: "workspace",
+      title: "Workspace",
+      path: "/",
+      alwaysOnTop: false,
+    });
+    expect(
+      resolveDesktopWorkspaceWindowOptions("open-settings-desktop"),
+    ).toBeUndefined();
   });
 });

--- a/packages/app-core/platforms/electrobun/src/application-menu.ts
+++ b/packages/app-core/platforms/electrobun/src/application-menu.ts
@@ -2,6 +2,27 @@
 import { getBrandConfig } from "./brand-config";
 import type { ManagedWindowSnapshot } from "./surface-windows";
 
+export const OPEN_DESKTOP_WORKSPACE_ACTION = "open-desktop-workspace";
+
+export interface DesktopWorkspaceWindowOptions {
+  readonly slug: "workspace";
+  readonly title: "Workspace";
+  readonly path: "/";
+  readonly alwaysOnTop: false;
+}
+
+export function resolveDesktopWorkspaceWindowOptions(
+  action: string | undefined,
+): DesktopWorkspaceWindowOptions | undefined {
+  if (action !== OPEN_DESKTOP_WORKSPACE_ACTION) return undefined;
+  return {
+    slug: "workspace",
+    title: "Workspace",
+    path: "/",
+    alwaysOnTop: false,
+  };
+}
+
 // Minimal slug + display + windowPath slice mirroring the renderer-side
 // internal-tool ViewDeclarations in `packages/ui/src/components/apps/
 // internal-tool-apps.ts` (the source of truth — it owns hero images,
@@ -243,7 +264,10 @@ function buildDesktopMenu(isMac: boolean): ApplicationMenuItem {
   return {
     label: "Desktop",
     submenu: [
-      { label: "Desktop Workspace", action: "open-settings-desktop" },
+      {
+        label: "Desktop Workspace",
+        action: OPEN_DESKTOP_WORKSPACE_ACTION,
+      },
       { label: "Voice Controls", action: "open-settings-voice" },
       { label: "Permissions", action: "open-settings-permissions" },
       { label: "Cloud Settings", action: "open-settings-cloud" },

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -31,6 +31,7 @@ import {
   findViewMenuEntryById,
   parseSettingsWindowAction,
   parseViewWindowAction,
+  resolveDesktopWorkspaceWindowOptions,
 } from "./application-menu";
 import { setApplicationMenuActionHandler } from "./application-menu-action-registry";
 import { showBackgroundNoticeOnce } from "./background-notice";
@@ -2124,6 +2125,11 @@ async function setupUpdater(): Promise<void> {
     };
 
     const handleSurfaceMenuAction = (action: string | undefined): boolean => {
+      const workspaceOptions = resolveDesktopWorkspaceWindowOptions(action);
+      if (workspaceOptions) {
+        void getDesktopManager().openAppWindow(workspaceOptions);
+        return true;
+      }
       // "Views" submenu (#10716): `new-window:view-<id>` opens a builtin view in
       // its own window via the same app-window path detached surfaces use.
       // Checked before the generic `new-window:` surface branch because that

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -2127,7 +2127,19 @@ async function setupUpdater(): Promise<void> {
     const handleSurfaceMenuAction = (action: string | undefined): boolean => {
       const workspaceOptions = resolveDesktopWorkspaceWindowOptions(action);
       if (workspaceOptions) {
-        void getDesktopManager().openAppWindow(workspaceOptions);
+        void getDesktopManager()
+          .openAppWindow(workspaceOptions)
+          .catch((error: unknown) => {
+            // error-policy:J1 The native application-menu boundary translates
+            // launch failure into diagnostics and a visible OS notification.
+            logger.error(
+              `[Main] Desktop workspace launch failed: ${formatError(error)}`,
+            );
+            Utils.showNotification({
+              title: "Desktop Workspace Failed",
+              body: "Unable to open the desktop workspace. Please retry.",
+            });
+          });
         return true;
       }
       // "Views" submenu (#10716): `new-window:view-<id>` opens a builtin view in

--- a/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
+++ b/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
@@ -322,6 +322,64 @@ describe("SurfaceWindowManager app windows", () => {
     expect(fixture.created[0]?.focus).toHaveBeenCalledOnce();
   });
 
+  it("serializes concurrent opens for the same app slug", async () => {
+    let releaseRendererUrl: ((url: string) => void) | undefined;
+    const rendererUrl = new Promise<string>((resolve) => {
+      releaseRendererUrl = resolve;
+    });
+    const fixture = createFixture({
+      resolveRendererUrl: () => rendererUrl,
+    });
+
+    const first = fixture.manager.openAppWindow({
+      slug: "workspace",
+      title: "Workspace",
+      path: "/",
+    });
+    const second = fixture.manager.openAppWindow({
+      slug: "workspace",
+      title: "Ignored Duplicate",
+      path: "/settings",
+      alwaysOnTop: true,
+    });
+
+    releaseRendererUrl?.("http://127.0.0.1:5173/?boot=1#old");
+    const [firstWindow, secondWindow] = await Promise.all([first, second]);
+
+    expect(secondWindow).toEqual({ ...firstWindow, alwaysOnTop: true });
+    expect(fixture.created).toHaveLength(1);
+    expect(fixture.created[0]?.setAlwaysOnTop).toHaveBeenCalledWith(true);
+    expect(fixture.created[0]?.options.url).toBe(
+      "http://127.0.0.1:5173/?boot=1&appWindow=1#/",
+    );
+  });
+
+  it("clears a failed app-slug reservation so a later open can retry", async () => {
+    const resolveRendererUrl = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("renderer unavailable"))
+      .mockResolvedValueOnce("http://127.0.0.1:5173/?boot=1#old");
+    const fixture = createFixture({ resolveRendererUrl });
+
+    await expect(
+      fixture.manager.openAppWindow({
+        slug: "workspace",
+        title: "Workspace",
+        path: "/",
+      }),
+    ).rejects.toThrow("renderer unavailable");
+
+    await expect(
+      fixture.manager.openAppWindow({
+        slug: "workspace",
+        title: "Workspace",
+        path: "/",
+      }),
+    ).resolves.toMatchObject({ id: "app_workspace" });
+    expect(resolveRendererUrl).toHaveBeenCalledTimes(2);
+    expect(fixture.created).toHaveLength(1);
+  });
+
   it("focuses, mutates always-on-top, lists, traverses, and loads existing app windows", async () => {
     const fixture = createFixture();
 

--- a/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
+++ b/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
@@ -390,6 +390,37 @@ describe("SurfaceWindowManager app windows", () => {
     expect(fixture.manager.listWindows()).toHaveLength(2);
   });
 
+  // The leader's window is raised by createManagedWindow's own dedupe, but a
+  // follower that joins a launch already in flight never goes through that
+  // path. Without an explicit focus, a burst of tray clicks resolves every
+  // caller against a window nobody raised.
+  it("raises the window once for each concurrent follower and not for the leader", async () => {
+    let releaseRendererUrl: ((url: string) => void) | undefined;
+    const rendererUrl = new Promise<string>((resolve) => {
+      releaseRendererUrl = resolve;
+    });
+    const fixture = createFixture({
+      resolveRendererUrl: () => rendererUrl,
+    });
+
+    const leader = fixture.manager.openAppWindow({
+      slug: "workspace",
+      title: "Workspace",
+      path: "/",
+    });
+    const follower = fixture.manager.openAppWindow({
+      slug: "workspace",
+      title: "Workspace",
+      path: "/",
+    });
+
+    releaseRendererUrl?.("http://127.0.0.1:5173/?boot=1#old");
+    await Promise.all([leader, follower]);
+
+    expect(fixture.created).toHaveLength(1);
+    expect(fixture.created[0]?.focus).toHaveBeenCalledTimes(1);
+  });
+
   it("notifies the registry when a concurrent open promotes always-on-top after creation", async () => {
     let releaseRendererUrl: ((url: string) => void) | undefined;
     const rendererUrl = new Promise<string>((resolve) => {

--- a/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
+++ b/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
@@ -364,6 +364,63 @@ describe("SurfaceWindowManager app windows", () => {
     );
   });
 
+  it("gives every slug-less app window its own managed record instead of sharing one reservation", async () => {
+    let releaseRendererUrl: ((url: string) => void) | undefined;
+    const rendererUrl = new Promise<string>((resolve) => {
+      releaseRendererUrl = resolve;
+    });
+    const fixture = createFixture({ resolveRendererUrl: () => rendererUrl });
+
+    const first = fixture.manager.openAppWindow({
+      title: "Scratch One",
+      path: "/apps/one",
+    });
+    const second = fixture.manager.openAppWindow({
+      title: "Scratch Two",
+      path: "/apps/two",
+    });
+
+    releaseRendererUrl?.("http://127.0.0.1:5173/?boot=1#old");
+    const [firstSnapshot, secondSnapshot] = await Promise.all([first, second]);
+
+    expect(firstSnapshot.id).not.toBe(secondSnapshot.id);
+    expect(firstSnapshot.title).toBe("Scratch One");
+    expect(secondSnapshot.title).toBe("Scratch Two");
+    expect(fixture.created).toHaveLength(2);
+    expect(fixture.manager.listWindows()).toHaveLength(2);
+  });
+
+  it("notifies the registry when a concurrent open promotes always-on-top after creation", async () => {
+    let releaseRendererUrl: ((url: string) => void) | undefined;
+    const rendererUrl = new Promise<string>((resolve) => {
+      releaseRendererUrl = resolve;
+    });
+    const fixture = createFixture({ resolveRendererUrl: () => rendererUrl });
+
+    const first = fixture.manager.openAppWindow({
+      slug: "workspace",
+      title: "Workspace",
+      path: "/",
+    });
+    const second = fixture.manager.openAppWindow({
+      slug: "workspace",
+      title: "Workspace",
+      path: "/",
+      alwaysOnTop: true,
+    });
+
+    releaseRendererUrl?.("http://127.0.0.1:5173/?boot=1#old");
+    await Promise.all([first, second]);
+
+    expect(fixture.created[0]?.setAlwaysOnTop).toHaveBeenCalledWith(true);
+    // Creation notifies once; the post-creation promotion must notify again so
+    // the tray/menu window list does not keep a stale alwaysOnTop flag.
+    expect(fixture.registryChanged.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(fixture.manager.listWindows()).toEqual([
+      expect.objectContaining({ id: "app_workspace", alwaysOnTop: true }),
+    ]);
+  });
+
   it("clears a failed app-slug reservation so a later open can retry", async () => {
     const resolveRendererUrl = vi
       .fn<() => Promise<string>>()

--- a/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
+++ b/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
@@ -322,7 +322,7 @@ describe("SurfaceWindowManager app windows", () => {
     expect(fixture.created[0]?.focus).toHaveBeenCalledOnce();
   });
 
-  it("serializes concurrent opens for the same app slug", async () => {
+  it("serializes false-true-false concurrent opens and returns the authoritative promoted snapshot", async () => {
     let releaseRendererUrl: ((url: string) => void) | undefined;
     const rendererUrl = new Promise<string>((resolve) => {
       releaseRendererUrl = resolve;
@@ -342,11 +342,21 @@ describe("SurfaceWindowManager app windows", () => {
       path: "/settings",
       alwaysOnTop: true,
     });
+    const third = fixture.manager.openAppWindow({
+      slug: "workspace",
+      title: "Ignored Later Duplicate",
+      path: "/chat",
+      alwaysOnTop: false,
+    });
 
     releaseRendererUrl?.("http://127.0.0.1:5173/?boot=1#old");
-    const [firstWindow, secondWindow] = await Promise.all([first, second]);
+    const snapshots = await Promise.all([first, second, third]);
 
-    expect(secondWindow).toEqual({ ...firstWindow, alwaysOnTop: true });
+    expect(snapshots).toEqual([
+      expect.objectContaining({ id: "app_workspace", alwaysOnTop: true }),
+      expect.objectContaining({ id: "app_workspace", alwaysOnTop: true }),
+      expect.objectContaining({ id: "app_workspace", alwaysOnTop: true }),
+    ]);
     expect(fixture.created).toHaveLength(1);
     expect(fixture.created[0]?.setAlwaysOnTop).toHaveBeenCalledWith(true);
     expect(fixture.created[0]?.options.url).toBe(

--- a/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
+++ b/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
@@ -295,6 +295,33 @@ describe("SurfaceWindowManager app windows", () => {
     expect(fixture.manager.listWindows()).toEqual([second]);
   });
 
+  it("opens the full workspace shell at the root and deduplicates its managed window", async () => {
+    const fixture = createFixture();
+
+    const first = await fixture.manager.openAppWindow({
+      slug: "workspace",
+      title: "Workspace",
+      path: "/",
+    });
+    const second = await fixture.manager.openAppWindow({
+      slug: "workspace",
+      title: "Ignored Duplicate",
+      path: "/settings",
+    });
+
+    expect(first).toMatchObject({
+      id: "app_workspace",
+      surface: "app",
+      title: "Workspace",
+    });
+    expect(second).toEqual(first);
+    expect(fixture.created).toHaveLength(1);
+    expect(fixture.created[0]?.options.url).toBe(
+      "http://127.0.0.1:5173/?boot=1&appWindow=1#/",
+    );
+    expect(fixture.created[0]?.focus).toHaveBeenCalledOnce();
+  });
+
   it("focuses, mutates always-on-top, lists, traverses, and loads existing app windows", async () => {
     const fixture = createFixture();
 

--- a/packages/app-core/platforms/electrobun/src/surface-windows.ts
+++ b/packages/app-core/platforms/electrobun/src/surface-windows.ts
@@ -195,6 +195,10 @@ export class SurfaceWindowManager {
     string,
     Promise<ManagedWindowSnapshot>
   >();
+  private readonly pendingAppWindows = new Map<
+    string,
+    Promise<ManagedWindowSnapshot>
+  >();
   private counter = 0;
 
   constructor(options: SurfaceWindowManagerOptions) {
@@ -305,7 +309,29 @@ export class SurfaceWindowManager {
     path: string;
     alwaysOnTop?: boolean;
   }): Promise<ManagedWindowSnapshot> {
-    return this.createManagedWindow(
+    if (!options.slug) {
+      return this.createManagedWindow(
+        "app",
+        undefined,
+        false,
+        undefined,
+        options.path,
+        options.title,
+        options.alwaysOnTop === true,
+      );
+    }
+
+    const pending = this.pendingAppWindows.get(options.slug);
+    if (pending) {
+      const snapshot = await pending;
+      if (options.alwaysOnTop === true && !snapshot.alwaysOnTop) {
+        this.setWindowAlwaysOnTop(snapshot.id, true);
+        return { ...snapshot, alwaysOnTop: true };
+      }
+      return snapshot;
+    }
+
+    const task = this.createManagedWindow(
       "app",
       undefined,
       false,
@@ -315,6 +341,14 @@ export class SurfaceWindowManager {
       options.alwaysOnTop === true,
       options.slug,
     );
+    this.pendingAppWindows.set(options.slug, task);
+    try {
+      return await task;
+    } finally {
+      if (this.pendingAppWindows.get(options.slug) === task) {
+        this.pendingAppWindows.delete(options.slug);
+      }
+    }
   }
 
   findWindowBySlug(slug: string): ManagedWindowSnapshot | undefined {

--- a/packages/app-core/platforms/electrobun/src/surface-windows.ts
+++ b/packages/app-core/platforms/electrobun/src/surface-windows.ts
@@ -69,6 +69,11 @@ interface ManagedWindowRecord extends ManagedWindowSnapshot {
   slug?: string;
 }
 
+interface PendingAppWindow {
+  readonly task: Promise<ManagedWindowSnapshot>;
+  alwaysOnTopRequested: boolean;
+}
+
 interface SurfaceWindowManagerOptions {
   createWindow: (options: CreateManagedWindowOptions) => ManagedWindowLike;
   resolveRendererUrl: () => Promise<string>;
@@ -195,10 +200,7 @@ export class SurfaceWindowManager {
     string,
     Promise<ManagedWindowSnapshot>
   >();
-  private readonly pendingAppWindows = new Map<
-    string,
-    Promise<ManagedWindowSnapshot>
-  >();
+  private readonly pendingAppWindows = new Map<string, PendingAppWindow>();
   private counter = 0;
 
   constructor(options: SurfaceWindowManagerOptions) {
@@ -323,32 +325,51 @@ export class SurfaceWindowManager {
 
     const pending = this.pendingAppWindows.get(options.slug);
     if (pending) {
-      const snapshot = await pending;
-      if (options.alwaysOnTop === true && !snapshot.alwaysOnTop) {
-        this.setWindowAlwaysOnTop(snapshot.id, true);
-        return { ...snapshot, alwaysOnTop: true };
-      }
-      return snapshot;
+      pending.alwaysOnTopRequested ||= options.alwaysOnTop === true;
+      await pending.task;
+      return this.finishPendingAppWindow(options.slug, pending);
     }
 
-    const task = this.createManagedWindow(
-      "app",
-      undefined,
-      false,
-      undefined,
-      options.path,
-      options.title,
-      options.alwaysOnTop === true,
-      options.slug,
-    );
-    this.pendingAppWindows.set(options.slug, task);
+    const pendingAppWindow: PendingAppWindow = {
+      task: this.createManagedWindow(
+        "app",
+        undefined,
+        false,
+        undefined,
+        options.path,
+        options.title,
+        options.alwaysOnTop === true,
+        options.slug,
+      ),
+      alwaysOnTopRequested: options.alwaysOnTop === true,
+    };
+    this.pendingAppWindows.set(options.slug, pendingAppWindow);
     try {
-      return await task;
+      await pendingAppWindow.task;
+      return this.finishPendingAppWindow(options.slug, pendingAppWindow);
     } finally {
-      if (this.pendingAppWindows.get(options.slug) === task) {
+      if (this.pendingAppWindows.get(options.slug) === pendingAppWindow) {
         this.pendingAppWindows.delete(options.slug);
       }
     }
+  }
+
+  private finishPendingAppWindow(
+    slug: string,
+    pending: PendingAppWindow,
+  ): ManagedWindowSnapshot {
+    const record = Array.from(this.windows.values()).find(
+      (entry) => entry.slug === slug,
+    );
+    if (!record) {
+      throw new Error(`Managed app window closed during launch: ${slug}`);
+    }
+    if (pending.alwaysOnTopRequested && !record.alwaysOnTop) {
+      record.window.setAlwaysOnTop(true);
+      record.alwaysOnTop = true;
+      this.notifyRegistryChanged();
+    }
+    return this.toSnapshot(record);
   }
 
   findWindowBySlug(slug: string): ManagedWindowSnapshot | undefined {

--- a/packages/app-core/platforms/electrobun/src/surface-windows.ts
+++ b/packages/app-core/platforms/electrobun/src/surface-windows.ts
@@ -327,7 +327,13 @@ export class SurfaceWindowManager {
     if (pending) {
       pending.alwaysOnTopRequested ||= options.alwaysOnTop === true;
       await pending.task;
-      return this.finishPendingAppWindow(options.slug, pending);
+      const snapshot = this.finishPendingAppWindow(options.slug, pending);
+      // A follower joined a launch already in flight, so createManagedWindow's
+      // own dedupe never ran for it and nothing raised the window on its
+      // behalf. The leader's branch below is already focused by that path;
+      // focusing there too would raise it once per concurrent caller.
+      this.focusWindow(snapshot.id);
+      return snapshot;
     }
 
     const pendingAppWindow: PendingAppWindow = {

--- a/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
@@ -20,6 +20,7 @@ import {
   dispatchOpenNotificationCenter,
   TRAY_ACTION_EVENT,
 } from "@elizaos/ui/events";
+import { TOAST_TTL_MS } from "@elizaos/ui/state/action-notice";
 import {
   type DesktopLauncherEntry,
   type DesktopLauncherIconId,
@@ -286,9 +287,12 @@ export function DesktopTrayRuntime() {
         // error-policy:J4 Tray commands terminate at this UI boundary, so an
         // RPC failure must remain visibly distinct from successful dispatch.
         setActionNotice(
-          "Unable to complete the desktop action. Please retry.",
+          t("desktop.tray.actionFailed", {
+            defaultValue:
+              "Unable to complete the desktop action. Please retry.",
+          }),
           "error",
-          7_000,
+          TOAST_TTL_MS.notificationInterruptive,
         );
       });
     };

--- a/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
@@ -26,7 +26,10 @@ import {
   setDesktopLauncherEntries,
 } from "@elizaos/ui/state/desktop-tray-launcher";
 import { useApp } from "@elizaos/ui/state/useApp";
-import { openDesktopSettingsWindow } from "@elizaos/ui/utils/desktop-workspace";
+import {
+  openDesktopSettingsWindow,
+  openDesktopWorkspaceWindow,
+} from "@elizaos/ui/utils/desktop-workspace";
 import { useEffect } from "react";
 import {
   DESKTOP_VIEW_WINDOWS,
@@ -227,7 +230,7 @@ export function DesktopTrayRuntime() {
             await showAndFocusWindow();
             return;
           case "tray-open-desktop-workspace":
-            await openDesktopSettingsWindow("desktop");
+            await openDesktopWorkspaceWindow();
             return;
           case "tray-open-voice-controls":
             await openDesktopSettingsWindow("voice");

--- a/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
@@ -8,6 +8,7 @@
  * show/hide/quit — all through the electrobun-rpc bridge. Only active under
  * isElectrobunRuntime(); polls with backoff until the RPC bridge attaches.
  */
+import { logger } from "@elizaos/logger";
 import {
   getElectrobunRendererRpc,
   invokeDesktopBridgeRequest,
@@ -283,9 +284,13 @@ export function DesktopTrayRuntime() {
         }
       };
 
-      void run().catch(() => {
+      void run().catch((error: unknown) => {
         // error-policy:J4 Tray commands terminate at this UI boundary, so an
         // RPC failure must remain visibly distinct from successful dispatch.
+        // This wraps all eleven tray actions, so the cause is logged rather
+        // than discarded — otherwise every one of them collapses into the same
+        // undiagnosable notice.
+        logger.error({ error }, "[DesktopTrayRuntime] tray action failed");
         setActionNotice(
           t("desktop.tray.actionFailed", {
             defaultValue:

--- a/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
@@ -72,6 +72,7 @@ export function DesktopTrayRuntime() {
     handleResetAppliedFromMain,
     handleStart,
     handleStop,
+    setActionNotice,
     setTab,
     switchShellView,
     t,
@@ -281,10 +282,15 @@ export function DesktopTrayRuntime() {
         }
       };
 
-      // error-policy:J6 best-effort UI dispatch from a DOM event handler; a
-      // failed tray action leaves the window in its current (visible) state,
-      // which the user sees and can retry — nothing to unwind here.
-      void run().catch(() => {});
+      void run().catch(() => {
+        // error-policy:J4 Tray commands terminate at this UI boundary, so an
+        // RPC failure must remain visibly distinct from successful dispatch.
+        setActionNotice(
+          "Unable to complete the desktop action. Please retry.",
+          "error",
+          7_000,
+        );
+      });
     };
 
     document.addEventListener(TRAY_ACTION_EVENT, handleTrayAction);
@@ -296,6 +302,7 @@ export function DesktopTrayRuntime() {
     handleRestart,
     handleStart,
     handleStop,
+    setActionNotice,
     setTab,
     switchShellView,
     t,

--- a/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.workspace.test.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.workspace.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Behavioral coverage for the tray "Open Desktop Workspace" route and the tray
+ * error-visibility boundary in DesktopTrayRuntime. Renders the real headless
+ * component in jsdom and drives the real TRAY_ACTION_EVENT listener; only the
+ * cross-package @elizaos/ui bridge/store boundaries are substituted, so the
+ * component's own routing and failure translation are exercised for real.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { bridge, store } = vi.hoisted(() => ({
+  bridge: {
+    openDesktopWorkspaceWindow: vi.fn(async () => {}),
+    openDesktopSettingsWindow: vi.fn(async () => {}),
+    invokeDesktopBridgeRequest: vi.fn(async () => undefined),
+    openDesktopAppWindow: vi.fn(async () => ({ id: "app_view" })),
+  },
+  store: {
+    agentStatus: { state: "stopped" },
+    handleRestart: vi.fn(async () => {}),
+    handleReset: vi.fn(async () => {}),
+    handleResetAppliedFromMain: vi.fn(),
+    handleStart: vi.fn(async () => {}),
+    handleStop: vi.fn(async () => {}),
+    setActionNotice: vi.fn(),
+    setTab: vi.fn(),
+    switchShellView: vi.fn(),
+    t: (_key: string, vars?: { defaultValue?: string }) =>
+      vars?.defaultValue ?? "",
+  },
+}));
+
+vi.mock("@elizaos/ui/bridge/electrobun-rpc", () => ({
+  getElectrobunRendererRpc: () => ({ request: {} }),
+  invokeDesktopBridgeRequest: bridge.invokeDesktopBridgeRequest,
+  openDesktopAppWindow: bridge.openDesktopAppWindow,
+  subscribeDesktopBridgeEvent: () => () => {},
+}));
+
+vi.mock("@elizaos/ui/bridge/electrobun-runtime", () => ({
+  isElectrobunRuntime: () => true,
+}));
+
+vi.mock("@elizaos/ui/utils/desktop-workspace", () => ({
+  openDesktopWorkspaceWindow: bridge.openDesktopWorkspaceWindow,
+  openDesktopSettingsWindow: bridge.openDesktopSettingsWindow,
+}));
+
+vi.mock("@elizaos/ui/state/useApp", () => ({ useApp: () => store }));
+
+import { TRAY_ACTION_EVENT } from "@elizaos/ui/events";
+import { TOAST_TTL_MS } from "@elizaos/ui/state/action-notice";
+import { DesktopTrayRuntime } from "./DesktopTrayRuntime";
+
+function clickTray(itemId: string): void {
+  document.dispatchEvent(
+    new CustomEvent(TRAY_ACTION_EVENT, { detail: { itemId } }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  bridge.openDesktopWorkspaceWindow.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DesktopTrayRuntime — Desktop Workspace launch", () => {
+  it("routes the tray item to the managed workspace shell, not the settings window", async () => {
+    render(<DesktopTrayRuntime />);
+
+    clickTray("tray-open-desktop-workspace");
+
+    await waitFor(() => {
+      expect(bridge.openDesktopWorkspaceWindow).toHaveBeenCalledOnce();
+    });
+    expect(bridge.openDesktopSettingsWindow).not.toHaveBeenCalled();
+    expect(store.setActionNotice).not.toHaveBeenCalled();
+  });
+
+  it("shows a distinct error notice when the workspace launch rejects", async () => {
+    bridge.openDesktopWorkspaceWindow.mockRejectedValueOnce(
+      new Error("Desktop workspace bridge returned no managed window"),
+    );
+    render(<DesktopTrayRuntime />);
+
+    clickTray("tray-open-desktop-workspace");
+
+    await waitFor(() => {
+      expect(store.setActionNotice).toHaveBeenCalledWith(
+        "Unable to complete the desktop action. Please retry.",
+        "error",
+        TOAST_TTL_MS.notificationInterruptive,
+      );
+    });
+  });
+
+  it("shows the same error notice when any other tray RPC rejects", async () => {
+    bridge.invokeDesktopBridgeRequest.mockRejectedValueOnce(
+      new Error("bridge detached"),
+    );
+    render(<DesktopTrayRuntime />);
+
+    clickTray("tray-hide-window");
+
+    await waitFor(() => {
+      expect(store.setActionNotice).toHaveBeenCalledWith(
+        expect.any(String),
+        "error",
+        TOAST_TTL_MS.notificationInterruptive,
+      );
+    });
+  });
+
+  it("raises no notice for a successful tray dispatch", async () => {
+    render(<DesktopTrayRuntime />);
+
+    clickTray("tray-hide-window");
+
+    await waitFor(() => {
+      expect(bridge.invokeDesktopBridgeRequest).toHaveBeenCalled();
+    });
+    await Promise.resolve();
+    expect(store.setActionNotice).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/src/runtime/desktop/tray-menu.test.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.test.ts
@@ -13,9 +13,6 @@ import { DESKTOP_TRAY_CLICK_AUDIT, DESKTOP_TRAY_MENU_ITEMS } from "./tray-menu";
 const trayRuntimePath = fileURLToPath(
   new URL("./DesktopTrayRuntime.tsx", import.meta.url),
 );
-const workspaceBridgePath = fileURLToPath(
-  new URL("../../../../ui/src/utils/desktop-workspace.ts", import.meta.url),
-);
 
 describe("desktop tray menu — Notifications entry (#10706)", () => {
   it("exposes desktop views under a native Windows submenu and keeps Quit", () => {
@@ -81,21 +78,16 @@ describe("desktop tray menu — Notifications entry (#10706)", () => {
     );
   });
 
-  it("opens Desktop Workspace as the complete managed shell", () => {
+  // The runtime routing itself is exercised behaviorally in
+  // DesktopTrayRuntime.workspace.test.tsx; this only pins the audit row that
+  // the click-audit report renders.
+  it("audits the Desktop Workspace click as the complete managed shell", () => {
     const audit = DESKTOP_TRAY_CLICK_AUDIT.find(
       (entry) => entry.id === "tray-open-desktop-workspace",
     );
-    expect(audit?.expectedAction).toContain("complete Eliza shell");
-
-    const source = readFileSync(trayRuntimePath, "utf8");
-    expect(source).toContain('case "tray-open-desktop-workspace"');
-    expect(source).toContain("await openDesktopWorkspaceWindow()");
-    expect(source).not.toContain('openDesktopSettingsWindow("desktop")');
-
-    const bridgeSource = readFileSync(workspaceBridgePath, "utf8");
-    expect(bridgeSource).toContain('"desktopOpenAppWindow"');
-    expect(bridgeSource).toContain('"desktop:openAppWindow"');
-    expect(bridgeSource).toContain('slug: "workspace"');
-    expect(bridgeSource).toContain('path: "/"');
+    expect(audit?.expectedAction).toBe(
+      "Open the complete Eliza shell in a managed app window.",
+    );
+    expect(audit?.coverage).toBe("automated");
   });
 });

--- a/packages/app-core/src/runtime/desktop/tray-menu.test.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.test.ts
@@ -13,6 +13,9 @@ import { DESKTOP_TRAY_CLICK_AUDIT, DESKTOP_TRAY_MENU_ITEMS } from "./tray-menu";
 const trayRuntimePath = fileURLToPath(
   new URL("./DesktopTrayRuntime.tsx", import.meta.url),
 );
+const workspaceBridgePath = fileURLToPath(
+  new URL("../../../../ui/src/utils/desktop-workspace.ts", import.meta.url),
+);
 
 describe("desktop tray menu — Notifications entry (#10706)", () => {
   it("exposes desktop views under a native Windows submenu and keeps Quit", () => {
@@ -76,5 +79,23 @@ describe("desktop tray menu — Notifications entry (#10706)", () => {
     expect(source).not.toContain(
       'case "tray-open-chat":\n            switchShellView("desktop");',
     );
+  });
+
+  it("opens Desktop Workspace as the complete managed shell", () => {
+    const audit = DESKTOP_TRAY_CLICK_AUDIT.find(
+      (entry) => entry.id === "tray-open-desktop-workspace",
+    );
+    expect(audit?.expectedAction).toContain("complete Eliza shell");
+
+    const source = readFileSync(trayRuntimePath, "utf8");
+    expect(source).toContain('case "tray-open-desktop-workspace"');
+    expect(source).toContain("await openDesktopWorkspaceWindow()");
+    expect(source).not.toContain('openDesktopSettingsWindow("desktop")');
+
+    const bridgeSource = readFileSync(workspaceBridgePath, "utf8");
+    expect(bridgeSource).toContain('"desktopOpenAppWindow"');
+    expect(bridgeSource).toContain('"desktop:openAppWindow"');
+    expect(bridgeSource).toContain('slug: "workspace"');
+    expect(bridgeSource).toContain('path: "/"');
   });
 });

--- a/packages/app-core/src/runtime/desktop/tray-menu.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.ts
@@ -226,8 +226,7 @@ export const DESKTOP_TRAY_CLICK_AUDIT: readonly DesktopClickAuditItem[] = [
     id: "tray-open-desktop-workspace",
     entryPoint: "tray",
     label: "Open Desktop Workspace",
-    expectedAction:
-      "Open a detached settings window focused on the desktop workspace section.",
+    expectedAction: "Open the complete Eliza shell in a managed app window.",
     runtimeRequirement: "desktop",
     coverage: "automated",
   },

--- a/packages/ui/src/chat/build-commands.test.ts
+++ b/packages/ui/src/chat/build-commands.test.ts
@@ -31,6 +31,7 @@ function args(over: Partial<BuildCommandsArgs> = {}): BuildCommandsArgs {
     openBugReport: vi.fn(),
     desktopRuntime: false,
     focusDesktopMainWindow: vi.fn(),
+    openDesktopWorkspaceWindow: vi.fn(),
     openDesktopSettingsWindow: vi.fn(),
     openDesktopSurfaceWindow: vi.fn(),
     ...over,
@@ -38,6 +39,25 @@ function args(over: Partial<BuildCommandsArgs> = {}): BuildCommandsArgs {
 }
 
 describe("buildCommands — palette launcher (#8792)", () => {
+  it("opens Desktop Workspace through the full managed-shell launcher", () => {
+    const openDesktopWorkspaceWindow = vi.fn();
+    const openDesktopSettingsWindow = vi.fn();
+    const commands = buildCommands(
+      args({
+        desktopRuntime: true,
+        openDesktopWorkspaceWindow,
+        openDesktopSettingsWindow,
+      }),
+    );
+
+    commands
+      .find((command) => command.id === "desktop-open-workspace")
+      ?.action();
+
+    expect(openDesktopWorkspaceWindow).toHaveBeenCalledOnce();
+    expect(openDesktopSettingsWindow).not.toHaveBeenCalled();
+  });
+
   it("navigates built-in tabs through navigateTab (which reports VIEW_SWITCHED)", () => {
     const navigateTab = vi.fn();
     const commands = buildCommands(args({ navigateTab }));

--- a/packages/ui/src/chat/index.ts
+++ b/packages/ui/src/chat/index.ts
@@ -219,6 +219,7 @@ export interface BuildCommandsArgs {
   openBugReport: () => void;
   desktopRuntime: boolean;
   focusDesktopMainWindow: () => void;
+  openDesktopWorkspaceWindow: () => void;
   openDesktopSettingsWindow: (tabHint?: string) => void;
   openDesktopSurfaceWindow: (
     surface: DesktopWorkspaceSurface,
@@ -231,8 +232,7 @@ export const DESKTOP_COMMAND_CLICK_AUDIT: readonly DesktopClickAuditItem[] = [
     id: "desktop-open-workspace",
     entryPoint: "command-palette",
     label: "Open Desktop Workspace",
-    expectedAction:
-      "Open a detached settings window focused on the desktop workspace section.",
+    expectedAction: "Open the complete Eliza shell in a managed app window.",
     runtimeRequirement: "desktop",
     coverage: "automated",
   },
@@ -284,6 +284,7 @@ export function buildCommands(args: BuildCommandsArgs): CommandItem[] {
     openBugReport,
     desktopRuntime,
     focusDesktopMainWindow,
+    openDesktopWorkspaceWindow,
     openDesktopSettingsWindow,
     openDesktopSurfaceWindow,
   } = args;
@@ -359,7 +360,7 @@ export function buildCommands(args: BuildCommandsArgs): CommandItem[] {
         id: "desktop-open-workspace",
         label: "Open Desktop Workspace",
         category: "desktop",
-        action: () => openDesktopSettingsWindow("desktop"),
+        action: openDesktopWorkspaceWindow,
       },
       {
         id: "desktop-open-voice-controls",

--- a/packages/ui/src/components/shell/CommandPalette.tsx
+++ b/packages/ui/src/components/shell/CommandPalette.tsx
@@ -41,6 +41,7 @@ import { useEnabledViewKinds } from "../../state/useViewKinds";
 import {
   openDesktopSettingsWindow,
   openDesktopSurfaceWindow,
+  openDesktopWorkspaceWindow,
   requestDesktopBridge,
 } from "../../utils";
 import { Button } from "../ui/button";
@@ -156,6 +157,9 @@ export function CommandPalette() {
           "desktopFocusWindow",
           "desktop:focusWindow",
         );
+      },
+      openDesktopWorkspaceWindow: () => {
+        void openDesktopWorkspaceWindow();
       },
       openDesktopSettingsWindow: (tabHint?: string) => {
         void openDesktopSettingsWindow(tabHint);

--- a/packages/ui/src/components/shell/CommandPalette.tsx
+++ b/packages/ui/src/components/shell/CommandPalette.tsx
@@ -37,6 +37,7 @@ import { useAvailableViews } from "../../hooks/useAvailableViews";
 import { SHORTCUT_OPEN_COMMAND_PALETTE } from "../../hooks/useKeyboardShortcuts";
 import type { Tab } from "../../navigation";
 import { useAppSelectorShallow } from "../../state";
+import { TOAST_TTL_MS } from "../../state/action-notice";
 import { useEnabledViewKinds } from "../../state/useViewKinds";
 import {
   openDesktopSettingsWindow,
@@ -165,9 +166,12 @@ export function CommandPalette() {
           // error-policy:J4 a native window launch failure remains visible in
           // the shell instead of becoming an unhandled command rejection.
           setActionNotice(
-            "Unable to open the desktop workspace. Please retry.",
+            t("desktop.workspace.launchFailed", {
+              defaultValue:
+                "Unable to open the desktop workspace. Please retry.",
+            }),
             "error",
-            7_000,
+            TOAST_TTL_MS.notificationInterruptive,
           );
         });
       },
@@ -196,6 +200,7 @@ export function CommandPalette() {
     setActionNotice,
     openBugReport,
     desktopRuntime,
+    t,
   ]);
 
   // Filter commands by query

--- a/packages/ui/src/components/shell/CommandPalette.tsx
+++ b/packages/ui/src/components/shell/CommandPalette.tsx
@@ -13,6 +13,7 @@
  * mirrors the view catalog, so hidden developer/preview views never leak.
  */
 
+import { logger } from "@elizaos/logger";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   useCallback,
@@ -162,9 +163,16 @@ export function CommandPalette() {
         );
       },
       openDesktopWorkspaceWindow: () => {
-        void openDesktopWorkspaceWindow().catch(() => {
-          // error-policy:J4 a native window launch failure remains visible in
-          // the shell instead of becoming an unhandled command rejection.
+        void openDesktopWorkspaceWindow().catch((error: unknown) => {
+          // error-policy:J4 a native window launch failure becomes a visible
+          // shell notice instead of an unhandled command rejection. The catch
+          // is unconditional, so the cause is logged rather than discarded — a
+          // programming error here would otherwise leave nothing behind but
+          // generic retry text.
+          logger.error(
+            { error },
+            "[CommandPalette] desktop workspace launch failed",
+          );
           setActionNotice(
             t("desktop.workspace.launchFailed", {
               defaultValue:

--- a/packages/ui/src/components/shell/CommandPalette.tsx
+++ b/packages/ui/src/components/shell/CommandPalette.tsx
@@ -71,6 +71,7 @@ export function CommandPalette() {
     handleChatClear,
     activeGameViewerUrl,
     setState,
+    setActionNotice,
     t,
   } = useAppSelectorShallow((s) => ({
     commandPaletteOpen: s.commandPaletteOpen,
@@ -88,6 +89,7 @@ export function CommandPalette() {
     handleChatClear: s.handleChatClear,
     activeGameViewerUrl: s.activeGameViewerUrl,
     setState: s.setState,
+    setActionNotice: s.setActionNotice,
     t: s.t,
   }));
   const { open: openBugReport } = useBugReport();
@@ -159,7 +161,15 @@ export function CommandPalette() {
         );
       },
       openDesktopWorkspaceWindow: () => {
-        void openDesktopWorkspaceWindow();
+        void openDesktopWorkspaceWindow().catch(() => {
+          // error-policy:J4 a native window launch failure remains visible in
+          // the shell instead of becoming an unhandled command rejection.
+          setActionNotice(
+            "Unable to open the desktop workspace. Please retry.",
+            "error",
+            7_000,
+          );
+        });
       },
       openDesktopSettingsWindow: (tabHint?: string) => {
         void openDesktopSettingsWindow(tabHint);
@@ -183,6 +193,7 @@ export function CommandPalette() {
     loadLogs,
     loadWorkbench,
     handleChatClear,
+    setActionNotice,
     openBugReport,
     desktopRuntime,
   ]);

--- a/packages/ui/src/components/shell/CommandPalette.workspace-launch.test.tsx
+++ b/packages/ui/src/components/shell/CommandPalette.workspace-launch.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Behavioral coverage for the palette's "Open Desktop Workspace" entry: the
+ * real <CommandPalette> is rendered in jsdom and the real option is clicked, so
+ * both the managed-shell route and the error-visibility boundary are exercised
+ * end to end within the component. Only the desktop bridge, view catalog, and
+ * shell store boundaries are substituted.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { bridge, state } = vi.hoisted(() => ({
+  bridge: {
+    openDesktopWorkspaceWindow: vi.fn(async () => {}),
+    openDesktopSettingsWindow: vi.fn(async () => {}),
+    openDesktopSurfaceWindow: vi.fn(async () => {}),
+    requestDesktopBridge: vi.fn(async () => undefined),
+  },
+  state: {
+    commandPaletteOpen: true,
+    commandQuery: "Desktop Workspace",
+    commandActiveIndex: 0,
+    agentStatus: { state: "stopped" },
+    handleStart: vi.fn(),
+    handleStop: vi.fn(),
+    handleRestart: vi.fn(),
+    setTab: vi.fn(),
+    loadPlugins: vi.fn(),
+    loadSkills: vi.fn(),
+    loadLogs: vi.fn(),
+    loadWorkbench: vi.fn(),
+    handleChatClear: vi.fn(),
+    activeGameViewerUrl: "",
+    setState: vi.fn(),
+    setActionNotice: vi.fn(),
+    t: (_key: string, vars?: { defaultValue?: string }) =>
+      vars?.defaultValue ?? "",
+  },
+}));
+
+vi.mock("../../bridge", () => ({ isElectrobunRuntime: () => true }));
+vi.mock("../../utils", () => bridge);
+vi.mock("../../hooks", () => ({ useBugReport: () => ({ open: vi.fn() }) }));
+vi.mock("../../hooks/useAvailableViews", () => ({
+  useAvailableViews: () => ({ views: [] }),
+}));
+vi.mock("../../state/useViewKinds", () => ({
+  useEnabledViewKinds: () => new Set<string>(),
+}));
+vi.mock("../../state", () => ({
+  useAppSelectorShallow: <T,>(selector: (s: typeof state) => T): T =>
+    selector(state),
+}));
+
+import { TOAST_TTL_MS } from "../../state/action-notice";
+import { CommandPalette } from "./CommandPalette";
+
+async function clickWorkspaceCommand(): Promise<void> {
+  render(<CommandPalette />);
+  const option = await screen.findByText("Open Desktop Workspace");
+  (option.closest("button") ?? option).dispatchEvent(
+    new MouseEvent("click", { bubbles: true }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  bridge.openDesktopWorkspaceWindow.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("<CommandPalette> Desktop Workspace entry", () => {
+  it("launches the managed workspace shell instead of the settings window", async () => {
+    await clickWorkspaceCommand();
+
+    await waitFor(() => {
+      expect(bridge.openDesktopWorkspaceWindow).toHaveBeenCalledOnce();
+    });
+    expect(bridge.openDesktopSettingsWindow).not.toHaveBeenCalled();
+    expect(state.setActionNotice).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a distinct error notice when the launch rejects", async () => {
+    bridge.openDesktopWorkspaceWindow.mockRejectedValueOnce(
+      new Error("Desktop workspace bridge returned no managed window"),
+    );
+
+    await clickWorkspaceCommand();
+
+    await waitFor(() => {
+      expect(state.setActionNotice).toHaveBeenCalledWith(
+        "Unable to open the desktop workspace. Please retry.",
+        "error",
+        TOAST_TTL_MS.notificationInterruptive,
+      );
+    });
+  });
+});

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -8272,6 +8272,8 @@
   "desktop.tray.quit": "Quit",
   "desktop.tray.testNotification.title": "Desktop",
   "desktop.tray.testNotification.body": "Renderer tray actions are wired and responding.",
+  "desktop.tray.actionFailed": "Unable to complete the desktop action. Please retry.",
+  "desktop.workspace.launchFailed": "Unable to open the desktop workspace. Please retry.",
   "mediagalleryview.Download": "Download",
   "mediagalleryview.DownloadFailed": "Could not download {{name}}: {{message}}",
   "mediagalleryview.Share": "Share",

--- a/packages/ui/src/utils/desktop-workspace.test.ts
+++ b/packages/ui/src/utils/desktop-workspace.test.ts
@@ -61,7 +61,7 @@ describe("openDesktopWorkspaceWindow", () => {
 
   it("rejects when the native bridge is unavailable so callers can show an error", async () => {
     await expect(openDesktopWorkspaceWindow()).rejects.toThrow(
-      "Desktop workspace bridge is unavailable",
+      "Desktop workspace bridge returned no managed window",
     );
   });
 
@@ -73,7 +73,22 @@ describe("openDesktopWorkspaceWindow", () => {
     };
 
     await expect(openDesktopWorkspaceWindow()).rejects.toThrow(
-      "Desktop workspace bridge is unavailable",
+      "Desktop workspace bridge returned no managed window",
     );
   });
+
+  it.each([{}, { id: "" }, { id: "   " }, { id: 42 }])(
+    "rejects malformed native window receipt %j",
+    async (receipt) => {
+      desktopWindow.__ELIZA_ELECTROBUN_RPC__ = {
+        request: { desktopOpenAppWindow: vi.fn(async () => receipt) },
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+      };
+
+      await expect(openDesktopWorkspaceWindow()).rejects.toThrow(
+        "Desktop workspace bridge returned no managed window",
+      );
+    },
+  );
 });

--- a/packages/ui/src/utils/desktop-workspace.test.ts
+++ b/packages/ui/src/utils/desktop-workspace.test.ts
@@ -1,0 +1,67 @@
+/** Verifies the desktop workspace launcher uses one exact managed-shell RPC contract. */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { openDesktopWorkspaceWindow } from "./desktop-workspace";
+
+interface DesktopBridgeTestWindow extends Window {
+  __ELIZA_ELECTROBUN_RPC__?: {
+    request: Record<string, (params?: unknown) => Promise<unknown>>;
+    onMessage: () => void;
+    offMessage: () => void;
+  };
+}
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const desktopWindow = {} as DesktopBridgeTestWindow;
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: desktopWindow,
+  });
+});
+
+afterEach(() => {
+  delete desktopWindow.__ELIZA_ELECTROBUN_RPC__;
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  if (originalWindow)
+    Object.defineProperty(globalThis, "window", originalWindow);
+  else Reflect.deleteProperty(globalThis, "window");
+});
+
+describe("openDesktopWorkspaceWindow", () => {
+  it("opens the canonical root shell with the stable dedupe slug", async () => {
+    const open = vi.fn(async () => undefined);
+    desktopWindow.__ELIZA_ELECTROBUN_RPC__ = {
+      request: { desktopOpenAppWindow: open },
+      onMessage: vi.fn(),
+      offMessage: vi.fn(),
+    };
+
+    await openDesktopWorkspaceWindow();
+
+    expect(open).toHaveBeenCalledWith({
+      slug: "workspace",
+      title: "Workspace",
+      path: "/",
+      alwaysOnTop: false,
+    });
+  });
+
+  it("rejects when the native bridge is unavailable so callers can show an error", async () => {
+    await expect(openDesktopWorkspaceWindow()).rejects.toThrow(
+      "Desktop workspace bridge is unavailable",
+    );
+  });
+});

--- a/packages/ui/src/utils/desktop-workspace.test.ts
+++ b/packages/ui/src/utils/desktop-workspace.test.ts
@@ -42,7 +42,7 @@ afterAll(() => {
 
 describe("openDesktopWorkspaceWindow", () => {
   it("opens the canonical root shell with the stable dedupe slug", async () => {
-    const open = vi.fn(async () => undefined);
+    const open = vi.fn(async () => ({ id: "app_workspace" }));
     desktopWindow.__ELIZA_ELECTROBUN_RPC__ = {
       request: { desktopOpenAppWindow: open },
       onMessage: vi.fn(),
@@ -60,6 +60,18 @@ describe("openDesktopWorkspaceWindow", () => {
   });
 
   it("rejects when the native bridge is unavailable so callers can show an error", async () => {
+    await expect(openDesktopWorkspaceWindow()).rejects.toThrow(
+      "Desktop workspace bridge is unavailable",
+    );
+  });
+
+  it("rejects an empty native response instead of reporting a successful launch", async () => {
+    desktopWindow.__ELIZA_ELECTROBUN_RPC__ = {
+      request: { desktopOpenAppWindow: vi.fn(async () => undefined) },
+      onMessage: vi.fn(),
+      offMessage: vi.fn(),
+    };
+
     await expect(openDesktopWorkspaceWindow()).rejects.toThrow(
       "Desktop workspace bridge is unavailable",
     );

--- a/packages/ui/src/utils/desktop-workspace.ts
+++ b/packages/ui/src/utils/desktop-workspace.ts
@@ -173,6 +173,20 @@ export async function openDesktopSettingsWindow(
   );
 }
 
+/** Open the complete Eliza shell in one deduplicated managed desktop window. */
+export async function openDesktopWorkspaceWindow(): Promise<void> {
+  await requestDesktopBridge<void>(
+    "desktopOpenAppWindow",
+    "desktop:openAppWindow",
+    {
+      slug: "workspace",
+      title: "Workspace",
+      path: "/",
+      alwaysOnTop: false,
+    },
+  );
+}
+
 export async function openDesktopSurfaceWindow(
   surface: DesktopWorkspaceSurface,
   options?: { browse?: string },

--- a/packages/ui/src/utils/desktop-workspace.ts
+++ b/packages/ui/src/utils/desktop-workspace.ts
@@ -175,7 +175,7 @@ export async function openDesktopSettingsWindow(
 
 /** Open the complete Eliza shell in one deduplicated managed desktop window. */
 export async function openDesktopWorkspaceWindow(): Promise<void> {
-  const response = await requestDesktopBridge<void>(
+  const response = await requestDesktopBridge<{ id: string }>(
     "desktopOpenAppWindow",
     "desktop:openAppWindow",
     {
@@ -185,7 +185,7 @@ export async function openDesktopWorkspaceWindow(): Promise<void> {
       alwaysOnTop: false,
     },
   );
-  if (response === null) {
+  if (response == null) {
     throw new Error("Desktop workspace bridge is unavailable");
   }
 }

--- a/packages/ui/src/utils/desktop-workspace.ts
+++ b/packages/ui/src/utils/desktop-workspace.ts
@@ -175,7 +175,7 @@ export async function openDesktopSettingsWindow(
 
 /** Open the complete Eliza shell in one deduplicated managed desktop window. */
 export async function openDesktopWorkspaceWindow(): Promise<void> {
-  const response = await requestDesktopBridge<{ id: string }>(
+  const response = await requestDesktopBridge<unknown>(
     "desktopOpenAppWindow",
     "desktop:openAppWindow",
     {
@@ -185,8 +185,12 @@ export async function openDesktopWorkspaceWindow(): Promise<void> {
       alwaysOnTop: false,
     },
   );
-  if (response == null) {
-    throw new Error("Desktop workspace bridge is unavailable");
+  const managedWindowId =
+    response && typeof response === "object" && "id" in response
+      ? response.id
+      : undefined;
+  if (typeof managedWindowId !== "string" || !managedWindowId.trim()) {
+    throw new Error("Desktop workspace bridge returned no managed window");
   }
 }
 

--- a/packages/ui/src/utils/desktop-workspace.ts
+++ b/packages/ui/src/utils/desktop-workspace.ts
@@ -175,7 +175,7 @@ export async function openDesktopSettingsWindow(
 
 /** Open the complete Eliza shell in one deduplicated managed desktop window. */
 export async function openDesktopWorkspaceWindow(): Promise<void> {
-  await requestDesktopBridge<void>(
+  const response = await requestDesktopBridge<void>(
     "desktopOpenAppWindow",
     "desktop:openAppWindow",
     {
@@ -185,6 +185,9 @@ export async function openDesktopWorkspaceWindow(): Promise<void> {
       alwaysOnTop: false,
     },
   );
+  if (response === null) {
+    throw new Error("Desktop workspace bridge is unavailable");
+  }
 }
 
 export async function openDesktopSurfaceWindow(


### PR DESCRIPTION
# Relates to

Fixes #23393.

Relates to #20714; this bounded launcher repair does not complete that broader canonical pill/chat/voice/mobile issue.

# Summary

Current `develop` already contains the canonical pill `ChatOverlay` and complete app-window renderer. This PR repairs the remaining launcher/window-ownership defect: tray, command-palette, and native Desktop → Desktop Workspace actions open the complete Eliza shell through one slug-deduplicated managed `workspace` window at `/`, rather than routing to Settings.

It also closes the source failure paths:

- renderer launch requires a valid managed-window receipt with a non-empty string id;
- command-palette and tray failures become visible shell error notices, routed through `t()` with the canonical `TOAST_TTL_MS.notificationInterruptive` dwell;
- native application-menu launch failures are logged and translated into an OS notification instead of becoming an unobserved rejection;
- **concurrent** opens serialize by slug, preserve aggregate always-on-top intent, return the authoritative final snapshot to every caller, clear failed reservations for retry, and focus the existing window rather than creating a duplicate. Sequential slug dedupe already existed at the merge base; the addition here is the in-flight/concurrent case.

# Exact-head review and verification

Current head: `a918b5f7bda0fb65a196af8aa46787e062e6ab44`
Rebased on: `f556c9003007c0423fac0755729228d1221542b2`

- Full Electrobun suite (`vitest.electrobun.config.ts`): 77 files / 588 tests pass, including the new `SurfaceWindowManager` regressions for slug-less concurrent opens and post-creation always-on-top registry notification. Both were confirmed to fail against a mutated implementation.
- Behavioral launcher coverage replaces the previous source-text grep assertions: `DesktopTrayRuntime.workspace.test.tsx` renders the real headless runtime and drives the real `TRAY_ACTION_EVENT`; `CommandPalette.workspace-launch.test.tsx` renders the real palette and clicks the real option. Both assert the managed-shell route and the distinct `error`-tone notice when the bridge rejects.
- Changed receipt tests reject missing, empty, whitespace, numeric, and object-only native responses.
- `packages/ui` and `packages/app-core` typecheck: the error sets on this head are byte-identical to the error sets produced by the same commands on `origin/develop` in the same worktree (app-core 57 = 57; ui 1 = 1). None of them are in files this PR touches.
- Biome `lint:check`: `packages/ui` clean (5 pre-existing warnings), Electrobun clean, `packages/app-core` reports one pre-existing `organizeImports` error in the untouched `src/runtime/agent-host-bridge-cookie-cors.test.ts`.
- Root `verify` and `audit:app` are still not claimed as passing on this head; see the blockers below.

# Evidence Gate

<!-- evidence-head:a918b5f7bda0fb65a196af8aa46787e062e6ab44 -->

<!-- evidence-row:before-screenshots -->
- [ ] Pending - packaged baseline showing the prior Settings launch behavior or an exact equivalent recorded comparison.
<!-- evidence-row:after-screenshots -->
- [ ] Pending - current-revision packaged full-workspace capture.
<!-- evidence-row:walkthrough-video -->
- [ ] Pending - current-revision packaged tray, command-palette, and native menu click walkthrough.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service change; native/renderer launch diagnostics belong in frontend logs.
<!-- evidence-row:frontend-logs -->
- [ ] Pending - current-revision packaged renderer/native launch log.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database or generated domain artifact changes.
<!-- evidence-row:ocr-review -->
- [ ] Pending - OCR/review of the packaged full workspace window.

# Known merge blockers

- Exact-head hosted checks must run on `09b68bcc`.
- The app-audit source-condition leak must be repaired or the canonical `bun run --cwd packages/app audit:app` must otherwise pass on this exact head.
- Rebuilt/installed macOS, Windows, and Linux packages must exercise tray, command palette, and native menu; attach screenshot, MP4, OCR, native/frontend logs, and build/install identity. This is human-only evidence and cannot be produced from a headless agent session.
- Distinct exact-head review is required.

# Provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`, `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`, `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a8327473d3082363d3f6087fd11cbdc12054a1e3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

