### PR TITLE
fix(shared): add getBrowserTabsRendererImpl accessor and unit test suite

### DIFF
--- a/packages/shared/src/utils/browser-tabs-renderer-registry.test.ts
+++ b/packages/shared/src/utils/browser-tabs-renderer-registry.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for browser tabs renderer registry and preload script export.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BROWSER_TAB_PRELOAD_SCRIPT,
+  type BrowserTabsRendererImpl,
+  getBrowserTabsRendererImpl,
+  setBrowserTabsRendererImpl,
+} from "./browser-tabs-renderer-registry.ts";
+
+describe("browser-tabs-renderer-registry", () => {
+  beforeEach(() => {
+    (globalThis as unknown as { window: unknown }).window = globalThis;
+    setBrowserTabsRendererImpl(null);
+  });
+
+  afterEach(() => {
+    setBrowserTabsRendererImpl(null);
+    delete (globalThis as unknown as { window?: unknown }).window;
+  });
+
+  it("registers and retrieves a BrowserTabsRendererImpl instance", () => {
+    const mockImpl: BrowserTabsRendererImpl = {
+      evaluate: vi.fn(async () => ({ ok: true, result: 42 })),
+      getTabRect: vi.fn(async () => ({ x: 0, y: 0, width: 800, height: 600 })),
+    };
+
+    setBrowserTabsRendererImpl(mockImpl);
+    expect(getBrowserTabsRendererImpl()).toBe(mockImpl);
+  });
+
+  it("unregisters renderer when set to null or undefined", () => {
+    const mockImpl: BrowserTabsRendererImpl = {
+      evaluate: vi.fn(async () => ({ ok: true })),
+      getTabRect: vi.fn(async () => null),
+    };
+
+    setBrowserTabsRendererImpl(mockImpl);
+    expect(getBrowserTabsRendererImpl()).toBe(mockImpl);
+
+    setBrowserTabsRendererImpl(null);
+    expect(getBrowserTabsRendererImpl()).toBeUndefined();
+
+    setBrowserTabsRendererImpl(mockImpl);
+    setBrowserTabsRendererImpl(undefined);
+    expect(getBrowserTabsRendererImpl()).toBeUndefined();
+  });
+
+  it("clears registry when passed non-object values", () => {
+    setBrowserTabsRendererImpl(123 as unknown as BrowserTabsRendererImpl);
+    expect(getBrowserTabsRendererImpl()).toBeUndefined();
+  });
+
+  it("exports BROWSER_TAB_PRELOAD_SCRIPT containing core runtime handlers", () => {
+    expect(typeof BROWSER_TAB_PRELOAD_SCRIPT).toBe("string");
+    expect(BROWSER_TAB_PRELOAD_SCRIPT.length).toBeGreaterThan(100);
+    expect(BROWSER_TAB_PRELOAD_SCRIPT).toContain("__elizaTabExec");
+    expect(BROWSER_TAB_PRELOAD_SCRIPT).toContain("__elizaTabKit");
+    expect(BROWSER_TAB_PRELOAD_SCRIPT).toContain("__elizaWalletReply");
+    expect(BROWSER_TAB_PRELOAD_SCRIPT).toContain("__elizaVaultAutofillRequest");
+  });
+});

--- a/packages/shared/src/utils/browser-tabs-renderer-registry.ts
+++ b/packages/shared/src/utils/browser-tabs-renderer-registry.ts
@@ -1293,12 +1293,19 @@ declare global {
 }
 
 export function setBrowserTabsRendererImpl(
-  impl: BrowserTabsRendererImpl | null,
+  impl: BrowserTabsRendererImpl | null | undefined,
 ): void {
   if (typeof window === "undefined") return;
-  if (impl) {
+  if (impl && typeof impl === "object") {
     window[REGISTRY_KEY] = impl;
   } else {
     delete window[REGISTRY_KEY];
   }
+}
+
+export function getBrowserTabsRendererImpl():
+  | BrowserTabsRendererImpl
+  | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window[REGISTRY_KEY];
 }


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Add and export `getBrowserTabsRendererImpl(): BrowserTabsRendererImpl | undefined` to access the registered renderer implementation across module and test boundaries.
- Guard `setBrowserTabsRendererImpl` against non-object arguments.
- Add a dedicated unit test suite in `packages/shared/src/utils/browser-tabs-renderer-registry.test.ts` testing registration, retrieval, clearing, non-object handling, and `BROWSER_TAB_PRELOAD_SCRIPT` export integrity with 100% test coverage.

## Related Issues

- Fixes #21904

## Testing

- Added `packages/shared/src/utils/browser-tabs-renderer-registry.test.ts` with 4 tests covering:
  - Registration and retrieval via `setBrowserTabsRendererImpl` and `getBrowserTabsRendererImpl`
  - Unregistering via `null` and `undefined`
  - Clearing registry on non-object inputs
  - `BROWSER_TAB_PRELOAD_SCRIPT` export integrity and key string markers
- `bun test packages/shared/src/utils/browser-tabs-renderer-registry.test.ts` passes (4/4 tests, 11 assertions, 100% line & func coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/utils/browser-tabs-renderer-registry.test.ts:
✓ browser-tabs-renderer-registry > registers and retrieves a BrowserTabsRendererImpl instance [0.25ms]
✓ browser-tabs-renderer-registry > unregisters renderer when set to null or undefined [0.11ms]
✓ browser-tabs-renderer-registry > clears registry when passed non-object values [0.03ms]
✓ browser-tabs-renderer-registry > exports BROWSER_TAB_PRELOAD_SCRIPT containing core runtime handlers [0.16ms]
-------------------------------------------------------------|---------|---------|-------------------
File                                                         | % Funcs | % Lines | Uncovered Line #s
-------------------------------------------------------------|---------|---------|-------------------
 packages/shared/src/utils/browser-tabs-renderer-registry.ts |  100.00 |  100.00 | 
-------------------------------------------------------------|---------|---------|-------------------

 4 pass
 0 fail
 11 expect() calls
Ran 4 tests across 1 file. [111.00ms]
```
