### PR TITLE
fix(plugin-bluebubbles): compose caller signals with the request deadline instead of replacing it

### DIFF
--- a/plugins/plugin-bluebubbles/src/client-timeout.test.ts
+++ b/plugins/plugin-bluebubbles/src/client-timeout.test.ts
@@ -100,6 +100,37 @@ describe("BlueBubbles client request deadlines", () => {
 		).rejects.toMatchObject({ name: "TimeoutError" });
 	});
 
+	it("keeps the composed deadline armed while the response body stalls", async () => {
+		const controller = new AbortController();
+		const fetchImpl: typeof fetch = async (_input, init) => {
+			const signal = init?.signal;
+			if (!signal) throw new Error("expected bluebubbles abort signal");
+
+			return new Response(
+				new ReadableStream({
+					start(streamController) {
+						const onAbort = () => streamController.error(signal.reason);
+						if (signal.aborted) {
+							onAbort();
+							return;
+						}
+						signal.addEventListener("abort", onAbort, { once: true });
+					},
+				}),
+				{ headers: { "Content-Type": "application/json" } },
+			);
+		};
+
+		await expect(
+			blueBubblesRequestWithFetch(
+				REQUEST_URL,
+				{ signal: controller.signal },
+				fetchImpl,
+				10,
+			),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+	});
+
 	it("honors caller abort without waiting for the request deadline", async () => {
 		const controller = new AbortController();
 		controller.abort();

--- a/plugins/plugin-bluebubbles/src/client-timeout.test.ts
+++ b/plugins/plugin-bluebubbles/src/client-timeout.test.ts
@@ -67,10 +67,13 @@ describe("BlueBubbles client request deadlines", () => {
 		expect(payload.data.guid).toBe("msg-1");
 	});
 
-	it("preserves a caller-supplied cancellation signal", async () => {
+	it("composes a caller-supplied signal with the deadline instead of replacing it", async () => {
 		const controller = new AbortController();
 		const fetchImpl: typeof fetch = async (_input, init) => {
-			expect(init?.signal).toBe(controller.signal);
+			// The forwarded signal is the composed one, not the caller's raw
+			// signal — asserting identity here previously pinned the bypass in.
+			expect(init?.signal).toBeDefined();
+			expect(init?.signal?.aborted).toBe(false);
 			return Response.json({ data: { guid: "caller" } });
 		};
 
@@ -78,8 +81,23 @@ describe("BlueBubbles client request deadlines", () => {
 			REQUEST_URL,
 			{ signal: controller.signal },
 			fetchImpl,
-			10,
+			1_000,
 		);
+	});
+
+	it("keeps the deadline armed while a caller signal is present", async () => {
+		// The regression #21881 closes: a never-firing caller signal must not
+		// discard timeoutMs and leave the fetch unbounded.
+		const controller = new AbortController();
+
+		await expect(
+			blueBubblesRequestWithFetch(
+				REQUEST_URL,
+				{ signal: controller.signal },
+				stallUntilAborted(),
+				10,
+			),
+		).rejects.toMatchObject({ name: "TimeoutError" });
 	});
 
 	it("honors caller abort without waiting for the request deadline", async () => {

--- a/plugins/plugin-bluebubbles/src/client.ts
+++ b/plugins/plugin-bluebubbles/src/client.ts
@@ -36,7 +36,12 @@ export async function blueBubblesRequestWithFetch<T>(
 	fetchImpl: typeof fetch = globalThis.fetch,
 	timeoutMs: number = BLUEBUBBLES_REQUEST_TIMEOUT_MS,
 ): Promise<T> {
-	const signal = options.signal ?? AbortSignal.timeout(timeoutMs);
+	// The deadline always applies: a caller-supplied signal composes with the
+	// timeout instead of replacing it, so cancellation-aware callers cannot
+	// accidentally opt back into the unbounded-fetch hang this bound removed.
+	const signal = options.signal
+		? AbortSignal.any([options.signal, AbortSignal.timeout(timeoutMs)])
+		: AbortSignal.timeout(timeoutMs);
 	const response = (await fetchImpl(urlWithPassword, {
 		...options,
 		headers: {


### PR DESCRIPTION
# Relates to

Fixes #21881. Corrective follow-up to merged #21766.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] Focused tests, full plugin suite, typecheck, and Biome pass at the exact head.
- [x] A reviewer can confirm the behavior from the executed repro and the mutation-checked test transcript attached below.

# Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-fable-5
- Client / agent tooling: Claude Code
- Attribution status: self-reported

## What

`blueBubblesRequestWithFetch` (as merged by #21766) selected its abort signal with `options.signal ?? AbortSignal.timeout(timeoutMs)` — any caller supplying a signal **replaced** the deadline, reopening the unbounded-fetch hang that PR closed, for exactly the callers most likely to care about cancellation. This is live, not latent: `probe()` passes its own controller signal, so every probe request ran with no `timeoutMs` deadline. The merged caller-signal test pinned the bypass by asserting signal *identity* (`init?.signal === controller.signal`).

The fix composes via `AbortSignal.any([options.signal, AbortSignal.timeout(timeoutMs)])`, matching the wallet-family convention (#21806/#21809): the request aborts on whichever fires first. The identity assertion becomes behavior assertions — a new regression proves the deadline stays armed under an idle caller signal, and the existing caller-abort test still passes unchanged (caller cancellation is honored without waiting for the deadline). (This was flagged as finding 1 in #21766's pre-merge review.)

## Verification (exact head `d7c7184e1`)

- Focused suite `client-timeout.test.ts` — **10/10** (was 9; +1 new deadline-stays-armed regression, and the identity test rewritten to assert behavior).
- **Mutation-checked live**: with `client.ts` reverted to the merged #21766 code and the new tests kept, the deadline regression fails by timing out at vitest's 5s ceiling — the unbounded fetch, observed (`1 failed | 9 passed`). Restored to the fix: 10/10.
- Full `plugin-bluebubbles` suite: **70/70** across 8 files. Typecheck and `lint:check` clean.
- Executed repro (attached): with the old selection, a 25ms deadline never fires under an idle caller signal within 200ms (`aborted: false` — unbounded); with the composition, the same scenario aborts with `TimeoutError`, and a pre-aborted caller signal aborts immediately with `AbortError` without waiting out a 5s deadline.

# Evidence Gate

<!-- evidence-head:7732dae3c0d815ffd265c109d04f427c501e2965 -->

Backend HTTP-client control-flow change with no rendered UI surface.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only signal selection; no rendered visual surface exists to capture.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only signal selection; no rendered visual surface exists to capture.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow; the failure mode is a discarded abort deadline.
<!-- evidence-row:backend-logs -->
- [x] Exact-head validation log: https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21911-pr21911-validation-v2.log
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface calls this client.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes; the fix is abort-signal composition.
<!-- evidence-row:domain-artifacts -->
- [x] Signal-composition matrix: https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21911-pr21911-domain.json
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Maintainer repair validation

Rebased onto current `develop` and added a response-body stall regression, proving the composed signal remains active through JSON consumption rather than only until headers arrive. Exact repaired head `7732dae3c0d815ffd265c109d04f427c501e2965`: focused 11/11; full plugin 71/71 across 8 files; package TypeScript; package Biome; and `git diff --check` all pass.

Repair contribution: OpenAI / gpt-5.6-sol via Codex desktop / multi-agent.






<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5, OpenAI/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Claude Code; Codex desktop / multi-agent
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported


