### PR TITLE
fix(plugin-app-control): bound view-manager list fetch

### DIFF
--- a/plugins/plugin-app-control/src/views/viewManagerData.interact.test.ts
+++ b/plugins/plugin-app-control/src/views/viewManagerData.interact.test.ts
@@ -140,15 +140,17 @@ describe("interact() error paths", () => {
 	});
 });
 
-function stallUntilAborted(): typeof fetch {
-	return ((_input, init) =>
-		new Promise<Response>((_resolve, reject) => {
-			const signal = init?.signal;
-			if (!signal) throw new Error("expected view-manager abort signal");
-			signal.addEventListener("abort", () => reject(signal.reason), {
-				once: true,
-			});
-		})) as typeof fetch;
+function stallUntilAborted() {
+	return vi.fn(
+		(_input: string, init?: RequestInit) =>
+			new Promise<Response>((_resolve, reject) => {
+				const signal = init?.signal;
+				if (!signal) throw new Error("expected view-manager abort signal");
+				signal.addEventListener("abort", () => reject(signal.reason), {
+					once: true,
+				});
+			}),
+	);
 }
 
 describe("view-manager list request deadline", () => {
@@ -157,13 +159,39 @@ describe("view-manager list request deadline", () => {
 	});
 
 	it("aborts a stalled /api/views GET at the injected deadline", async () => {
+		const fetchImpl = stallUntilAborted();
 		await expect(
-			getViewEntriesWithFetch(undefined, stallUntilAborted(), 10),
+			getViewEntriesWithFetch(undefined, fetchImpl, 10),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+		expect(fetchImpl).toHaveBeenCalledWith(
+			"/api/views",
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+			{ timeoutMs: 10 },
+		);
+	});
+
+	it("keeps the deadline active while the response body stalls", async () => {
+		const fetchImpl = vi.fn(async (_input: string, init?: RequestInit) => {
+			const signal = init?.signal;
+			if (!signal) throw new Error("expected view-manager abort signal");
+			return {
+				ok: true,
+				status: 200,
+				json: () =>
+					new Promise((_resolve, reject) => {
+						signal.addEventListener("abort", () => reject(signal.reason), {
+							once: true,
+						});
+					}),
+			} as Response;
+		});
+		await expect(
+			getViewEntriesWithFetch(undefined, fetchImpl, 10),
 		).rejects.toMatchObject({ name: "TimeoutError" });
 	});
 
 	it("surfaces a provider error from a completed /api/views GET", async () => {
-		const fetchImpl: typeof fetch = async () =>
+		const fetchImpl = async () =>
 			new Response("nope", { status: 503, statusText: "Service Unavailable" });
 		await expect(
 			getViewEntriesWithFetch(undefined, fetchImpl, 1_000),
@@ -175,14 +203,16 @@ describe("view-manager list request deadline", () => {
 
 	it("uses the injected fetch for a successful /api/views GET", async () => {
 		const signals: AbortSignal[] = [];
-		const fetchImpl: typeof fetch = async (_input, init) => {
+		const fetchImpl = vi.fn(async (_input: string, init?: RequestInit) => {
 			if (init?.signal) signals.push(init.signal);
 			return jsonResponse(viewList);
-		};
+		});
 		const entries = await getViewEntriesWithFetch(undefined, fetchImpl, 1_000);
 		expect(signals).toHaveLength(1);
 		expect(signals[0]?.aborted).toBe(false);
 		expect(entries.map((entry) => entry.id)).toEqual(["wallet", "messages"]);
+		expect(fetchImpl).toHaveBeenCalledWith("/api/views", expect.any(Object), {
+			timeoutMs: 1_000,
+		});
 	});
 });
-

--- a/plugins/plugin-app-control/src/views/viewManagerData.interact.test.ts
+++ b/plugins/plugin-app-control/src/views/viewManagerData.interact.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { interact } from "./viewManagerData";
+import {
+	getViewEntriesWithFetch,
+	interact,
+	VIEW_MANAGER_LIST_FETCH_TIMEOUT_MS,
+} from "./viewManagerData";
 
 const viewList = {
 	views: [
@@ -117,7 +121,10 @@ describe("interact() error paths", () => {
 		await expect(interact("open-view", { viewId: "ghost" })).rejects.toThrow(
 			'View "ghost" not found',
 		);
-		expect(fetchMock).toHaveBeenCalledWith("/api/views");
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/views",
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
 		expect(
 			fetchMock.mock.calls.some((c) => String(c[0]).includes("/navigate")),
 		).toBe(false);
@@ -132,3 +139,50 @@ describe("interact() error paths", () => {
 		);
 	});
 });
+
+function stallUntilAborted(): typeof fetch {
+	return ((_input, init) =>
+		new Promise<Response>((_resolve, reject) => {
+			const signal = init?.signal;
+			if (!signal) throw new Error("expected view-manager abort signal");
+			signal.addEventListener("abort", () => reject(signal.reason), {
+				once: true,
+			});
+		})) as typeof fetch;
+}
+
+describe("view-manager list request deadline", () => {
+	it("keeps a documented UI fetch budget", () => {
+		expect(VIEW_MANAGER_LIST_FETCH_TIMEOUT_MS).toBe(15_000);
+	});
+
+	it("aborts a stalled /api/views GET at the injected deadline", async () => {
+		await expect(
+			getViewEntriesWithFetch(undefined, stallUntilAborted(), 10),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+	});
+
+	it("surfaces a provider error from a completed /api/views GET", async () => {
+		const fetchImpl: typeof fetch = async () =>
+			new Response("nope", { status: 503, statusText: "Service Unavailable" });
+		await expect(
+			getViewEntriesWithFetch(undefined, fetchImpl, 1_000),
+		).rejects.toMatchObject({
+			name: "ElizaError",
+			message: "GET /api/views returned HTTP 503",
+		});
+	});
+
+	it("uses the injected fetch for a successful /api/views GET", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchImpl: typeof fetch = async (_input, init) => {
+			if (init?.signal) signals.push(init.signal);
+			return jsonResponse(viewList);
+		};
+		const entries = await getViewEntriesWithFetch(undefined, fetchImpl, 1_000);
+		expect(signals).toHaveLength(1);
+		expect(signals[0]?.aborted).toBe(false);
+		expect(entries.map((entry) => entry.id)).toEqual(["wallet", "messages"]);
+	});
+});
+

--- a/plugins/plugin-app-control/src/views/viewManagerData.ts
+++ b/plugins/plugin-app-control/src/views/viewManagerData.ts
@@ -204,11 +204,18 @@ function parseViewEntry(value: unknown, index: number): ViewEntry {
 	};
 }
 
-export async function fetchViewEntries(
-	viewType?: "gui" | "tui" | "xr",
+/** View-list GET is a short UI hop — same 15s Fal #21205 family. */
+export const VIEW_MANAGER_LIST_FETCH_TIMEOUT_MS = 15_000;
+
+export async function getViewEntriesWithFetch(
+	viewType: "gui" | "tui" | "xr" | undefined,
+	fetchImpl: typeof fetch,
+	timeoutMs: number = VIEW_MANAGER_LIST_FETCH_TIMEOUT_MS,
 ): Promise<ViewEntry[]> {
 	const qs = viewType ? `?viewType=${viewType}` : "";
-	const res = await fetch(`/api/views${qs}`);
+	const res = await fetchImpl(`/api/views${qs}`, {
+		signal: AbortSignal.timeout(timeoutMs),
+	});
 	if (!res.ok) {
 		throw new ElizaError(`GET /api/views returned HTTP ${res.status}`, {
 			code: "VIEW_MANAGER_LIST_HTTP_FAILED",
@@ -234,6 +241,12 @@ export async function fetchViewEntries(
 		);
 	}
 	return data.views.map(parseViewEntry);
+}
+
+export async function fetchViewEntries(
+	viewType?: "gui" | "tui" | "xr",
+): Promise<ViewEntry[]> {
+	return getViewEntriesWithFetch(viewType, globalThis.fetch);
 }
 
 export async function requestViewNavigation(

--- a/plugins/plugin-app-control/src/views/viewManagerData.ts
+++ b/plugins/plugin-app-control/src/views/viewManagerData.ts
@@ -1,7 +1,7 @@
 /**
- * React-free data layer for the View Manager bundle. Read requests use the
- * browser fetch surface, while mutations go through the shell's authenticated
- * API transport so cookie sessions and native hosts share one security path.
+ * React-free data layer for the View Manager bundle. Requests use the shell's
+ * authenticated platform transport so browser sessions and native hosts share
+ * one routing, authorization, and deadline path.
  */
 
 import { ElizaError } from "@elizaos/core";
@@ -207,15 +207,23 @@ function parseViewEntry(value: unknown, index: number): ViewEntry {
 /** View-list GET is a short UI hop — same 15s Fal #21205 family. */
 export const VIEW_MANAGER_LIST_FETCH_TIMEOUT_MS = 15_000;
 
+type ViewListFetcher = (
+	url: string,
+	init?: RequestInit,
+	context?: { timeoutMs?: number },
+) => Promise<Response>;
+
 export async function getViewEntriesWithFetch(
 	viewType: "gui" | "tui" | "xr" | undefined,
-	fetchImpl: typeof fetch,
+	fetchImpl: ViewListFetcher,
 	timeoutMs: number = VIEW_MANAGER_LIST_FETCH_TIMEOUT_MS,
 ): Promise<ViewEntry[]> {
 	const qs = viewType ? `?viewType=${viewType}` : "";
-	const res = await fetchImpl(`/api/views${qs}`, {
-		signal: AbortSignal.timeout(timeoutMs),
-	});
+	const res = await fetchImpl(
+		`/api/views${qs}`,
+		{ signal: AbortSignal.timeout(timeoutMs) },
+		{ timeoutMs },
+	);
 	if (!res.ok) {
 		throw new ElizaError(`GET /api/views returned HTTP ${res.status}`, {
 			code: "VIEW_MANAGER_LIST_HTTP_FAILED",
@@ -226,6 +234,12 @@ export async function getViewEntriesWithFetch(
 	try {
 		data = await res.json();
 	} catch (cause) {
+		if (
+			cause instanceof Error &&
+			(cause.name === "AbortError" || cause.name === "TimeoutError")
+		) {
+			throw cause;
+		}
 		// error-policy:J2 preserve the JSON parser failure while adding the API
 		// boundary and response status needed to diagnose a broken registry payload.
 		return invalidViewListResponse(
@@ -246,7 +260,7 @@ export async function getViewEntriesWithFetch(
 export async function fetchViewEntries(
 	viewType?: "gui" | "tui" | "xr",
 ): Promise<ViewEntry[]> {
-	return getViewEntriesWithFetch(viewType, globalThis.fetch);
+	return getViewEntriesWithFetch(viewType, fetchWithCsrf);
 }
 
 export async function requestViewNavigation(


### PR DESCRIPTION
# Relates to

Fixes a stalled `GET /api/views` hanging the View Manager. The submitted raw-fetch signal worked only in a browser test double: native Android/iOS/desktop agent transports do not consume that signal, and the raw path skipped configured base-URL and authentication handling. This repaired head uses the canonical authenticated platform transport, forwards an explicit 15-second native timeout context, retains a browser/body `AbortSignal`, and preserves typed response validation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; OpenAI gpt-5.6
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported; maintainer repair validated

# Sync with develop

- [x] Rebased onto `ac5b77ca7` with zero conflicts.
- [x] Exact focused tests, package typecheck, Biome, and diff checks pass.

# Risks

Low and limited to the View Manager list read. Navigation and registry contracts are unchanged. Browser requests now retain the 15-second signal through JSON body consumption; native/desktop requests receive the same budget through the canonical transport context. Abort/timeout failures remain distinct from malformed JSON instead of being mislabeled as registry corruption.

# Background

## What does this PR do?

- Routes `/api/views` through `fetchWithCsrf`, which resolves configured API bases, credentials, and Android/iOS/desktop transports.
- Supplies `{ timeoutMs: 15_000 }` for native bridges and an `AbortSignal.timeout(15_000)` for browser request/body consumption.
- Preserves `AbortError`/`TimeoutError` from body reads while retaining typed `ElizaError` wrapping for actual malformed JSON.
- Tests timeout context, stalled request, stalled body, provider error, successful parsing, and existing production view-list contracts.

## What kind of change is this?

Bug fix; no API, storage, or rendered-layout change.

# Testing

```bash
cd plugins/plugin-app-control
/opt/homebrew/opt/node@24/bin/node ../../node_modules/vitest/vitest.mjs run src/views/viewManagerData.interact.test.ts src/views/viewManagerData.contract.test.ts --config vitest.config.ts --pool=forks --maxWorkers=1
/opt/homebrew/opt/node@24/bin/node ../../node_modules/typescript/bin/tsc -p tsconfig.json --noEmit --pretty false
/opt/homebrew/opt/node@24/bin/node ../../node_modules/@biomejs/biome/bin/biome check src/views/viewManagerData.ts src/views/viewManagerData.interact.test.ts
```

Exact head: 2 files passed, 19 tests passed; package TypeScript passed; Biome and `git diff --check` clean.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered layout or style changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered layout or style changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - internal read transport only; deterministic production-path tests are the relevant artifact.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend implementation change.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no logging change; focused transport/context assertions are recorded above.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistence or domain artifact change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Backend + frontend logs

N/A. The exact focused suite proves request timeout, response-body timeout, native timeout-context forwarding, browser signal forwarding, HTTP failures, JSON validation, and successful parsing.

## Known gaps / failures

The required shared-app audit is intentionally queued under the coordinated serialized audit semaphore. This head must not merge until that audit completes.

<!-- evidence-head:73430a15e0004a41c2f4faaae9a0ba4389abf6a6 -->

AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6
Client / agent tooling: Cursor; Codex
Attribution status: self-reported; maintainer repair validated
— [cursor-ss251] [codex-maintainer-review]
<!-- eliza-computer-attribution:v1 {"provider":"xai+openai","model":"grok-4.6+gpt-5.6","client":"Cursor+Codex","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
