### PR TITLE
fix(shared): guard nullish and non-string inputs in autoLabel and expand unit test suite

### DIFF
--- a/packages/shared/src/utils/labels.test.ts
+++ b/packages/shared/src/utils/labels.test.ts
@@ -34,4 +34,16 @@ describe("autoLabel", () => {
     expect(autoLabel("plugin_rpc_url", "plugin")).toBe("RPC URL");
     expect(autoLabel("custom_client_secret", "custom")).toBe("Client Secret");
   });
+
+  it("handles nullish, non-string, empty, and whitespace-only inputs safely", () => {
+    expect(autoLabel("", "plugin")).toBe("");
+    expect(autoLabel("   ", "plugin")).toBe("");
+    expect(autoLabel(null as unknown as string, "plugin")).toBe("");
+    expect(autoLabel(undefined as unknown as string, "plugin")).toBe("");
+    expect(autoLabel(123 as unknown as string, "plugin")).toBe("");
+    expect(autoLabel("API_KEY", null as unknown as string)).toBe("API Key");
+    expect(autoLabel("API_KEY", undefined as unknown as string)).toBe(
+      "API Key",
+    );
+  });
 });

--- a/packages/shared/src/utils/labels.ts
+++ b/packages/shared/src/utils/labels.ts
@@ -22,12 +22,18 @@ export const ENV_KEY_ACRONYMS: Set<string> = new Set([
 ]);
 
 export function autoLabel(key: string, pluginId: string): string {
-  const prefixes = [
-    `${pluginId.toUpperCase().replace(/-/g, "_")}_`,
-    `${pluginId.toUpperCase().replace(/-/g, "")}_`,
-  ];
+  if (typeof key !== "string" || key.trim() === "") {
+    return "";
+  }
+  const cleanPluginId = typeof pluginId === "string" ? pluginId.trim() : "";
+  const prefixes = cleanPluginId
+    ? [
+        `${cleanPluginId.toUpperCase().replace(/-/g, "_")}_`,
+        `${cleanPluginId.toUpperCase().replace(/-/g, "")}_`,
+      ]
+    : [];
 
-  let remainder = key;
+  let remainder = key.trim();
   for (const prefix of prefixes) {
     if (
       remainder.toUpperCase().startsWith(prefix) &&


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `typeof key !== "string"` and return `""` when `key` is empty or non-string in `autoLabel`.
- Guard `typeof pluginId !== "string"` before building plugin prefix patterns.
- Trim whitespace on `key` and `pluginId` before prefix extraction and word segmentation.
- Expand unit test suite in `packages/shared/src/utils/labels.test.ts` to test nullish, non-string, empty, and whitespace-only inputs.

## Related Issues

- Fixes #21890

## Testing

- Added test cases in `packages/shared/src/utils/labels.test.ts` covering:
  - Empty string and whitespace-only `key`
  - Null and undefined `key`
  - Non-string numbers as `key`
  - Null and undefined `pluginId`
- `bun test packages/shared/src/utils/labels.test.ts` passes (7/7 tests, 16 assertions, 100% line coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/utils/labels.test.ts:
✓ autoLabel > strips the underscored plugin prefix and preserves acronyms [1.23ms]
✓ autoLabel > strips the collapsed (hyphen-removed) plugin prefix [0.12ms]
✓ autoLabel > title-cases ordinary words [0.07ms]
✓ autoLabel > leaves a key without the plugin prefix as a single title-cased token [0.09ms]
✓ autoLabel > does not strip a prefix-only key (length must strictly exceed the prefix) [0.07ms]
✓ autoLabel > handles lowercase and mixed-case keys and plugin ids [0.15ms]
✓ autoLabel > handles nullish, non-string, empty, and whitespace-only inputs safely [0.13ms]
-------------------------------------|---------|---------|-------------------
File                                 | % Funcs | % Lines | Uncovered Line #s
-------------------------------------|---------|---------|-------------------
 packages/shared/src/utils/labels.ts |  100.00 |  100.00 | 
-------------------------------------|---------|---------|-------------------

 7 pass
 0 fail
 16 expect() calls
Ran 7 tests across 1 file. [208.00ms]
```
