### PR TITLE
fix(agent): run the capability-encoding suite under vitest

### DIFF
--- a/packages/agent/src/services/remote-capability-router.encoding.test.ts
+++ b/packages/agent/src/services/remote-capability-router.encoding.test.ts
@@ -1,6 +1,7 @@
 /** Exercises malformed request input with deterministic route collaborators. */
-import { describe, expect, mock, test } from "bun:test";
+
 import { UnavailableCapabilityRouter } from "@elizaos/core";
+import { describe, expect, test, vi } from "vitest";
 import { createRemoteCapabilityFetchHandler } from "./remote-capability-router.ts";
 
 describe("remote capability asset path encoding", () => {
@@ -24,7 +25,7 @@ describe("remote capability asset path encoding", () => {
 
   test("passes the decoded module id and asset path to the router", async () => {
     const router = new UnavailableCapabilityRouter("server");
-    const getAsset = mock(async () => ({
+    const getAsset = vi.fn(async () => ({
       path: "/views/demo.js",
       contentType: "text/javascript",
       bodyBase64: Buffer.from("asset bytes").toString("base64"),


### PR DESCRIPTION
The new remote-capability-router.encoding.test.ts imports bun:test, but the agent package's deterministic test lane runs vitest, which cannot resolve that module (release candidate run 32107595638 — the only red in the full test lane). Converted to vitest imports (mock → vi.fn). Suite 2/2; Biome clean.