### PR TITLE
feat(shared): add getApiKeyPrefixHint and matchesApiKeyPrefixHint validation helpers and unit test suite

### DIFF
--- a/packages/shared/src/config/api-key-prefix-hints.test.ts
+++ b/packages/shared/src/config/api-key-prefix-hints.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for API key prefix hints and prefix matching validation helpers.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  API_KEY_PREFIX_HINTS,
+  getApiKeyPrefixHint,
+  matchesApiKeyPrefixHint,
+} from "./api-key-prefix-hints.ts";
+
+describe("API_KEY_PREFIX_HINTS", () => {
+  it("contains expected prefix definitions for major AI providers", () => {
+    expect(API_KEY_PREFIX_HINTS.ANTHROPIC_API_KEY).toEqual({
+      prefix: "sk-ant-",
+      label: "Anthropic",
+    });
+    expect(API_KEY_PREFIX_HINTS.OPENAI_API_KEY).toEqual({
+      prefix: "sk-",
+      label: "OpenAI",
+    });
+    expect(API_KEY_PREFIX_HINTS.GROQ_API_KEY).toEqual({
+      prefix: "gsk_",
+      label: "Groq",
+    });
+    expect(API_KEY_PREFIX_HINTS.XAI_API_KEY).toEqual({
+      prefix: "xai-",
+      label: "xAI",
+    });
+    expect(API_KEY_PREFIX_HINTS.OPENROUTER_API_KEY).toEqual({
+      prefix: "sk-or-",
+      label: "OpenRouter",
+    });
+  });
+});
+
+describe("getApiKeyPrefixHint", () => {
+  it("retrieves prefix hint for known configuration keys", () => {
+    expect(getApiKeyPrefixHint("ANTHROPIC_API_KEY")?.prefix).toBe("sk-ant-");
+    expect(getApiKeyPrefixHint("  OPENROUTER_API_KEY  ")?.prefix).toBe(
+      "sk-or-",
+    );
+  });
+
+  it("returns undefined for unknown keys or nullish inputs", () => {
+    expect(getApiKeyPrefixHint("UNKNOWN_KEY")).toBeUndefined();
+    expect(getApiKeyPrefixHint(null)).toBeUndefined();
+    expect(getApiKeyPrefixHint(undefined)).toBeUndefined();
+    expect(getApiKeyPrefixHint(123 as unknown as string)).toBeUndefined();
+  });
+});
+
+describe("matchesApiKeyPrefixHint", () => {
+  it("returns true when value starts with expected prefix", () => {
+    expect(
+      matchesApiKeyPrefixHint(
+        "ANTHROPIC_API_KEY",
+        "sk-ant-api03-example-token",
+      ),
+    ).toBe(true);
+    expect(
+      matchesApiKeyPrefixHint("OPENAI_API_KEY", "sk-proj-example-token"),
+    ).toBe(true);
+    expect(matchesApiKeyPrefixHint("GROQ_API_KEY", "gsk_example_token")).toBe(
+      true,
+    );
+    expect(
+      matchesApiKeyPrefixHint("OPENROUTER_API_KEY", "  sk-or-v1-token  "),
+    ).toBe(true);
+  });
+
+  it("returns false when value does not start with expected prefix", () => {
+    expect(
+      matchesApiKeyPrefixHint("OPENROUTER_API_KEY", "tencent/hy3-preview"),
+    ).toBe(false);
+    expect(matchesApiKeyPrefixHint("ANTHROPIC_API_KEY", "sk-invalid")).toBe(
+      false,
+    );
+  });
+
+  it("returns true for unhinted keys", () => {
+    expect(matchesApiKeyPrefixHint("CUSTOM_API_KEY", "anything")).toBe(true);
+    expect(matchesApiKeyPrefixHint(null, "anything")).toBe(true);
+  });
+
+  it("returns true for empty or whitespace values so empty-field validators handle them", () => {
+    expect(matchesApiKeyPrefixHint("ANTHROPIC_API_KEY", "")).toBe(true);
+    expect(matchesApiKeyPrefixHint("ANTHROPIC_API_KEY", "   ")).toBe(true);
+  });
+
+  it("returns false for non-string values on hinted keys", () => {
+    expect(
+      matchesApiKeyPrefixHint("ANTHROPIC_API_KEY", 123 as unknown as string),
+    ).toBe(false);
+    expect(
+      matchesApiKeyPrefixHint("ANTHROPIC_API_KEY", null as unknown as string),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/config/api-key-prefix-hints.ts
+++ b/packages/shared/src/config/api-key-prefix-hints.ts
@@ -32,3 +32,22 @@ export const API_KEY_PREFIX_HINTS: Readonly<Record<string, ApiKeyPrefixHint>> =
     DEEPSEEK_API_KEY: { prefix: "sk-", label: "DeepSeek" },
     MOONSHOT_API_KEY: { prefix: "sk-", label: "Kimi / Moonshot" },
   };
+
+export function getApiKeyPrefixHint(
+  key: string | null | undefined,
+): ApiKeyPrefixHint | undefined {
+  if (typeof key !== "string") return undefined;
+  return API_KEY_PREFIX_HINTS[key.trim()];
+}
+
+export function matchesApiKeyPrefixHint(
+  key: string | null | undefined,
+  value: string | null | undefined,
+): boolean {
+  const hint = getApiKeyPrefixHint(key);
+  if (!hint) return true;
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  return trimmed.startsWith(hint.prefix);
+}


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Add and export `getApiKeyPrefixHint(key: string | null | undefined): ApiKeyPrefixHint | undefined`.
- Add and export `matchesApiKeyPrefixHint(key: string | null | undefined, value: string | null | undefined): boolean` with whitespace trimming and pass-through for unhinted keys.
- Add a dedicated unit test suite in `packages/shared/src/config/api-key-prefix-hints.test.ts` testing known prefix mappings, key lookup, prefix validation matching, and non-string/nullish edge cases with 100% coverage.

## Related Issues

- Fixes #21914

## Testing

- Added `packages/shared/src/config/api-key-prefix-hints.test.ts` with 8 tests covering:
  - Definition mapping verification for Anthropic, OpenAI, Groq, xAI, OpenRouter
  - Key lookup via `getApiKeyPrefixHint`
  - Successful prefix matching
  - Mismatched prefix detection
  - Unhinted key pass-through
  - Empty/whitespace value pass-through
  - Non-string value rejection
- `bun test packages/shared/src/config/api-key-prefix-hints.test.ts` passes (8/8 tests, 23 assertions, 100% line & func coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/config/api-key-prefix-hints.test.ts:
✓ API_KEY_PREFIX_HINTS > contains expected prefix definitions for major AI providers [0.14ms]
✓ getApiKeyPrefixHint > retrieves prefix hint for known configuration keys [0.12ms]
✓ getApiKeyPrefixHint > returns undefined for unknown keys or nullish inputs [0.09ms]
✓ matchesApiKeyPrefixHint > returns true when value starts with expected prefix [0.41ms]
✓ matchesApiKeyPrefixHint > returns false when value does not start with expected prefix [0.04ms]
✓ matchesApiKeyPrefixHint > returns true for unhinted keys [0.03ms]
✓ matchesApiKeyPrefixHint > returns true for empty or whitespace values so empty-field validators handle them [0.03ms]
✓ matchesApiKeyPrefixHint > returns false for non-string values on hinted keys [0.03ms]
----------------------------------------------------|---------|---------|-------------------
File                                                | % Funcs | % Lines | Uncovered Line #s
----------------------------------------------------|---------|---------|-------------------
 packages/shared/src/config/api-key-prefix-hints.ts |  100.00 |  100.00 | 
----------------------------------------------------|---------|---------|-------------------

 8 pass
 0 fail
 23 expect() calls
Ran 8 tests across 1 file. [100.00ms]
```
