### PR TITLE
fix(plugin-slack): bound Slack OAuth token fetch

### DIFF
--- a/plugins/plugin-slack/src/connector-account-provider.test.ts
+++ b/plugins/plugin-slack/src/connector-account-provider.test.ts
@@ -3,6 +3,8 @@
  * patches, and deletes accounts against a mocked `ConnectorAccountManager` and a
  * fake runtime whose `getSetting` returns canned env values. No live Slack API.
  */
+
+import http from "node:http";
 import {
   type ConnectorAccount,
   type ConnectorAccountPatch,
@@ -320,12 +322,48 @@ describe("Slack OAuth token-exchange deadlines", () => {
       oauthTimeoutMs: 10,
     });
     await expect(
-      provider.completeOAuth?.(oauthRequest(), createOAuthCallbackManager(
-        SLACK_SERVICE_NAME,
-        "acct_slack_timeout",
-        vi.fn(async () => undefined),
-      ) as never),
+      provider.completeOAuth?.(
+        oauthRequest(),
+        createOAuthCallbackManager(
+          SLACK_SERVICE_NAME,
+          "acct_slack_timeout",
+          vi.fn(async () => undefined),
+        ) as never,
+      ),
     ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("keeps the deadline active while the token response body stalls", async () => {
+    const server = http.createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.write('{"ok":true');
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address() as import("node:net").AddressInfo;
+    const fetchImpl: typeof fetch = (_input, init) =>
+      fetch(`http://127.0.0.1:${address.port}/oauth`, init);
+    const provider = createSlackConnectorAccountProvider(oauthRuntime(), {
+      fetchImpl,
+      oauthTimeoutMs: 10,
+    });
+
+    try {
+      await expect(
+        provider.completeOAuth?.(
+          oauthRequest(),
+          createOAuthCallbackManager(
+            SLACK_SERVICE_NAME,
+            "acct_slack_body_timeout",
+            vi.fn(async () => undefined),
+          ) as never,
+        ),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("translates a completed token-exchange provider error", async () => {
@@ -339,11 +377,14 @@ describe("Slack OAuth token-exchange deadlines", () => {
       oauthTimeoutMs: 1_000,
     });
     await expect(
-      provider.completeOAuth?.(oauthRequest(), createOAuthCallbackManager(
-        SLACK_SERVICE_NAME,
-        "acct_slack_timeout",
-        vi.fn(async () => undefined),
-      ) as never),
+      provider.completeOAuth?.(
+        oauthRequest(),
+        createOAuthCallbackManager(
+          SLACK_SERVICE_NAME,
+          "acct_slack_timeout",
+          vi.fn(async () => undefined),
+        ) as never,
+      ),
     ).rejects.toThrow("Slack token exchange failed with 401");
   });
 
@@ -402,12 +443,11 @@ describe("Slack OAuth token-exchange deadlines", () => {
       id: "acct_slack_success",
       status: "connected",
     });
-    expect(vault.get("connector.agent-1.slack.acct_slack_success.oauth_tokens")).toContain(
-      "slack-access-token",
-    );
+    expect(
+      vault.get("connector.agent-1.slack.acct_slack_success.oauth_tokens"),
+    ).toContain("slack-access-token");
   });
 });
-
 
 function createOAuthCallbackManager(
   provider: string,

--- a/plugins/plugin-slack/src/connector-account-provider.test.ts
+++ b/plugins/plugin-slack/src/connector-account-provider.test.ts
@@ -10,7 +10,11 @@ import {
   type IAgentRuntime,
 } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createSlackConnectorAccountProvider } from "./connector-account-provider";
+import {
+  createSlackConnectorAccountProvider,
+  exchangeSlackOAuthTokenWithFetch,
+  SLACK_OAUTH_TIMEOUT_MS,
+} from "./connector-account-provider";
 import { SLACK_SERVICE_NAME } from "./types";
 
 function runtime(settings: Record<string, unknown>): IAgentRuntime {
@@ -261,6 +265,149 @@ describe("Slack ConnectorAccountManager provider", () => {
     ).rejects.toThrow(/durable connector credential store|vault writer/i);
   });
 });
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected slack oauth abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+function oauthRuntime(): IAgentRuntime {
+  return {
+    agentId: "agent-1",
+    character: {},
+    getSetting: vi.fn(
+      (key: string) =>
+        ({
+          SLACK_CLIENT_ID: "slack-client",
+          SLACK_CLIENT_SECRET: "slack-secret",
+          SLACK_REDIRECT_URI: "http://localhost/oauth/slack/callback",
+        })[key],
+    ),
+    getService: () => null,
+  } as IAgentRuntime;
+}
+
+function oauthRequest() {
+  return {
+    provider: SLACK_SERVICE_NAME,
+    code: "oauth-code",
+    query: {},
+    flow: {
+      id: "flow-1",
+      provider: SLACK_SERVICE_NAME,
+      state: "state-1",
+      status: "pending" as const,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
+  };
+}
+
+describe("Slack OAuth token-exchange deadlines", () => {
+  it("keeps a documented OAuth budget", () => {
+    expect(SLACK_OAUTH_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("aborts a stalled token exchange through completeOAuth()", async () => {
+    const provider = createSlackConnectorAccountProvider(oauthRuntime(), {
+      fetchImpl: stallUntilAborted(),
+      oauthTimeoutMs: 10,
+    });
+    await expect(
+      provider.completeOAuth?.(oauthRequest(), createOAuthCallbackManager(
+        SLACK_SERVICE_NAME,
+        "acct_slack_timeout",
+        vi.fn(async () => undefined),
+      ) as never),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("translates a completed token-exchange provider error", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("invalid_code", {
+        status: 401,
+        statusText: "Unauthorized",
+      });
+    const provider = createSlackConnectorAccountProvider(oauthRuntime(), {
+      fetchImpl,
+      oauthTimeoutMs: 1_000,
+    });
+    await expect(
+      provider.completeOAuth?.(oauthRequest(), createOAuthCallbackManager(
+        SLACK_SERVICE_NAME,
+        "acct_slack_timeout",
+        vi.fn(async () => undefined),
+      ) as never),
+    ).rejects.toThrow("Slack token exchange failed with 401");
+  });
+
+  it("translates a Slack ok:false token payload", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      Response.json({ ok: false, error: "invalid_code" });
+    await expect(
+      exchangeSlackOAuthTokenWithFetch("client_id=x", fetchImpl, 1_000),
+    ).rejects.toThrow("Slack token exchange returned an error: invalid_code");
+  });
+
+  it("exchanges an authorization code through completeOAuth()", async () => {
+    const signals: AbortSignal[] = [];
+    const vault = new Map<string, string>();
+    const setCredentialRef = vi.fn(async () => undefined);
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({
+        ok: true,
+        access_token: "slack-access-token",
+        refresh_token: "slack-refresh-token",
+        expires_in: 3600,
+        token_type: "bot",
+        scope: "chat:write,channels:read",
+        bot_user_id: "B123",
+        app_id: "A123",
+        team: { id: "T123", name: "Ada Team" },
+      });
+    };
+    const rt = {
+      ...oauthRuntime(),
+      getService: (serviceType: string) =>
+        serviceType === "vault"
+          ? {
+              set: async (key: string, value: string) => {
+                vault.set(key, value);
+              },
+            }
+          : null,
+    } as IAgentRuntime;
+    const provider = createSlackConnectorAccountProvider(rt, {
+      fetchImpl,
+      oauthTimeoutMs: 1_000,
+    });
+    const result = await provider.completeOAuth?.(
+      oauthRequest(),
+      createOAuthCallbackManager(
+        SLACK_SERVICE_NAME,
+        "acct_slack_success",
+        setCredentialRef,
+      ) as never,
+    );
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(result?.account).toMatchObject({
+      id: "acct_slack_success",
+      status: "connected",
+    });
+    expect(vault.get("connector.agent-1.slack.acct_slack_success.oauth_tokens")).toContain(
+      "slack-access-token",
+    );
+  });
+});
+
 
 function createOAuthCallbackManager(
   provider: string,

--- a/plugins/plugin-slack/src/connector-account-provider.ts
+++ b/plugins/plugin-slack/src/connector-account-provider.ts
@@ -34,7 +34,41 @@ import { persistConnectorCredentialRefs } from "./connector-credential-refs";
 import { SLACK_SERVICE_NAME } from "./types";
 
 const SLACK_OAUTH_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize";
-const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";
+export const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";
+
+/** Slack token-exchange POST — same 15s Fal #21205 family as Discord OAuth. */
+export const SLACK_OAUTH_TIMEOUT_MS = 15_000;
+
+export interface SlackConnectorAccountProviderOptions {
+  fetchImpl?: typeof fetch;
+  oauthTimeoutMs?: number;
+}
+
+export async function exchangeSlackOAuthTokenWithFetch(
+  body: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = SLACK_OAUTH_TIMEOUT_MS,
+): Promise<SlackOAuthV2Response> {
+  const response = await fetchImpl(SLACK_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `Slack token exchange failed with ${response.status}: ${text}`,
+    );
+  }
+  const parsed = (await response.json()) as SlackOAuthV2Response;
+  if (!parsed.ok || !parsed.access_token) {
+    throw new Error(
+      `Slack token exchange returned an error: ${parsed.error ?? "unknown"}`,
+    );
+  }
+  return parsed;
+}
 
 const DEFAULT_BOT_SCOPES = [
   "app_mentions:read",
@@ -209,7 +243,10 @@ function mergeStoredAccountPatch(
 
 export function createSlackConnectorAccountProvider(
   runtime: IAgentRuntime,
+  options: SlackConnectorAccountProviderOptions = {},
 ): ConnectorAccountProvider {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const oauthTimeoutMs = options.oauthTimeoutMs ?? SLACK_OAUTH_TIMEOUT_MS;
   return {
     provider: SLACK_SERVICE_NAME,
     label: "Slack",
@@ -336,23 +373,11 @@ export function createSlackConnectorAccountProvider(
         redirect_uri: redirectUri,
       });
 
-      const response = await fetch(SLACK_OAUTH_TOKEN_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: tokenParams.toString(),
-      });
-      if (!response.ok) {
-        const body = await response.text();
-        throw new Error(
-          `Slack token exchange failed with ${response.status}: ${body}`,
-        );
-      }
-      const parsed = (await response.json()) as SlackOAuthV2Response;
-      if (!parsed.ok || !parsed.access_token) {
-        throw new Error(
-          `Slack token exchange returned an error: ${parsed.error ?? "unknown"}`,
-        );
-      }
+      const parsed = await exchangeSlackOAuthTokenWithFetch(
+        tokenParams.toString(),
+        fetchImpl,
+        oauthTimeoutMs,
+      );
 
       const teamId = parsed.team?.id;
       if (!teamId) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). Slack `completeOAuth` used unbounded `fetch` for `POST https://slack.com/api/oauth.v2.access`, so a stalled token hop hangs the connector OAuth callback. This PR is Fal `#21205` **service-level** bar matching Discord `#21768` / Google `#21740`: injected `fetchImpl` on `createSlackConnectorAccountProvider`, TimeoutError, provider-error translation, and success, with a documented 15s OAuth deadline. Tests call `completeOAuth()` under abort. Not extra-decode. Not list-limit. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Not Twilio. Not shared-runtime. Not GitHub OAuth (`#21765` closed). Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Account list/create/patch/delete and startOAuth URL building unchanged. `createSlackConnectorAccountProvider(runtime)` stays valid; optional inject bag is backward-compatible. Unfixed head: token-exchange `fetch` had **no signal** and a hung POST never settled (80ms race → `HUNG` / `sawSignal: false`). After: 10ms deadline → `TimeoutError`. OAuth budget is 15s.

# Background

## What does this PR do?

`completeOAuth` called `fetch` with no `signal` when exchanging a Slack authorization code. A stalled Slack token hop never returns. This PR injects `exchangeSlackOAuthTokenWithFetch` plus optional `fetchImpl` (Fal `#21205` / Discord `#21768` shape) and adds `AbortSignal.timeout`.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Bot-token Slack paths untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-slack/src/connector-account-provider.test.ts` — `completeOAuth()` token-exchange timeout, provider-error translation, Slack `ok:false`, and success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-slack && bunx vitest run --config ./vitest.config.ts src/connector-account-provider.test.ts
```

Unfixed head `ad68010c470`: token-exchange `signal` was undefined and the call hung (`HUNG` / `sawSignal: false`). After the fix: 9 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface. Slack OAuth fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error translation, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live Slack OAuth path. vitest asserts TimeoutError, provider 401 / ok:false, and persisted token payload.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - Slack OAuth transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI and no live Slack. Unfixed hang: no signal, 80ms race `HUNG` / `sawSignal: false` on `completeOAuth()`. After the fix, vitest asserts TimeoutError, `401` / Slack `ok:false` translation, and successful token persist.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface change.

## Audio / voice walkthrough

N/A - OAuth provider HTTP only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`9 pass`). Root verify is an unrelated full-repo cost. No `bun install`.

<!-- evidence-head:ef02a398d6d0ecb2e263736b90319a549c906228 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Maintainer repair and exact-head validation

Reviewed and repaired at `ef02a398d6d0ecb2e263736b90319a549c906228` after rebasing onto current `develop`.

- Added a real local HTTP response whose JSON body remains open; production `completeOAuth()` now proves the same 15-second signal remains effective through body consumption and rejects with `TimeoutError`.
- Repaired the submitted test formatting.
- Focused connector-account provider: 10/10 tests pass.
- Full plugin suite: 6 files / 116 tests pass; one additional channel-gating file is collection-blocked only because the isolated sparse checkout omits `packages/agent`, with no assertion failure.
- Plugin TypeScript: PASS.
- Touched-file Biome and diff-check: PASS.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@ef02a398d6d0ecb2e263736b90319a549c906228:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [OpenAI]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@ef02a398d6d0ecb2e263736b90319a549c906228:packages/skills/skills/contribute-to-eliza"} -->
