### PR TITLE
fix(shared): guard nullish options in shouldUseCloudOnlyBranding and add unit test suite

### DIFF
--- a/packages/shared/src/config/cloud-only.test.ts
+++ b/packages/shared/src/config/cloud-only.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for cloud-only branding selection logic in shouldUseCloudOnlyBranding.
+ */
+import { describe, expect, it } from "vitest";
+import { shouldUseCloudOnlyBranding } from "./cloud-only.ts";
+
+describe("shouldUseCloudOnlyBranding", () => {
+  it("prioritizes explicit desktop cloud runtime mode over dev and injected backend", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: true,
+        injectedApiBase: "http://127.0.0.1:3000",
+        desktopRuntimeMode: "cloud",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: true,
+        desktopRuntimeMode: "elizacloud",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false in dev mode when desktop cloud mode is not set", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: true,
+        desktopRuntimeMode: "local",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when an injected API base is present in production", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        injectedApiBase: "http://localhost:3000",
+      }),
+    ).toBe(false);
+  });
+
+  it("evaluates native platform runtime mode correctly", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        isNativePlatform: true,
+        nativeRuntimeMode: "cloud",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        isNativePlatform: true,
+        nativeRuntimeMode: "local",
+      }),
+    ).toBe(false);
+  });
+
+  it("defaults to true for production web builds", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("handles nullish or empty options safely", () => {
+    expect(shouldUseCloudOnlyBranding(null)).toBe(true);
+    expect(shouldUseCloudOnlyBranding(undefined)).toBe(true);
+    expect(shouldUseCloudOnlyBranding({})).toBe(true);
+  });
+});

--- a/packages/shared/src/config/cloud-only.ts
+++ b/packages/shared/src/config/cloud-only.ts
@@ -4,13 +4,18 @@
  * cloud-login proxy, so an explicit desktop `cloud` runtime mode wins over the
  * dev / injected-backend fall-throughs.
  */
-export function shouldUseCloudOnlyBranding(options: {
-  isDev: boolean;
-  injectedApiBase?: string | null;
-  isNativePlatform?: boolean;
-  nativeRuntimeMode?: string | null;
-  desktopRuntimeMode?: string | null;
-}): boolean {
+export function shouldUseCloudOnlyBranding(
+  options?: {
+    isDev?: boolean;
+    injectedApiBase?: string | null;
+    isNativePlatform?: boolean;
+    nativeRuntimeMode?: string | null;
+    desktopRuntimeMode?: string | null;
+  } | null,
+): boolean {
+  if (!options || typeof options !== "object") {
+    return true;
+  }
   // An explicit desktop "cloud" runtime mode forces cloud-only regardless of
   // dev mode or an injected loopback backend. The desktop shell deliberately
   // runs cloud-only and keeps the loopback agent solely as the cloud-login


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `options` in `shouldUseCloudOnlyBranding` to handle null, undefined, and non-object inputs safely by falling back to the production web default (`true`).
- Add a dedicated unit test suite in `packages/shared/src/config/cloud-only.test.ts` testing precedence rules between desktop cloud runtime mode, dev mode, injected loopback backend, native platform mode, and nullish options with 100% coverage.

## Related Issues

- Fixes #21910

## Testing

- Added `packages/shared/src/config/cloud-only.test.ts` with 6 tests covering:
  - Explicit desktop runtime mode (`cloud`, `elizacloud`) overriding dev mode and injected backend
  - Development mode disabling cloud-only branding when desktop mode is not set
  - Injected API base in production disabling cloud-only branding
  - Native platform runtime mode evaluation (`cloud` vs `local`)
  - Production web default
  - Nullish, undefined, and empty options safety
- `bun test packages/shared/src/config/cloud-only.test.ts` passes (6/6 tests, 11 assertions, 100% coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/config/cloud-only.test.ts:
✓ shouldUseCloudOnlyBranding > prioritizes explicit desktop cloud runtime mode over dev and injected backend [0.15ms]
✓ shouldUseCloudOnlyBranding > returns false in dev mode when desktop cloud mode is not set [0.04ms]
✓ shouldUseCloudOnlyBranding > returns false when an injected API base is present in production [0.02ms]
✓ shouldUseCloudOnlyBranding > evaluates native platform runtime mode correctly [0.06ms]
✓ shouldUseCloudOnlyBranding > defaults to true for production web builds [0.02ms]
✓ shouldUseCloudOnlyBranding > handles nullish or empty options safely [0.04ms]
------------------------------------------|---------|---------|-------------------
File                                      | % Funcs | % Lines | Uncovered Line #s
------------------------------------------|---------|---------|-------------------
 packages/shared/src/config/cloud-only.ts |  100.00 |  100.00 | 
------------------------------------------|---------|---------|-------------------

 6 pass
 0 fail
 11 expect() calls
Ran 6 tests across 1 file. [130.00ms]
```
