### PR TITLE
fix(shared): guard handler in setRestartHandler and add unit test suite

### DIFF
--- a/packages/shared/src/restart.test.ts
+++ b/packages/shared/src/restart.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for restart infrastructure (setRestartHandler, requestRestart, resetRestartHandlerForTests).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  RESTART_EXIT_CODE,
+  requestRestart,
+  resetRestartHandlerForTests,
+  setRestartHandler,
+} from "./restart.ts";
+
+describe("restart module", () => {
+  afterEach(() => {
+    resetRestartHandlerForTests();
+  });
+
+  it("exports RESTART_EXIT_CODE as a number", () => {
+    expect(typeof RESTART_EXIT_CODE).toBe("number");
+    expect(Number.isInteger(RESTART_EXIT_CODE)).toBe(true);
+  });
+
+  it("executes default noop handler without error", () => {
+    expect(() => requestRestart()).not.toThrow();
+    expect(() => requestRestart("some reason")).not.toThrow();
+  });
+
+  it("invokes custom restart handler with trimmed reason", () => {
+    const handler = vi.fn();
+    setRestartHandler(handler);
+
+    requestRestart("  config updated  ");
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith("config updated");
+  });
+
+  it("invokes custom async restart handler", async () => {
+    let resolvedReason: string | undefined;
+    setRestartHandler(async (reason) => {
+      resolvedReason = reason;
+    });
+
+    await requestRestart("manual-restart");
+    expect(resolvedReason).toBe("manual-restart");
+  });
+
+  it("safely ignores non-function handlers and falls back to default noop", () => {
+    setRestartHandler(null as unknown as () => void);
+    expect(() => requestRestart()).not.toThrow();
+
+    setRestartHandler(123 as unknown as () => void);
+    expect(() => requestRestart()).not.toThrow();
+  });
+
+  it("resets handler back to default with resetRestartHandlerForTests", () => {
+    const handler = vi.fn();
+    setRestartHandler(handler);
+
+    resetRestartHandlerForTests();
+    requestRestart("after-reset");
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/restart.ts
+++ b/packages/shared/src/restart.ts
@@ -23,18 +23,27 @@ export const RESTART_EXIT_CODE = restartExitCodeDefinition.restartExitCode;
 export type RestartHandler = (reason?: string) => void | Promise<void>;
 
 // Browser-safe default. Server hosts register a real handler.
-let _handler: RestartHandler = () => {};
+const DEFAULT_RESTART_HANDLER: RestartHandler = () => {};
+let _handler: RestartHandler = DEFAULT_RESTART_HANDLER;
 
 /**
  * Replace the active restart handler.
  */
 export function setRestartHandler(handler: RestartHandler): void {
-  _handler = handler;
+  _handler = typeof handler === "function" ? handler : DEFAULT_RESTART_HANDLER;
+}
+
+/**
+ * Reset the active restart handler to the default noop function (for test cleanup).
+ */
+export function resetRestartHandlerForTests(): void {
+  _handler = DEFAULT_RESTART_HANDLER;
 }
 
 /**
  * Trigger a restart. Delegates to whatever handler is currently registered.
  */
 export function requestRestart(reason?: string): void | Promise<void> {
-  return _handler(reason);
+  const cleanReason = typeof reason === "string" ? reason.trim() : undefined;
+  return _handler(cleanReason);
 }


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `setRestartHandler` against non-function arguments, safely falling back to the default noop handler.
- Export `resetRestartHandlerForTests()` to prevent test state pollution.
- Trim `reason` string in `requestRestart`.
- Add a comprehensive unit test suite in `packages/shared/src/restart.test.ts` testing default noop execution, custom sync/async handlers, non-function handler fallback, reason trimming, and test resetting with 100% line & function coverage.

## Related Issues

- Fixes #21898

## Testing

- Added `packages/shared/src/restart.test.ts` with 6 test cases covering:
  - `RESTART_EXIT_CODE` numeric export
  - Default noop handler execution
  - Custom synchronous restart handler with trimmed reason
  - Custom asynchronous restart handler
  - Non-function fallback to default noop handler
  - Handler reset via `resetRestartHandlerForTests()`
- `bun test packages/shared/src/restart.test.ts` passes (6/6 tests, 10 assertions, 100% line & func coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/restart.test.ts:
✓ restart module > exports RESTART_EXIT_CODE as a number [0.23ms]
✓ restart module > executes default noop handler without error [0.99ms]
✓ restart module > invokes custom restart handler with trimmed reason [0.58ms]
✓ restart module > invokes custom async restart handler [0.39ms]
✓ restart module > safely ignores non-function handlers and falls back to default noop [0.17ms]
✓ restart module > resets handler back to default with resetRestartHandlerForTests [0.08ms]
--------------------------------|---------|---------|-------------------
File                            | % Funcs | % Lines | Uncovered Line #s
--------------------------------|---------|---------|-------------------
 packages/shared/src/restart.ts |  100.00 |  100.00 | 
--------------------------------|---------|---------|-------------------

 6 pass
 0 fail
 10 expect() calls
Ran 6 tests across 1 file. [195.00ms]
```
