### PR TITLE
fix(shared): guard invalid files and handle canvas failures in documents-upload-image

### DIFF
--- a/packages/shared/src/utils/documents-upload-image.test.ts
+++ b/packages/shared/src/utils/documents-upload-image.test.ts
@@ -45,7 +45,7 @@ describe("documents-upload-image utilities", () => {
       );
     });
 
-    it("returns false for non-image files", () => {
+    it("returns false for non-image files and nullish/invalid inputs", () => {
       expect(
         isDocumentImageFile({
           name: "contract.pdf",
@@ -67,6 +67,9 @@ describe("documents-upload-image utilities", () => {
           type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         }),
       ).toBe(false);
+      expect(isDocumentImageFile(null)).toBe(false);
+      expect(isDocumentImageFile(undefined)).toBe(false);
+      expect(isDocumentImageFile({} as unknown as File)).toBe(false);
     });
   });
 
@@ -87,6 +90,15 @@ describe("documents-upload-image utilities", () => {
       expect(result.file).toBe(nonImageFile);
       expect(result.originalSize).toBe(nonImageFile.size);
       expect(result.optimizedSize).toBe(nonImageFile.size);
+    });
+
+    it("handles nullish/invalid file inputs safely", async () => {
+      const result = await maybeCompressDocumentUploadImage(
+        null as unknown as DocumentImageUploadFile,
+      );
+      expect(result.optimized).toBe(false);
+      expect(result.originalSize).toBe(0);
+      expect(result.optimizedSize).toBe(0);
     });
 
     it("skips images within size threshold", async () => {
@@ -114,6 +126,60 @@ describe("documents-upload-image utilities", () => {
         MAX_DOCUMENT_IMAGE_PROCESSING_BYTES + 1024,
       );
       const largeImageFile = new File([largeImageBytes], "large.jpg", {
+        type: "image/jpeg",
+      }) as DocumentImageUploadFile;
+
+      const result = await maybeCompressDocumentUploadImage(
+        largeImageFile,
+        mockPlatform,
+      );
+      expect(result.optimized).toBe(false);
+      expect(result.file).toBe(largeImageFile);
+    });
+
+    it("compresses large image successfully when platform is available", async () => {
+      const compressedBlob = new Blob([new Uint8Array(1024 * 1024)], {
+        type: "image/jpeg",
+      });
+      const mockPlatform: DocumentImageCompressionPlatform = {
+        isAvailable: () => true,
+        loadImageSource: async () => ({
+          source: {} as CanvasImageSource,
+          width: 3000,
+          height: 2000,
+        }),
+        renderBlob: async () => compressedBlob,
+      };
+
+      const largeImageBytes = new Uint8Array(
+        MAX_DOCUMENT_IMAGE_PROCESSING_BYTES + 1024,
+      );
+      const largeImageFile = new File([largeImageBytes], "large.jpg", {
+        type: "image/jpeg",
+      }) as DocumentImageUploadFile;
+
+      const result = await maybeCompressDocumentUploadImage(
+        largeImageFile,
+        mockPlatform,
+      );
+      expect(result.optimized).toBe(true);
+      expect(result.originalSize).toBe(largeImageFile.size);
+      expect(result.optimizedSize).toBe(compressedBlob.size);
+    });
+
+    it("falls back to original file if loadImageSource throws", async () => {
+      const mockPlatform: DocumentImageCompressionPlatform = {
+        isAvailable: () => true,
+        loadImageSource: async () => {
+          throw new Error("Corrupted image file");
+        },
+        renderBlob: async () => new Blob([""]),
+      };
+
+      const largeImageBytes = new Uint8Array(
+        MAX_DOCUMENT_IMAGE_PROCESSING_BYTES + 1024,
+      );
+      const largeImageFile = new File([largeImageBytes], "corrupted.jpg", {
         type: "image/jpeg",
       }) as DocumentImageUploadFile;
 

--- a/packages/shared/src/utils/documents-upload-image.ts
+++ b/packages/shared/src/utils/documents-upload-image.ts
@@ -128,11 +128,17 @@ function cloneUploadFile(
 }
 
 export function isDocumentImageFile(
-  file: Pick<File, "name" | "type">,
+  file?: Pick<File, "name" | "type"> | null,
 ): boolean {
-  if (file.type.startsWith("image/")) return true;
-  const lowerName = file.name.toLowerCase();
-  return IMAGE_EXTENSIONS.some((extension) => lowerName.endsWith(extension));
+  if (!file || typeof file !== "object") return false;
+  if (typeof file.type === "string" && file.type.startsWith("image/")) {
+    return true;
+  }
+  if (typeof file.name === "string") {
+    const lowerName = file.name.toLowerCase();
+    return IMAGE_EXTENSIONS.some((extension) => lowerName.endsWith(extension));
+  }
+  return false;
 }
 
 export async function maybeCompressDocumentUploadImage(
@@ -145,70 +151,78 @@ export async function maybeCompressDocumentUploadImage(
   optimizedSize: number;
 }> {
   if (
+    !file ||
+    typeof file !== "object" ||
+    typeof file.size !== "number" ||
     !isDocumentImageFile(file) ||
     file.size <= MAX_DOCUMENT_IMAGE_PROCESSING_BYTES ||
-    !platform.isAvailable()
+    !platform?.isAvailable?.()
   ) {
+    const size = typeof file?.size === "number" ? file.size : 0;
     return {
       file,
       optimized: false,
-      originalSize: file.size,
-      optimizedSize: file.size,
+      originalSize: size,
+      optimizedSize: size,
     };
   }
 
-  const image = await platform.loadImageSource(file);
-  let { width, height } = clampDimensions(
-    image.width,
-    image.height,
-    IMAGE_MAX_DIMENSION,
-  );
-  let bestBlob: Blob | null = null;
+  try {
+    const image = await platform.loadImageSource(file);
+    let { width, height } = clampDimensions(
+      image.width,
+      image.height,
+      IMAGE_MAX_DIMENSION,
+    );
+    let bestBlob: Blob | null = null;
 
-  while (true) {
-    for (const quality of IMAGE_QUALITY_STEPS) {
-      const blob = await platform.renderBlob({
-        source: image.source,
-        width,
-        height,
-        outputType: IMAGE_OUTPUT_TYPE,
-        quality,
-      });
+    while (true) {
+      for (const quality of IMAGE_QUALITY_STEPS) {
+        const blob = await platform.renderBlob({
+          source: image.source,
+          width,
+          height,
+          outputType: IMAGE_OUTPUT_TYPE,
+          quality,
+        });
 
-      if (!bestBlob || blob.size < bestBlob.size) {
-        bestBlob = blob;
+        if (!bestBlob || blob.size < bestBlob.size) {
+          bestBlob = blob;
+        }
+
+        if (blob.size <= TARGET_DOCUMENT_IMAGE_BYTES) {
+          return {
+            file: cloneUploadFile(file, blob),
+            optimized: true,
+            originalSize: file.size,
+            optimizedSize: blob.size,
+          };
+        }
       }
 
-      if (blob.size <= TARGET_DOCUMENT_IMAGE_BYTES) {
-        return {
-          file: cloneUploadFile(file, blob),
-          optimized: true,
-          originalSize: file.size,
-          optimizedSize: blob.size,
-        };
-      }
+      const largestEdge = Math.max(width, height);
+      if (largestEdge <= IMAGE_MIN_DIMENSION) break;
+
+      const nextScale = Math.max(
+        IMAGE_MIN_DIMENSION / largestEdge,
+        IMAGE_SCALE_STEP,
+      );
+      if (nextScale >= 1) break;
+
+      width = Math.max(1, Math.round(width * nextScale));
+      height = Math.max(1, Math.round(height * nextScale));
     }
 
-    const largestEdge = Math.max(width, height);
-    if (largestEdge <= IMAGE_MIN_DIMENSION) break;
-
-    const nextScale = Math.max(
-      IMAGE_MIN_DIMENSION / largestEdge,
-      IMAGE_SCALE_STEP,
-    );
-    if (nextScale >= 1) break;
-
-    width = Math.max(1, Math.round(width * nextScale));
-    height = Math.max(1, Math.round(height * nextScale));
-  }
-
-  if (bestBlob && bestBlob.size < file.size) {
-    return {
-      file: cloneUploadFile(file, bestBlob),
-      optimized: true,
-      originalSize: file.size,
-      optimizedSize: bestBlob.size,
-    };
+    if (bestBlob && bestBlob.size < file.size) {
+      return {
+        file: cloneUploadFile(file, bestBlob),
+        optimized: true,
+        originalSize: file.size,
+        optimizedSize: bestBlob.size,
+      };
+    }
+  } catch {
+    // error-policy:J4 gracefully degrade to uncompressed file if canvas processing fails
   }
 
   return {


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `isDocumentImageFile` against nullish or non-object file arguments and check `typeof file.name === "string"` and `typeof file.type === "string"`.
- Guard `maybeCompressDocumentUploadImage` against nullish/malformed file objects and unavailable platforms.
- Wrap platform image loading and canvas rendering in try/catch to gracefully fall back to the uncompressed original file when image decoding or canvas rendering fails (e.g. unsupported format or corrupt image bytes).
- Expand unit test suite in `packages/shared/src/utils/documents-upload-image.test.ts` to test invalid/nullish inputs, successful mock compression, and failure fallback.

## Related Issues

- Fixes #21894

## Testing

- Expanded `packages/shared/src/utils/documents-upload-image.test.ts` with 10 tests covering:
  - MIME type identification
  - Extension identification
  - Rejection of non-image, null, undefined, and malformed inputs
  - Handling of nullish/invalid file objects in `maybeCompressDocumentUploadImage`
  - Successful image compression when platform is available
  - Graceful fallback when platform `loadImageSource` throws an error
- `bun test packages/shared/src/utils/documents-upload-image.test.ts` passes (10/10 tests, 33 assertions).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/utils/documents-upload-image.test.ts:
✓ documents-upload-image utilities > isDocumentImageFile > identifies image files by MIME type [0.30ms]
✓ documents-upload-image utilities > isDocumentImageFile > identifies image files by extension when MIME type is generic or empty [0.35ms]
✓ documents-upload-image utilities > isDocumentImageFile > returns false for non-image files and nullish/invalid inputs [0.35ms]
✓ documents-upload-image utilities > MAX_DOCUMENT_IMAGE_PROCESSING_BYTES > exports the 5MB processing threshold (5,242,880 bytes) [0.08ms]
✓ documents-upload-image utilities > maybeCompressDocumentUploadImage > skips non-image files without attempting compression [11.35ms]
✓ documents-upload-image utilities > maybeCompressDocumentUploadImage > handles nullish/invalid file inputs safely [0.49ms]
✓ documents-upload-image utilities > maybeCompressDocumentUploadImage > skips images within size threshold [0.30ms]
✓ documents-upload-image utilities > maybeCompressDocumentUploadImage > returns unoptimized when compression platform is unavailable [22.94ms]
✓ documents-upload-image utilities > maybeCompressDocumentUploadImage > compresses large image successfully when platform is available [12.33ms]
✓ documents-upload-image utilities > maybeCompressDocumentUploadImage > falls back to original file if loadImageSource throws [10.30ms]
-----------------------------------------------------|---------|---------|-------------------
File                                                 | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------------|---------|---------|-------------------
 packages/shared/src/utils/documents-upload-image.ts |   70.00 |   54.24 | 
-----------------------------------------------------|---------|---------|-------------------

 10 pass
 0 fail
 33 expect() calls
Ran 10 tests across 1 file. [256.00ms]
```
