### PR TITLE
fix(plugin-x): guard MAX_RETRIES parse against NaN

### DIFF
--- a/plugins/plugin-x/src/base.ts
+++ b/plugins/plugin-x/src/base.ts
@@ -570,9 +570,11 @@ export class ClientBase {
     );
     const provider = createTwitterAuthProvider(this.runtime, this.state);
 
-    const maxRetries = process.env.MAX_RETRIES
+    const parsedRetries = process.env.MAX_RETRIES
       ? parseInt(process.env.MAX_RETRIES, 10)
       : 3;
+    const maxRetries =
+      Number.isFinite(parsedRetries) && parsedRetries > 0 ? parsedRetries : 3;
     let retryCount = 0;
     let lastError: Error | null = null;
 


### PR DESCRIPTION
## Summary

Validates that `MAX_RETRIES` env var parses to a finite positive integer. Falls back to default (3) if the env var is missing, non-numeric, NaN, Infinity, or <= 0.

## Problem

`parseInt(process.env.MAX_RETRIES, 10)` returns `NaN` for non-numeric values like `"abc"`. This causes:
1. `retryCount < maxRetries` (0 < NaN) → `false` → authentication loop never runs
2. `retryCount >= maxRetries` (0 >= NaN) → `false` → no error thrown

Result: silently skips authentication entirely.

## Fix

```ts
const parsedRetries = process.env.MAX_RETRIES
  ? parseInt(process.env.MAX_RETRIES, 10)
  : 3;
const maxRetries =
  Number.isFinite(parsedRetries) && parsedRetries > 0 ? parsedRetries : 3;
```

## Test

- `MAX_RETRIES=abc` → falls back to 3
- `MAX_RETRIES=NaN` → falls back to 3
- `MAX_RETRIES=-5` → falls back to 3
- `MAX_RETRIES=5` → uses 5
- `MAX_RETRIES=` → falls back to 3

Closes #21859