### PR TITLE
fix(ui): bound content-pack manifest fetch

### DIFF
--- a/packages/ui/src/content-packs/load-pack-timeout.test.ts
+++ b/packages/ui/src/content-packs/load-pack-timeout.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Exercises the content-pack manifest deadline, provider errors, successful
+ * body consumption, and the exported URL-loader wiring.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/shared", () => ({
+  CONTENT_PACK_MANIFEST_FILENAME: "pack.json",
+  validateContentPackManifest: () => [],
+}));
+
+import {
+  CONTENT_PACK_MANIFEST_FETCH_TIMEOUT_MS,
+  ContentPackLoadError,
+  getContentPackManifestJsonWithFetch,
+  loadContentPackFromUrl,
+} from "./load-pack";
+
+const MANIFEST_URL = "https://example.com/packs/cyberpunk-neon/pack.json";
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected content-pack abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("content-pack manifest deadline", () => {
+  it("keeps a documented UI fetch budget", () => {
+    expect(CONTENT_PACK_MANIFEST_FETCH_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("aborts a stalled manifest GET at the injected deadline", async () => {
+    await expect(
+      getContentPackManifestJsonWithFetch(
+        MANIFEST_URL,
+        stallUntilAborted(),
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("keeps the same deadline active while the response body stalls", async () => {
+    const fetchImpl: typeof fetch = async (_input, init) =>
+      ({
+        ok: true,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            const signal = init?.signal;
+            if (!signal) throw new Error("expected content-pack abort signal");
+            signal.addEventListener("abort", () => reject(signal.reason), {
+              once: true,
+            });
+          }),
+      }) as Response;
+
+    await expect(
+      getContentPackManifestJsonWithFetch(MANIFEST_URL, fetchImpl, 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed manifest GET", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 503, statusText: "Service Unavailable" });
+
+    await expect(
+      getContentPackManifestJsonWithFetch(MANIFEST_URL, fetchImpl, 1_000),
+    ).rejects.toThrow("503");
+  });
+
+  it("consumes successful JSON with a live, non-aborted signal", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return Response.json({ id: "cyberpunk-neon" });
+    };
+
+    await expect(
+      getContentPackManifestJsonWithFetch<{ id: string }>(
+        MANIFEST_URL,
+        fetchImpl,
+        1_000,
+      ),
+    ).resolves.toEqual({ id: "cyberpunk-neon" });
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+  });
+
+  it("wires the exported URL loader through the bounded fetch seam", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      expect(init?.method).toBe("GET");
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return Response.json({
+        id: "cyberpunk-neon",
+        name: "Cyberpunk Neon",
+        version: "1.0.0",
+        assets: {},
+      });
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+
+    const pack = await loadContentPackFromUrl(
+      "https://example.com/packs/cyberpunk-neon",
+    );
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe(MANIFEST_URL);
+    expect(pack.source).toEqual({
+      kind: "url",
+      url: "https://example.com/packs/cyberpunk-neon/",
+    });
+  });
+
+  it("preserves the loader's structured boundary error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        Promise.reject(new DOMException("deadline", "TimeoutError")),
+      ),
+    );
+
+    const error = await loadContentPackFromUrl(
+      "https://example.com/packs/cyberpunk-neon/",
+    ).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ContentPackLoadError);
+    expect(error).toMatchObject({
+      source: {
+        kind: "url",
+        url: "https://example.com/packs/cyberpunk-neon/",
+      },
+      cause: { name: "TimeoutError" },
+    });
+  });
+});

--- a/packages/ui/src/content-packs/load-pack.ts
+++ b/packages/ui/src/content-packs/load-pack.ts
@@ -14,6 +14,25 @@ import {
   validateContentPackManifest,
 } from "@elizaos/shared";
 
+/** Manifest reads are short UI requests and must not stall pack loading. */
+export const CONTENT_PACK_MANIFEST_FETCH_TIMEOUT_MS = 15_000;
+
+/** Fetch and fully consume one manifest within a single request/body deadline. */
+export async function getContentPackManifestJsonWithFetch<T>(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = CONTENT_PACK_MANIFEST_FETCH_TIMEOUT_MS,
+): Promise<T> {
+  const response = await fetchImpl(url, {
+    method: "GET",
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as T;
+}
+
 export class ContentPackLoadError extends Error {
   constructor(
     message: string,
@@ -40,12 +59,12 @@ export async function loadContentPackFromUrl(
 
   let raw: unknown;
   try {
-    const res = await fetch(manifestUrl);
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status} ${res.statusText}`);
-    }
-    raw = await res.json();
+    raw = await getContentPackManifestJsonWithFetch(
+      manifestUrl,
+      globalThis.fetch,
+    );
   } catch (err) {
+    // error-policy:J2 add manifest URL context while preserving the fetch failure.
     throw new ContentPackLoadError(
       `Failed to fetch pack manifest from ${manifestUrl}`,
       source,
@@ -88,6 +107,7 @@ export async function loadContentPackFromFiles(
   try {
     raw = JSON.parse(await packFile.text());
   } catch (err) {
+    // error-policy:J2 add local-pack context while preserving the parse failure.
     throw new ContentPackLoadError(
       "Failed to parse pack.json",
       { kind: "file", path: "local-folder" },


### PR DESCRIPTION
# Relates to

Replaces #21831 because the contributor fork rejected maintainer repair pushes. The original bug is an unbounded external content-pack `pack.json` request; this repair bounds both the request and response-body read without routing an arbitrary external URL through the authenticated Eliza API client.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill path: N/A - repository-native review workflow
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto current `origin/develop` at `ad68010c47040d9b0e4a5684243d328e2997df58` with zero conflicts.
- [x] Exact-head focused tests, owning-package typecheck, Biome, and diff checks pass.

# Risks

Low and bounded. Existing manifest validation, asset resolution, and structured `ContentPackLoadError` translation are unchanged. The single `AbortSignal.timeout` remains active through `response.json()`, so a stalled body cannot outlive the request deadline.

# Background

## What does this PR do?

Adds a 15-second deadline to external content-pack manifest reads, tests request stalls and body stalls, preserves provider failures and successful loading, and documents both retained error-policy boundaries. It also keeps the existing bundled-pack path covered.

## What kind of change is this?

Bug fix; no schema or rendered-layout change.

# Testing

Exact repaired head `608e80c2f87eee10c9181fb7989d90074219ab05`:

- `vitest` content-pack timeout + bundled-pack suites: 2 files, 11/11 tests.
- `bun run --cwd packages/ui typecheck`: pass.
- Biome on both touched files: pass.
- `git diff --check origin/develop...HEAD`: pass.
- Mandatory app capture: 218/219 passed; zero broken views. The final aggregate reproduced the same unrelated three minimalism ratchets and nine hover-probe timeouts independently observed on #21804.
- Packaged OCR: 194/216 verified. The only new OCR regression was unrelated `plugin-health-gui` mobile-landscape, whose screenshot visibly clips the Health title; this PR never imports or renders that plugin.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - transport-only content-pack loader change; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - transport-only content-pack loader change; full app capture was nevertheless run.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user interaction or layout change.
<!-- evidence-row:backend-logs -->
- [x] N/A - browser-side external manifest request.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no console/network logging contract changed; focused tests directly prove request timeout, body timeout, 503 propagation, successful JSON, production loader wiring, and structured error preservation.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model/prompt behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, or native artifact.
<!-- evidence-row:ocr-review -->
- [x] Packaged OCR completed: 194 verified, 19 needs-eyeball, 3 broken baseline views; the sole new unrelated Health-title crop is documented above.

## Known gaps / failures

The strict app aggregate and OCR exit nonzero only for the unrelated baseline findings listed above. The changed content-pack code has no rendered view and all exact-head functional/type/format gates pass.

<!-- evidence-head:608e80c2f87eee10c9181fb7989d90074219ab05 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Attribution status: exact runtime self-reported
