### PR TITLE
fix(security): drop serializer hooks in core log-sink redactor clone

### DIFF
--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -628,6 +628,43 @@ describe("redactLogArgs (log-sink redaction, not opt-in)", () => {
 		expect(serialized).not.toContain("resurrected");
 	});
 
+	it("does not invoke a caller-owned array map or preserve a hostile array species", () => {
+		const secret = "sk-array-clone-hook-secret-value";
+		const ownMap = [{ apiKey: secret }];
+		Object.assign(ownMap, {
+			map: () => ownMap,
+			toJSON: () => ({ marker: "own-map-resurrected", secret }),
+		});
+
+		class HostileArray extends Array<unknown> {
+			toJSON() {
+				return { marker: "species-resurrected", secret };
+			}
+		}
+		const hostileSpecies = new HostileArray();
+		hostileSpecies.push({ apiKey: secret });
+
+		const [ownMapOut, speciesOut] = redactLogArgs([ownMap, hostileSpecies]) as [
+			unknown[],
+			unknown[],
+		];
+		expect(ownMapOut).not.toBe(ownMap);
+		expect(speciesOut).not.toBeInstanceOf(HostileArray);
+		expect(ownMapOut).toEqual([{ apiKey: "[REDACTED]" }]);
+		expect(speciesOut).toEqual([{ apiKey: "[REDACTED]" }]);
+		const serialized = JSON.stringify([ownMapOut, speciesOut]);
+		expect(serialized).not.toContain(secret);
+		expect(serialized).not.toContain("resurrected");
+	});
+
+	it("uses a null-prototype object clone", () => {
+		const input = JSON.parse('{"__proto__":{"note":"untrusted"},"ok":1}');
+		const [out] = redactLogArgs([input]) as [Record<string, unknown>];
+		expect(Object.getPrototypeOf(out)).toBeNull();
+		expect(Object.hasOwn(out, "__proto__")).toBe(true);
+		expect(out.ok).toBe(1);
+	});
+
 	it("drops valueOf/toString hooks alongside toJSON", () => {
 		const secret = "sk-valueof-hook-secret-value";
 		const [ctx] = redactLogArgs([

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -520,6 +520,31 @@ describe("isSensitiveKeyName", () => {
 		}
 		expect(isSensitiveKeyName("accessTokens")).toBe(true);
 	});
+
+	it("flags the closed concat key set without catching key lookalikes", () => {
+		// master/encryption concatenations had no word boundary for the substring
+		// rules, so pattern-inert values under them leaked; the closed suffix set
+		// matches the leaf logger's isSensitiveLogKey and the agent's
+		// isSensitiveConfigKey without opening `key$` to lookalikes.
+		for (const key of [
+			"masterKey",
+			"master_key",
+			"MASTERKEY",
+			"MASTER_KEY",
+			"encryptionKey",
+			"encryption-key",
+			"ENCRYPTIONKEY",
+			"signingKey",
+			"SIGNINGKEY",
+			"sshKey",
+			"SSHKEY",
+		]) {
+			expect(isSensitiveKeyName(key), key).toBe(true);
+		}
+		for (const key of ["monkey", "turnkey", "hotkey", "keyboard", "KEYBOARD"]) {
+			expect(isSensitiveKeyName(key), key).toBe(false);
+		}
+	});
 });
 
 /**
@@ -733,6 +758,62 @@ describe("redactLogArgs (log-sink redaction, not opt-in)", () => {
 		const [out] = redactLogArgs([fn]);
 		expect(out).toBeNull();
 		expect(JSON.stringify(redactLogArgs([fn]))).not.toContain(secret);
+	});
+
+	it("masks a pattern-inert value under a concat credential key", () => {
+		// Neither value matches a credential shape — only the key name can catch
+		// them. masterKey/encryptionKey had no separator for the substring rules
+		// before the closed concat set, so these leaked verbatim.
+		const [ctx] = redactLogArgs([
+			{
+				encryptionKey: "correct-horse-battery-staple",
+				masterKey: "hunter2-master-value",
+				monkey: "visible",
+			},
+		]) as [Record<string, unknown>];
+		expect(ctx.encryptionKey).toBe("[REDACTED]");
+		expect(ctx.masterKey).toBe("[REDACTED]");
+		expect(ctx.monkey).toBe("visible");
+		const serialized = JSON.stringify(ctx);
+		expect(serialized).not.toContain("correct-horse-battery-staple");
+		expect(serialized).not.toContain("hunter2-master-value");
+	});
+
+	it("masks Buffer/TypedArray/DataView/ArrayBuffer payloads with a size-only marker", () => {
+		const secret = "sk-buffer-payload-secret";
+		const buf = Buffer.from(secret, "utf8");
+		const bytes = new TextEncoder().encode(secret);
+		const view = new DataView(new ArrayBuffer(16));
+		const raw = new ArrayBuffer(8);
+		// A distinct instance for the nested slot: reusing `buf` would trip the
+		// cycle guard on the second encounter, not the buffer branch.
+		const deep = Buffer.from(secret, "utf8");
+		const [ctx] = redactLogArgs([
+			{ buf, bytes, view, raw, nested: { deep } },
+		]) as [Record<string, unknown>];
+		expect(ctx.buf).toBe(`[BUFFER REDACTED ${buf.byteLength} bytes]`);
+		expect(ctx.bytes).toBe(`[BUFFER REDACTED ${bytes.byteLength} bytes]`);
+		expect(ctx.view).toBe("[BUFFER REDACTED 16 bytes]");
+		expect(ctx.raw).toBe("[BUFFER REDACTED 8 bytes]");
+		expect(ctx.nested).toEqual({
+			deep: `[BUFFER REDACTED ${deep.byteLength} bytes]`,
+		});
+		const serialized = JSON.stringify(ctx);
+		// The pre-fix walk emitted the bytes as indexed properties (115 is 's'),
+		// and Buffer's own toJSON would emit them as a data array — either shape
+		// reconstitutes the secret byte-for-byte.
+		expect(serialized).not.toContain('"0":115');
+		expect(serialized).not.toContain("115,107");
+	});
+
+	it("does not let a hostile own toJSON on a Buffer reconstitute its bytes", () => {
+		const secret = "sk-buffer-hook-secret-value";
+		const hostile = Object.assign(Buffer.from(secret, "utf8"), {
+			toJSON: () => secret,
+		});
+		const [out] = redactLogArgs([hostile]);
+		expect(out).toBe(`[BUFFER REDACTED ${hostile.byteLength} bytes]`);
+		expect(JSON.stringify(out)).not.toContain(secret);
 	});
 
 	it("leaves non-string, non-object arguments untouched", () => {

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -525,7 +525,9 @@ describe("isSensitiveKeyName", () => {
 /**
  * redactLogArgs is the sink-level redactor: it masks secrets structurally so a
  * logger that pipes its args through it protects `{ apiKey }` with no
- * redact.context() at the call site (#12229 M6).
+ * redact.context() at the call site (#12229 M6). The clone also drops function
+ * values outright — a copied toJSON/valueOf hook re-runs when the sink
+ * JSON-stringifies the output and would reconstitute the masked secrets.
  */
 describe("redactLogArgs (log-sink redaction, not opt-in)", () => {
 	it("masks a value under a credential-named key without any wrapping", () => {
@@ -578,6 +580,122 @@ describe("redactLogArgs (log-sink redaction, not opt-in)", () => {
 		cyclic.self = cyclic;
 		const [out] = redactLogArgs([cyclic]) as [Record<string, unknown>];
 		expect(out.name).toBe("x");
+	});
+
+	it("drops a hostile own toJSON so serialization cannot reconstitute secrets", () => {
+		const secret = "sk-tojson-resurrected-secret";
+		const hostile = {
+			apiKey: secret,
+			note: "kept",
+			// The marker is not pattern-shaped, so it can only reach the output
+			// by the hook re-running at JSON.stringify.
+			toJSON: () => ({ apiKey: secret, marker: "top-resurrected" }),
+		};
+		const [ctx] = redactLogArgs([hostile]) as [Record<string, unknown>];
+		expect("toJSON" in ctx).toBe(false);
+		expect(ctx.apiKey).toBe("[REDACTED]");
+		expect(ctx.note).toBe("kept");
+		const serialized = JSON.stringify(ctx);
+		expect(serialized).not.toContain(secret);
+		expect(serialized).not.toContain("top-resurrected");
+	});
+
+	it("drops serializer hooks in nested objects and array elements", () => {
+		const secret = "sk-nested-hook-secret-value";
+		const [ctx] = redactLogArgs([
+			{
+				nested: {
+					hook: { toJSON: () => ({ marker: "nested-resurrected" }) },
+					ok: 1,
+				},
+				list: [
+					{ toJSON: () => ({ marker: "array-resurrected" }) },
+					secret,
+					Object.assign(() => secret, {
+						toJSON: () => ({ marker: "fn-resurrected" }),
+					}),
+				],
+			},
+		]) as [Record<string, unknown>];
+		const nested = ctx.nested as Record<string, unknown>;
+		expect(nested.ok).toBe(1);
+		expect(nested.hook).toEqual({});
+		// A function inside an array collapses to null, matching JSON array
+		// serialization semantics.
+		expect(ctx.list).toEqual([{}, "sk-nes…alue", null]);
+		const serialized = JSON.stringify(ctx);
+		expect(serialized).not.toContain(secret);
+		expect(serialized).not.toContain("resurrected");
+	});
+
+	it("drops valueOf/toString hooks alongside toJSON", () => {
+		const secret = "sk-valueof-hook-secret-value";
+		const [ctx] = redactLogArgs([
+			{
+				note: "kept",
+				valueOf: () => secret,
+				toString: () => secret,
+			},
+		]) as [Record<string, unknown>];
+		expect(ctx).toEqual({ note: "kept" });
+		expect(JSON.stringify(ctx)).not.toContain(secret);
+	});
+
+	it("drops an own toJSON on a class instance and never inherits the prototype's", () => {
+		const secret = "sk-class-hook-secret-value";
+		class Payload {
+			note = "kept";
+			apiKey = secret;
+			toJSON() {
+				return { marker: "prototype-resurrected" };
+			}
+		}
+		const ownHooked = Object.assign(new Payload(), {
+			toJSON: () => ({ marker: "own-resurrected" }),
+		});
+		const [plain, hooked] = redactLogArgs([new Payload(), ownHooked]) as [
+			Record<string, unknown>,
+			Record<string, unknown>,
+		];
+		for (const clone of [plain, hooked]) {
+			expect("toJSON" in clone).toBe(false);
+			expect(clone.apiKey).toBe("[REDACTED]");
+			expect(clone.note).toBe("kept");
+		}
+		const serialized = JSON.stringify([plain, hooked]);
+		expect(serialized).not.toContain(secret);
+		expect(serialized).not.toContain("resurrected");
+	});
+
+	it("keeps the Error shape while a hostile own toJSON does not survive", () => {
+		const secret = "sk-error-hook-secret-value";
+		const err = Object.assign(new Error(`boom ${secret}`), {
+			toJSON: () => ({ marker: "error-resurrected", secret }),
+		});
+		const [out] = redactLogArgs([err]) as [Error];
+		expect(out).toBeInstanceOf(Error);
+		expect(out.name).toBe("Error");
+		expect(out.message).not.toContain(secret);
+		expect("toJSON" in out).toBe(false);
+		const serialized = JSON.stringify(out);
+		expect(serialized).not.toContain(secret);
+		expect(serialized).not.toContain("error-resurrected");
+	});
+
+	it("does not let a hostile own toJSON on a Date reconstitute a secret", () => {
+		const secret = "sk-date-hook-secret-value";
+		const when = new Date("2026-01-02T03:04:05.000Z");
+		when.toJSON = () => secret;
+		const [ctx] = redactLogArgs([{ when }]) as [Record<string, unknown>];
+		expect(JSON.stringify(ctx)).not.toContain(secret);
+	});
+
+	it("collapses a bare function argument even when it carries a hostile toJSON", () => {
+		const secret = "sk-function-hook-secret-value";
+		const fn = Object.assign(() => secret, { toJSON: () => secret });
+		const [out] = redactLogArgs([fn]);
+		expect(out).toBeNull();
+		expect(JSON.stringify(redactLogArgs([fn]))).not.toContain(secret);
 	});
 
 	it("leaves non-string, non-object arguments untouched", () => {

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -561,7 +561,15 @@ function redactLogArg(
 	}
 	seen.add(value);
 	if (Array.isArray(value)) {
-		return value.map((item) => redactLogArg(item, seen, depth + 1));
+		// Do not call value.map: an Array subclass, custom Symbol.species, or own
+		// map property can return caller-owned data carrying a serializer hook.
+		// Index into the input but construct the output with the intrinsic Array
+		// constructor so no caller-controlled method or result prototype survives.
+		const result: unknown[] = [];
+		for (let index = 0; index < value.length; index += 1) {
+			result.push(redactLogArg(value[index], seen, depth + 1));
+		}
+		return result;
 	}
 	if (value instanceof Error) {
 		// Preserve the Error shape (name/stack) callers rely on, but scrub the
@@ -571,7 +579,9 @@ function redactLogArg(
 		redacted.stack = value.stack ? redactSensitiveText(value.stack) : undefined;
 		return redacted;
 	}
-	const result: Record<string, unknown> = {};
+	// A null-prototype target prevents a __proto__ input key from changing the
+	// clone's prototype and reintroducing inherited serializer behavior.
+	const result = Object.create(null) as Record<string, unknown>;
 	for (const [key, entry] of Object.entries(value)) {
 		if (isSensitiveKeyName(key)) {
 			result[key] = REDACTED_MASK;

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -529,6 +529,15 @@ const MAX_LOG_REDACT_DEPTH = 8;
  * pipes its arguments through {@link redactLogArgs} masks `{ apiKey }` whether
  * or not the caller wrapped the context first.
  *
+ * Function values never survive the walk. They are executable serializer hooks
+ * (toJSON/valueOf/toString), and a copied hook re-runs when a JSON sink
+ * stringifies the clone, able to reconstitute the very secrets the walk just
+ * masked. A bare function argument collapses to null and a function-valued
+ * property is dropped outright — matching JSON.stringify, which emits null for
+ * array functions and omits object function props. Symbol-keyed hooks such as
+ * util.inspect.custom never reach the clone because the walk copies string keys
+ * only.
+ *
  * Depth is bounded and cycles are broken (returning the mask) so a pathological
  * log payload cannot hang or blow the stack — a redactor must never be the thing
  * that takes the process down.
@@ -540,6 +549,9 @@ function redactLogArg(
 ): unknown {
 	if (typeof value === "string") {
 		return redactSensitiveText(value);
+	}
+	if (typeof value === "function") {
+		return null;
 	}
 	if (value === null || typeof value !== "object") {
 		return value;
@@ -563,6 +575,14 @@ function redactLogArg(
 	for (const [key, entry] of Object.entries(value)) {
 		if (isSensitiveKeyName(key)) {
 			result[key] = REDACTED_MASK;
+			continue;
+		}
+		// Function-valued properties are executable serializer hooks
+		// (toJSON/valueOf/toString): a copied hook re-runs when a sink
+		// JSON-stringifies the clone and can reconstitute the very secrets the
+		// walk just masked. JSON.stringify omits function props anyway, so
+		// dropping the key matches serialization semantics.
+		if (typeof entry === "function") {
 			continue;
 		}
 		result[key] = redactLogArg(entry, seen, depth + 1);

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -167,6 +167,14 @@ export function isSensitiveKeyName(key: string): boolean {
 	) {
 		return true;
 	}
+	// Separator-free concatenations (masterKey, MASTERKEY, encryption-key, …)
+	// have no word boundary for the substring rules above; a closed suffix set
+	// on the normalized name catches them without opening `key$` to lookalikes
+	// (monkey/turnkey/KEYBOARD stay non-sensitive). Same closed set as the leaf
+	// logger's isSensitiveLogKey and the agent's isSensitiveConfigKey.
+	if (/(?:master|signing|ssh|encryption)key$/i.test(normalized)) {
+		return true;
+	}
 	return false;
 }
 
@@ -538,6 +546,11 @@ const MAX_LOG_REDACT_DEPTH = 8;
  * util.inspect.custom never reach the clone because the walk copies string keys
  * only.
  *
+ * Buffer/TypedArray/DataView/ArrayBuffer values collapse to a size-only marker:
+ * the indexed walk would otherwise emit the raw bytes as {"0":115,…} under an
+ * innocent-looking key, and JSON.stringify would emit them as
+ * {"type":"Buffer","data":[…]} — either way secret bytes survive in every sink.
+ *
  * Depth is bounded and cycles are broken (returning the mask) so a pathological
  * log payload cannot hang or blow the stack — a redactor must never be the thing
  * that takes the process down.
@@ -578,6 +591,13 @@ function redactLogArg(
 		redacted.name = value.name;
 		redacted.stack = value.stack ? redactSensitiveText(value.stack) : undefined;
 		return redacted;
+	}
+	// Binary payloads carry raw bytes that JSON serializes verbatim
+	// ({"type":"Buffer","data":[...]}); walked as indexed objects they emit the
+	// same bytes as {"0":115,...} under an innocent-looking key, so mask with a
+	// size-only marker (same marker shape as the leaf logger's).
+	if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+		return `[BUFFER REDACTED ${value.byteLength} bytes]`;
 	}
 	// A null-prototype target prevents a __proto__ input key from changing the
 	// clone's prototype and reintroducing inherited serializer behavior.


### PR DESCRIPTION
## Summary

Wave-11 closing sweep items against the core log-sink redactor (`packages/core/src/security/redact.ts`). Three holes closed, one behavior deliberately kept.

**(1) Serializer hooks survive the clone (original scope — same class as logger OPEN-1, #21761).** `redactLogArg` copied own function values verbatim into the redacted clone, so a hostile own `toJSON` re-ran when a JSON sink stringified the output — reconstituting the very secrets the walk just masked. Reachable shape: `describeUnhandledError` (`packages/cloud/shared/src/lib/utils/unhandled-error-detail.ts`) passes `err.context` through `redactLogArgs` into Cloudflare JSON tail sinks. Fix (ported from the logger): a bare function argument collapses to `null`, and function-valued properties are dropped outright — matching `JSON.stringify` semantics. Symbol-keyed hooks (`util.inspect.custom`) never reach the clone because the walk copies string keys only.

**(2) Binary payloads emitted byte-for-byte (wave-11 verifier residual a).** Buffer/TypedArray/DataView/ArrayBuffer values fell through to the indexed object walk, emitting raw bytes as `{"0":115,…}` under an innocent-looking key (`JSON.stringify` on a raw Buffer emits the same bytes as `{"type":"Buffer","data":[…]}`). They now collapse to a size-only `[BUFFER REDACTED <n> bytes]` marker, same shape as the leaf logger. The branch runs before the property walk, so a hostile own `toJSON` on a Buffer never survives either.

**(3) Concat credential-key names not classified (wave-11 verifier residual b).** Core `isSensitiveKeyName` had no closed concat set, so pattern-inert values under `masterKey`/`encryptionKey`/`MASTERKEY`/`ENCRYPTIONKEY` leaked through `redactLogArgs` and every `redact.context()` consumer (the cloud Worker logger delegates to this predicate via the `elizaos-core` stub, which re-exports the real module — no stub change needed). Added the `/(?:master|signing|ssh|encryption)key$/i` closed suffix rule on the normalized name — the same set the leaf logger's `isSensitiveLogKey` and the agent's `isSensitiveConfigKey` already apply — keeping lookalikes (`monkey`/`turnkey`/`hotkey`/`KEYBOARD`) non-sensitive.

**Deliberately kept (verifier residual c):** the `Error` branch rebuilds a fresh `Error` with scrubbed message/stack and copies **no** own enumerable properties. That is data-loss-not-leak (axios-style `err.config` detail is dropped from log output, but nothing can reconstitute through it), so the behavior stays as-is.

## Classifier sync-contract check

The logger↔core sync contract (`redact.test.ts`: "keeps the core and leaf logger credential-shape policies synchronized") compares **pattern lists** only, via `__loggerTestHooks.getSensitiveTextPatternsForTests()`; it still passes — patterns untouched. **No sync contract covers the key-name classifiers**: logger `isSensitiveLogKey` is module-private, agent `isSensitiveConfigKey` has its own suite, and both already carry the concat rule — so (3) is a core-side catch-up that makes the three classifiers agree, not a contract change.

## Tests

`packages/core/src/security/redact.test.ts` adversarial additions (each asserts the secret **and** a non-pattern marker never reach `JSON.stringify` output):

- hostile own `toJSON`: top level, nested objects, array elements, class instances (own field dropped / prototype never inherited), `Error` (shape intact), `Date`, bare hooked function arg → `null`
- `valueOf`/`toString` hooks alongside `toJSON`
- concat key set (`masterKey`, `MASTER_KEY`, `ENCRYPTIONKEY`, …) vs lookalikes (`monkey`/`turnkey`/`hotkey`/`KEYBOARD`), and pattern-inert values under concat keys through `redactLogArgs`
- binary payloads: Buffer, Uint8Array, DataView, ArrayBuffer, nested buffer, hostile-`toJSON` Buffer — raw byte sequences never serialized

## Verification (final state, includes reviewer hardening commits)

- `packages/core` security lane: **34 files / 521 tests passed** (incl. the logger pattern-sync contract and the reviewer's array-clone isolation tests)
- `packages/cloud/shared` redact consumers: **12/12 passed** (`logger.test.ts` + `unhandled-error-detail.test.ts`, incl. the `redact.context()` ↔ sink-predicate agreement contract)
- `packages/logger` suite: **48/48 passed** (untouched)
- `tsc --noEmit -p packages/core/tsconfig.json`: clean
- `biome check` on both touched files: clean

Evidence: N/A for UI capture — redactor-only change, no view or model path affected.