### PR TITLE
fix(ui): bound aec-loop harness fetches per hop

### DIFF
--- a/packages/ui/src/voice/aec-loop-harness.test.ts
+++ b/packages/ui/src/voice/aec-loop-harness.test.ts
@@ -6,7 +6,22 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { parseAecLoopHash } from "./aec-loop-harness";
+import {
+  AEC_LOOP_AEC_CAPTURE_GET_TIMEOUT_MS,
+  AEC_LOOP_AEC_CAPTURE_POST_TIMEOUT_MS,
+  AEC_LOOP_AUDIO_FRAMES_POST_TIMEOUT_MS,
+  AEC_LOOP_AUDIO_URL_GET_TIMEOUT_MS,
+  AEC_LOOP_NEAR_END_AUDIO_GET_TIMEOUT_MS,
+  AEC_LOOP_PLAYBACK_FRAMES_POST_TIMEOUT_MS,
+  AEC_LOOP_STATUS_GET_TIMEOUT_MS,
+  AEC_LOOP_TTS_POST_TIMEOUT_MS,
+  getAecLoopAudioUrlWithFetch,
+  getAecLoopJsonWithFetch,
+  getAecLoopNearEndAudioWithFetch,
+  parseAecLoopHash,
+  postAecLoopJsonWithFetch,
+  postAecLoopTtsWithFetch,
+} from "./aec-loop-harness";
 
 describe("parseAecLoopHash (#11373)", () => {
   it("returns null for unrelated hashes", () => {
@@ -47,3 +62,235 @@ describe("parseAecLoopHash (#11373)", () => {
     ).toEqual({});
   });
 });
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected aec-loop abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+const STATUS_URL = "/api/voice/audio-frames/status";
+const AEC_CAPTURE_URL = "/api/voice/aec-capture";
+const TTS_URL = "/api/tts/local-inference";
+const AUDIO_URL = "https://example.test/far.wav";
+const NEAR_URL = "https://example.test/near.wav";
+
+describe("aec-loop independent request deadlines", () => {
+  it("keeps a documented 15s budget per hop", () => {
+    expect(AEC_LOOP_STATUS_GET_TIMEOUT_MS).toBe(15_000);
+    expect(AEC_LOOP_AEC_CAPTURE_GET_TIMEOUT_MS).toBe(15_000);
+    expect(AEC_LOOP_AEC_CAPTURE_POST_TIMEOUT_MS).toBe(15_000);
+    expect(AEC_LOOP_PLAYBACK_FRAMES_POST_TIMEOUT_MS).toBe(15_000);
+    expect(AEC_LOOP_AUDIO_FRAMES_POST_TIMEOUT_MS).toBe(15_000);
+    expect(AEC_LOOP_AUDIO_URL_GET_TIMEOUT_MS).toBe(15_000);
+    expect(AEC_LOOP_TTS_POST_TIMEOUT_MS).toBe(15_000);
+    expect(AEC_LOOP_NEAR_END_AUDIO_GET_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("aborts a stalled status GET at the injected deadline", async () => {
+    await expect(
+      getAecLoopJsonWithFetch(STATUS_URL, stallUntilAborted(), 10, STATUS_URL),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed status GET", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("{}", { status: 503, statusText: "Service Unavailable" });
+    await expect(
+      getAecLoopJsonWithFetch(STATUS_URL, fetchImpl, 1_000, STATUS_URL),
+    ).rejects.toThrow("503");
+  });
+
+  it("uses the injected fetch for a successful status GET", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({ ok: true });
+    };
+    await expect(
+      getAecLoopJsonWithFetch(STATUS_URL, fetchImpl, 1_000, STATUS_URL),
+    ).resolves.toEqual({ ok: true });
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+  });
+
+  it("aborts a stalled aec-capture GET at its own deadline", async () => {
+    await expect(
+      getAecLoopJsonWithFetch(
+        AEC_CAPTURE_URL,
+        stallUntilAborted(),
+        10,
+        AEC_CAPTURE_URL,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed aec-capture GET", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("{}", { status: 503, statusText: "Service Unavailable" });
+    await expect(
+      getAecLoopJsonWithFetch(
+        AEC_CAPTURE_URL,
+        fetchImpl,
+        1_000,
+        AEC_CAPTURE_URL,
+      ),
+    ).rejects.toThrow("503");
+  });
+
+  it("uses the injected fetch for a successful aec-capture GET", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({ armed: false });
+    };
+    await expect(
+      getAecLoopJsonWithFetch(
+        AEC_CAPTURE_URL,
+        fetchImpl,
+        1_000,
+        AEC_CAPTURE_URL,
+      ),
+    ).resolves.toEqual({ armed: false });
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+  });
+
+  it("aborts a stalled aec-capture POST at its own deadline", async () => {
+    await expect(
+      postAecLoopJsonWithFetch(
+        AEC_CAPTURE_URL,
+        { arm: true },
+        stallUntilAborted(),
+        10,
+        AEC_CAPTURE_URL,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed aec-capture POST", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("{}", { status: 503, statusText: "Service Unavailable" });
+    await expect(
+      postAecLoopJsonWithFetch(
+        AEC_CAPTURE_URL,
+        { arm: true },
+        fetchImpl,
+        1_000,
+        AEC_CAPTURE_URL,
+      ),
+    ).rejects.toThrow("503");
+  });
+
+  it("uses the injected fetch for a successful aec-capture POST", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({ armed: true });
+    };
+    await expect(
+      postAecLoopJsonWithFetch(
+        AEC_CAPTURE_URL,
+        { arm: true },
+        fetchImpl,
+        1_000,
+        AEC_CAPTURE_URL,
+      ),
+    ).resolves.toEqual({ armed: true });
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+  });
+
+  it("aborts a stalled far-end audioUrl GET at its own deadline", async () => {
+    await expect(
+      getAecLoopAudioUrlWithFetch(AUDIO_URL, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed audioUrl GET", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 404, statusText: "Not Found" });
+    await expect(
+      getAecLoopAudioUrlWithFetch(AUDIO_URL, fetchImpl, 1_000),
+    ).rejects.toThrow("audioUrl -> 404");
+  });
+
+  it("uses the injected fetch for a successful audioUrl GET", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    };
+    const bytes = await getAecLoopAudioUrlWithFetch(AUDIO_URL, fetchImpl, 1_000);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(bytes.byteLength).toBe(3);
+  });
+
+  it("aborts a stalled TTS POST at its own deadline", async () => {
+    await expect(
+      postAecLoopTtsWithFetch(TTS_URL, { text: "hi" }, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed TTS POST", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 503, statusText: "Service Unavailable" });
+    await expect(
+      postAecLoopTtsWithFetch(TTS_URL, { text: "hi" }, fetchImpl, 1_000),
+    ).rejects.toThrow("tts -> 503");
+  });
+
+  it("uses the injected fetch for a successful TTS POST", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response(new Uint8Array([9]), { status: 200 });
+    };
+    const bytes = await postAecLoopTtsWithFetch(
+      TTS_URL,
+      { text: "hi" },
+      fetchImpl,
+      1_000,
+    );
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(bytes.byteLength).toBe(1);
+  });
+
+  it("aborts a stalled near-end audio GET at its own deadline", async () => {
+    await expect(
+      getAecLoopNearEndAudioWithFetch(NEAR_URL, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed near-end audio GET", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 502, statusText: "Bad Gateway" });
+    await expect(
+      getAecLoopNearEndAudioWithFetch(NEAR_URL, fetchImpl, 1_000),
+    ).rejects.toThrow("nearEndAudioUrl -> 502");
+  });
+
+  it("uses the injected fetch for a successful near-end audio GET", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response(new Uint8Array([4, 5]), { status: 200 });
+    };
+    const bytes = await getAecLoopNearEndAudioWithFetch(
+      NEAR_URL,
+      fetchImpl,
+      1_000,
+    );
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(bytes.byteLength).toBe(2);
+  });
+});
+

--- a/packages/ui/src/voice/aec-loop-harness.test.ts
+++ b/packages/ui/src/voice/aec-loop-harness.test.ts
@@ -1,11 +1,10 @@
 /**
- * `#aec-loop?...` hash-trigger parsing for the on-device AEC evidence harness
- * (#11373). The acoustic loop itself is device-only (getUserMedia + Web Audio
- * + the on-device agent); what is unit-testable is the trigger contract the
- * `elizaos://aec-loop?...` deep link relies on.
+ * Verifies the AEC evidence harness hash contract and request deadlines through
+ * the production native-client seam, with raw fetch reserved for external audio.
  */
-
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createAndroidNativeAgentTransport } from "../api/android-native-agent-transport";
+import { ElizaClient } from "../api/client-base";
 import {
   AEC_LOOP_AEC_CAPTURE_GET_TIMEOUT_MS,
   AEC_LOOP_AEC_CAPTURE_POST_TIMEOUT_MS,
@@ -14,14 +13,37 @@ import {
   AEC_LOOP_NEAR_END_AUDIO_GET_TIMEOUT_MS,
   AEC_LOOP_PLAYBACK_FRAMES_POST_TIMEOUT_MS,
   AEC_LOOP_STATUS_GET_TIMEOUT_MS,
-  AEC_LOOP_TTS_POST_TIMEOUT_MS,
   getAecLoopAudioUrlWithFetch,
-  getAecLoopJsonWithFetch,
+  getAecLoopJsonWithClient,
   getAecLoopNearEndAudioWithFetch,
   parseAecLoopHash,
-  postAecLoopJsonWithFetch,
-  postAecLoopTtsWithFetch,
+  postAecLoopJsonWithClient,
+  postAecLoopTtsWithClient,
 } from "./aec-loop-harness";
+
+interface NativeRequestOptions {
+  method?: string;
+  path: string;
+  headers?: Record<string, string>;
+  body?: string | null;
+  timeoutMs?: number;
+}
+
+interface NativeRequestResult {
+  status: number;
+  statusText?: string;
+  headers?: Record<string, string>;
+  body?: string | null;
+  bodyBase64?: string | null;
+}
+
+function clientWithNativeRequest(
+  request: (options: NativeRequestOptions) => Promise<NativeRequestResult>,
+): ElizaClient {
+  const apiClient = new ElizaClient("eliza-local-agent://ipc", "token");
+  apiClient.setRequestTransport(createAndroidNativeAgentTransport({ request }));
+  return apiClient;
+}
 
 describe("parseAecLoopHash (#11373)", () => {
   it("returns null for unrelated hashes", () => {
@@ -63,234 +85,187 @@ describe("parseAecLoopHash (#11373)", () => {
   });
 });
 
-function stallUntilAborted(): typeof fetch {
-  return ((_input, init) =>
-    new Promise<Response>((_resolve, reject) => {
-      const signal = init?.signal;
-      if (!signal) throw new Error("expected aec-loop abort signal");
-      signal.addEventListener("abort", () => reject(signal.reason), {
-        once: true,
-      });
-    })) as typeof fetch;
-}
-
-const STATUS_URL = "/api/voice/audio-frames/status";
-const AEC_CAPTURE_URL = "/api/voice/aec-capture";
-const TTS_URL = "/api/tts/local-inference";
-const AUDIO_URL = "https://example.test/far.wav";
-const NEAR_URL = "https://example.test/near.wav";
-
-describe("aec-loop independent request deadlines", () => {
-  it("keeps a documented 15s budget per hop", () => {
+describe("AEC-loop internal native-client deadlines", () => {
+  it("keeps documented independent JSON and external-audio budgets", () => {
     expect(AEC_LOOP_STATUS_GET_TIMEOUT_MS).toBe(15_000);
     expect(AEC_LOOP_AEC_CAPTURE_GET_TIMEOUT_MS).toBe(15_000);
     expect(AEC_LOOP_AEC_CAPTURE_POST_TIMEOUT_MS).toBe(15_000);
     expect(AEC_LOOP_PLAYBACK_FRAMES_POST_TIMEOUT_MS).toBe(15_000);
     expect(AEC_LOOP_AUDIO_FRAMES_POST_TIMEOUT_MS).toBe(15_000);
     expect(AEC_LOOP_AUDIO_URL_GET_TIMEOUT_MS).toBe(15_000);
-    expect(AEC_LOOP_TTS_POST_TIMEOUT_MS).toBe(15_000);
     expect(AEC_LOOP_NEAR_END_AUDIO_GET_TIMEOUT_MS).toBe(15_000);
   });
 
-  it("aborts a stalled status GET at the injected deadline", async () => {
-    await expect(
-      getAecLoopJsonWithFetch(STATUS_URL, stallUntilAborted(), 10, STATUS_URL),
-    ).rejects.toMatchObject({ name: "TimeoutError" });
-  });
+  it("forwards a JSON GET deadline into the native request context", async () => {
+    const request = vi.fn(async () => ({
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ready: true }),
+    }));
+    const apiClient = clientWithNativeRequest(request);
 
-  it("surfaces a provider error from a completed status GET", async () => {
-    const fetchImpl: typeof fetch = async () =>
-      new Response("{}", { status: 503, statusText: "Service Unavailable" });
     await expect(
-      getAecLoopJsonWithFetch(STATUS_URL, fetchImpl, 1_000, STATUS_URL),
-    ).rejects.toThrow("503");
-  });
-
-  it("uses the injected fetch for a successful status GET", async () => {
-    const signals: AbortSignal[] = [];
-    const fetchImpl: typeof fetch = async (_input, init) => {
-      if (init?.signal) signals.push(init.signal);
-      return Response.json({ ok: true });
-    };
-    await expect(
-      getAecLoopJsonWithFetch(STATUS_URL, fetchImpl, 1_000, STATUS_URL),
-    ).resolves.toEqual({ ok: true });
-    expect(signals).toHaveLength(1);
-    expect(signals[0]?.aborted).toBe(false);
-  });
-
-  it("aborts a stalled aec-capture GET at its own deadline", async () => {
-    await expect(
-      getAecLoopJsonWithFetch(
-        AEC_CAPTURE_URL,
-        stallUntilAborted(),
-        10,
-        AEC_CAPTURE_URL,
+      getAecLoopJsonWithClient(
+        "/api/voice/audio-frames/status",
+        apiClient,
+        3210,
       ),
-    ).rejects.toMatchObject({ name: "TimeoutError" });
+    ).resolves.toEqual({ ready: true });
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/voice/audio-frames/status",
+        timeoutMs: 3210,
+      }),
+    );
   });
 
-  it("surfaces a provider error from a completed aec-capture GET", async () => {
-    const fetchImpl: typeof fetch = async () =>
-      new Response("{}", { status: 503, statusText: "Service Unavailable" });
-    await expect(
-      getAecLoopJsonWithFetch(
-        AEC_CAPTURE_URL,
-        fetchImpl,
-        1_000,
-        AEC_CAPTURE_URL,
-      ),
-    ).rejects.toThrow("503");
-  });
+  it("forwards a JSON POST deadline and body into native", async () => {
+    const request = vi.fn(async () => ({
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ armed: true }),
+    }));
+    const apiClient = clientWithNativeRequest(request);
 
-  it("uses the injected fetch for a successful aec-capture GET", async () => {
-    const signals: AbortSignal[] = [];
-    const fetchImpl: typeof fetch = async (_input, init) => {
-      if (init?.signal) signals.push(init.signal);
-      return Response.json({ armed: false });
-    };
     await expect(
-      getAecLoopJsonWithFetch(
-        AEC_CAPTURE_URL,
-        fetchImpl,
-        1_000,
-        AEC_CAPTURE_URL,
-      ),
-    ).resolves.toEqual({ armed: false });
-    expect(signals).toHaveLength(1);
-    expect(signals[0]?.aborted).toBe(false);
-  });
-
-  it("aborts a stalled aec-capture POST at its own deadline", async () => {
-    await expect(
-      postAecLoopJsonWithFetch(
-        AEC_CAPTURE_URL,
+      postAecLoopJsonWithClient(
+        "/api/voice/aec-capture",
         { arm: true },
-        stallUntilAborted(),
-        10,
-        AEC_CAPTURE_URL,
-      ),
-    ).rejects.toMatchObject({ name: "TimeoutError" });
-  });
-
-  it("surfaces a provider error from a completed aec-capture POST", async () => {
-    const fetchImpl: typeof fetch = async () =>
-      new Response("{}", { status: 503, statusText: "Service Unavailable" });
-    await expect(
-      postAecLoopJsonWithFetch(
-        AEC_CAPTURE_URL,
-        { arm: true },
-        fetchImpl,
-        1_000,
-        AEC_CAPTURE_URL,
-      ),
-    ).rejects.toThrow("503");
-  });
-
-  it("uses the injected fetch for a successful aec-capture POST", async () => {
-    const signals: AbortSignal[] = [];
-    const fetchImpl: typeof fetch = async (_input, init) => {
-      if (init?.signal) signals.push(init.signal);
-      return Response.json({ armed: true });
-    };
-    await expect(
-      postAecLoopJsonWithFetch(
-        AEC_CAPTURE_URL,
-        { arm: true },
-        fetchImpl,
-        1_000,
-        AEC_CAPTURE_URL,
+        apiClient,
+        4321,
       ),
     ).resolves.toEqual({ armed: true });
-    expect(signals).toHaveLength(1);
-    expect(signals[0]?.aborted).toBe(false);
-  });
-
-  it("aborts a stalled far-end audioUrl GET at its own deadline", async () => {
-    await expect(
-      getAecLoopAudioUrlWithFetch(AUDIO_URL, stallUntilAborted(), 10),
-    ).rejects.toMatchObject({ name: "TimeoutError" });
-  });
-
-  it("surfaces a provider error from a completed audioUrl GET", async () => {
-    const fetchImpl: typeof fetch = async () =>
-      new Response("nope", { status: 404, statusText: "Not Found" });
-    await expect(
-      getAecLoopAudioUrlWithFetch(AUDIO_URL, fetchImpl, 1_000),
-    ).rejects.toThrow("audioUrl -> 404");
-  });
-
-  it("uses the injected fetch for a successful audioUrl GET", async () => {
-    const signals: AbortSignal[] = [];
-    const fetchImpl: typeof fetch = async (_input, init) => {
-      if (init?.signal) signals.push(init.signal);
-      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
-    };
-    const bytes = await getAecLoopAudioUrlWithFetch(AUDIO_URL, fetchImpl, 1_000);
-    expect(signals).toHaveLength(1);
-    expect(signals[0]?.aborted).toBe(false);
-    expect(bytes.byteLength).toBe(3);
-  });
-
-  it("aborts a stalled TTS POST at its own deadline", async () => {
-    await expect(
-      postAecLoopTtsWithFetch(TTS_URL, { text: "hi" }, stallUntilAborted(), 10),
-    ).rejects.toMatchObject({ name: "TimeoutError" });
-  });
-
-  it("surfaces a provider error from a completed TTS POST", async () => {
-    const fetchImpl: typeof fetch = async () =>
-      new Response("nope", { status: 503, statusText: "Service Unavailable" });
-    await expect(
-      postAecLoopTtsWithFetch(TTS_URL, { text: "hi" }, fetchImpl, 1_000),
-    ).rejects.toThrow("tts -> 503");
-  });
-
-  it("uses the injected fetch for a successful TTS POST", async () => {
-    const signals: AbortSignal[] = [];
-    const fetchImpl: typeof fetch = async (_input, init) => {
-      if (init?.signal) signals.push(init.signal);
-      return new Response(new Uint8Array([9]), { status: 200 });
-    };
-    const bytes = await postAecLoopTtsWithFetch(
-      TTS_URL,
-      { text: "hi" },
-      fetchImpl,
-      1_000,
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/voice/aec-capture",
+        timeoutMs: 4321,
+        body: JSON.stringify({ arm: true }),
+      }),
     );
-    expect(signals).toHaveLength(1);
-    expect(signals[0]?.aborted).toBe(false);
-    expect(bytes.byteLength).toBe(1);
   });
 
-  it("aborts a stalled near-end audio GET at its own deadline", async () => {
+  it("preserves the canonical three-minute cold local-TTS budget", async () => {
+    const request = vi.fn(async () => ({
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "audio/wav" },
+      bodyBase64: "AQID",
+    }));
+    const apiClient = clientWithNativeRequest(request);
+
+    const bytes = await postAecLoopTtsWithClient(
+      "/api/tts/local-inference",
+      { text: "hello" },
+      apiClient,
+    );
+
+    expect(new Uint8Array(bytes)).toEqual(new Uint8Array([1, 2, 3]));
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/tts/local-inference",
+        timeoutMs: 180_000,
+      }),
+    );
+  });
+
+  it("surfaces non-ok internal responses through ApiError", async () => {
+    const request = vi.fn(async () => ({
+      status: 503,
+      statusText: "Service Unavailable",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ error: "unavailable" }),
+    }));
+
     await expect(
-      getAecLoopNearEndAudioWithFetch(NEAR_URL, stallUntilAborted(), 10),
+      getAecLoopJsonWithClient(
+        "/api/voice/audio-frames/status",
+        clientWithNativeRequest(request),
+        5000,
+      ),
+    ).rejects.toMatchObject({ status: 503 });
+  });
+});
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected AEC-loop abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+describe("AEC-loop external audio deadlines", () => {
+  it("aborts a stalled far-end audio request", async () => {
+    await expect(
+      getAecLoopAudioUrlWithFetch(
+        "https://example.test/far.wav",
+        stallUntilAborted(),
+        10,
+      ),
     ).rejects.toMatchObject({ name: "TimeoutError" });
   });
 
-  it("surfaces a provider error from a completed near-end audio GET", async () => {
-    const fetchImpl: typeof fetch = async () =>
-      new Response("nope", { status: 502, statusText: "Bad Gateway" });
+  it("keeps the deadline active while an external audio body stalls", async () => {
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected external-audio abort signal");
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          signal.addEventListener(
+            "abort",
+            () => controller.error(signal.reason),
+            { once: true },
+          );
+        },
+      });
+      return new Response(body, { status: 200 });
+    };
+
     await expect(
-      getAecLoopNearEndAudioWithFetch(NEAR_URL, fetchImpl, 1_000),
-    ).rejects.toThrow("nearEndAudioUrl -> 502");
+      getAecLoopAudioUrlWithFetch(
+        "https://example.test/far.wav",
+        fetchImpl,
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
   });
 
-  it("uses the injected fetch for a successful near-end audio GET", async () => {
+  it("bounds the external response body and returns its bytes", async () => {
     const signals: AbortSignal[] = [];
     const fetchImpl: typeof fetch = async (_input, init) => {
       if (init?.signal) signals.push(init.signal);
       return new Response(new Uint8Array([4, 5]), { status: 200 });
     };
+
     const bytes = await getAecLoopNearEndAudioWithFetch(
-      NEAR_URL,
+      "https://example.test/near.wav",
       fetchImpl,
-      1_000,
+      1000,
     );
+
+    expect(new Uint8Array(bytes)).toEqual(new Uint8Array([4, 5]));
     expect(signals).toHaveLength(1);
     expect(signals[0]?.aborted).toBe(false);
-    expect(bytes.byteLength).toBe(2);
+  });
+
+  it("surfaces non-ok external audio responses", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 404, statusText: "Not Found" });
+
+    await expect(
+      getAecLoopAudioUrlWithFetch(
+        "https://example.test/far.wav",
+        fetchImpl,
+        1000,
+      ),
+    ).rejects.toThrow("audioUrl -> 404");
   });
 });
-

--- a/packages/ui/src/voice/aec-loop-harness.ts
+++ b/packages/ui/src/voice/aec-loop-harness.ts
@@ -42,6 +42,16 @@ const FRAME_SAMPLES = 320; // 20 ms @ 16 kHz — the device wire frame size
 const SHIP_INTERVAL_MS = 200;
 const RESULT_FILENAME = "eliza-aec-loop-result.json";
 
+/** Independent UI hops — same 15s Fal #21205 family, separate deadlines. */
+export const AEC_LOOP_STATUS_GET_TIMEOUT_MS = 15_000;
+export const AEC_LOOP_AEC_CAPTURE_GET_TIMEOUT_MS = 15_000;
+export const AEC_LOOP_AEC_CAPTURE_POST_TIMEOUT_MS = 15_000;
+export const AEC_LOOP_PLAYBACK_FRAMES_POST_TIMEOUT_MS = 15_000;
+export const AEC_LOOP_AUDIO_FRAMES_POST_TIMEOUT_MS = 15_000;
+export const AEC_LOOP_AUDIO_URL_GET_TIMEOUT_MS = 15_000;
+export const AEC_LOOP_TTS_POST_TIMEOUT_MS = 15_000;
+export const AEC_LOOP_NEAR_END_AUDIO_GET_TIMEOUT_MS = 15_000;
+
 export interface AecLoopRunOptions {
   /** Text synthesized by the on-device TTS and played from the speaker. */
   ttsText?: string;
@@ -232,11 +242,15 @@ class WireFramer {
   }
 }
 
-async function postJson(path: string, body: unknown): Promise<unknown> {
-  const res = await fetch(resolveApiUrl(path), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
+export async function getAecLoopJsonWithFetch(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+  failPath: string,
+): Promise<unknown> {
+  const res = await fetchImpl(url, {
+    headers: { accept: "application/json" },
+    signal: AbortSignal.timeout(timeoutMs),
   });
   // error-policy:J3 body parse is best-effort context for the thrown error;
   // non-2xx always throws below with the status either way
@@ -244,14 +258,23 @@ async function postJson(path: string, body: unknown): Promise<unknown> {
   // HTTP status is the real signal (thrown below), the body is only diagnostic.
   const json: unknown = await res.json().catch(() => null);
   if (!res.ok) {
-    throw new Error(`${path} -> ${res.status} ${JSON.stringify(json)}`);
+    throw new Error(`${failPath} -> ${res.status} ${JSON.stringify(json)}`);
   }
   return json;
 }
 
-async function getJson(path: string): Promise<unknown> {
-  const res = await fetch(resolveApiUrl(path), {
-    headers: { accept: "application/json" },
+export async function postAecLoopJsonWithFetch(
+  url: string,
+  body: unknown,
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+  failPath: string,
+): Promise<unknown> {
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   // error-policy:J3 body parse is best-effort context for the thrown error;
   // non-2xx always throws below with the status either way
@@ -259,9 +282,72 @@ async function getJson(path: string): Promise<unknown> {
   // HTTP status is the real signal (thrown below), the body is only diagnostic.
   const json: unknown = await res.json().catch(() => null);
   if (!res.ok) {
-    throw new Error(`${path} -> ${res.status} ${JSON.stringify(json)}`);
+    throw new Error(`${failPath} -> ${res.status} ${JSON.stringify(json)}`);
   }
   return json;
+}
+
+export async function getAecLoopAudioUrlWithFetch(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = AEC_LOOP_AUDIO_URL_GET_TIMEOUT_MS,
+): Promise<ArrayBuffer> {
+  const res = await fetchImpl(url, {
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) throw new Error(`audioUrl -> ${res.status}`);
+  return res.arrayBuffer();
+}
+
+export async function postAecLoopTtsWithFetch(
+  url: string,
+  body: { text: string },
+  fetchImpl: typeof fetch,
+  timeoutMs: number = AEC_LOOP_TTS_POST_TIMEOUT_MS,
+): Promise<ArrayBuffer> {
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) throw new Error(`tts -> ${res.status}`);
+  return res.arrayBuffer();
+}
+
+export async function getAecLoopNearEndAudioWithFetch(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = AEC_LOOP_NEAR_END_AUDIO_GET_TIMEOUT_MS,
+): Promise<ArrayBuffer> {
+  const res = await fetchImpl(url, {
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) throw new Error(`nearEndAudioUrl -> ${res.status}`);
+  return res.arrayBuffer();
+}
+
+async function postJson(
+  path: string,
+  body: unknown,
+  timeoutMs: number,
+): Promise<unknown> {
+  return postAecLoopJsonWithFetch(
+    resolveApiUrl(path),
+    body,
+    globalThis.fetch,
+    timeoutMs,
+    path,
+  );
+}
+
+async function getJson(path: string, timeoutMs: number): Promise<unknown> {
+  return getAecLoopJsonWithFetch(
+    resolveApiUrl(path),
+    globalThis.fetch,
+    timeoutMs,
+    path,
+  );
 }
 
 /** Best-effort native Documents sink (Capacitor Filesystem when present). */
@@ -332,7 +418,10 @@ async function runAecLoop(
     const bootDeadline = Date.now() + 300_000;
     for (;;) {
       try {
-        statusBefore = await getJson("/api/voice/audio-frames/status");
+        statusBefore = await getJson(
+          "/api/voice/audio-frames/status",
+          AEC_LOOP_STATUS_GET_TIMEOUT_MS,
+        );
         break;
       } catch (err) {
         // error-policy:J4 boot poll — retry until the deadline, then rethrow
@@ -343,7 +432,11 @@ async function runAecLoop(
     }
 
     log("arm aec-capture");
-    await postJson("/api/voice/aec-capture", { arm: true, maxSeconds });
+    await postJson(
+      "/api/voice/aec-capture",
+      { arm: true, maxSeconds },
+      AEC_LOOP_AEC_CAPTURE_POST_TIMEOUT_MS,
+    );
 
     log("getUserMedia (OS AEC disabled)");
     const stream = await navigator.mediaDevices.getUserMedia({
@@ -382,18 +475,17 @@ async function runAecLoop(
     let ttsBytes: ArrayBuffer;
     if (options.audioUrl) {
       log(`fetch far-end audio from ${options.audioUrl}`);
-      const audioRes = await fetch(options.audioUrl);
-      if (!audioRes.ok) throw new Error(`audioUrl -> ${audioRes.status}`);
-      ttsBytes = await audioRes.arrayBuffer();
+      ttsBytes = await getAecLoopAudioUrlWithFetch(
+        options.audioUrl,
+        globalThis.fetch,
+      );
     } else {
       log("fetch TTS");
-      const ttsRes = await fetch(resolveApiUrl("/api/tts/local-inference"), {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ text: ttsText }),
-      });
-      if (!ttsRes.ok) throw new Error(`tts -> ${ttsRes.status}`);
-      ttsBytes = await ttsRes.arrayBuffer();
+      ttsBytes = await postAecLoopTtsWithFetch(
+        resolveApiUrl("/api/tts/local-inference"),
+        { text: ttsText },
+        globalThis.fetch,
+      );
     }
     const ttsBuffer = await ctx.decodeAudioData(ttsBytes.slice(0));
     log(
@@ -425,9 +517,11 @@ async function runAecLoop(
     let nearEndDurationMs: number | null = null;
     if (options.nearEndAudioUrl) {
       log(`fetch near-end audio from ${options.nearEndAudioUrl.slice(0, 64)}`);
-      const nearRes = await fetch(options.nearEndAudioUrl);
-      if (!nearRes.ok) throw new Error(`nearEndAudioUrl -> ${nearRes.status}`);
-      const nearBuffer = await ctx.decodeAudioData(await nearRes.arrayBuffer());
+      const nearBytes = await getAecLoopNearEndAudioWithFetch(
+        options.nearEndAudioUrl,
+        globalThis.fetch,
+      );
+      const nearBuffer = await ctx.decodeAudioData(nearBytes.slice(0));
       nearEndDurationMs = Math.round(nearBuffer.duration * 1000);
       nearSource = ctx.createBufferSource();
       nearSource.buffer = nearBuffer;
@@ -443,11 +537,19 @@ async function runAecLoop(
       const micFrames = micFramer.take();
       try {
         if (playFrames.length) {
-          await postJson("/api/voice/playback-frames", { frames: playFrames });
+          await postJson(
+            "/api/voice/playback-frames",
+            { frames: playFrames },
+            AEC_LOOP_PLAYBACK_FRAMES_POST_TIMEOUT_MS,
+          );
           playPosts += 1;
         }
         if (micFrames.length) {
-          await postJson("/api/voice/audio-frames", { frames: micFrames });
+          await postJson(
+            "/api/voice/audio-frames",
+            { frames: micFrames },
+            AEC_LOOP_AUDIO_FRAMES_POST_TIMEOUT_MS,
+          );
           micPosts += 1;
         }
       } catch (err) {
@@ -484,10 +586,24 @@ async function runAecLoop(
     clearInterval(shipTimer);
     await ship();
     log("final flush");
-    await postJson("/api/voice/audio-frames", { frames: [], flush: true });
-    const statusAfter = await getJson("/api/voice/audio-frames/status");
-    await postJson("/api/voice/aec-capture", { disarm: true });
-    const aecCapture = await getJson("/api/voice/aec-capture");
+    await postJson(
+      "/api/voice/audio-frames",
+      { frames: [], flush: true },
+      AEC_LOOP_AUDIO_FRAMES_POST_TIMEOUT_MS,
+    );
+    const statusAfter = await getJson(
+      "/api/voice/audio-frames/status",
+      AEC_LOOP_STATUS_GET_TIMEOUT_MS,
+    );
+    await postJson(
+      "/api/voice/aec-capture",
+      { disarm: true },
+      AEC_LOOP_AEC_CAPTURE_POST_TIMEOUT_MS,
+    );
+    const aecCapture = await getJson(
+      "/api/voice/aec-capture",
+      AEC_LOOP_AEC_CAPTURE_GET_TIMEOUT_MS,
+    );
 
     track?.stop();
     micTap.disconnect();

--- a/packages/ui/src/voice/aec-loop-harness.ts
+++ b/packages/ui/src/voice/aec-loop-harness.ts
@@ -29,7 +29,7 @@
  * direct `window.__aecLoop.run(...)` call.
  */
 
-import { resolveApiUrl } from "../utils/asset-url";
+import { client } from "../api";
 
 declare global {
   interface Window {
@@ -49,7 +49,6 @@ export const AEC_LOOP_AEC_CAPTURE_POST_TIMEOUT_MS = 15_000;
 export const AEC_LOOP_PLAYBACK_FRAMES_POST_TIMEOUT_MS = 15_000;
 export const AEC_LOOP_AUDIO_FRAMES_POST_TIMEOUT_MS = 15_000;
 export const AEC_LOOP_AUDIO_URL_GET_TIMEOUT_MS = 15_000;
-export const AEC_LOOP_TTS_POST_TIMEOUT_MS = 15_000;
 export const AEC_LOOP_NEAR_END_AUDIO_GET_TIMEOUT_MS = 15_000;
 
 export interface AecLoopRunOptions {
@@ -242,49 +241,38 @@ class WireFramer {
   }
 }
 
-export async function getAecLoopJsonWithFetch(
-  url: string,
-  fetchImpl: typeof fetch,
-  timeoutMs: number,
-  failPath: string,
-): Promise<unknown> {
-  const res = await fetchImpl(url, {
-    headers: { accept: "application/json" },
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-  // error-policy:J3 body parse is best-effort context for the thrown error;
-  // non-2xx always throws below with the status either way
-  // error-policy:J3 parse-sanitize — an empty/non-JSON body becomes null; the
-  // HTTP status is the real signal (thrown below), the body is only diagnostic.
-  const json: unknown = await res.json().catch(() => null);
-  if (!res.ok) {
-    throw new Error(`${failPath} -> ${res.status} ${JSON.stringify(json)}`);
-  }
-  return json;
+interface AecLoopApiClient {
+  fetch<T>(
+    path: string,
+    init?: RequestInit,
+    options?: { timeoutMs?: number },
+  ): Promise<T>;
+  rawRequest(
+    path: string,
+    init?: RequestInit,
+    options?: { timeoutMs?: number },
+  ): Promise<Response>;
 }
 
-export async function postAecLoopJsonWithFetch(
-  url: string,
-  body: unknown,
-  fetchImpl: typeof fetch,
+export async function getAecLoopJsonWithClient(
+  path: string,
+  apiClient: AecLoopApiClient,
   timeoutMs: number,
-  failPath: string,
 ): Promise<unknown> {
-  const res = await fetchImpl(url, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-  // error-policy:J3 body parse is best-effort context for the thrown error;
-  // non-2xx always throws below with the status either way
-  // error-policy:J3 parse-sanitize — an empty/non-JSON body becomes null; the
-  // HTTP status is the real signal (thrown below), the body is only diagnostic.
-  const json: unknown = await res.json().catch(() => null);
-  if (!res.ok) {
-    throw new Error(`${failPath} -> ${res.status} ${JSON.stringify(json)}`);
-  }
-  return json;
+  return apiClient.fetch<unknown>(path, undefined, { timeoutMs });
+}
+
+export async function postAecLoopJsonWithClient(
+  path: string,
+  body: unknown,
+  apiClient: AecLoopApiClient,
+  timeoutMs: number,
+): Promise<unknown> {
+  return apiClient.fetch<unknown>(
+    path,
+    { method: "POST", body: JSON.stringify(body) },
+    { timeoutMs },
+  );
 }
 
 export async function getAecLoopAudioUrlWithFetch(
@@ -299,19 +287,18 @@ export async function getAecLoopAudioUrlWithFetch(
   return res.arrayBuffer();
 }
 
-export async function postAecLoopTtsWithFetch(
-  url: string,
+export async function postAecLoopTtsWithClient(
+  path: string,
   body: { text: string },
-  fetchImpl: typeof fetch,
-  timeoutMs: number = AEC_LOOP_TTS_POST_TIMEOUT_MS,
+  apiClient: AecLoopApiClient,
 ): Promise<ArrayBuffer> {
-  const res = await fetchImpl(url, {
+  // Do not override the canonical local-TTS budget: valid mobile CPU inference
+  // routinely exceeds ordinary request deadlines, especially on a cold load.
+  const res = await apiClient.rawRequest(path, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
-    signal: AbortSignal.timeout(timeoutMs),
   });
-  if (!res.ok) throw new Error(`tts -> ${res.status}`);
   return res.arrayBuffer();
 }
 
@@ -332,22 +319,11 @@ async function postJson(
   body: unknown,
   timeoutMs: number,
 ): Promise<unknown> {
-  return postAecLoopJsonWithFetch(
-    resolveApiUrl(path),
-    body,
-    globalThis.fetch,
-    timeoutMs,
-    path,
-  );
+  return postAecLoopJsonWithClient(path, body, client, timeoutMs);
 }
 
 async function getJson(path: string, timeoutMs: number): Promise<unknown> {
-  return getAecLoopJsonWithFetch(
-    resolveApiUrl(path),
-    globalThis.fetch,
-    timeoutMs,
-    path,
-  );
+  return getAecLoopJsonWithClient(path, client, timeoutMs);
 }
 
 /** Best-effort native Documents sink (Capacitor Filesystem when present). */
@@ -481,10 +457,10 @@ async function runAecLoop(
       );
     } else {
       log("fetch TTS");
-      ttsBytes = await postAecLoopTtsWithFetch(
-        resolveApiUrl("/api/tts/local-inference"),
+      ttsBytes = await postAecLoopTtsWithClient(
+        "/api/tts/local-inference",
         { text: ttsText },
-        globalThis.fetch,
+        client,
       );
     }
     const ttsBuffer = await ctx.decodeAudioData(ttsBytes.slice(0));


### PR DESCRIPTION
# Relates to

Bounds the AEC evidence harness request hops without bypassing native transport semantics or aborting valid cold local-TTS inference.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

Rebased onto exact `develop` SHA `ad68010c47040d9b0e4a5684243d328e2997df58` before repair and validation.

# Risks

Low after repair. Internal JSON routes use the canonical client with explicit per-hop timeout context. Internal binary TTS uses canonical `rawRequest` and intentionally inherits the established 180-second local-inference budget. Arbitrary external far/near audio URLs retain raw fetch with an active abort signal across headers and response-body consumption. Acoustic-loop processing and evidence output are unchanged.

# Background

The submitted head attached `AbortSignal.timeout` to every global fetch. Android and iOS local-agent fetch bridges discard that signal before native dispatch, so the claimed internal 15-second deadline never reached production. It also assigned `/api/tts/local-inference` a 15-second deadline, contradicting the canonical request policy: valid mobile CPU clips commonly take 15–30 seconds and cold inference may take much longer.

The repaired head separates the route classes. Internal agent JSON calls use `client.fetch(..., { timeoutMs })`; native Android/iOS transports receive the deadline in their request context and the client bounds JSON-body parsing. Local TTS uses `client.rawRequest` without overriding its route-specific 180-second policy. Only external audio URLs remain raw fetches because they are not agent routes and the browser/native HTTP signal correctly governs those requests.

# Testing

- AEC hash, native transport, cold-TTS budget, external request/body timeout, non-ok, and success suite: 14/14 passing.
- Biome on both changed files and `git diff --check`: pass.
- Full UI typecheck attempted; the isolated worktree lacks unrelated cloud `drizzle-orm`/`stripe` and task-coordinator/prompts workspace dependencies. It emits no diagnostic in either changed AEC file.
- App audit: pending the serialized shared audit queue; no rendered component or style changed.

# Evidence Gate

<!-- evidence-head:19f0100371ff3cdc2a689e11660540d390f3e2dc -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - device evidence harness transport only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - device evidence harness transport only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive product flow changed; the harness remains explicit-trigger only.
<!-- evidence-row:backend-logs -->
- [x] Exact-head validation transcript:
```text
AEC-loop focused suite: Test Files 1 passed; Tests 14 passed
Native context assertions: JSON GET/POST deadlines and cold TTS timeout 180000 observed
External audio: request stall and response-body stall abort; Biome/diff checks clean
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no product frontend logging changed; request options are asserted at the native boundary.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, or persisted evidence format changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or text changed.

## Known gaps / failures

The required app audit is held for the serialized shared audit queue and must pass before merge. The isolated full UI typecheck is blocked only by absent unrelated workspace dependencies listed above; focused compilation/tests and changed-file checks are clean.

---

AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol  
Client / agent tooling: Cursor; Codex desktop / multi-agent  
Contribution skill revision: elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@ad68010c47040d9b0e4a5684243d328e2997df58:packages/skills/skills/contribute-to-eliza"} -->
