### PR TITLE
fix(wallet): validate Kamino liquidity timeout boundary

### DIFF
--- a/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoLiquidityService.timeout.test.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoLiquidityService.timeout.test.ts
@@ -1,0 +1,116 @@
+/**
+ * KaminoLiquidityService fetch deadlines — proves the production service aborts
+ * on timeout via mocked hanging fetch, covering the central makeApiRequest path.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_KAMINO_LIQUIDITY_FETCH_TIMEOUT_MS,
+  KaminoLiquidityService,
+} from "./kaminoLiquidityService";
+
+describe("KaminoLiquidityService fetch timeout", () => {
+  it("exposes the documented 10s budget", () => {
+    expect(DEFAULT_KAMINO_LIQUIDITY_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("aborts a stalled makeApiRequest at the deadline", async () => {
+    const svc = new KaminoLiquidityService();
+    const orig = AbortSignal.timeout.bind(AbortSignal);
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => orig(10));
+    const spy = vi.fn(async (_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const sig = init?.signal as AbortSignal | undefined;
+        if (!sig) throw new Error("signal missing kamino liquidity");
+        sig.addEventListener("abort", () => reject(sig.reason), { once: true });
+      });
+    });
+    const prev = globalThis.fetch;
+    globalThis.fetch = spy as unknown as typeof fetch;
+    try {
+      await expect(
+        (
+          svc as unknown as { makeApiRequest: (e: string) => Promise<unknown> }
+        ).makeApiRequest("/v2/staking-yields"),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining("api.kamino.finance"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    } finally {
+      globalThis.fetch = prev;
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("merges a caller signal via AbortSignal.any", async () => {
+    const svc = new KaminoLiquidityService();
+    const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => origTimeout(10));
+    const anySpy = vi.spyOn(AbortSignal, "any");
+    const controller = new AbortController();
+    const spy = vi.fn(async (_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const sig = init?.signal as AbortSignal | undefined;
+        if (!sig) throw new Error("signal missing merge");
+        sig.addEventListener("abort", () => reject(sig.reason), { once: true });
+      });
+    });
+    const prev = globalThis.fetch;
+    globalThis.fetch = spy as unknown as typeof fetch;
+    try {
+      const pending = (
+        svc as unknown as {
+          makeApiRequest: (e: string, o?: RequestInit) => Promise<unknown>;
+        }
+      ).makeApiRequest("/v2/staking-yields", { signal: controller.signal });
+      controller.abort(new DOMException("caller abort", "AbortError"));
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(anySpy).toHaveBeenCalledWith(
+        expect.arrayContaining([controller.signal, expect.any(AbortSignal)]),
+      );
+    } finally {
+      globalThis.fetch = prev;
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("sends the abort signal and succeeds on a fast upstream", async () => {
+    const svc = new KaminoLiquidityService();
+    const spy = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (!init?.signal) throw new Error("signal missing success");
+      return Response.json([{ apy: "5.5", tokenMint: "So111" }]);
+    });
+    const prev = globalThis.fetch;
+    globalThis.fetch = spy as unknown as typeof fetch;
+    try {
+      const result = await (
+        svc as unknown as { makeApiRequest: (e: string) => Promise<unknown> }
+      ).makeApiRequest("/v2/staking-yields");
+      expect(result).toEqual([{ apy: "5.5", tokenMint: "So111" }]);
+      expect(spy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    } finally {
+      globalThis.fetch = prev;
+    }
+  });
+
+  it("surfaces a provider error from a completed upstream", async () => {
+    const svc = new KaminoLiquidityService();
+    const spy = vi.fn(
+      async () => new Response("Service Unavailable", { status: 503 }),
+    );
+    const prev = globalThis.fetch;
+    globalThis.fetch = spy as unknown as typeof fetch;
+    try {
+      await expect(
+        (
+          svc as unknown as { makeApiRequest: (e: string) => Promise<unknown> }
+        ).makeApiRequest("/v2/staking-yields"),
+      ).rejects.toThrow("API request failed: 503");
+    } finally {
+      globalThis.fetch = prev;
+    }
+  });
+});

--- a/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoLiquidityService.timeout.test.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoLiquidityService.timeout.test.ts
@@ -42,6 +42,41 @@ describe("KaminoLiquidityService fetch timeout", () => {
     }
   });
 
+  it("keeps the deadline active while the response body stalls", async () => {
+    const svc = new KaminoLiquidityService();
+    const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() =>
+      originalTimeout(10),
+    );
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("signal missing Kamino response body");
+      return {
+        ok: true,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            signal.addEventListener("abort", () => reject(signal.reason), {
+              once: true,
+            });
+          }),
+      } as Response;
+    });
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      await expect(
+        (
+          svc as unknown as {
+            makeApiRequest: (endpoint: string) => Promise<unknown>;
+          }
+        ).makeApiRequest("/v2/staking-yields"),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+    } finally {
+      globalThis.fetch = previousFetch;
+      vi.restoreAllMocks();
+    }
+  });
+
   it("merges a caller signal via AbortSignal.any", async () => {
     const svc = new KaminoLiquidityService();
     const origTimeout = AbortSignal.timeout.bind(AbortSignal);

--- a/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoLiquidityService.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoLiquidityService.ts
@@ -14,6 +14,8 @@ import { logger, Service } from "@elizaos/core";
 const KAMINO_API_BASE_URL = "https://api.kamino.finance";
 const KAMINO_LIQUIDITY_PROGRAM_ID = "kamino-rest-api";
 
+export const DEFAULT_KAMINO_LIQUIDITY_FETCH_TIMEOUT_MS = 10_000;
+
 const KNOWN_TOKENS: Record<string, string> = {
   HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC: "AI16Z Token",
   ai16z: "AI16Z Token (Symbol)",
@@ -238,6 +240,12 @@ export class KaminoLiquidityService extends Service {
           "Content-Type": "application/json",
           ...options.headers,
         },
+        signal: options.signal
+          ? AbortSignal.any([
+              options.signal,
+              AbortSignal.timeout(DEFAULT_KAMINO_LIQUIDITY_FETCH_TIMEOUT_MS),
+            ])
+          : AbortSignal.timeout(DEFAULT_KAMINO_LIQUIDITY_FETCH_TIMEOUT_MS),
       });
 
       if (!response.ok) {

--- a/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoLiquidityService.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoLiquidityService.ts
@@ -232,36 +232,28 @@ export class KaminoLiquidityService extends Service {
     endpoint: string,
     options: RequestInit = {},
   ): Promise<T> {
-    try {
-      const url = `${this.apiBaseUrl}${endpoint}`;
-      const response = await fetch(url, {
-        ...options,
-        headers: {
-          "Content-Type": "application/json",
-          ...options.headers,
-        },
-        signal: options.signal
-          ? AbortSignal.any([
-              options.signal,
-              AbortSignal.timeout(DEFAULT_KAMINO_LIQUIDITY_FETCH_TIMEOUT_MS),
-            ])
-          : AbortSignal.timeout(DEFAULT_KAMINO_LIQUIDITY_FETCH_TIMEOUT_MS),
-      });
+    const url = `${this.apiBaseUrl}${endpoint}`;
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+      signal: options.signal
+        ? AbortSignal.any([
+            options.signal,
+            AbortSignal.timeout(DEFAULT_KAMINO_LIQUIDITY_FETCH_TIMEOUT_MS),
+          ])
+        : AbortSignal.timeout(DEFAULT_KAMINO_LIQUIDITY_FETCH_TIMEOUT_MS),
+    });
 
-      if (!response.ok) {
-        throw new Error(
-          `API request failed: ${response.status} ${response.statusText}`,
-        );
-      }
-
-      return await response.json();
-    } catch (error) {
-      logger.error(
-        `API request failed for ${endpoint}:`,
-        formatLogError(error),
+    if (!response.ok) {
+      throw new Error(
+        `API request failed: ${response.status} ${response.statusText}`,
       );
-      throw error;
     }
+
+    return await response.json();
   }
 
   async resolveTokenWithBirdeye(


### PR DESCRIPTION
# Relates to

Supersedes #21874 after maintainer review found that the original timeout tests did not prove the response-body deadline and the newly touched catch violated the repository error policy by logging and rethrowing without adding context.

# What changed

- Preserves the submitted 10-second external Kamino API deadline and caller-signal merge.
- Keeps the same abort signal active through `response.json()`, bounding both request and response-body stalls.
- Removes the redundant log-and-rethrow catch so `TimeoutError`, caller `AbortError`, provider errors, and JSON failures retain their original identity for the owning boundary.
- Adds a deterministic production-method body-stall regression.

# Validation

- Pinned Bun 1.3.14 focused production tests: 7/7 passed (six `KaminoLiquidityService` cases plus the sibling `KaminoService` timeout contract). Bun's coverage reporter then remained alive during teardown and was interrupted after all assertions completed; there was no failure output.
- `tsc --noEmit -p plugins/plugin-wallet/tsconfig.json`: PASS.
- Biome on both touched files: PASS.
- `git diff --check origin/develop...HEAD`: PASS.
- The UI half of the wallet aggregate typecheck is blocked in the isolated sparse review checkout by missing built `@elizaos/ui/*` aliases; the Node/service project above is green and no changed-file diagnostic was emitted.

# Evidence Gate

<!-- evidence-head:dd204b2711e0f14b92c93686a7c67efcc58a1732 -->
<!-- evidence-row:before-screenshots -->
- Before/after screenshots: N/A — backend-only external wallet service.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — backend-only external wallet service.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — no interactive surface.
<!-- evidence-row:backend-logs -->
- Backend logs:
  <details><summary>Pinned Bun 1.3.14 focused production-path result</summary>

  `KaminoLiquidityService fetch timeout`: 6/6 passed, including a stalled request, stalled response body, caller cancellation, fast success, and provider error.
  `KaminoService timeout`: 1/1 sibling contract passed; its expected timeout diagnostic was emitted.
  The coverage reporter remained alive only during teardown and was interrupted after all seven assertions completed with no failure output.
  </details>
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A — no frontend change.
<!-- evidence-row:llm-trajectory -->
- LLM trajectory: N/A — no agent/model behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifact:
  <details><summary>Exact-head service validation</summary>

  The production private `makeApiRequest` method received a real AbortSignal created from the documented 10,000 ms constant.
  A mocked response whose `json()` remained pending rejected with `TimeoutError`, proving the same signal bounds response consumption.
  Node/service TypeScript, touched-file Biome, and diff checks all passed at `dd204b2711e0f14b92c93686a7c67efcc58a1732`.
  </details>
<!-- evidence-row:ocr-review -->
- OCR: N/A — no rendered UI.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@dd204b2711e0f14b92c93686a7c67efcc58a1732:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Attribution status: reviewed exact head
— [OpenAI]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@dd204b2711e0f14b92c93686a7c67efcc58a1732:packages/skills/skills/contribute-to-eliza"} -->
