### PR TITLE
fix(taskmarket): preserve Unicode code points at text length caps

### DIFF
--- a/plugins/plugin-taskmarket/src/client.ts
+++ b/plugins/plugin-taskmarket/src/client.ts
@@ -71,6 +71,9 @@ const TASK_TEXT_LIMITS = {
   cursor: 256,
 } as const;
 const MAX_TASK_TAGS = 10;
+const REMOTE_TEXT_SEGMENTER = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -88,14 +91,26 @@ function requireString(record: Record<string, unknown>, key: string): string {
 }
 
 function sanitizeRemoteText(value: string, maxLength: number): string {
-  return Array.from(value, (character) => {
+  const normalized = Array.from(value, (character) => {
     const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint >= 0xd800 && codePoint <= 0xdfff) return "\uFFFD";
     return codePoint < 32 || codePoint === 127 ? " " : character;
   })
     .join("")
     .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, maxLength);
+    .trim();
+
+  let result = "";
+  let codePointCount = 0;
+  // Keep the hard code-point budget, but never spend a partial grapheme: a
+  // combining or ZWJ cluster that does not fit is omitted as one unit.
+  for (const { segment } of REMOTE_TEXT_SEGMENTER.segment(normalized)) {
+    const segmentLength = Array.from(segment).length;
+    if (codePointCount + segmentLength > maxLength) break;
+    result += segment;
+    codePointCount += segmentLength;
+  }
+  return result;
 }
 
 function requireSanitizedString(

--- a/plugins/plugin-taskmarket/tests/client.test.ts
+++ b/plugins/plugin-taskmarket/tests/client.test.ts
@@ -169,6 +169,57 @@ describe("TaskmarketClient", () => {
     expect(page.nextCursor).not.toContain("\n");
   });
 
+  it.each([
+    {
+      label: "astral code point",
+      description: `${"a".repeat(179)}😀tail`,
+      expected: `${"a".repeat(179)}😀`,
+    },
+    {
+      label: "combining sequence",
+      description: `${"a".repeat(179)}e\u0301tail`,
+      expected: "a".repeat(179),
+    },
+    {
+      label: "ZWJ emoji sequence",
+      description: `${"a".repeat(174)}👨‍👩‍👧‍👦tail`,
+      expected: "a".repeat(174),
+    },
+    {
+      label: "many astral code points",
+      description: "😀".repeat(181),
+      expected: "😀".repeat(180),
+    },
+    {
+      label: "unpaired input surrogate",
+      description: "safe\ud83dtext",
+      expected: "safe\uFFFDtext",
+    },
+  ])(
+    "preserves a $label at the planner-visible cap",
+    async ({ description, expected }) => {
+      const fetcher = vi.fn(async () =>
+        response({
+          tasks: [{ ...validTask, description }],
+          hasMore: false,
+          nextCursor: null,
+        }),
+      );
+
+      const page = await new TaskmarketClient(
+        "https://example.test",
+        fetcher as typeof fetch,
+      ).listTasks();
+
+      const actual = page.tasks[0].description;
+      expect(actual).toBe(expected);
+      expect(new TextDecoder().decode(new TextEncoder().encode(actual))).toBe(
+        actual,
+      );
+      expect(Array.from(actual).length).toBeLessThanOrEqual(180);
+    },
+  );
+
   it("blocks redirects to private metadata addresses", async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(
       new Response(null, {


### PR DESCRIPTION
# Proposed changes

Taskmarket's remote-text sanitizer now enforces two independent invariants:

- The planner-visible hard limit remains a Unicode code-point budget.
- Truncation admits only complete grapheme clusters within that budget.

Malformed lone input surrogates are normalized to U+FFFD, so provider JSON cannot emit ill-formed strings.

# Why this approach

The submitted code-point slice correctly prevents splitting an astral surrogate pair, but it can still cut a combining sequence or ZWJ emoji cluster. A pure grapheme-count limit would weaken the security budget because one grapheme can contain arbitrarily many code points. The repaired implementation segments by grapheme while charging each segment's code points against the existing hard limit.

The repository pins Node 24, whose `Intl.Segmenter` implementation supports this server-side plugin path.

# Contribution provenance

The original author self-reported OpenAI Codex gpt-5.6-sol assistance and independent Anthropic claude-sonnet-5 verification. This final review and repair used the exact runtime below.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d117d213f579e55b66a1528fbef4229b0b9181f6:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Verification

- Exact reviewed head: `d117d213f579e55b66a1528fbef4229b0b9181f6`
- Full package tests: 20/20 passed across 2 files.
- Typecheck: passed.
- Build: passed.
- Biome lint:check: 10 files checked, no fixes.
- Cases cover astral boundaries, all-astral capacity, combining sequences, ZWJ emoji, malformed lone surrogates, UTF-8 round-trip well-formedness, and the hard code-point cap.
- Mutation proof: original UTF-16 slicing fails four cases; submitted code-point slicing still fails the combining and ZWJ cases; repaired dual-invariant logic passes all cases.

# Evidence Gate

<!-- evidence-head:d117d213f579e55b66a1528fbef4229b0b9181f6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only remote-text normalization; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only remote-text normalization; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic string normalization has no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - direct production client tests exercise the external-response boundary; no server route fires.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, model, prompt, provider, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head Unicode budget and mutation evidence](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21862-domain-artifacts.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Risk

Low and fail-closed. Under-limit well-formed text is unchanged. A grapheme that would cross the cap is omitted as a unit, and the output can never exceed the existing code-point budget.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@d117d213f579e55b66a1528fbef4229b0b9181f6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-c2]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@d117d213f579e55b66a1528fbef4229b0b9181f6:packages/skills/skills/contribute-to-eliza"} -->
