### PR TITLE
fix(shared): canonicalize allowed host configuration

### DIFF
--- a/packages/shared/src/config/allowed-hosts.test.ts
+++ b/packages/shared/src/config/allowed-hosts.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Exercises the real allowed-host environment boundary and its Vite and
+ * Capacitor transforms with deterministic host parsing; no network is used.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  parseAllowedHostEnv,
+  toCapacitorAllowNavigation,
+  toViteAllowedHosts,
+} from "./allowed-hosts.ts";
+
+describe("parseAllowedHostEnv", () => {
+  it("treats nullish or empty environment configuration as absent", () => {
+    expect(parseAllowedHostEnv(undefined)).toEqual([]);
+    expect(parseAllowedHostEnv(null)).toEqual([]);
+    expect(parseAllowedHostEnv("  ,  ")).toEqual([]);
+  });
+
+  it("canonicalizes bare DNS, IDN, IPv4, and bracketed IPv6 hosts", () => {
+    expect(
+      parseAllowedHostEnv(
+        "Example.COM., münich.example, 127.1, 0x7f000001, [2001:0db8:0:0:0:0:0:1], 2001:db8::1",
+      ),
+    ).toEqual([
+      { host: "example.com", includeSubdomains: false },
+      { host: "xn--mnich-kva.example", includeSubdomains: false },
+      { host: "127.0.0.1", includeSubdomains: false },
+      { host: "[2001:db8::1]", includeSubdomains: false },
+    ]);
+  });
+
+  it("accepts wildcard and leading-dot DNS patterns", () => {
+    expect(parseAllowedHostEnv("*.elizaos.ai, .internal.net")).toEqual([
+      { host: "elizaos.ai", includeSubdomains: true },
+      { host: "internal.net", includeSubdomains: true },
+    ]);
+  });
+
+  it("extracts canonical hosts and discards URL or bare-host ports", () => {
+    expect(
+      parseAllowedHostEnv(
+        "https://API.elizaos.ai:8443, localhost:5173, http://[::1]:5173/",
+      ),
+    ).toEqual([
+      { host: "api.elizaos.ai", includeSubdomains: false },
+      { host: "localhost", includeSubdomains: false },
+      { host: "[::1]", includeSubdomains: false },
+    ]);
+  });
+
+  it("deduplicates equivalent canonical host patterns", () => {
+    expect(
+      parseAllowedHostEnv(
+        "example.com, EXAMPLE.com., münich.example, xn--mnich-kva.example",
+      ),
+    ).toEqual([
+      { host: "example.com", includeSubdomains: false },
+      { host: "xn--mnich-kva.example", includeSubdomains: false },
+    ]);
+  });
+
+  it.each(["ftp://example.com", "file://example.com"])(
+    "rejects unsupported URL protocol %s",
+    (value) => {
+      expect(() => parseAllowedHostEnv(value)).toThrow(/unsupported protocol/);
+    },
+  );
+
+  it.each([
+    "https://example.com/subpath",
+    "https://example.com?query=1",
+    "https://example.com#fragment",
+    "example.com/subpath",
+    "example.com?query=1",
+    "example.com#fragment",
+  ])("rejects path, query, and fragment syntax in %s", (value) => {
+    expect(() => parseAllowedHostEnv(value)).toThrow(/host|host pattern/);
+  });
+
+  it.each([
+    "https://user@example.com/",
+    "https://user:secret@example.com/",
+    "https://@example.com/",
+    "user@example.com",
+    "@example.com",
+  ])("rejects embedded credentials in %s", (value) => {
+    expect(() => parseAllowedHostEnv(value)).toThrow(
+      /credentials|host pattern/,
+    );
+  });
+
+  it.each([
+    "*",
+    "foo.*.example.com",
+    "*.127.0.0.1",
+    "*.[::1]",
+    "example.com..",
+    "[not-an-ipv6-address]",
+    "example.com\t.evil.test",
+  ])("rejects unsupported host pattern %s", (value) => {
+    expect(() => parseAllowedHostEnv(value)).toThrow(/host pattern/);
+  });
+
+  it("fails fast for a cast-only non-string value", () => {
+    expect(() => parseAllowedHostEnv(123 as unknown as string)).toThrow();
+  });
+});
+
+describe("allowed-host consumer transforms", () => {
+  it("feeds canonical patterns into Vite and Capacitor formats", () => {
+    const patterns = parseAllowedHostEnv("localhost, *.elizaos.ai");
+    expect(toViteAllowedHosts(patterns)).toEqual(["localhost", ".elizaos.ai"]);
+    expect(toCapacitorAllowNavigation(patterns)).toEqual([
+      "localhost",
+      "*.elizaos.ai",
+    ]);
+  });
+
+  it("does not silently turn cast-only arrays into an empty allow-list", () => {
+    expect(() =>
+      toViteAllowedHosts(null as unknown as readonly never[]),
+    ).toThrow();
+    expect(() =>
+      toCapacitorAllowNavigation(undefined as unknown as readonly never[]),
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/config/allowed-hosts.ts
+++ b/packages/shared/src/config/allowed-hosts.ts
@@ -1,7 +1,7 @@
 /**
- * Parser for the `ELIZA_ALLOWED_HOSTS` env var into structured host patterns
- * (bare host or URL, with optional subdomain wildcards). Feeds the network
- * allow-list used to gate outbound/SSRF-sensitive requests.
+ * Parses `ELIZA_ALLOWED_HOSTS` into canonical host patterns consumed by Vite
+ * host checks and Capacitor navigation configuration. Inputs may be bare
+ * hosts or HTTP(S) origins, with optional subdomain wildcards.
  */
 export type AllowedHostPattern = {
   readonly host: string;
@@ -9,11 +9,22 @@ export type AllowedHostPattern = {
 };
 
 function parseHostPattern(rawValue: string): AllowedHostPattern {
-  let value = rawValue.trim();
+  const value = rawValue.trim();
   if (!value) {
     throw new Error("ELIZA_ALLOWED_HOSTS contains an empty host entry");
   }
+  if (
+    [...value].some((character) => {
+      const codePoint = character.charCodeAt(0);
+      return codePoint <= 0x20 || codePoint === 0x7f;
+    })
+  ) {
+    throw new Error(
+      `ELIZA_ALLOWED_HOSTS entry is not a supported host pattern: ${rawValue}`,
+    );
+  }
 
+  let hostValue = value;
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) {
     const url = new URL(value);
     if (url.protocol !== "http:" && url.protocol !== "https:") {
@@ -21,19 +32,60 @@ function parseHostPattern(rawValue: string): AllowedHostPattern {
         `ELIZA_ALLOWED_HOSTS entry has unsupported protocol: ${rawValue}`,
       );
     }
-    if (url.pathname !== "/" || url.search || url.hash) {
+    if (url.pathname !== "/" || value.includes("?") || value.includes("#")) {
       throw new Error(
         `ELIZA_ALLOWED_HOSTS entry must be a host, not a URL path: ${rawValue}`,
       );
     }
-    value = url.hostname;
+    if (url.username || url.password || value.includes("@")) {
+      throw new Error(
+        `ELIZA_ALLOWED_HOSTS entry must not contain credentials: ${rawValue}`,
+      );
+    }
+    hostValue = url.hostname;
   }
 
-  const includeSubdomains = value.startsWith("*.") || value.startsWith(".");
-  const host = (
-    includeSubdomains ? value.replace(/^(\*\.)|\./, "") : value
-  ).toLowerCase();
-  if (!host || host.includes("/") || host.includes("*")) {
+  const includeSubdomains =
+    hostValue.startsWith("*.") || hostValue.startsWith(".");
+  const candidate = includeSubdomains
+    ? hostValue.replace(/^(\*\.)|\./, "")
+    : hostValue;
+  const candidateForUrl =
+    candidate.indexOf(":") !== candidate.lastIndexOf(":") &&
+    !candidate.startsWith("[")
+      ? `[${candidate}]`
+      : candidate;
+
+  let parsedHost: URL;
+  try {
+    parsedHost = new URL(`http://${candidateForUrl}`);
+  } catch {
+    // error-policy:J3 Invalid configuration is rejected at its parsing boundary.
+    throw new Error(
+      `ELIZA_ALLOWED_HOSTS entry is not a supported host pattern: ${rawValue}`,
+    );
+  }
+  if (
+    parsedHost.username ||
+    parsedHost.password ||
+    candidate.includes("@") ||
+    parsedHost.pathname !== "/" ||
+    parsedHost.search ||
+    parsedHost.hash
+  ) {
+    throw new Error(
+      `ELIZA_ALLOWED_HOSTS entry is not a supported host pattern: ${rawValue}`,
+    );
+  }
+
+  const host = parsedHost.hostname.toLowerCase().replace(/\.$/, "");
+  const isIpLiteral = host.startsWith("[") || /^\d+\.\d+\.\d+\.\d+$/.test(host);
+  if (
+    !host ||
+    host.endsWith(".") ||
+    host.includes("*") ||
+    (includeSubdomains && isIpLiteral)
+  ) {
     throw new Error(
       `ELIZA_ALLOWED_HOSTS entry is not a supported host pattern: ${rawValue}`,
     );
@@ -43,11 +95,12 @@ function parseHostPattern(rawValue: string): AllowedHostPattern {
 }
 
 export function parseAllowedHostEnv(
-  value: string | undefined,
+  value: string | undefined | null,
 ): AllowedHostPattern[] {
+  if (value == null) return [];
   const seen = new Set<string>();
   const entries: AllowedHostPattern[] = [];
-  for (const raw of (value ?? "").split(",")) {
+  for (const raw of value.split(",")) {
     if (!raw.trim()) continue;
     const entry = parseHostPattern(raw);
     const key = `${entry.includeSubdomains ? "*." : ""}${entry.host}`;


### PR DESCRIPTION
# Relates to

Fixes #21906.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Rebased on exact `origin/develop` `26130d316b32b86f306d5e105cee94ed8b920aea` with zero conflicts.
- [x] Exact-head focused tests, owning-package typecheck, changed-file Biome, and diff check pass.
- [x] The real scaffolded Capacitor configuration boundary was loaded and its produced navigation allow-list inspected.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@26130d316b32b86f306d5e105cee94ed8b920aea:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: self-reported

## What

`ELIZA_ALLOWED_HOSTS` is a string configuration boundary that ultimately feeds Vite host checks and the scaffolded app's Capacitor `allowNavigation`. Nullish environment absence is valid. In contrast, null/non-array values passed to the typed consumer transforms can only be manufactured through casts; silently converting those programming errors to an empty allow-list hid invalid state and was removed from the submitted patch.

The reachable string parser is now hardened instead:

- Canonicalizes case, IDNs to ASCII/punycode, trailing-dot aliases, IPv4 alternate notation, IPv6 compression, and URL/bare-host ports.
- Deduplicates after canonicalization.
- Rejects embedded credentials, path/query/fragment syntax, internal ASCII whitespace/control characters, unsupported schemes, malformed wildcard placement, and wildcard IP literals.
- Preserves the established exact-host and DNS subdomain-wildcard transforms for Vite and Capacitor.

This matters at the real mobile build boundary: non-canonical loopback `0x7f000001` previously remained opaque to the iOS-store private-host filter. It now canonicalizes to `127.0.0.1` and is removed before `allowNavigation` is produced.

## Verification (exact head `b0d8b746578d5845ffedfc13d2b5a8d2080a42ed`)

- `bun x vitest run --config ./vitest.config.ts src/config/allowed-hosts.test.ts` — **28/28 passed**.
- Adversarial matrix covers nullish absence, cast-only invalid values/arrays, IDN, IPv4 alternate forms, bracketed and unbracketed IPv6, credentials (including empty credential markers), URL and bare ports, trailing dots, paths, query, fragments, control whitespace, unsupported schemes, malformed wildcards, and wildcard IP literals.
- `bun run typecheck` in `packages/shared` — **passed**, including keyword generation and TypeScript.
- Changed-file Biome — **passed**, no fixes.
- `git diff --check origin/develop...HEAD` — **passed**.
- Full `packages/shared` suite — **151 files / 1,940 tests passed**. Two unrelated current-develop blockers remain: `sandbox-registry.test.ts` has a stale full mock missing the newly required `ElizaError` export, and one `host-execution-env.test.ts` fresh-process PATH assertion returns `{}`; each reproduces alone and neither imports or touches allowed-host code.

### Real consumer artifact

Executed the scaffold's actual `capacitor.config.ts` with Node 24 + `tsx` under an iOS store build:

```text
ELIZA_ALLOWED_HOSTS=0x7f000001,Example.COM.:8443,*.münich.example
allowNavigation => ["eliza.app","*.eliza.app","*.elizacloud.ai","example.com","*.xn--mnich-kva.example"]
```

The alternative loopback form is absent, the port/trailing dot is canonicalized, and the wildcard IDN is emitted as ASCII.

# Evidence Gate

<!-- evidence-head:b0d8b746578d5845ffedfc13d2b5a8d2080a42ed -->

Build-time configuration and security-policy output only; no rendered surface changes.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; the before state is a host-policy parser.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; the produced policy artifact is recorded above.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head parser tests, typecheck, and real Capacitor config output are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact `allowNavigation` array from the real scaffold configuration is recorded above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changed.
