### PR TITLE
fix(shared): extract stack and message from error-like objects in formatErrorWithStack and add unit test suite

### DIFF
--- a/packages/shared/src/format-error.test.ts
+++ b/packages/shared/src/format-error.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for browser-safe error formatting in formatErrorWithStack.
+ */
+import { describe, expect, it } from "vitest";
+import { formatErrorWithStack } from "./format-error.ts";
+
+describe("formatErrorWithStack", () => {
+  it("formats standard Error instances with stack", () => {
+    const error = new Error("something went wrong");
+    const formatted = formatErrorWithStack(error);
+    expect(formatted).toContain("Error: something went wrong");
+    expect(formatted).toContain("format-error.test.ts");
+  });
+
+  it("falls back to message when Error stack is empty or whitespace", () => {
+    const error = new Error("custom message");
+    error.stack = "";
+    expect(formatErrorWithStack(error)).toBe("custom message");
+
+    error.stack = "   ";
+    expect(formatErrorWithStack(error)).toBe("custom message");
+  });
+
+  it("extracts stack from error-like plain objects", () => {
+    const errorObj = {
+      message: "rpc failed",
+      stack: "Error: rpc failed\n    at remoteWorker (worker.js:10:5)",
+    };
+    expect(formatErrorWithStack(errorObj)).toBe(
+      "Error: rpc failed\n    at remoteWorker (worker.js:10:5)",
+    );
+  });
+
+  it("extracts message from error-like plain objects without stack", () => {
+    const errorObj = { message: "network timeout" };
+    expect(formatErrorWithStack(errorObj)).toBe("network timeout");
+  });
+
+  it("falls back to message when error-like object stack is whitespace", () => {
+    const errorObj = { message: "db unavailable", stack: "   " };
+    expect(formatErrorWithStack(errorObj)).toBe("db unavailable");
+  });
+
+  it("formats primitive strings directly", () => {
+    expect(formatErrorWithStack("direct string error")).toBe(
+      "direct string error",
+    );
+  });
+
+  it("formats numbers and booleans via String conversion", () => {
+    expect(formatErrorWithStack(404)).toBe("404");
+    expect(formatErrorWithStack(false)).toBe("false");
+  });
+
+  it("handles null and undefined safely", () => {
+    expect(formatErrorWithStack(null)).toBe("null");
+    expect(formatErrorWithStack(undefined)).toBe("undefined");
+  });
+
+  it("falls back to String representation for arbitrary plain objects", () => {
+    expect(formatErrorWithStack({})).toBe("[object Object]");
+  });
+});

--- a/packages/shared/src/format-error.ts
+++ b/packages/shared/src/format-error.ts
@@ -14,5 +14,17 @@
 export { formatError } from "@elizaos/core/client-public";
 
 export function formatErrorWithStack(err: unknown): string {
-  return err instanceof Error ? (err.stack ?? err.message) : String(err);
+  if (err instanceof Error) {
+    return err.stack?.trim() ? err.stack : err.message;
+  }
+  if (typeof err === "object" && err !== null) {
+    const record = err as { stack?: unknown; message?: unknown };
+    if (typeof record.stack === "string" && record.stack.trim()) {
+      return record.stack;
+    }
+    if (typeof record.message === "string" && record.message.trim()) {
+      return record.message;
+    }
+  }
+  return typeof err === "string" ? err : String(err);
 }


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Support extracting `stack` and `message` properties from error-like plain objects in `formatErrorWithStack` when `!(err instanceof Error)` (e.g. serialized errors from IPC, Web Worker RPC, or API payloads).
- Safely fall back to `message` when `stack` is empty or whitespace-only.
- Add a dedicated unit test suite in `packages/shared/src/format-error.test.ts` with 100% code coverage.

## Related Issues

- Fixes #21886

## Testing

- Added `packages/shared/src/format-error.test.ts` with 9 test cases covering:
  - Standard `Error` instances with stack
  - `Error` instances with empty/whitespace stack falling back to message
  - Error-like objects with `stack` and `message`
  - Error-like objects with `message` only
  - Error-like objects with whitespace stack falling back to message
  - Primitive strings
  - Numbers and booleans
  - Nullish inputs (`null`, `undefined`)
  - Arbitrary plain objects
- `bun test packages/shared/src/format-error.test.ts` passes (9/9 tests, 13 assertions, 100% line coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/format-error.test.ts:
✓ formatErrorWithStack > formats standard Error instances with stack [0.51ms]
✓ formatErrorWithStack > falls back to message when Error stack is empty or whitespace [0.19ms]
✓ formatErrorWithStack > extracts stack from error-like plain objects [0.12ms]
✓ formatErrorWithStack > extracts message from error-like plain objects without stack [0.06ms]
✓ formatErrorWithStack > falls back to message when error-like object stack is whitespace [0.07ms]
✓ formatErrorWithStack > formats primitive strings directly [0.08ms]
✓ formatErrorWithStack > formats numbers and booleans via String conversion [0.08ms]
✓ formatErrorWithStack > handles null and undefined safely [4.14ms]
✓ formatErrorWithStack > falls back to String representation for arbitrary plain objects [0.23ms]
-----------------------------------------|---------|---------|-------------------
File                                     | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------|---------|---------|-------------------
 packages/shared/src/format-error.ts     |  100.00 |  100.00 | 
-----------------------------------------|---------|---------|-------------------

 9 pass
 0 fail
 13 expect() calls
Ran 9 tests across 1 file. [262.00ms]
```
