### PR TITLE
fix(shared): guard non-string and malformed options in resolveElizaPackageRoot and add unit test suite

### DIFF
--- a/packages/shared/src/utils/eliza-root.test.ts
+++ b/packages/shared/src/utils/eliza-root.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for elizaOS package root resolution in resolveElizaPackageRoot and
+ * resolveElizaPackageRootSync.
+ */
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  resolveElizaPackageRoot,
+  resolveElizaPackageRootSync,
+} from "./eliza-root.ts";
+
+describe("resolveElizaPackageRoot", () => {
+  it("resolves the root package directory when given cwd", async () => {
+    const cwd = process.cwd();
+    const resolved = await resolveElizaPackageRoot({ cwd });
+    expect(resolved).toBeTruthy();
+    expect(typeof resolved).toBe("string");
+  });
+
+  it("resolves the root package directory when given moduleUrl", async () => {
+    const moduleUrl = import.meta.url;
+    const resolved = await resolveElizaPackageRoot({ moduleUrl });
+    expect(resolved).toBeTruthy();
+    expect(typeof resolved).toBe("string");
+  });
+
+  it("resolves the root package directory when given argv1", async () => {
+    const argv1 = path.join(process.cwd(), "packages/shared/src/index.ts");
+    const resolved = await resolveElizaPackageRoot({ argv1 });
+    expect(resolved).toBeTruthy();
+    expect(typeof resolved).toBe("string");
+  });
+
+  it("resolves from node_modules .bin argv1 candidate path", async () => {
+    const fakeBin = path.join(
+      process.cwd(),
+      "node_modules",
+      ".bin",
+      "eliza-cli",
+    );
+    const resolved = await resolveElizaPackageRoot({ argv1: fakeBin });
+    expect(resolved).toBeTruthy();
+  });
+
+  it("returns null when no candidate matches the eliza package root", async () => {
+    const resolved = await resolveElizaPackageRoot({
+      cwd: path.parse(process.cwd()).root,
+    });
+    expect(resolved).toBeNull();
+  });
+
+  it("handles nullish, empty, or malformed options safely", async () => {
+    expect(await resolveElizaPackageRoot({})).toBeNull();
+    expect(
+      await resolveElizaPackageRoot(null as unknown as { cwd?: string }),
+    ).toBeNull();
+    expect(
+      await resolveElizaPackageRoot(undefined as unknown as { cwd?: string }),
+    ).toBeNull();
+    expect(
+      await resolveElizaPackageRoot({
+        moduleUrl: "invalid-url",
+        argv1: "",
+        cwd: "   ",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveElizaPackageRootSync", () => {
+  it("resolves the root package directory synchronously when given cwd", () => {
+    const cwd = process.cwd();
+    const resolved = resolveElizaPackageRootSync({ cwd });
+    expect(resolved).toBeTruthy();
+    expect(typeof resolved).toBe("string");
+  });
+
+  it("resolves the root package directory synchronously when given moduleUrl", () => {
+    const moduleUrl = import.meta.url;
+    const resolved = resolveElizaPackageRootSync({ moduleUrl });
+    expect(resolved).toBeTruthy();
+    expect(typeof resolved).toBe("string");
+  });
+
+  it("returns null when no candidate matches in synchronous resolution", () => {
+    const resolved = resolveElizaPackageRootSync({
+      cwd: path.parse(process.cwd()).root,
+    });
+    expect(resolved).toBeNull();
+  });
+
+  it("matches async result for identical options", async () => {
+    const opts = { moduleUrl: import.meta.url, cwd: process.cwd() };
+    const asyncResult = await resolveElizaPackageRoot(opts);
+    const syncResult = resolveElizaPackageRootSync(opts);
+    expect(asyncResult).toBe(syncResult);
+  });
+});

--- a/packages/shared/src/utils/eliza-root.ts
+++ b/packages/shared/src/utils/eliza-root.ts
@@ -33,9 +33,18 @@ function readPackageNameSync(dir: string): string | null {
 }
 
 function listAncestorDirs(startDir: string, maxDepth = 12): string[] {
+  if (typeof startDir !== "string" || startDir.trim() === "") {
+    return [];
+  }
+  const depthLimit =
+    typeof maxDepth === "number" &&
+    Number.isSafeInteger(maxDepth) &&
+    maxDepth > 0
+      ? maxDepth
+      : 12;
   const dirs: string[] = [];
-  let current = path.resolve(startDir);
-  for (let i = 0; i < maxDepth; i += 1) {
+  let current = path.resolve(startDir.trim());
+  for (let i = 0; i < depthLimit; i += 1) {
     dirs.push(current);
     const parent = path.dirname(current);
     if (parent === current) {
@@ -70,7 +79,10 @@ function findPackageRootSync(startDir: string, maxDepth = 12): string | null {
 }
 
 function candidateDirsFromArgv1(argv1: string): string[] {
-  const normalized = path.resolve(argv1);
+  if (typeof argv1 !== "string" || argv1.trim() === "") {
+    return [];
+  }
+  const normalized = path.resolve(argv1.trim());
   const candidates = [path.dirname(normalized)];
   const parts = normalized.split(path.sep);
   const binIndex = parts.lastIndexOf(".bin");
@@ -88,17 +100,26 @@ type ResolveElizaRootOptions = {
   moduleUrl?: string;
 };
 
-function candidateDirsFromOptions(opts: ResolveElizaRootOptions): string[] {
+function candidateDirsFromOptions(
+  opts?: ResolveElizaRootOptions | null,
+): string[] {
+  if (!opts || typeof opts !== "object") {
+    return [];
+  }
   const candidates: string[] = [];
 
-  if (opts.moduleUrl) {
-    candidates.push(path.dirname(fileURLToPath(opts.moduleUrl)));
+  if (typeof opts.moduleUrl === "string" && opts.moduleUrl.trim() !== "") {
+    try {
+      candidates.push(path.dirname(fileURLToPath(opts.moduleUrl.trim())));
+    } catch {
+      // error-policy:J3 ignore malformed URL inputs
+    }
   }
-  if (opts.argv1) {
+  if (typeof opts.argv1 === "string" && opts.argv1.trim() !== "") {
     candidates.push(...candidateDirsFromArgv1(opts.argv1));
   }
-  if (opts.cwd) {
-    candidates.push(opts.cwd);
+  if (typeof opts.cwd === "string" && opts.cwd.trim() !== "") {
+    candidates.push(opts.cwd.trim());
   }
 
   return candidates;


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `opts` parameter in `candidateDirsFromOptions` against nullish and non-object inputs.
- Guard `typeof argv1 !== "string"` and empty strings in `candidateDirsFromArgv1`.
- Wrap `fileURLToPath(opts.moduleUrl)` in try/catch to safely handle malformed URL strings without throwing `TypeError`.
- Ensure `maxDepth` in `listAncestorDirs` is a positive safe integer.
- Create a comprehensive unit test suite in `packages/shared/src/utils/eliza-root.test.ts` covering directory ancestry, argv1 candidate generation, `.bin` node_modules candidate generation, malformed/invalid inputs, and sync/async parity.

## Related Issues

- Fixes #21883

## Testing

- Added `packages/shared/src/utils/eliza-root.test.ts` with 10 tests covering:
  - Root resolution via `cwd`
  - Root resolution via `moduleUrl`
  - Root resolution via `argv1`
  - Root resolution via `node_modules/.bin` argv1 candidate
  - Unmatched candidate fallback returning `null`
  - Handling of nullish, empty, or malformed options
  - Synchronous `resolveElizaPackageRootSync` execution
  - Sync and async resolution parity
- `bun test packages/shared/src/utils/eliza-root.test.ts` passes (10/10 tests, 18 assertions, 98.25% line coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/utils/eliza-root.test.ts:
✓ resolveElizaPackageRoot > resolves the root package directory when given cwd [8.76ms]
✓ resolveElizaPackageRoot > resolves the root package directory when given moduleUrl [2.00ms]
✓ resolveElizaPackageRoot > resolves the root package directory when given argv1 [1.75ms]
✓ resolveElizaPackageRoot > resolves from node_modules .bin argv1 candidate path [1.18ms]
✓ resolveElizaPackageRoot > returns null when no candidate matches the eliza package root [0.48ms]
✓ resolveElizaPackageRoot > handles nullish, empty, or malformed options safely [0.55ms]
✓ resolveElizaPackageRootSync > resolves the root package directory synchronously when given cwd [1.08ms]
✓ resolveElizaPackageRootSync > resolves the root package directory synchronously when given moduleUrl [0.98ms]
✓ resolveElizaPackageRootSync > returns null when no candidate matches in synchronous resolution [0.21ms]
✓ resolveElizaPackageRootSync > matches async result for identical options [2.74ms]
-----------------------------------------|---------|---------|-------------------
File                                     | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------|---------|---------|-------------------
All files                                |  100.00 |   98.25 |
 packages/shared/src/utils/eliza-root.ts |  100.00 |   98.25 | 37
-----------------------------------------|---------|---------|-------------------

 10 pass
 0 fail
 18 expect() calls
Ran 10 tests across 1 file. [229.00ms]
```
