### PR TITLE
fix(shared): guard nullish inputs in app-hero-art and add unit test suite

### DIFF
--- a/packages/shared/src/app-hero-art.test.ts
+++ b/packages/shared/src/app-hero-art.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for deterministic app hero artwork generation, monograms, labels, and theme keys.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  createGeneratedAppHeroDataUrl,
+  createGeneratedAppHeroSvg,
+  getAppHeroDisplayLabel,
+  getAppHeroMonogram,
+  getAppHeroThemeKey,
+} from "./app-hero-art.ts";
+
+describe("getAppHeroDisplayLabel", () => {
+  it("strips package scopes and plugin/app prefixes", () => {
+    expect(getAppHeroDisplayLabel({ name: "@elizaos/plugin-solana" })).toBe(
+      "solana",
+    );
+    expect(getAppHeroDisplayLabel({ name: "plugin-browser" })).toBe("browser");
+    expect(getAppHeroDisplayLabel({ name: "app-chat" })).toBe("chat");
+  });
+
+  it("prioritizes displayName when present", () => {
+    expect(
+      getAppHeroDisplayLabel({
+        name: "plugin-twitter",
+        displayName: "Twitter Connector",
+      }),
+    ).toBe("Twitter Connector");
+  });
+
+  it("handles nullish or invalid inputs safely", () => {
+    expect(getAppHeroDisplayLabel(null)).toBe("");
+    expect(getAppHeroDisplayLabel(undefined)).toBe("");
+    expect(getAppHeroDisplayLabel({} as unknown as { name: string })).toBe("");
+  });
+});
+
+describe("getAppHeroMonogram", () => {
+  it("extracts 2-letter initials for multi-word and compound names", () => {
+    expect(getAppHeroMonogram({ name: "Solana Trader" })).toBe("ST");
+    expect(getAppHeroMonogram({ name: "crypto-wallet" })).toBe("CW");
+    expect(getAppHeroMonogram({ name: "my_cool.agent" })).toBe("MC");
+  });
+
+  it("uses first two letters for single words", () => {
+    expect(getAppHeroMonogram({ name: "Browser" })).toBe("BR");
+    expect(getAppHeroMonogram({ name: "X" })).toBe("X");
+  });
+
+  it("handles empty or nullish inputs by returning ?", () => {
+    expect(getAppHeroMonogram(null)).toBe("?");
+    expect(getAppHeroMonogram(undefined)).toBe("?");
+    expect(getAppHeroMonogram({ name: "" })).toBe("?");
+  });
+});
+
+describe("getAppHeroThemeKey", () => {
+  it("classifies apps into thematic categories based on metadata", () => {
+    expect(getAppHeroThemeKey({ name: "arcade-quest", category: "game" })).toBe(
+      "play",
+    );
+    expect(
+      getAppHeroThemeKey({
+        name: "discord-bot",
+        description: "social companion message chat",
+      }),
+    ).toBe("chat");
+    expect(
+      getAppHeroThemeKey({
+        name: "solana-dex",
+        category: "finance trade wallet",
+      }),
+    ).toBe("money");
+    expect(
+      getAppHeroThemeKey({
+        name: "dev-debugger",
+        description: "runtime memory viewer utility",
+      }),
+    ).toBe("tools");
+    expect(
+      getAppHeroThemeKey({
+        name: "web-crawler",
+        description: "browser network",
+      }),
+    ).toBe("world");
+    expect(
+      getAppHeroThemeKey({
+        name: "task-runner",
+        description: "team calendar life ops",
+      }),
+    ).toBe("ops");
+    expect(
+      getAppHeroThemeKey({
+        name: "random-unclassified-entity",
+      }),
+    ).toBe("app");
+  });
+
+  it("handles nullish inputs safely", () => {
+    expect(getAppHeroThemeKey(null)).toBe("app");
+    expect(getAppHeroThemeKey(undefined)).toBe("app");
+  });
+});
+
+describe("createGeneratedAppHeroSvg and createGeneratedAppHeroDataUrl", () => {
+  it("generates valid SVG artwork containing theme elements and title", () => {
+    const svg = createGeneratedAppHeroSvg({
+      name: "plugin-chat",
+      displayName: "Chat & Social",
+    });
+
+    expect(typeof svg).toBe("string");
+    expect(svg.startsWith("<svg")).toBe(true);
+    expect(svg.endsWith("</svg>")).toBe(true);
+    expect(svg).toContain("<title>Chat &amp; Social</title>");
+    expect(svg).toContain('<linearGradient id="bg"');
+  });
+
+  it("renders distinct motifs for each supported theme", () => {
+    const themes = [
+      { name: "game-app", category: "game" },
+      { name: "chat-bot", category: "chat" },
+      { name: "crypto-wallet", category: "money" },
+      { name: "dev-debugger", category: "utility" },
+      { name: "world-net", category: "world" },
+      { name: "ops-manager", category: "ops" },
+      { name: "plain-app" },
+    ];
+
+    for (const app of themes) {
+      const svg = createGeneratedAppHeroSvg(app);
+      expect(typeof svg).toBe("string");
+      expect(svg.length).toBeGreaterThan(200);
+    }
+  });
+
+  it("generates valid data URLs with URL-encoded SVG", () => {
+    const dataUrl = createGeneratedAppHeroDataUrl({
+      name: "@elizaos/plugin-solana",
+      category: "wallet",
+    });
+
+    expect(dataUrl.startsWith("data:image/svg+xml;charset=utf-8,")).toBe(true);
+    expect(dataUrl).toContain(encodeURIComponent("<svg"));
+  });
+
+  it("handles nullish inputs safely", () => {
+    const svg = createGeneratedAppHeroSvg(null);
+    expect(svg.startsWith("<svg")).toBe(true);
+  });
+});

--- a/packages/shared/src/app-hero-art.ts
+++ b/packages/shared/src/app-hero-art.ts
@@ -73,20 +73,30 @@ const HERO_PALETTES: readonly HeroPalette[] = [
   },
 ] as const;
 
-function trimPackagePrefix(value: string): string {
+function trimPackagePrefix(value: string | null | undefined): string {
+  if (typeof value !== "string") return "";
   return value
     .replace(/^@[^/]+\//, "")
     .replace(/^(app|plugin)-/i, "")
     .trim();
 }
 
-export function getAppHeroDisplayLabel(app: AppHeroArtworkSource): string {
+export function getAppHeroDisplayLabel(
+  app: AppHeroArtworkSource | null | undefined,
+): string {
+  if (!app || typeof app !== "object") return "";
   return trimPackagePrefix(app.displayName ?? app.name);
 }
 
-export function getAppHeroMonogram(app: AppHeroArtworkSource): string {
+export function getAppHeroMonogram(
+  app: AppHeroArtworkSource | null | undefined,
+): string {
+  if (!app || typeof app !== "object") return "?";
   const label = trimPackagePrefix(app.displayName ?? app.name);
   const words = label.split(/[\s._/-]+/).filter(Boolean);
+  if (words.length === 1) {
+    return (words[0].slice(0, 2).toUpperCase() || "?").slice(0, 2);
+  }
   const initials = words
     .slice(0, 2)
     .map((word) => word[0]?.toUpperCase() ?? "")
@@ -94,9 +104,12 @@ export function getAppHeroMonogram(app: AppHeroArtworkSource): string {
   return (initials || label.slice(0, 2).toUpperCase() || "?").slice(0, 2);
 }
 
-export function getAppHeroThemeKey(app: AppHeroArtworkSource): AppHeroThemeKey {
+export function getAppHeroThemeKey(
+  app: AppHeroArtworkSource | null | undefined,
+): AppHeroThemeKey {
+  if (!app || typeof app !== "object") return "app";
   const blob = [
-    app.name,
+    app.name ?? "",
     app.displayName ?? "",
     app.category ?? "",
     app.description ?? "",
@@ -129,8 +142,9 @@ export function getAppHeroThemeKey(app: AppHeroArtworkSource): AppHeroThemeKey {
   return "app";
 }
 
-function getHeroPalette(name: string): HeroPalette {
-  return HERO_PALETTES[hashString(name) % HERO_PALETTES.length];
+function getHeroPalette(name: string | null | undefined): HeroPalette {
+  const safeName = typeof name === "string" ? name : "app";
+  return HERO_PALETTES[hashString(safeName) % HERO_PALETTES.length];
 }
 
 function getSeededOffset(
@@ -348,17 +362,20 @@ function renderThemeMotif(
   }
 }
 
-export function createGeneratedAppHeroSvg(app: AppHeroArtworkSource): string {
-  const palette = getHeroPalette(app.name);
-  const theme = getAppHeroThemeKey(app);
-  const seed = hashString(app.name);
+export function createGeneratedAppHeroSvg(
+  app?: AppHeroArtworkSource | null,
+): string {
+  const safeApp = app && typeof app === "object" ? app : { name: "app" };
+  const palette = getHeroPalette(safeApp.name);
+  const theme = getAppHeroThemeKey(safeApp);
+  const seed = hashString(safeApp.name || "app");
   const gridOffsetX = 16 + (seed % 14);
   const gridOffsetY = 10 + ((seed >> 4) % 10);
   const radialX = 18 + (seed % 44);
   const radialY = 10 + ((seed >> 6) % 30);
   const arcTilt = (seed % 24) - 12;
   const motif = renderThemeMotif(theme, seed, palette);
-  const title = escapeXmlText(getAppHeroDisplayLabel(app));
+  const title = escapeXmlText(getAppHeroDisplayLabel(safeApp));
 
   // The app card already renders the display name as a small label below
   // the hero. Baking the name into the generated SVG produced a duplicate


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `trimPackagePrefix`, `getAppHeroDisplayLabel`, `getAppHeroMonogram`, `getAppHeroThemeKey`, and `createGeneratedAppHeroSvg` against null, undefined, and non-object inputs to prevent unhandled `TypeError` exceptions.
- Improve `getAppHeroMonogram` to extract 2-letter monograms for single-word names (e.g. `Browser` -> `BR`).
- Add a comprehensive unit test suite in `packages/shared/src/app-hero-art.test.ts` covering display label formatting, scoped package prefix stripping, monogram generation, theme key classification across all 7 categories, SVG generation, Data URL encoding, and nullish input handling with 100% line & func coverage.

## Related Issues

- Fixes #21917

## Testing

- Added `packages/shared/src/app-hero-art.test.ts` with 12 tests covering:
  - Stripping package scopes (`@elizaos/...`) and `plugin-`/`app-` prefixes
  - Display name override precedence
  - Monogram extraction for compound and single-word names
  - Monogram fallback (`?`)
  - Theme key categorization (`play`, `chat`, `money`, `tools`, `world`, `ops`, `app`)
  - Deterministic SVG artwork generation
  - Data URL generation
  - Motif rendering across all 7 theme variations
  - Nullish / empty object safety
- `bun test packages/shared/src/app-hero-art.test.ts` passes (12/12 tests, 46 assertions, 100% coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/app-hero-art.test.ts:
✓ getAppHeroDisplayLabel > strips package scopes and plugin/app prefixes [0.36ms]
✓ getAppHeroDisplayLabel > prioritizes displayName when present [0.04ms]
✓ getAppHeroDisplayLabel > handles nullish or invalid inputs safely [0.05ms]
✓ getAppHeroMonogram > extracts 2-letter initials for multi-word and compound names [0.76ms]
✓ getAppHeroMonogram > uses first two letters for single words [0.05ms]
✓ getAppHeroMonogram > handles empty or nullish inputs by returning ? [0.06ms]
✓ getAppHeroThemeKey > classifies apps into thematic categories based on metadata [0.34ms]
✓ getAppHeroThemeKey > handles nullish inputs safely [0.03ms]
✓ createGeneratedAppHeroSvg and createGeneratedAppHeroDataUrl > generates valid SVG artwork containing theme elements and title [0.55ms]
✓ createGeneratedAppHeroSvg and createGeneratedAppHeroDataUrl > renders distinct motifs for each supported theme [0.65ms]
✓ createGeneratedAppHeroSvg and createGeneratedAppHeroDataUrl > generates valid data URLs with URL-encoded SVG [0.17ms]
✓ createGeneratedAppHeroSvg and createGeneratedAppHeroDataUrl > handles nullish inputs safely [0.20ms]
------------------------------------------|---------|---------|-------------------
File                                      | % Funcs | % Lines | Uncovered Line #s
------------------------------------------|---------|---------|-------------------
 packages/shared/src/app-hero-art.ts      |  100.00 |  100.00 | 
 packages/shared/src/utils/string-hash.ts |  100.00 |  100.00 | 
------------------------------------------|---------|---------|-------------------

 12 pass
 0 fail
 46 expect() calls
Ran 12 tests across 1 file. [108.00ms]
```
