### PR TITLE
fix(ui): bound content-pack manifest response bytes

### DIFF
--- a/packages/ui/src/content-packs/load-pack-timeout.test.ts
+++ b/packages/ui/src/content-packs/load-pack-timeout.test.ts
@@ -27,19 +27,21 @@ describe("content-pack manifest deadline", () => {
 
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => ({
-        ok: true,
-        json: () => {
-          bodyStarted = true;
-          return new Promise((_resolve, reject) => {
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = new ReadableStream({
+          start(controller) {
             init?.signal?.addEventListener(
               "abort",
-              () => reject(init.signal?.reason),
+              () => controller.error(init.signal?.reason),
               { once: true },
             );
-          });
-        },
-      })) as unknown as typeof fetch,
+          },
+          pull() {
+            bodyStarted = true;
+          },
+        });
+        return new Response(body);
+      }) as typeof fetch,
     );
 
     const pending = loadContentPackFromUrl(BASE_URL);

--- a/packages/ui/src/content-packs/load-pack.test.ts
+++ b/packages/ui/src/content-packs/load-pack.test.ts
@@ -141,8 +141,8 @@ describe("loadContentPackFromUrl", () => {
 
   it("cancels a body that ignores the request signal when the deadline expires", async () => {
     const cancel = vi.fn();
-    const fetchImpl: typeof fetch = async () =>
-      new Response(new ReadableStream({ pull() {}, cancel }));
+    const body = new ReadableStream({ pull() {}, cancel });
+    const fetchImpl: typeof fetch = async () => new Response(body);
 
     await expect(
       getContentPackManifestJsonWithFetch(
@@ -152,22 +152,22 @@ describe("loadContentPackFromUrl", () => {
       ),
     ).rejects.toMatchObject({ name: "TimeoutError" });
     expect(cancel).toHaveBeenCalledOnce();
+    expect(body.locked).toBe(false);
   });
 
   it("rejects and cancels a chunked body as soon as it crosses the byte cap", async () => {
     let requestSignal: AbortSignal | undefined;
     const cancel = vi.fn();
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(8));
+        controller.enqueue(new Uint8Array(8));
+      },
+      cancel,
+    });
     const fetchImpl: typeof fetch = async (_input, init) => {
       requestSignal = init?.signal ?? undefined;
-      return new Response(
-        new ReadableStream({
-          start(controller) {
-            controller.enqueue(new Uint8Array(8));
-            controller.enqueue(new Uint8Array(8));
-          },
-          cancel,
-        }),
-      );
+      return new Response(body);
     };
 
     await expect(
@@ -180,6 +180,28 @@ describe("loadContentPackFromUrl", () => {
     ).rejects.toMatchObject({ name: "ContentPackManifestTooLargeError" });
     expect(requestSignal?.aborted).toBe(true);
     expect(cancel).toHaveBeenCalledOnce();
+    expect(body.locked).toBe(false);
+  });
+
+  it("releases the reader when cancellation rejects", async () => {
+    const cancellationFailure = new Error("cancel failed");
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(11));
+      },
+      cancel: () => Promise.reject(cancellationFailure),
+    });
+    const fetchImpl: typeof fetch = async () => new Response(body);
+
+    await expect(
+      getContentPackManifestJsonWithFetch(
+        "https://example.com/pack.json",
+        fetchImpl,
+        1_000,
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "ContentPackManifestTooLargeError" });
+    expect(body.locked).toBe(false);
   });
 
   it("bounds decompressed bytes despite a smaller declared wire size", async () => {
@@ -233,16 +255,14 @@ describe("loadContentPackFromUrl", () => {
 
   it("accepts valid multi-byte JSON split across chunks at the exact cap", async () => {
     const bytes = new TextEncoder().encode('{"value":"€"}');
-    const fetchImpl: typeof fetch = async () =>
-      new Response(
-        new ReadableStream({
-          start(controller) {
-            controller.enqueue(bytes.subarray(0, bytes.length - 2));
-            controller.enqueue(bytes.subarray(bytes.length - 2));
-            controller.close();
-          },
-        }),
-      );
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(bytes.subarray(0, bytes.length - 2));
+        controller.enqueue(bytes.subarray(bytes.length - 2));
+        controller.close();
+      },
+    });
+    const fetchImpl: typeof fetch = async () => new Response(body);
 
     await expect(
       getContentPackManifestJsonWithFetch(
@@ -252,6 +272,7 @@ describe("loadContentPackFromUrl", () => {
         bytes.length,
       ),
     ).resolves.toEqual({ value: "€" });
+    expect(body.locked).toBe(false);
   });
 
   it("rejects malformed UTF-8 instead of repairing manifest text", async () => {

--- a/packages/ui/src/content-packs/load-pack.test.ts
+++ b/packages/ui/src/content-packs/load-pack.test.ts
@@ -4,7 +4,7 @@
  * response body is consumed.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@elizaos/shared", () => ({
   CONTENT_PACK_MANIFEST_FILENAME: "pack.json",
@@ -14,7 +14,12 @@ vi.mock("@elizaos/shared", () => ({
       : [{ field: "root", message: "invalid" }],
 }));
 
-import { ContentPackLoadError, loadContentPackFromUrl } from "./load-pack";
+import {
+  CONTENT_PACK_MANIFEST_MAX_BYTES,
+  ContentPackLoadError,
+  getContentPackManifestJsonWithFetch,
+  loadContentPackFromUrl,
+} from "./load-pack";
 
 const MANIFEST = {
   id: "cyberpunk-neon",
@@ -22,6 +27,10 @@ const MANIFEST = {
   version: "1.0.0",
   assets: {},
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("loadContentPackFromUrl", () => {
   it("loads and resolves a valid remote manifest", async () => {
@@ -83,20 +92,18 @@ describe("loadContentPackFromUrl", () => {
       .mockReturnValue(timeoutController.signal);
     vi.spyOn(globalThis, "fetch").mockImplementation(
       async (_input, init) =>
-        ({
-          ok: true,
-          status: 200,
-          statusText: "OK",
-          json: () =>
-            new Promise<unknown>((_resolve, reject) => {
+        new Response(
+          new ReadableStream({
+            start(controller) {
               markBodyStarted();
               init?.signal?.addEventListener(
                 "abort",
-                () => reject(init.signal?.reason),
+                () => controller.error(init.signal?.reason),
                 { once: true },
               );
-            }),
-        }) as Response,
+            },
+          }),
+        ),
     );
 
     const pending = loadContentPackFromUrl("https://example.com/packs/a");
@@ -129,6 +136,187 @@ describe("loadContentPackFromUrl", () => {
       cause: expect.objectContaining({
         message: expect.stringContaining("503"),
       }),
+    });
+  });
+
+  it("cancels a body that ignores the request signal when the deadline expires", async () => {
+    const cancel = vi.fn();
+    const fetchImpl: typeof fetch = async () =>
+      new Response(new ReadableStream({ pull() {}, cancel }));
+
+    await expect(
+      getContentPackManifestJsonWithFetch(
+        "https://example.com/pack.json",
+        fetchImpl,
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("rejects and cancels a chunked body as soon as it crosses the byte cap", async () => {
+    let requestSignal: AbortSignal | undefined;
+    const cancel = vi.fn();
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      requestSignal = init?.signal ?? undefined;
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(8));
+            controller.enqueue(new Uint8Array(8));
+          },
+          cancel,
+        }),
+      );
+    };
+
+    await expect(
+      getContentPackManifestJsonWithFetch(
+        "https://example.com/pack.json",
+        fetchImpl,
+        1_000,
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "ContentPackManifestTooLargeError" });
+    expect(requestSignal?.aborted).toBe(true);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("bounds decompressed bytes despite a smaller declared wire size", async () => {
+    const cancel = vi.fn();
+    const fetchImpl: typeof fetch = async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(11));
+          },
+          cancel,
+        }),
+        {
+          headers: {
+            "content-encoding": "gzip",
+            "content-length": "2",
+          },
+        },
+      );
+
+    await expect(
+      getContentPackManifestJsonWithFetch(
+        "https://example.com/pack.json",
+        fetchImpl,
+        1_000,
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "ContentPackManifestTooLargeError" });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("rejects and cancels a declared oversized body before reading", async () => {
+    const cancel = vi.fn();
+    const fetchImpl: typeof fetch = async () =>
+      ({
+        ok: true,
+        headers: new Headers({ "content-length": "11" }),
+        body: new ReadableStream({ cancel }),
+      }) as Response;
+
+    await expect(
+      getContentPackManifestJsonWithFetch(
+        "https://example.com/pack.json",
+        fetchImpl,
+        1_000,
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "ContentPackManifestTooLargeError" });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("accepts valid multi-byte JSON split across chunks at the exact cap", async () => {
+    const bytes = new TextEncoder().encode('{"value":"€"}');
+    const fetchImpl: typeof fetch = async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(bytes.subarray(0, bytes.length - 2));
+            controller.enqueue(bytes.subarray(bytes.length - 2));
+            controller.close();
+          },
+        }),
+      );
+
+    await expect(
+      getContentPackManifestJsonWithFetch(
+        "https://example.com/pack.json",
+        fetchImpl,
+        1_000,
+        bytes.length,
+      ),
+    ).resolves.toEqual({ value: "€" });
+  });
+
+  it("rejects malformed UTF-8 instead of repairing manifest text", async () => {
+    const malformedJson = new Uint8Array([
+      0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d,
+    ]);
+    const fetchImpl: typeof fetch = async () => new Response(malformedJson);
+
+    await expect(
+      getContentPackManifestJsonWithFetch(
+        "https://example.com/pack.json",
+        fetchImpl,
+        1_000,
+      ),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("rejects invalid injected limits instead of disabling the byte cap", async () => {
+    const fetchImpl: typeof fetch = async () => Response.json(MANIFEST);
+
+    await expect(
+      getContentPackManifestJsonWithFetch(
+        "https://example.com/pack.json",
+        fetchImpl,
+        1_000,
+        Number.POSITIVE_INFINITY,
+      ),
+    ).rejects.toBeInstanceOf(RangeError);
+  });
+
+  it("omits auth, referrer, and cache reuse for an untrusted pack origin", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => Response.json(MANIFEST));
+
+    await getContentPackManifestJsonWithFetch(
+      "https://example.com/pack.json",
+      fetchImpl,
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://example.com/pack.json",
+      expect.objectContaining({
+        credentials: "omit",
+        cache: "no-store",
+        referrerPolicy: "no-referrer",
+      }),
+    );
+  });
+
+  it("surfaces the byte-limit reason through the loader boundary", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array(), {
+        headers: {
+          "content-length": String(CONTENT_PACK_MANIFEST_MAX_BYTES + 1),
+        },
+      }),
+    );
+
+    const error = await loadContentPackFromUrl(
+      "https://example.com/packs/a",
+    ).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ContentPackLoadError);
+    expect(error).toMatchObject({
+      message: `Content pack manifest exceeds ${CONTENT_PACK_MANIFEST_MAX_BYTES} bytes`,
+      cause: { name: "ContentPackManifestTooLargeError" },
     });
   });
 });

--- a/packages/ui/src/content-packs/load-pack.ts
+++ b/packages/ui/src/content-packs/load-pack.ts
@@ -14,7 +14,123 @@ import {
   validateContentPackManifest,
 } from "@elizaos/shared";
 
-const CONTENT_PACK_MANIFEST_FETCH_TIMEOUT_MS = 15_000;
+/** Manifest reads are short UI requests and must not stall pack loading. */
+export const CONTENT_PACK_MANIFEST_FETCH_TIMEOUT_MS = 15_000;
+
+/** A manifest is metadata, so bound it independently of its asset payloads. */
+export const CONTENT_PACK_MANIFEST_MAX_BYTES = 1024 * 1024;
+
+class ContentPackManifestTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Content pack manifest exceeds ${maxBytes} bytes`);
+    this.name = "ContentPackManifestTooLargeError";
+  }
+}
+
+function cancelManifestBody(
+  body: Pick<ReadableStream<Uint8Array>, "cancel"> | undefined | null,
+  reason: unknown,
+): void {
+  if (!body) return;
+  // error-policy:J5 allSettled observes a best-effort cancellation rejection;
+  // the original transport/validation failure remains the caller-visible one.
+  void Promise.allSettled([body.cancel(reason)]);
+}
+
+async function readBoundedManifestJson<T>(
+  response: Response,
+  signal: AbortSignal,
+  sizeAbort: AbortController,
+  maxBytes: number,
+): Promise<T> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new RangeError(
+      "Content pack manifest byte limit must be a positive safe integer",
+    );
+  }
+
+  const contentLength = response.headers.get("content-length");
+  if (contentLength && /^\d+$/.test(contentLength)) {
+    const declaredBytes = Number(contentLength);
+    if (!Number.isSafeInteger(declaredBytes) || declaredBytes > maxBytes) {
+      const error = new ContentPackManifestTooLargeError(maxBytes);
+      cancelManifestBody(response.body, error);
+      sizeAbort.abort(error);
+      throw error;
+    }
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("Content pack manifest response has no body");
+
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let receivedBytes = 0;
+  let json = "";
+  let bodyComplete = false;
+  let rejectOnAbort: ((reason: unknown) => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = reject;
+  });
+  const onAbort = () => rejectOnAbort?.(signal.reason);
+  if (signal.aborted) onAbort();
+  else signal.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    while (true) {
+      const { done, value } = await Promise.race([reader.read(), aborted]);
+      if (done) {
+        bodyComplete = true;
+        break;
+      }
+      receivedBytes += value.byteLength;
+      if (receivedBytes > maxBytes) {
+        const error = new ContentPackManifestTooLargeError(maxBytes);
+        sizeAbort.abort(error);
+        throw error;
+      }
+      json += decoder.decode(value, { stream: true });
+    }
+    json += decoder.decode();
+    return JSON.parse(json) as T;
+  } catch (error) {
+    if (!bodyComplete) cancelManifestBody(reader, error);
+    throw error;
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+  }
+}
+
+/** Fetch and fully consume one manifest within a single request/body deadline. */
+export async function getContentPackManifestJsonWithFetch<T>(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = CONTENT_PACK_MANIFEST_FETCH_TIMEOUT_MS,
+  maxBytes: number = CONTENT_PACK_MANIFEST_MAX_BYTES,
+  callerSignal?: AbortSignal,
+): Promise<T> {
+  const sizeAbort = new AbortController();
+  const signals = [AbortSignal.timeout(timeoutMs), sizeAbort.signal];
+  if (callerSignal) signals.push(callerSignal);
+  const signal = AbortSignal.any(signals);
+  const response = await fetchImpl(url, {
+    method: "GET",
+    credentials: "omit",
+    cache: "no-store",
+    referrerPolicy: "no-referrer",
+    signal,
+  });
+  if (!response.ok) {
+    const error = new Error(`HTTP ${response.status} ${response.statusText}`);
+    cancelManifestBody(response.body, error);
+    throw error;
+  }
+  return await readBoundedManifestJson<T>(
+    response,
+    signal,
+    sizeAbort,
+    maxBytes,
+  );
+}
 
 export class ContentPackLoadError extends Error {
   constructor(
@@ -43,25 +159,20 @@ export async function loadContentPackFromUrl(
 
   let raw: unknown;
   try {
-    const timeoutSignal = AbortSignal.timeout(
+    raw = await getContentPackManifestJsonWithFetch(
+      manifestUrl,
+      globalThis.fetch,
       CONTENT_PACK_MANIFEST_FETCH_TIMEOUT_MS,
+      CONTENT_PACK_MANIFEST_MAX_BYTES,
+      options.signal,
     );
-    const signal = options.signal
-      ? AbortSignal.any([options.signal, timeoutSignal])
-      : timeoutSignal;
-    const response = await globalThis.fetch(manifestUrl, {
-      method: "GET",
-      signal,
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} ${response.statusText}`);
-    }
-    raw = await response.json();
   } catch (err) {
     // error-policy:J2 retain the source URL while preserving the transport,
     // body-read, timeout, or caller-cancellation failure as the cause.
     throw new ContentPackLoadError(
-      `Failed to fetch pack manifest from ${manifestUrl}`,
+      err instanceof ContentPackManifestTooLargeError
+        ? err.message
+        : `Failed to fetch pack manifest from ${manifestUrl}`,
       source,
       err,
     );

--- a/packages/ui/src/content-packs/load-pack.ts
+++ b/packages/ui/src/content-packs/load-pack.ts
@@ -20,6 +20,9 @@ export const CONTENT_PACK_MANIFEST_FETCH_TIMEOUT_MS = 15_000;
 /** A manifest is metadata, so bound it independently of its asset payloads. */
 export const CONTENT_PACK_MANIFEST_MAX_BYTES = 1024 * 1024;
 
+/** Teardown must not turn an untrusted stream's cancel hook into a new stall. */
+const CONTENT_PACK_READER_CANCEL_TIMEOUT_MS = 250;
+
 class ContentPackManifestTooLargeError extends Error {
   constructor(maxBytes: number) {
     super(`Content pack manifest exceeds ${maxBytes} bytes`);
@@ -35,6 +38,23 @@ function cancelManifestBody(
   // error-policy:J5 allSettled observes a best-effort cancellation rejection;
   // the original transport/validation failure remains the caller-visible one.
   void Promise.allSettled([body.cancel(reason)]);
+}
+
+async function cancelManifestReader(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reason: unknown,
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timeoutId = setTimeout(resolve, CONTENT_PACK_READER_CANCEL_TIMEOUT_MS);
+  });
+  // error-policy:J5 allSettled observes a hostile or failed cancel hook; the
+  // bounded race ensures teardown cannot replace the original body failure.
+  await Promise.race([
+    Promise.allSettled([reader.cancel(reason)]).then(() => undefined),
+    timeout,
+  ]);
+  if (timeoutId !== undefined) clearTimeout(timeoutId);
 }
 
 async function readBoundedManifestJson<T>(
@@ -67,6 +87,7 @@ async function readBoundedManifestJson<T>(
   let receivedBytes = 0;
   let json = "";
   let bodyComplete = false;
+  let bodyFailed = false;
   let rejectOnAbort: ((reason: unknown) => void) | undefined;
   const aborted = new Promise<never>((_resolve, reject) => {
     rejectOnAbort = reject;
@@ -93,10 +114,20 @@ async function readBoundedManifestJson<T>(
     json += decoder.decode();
     return JSON.parse(json) as T;
   } catch (error) {
-    if (!bodyComplete) cancelManifestBody(reader, error);
+    bodyFailed = true;
+    if (!bodyComplete) await cancelManifestReader(reader, error);
     throw error;
   } finally {
     signal.removeEventListener("abort", onAbort);
+    if (!bodyFailed) {
+      reader.releaseLock();
+    } else {
+      // error-policy:J5 a timed-out cancel can leave a read pending, so observe
+      // releaseLock rejection without masking the original caller-visible error.
+      await Promise.allSettled([
+        Promise.resolve().then(() => reader.releaseLock()),
+      ]);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #21912. Follow-up to merged #21867.

The existing 15-second request/body deadline remains intact. Manifest reads now enforce a 1 MiB cap over bytes delivered by the response stream (including decompressed bytes), reject oversized declared lengths before reading, use fatal UTF-8 decoding, omit credentials/referrer/cache reuse for untrusted pack origins, and preserve caller cancellation. Failure teardown cancels the reader within a bounded 250 ms budget and releases completed readers without replacing the original error.

Exact-head validation on rebased head `3daa20906d8729a845be0964db4d263d94ebefde` (tree `d890dfe0d46fcc0e5b5e58b04b4cc24fc0b1b062`):

- Rebased cleanly onto current `origin/develop` and force-pushed with an exact lease.
- Focused production-boundary suite: 2 files, 18/18 tests passed.
- `packages/ui` typecheck: passed.
- Changed-file Biome and `git diff --check`: passed.
- The production loader enforces the 1 MiB streaming/decompressed-byte cap, declared-length precheck, fatal UTF-8, caller cancellation, 15-second deadline, bounded 250 ms reader cancellation, and original-error preservation.
- No production UI pixels, model behavior, backend behavior, or persisted domain schema changed; those evidence rows are correctly N/A.
- Exact-head receipt: https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/21916-rebase-validation.md

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - independent PR audit and repair
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3daa20906d8729a845be0964db4d263d94ebefde -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - response-byte hardening has no stable visual before-state; intentionally exhausting renderer memory is unsafe.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - production UI rendering is unchanged; this patch modifies only the content-pack fetch boundary and focused tests.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - non-interactive manifest transport boundary covered by production loader tests.
<!-- evidence-row:backend-logs -->
- [ ] N/A - browser fetch boundary only.
<!-- evidence-row:frontend-logs -->
- [x] [21916-focused-result.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/21916-focused-result.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [21916-rebase-validation.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/21916-rebase-validation.md)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI pixels changed.

