### PR TITLE
fix(health): drop Fitbit sleep stages with non-positive durations

### DIFF
--- a/plugins/plugin-health/src/health-bridge/health-connectors.ts
+++ b/plugins/plugin-health/src/health-bridge/health-connectors.ts
@@ -682,7 +682,7 @@ function fitbitStageSamples(
   for (const entry of data) {
     const startAt = normalizeIso(getText(entry, "dateTime"));
     const seconds = getNumber(entry, "seconds");
-    if (!startAt || seconds === null) {
+    if (!startAt || seconds === null || seconds <= 0) {
       continue;
     }
     samples.push({

--- a/plugins/plugin-health/test/fitbit-connector.contract.test.ts
+++ b/plugins/plugin-health/test/fitbit-connector.contract.test.ts
@@ -78,6 +78,44 @@ afterEach(() => {
 });
 
 describe("Fitbit connector — recorded real API contract", () => {
+  it.each([
+    { label: "negative", seconds: -1800 },
+    { label: "zero", seconds: 0 },
+  ])("drops a $label-duration sleep stage", async ({ seconds }) => {
+    const malformedSleep = structuredClone(recorded.sleep);
+    const sleep = malformedSleep.sleep as Array<Record<string, unknown>>;
+    const levels = sleep[0]?.levels as Record<string, unknown>;
+    const data = levels?.data as Array<Record<string, unknown>>;
+    data[0] = { ...data[0], seconds };
+
+    vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/sleep/date/")) return jsonResponse(malformedSleep);
+      if (url.includes("/activities/heart/"))
+        return jsonResponse(recorded.heart);
+      if (url.includes("/activities/date/"))
+        return jsonResponse(recorded.activity);
+      if (url.includes("/body/log/weight/"))
+        return jsonResponse(recorded.weight);
+      if (url.includes("/profile.json")) return jsonResponse(recorded.profile);
+      throw new Error(`unexpected Fitbit fetch: ${url}`);
+    });
+
+    const payload = await syncHealthConnectorData({
+      token,
+      grantId: "grant-fitbit",
+      startDate: "2026-05-01",
+      endDate: "2026-05-01",
+    });
+
+    expect(payload.sleepEpisodes[0]?.stageSamples).toHaveLength(3);
+    expect(
+      payload.sleepEpisodes[0]?.stageSamples.every(
+        (sample) => Date.parse(sample.endAt) > Date.parse(sample.startAt),
+      ),
+    ).toBe(true);
+  });
+
   it("normalizes the real Fitbit per-date shapes into a contract-shaped payload", async () => {
     const payload = await syncHealthConnectorData({
       token,


### PR DESCRIPTION
# Proposed changes

Fitbit sleep-stage rows now require a strictly positive `levels.data[].seconds` value before the connector emits a stage interval. This prevents zero-length and backward intervals from reaching sleep analysis.

Fixes the provider-boundary defect described in this PR.

# Provider contract research

Fitbit documents `levels.data[].seconds` as the length of time spent in the stage and states that stage data has 30-second granularity: https://dev.fitbit.com/build/reference/web-api/sleep/get-sleep-log-by-date/

The documentation does not publish a numeric minimum. Rejecting only non-positive values is therefore the narrow correction; this PR does not impose an undocumented 30-second minimum.

# Contribution provenance

The original author self-reported initial OpenAI Codex gpt-5.6-sol assistance and independent Anthropic claude-sonnet-5 verification. This final review and repair used the exact runtime below.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8b12a633d4b3e271ea85e152a01ddca2a5f3e7cc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Verification

- Exact reviewed head: `8b12a633d4b3e271ea85e152a01ddca2a5f3e7cc`
- Focused recorded-provider contract: 6/6 passed, with separate negative and zero cases.
- Full plugin-health lane: 35 files passed, 4 skipped; 191 tests passed, 4 skipped.
- Mutation proof: removing only the source guard made both new cases fail (`expected 3, got 4`); restoring it returned green.
- plugin-health typecheck: passed.
- plugin-health build (JS, views, types): passed.
- plugin-health lint:check: 119 files checked, no fixes.

# Evidence Gate

<!-- evidence-head:8b12a633d4b3e271ea85e152a01ddca2a5f3e7cc -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Fitbit normalization; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Fitbit normalization; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic connector normalization has no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - recorded provider JSON was replayed through the production connector normalizer; no server route fires.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, model, prompt, provider, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head Fitbit contract and mutation evidence](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21865-domain-artifacts.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Risk

Low and fail-closed. All positive durations remain accepted. Missing, non-numeric, zero, and negative durations are omitted rather than converted into invalid intervals.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@8b12a633d4b3e271ea85e152a01ddca2a5f3e7cc:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-c2]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@8b12a633d4b3e271ea85e152a01ddca2a5f3e7cc:packages/skills/skills/contribute-to-eliza"} -->

