### PR TITLE
fix(plugin-x): guard MAX_RETRIES so a NaN budget cannot bypass the authentication loop

### DIFF
--- a/plugins/plugin-x/src/base.max-retries.test.ts
+++ b/plugins/plugin-x/src/base.max-retries.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Deterministic unit coverage for the authentication retry-budget resolver:
+ * MAX_RETRIES values that are non-numeric, zero, or negative must fall back to
+ * the default instead of producing a NaN/non-positive budget that both skips
+ * the authenticate loop and defeats its failure guard.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./client/accounts", () => ({
+  resolveRequestedXAccountId: (
+    _runtime: unknown,
+    _state: unknown,
+    accountId: string | undefined,
+  ) => accountId ?? "default",
+  resolveTwitterAccountConfig: async (
+    _runtime: unknown,
+    options: { state: unknown },
+  ) => options.state,
+}));
+
+vi.mock("./client/auth-providers/factory", () => ({
+  createTwitterAuthProvider: () => ({}),
+}));
+
+import { ClientBase, resolveMaxAuthRetries, type TwitterProfile } from "./base";
+import type { TwitterClientState } from "./types";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("resolveMaxAuthRetries", () => {
+  it("defaults to 3 when MAX_RETRIES is unset or whitespace-only", () => {
+    expect(resolveMaxAuthRetries(undefined)).toBe(3);
+    expect(resolveMaxAuthRetries("")).toBe(3);
+    expect(resolveMaxAuthRetries(" \t\n ")).toBe(3);
+  });
+
+  it("accepts canonical positive safe integers with surrounding env whitespace", () => {
+    expect(resolveMaxAuthRetries("1")).toBe(1);
+    expect(resolveMaxAuthRetries("5")).toBe(5);
+    expect(resolveMaxAuthRetries(" 10 ")).toBe(10);
+    expect(resolveMaxAuthRetries(String(Number.MAX_SAFE_INTEGER))).toBe(
+      Number.MAX_SAFE_INTEGER,
+    );
+  });
+
+  it("rejects non-canonical decimal, exponent, sign, prefix, and suffix forms", () => {
+    for (const raw of [
+      "2.9",
+      "1.0",
+      ".5",
+      "1e3",
+      "+2",
+      "01",
+      "0x10",
+      "5junk",
+      "5n",
+    ]) {
+      expect(resolveMaxAuthRetries(raw)).toBe(3);
+    }
+  });
+
+  it("rejects zero, negatives, non-numbers, and unsafe integers", () => {
+    for (const raw of [
+      "0",
+      "-1",
+      "-100",
+      "abc",
+      "NaN",
+      "Infinity",
+      String(Number.MAX_SAFE_INTEGER + 1),
+      "9".repeat(400),
+    ]) {
+      expect(resolveMaxAuthRetries(raw)).toBe(3);
+    }
+  });
+
+  it("routes malformed budgets through the real init authentication call", async () => {
+    const profile: TwitterProfile = {
+      id: "account-1",
+      username: "agent",
+      screenName: "Agent",
+      bio: "",
+      nicknames: [],
+    };
+
+    for (const raw of ["abc", "2.9", "1e3", "5junk", "0", "-1"]) {
+      vi.stubEnv("MAX_RETRIES", raw);
+      const authenticate = vi.fn(async () => {});
+      const isLoggedIn = vi.fn(async () => true);
+      const client = new ClientBase(
+        {
+          agentId: "agent-1",
+          character: { name: "Agent" },
+          getSetting: () => undefined,
+        } as unknown as IAgentRuntime,
+        { accountId: "default" } as TwitterClientState,
+      );
+      client.twitterClient = {
+        authenticate,
+        isLoggedIn,
+      } as unknown as ClientBase["twitterClient"];
+      Object.assign(client, {
+        getAuthenticatedProfile: vi.fn(async () => profile),
+        populateTimeline: vi.fn(async () => {}),
+      });
+
+      await client.init();
+
+      expect(authenticate, raw).toHaveBeenCalledOnce();
+      expect(isLoggedIn, raw).toHaveBeenCalledOnce();
+      vi.unstubAllEnvs();
+    }
+  });
+});

--- a/plugins/plugin-x/src/base.ts
+++ b/plugins/plugin-x/src/base.ts
@@ -126,6 +126,24 @@ function errorDetail(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+const DEFAULT_MAX_AUTH_RETRIES = 3;
+
+/**
+ * Resolve the authentication retry budget from MAX_RETRIES. The budget feeds
+ * both `retryCount < maxRetries` and the `retryCount >= maxRetries` failure
+ * guard, and NaN is false in both — a non-numeric value would skip the
+ * authenticate loop AND its failure throw, letting init() continue
+ * unauthenticated. Surrounding environment whitespace is ignored, but any
+ * token that is not a canonical positive safe integer falls back to the
+ * default so authentication always gets at least one attempt.
+ */
+export function resolveMaxAuthRetries(raw: string | undefined): number {
+  const normalized = raw?.trim() ?? "";
+  if (!/^[1-9]\d*$/.test(normalized)) return DEFAULT_MAX_AUTH_RETRIES;
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) ? parsed : DEFAULT_MAX_AUTH_RETRIES;
+}
+
 /**
  * Class representing a request queue for handling asynchronous requests in a controlled manner.
  */
@@ -570,9 +588,7 @@ export class ClientBase {
     );
     const provider = createTwitterAuthProvider(this.runtime, this.state);
 
-    const maxRetries = process.env.MAX_RETRIES
-      ? parseInt(process.env.MAX_RETRIES, 10)
-      : 3;
+    const maxRetries = resolveMaxAuthRetries(process.env.MAX_RETRIES);
     let retryCount = 0;
     let lastError: Error | null = null;
 


### PR DESCRIPTION
# Relates to

Fixes #21859.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, rebased on exact `20b60f946097d4413facc30c6e13cff78e657ac0`, with zero conflicts.
- [x] Focused production-path tests, package typecheck, and changed-file Biome pass at the exact head.
- [x] Full plugin-suite result and its unrelated pre-existing runner incompatibility are recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`, `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: Codex desktop / multi-agent; Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@20b60f946097d4413facc30c6e13cff78e657ac0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: self-reported

Maintainer repair preserves the contributor's authorship and Claude co-author trailer.

## What

`ClientBase.init()` previously parsed `MAX_RETRIES` with a permissive `parseInt`. `NaN` made both the only authentication-loop condition and the post-loop failure guard false, allowing initialization to continue without authenticating. Zero and negative values skipped all valid credential attempts.

The repaired resolver trims ordinary environment whitespace, then accepts only a canonical base-10 positive safe integer (`/^[1-9]\\d*$/` plus `Number.isSafeInteger`). Decimal, exponent, sign, leading-zero, prefixed, suffixed, zero, negative, overflow, and arbitrarily large forms all fall back to the established default of 3.

The tests do not stop at the parser: malformed environment values are passed through the real `ClientBase.init()` implementation, and the production authentication and logged-in calls are asserted.

## Verification (exact head `e867d64b02db49a8d6e8d7dc7fa32b9053e88340`)

- `bun x vitest run --config ./vitest.config.ts src/base.max-retries.test.ts` — **5/5 passed**.
- Parser matrix includes unset/empty/whitespace, valid values including `Number.MAX_SAFE_INTEGER`, decimals (`2.9`, `1.0`, `.5`), exponent (`1e3`), sign (`+2`), leading zero (`01`), prefix (`0x10`), suffixes (`5junk`, `5n`), zero/negative, `NaN`/`Infinity`, `MAX_SAFE_INTEGER + 1`, and a 400-digit value.
- Real `ClientBase.init()` auth-wiring proof covers `abc`, `2.9`, `1e3`, `5junk`, `0`, and `-1`; every case invokes `authenticate()` and `isLoggedIn()`.
- `bun run typecheck` — **passed**.
- `bun x biome check src/base.ts src/base.max-retries.test.ts` — **passed**, no fixes.
- `git diff --check origin/develop...HEAD` — **passed**.
- `bun run test` — **31 files passed, 1 skipped; 229 tests passed, 13 skipped**. One unrelated pre-existing file fails collection because `src/lifeops-message-adapter.encoding.test.ts` imports `bun:test`, which Vitest cannot resolve. The changed suite is green and this patch does not touch that file.

# Evidence Gate

<!-- evidence-head:e867d64b02db49a8d6e8d7dc7fa32b9053e88340 -->

Backend authentication control-flow change with no rendered UI surface.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only control flow; no rendered visual surface exists to capture.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only control flow; no rendered visual surface exists to capture.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow; the failure mode is a skipped authentication loop.
<!-- evidence-row:backend-logs -->
- [x] Exact-head focused and package-wide command results are recorded in Verification above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface reads `MAX_RETRIES`.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, provider, model, or planner behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head parser boundary matrix and real `ClientBase.init()` auth-wiring assertions are committed in `base.max-retries.test.ts`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changes.
