### PR TITLE
fix(shared): normalize language and guard system prompt in addLanguageRule and expand tests

### DIFF
--- a/packages/shared/src/character-language.test.ts
+++ b/packages/shared/src/character-language.test.ts
@@ -5,7 +5,11 @@
  * non-string input. Pure string logic, no mocks.
  */
 import { describe, expect, it } from "vitest";
-import { normalizeCharacterLanguage } from "./character-language";
+import {
+  addLanguageRule,
+  LANGUAGE_REPLY_RULES,
+  normalizeCharacterLanguage,
+} from "./character-language";
 
 /**
  * `normalizeCharacterLanguage` is on the eager renderer path (the i18n keyword
@@ -51,5 +55,35 @@ describe("normalizeCharacterLanguage", () => {
     expect(normalizeCharacterLanguage(undefined)).toBe("en");
     expect(normalizeCharacterLanguage(42)).toBe("en");
     expect(normalizeCharacterLanguage({})).toBe("en");
+  });
+});
+
+describe("addLanguageRule", () => {
+  it("appends language reply rule to existing system prompt", () => {
+    const result = addLanguageRule("You are a helpful assistant.", "en");
+    expect(result).toBe(
+      `You are a helpful assistant. ${LANGUAGE_REPLY_RULES.en}`,
+    );
+  });
+
+  it("normalizes language alias before appending rule", () => {
+    const resultZh = addLanguageRule("You are helpful.", "zh-Hans" as never);
+    expect(resultZh).toBe(`You are helpful. ${LANGUAGE_REPLY_RULES["zh-CN"]}`);
+
+    const resultKo = addLanguageRule("You are helpful.", "ko-KR" as never);
+    expect(resultKo).toBe(`You are helpful. ${LANGUAGE_REPLY_RULES.ko}`);
+  });
+
+  it("falls back to English rule when language is unknown or invalid", () => {
+    const result = addLanguageRule("You are helpful.", "unknown-lang" as never);
+    expect(result).toBe(`You are helpful. ${LANGUAGE_REPLY_RULES.en}`);
+  });
+
+  it("returns rule without leading space when system prompt is empty or whitespace", () => {
+    expect(addLanguageRule("", "es")).toBe(LANGUAGE_REPLY_RULES.es);
+    expect(addLanguageRule("   ", "es")).toBe(LANGUAGE_REPLY_RULES.es);
+    expect(addLanguageRule(null as unknown as string, "es")).toBe(
+      LANGUAGE_REPLY_RULES.es,
+    );
   });
 });

--- a/packages/shared/src/character-language.ts
+++ b/packages/shared/src/character-language.ts
@@ -30,8 +30,12 @@ export function addLanguageRule(
   system: string,
   language: CharacterLanguage,
 ): string {
-  const rule = LANGUAGE_REPLY_RULES[language];
-  return `${system} ${rule}`;
+  const normLang = normalizeCharacterLanguage(language);
+  const rule =
+    LANGUAGE_REPLY_RULES[normLang] ??
+    LANGUAGE_REPLY_RULES[DEFAULT_CHARACTER_LANGUAGE];
+  const prefix = typeof system === "string" ? system.trim() : "";
+  return prefix ? `${prefix} ${rule}` : rule;
 }
 
 export function normalizeCharacterLanguage(input: unknown): CharacterLanguage {


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Normalize `language` in `addLanguageRule` via `normalizeCharacterLanguage(language)` with safe fallback to `DEFAULT_CHARACTER_LANGUAGE`, avoiding `undefined` rule values when given language aliases (e.g. `zh`, `ko-KR`, `fil`).
- Guard `system` against non-string / empty / whitespace values, trimming whitespace and avoiding leading spaces when `system` is empty.
- Expand unit test suite in `packages/shared/src/character-language.test.ts` to test `addLanguageRule` across canonical languages, language aliases, invalid language keys, and empty system prompts with 100% coverage.

## Related Issues

- Fixes #21892

## Testing

- Added test cases in `packages/shared/src/character-language.test.ts` covering:
  - Appending rule to existing system prompt
  - Normalizing language aliases (`zh-Hans` -> `zh-CN`, `ko-KR` -> `ko`)
  - Fallback to English rule on invalid or unknown language
  - Empty or whitespace system prompt without leading spaces
- `bun test packages/shared/src/character-language.test.ts` passes (9/9 tests, 31 assertions, 100% line & function coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/character-language.test.ts:
✓ normalizeCharacterLanguage > passes an exact canonical language through unchanged [0.59ms]
✓ normalizeCharacterLanguage > collapses every Chinese variant onto zh-CN [0.29ms]
✓ normalizeCharacterLanguage > normalizes regional/script tags by language prefix [0.28ms]
✓ normalizeCharacterLanguage > trims surrounding whitespace before matching [0.09ms]
✓ normalizeCharacterLanguage > falls back to en for unknown, empty, or non-string input [0.22ms]
✓ addLanguageRule > appends language reply rule to existing system prompt [0.28ms]
✓ addLanguageRule > normalizes language alias before appending rule [0.14ms]
✓ addLanguageRule > falls back to English rule when language is unknown or invalid [0.10ms]
✓ addLanguageRule > returns rule without leading space when system prompt is empty or whitespace [0.10ms]
----------------------------------------------------|---------|---------|-------------------
File                                                | % Funcs | % Lines | Uncovered Line #s
----------------------------------------------------|---------|---------|-------------------
 packages/shared/src/character-language.ts          |  100.00 |  100.00 | 
----------------------------------------------------|---------|---------|-------------------

 9 pass
 0 fail
 31 expect() calls
Ran 9 tests across 1 file. [227.00ms]
```
