### PR TITLE
test(shared): add comprehensive unit test suite for brand-env-aliases

### DIFF
--- a/packages/shared/src/config/brand-env-aliases.test.ts
+++ b/packages/shared/src/config/brand-env-aliases.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for brand environment alias mapping and prefix normalization.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  BRAND_ENV_ALIAS_DEFINITIONS,
+  buildBrandEnvAliases,
+  buildBrandEnvSyncAliases,
+  normalizeBrandEnvPrefix,
+} from "./brand-env-aliases.ts";
+
+describe("normalizeBrandEnvPrefix", () => {
+  it("defaults to ELIZA when prefix is undefined", () => {
+    expect(normalizeBrandEnvPrefix(undefined)).toBe("ELIZA");
+  });
+
+  it("normalizes lowercase and mixed-case identifiers to uppercase", () => {
+    expect(normalizeBrandEnvPrefix("custom")).toBe("CUSTOM");
+    expect(normalizeBrandEnvPrefix("AgentApp")).toBe("AGENTAPP");
+  });
+
+  it("replaces dashes, dots, and symbols with underscores and trims edge underscores", () => {
+    expect(normalizeBrandEnvPrefix("my-custom.app")).toBe("MY_CUSTOM_APP");
+    expect(normalizeBrandEnvPrefix("  ___my-cool_app___  ")).toBe(
+      "MY_COOL_APP",
+    );
+  });
+
+  it("throws for empty, whitespace-only, or purely symbolic prefixes", () => {
+    expect(() => normalizeBrandEnvPrefix("")).toThrow(/non-empty identifier/);
+    expect(() => normalizeBrandEnvPrefix("   ")).toThrow(
+      /non-empty identifier/,
+    );
+    expect(() => normalizeBrandEnvPrefix("---___...")).toThrow(
+      /non-empty identifier/,
+    );
+  });
+});
+
+describe("buildBrandEnvAliases", () => {
+  it("generates alias pairs for standard and Vite environment variables", () => {
+    const aliases = buildBrandEnvAliases("CUSTOM");
+    expect(Array.isArray(aliases)).toBe(true);
+    expect(aliases.length).toBe(BRAND_ENV_ALIAS_DEFINITIONS.length);
+
+    expect(aliases).toContainEqual(["CUSTOM_STATE_DIR", "ELIZA_STATE_DIR"]);
+    expect(aliases).toContainEqual(["CUSTOM_API_TOKEN", "ELIZA_API_TOKEN"]);
+    expect(aliases).toContainEqual([
+      "VITE_CUSTOM_SETTINGS_DEBUG",
+      "VITE_ELIZA_SETTINGS_DEBUG",
+    ]);
+  });
+});
+
+describe("buildBrandEnvSyncAliases", () => {
+  it("uses syncElizaKey overrides where defined", () => {
+    const syncAliases = buildBrandEnvSyncAliases("CUSTOM");
+    expect(Array.isArray(syncAliases)).toBe(true);
+    expect(syncAliases.length).toBe(BRAND_ENV_ALIAS_DEFINITIONS.length);
+
+    // PORT uses syncElizaKey: "ELIZA_UI_PORT"
+    expect(syncAliases).toContainEqual(["CUSTOM_PORT", "ELIZA_UI_PORT"]);
+
+    // Standard entries remain identical
+    expect(syncAliases).toContainEqual(["CUSTOM_STATE_DIR", "ELIZA_STATE_DIR"]);
+  });
+});
+
+describe("BRAND_ENV_ALIAS_DEFINITIONS", () => {
+  it("exports definitions array with valid suffix and elizaKey shapes", () => {
+    expect(Array.isArray(BRAND_ENV_ALIAS_DEFINITIONS)).toBe(true);
+    expect(BRAND_ENV_ALIAS_DEFINITIONS.length).toBeGreaterThan(20);
+    for (const def of BRAND_ENV_ALIAS_DEFINITIONS) {
+      expect(typeof def.brandSuffix).toBe("string");
+      expect(typeof def.elizaKey).toBe("string");
+      expect(def.brandSuffix.length).toBeGreaterThan(0);
+      expect(
+        def.elizaKey.startsWith("ELIZA_") ||
+          def.elizaKey.startsWith("VITE_ELIZA_"),
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Add a comprehensive unit test suite in `packages/shared/src/config/brand-env-aliases.test.ts` for brand environment alias builders and prefix normalization with 100% line & func coverage.
- Test prefix normalization across valid names, lowercase conversion, separator collapsing, leading/trailing underscore stripping, and empty/invalid string errors.
- Test `buildBrandEnvAliases` and `buildBrandEnvSyncAliases` mapping correctness, including Vite variable generation and `syncElizaKey` overrides.

## Related Issues

- Fixes #21908

## Testing

- Added `packages/shared/src/config/brand-env-aliases.test.ts` with 7 tests covering:
  - Default prefix fallback (`ELIZA`)
  - Uppercase conversion
  - Replacing dashes/dots/symbols with underscores
  - Exception handling for empty or symbolic prefixes
  - `buildBrandEnvAliases` output structure and Vite variables
  - `buildBrandEnvSyncAliases` output with `syncElizaKey` (e.g. `PORT` -> `ELIZA_UI_PORT`)
  - `BRAND_ENV_ALIAS_DEFINITIONS` constant structure
- `bun test packages/shared/src/config/brand-env-aliases.test.ts` passes (7/7 tests, 187 assertions, 100% coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/config/brand-env-aliases.test.ts:
✓ normalizeBrandEnvPrefix > defaults to ELIZA when prefix is undefined [0.24ms]
✓ normalizeBrandEnvPrefix > normalizes lowercase and mixed-case identifiers to uppercase [0.04ms]
✓ normalizeBrandEnvPrefix > replaces dashes, dots, and symbols with underscores and trims edge underscores [0.04ms]
✓ normalizeBrandEnvPrefix > throws for empty, whitespace-only, or purely symbolic prefixes [0.21ms]
✓ buildBrandEnvAliases > generates alias pairs for standard and Vite environment variables [0.56ms]
✓ buildBrandEnvSyncAliases > uses syncElizaKey overrides where defined [0.30ms]
✓ BRAND_ENV_ALIAS_DEFINITIONS > exports definitions array with valid suffix and elizaKey shapes [0.22ms]
-------------------------------------------------|---------|---------|-------------------
File                                             | % Funcs | % Lines | Uncovered Line #s
-------------------------------------------------|---------|---------|-------------------
 packages/shared/src/config/brand-env-aliases.ts |  100.00 |  100.00 | 
-------------------------------------------------|---------|---------|-------------------

 7 pass
 0 fail
 187 expect() calls
Ran 7 tests across 1 file. [108.00ms]
```
