### PR TITLE
fix(plugin-x): bound X OAuth token and users/me fetches

### DIFF
--- a/plugins/plugin-x/src/connector-account-provider.test.ts
+++ b/plugins/plugin-x/src/connector-account-provider.test.ts
@@ -5,7 +5,13 @@ import type {
   IAgentRuntime,
 } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createXConnectorAccountProvider } from "./connector-account-provider";
+import {
+  createXConnectorAccountProvider,
+  exchangeXOauthTokenWithFetch,
+  fetchXAuthenticatedUserWithFetch,
+  X_OAUTH_TOKEN_TIMEOUT_MS,
+  X_OAUTH_USERS_ME_TIMEOUT_MS,
+} from "./connector-account-provider";
 
 function asRuntime<T extends object>(runtime: T): IAgentRuntime & T {
   return runtime as IAgentRuntime & T;
@@ -177,6 +183,176 @@ describe("X connector account OAuth", () => {
         manager as never,
       ),
     ).rejects.toThrow(/durable connector credential store|vault writer/i);
+  });
+});
+
+function stallUntilAborted(label: string): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error(`expected ${label} abort signal`);
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+function oauthRuntime(): IAgentRuntime {
+  return asRuntime({
+    agentId: "agent-1",
+    getSetting: (key: string) =>
+      ({
+        TWITTER_CLIENT_ID: "x-client",
+        TWITTER_REDIRECT_URI: "http://localhost/oauth/x/callback",
+      })[key],
+    getService: () => null,
+  });
+}
+
+function oauthRequest() {
+  return {
+    provider: "x" as const,
+    code: "oauth-code",
+    query: {},
+    flow: {
+      id: "flow-1",
+      provider: "x" as const,
+      state: "state-1",
+      status: "pending" as const,
+      codeVerifier: "verifier",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      metadata: {},
+    },
+  };
+}
+
+const tokenArgs = {
+  clientId: "x-client",
+  redirectUri: "http://localhost/oauth/x/callback",
+  code: "oauth-code",
+  codeVerifier: "verifier",
+};
+
+describe("X OAuth request deadlines", () => {
+  it("keeps a documented token-exchange budget", () => {
+    expect(X_OAUTH_TOKEN_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("keeps a documented users/me budget", () => {
+    expect(X_OAUTH_USERS_ME_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("aborts a stalled token POST at the injected deadline", async () => {
+    await expect(
+      exchangeXOauthTokenWithFetch(tokenArgs, stallUntilAborted("token"), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("aborts a stalled users/me GET at the injected deadline", async () => {
+    await expect(
+      fetchXAuthenticatedUserWithFetch(
+        "x-access-token",
+        stallUntilAborted("users/me"),
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed token POST", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("invalid_code", {
+        status: 401,
+        statusText: "Unauthorized",
+      });
+    await expect(
+      exchangeXOauthTokenWithFetch(tokenArgs, fetchImpl, 1_000),
+    ).rejects.toThrow("Twitter token exchange failed (401)");
+  });
+
+  it("surfaces a provider error from a completed users/me GET", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 503, statusText: "Service Unavailable" });
+    await expect(
+      fetchXAuthenticatedUserWithFetch("x-access-token", fetchImpl, 1_000),
+    ).rejects.toThrow("Twitter users/me failed (503)");
+  });
+
+  it("uses the injected fetch for a successful completeOAuth()", async () => {
+    const signals: AbortSignal[] = [];
+    const vault = new Map<string, string>();
+    const setCredentialRef = vi.fn(async () => undefined);
+    const fetchImpl: typeof fetch = async (input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      const href = String(input);
+      if (href.includes("/oauth2/token")) {
+        return Response.json({
+          access_token: "x-access-token",
+          refresh_token: "x-refresh-token",
+          expires_in: 7200,
+          scope: "tweet.read tweet.write users.read offline.access",
+          token_type: "bearer",
+        });
+      }
+      if (href.includes("/users/me")) {
+        return Response.json({
+          data: { id: "x-user-1", username: "ada", name: "Ada" },
+        });
+      }
+      throw new Error(`Unexpected fetch ${href}`);
+    };
+    const runtime = asRuntime({
+      ...oauthRuntime(),
+      getService: (serviceType: string) =>
+        serviceType === "vault"
+          ? {
+              set: async (key: string, value: string) => {
+                vault.set(key, value);
+              },
+            }
+          : null,
+    });
+    const provider = createXConnectorAccountProvider(runtime, {
+      fetchImpl,
+      tokenTimeoutMs: 1_000,
+      usersMeTimeoutMs: 1_000,
+    });
+    const result = await provider.completeOAuth?.(
+      oauthRequest(),
+      createOAuthCallbackManager(
+        "x",
+        "acct_x_success",
+        setCredentialRef,
+      ) as never,
+    );
+    expect(signals).toHaveLength(2);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(signals[1]?.aborted).toBe(false);
+    expect(result?.account).toMatchObject({
+      id: "acct_x_success",
+      status: "connected",
+    });
+    expect(vault.get("connector.agent-1.x.acct_x_success.oauth_tokens")).toContain(
+      "x-access-token",
+    );
+  });
+
+  it("aborts completeOAuth() when the token hop stalls", async () => {
+    const provider = createXConnectorAccountProvider(oauthRuntime(), {
+      fetchImpl: stallUntilAborted("token"),
+      tokenTimeoutMs: 10,
+      usersMeTimeoutMs: 1_000,
+    });
+    await expect(
+      provider.completeOAuth?.(
+        oauthRequest(),
+        createOAuthCallbackManager(
+          "x",
+          "acct_x_timeout",
+          vi.fn(async () => undefined),
+        ) as never,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
   });
 });
 

--- a/plugins/plugin-x/src/connector-account-provider.ts
+++ b/plugins/plugin-x/src/connector-account-provider.ts
@@ -40,9 +40,20 @@ import { persistConnectorCredentialRefs } from "./connector-credential-refs";
 import { getSetting } from "./utils/settings";
 
 const TWITTER_AUTHORIZE_URL = "https://twitter.com/i/oauth2/authorize";
-const TWITTER_TOKEN_URL = "https://api.twitter.com/2/oauth2/token";
-const TWITTER_USERS_ME_URL =
+export const TWITTER_TOKEN_URL = "https://api.twitter.com/2/oauth2/token";
+export const TWITTER_USERS_ME_URL =
   "https://api.twitter.com/2/users/me?user.fields=id,name,username";
+
+/** X token-exchange POST — same 15s Fal #21205 family as Slack OAuth. */
+export const X_OAUTH_TOKEN_TIMEOUT_MS = 15_000;
+/** X users/me GET — independent hop, own 15s deadline. */
+export const X_OAUTH_USERS_ME_TIMEOUT_MS = 15_000;
+
+export interface XConnectorAccountProviderOptions {
+  fetchImpl?: typeof fetch;
+  tokenTimeoutMs?: number;
+  usersMeTimeoutMs?: number;
+}
 
 const DEFAULT_SCOPES = [
   "tweet.read",
@@ -123,12 +134,16 @@ function formEncode(params: Record<string, string>): string {
     .join("&");
 }
 
-async function exchangeCodeForToken(args: {
-  clientId: string;
-  redirectUri: string;
-  code: string;
-  codeVerifier: string;
-}): Promise<TwitterTokenResponse> {
+export async function exchangeXOauthTokenWithFetch(
+  args: {
+    clientId: string;
+    redirectUri: string;
+    code: string;
+    codeVerifier: string;
+  },
+  fetchImpl: typeof fetch,
+  timeoutMs: number = X_OAUTH_TOKEN_TIMEOUT_MS,
+): Promise<TwitterTokenResponse> {
   const body = formEncode({
     grant_type: "authorization_code",
     client_id: args.clientId,
@@ -136,10 +151,11 @@ async function exchangeCodeForToken(args: {
     code: args.code,
     code_verifier: args.codeVerifier,
   });
-  const res = await fetch(TWITTER_TOKEN_URL, {
+  const res = await fetchImpl(TWITTER_TOKEN_URL, {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
     body,
+    signal: AbortSignal.timeout(timeoutMs),
   });
   const json = (await res.json().catch(() => ({}))) as TwitterTokenResponse;
   if (!res.ok || !json.access_token) {
@@ -150,11 +166,14 @@ async function exchangeCodeForToken(args: {
   return json;
 }
 
-async function fetchAuthenticatedUser(
+export async function fetchXAuthenticatedUserWithFetch(
   accessToken: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number = X_OAUTH_USERS_ME_TIMEOUT_MS,
 ): Promise<{ id: string; username?: string; name?: string }> {
-  const res = await fetch(TWITTER_USERS_ME_URL, {
+  const res = await fetchImpl(TWITTER_USERS_ME_URL, {
     headers: { authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(timeoutMs),
   });
   const json = (await res.json().catch(() => ({}))) as TwitterUserMeResponse;
   if (!res.ok || !json.data?.id) {
@@ -223,7 +242,12 @@ function roleFromMetadata(metadata: unknown): ConnectorAccountRole {
 
 export function createXConnectorAccountProvider(
   runtime: IAgentRuntime,
+  options: XConnectorAccountProviderOptions = {},
 ): ConnectorAccountProvider {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const tokenTimeoutMs = options.tokenTimeoutMs ?? X_OAUTH_TOKEN_TIMEOUT_MS;
+  const usersMeTimeoutMs =
+    options.usersMeTimeoutMs ?? X_OAUTH_USERS_ME_TIMEOUT_MS;
   return {
     provider: X_PROVIDER,
     label: "X (Twitter)",
@@ -278,19 +302,27 @@ export function createXConnectorAccountProvider(
           "Twitter OAuth flow is missing code verifier — restart the flow",
         );
       }
-      const token = await exchangeCodeForToken({
-        clientId: config.clientId,
-        redirectUri,
-        code,
-        codeVerifier,
-      });
+      const token = await exchangeXOauthTokenWithFetch(
+        {
+          clientId: config.clientId,
+          redirectUri,
+          code,
+          codeVerifier,
+        },
+        fetchImpl,
+        tokenTimeoutMs,
+      );
       const accessToken = token.access_token;
       if (!accessToken) {
         throw new Error(
           "Twitter OAuth token exchange did not return an access_token",
         );
       }
-      const me = await fetchAuthenticatedUser(accessToken);
+      const me = await fetchXAuthenticatedUserWithFetch(
+        accessToken,
+        fetchImpl,
+        usersMeTimeoutMs,
+      );
       const expiresAt =
         typeof token.expires_in === "number"
           ? Date.now() + token.expires_in * 1000


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). Slack sibling `#21863`. X `completeOAuth` used unbounded `fetch` on two independent hops — `POST https://api.twitter.com/2/oauth2/token` and `GET https://api.twitter.com/2/users/me` — so a stalled hop hangs the connector OAuth callback. This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, **separate 15s deadlines per hop**. Tests execute the helpers and `completeOAuth()` under abort. Not extra-decode. Not list-limit. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Not Twilio. Not shared-runtime. Not GitHub OAuth (`#21765` closed). Not byt61 wallet timeouts. Not view-manager `#21871` (already posted). Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Account list/create/patch/delete and startOAuth URL building unchanged. `createXConnectorAccountProvider(runtime)` stays valid; optional inject bag is backward-compatible. Unfixed head: token POST and users/me GET `fetch` had **no signal** and a hung hop never settled (80ms race → `HUNG` / `sawSignal: false` on both hops). After: 10ms deadline → `TimeoutError` on each helper. Each hop has its own 15s constant.

# Background

## What does this PR do?

`completeOAuth` called `fetch` with no `signal` on the Twitter token exchange and the subsequent `users/me` hop. A stalled hop never returns. This PR injects `exchangeXOauthTokenWithFetch` / `fetchXAuthenticatedUserWithFetch` plus optional `fetchImpl` (Fal `#21205` / Slack `#21863` shape) and adds `AbortSignal.timeout` with a separate 15s constant per hop.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Env-token X paths untouched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/connector-account-provider.test.ts` — timeout, provider-error, and success on each hop.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-x && bunx vitest run --config ./vitest.config.ts src/connector-account-provider.test.ts
```

Unfixed head: token POST and users/me GET `signal` was undefined and each call hung (`HUNG` / `sawSignal: false`). After the fix: 10 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. X OAuth fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live Twitter hop. vitest asserts TimeoutError, provider 401/503, and success.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no new rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - X OAuth transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no live hop. Unfixed hang: no signal, 80ms race `HUNG` / `sawSignal: false` on token POST and on users/me GET. After the fix, vitest asserts TimeoutError, `401`/`503` provider responses, and a successful completeOAuth with two live signals and 15s constants.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface change.

## Audio / voice walkthrough

N/A - OAuth provider HTTP only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`10 pass`). Root verify is an unrelated full-repo cost. No `bun install`.

<!-- evidence-head:7e376c836714298da6d13d92ec1f64e60fb499b2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
