### PR TITLE
fix(shared): guard nullish env and collapse duplicate slashes in self-edit guards

### DIFF
--- a/packages/shared/src/self-edit.test.ts
+++ b/packages/shared/src/self-edit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for self-edit safety gate and path denylist helpers.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  DEV_MODE_ENV,
+  getSelfEditDeniedSuffixes,
+  isSelfEditEnabled,
+  isSelfEditPathDenied,
+  SELF_EDIT_ENABLE_ENV,
+} from "./self-edit.ts";
+
+describe("isSelfEditEnabled", () => {
+  it("returns false when enable env var is unset or falsey", () => {
+    expect(isSelfEditEnabled({})).toBe(false);
+    expect(isSelfEditEnabled({ [SELF_EDIT_ENABLE_ENV]: "0" })).toBe(false);
+    expect(isSelfEditEnabled({ [SELF_EDIT_ENABLE_ENV]: "false" })).toBe(false);
+    expect(isSelfEditEnabled({ [SELF_EDIT_ENABLE_ENV]: "" })).toBe(false);
+  });
+
+  it("returns true in non-production environments when enabled", () => {
+    expect(
+      isSelfEditEnabled({
+        [SELF_EDIT_ENABLE_ENV]: "1",
+        NODE_ENV: "development",
+      }),
+    ).toBe(true);
+    expect(
+      isSelfEditEnabled({
+        [SELF_EDIT_ENABLE_ENV]: "true",
+        NODE_ENV: "test",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false in production unless dev mode is explicitly active", () => {
+    expect(
+      isSelfEditEnabled({
+        [SELF_EDIT_ENABLE_ENV]: "1",
+        NODE_ENV: "production",
+      }),
+    ).toBe(false);
+
+    expect(
+      isSelfEditEnabled({
+        [SELF_EDIT_ENABLE_ENV]: "1",
+        NODE_ENV: "production",
+        [DEV_MODE_ENV]: "1",
+      }),
+    ).toBe(true);
+  });
+
+  it("handles nullish or invalid env safely", () => {
+    expect(
+      typeof isSelfEditEnabled(null as unknown as Record<string, string>),
+    ).toBe("boolean");
+    expect(
+      typeof isSelfEditEnabled(undefined as unknown as Record<string, string>),
+    ).toBe("boolean");
+  });
+});
+
+describe("isSelfEditPathDenied", () => {
+  it("denies paths inside .git directory or metadata", () => {
+    expect(isSelfEditPathDenied(".git")).toBe(true);
+    expect(isSelfEditPathDenied(".git/config")).toBe(true);
+    expect(isSelfEditPathDenied("/project/.git/HEAD")).toBe(true);
+    expect(isSelfEditPathDenied("C:\\project\\.git\\index")).toBe(true);
+    expect(isSelfEditPathDenied("project//.git//hooks")).toBe(true);
+  });
+
+  it("denies paths matching protected files in denylist", () => {
+    for (const suffix of getSelfEditDeniedSuffixes()) {
+      expect(isSelfEditPathDenied(`/workspace/${suffix}`)).toBe(true);
+      expect(
+        isSelfEditPathDenied(`C:\\workspace\\${suffix.replace(/\//g, "\\")}`),
+      ).toBe(true);
+      expect(isSelfEditPathDenied(suffix)).toBe(true);
+    }
+  });
+
+  it("allows normal project source files", () => {
+    expect(isSelfEditPathDenied("/workspace/packages/core/src/index.ts")).toBe(
+      false,
+    );
+    expect(isSelfEditPathDenied("/workspace/.gitignore")).toBe(false);
+    expect(isSelfEditPathDenied("/workspace/.gitmodules")).toBe(false);
+    expect(isSelfEditPathDenied("/workspace/README.md")).toBe(false);
+  });
+
+  it("returns false for non-string, empty, or whitespace inputs", () => {
+    expect(isSelfEditPathDenied("")).toBe(false);
+    expect(isSelfEditPathDenied("   ")).toBe(false);
+    expect(isSelfEditPathDenied(null as unknown as string)).toBe(false);
+    expect(isSelfEditPathDenied(undefined as unknown as string)).toBe(false);
+    expect(isSelfEditPathDenied(123 as unknown as string)).toBe(false);
+  });
+});
+
+describe("getSelfEditDeniedSuffixes", () => {
+  it("returns a non-empty array containing critical security files", () => {
+    const suffixes = getSelfEditDeniedSuffixes();
+    expect(Array.isArray(suffixes)).toBe(true);
+    expect(suffixes.length).toBeGreaterThan(0);
+    expect(suffixes).toContain("packages/shared/src/self-edit.ts");
+    expect(suffixes).toContain("packages/shared/src/restart.ts");
+  });
+});

--- a/packages/shared/src/self-edit.ts
+++ b/packages/shared/src/self-edit.ts
@@ -52,10 +52,11 @@ export function isSelfEditEnabled(
     | NodeJS.ProcessEnv
     | Record<string, string | undefined> = readProcessEnv(),
 ): boolean {
-  if (!isTruthyEnvValue(env[SELF_EDIT_ENABLE_ENV])) return false;
+  const currentEnv = env && typeof env === "object" ? env : readProcessEnv();
+  if (!isTruthyEnvValue(currentEnv[SELF_EDIT_ENABLE_ENV])) return false;
 
-  const nodeEnv = env.NODE_ENV;
-  const devModeFlag = isTruthyEnvValue(env[DEV_MODE_ENV]);
+  const nodeEnv = currentEnv.NODE_ENV;
+  const devModeFlag = isTruthyEnvValue(currentEnv[DEV_MODE_ENV]);
   const isProduction = nodeEnv === "production";
 
   // In production builds, the dev-mode flag must be explicitly set to override.
@@ -127,8 +128,8 @@ function readProcessEnv():
 }
 
 function normalizePathSeparators(p: string): string {
-  // Convert Windows-style separators to POSIX for uniform suffix matching.
-  return p.replace(/\\/g, "/");
+  // Convert Windows-style separators to POSIX and collapse multiple slashes.
+  return p.replace(/\\/g, "/").replace(/\/+/g, "/");
 }
 
 function containsGitDirSegment(normalized: string): boolean {


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `env` in `isSelfEditEnabled` against `null` and non-object values, falling back safely to `readProcessEnv()`.
- Collapse duplicate forward slashes in `normalizePathSeparators` to prevent path traversal evasion through redundant slash sequences (e.g. `repo//.git//HEAD`).
- Add comprehensive unit test suite in `packages/shared/src/self-edit.test.ts` testing environment gates, production overrides, `.git` metadata detection, denylist suffix matching, and Windows separator normalization.

## Related Issues

- Fixes #21900

## Testing

- Added `packages/shared/src/self-edit.test.ts` with 9 tests covering:
  - Unset or falsey `ELIZA_ENABLE_SELF_EDIT`
  - Non-production development and test environments
  - Production environment with and without `ELIZA_DEV_MODE` override
  - Nullish / undefined `env` arguments
  - `.git` directory detection across POSIX, Windows, and redundant slash paths
  - Denied file suffixes (`self-edit.ts`, `restart.ts`, `run-node.mjs`)
  - Safe project files (`.gitignore`, `.gitmodules`, `README.md`)
  - Non-string, empty, and whitespace paths
- `bun test packages/shared/src/self-edit.test.ts` passes (9/9 tests, 43 assertions).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/self-edit.test.ts:
✓ isSelfEditEnabled > returns false when enable env var is unset or falsey [0.65ms]
✓ isSelfEditEnabled > returns true in non-production environments when enabled [0.18ms]
✓ isSelfEditEnabled > returns false in production unless dev mode is explicitly active [0.14ms]
✓ isSelfEditEnabled > handles nullish or invalid env safely [0.48ms]
✓ isSelfEditPathDenied > denies paths inside .git directory or metadata [0.87ms]
✓ isSelfEditPathDenied > denies paths matching protected files in denylist [1.26ms]
✓ isSelfEditPathDenied > allows normal project source files [0.27ms]
✓ isSelfEditPathDenied > returns false for non-string, empty, or whitespace inputs [0.27ms]
✓ getSelfEditDeniedSuffixes > returns a non-empty array containing critical security files [8.27ms]
-----------------------------------------|---------|---------|-------------------
File                                     | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------|---------|---------|-------------------
 packages/shared/src/self-edit.ts        |  100.00 |   98.00 | 
-----------------------------------------|---------|---------|-------------------

 9 pass
 0 fail
 43 expect() calls
Ran 9 tests across 1 file. [208.00ms]
```
