### PR TITLE
fix(wallet): bound X402Client fetch with timeout

### DIFF
--- a/plugins/plugin-wallet/src/sdk/x402/client.timeout.test.ts
+++ b/plugins/plugin-wallet/src/sdk/x402/client.timeout.test.ts
@@ -12,6 +12,36 @@ function createWallet() {
   } as unknown as import("../wallet-core").AgentWallet;
 }
 
+function listen(server: http.Server): Promise<import("node:net").AddressInfo> {
+  return new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", resolve),
+  ).then(() => server.address() as import("node:net").AddressInfo);
+}
+
+function close(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+const PAYMENT_OPTION = {
+  scheme: "exact",
+  network: "base:8453",
+  asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  amount: "1",
+  payTo: "0x0000000000000000000000000000000000000002",
+  maxTimeoutSeconds: 60,
+  extra: {},
+} as const;
+
+const PAYMENT_REQUIRED = {
+  x402Version: 1,
+  resource: {
+    url: "https://example.test/data",
+    description: "test resource",
+    mimeType: "application/json",
+  },
+  accepts: [PAYMENT_OPTION],
+};
+
 describe("X402Client fetch timeout (real server)", () => {
   it("exposes the documented 10s budget", () => {
     expect(DEFAULT_X402_FETCH_TIMEOUT_MS).toBe(10_000);
@@ -72,6 +102,98 @@ describe("X402Client fetch timeout (real server)", () => {
     } finally {
       fetchSpy.mockRestore();
       await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("keeps the first-request deadline active while its body stalls", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write('{"ok":');
+    });
+    const addr = await listen(server);
+    const client = new X402Client(createWallet(), { autoPay: false });
+    const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation(() => originalTimeout(10));
+
+    try {
+      const response = await client.fetch(`http://127.0.0.1:${addr.port}/data`);
+      await expect(response.json()).rejects.toMatchObject({
+        name: "TimeoutError",
+      });
+      expect(timeoutSpy).toHaveBeenCalledWith(DEFAULT_X402_FETCH_TIMEOUT_MS);
+    } finally {
+      timeoutSpy.mockRestore();
+      await close(server);
+    }
+  });
+
+  it("propagates a deadline while parsing a stalled 402 body", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(402, { "content-type": "application/json" });
+      res.write('{"x402Version":');
+    });
+    const addr = await listen(server);
+    const client = new X402Client(createWallet());
+    const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation(() => originalTimeout(10));
+
+    try {
+      await expect(
+        client.fetch(`http://127.0.0.1:${addr.port}/data`),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+    } finally {
+      timeoutSpy.mockRestore();
+      await close(server);
+    }
+  });
+
+  it("keeps a fresh deadline active through the paid retry body", async () => {
+    let requestCount = 0;
+    let retryPaymentHeader: string | undefined;
+    const server = http.createServer((req, res) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        res.writeHead(402, {
+          "payment-required": btoa(JSON.stringify(PAYMENT_REQUIRED)),
+        });
+        res.end();
+        return;
+      }
+      retryPaymentHeader = req.headers["x-payment"];
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write('{"paid":');
+    });
+    const addr = await listen(server);
+    const client = new X402Client(createWallet(), {
+      supportedAssets: { "base:8453": [PAYMENT_OPTION.asset] },
+    });
+    Object.defineProperty(client, "executePayment", {
+      value: vi.fn(async () => ({
+        txHash:
+          "0x0000000000000000000000000000000000000000000000000000000000000001",
+      })),
+    });
+    const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation(() => originalTimeout(25));
+
+    try {
+      const response = await client.fetch(`http://127.0.0.1:${addr.port}/data`);
+      expect(requestCount).toBe(2);
+      expect(retryPaymentHeader).toBeTruthy();
+      await expect(response.json()).rejects.toMatchObject({
+        name: "TimeoutError",
+      });
+      expect(timeoutSpy).toHaveBeenCalledTimes(2);
+      expect(timeoutSpy).toHaveBeenCalledWith(DEFAULT_X402_FETCH_TIMEOUT_MS);
+    } finally {
+      timeoutSpy.mockRestore();
+      await close(server);
     }
   });
 

--- a/plugins/plugin-wallet/src/sdk/x402/client.timeout.test.ts
+++ b/plugins/plugin-wallet/src/sdk/x402/client.timeout.test.ts
@@ -1,0 +1,129 @@
+/**
+ * X402Client fetch deadline — proves the production client aborts on timeout
+ * via a real hanging HTTP server, not a stubbed helper.
+ */
+import http from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_X402_FETCH_TIMEOUT_MS, X402Client } from "./client";
+
+function createWallet() {
+  return {
+    address: "0x0000000000000000000000000000000000000001",
+  } as unknown as import("../wallet-core").AgentWallet;
+}
+
+describe("X402Client fetch timeout (real server)", () => {
+  it("exposes the documented 10s budget", () => {
+    expect(DEFAULT_X402_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("aborts a stalled X402 fetch via the client boundary", async () => {
+    const server = http.createServer((_req, _res) => {
+      // hang
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/data`;
+
+    const client = new X402Client(createWallet(), { autoPay: false });
+
+    const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation(() => originalTimeout(10));
+
+    try {
+      await expect(client.fetch(url)).rejects.toMatchObject({
+        name: "TimeoutError",
+      });
+      expect(timeoutSpy).toHaveBeenCalledWith(DEFAULT_X402_FETCH_TIMEOUT_MS);
+    } finally {
+      timeoutSpy.mockRestore();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("sends the abort signal and succeeds on a fast upstream", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/data`;
+
+    const client = new X402Client(createWallet(), { autoPay: false });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    try {
+      const res = await client.fetch(url);
+      expect(res.status).toBe(200);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      const signal = (fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined)
+        ?.signal as AbortSignal | undefined;
+      expect(signal?.aborted).toBe(false);
+    } finally {
+      fetchSpy.mockRestore();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("merges a caller signal via AbortSignal.any", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/data`;
+
+    const client = new X402Client(createWallet(), { autoPay: false });
+    const controller = new AbortController();
+    const anySpy = vi.spyOn(AbortSignal, "any");
+
+    try {
+      const res = await client.fetch(url, { signal: controller.signal });
+      expect(res.status).toBe(200);
+      expect(anySpy).toHaveBeenCalled();
+      const merged = anySpy.mock.calls[0]?.[0] as AbortSignal[] | undefined;
+      expect(merged).toContain(controller.signal);
+    } finally {
+      anySpy.mockRestore();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("honors caller abort without waiting for timeout", async () => {
+    const server = http.createServer((_req, _res) => {
+      // hang
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/data`;
+
+    const client = new X402Client(createWallet(), { autoPay: false });
+    const controller = new AbortController();
+    controller.abort();
+
+    try {
+      await expect(
+        client.fetch(url, { signal: controller.signal }),
+      ).rejects.toMatchObject({
+        name: "AbortError",
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/plugins/plugin-wallet/src/sdk/x402/client.ts
+++ b/plugins/plugin-wallet/src/sdk/x402/client.ts
@@ -29,6 +29,8 @@ import type {
 } from "./types.js";
 import { DEFAULT_SUPPORTED_NETWORKS } from "./types.js";
 
+export const DEFAULT_X402_FETCH_TIMEOUT_MS = 10_000;
+
 /**
  * [MAX-ADDED] x402 Payment Client for AgentWallet.
  *
@@ -62,7 +64,11 @@ export class X402Client {
    */
   async fetch(url: string | URL, init?: RequestInit): Promise<Response> {
     const urlStr = url.toString();
-    const response = await globalThis.fetch(url, init);
+    const timeoutSignal = AbortSignal.timeout(DEFAULT_X402_FETCH_TIMEOUT_MS);
+    const signal = init?.signal
+      ? AbortSignal.any([init.signal, timeoutSignal])
+      : timeoutSignal;
+    const response = await globalThis.fetch(url, { ...init, signal });
 
     if (response.status !== 402) {
       return response;
@@ -139,9 +145,16 @@ export class X402Client {
     const payloadB64 = btoa(JSON.stringify(paymentPayload));
     retryHeaders.set("X-PAYMENT", payloadB64);
 
+    const retryTimeoutSignal = AbortSignal.timeout(
+      DEFAULT_X402_FETCH_TIMEOUT_MS,
+    );
+    const retrySignal = init?.signal
+      ? AbortSignal.any([init.signal, retryTimeoutSignal])
+      : retryTimeoutSignal;
     const retryResponse = await globalThis.fetch(url, {
       ...init,
       headers: retryHeaders,
+      signal: retrySignal,
     });
 
     return retryResponse;

--- a/plugins/plugin-wallet/src/sdk/x402/client.ts
+++ b/plugins/plugin-wallet/src/sdk/x402/client.ts
@@ -176,6 +176,8 @@ export class X402Client {
         const decoded = JSON.parse(atob(headerValue));
         return decoded as X402PaymentRequired;
       } catch {
+        // error-policy:J3 an invalid untrusted payment header falls through to
+        // the response body; it is never treated as an accepted requirement.
         // Fall through to body parsing
       }
     }
@@ -186,8 +188,15 @@ export class X402Client {
       if (body.x402Version && body.accepts) {
         return body as X402PaymentRequired;
       }
-    } catch {
-      // Not parseable
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.name === "AbortError" || error.name === "TimeoutError")
+      ) {
+        throw error;
+      }
+      // error-policy:J3 an invalid untrusted payment body is an explicit
+      // unparseable result, distinct from a request cancellation or timeout.
     }
 
     return null;


### PR DESCRIPTION
# Relates to

Fixes unbounded first and paid-retry requests in `X402Client`. The repaired head also proves the 10-second signal remains active while consumers read ordinary and paid-retry response bodies, and while the client parses a body-based 402 requirement.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI gpt-5.6
<!-- attribution-row:client -->
- Agent tooling: Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@fe0cc7463:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported; maintainer repair validated

# Sync with develop

- [x] Rebased onto current `origin/develop` at `fe0cc7463` with zero conflicts.
- [x] Exact focused tests, wallet Node typecheck, Biome, and diff checks pass.

# Risks

Low and scoped to x402 HTTP deadlines. Caller cancellation is merged rather than overwritten. The paid retry receives a fresh independent 10-second budget. Invalid untrusted 402 JSON still returns the explicit unparseable result, while `AbortError` and `TimeoutError` now propagate rather than being misclassified as malformed payment metadata.

# Background

## What does this PR do?

- Adds a 10-second signal to the initial x402 request.
- Adds a fresh 10-second signal to the paid retry and preserves any caller signal on both hops.
- Keeps each signal active through response body consumption.
- Exercises the real production client and local HTTP server through ordinary body stall, 402 body parsing stall, automatic payment, paid retry, payment header, caller cancellation, and fast success.

## What kind of change is this?

Backend wallet SDK bug fix; no UI or storage change.

# Testing

```bash
cd plugins/plugin-wallet
/opt/homebrew/opt/node@24/bin/node ../../node_modules/vitest/vitest.mjs run src/sdk/x402/client.timeout.test.ts --config vitest.config.ts --pool=forks --maxWorkers=1
/opt/homebrew/opt/node@24/bin/node ../../node_modules/typescript/bin/tsc -p tsconfig.json --noEmit --pretty false
/opt/homebrew/opt/node@24/bin/node ../../node_modules/@biomejs/biome/bin/biome check src/sdk/x402/client.ts src/sdk/x402/client.timeout.test.ts
```

Exact head: 1 file passed, 8 tests passed; wallet Node TypeScript passed; Biome and `git diff --check` clean.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only wallet SDK.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic HTTP/payment flow; real local-server evidence is recorded above.
<!-- evidence-row:backend-logs -->
- [x] Real local-server tests execute first request, 402 parsing, payment retry, and body stalls.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model/prompt behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Payment retry artifact is the asserted `X-PAYMENT` header; on-chain transfer is deliberately isolated to avoid spending funds.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

# Evidence Details

## Backend + frontend logs

The exact 8-test suite uses real local HTTP sockets. It proves initial request timeout, ordinary body timeout, 402 requirement-body timeout, caller cancellation merge, fast success, and a complete automatic-payment retry with a fresh deadline and `X-PAYMENT` header whose stalled body aborts.

## Known gaps / failures

N/A. The payment selection/on-chain transfer is replaced only at the irreversible payment boundary; the production `X402Client.fetch` request, 402 parse, payload/header construction, retry, and body consumption all execute.

<!-- evidence-head:7e7e4509b0feb4deb2c1acffb035b4d59442eff8 -->

AI provider/model: OpenAI / gpt-5.6
Client / agent tooling: Codex
Attribution status: self-reported; maintainer repair validated
— [byt61] [codex-maintainer-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6","client":"Codex","skill_revision":"elizaOS/eliza@fe0cc7463:packages/skills/skills/contribute-to-eliza"} -->
