### PR TITLE
fix(shared): trim reason in isCloudStatusReasonApiKeyOnly and add unit test suite

### DIFF
--- a/packages/shared/src/utils/cloud-status.test.ts
+++ b/packages/shared/src/utils/cloud-status.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for cloud-status utility classifiers (isCloudStatusReasonApiKeyOnly and
+ * isCloudStatusAuthenticated).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isCloudStatusAuthenticated,
+  isCloudStatusReasonApiKeyOnly,
+} from "./cloud-status.ts";
+
+describe("isCloudStatusReasonApiKeyOnly", () => {
+  it("returns true for exact api_key_present_not_authenticated", () => {
+    expect(
+      isCloudStatusReasonApiKeyOnly("api_key_present_not_authenticated"),
+    ).toBe(true);
+  });
+
+  it("returns true for exact api_key_present_runtime_not_started", () => {
+    expect(
+      isCloudStatusReasonApiKeyOnly("api_key_present_runtime_not_started"),
+    ).toBe(true);
+  });
+
+  it("returns true for whitespace-padded API key reason strings", () => {
+    expect(
+      isCloudStatusReasonApiKeyOnly("  api_key_present_not_authenticated  "),
+    ).toBe(true);
+    expect(
+      isCloudStatusReasonApiKeyOnly("\napi_key_present_runtime_not_started\t"),
+    ).toBe(true);
+  });
+
+  it("returns false for other reason strings", () => {
+    expect(isCloudStatusReasonApiKeyOnly("connected")).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly("disconnected")).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly("invalid_credentials")).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly("")).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly("   ")).toBe(false);
+  });
+
+  it("returns false for nullish or non-string inputs", () => {
+    expect(isCloudStatusReasonApiKeyOnly(null)).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly(undefined)).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly(123 as unknown as string)).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly(true as unknown as string)).toBe(
+      false,
+    );
+    expect(isCloudStatusReasonApiKeyOnly({} as unknown as string)).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly([] as unknown as string)).toBe(false);
+  });
+});
+
+describe("isCloudStatusAuthenticated", () => {
+  it("returns true when connected is true and reason is nullish or ordinary", () => {
+    expect(isCloudStatusAuthenticated(true, undefined)).toBe(true);
+    expect(isCloudStatusAuthenticated(true, null)).toBe(true);
+    expect(isCloudStatusAuthenticated(true, "authenticated")).toBe(true);
+    expect(isCloudStatusAuthenticated(true, "active")).toBe(true);
+  });
+
+  it("returns false when connected is true but reason is API key only", () => {
+    expect(
+      isCloudStatusAuthenticated(true, "api_key_present_not_authenticated"),
+    ).toBe(false);
+    expect(
+      isCloudStatusAuthenticated(true, "api_key_present_runtime_not_started"),
+    ).toBe(false);
+    expect(
+      isCloudStatusAuthenticated(true, "  api_key_present_not_authenticated  "),
+    ).toBe(false);
+  });
+
+  it("returns false when connected is false", () => {
+    expect(isCloudStatusAuthenticated(false, undefined)).toBe(false);
+    expect(isCloudStatusAuthenticated(false, null)).toBe(false);
+    expect(isCloudStatusAuthenticated(false, "authenticated")).toBe(false);
+    expect(
+      isCloudStatusAuthenticated(false, "api_key_present_not_authenticated"),
+    ).toBe(false);
+  });
+
+  it("returns false for truthy non-boolean connected values", () => {
+    expect(
+      isCloudStatusAuthenticated(1 as unknown as boolean, "authenticated"),
+    ).toBe(false);
+    expect(
+      isCloudStatusAuthenticated("true" as unknown as boolean, "authenticated"),
+    ).toBe(false);
+    expect(
+      isCloudStatusAuthenticated({} as unknown as boolean, "authenticated"),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/cloud-status.ts
+++ b/packages/shared/src/utils/cloud-status.ts
@@ -11,14 +11,15 @@ const CLOUD_STATUS_API_KEY_ONLY_REASONS: ReadonlySet<string> = new Set([
 export function isCloudStatusReasonApiKeyOnly(
   reason: string | null | undefined,
 ): boolean {
-  return (
-    typeof reason === "string" && CLOUD_STATUS_API_KEY_ONLY_REASONS.has(reason)
-  );
+  if (typeof reason !== "string") {
+    return false;
+  }
+  return CLOUD_STATUS_API_KEY_ONLY_REASONS.has(reason.trim());
 }
 
 export function isCloudStatusAuthenticated(
   connected: boolean,
   reason: string | null | undefined,
 ): boolean {
-  return connected && !isCloudStatusReasonApiKeyOnly(reason);
+  return connected === true && !isCloudStatusReasonApiKeyOnly(reason);
 }


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `typeof reason !== "string"` and trim `reason.trim()` before checking against `CLOUD_STATUS_API_KEY_ONLY_REASONS` in `isCloudStatusReasonApiKeyOnly`.
- Explicitly verify `connected === true` in `isCloudStatusAuthenticated` to guard against truthy non-boolean values.
- Add comprehensive unit test suite in `packages/shared/src/utils/cloud-status.test.ts` verifying all reason classification paths, whitespace trimming, and authentication combinations with 100% test coverage.

## Related Issues

- Fixes #21877

## Testing

- Added `packages/shared/src/utils/cloud-status.test.ts` with 9 test cases covering:
  - Exact match for `"api_key_present_not_authenticated"` and `"api_key_present_runtime_not_started"`
  - Whitespace-padded API key reason strings
  - Disconnected, other reason strings, empty string, and whitespace-only strings
  - Nullish and non-string inputs
  - Connected vs disconnected state matrix
  - Truthy non-boolean connected values
- `bun test packages/shared/src/utils/cloud-status.test.ts` passes (9/9 tests, 29 assertions).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/utils/cloud-status.test.ts:
✓ isCloudStatusReasonApiKeyOnly > returns true for exact api_key_present_not_authenticated [0.33ms]
✓ isCloudStatusReasonApiKeyOnly > returns true for exact api_key_present_runtime_not_started [0.09ms]
✓ isCloudStatusReasonApiKeyOnly > returns true for whitespace-padded API key reason strings [0.09ms]
✓ isCloudStatusReasonApiKeyOnly > returns false for other reason strings [0.17ms]
✓ isCloudStatusReasonApiKeyOnly > returns false for nullish or non-string inputs [0.19ms]
✓ isCloudStatusAuthenticated > returns true when connected is true and reason is nullish or ordinary [0.21ms]
✓ isCloudStatusAuthenticated > returns false when connected is true but reason is API key only [0.15ms]
✓ isCloudStatusAuthenticated > returns false when connected is false [0.13ms]
✓ isCloudStatusAuthenticated > returns false for truthy non-boolean connected values [0.14ms]
-------------------------------------------|---------|---------|-------------------
File                                       | % Funcs | % Lines | Uncovered Line #s
-------------------------------------------|---------|---------|-------------------
All files                                  |  100.00 |  100.00 |
 packages/shared/src/utils/cloud-status.ts |  100.00 |  100.00 | 
-------------------------------------------|---------|---------|-------------------

 9 pass
 0 fail
 29 expect() calls
Ran 9 tests across 1 file. [161.00ms]
```
