### PR TITLE
fix(cloud,ui): preserve explicit Telegram claim confirmation across sign-in

### DIFF
--- a/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
@@ -663,7 +663,7 @@ describe("onboarding chat — trusted platform gateway caller", () => {
     resolveIdentity.mockResolvedValue({ user: userRow(), identity: undefined });
     await dataOf(
       await post({
-        sessionId: "platform:telegram-claim:test-claim-1",
+        sessionId: `platform:telegram-claim:${"a".repeat(64)}`,
         platform: "telegram",
         platformUserId: "9911",
         platformDisplayName: "Ada",
@@ -671,7 +671,7 @@ describe("onboarding chat — trusted platform gateway caller", () => {
       }),
     );
     const stored = sessionCache.get(
-      "eliza-app:onboarding:platform:telegram-claim:test-claim-1",
+      `eliza-app:onboarding:platform:telegram-claim:${"a".repeat(64)}`,
     ) as { continuationToken?: string };
     const continuation = stored?.continuationToken;
     if (!continuation) throw new Error("Expected a claim continuation token");
@@ -697,6 +697,34 @@ describe("onboarding chat — trusted platform gateway caller", () => {
       success: false,
       code: "access_denied",
     });
+  });
+
+  test("does not treat an account-bound ordinary Telegram session as claim authority", async () => {
+    resolveIdentity.mockResolvedValue({ user: userRow(), identity: undefined });
+    await dataOf(
+      await post({
+        sessionId: "platform:telegram:9911",
+        platform: "telegram",
+        platformUserId: "9911",
+        platformDisplayName: "Ada",
+        statusOnly: true,
+      }),
+    );
+    const stored = sessionCache.get(
+      "eliza-app:onboarding:platform:telegram:9911",
+    ) as { continuationToken?: string };
+    const continuation = stored?.continuationToken;
+    if (!continuation)
+      throw new Error("Expected an onboarding continuation token");
+
+    getCurrentUser.mockResolvedValue(activeStewardUser());
+    const preview = await get(continuation, STEWARD_JWT);
+    expect(preview.status).toBe(403);
+    expect(await preview.json()).toMatchObject({
+      success: false,
+      code: "access_denied",
+    });
+    expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();
   });
 
   test("a Steward caller can never mint a platform-scoped session or act as a trusted transport", async () => {

--- a/packages/cloud/api/auth/steward-nonce-exchange/route.ts
+++ b/packages/cloud/api/auth/steward-nonce-exchange/route.ts
@@ -22,10 +22,7 @@
  * first-party Eliza UI origins plus localhost in non-production.
  */
 
-import {
-  type StewardSessionErrorCode,
-  sanitizeTelegramAccountClaimContinuation,
-} from "@elizaos/shared/steward-session-client";
+import type { StewardSessionErrorCode } from "@elizaos/shared/steward-session-client";
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
 import {
@@ -42,11 +39,7 @@ import {
 } from "@/lib/auth/steward-client";
 import { stewardCookieNames } from "@/lib/auth/steward-cookies";
 import { signStewardMutatingRequest } from "@/lib/steward/sign";
-import {
-  describeSyncError,
-  StewardTelegramAccountClaimError,
-  syncUserFromSteward,
-} from "@/lib/steward-sync";
+import { describeSyncError, syncUserFromSteward } from "@/lib/steward-sync";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -299,9 +292,6 @@ app.post("/", async (c) => {
       : typeof body.code_verifier === "string"
         ? body.code_verifier.trim()
         : "";
-  const telegramContinuation = sanitizeTelegramAccountClaimContinuation(
-    body.telegramContinuation,
-  );
 
   if (!code) {
     logExchange("missing-code");
@@ -318,10 +308,10 @@ app.post("/", async (c) => {
       400,
     );
   }
-  if (body.telegramContinuation !== undefined && !telegramContinuation) {
-    logExchange("telegram-claim-invalid");
+  if (body.telegramContinuation !== undefined) {
+    logExchange("telegram-claim-not-permitted");
     return c.json(
-      errorBody("Invalid Telegram account claim", "telegram_claim_conflict"),
+      errorBody("Account confirmation required", "telegram_claim_conflict"),
       409,
     );
   }
@@ -409,19 +399,8 @@ app.post("/", async (c) => {
       email: claims.email,
       walletAddress: claims.walletAddress ?? claims.address,
       walletChainType: claims.walletChain,
-      telegramContinuation: telegramContinuation ?? undefined,
     });
   } catch (error) {
-    if (error instanceof StewardTelegramAccountClaimError) {
-      logExchange("telegram-claim-conflict");
-      return c.json(
-        errorBody(
-          "This Telegram chat cannot be linked automatically",
-          "telegram_claim_conflict",
-        ),
-        409,
-      );
-    }
     logExchange("sync-failed");
     // Workers Logs indexes only the message STRING — an Error passed in the
     // context object is dropped entirely (a week of these prod 500s was

--- a/packages/cloud/api/auth/steward-nonce-exchange/steward-nonce-exchange-telegram-claim.test.ts
+++ b/packages/cloud/api/auth/steward-nonce-exchange/steward-nonce-exchange-telegram-claim.test.ts
@@ -1,4 +1,4 @@
-/** Verifies OAuth code exchange carries Telegram claim authority into Cloud sync. */
+/** Verifies OAuth code exchange cannot carry Telegram claim authority. */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
@@ -21,8 +21,6 @@ const syncUserFromSteward = mock(async () => ({
   organization_id: "telegram-org-1",
 }));
 
-class MockStewardTelegramAccountClaimError extends Error {}
-
 mock.module("@/lib/auth/steward-client", () => ({
   STEWARD_AUTH_UPSTREAM_TIMEOUT_MS: 5_000,
   verifyStewardTokenCached,
@@ -31,7 +29,6 @@ mock.module("@/lib/auth/steward-client", () => ({
 mock.module("@/lib/steward-sync", () => ({
   describeSyncError: (error: unknown) =>
     error instanceof Error ? error.message : String(error),
-  StewardTelegramAccountClaimError: MockStewardTelegramAccountClaimError,
   syncUserFromSteward,
 }));
 
@@ -96,32 +93,7 @@ afterAll(() => {
 });
 
 describe("POST /api/auth/steward-nonce-exchange Telegram convergence", () => {
-  test("passes the opaque claim into sync before planting cookies", async () => {
-    const response = await post({
-      code: "one-time-code",
-      redirectUri: "https://cloud.eliza.app/login",
-      codeVerifier: "pkce-verifier",
-      telegramContinuation: "opaque-telegram-claim-token",
-    });
-
-    expect(response.status).toBe(200);
-    expect(syncUserFromSteward).toHaveBeenCalledWith({
-      stewardUserId: "steward-user-1",
-      email: undefined,
-      walletAddress: undefined,
-      walletChainType: undefined,
-      telegramContinuation: "opaque-telegram-claim-token",
-    });
-    expect(response.headers.get("set-cookie") ?? "").toContain(
-      "steward-token-staging=steward-access-token",
-    );
-  });
-
-  test("returns a conflict without cookies when the account cannot be claimed", async () => {
-    syncUserFromSteward.mockRejectedValueOnce(
-      new MockStewardTelegramAccountClaimError("ownership conflict"),
-    );
-
+  test("rejects an opaque claim before consuming the OAuth code", async () => {
     const response = await post({
       code: "one-time-code",
       redirectUri: "https://cloud.eliza.app/login",
@@ -134,6 +106,8 @@ describe("POST /api/auth/steward-nonce-exchange Telegram convergence", () => {
       code: "telegram_claim_conflict",
     });
     expect(response.headers.get("set-cookie")).toBeNull();
+    expect(upstreamFetch).not.toHaveBeenCalled();
+    expect(syncUserFromSteward).not.toHaveBeenCalled();
   });
 
   test("rejects a guessable platform session before consuming the OAuth code", async () => {

--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -7,6 +7,7 @@ import {
   type StewardSessionErrorCode,
   type StewardSessionRequest,
   type StewardSessionResponse,
+  type StewardTelegramClaimConfirmationRequest,
   sanitizeTelegramAccountClaimContinuation,
 } from "@elizaos/shared/steward-session-client";
 import { Hono } from "hono";
@@ -137,9 +138,9 @@ app.post("/", async (c) => {
 
     const body = (await c.req
       .json()
-      .catch(
-        () => ({}) as Partial<StewardSessionRequest>,
-      )) as Partial<StewardSessionRequest>;
+      .catch(() => ({}) as Partial<StewardSessionRequest>)) as Partial<
+      StewardSessionRequest & StewardTelegramClaimConfirmationRequest
+    >;
     const token = body.token;
     const refreshToken = body.refreshToken;
     const verifiedPhoneHint = body.verifiedPhone;
@@ -167,6 +168,29 @@ app.post("/", async (c) => {
       logStewardAuth("telegram-claim-invalid", null);
       return c.json(
         errorBody("Invalid Telegram account claim", "telegram_claim_conflict"),
+        409,
+      );
+    }
+    if (telegramContinuation && body.telegramClaimConfirmation !== "explicit") {
+      logStewardAuth("telegram-claim-confirmation-missing", null);
+      return c.json(
+        errorBody(
+          "Telegram account confirmation required",
+          "telegram_claim_conflict",
+        ),
+        409,
+      );
+    }
+    if (
+      body.telegramClaimConfirmation !== undefined &&
+      (!telegramContinuation || body.telegramClaimConfirmation !== "explicit")
+    ) {
+      logStewardAuth("telegram-claim-confirmation-invalid", null);
+      return c.json(
+        errorBody(
+          "Invalid Telegram account confirmation",
+          "telegram_claim_conflict",
+        ),
         409,
       );
     }

--- a/packages/cloud/api/auth/steward-session/steward-session-phone-convergence.test.ts
+++ b/packages/cloud/api/auth/steward-session/steward-session-phone-convergence.test.ts
@@ -134,6 +134,7 @@ describe("POST /api/auth/steward-session phone convergence", () => {
     const response = await post({
       token: "steward-session-token",
       telegramContinuation: "opaque-telegram-claim-token",
+      telegramClaimConfirmation: "explicit",
     });
 
     expect(response.status).toBe(200);
@@ -147,10 +148,22 @@ describe("POST /api/auth/steward-session phone convergence", () => {
     });
   });
 
+  test("rejects claim authority without the explicit confirmation contract", async () => {
+    const response = await post({
+      token: "steward-session-token",
+      telegramContinuation: "opaque-telegram-claim-token",
+    });
+
+    expect(response.status).toBe(409);
+    expect(syncUserFromSteward).not.toHaveBeenCalled();
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+
   test("rejects malformed Telegram claims before Steward sync", async () => {
     const response = await post({
       token: "steward-session-token",
       telegramContinuation: "platform:telegram:123456789",
+      telegramClaimConfirmation: "explicit",
     });
 
     expect(response.status).toBe(409);
@@ -169,6 +182,7 @@ describe("POST /api/auth/steward-session phone convergence", () => {
     const response = await post({
       token: "steward-session-token",
       telegramContinuation: "opaque-telegram-claim-token",
+      telegramClaimConfirmation: "explicit",
     });
 
     expect(response.status).toBe(409);

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -210,7 +210,7 @@ describe("runOnboardingChat", () => {
       platform: "telegram",
       platformUserId: "123456789",
       platformDisplayName: "Nubs",
-      sessionId: "platform:telegram:123456789",
+      sessionId: `platform:telegram-claim:${"b".repeat(64)}`,
       trustedPlatformIdentity: true,
       authenticatedUser: {
         userId: "telegram-user-1",
@@ -242,7 +242,7 @@ describe("runOnboardingChat", () => {
       platform: "telegram",
       platformUserId: "123456789",
       platformDisplayName: "Nubs",
-      sessionId: "platform:telegram:123456789",
+      sessionId: `platform:telegram-claim:${"c".repeat(64)}`,
       trustedPlatformIdentity: true,
       authenticatedUser: {
         userId: "telegram-user-1",
@@ -284,6 +284,39 @@ describe("runOnboardingChat", () => {
 
     await expect(
       inspectTelegramPersonalAccountContinuation(continuationToken(unbound)),
+    ).rejects.toMatchObject({
+      code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID",
+    });
+  });
+
+  test("rejects an account-bound ordinary Telegram session as claim authority", async () => {
+    getElizaAppProvisioningStatus.mockResolvedValue({
+      status: "none",
+      agentId: null,
+      bridgeUrl: null,
+      sandbox: null,
+    });
+    const ordinarySession = await runOnboardingChat({
+      platform: "telegram",
+      platformUserId: "123456789",
+      platformDisplayName: "Nubs",
+      sessionId: "platform:telegram:123456789",
+      trustedPlatformIdentity: true,
+      authenticatedUser: {
+        userId: "telegram-user-1",
+        organizationId: "telegram-org-1",
+        telegramId: "123456789",
+      },
+      statusOnly: true,
+    });
+
+    await expect(
+      inspectTelegramPersonalAccountContinuation(continuationToken(ordinarySession)),
+    ).rejects.toMatchObject({
+      code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID",
+    });
+    await expect(
+      previewTelegramPersonalAccountClaimContinuation(continuationToken(ordinarySession)),
     ).rejects.toMatchObject({
       code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID",
     });

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -155,6 +155,12 @@ export interface OnboardingChatResult {
 const SESSION_TTL_SECONDS = 14 * 24 * 60 * 60;
 const MAX_HISTORY_MESSAGES = 200;
 /**
+ * Claim authority is intentionally a separate session purpose from ordinary
+ * Telegram onboarding. There is no legacy fallback: callers with an older or
+ * generic session must mint a fresh claim through the trusted /connect path.
+ */
+const TELEGRAM_ACCOUNT_CLAIM_SESSION_PATTERN = /^platform:telegram-claim:[0-9a-f]{64}$/;
+/**
  * Hard byte bound on a stored user message. The public route already caps
  * message length, but gateway services call runOnboardingChat directly with
  * raw connector payloads, so the session store enforces its own bound.
@@ -457,7 +463,10 @@ export async function inspectTelegramPersonalAccountContinuation(
   continuationToken: string,
 ): Promise<TelegramPersonalAccountContinuation> {
   const sessionId = await resolveContinuationToken(continuationToken);
-  const session = sessionId ? await loadOnboardingSessionForValidation(sessionId) : null;
+  const session =
+    sessionId && TELEGRAM_ACCOUNT_CLAIM_SESSION_PATTERN.test(sessionId)
+      ? await loadOnboardingSessionForValidation(sessionId)
+      : null;
   if (
     !session ||
     session.platform !== "telegram" ||

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -98,8 +98,14 @@ export interface StewardSessionRequest {
   refreshToken?: string | null;
   /** Phone independently re-verified by the Cloud API against this bearer. */
   verifiedPhone?: string;
+}
+
+export interface StewardTelegramClaimConfirmationRequest
+  extends StewardSessionRequest {
   /** Opaque Telegram DM continuation that names an existing rowless account. */
-  telegramContinuation?: string;
+  telegramContinuation: string;
+  /** Explicit confirmation ceremony marker; ordinary login sync never sends it. */
+  telegramClaimConfirmation: "explicit";
 }
 
 const TELEGRAM_ACCOUNT_CLAIM_PATTERN = /^[a-zA-Z0-9:+_-]{8,180}$/;

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -369,8 +369,6 @@ export interface StewardNonceExchangeRequest {
   tenantId?: string;
   /** PKCE verifier paired with the `code_challenge` sent to Steward. */
   codeVerifier?: string;
-  /** Opaque Telegram DM continuation that names an existing rowless account. */
-  telegramContinuation?: string;
 }
 
 export interface StewardNonceExchangeResponse extends StewardSessionResponse {

--- a/packages/ui/src/cloud/join/GetStartedPage.test.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.test.tsx
@@ -8,7 +8,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearPendingOnboardingSession,
@@ -25,7 +25,7 @@ const pageState = vi.hoisted(() => ({
 }));
 
 const TOKEN = "aaaaaaaa-test-test-test-tokentoken01";
-const syncStewardSessionCookie = vi.fn(async () => {
+const confirmTelegramAccountClaim = vi.fn(async () => {
   clearPendingOnboardingSession();
 });
 
@@ -37,7 +37,7 @@ vi.mock("@elizaos/shared/steward-session-client", async (importOriginal) => ({
 }));
 
 vi.mock("../public-pages/lib/steward-session", () => ({
-  syncStewardSessionCookie,
+  confirmTelegramAccountClaim,
 }));
 
 vi.mock("./lib/use-join-session", () => ({
@@ -74,11 +74,26 @@ vi.mock("./lib/onboarding-continuation", async (importOriginal) => {
 
 const { default: GetStartedPage } = await import("./GetStartedPage");
 
+function LoginReturnFixture(): React.JSX.Element {
+  const navigate = useNavigate();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        pageState.session = { ready: true, authenticated: true };
+        navigate("/get-started");
+      }}
+    >
+      Finish login
+    </button>
+  );
+}
+
 beforeEach(() => {
   pageState.session = { ready: true, authenticated: true };
   pageState.persistenceBlocked = false;
   vi.mocked(storePendingOnboardingSession).mockClear();
-  syncStewardSessionCookie.mockClear();
+  confirmTelegramAccountClaim.mockClear();
   vi.mocked(previewPendingOnboardingContinuation).mockReset();
   vi.mocked(previewPendingOnboardingContinuation).mockResolvedValue({
     platform: "discord",
@@ -104,6 +119,54 @@ afterEach(() => {
 });
 
 describe("GetStartedPage", () => {
+  it("preserves a signed-out Telegram claim through login until preview and confirmation", async () => {
+    pageState.session = { ready: true, authenticated: false };
+    vi.mocked(previewPendingOnboardingContinuation).mockResolvedValue({
+      platform: "telegram",
+      platformUserId: "123456789",
+      platformDisplayName: "attested-telegram-user",
+      returnUrl: null,
+    });
+    const entry = `/get-started?onboardingSession=${TOKEN}&accountClaim=telegram`;
+    window.history.replaceState(null, "", entry);
+
+    render(
+      <MemoryRouter initialEntries={[entry]}>
+        <Routes>
+          <Route path="/get-started" element={<GetStartedPage />} />
+          <Route path="/login" element={<LoginReturnFixture />} />
+          <Route path="/join" element={<div>join</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Finish login")).toBeTruthy();
+    expect(confirmTelegramAccountClaim).not.toHaveBeenCalled();
+    expect(peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE)).toBe(
+      TOKEN,
+    );
+
+    fireEvent.click(screen.getByText("Finish login"));
+    expect(await screen.findByText("attested-telegram-user")).toBeTruthy();
+    expect(confirmTelegramAccountClaim).not.toHaveBeenCalled();
+    expect(peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE)).toBe(
+      TOKEN,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Connect this Telegram account/ }),
+    );
+    expect(await screen.findByText("join")).toBeTruthy();
+    expect(confirmTelegramAccountClaim).toHaveBeenCalledTimes(1);
+    expect(confirmTelegramAccountClaim).toHaveBeenCalledWith(
+      "existing-steward-token",
+      TOKEN,
+    );
+    expect(
+      peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE),
+    ).toBeNull();
+  });
+
   it("does not restore a URL continuation after a successful redemption rerender", async () => {
     const entry = `/get-started?onboardingSession=${TOKEN}`;
     window.history.replaceState(null, "", entry);
@@ -246,16 +309,15 @@ describe("GetStartedPage", () => {
     expect(await screen.findByText("attested-telegram-user")).toBeTruthy();
     expect(screen.getByText(/Telegram ID/)).toBeTruthy();
     expect(screen.getByText(/123456789/)).toBeTruthy();
-    expect(syncStewardSessionCookie).not.toHaveBeenCalled();
+    expect(confirmTelegramAccountClaim).not.toHaveBeenCalled();
 
     fireEvent.click(
       screen.getByRole("button", { name: /Connect this Telegram account/ }),
     );
     expect(await screen.findByText("join")).toBeTruthy();
-    expect(syncStewardSessionCookie).toHaveBeenCalledWith(
+    expect(confirmTelegramAccountClaim).toHaveBeenCalledWith(
       "existing-steward-token",
-      undefined,
-      { telegramContinuation: TOKEN },
+      TOKEN,
     );
     expect(
       peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE),
@@ -270,7 +332,7 @@ describe("GetStartedPage", () => {
       platformDisplayName: "attested-telegram-user",
       returnUrl: null,
     });
-    syncStewardSessionCookie.mockRejectedValueOnce(
+    confirmTelegramAccountClaim.mockRejectedValueOnce(
       new Error("claim temporarily unavailable"),
     );
     const entry = `/get-started?onboardingSession=${TOKEN}&accountClaim=telegram`;
@@ -295,7 +357,7 @@ describe("GetStartedPage", () => {
     ).toBeTruthy();
     fireEvent.click(screen.getByText("Try again"));
     expect(await screen.findByText("join")).toBeTruthy();
-    expect(syncStewardSessionCookie).toHaveBeenCalledTimes(2);
+    expect(confirmTelegramAccountClaim).toHaveBeenCalledTimes(2);
     expect(previewPendingOnboardingContinuation).toHaveBeenCalledTimes(1);
   });
 
@@ -323,7 +385,7 @@ describe("GetStartedPage", () => {
     expect(
       await screen.findByText("preview temporarily unavailable"),
     ).toBeTruthy();
-    expect(syncStewardSessionCookie).not.toHaveBeenCalled();
+    expect(confirmTelegramAccountClaim).not.toHaveBeenCalled();
     fireEvent.click(screen.getByText("Try again"));
 
     fireEvent.click(
@@ -333,11 +395,10 @@ describe("GetStartedPage", () => {
     );
     expect(await screen.findByText("join")).toBeTruthy();
     expect(previewPendingOnboardingContinuation).toHaveBeenCalledTimes(2);
-    expect(syncStewardSessionCookie).toHaveBeenCalledTimes(1);
-    expect(syncStewardSessionCookie).toHaveBeenCalledWith(
+    expect(confirmTelegramAccountClaim).toHaveBeenCalledTimes(1);
+    expect(confirmTelegramAccountClaim).toHaveBeenCalledWith(
       "existing-steward-token",
-      undefined,
-      { telegramContinuation: TOKEN },
+      TOKEN,
     );
   });
 

--- a/packages/ui/src/cloud/join/GetStartedPage.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.tsx
@@ -9,8 +9,9 @@
  * through the same confirm phase: the page shows the attested Telegram
  * identity and only the explicit confirmation gesture fires the claim, which
  * Steward sync consumes so the DM-created user and organization are adopted
- * before generic signup can create duplicates. A signed-out visit still
- * redirects to login, where session creation consumes the pending claim.
+ * before generic signup can create duplicates. A signed-out visit redirects
+ * to login, which establishes auth without consuming the pending claim; the
+ * returning visitor still sees this preview and confirmation.
  *
  * Signed-out visitors bounce to `/login?returnTo=/get-started`; the token
  * survives in storage, not the URL. A visit with no pending token just
@@ -23,7 +24,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Navigate, useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "../../components/ui/button";
 import { isSafeNavigationUrl } from "../lib/navigation-url";
-import { syncStewardSessionCookie } from "../public-pages/lib/steward-session";
+import { confirmTelegramAccountClaim } from "../public-pages/lib/steward-session";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import {
   completePendingOnboardingContinuation,
@@ -137,9 +138,7 @@ export default function GetStartedPage(): React.JSX.Element {
       if (!stewardToken) {
         throw new Error("Sign in again to connect this Telegram chat.");
       }
-      await syncStewardSessionCookie(stewardToken, undefined, {
-        telegramContinuation: continuation,
-      });
+      await confirmTelegramAccountClaim(stewardToken, continuation);
       setPhase("done");
     } catch (err) {
       // error-policy:J4 claim failures remain visible and retryable; the

--- a/packages/ui/src/cloud/join/lib/onboarding-continuation.test.ts
+++ b/packages/ui/src/cloud/join/lib/onboarding-continuation.test.ts
@@ -80,6 +80,24 @@ describe("pending-token persistence", () => {
     );
   });
 
+  it("uses the newest cross-tab continuation instead of a stale session entry", () => {
+    vi.useFakeTimers();
+    storePendingOnboardingSession(TOKEN, TELEGRAM_ACCOUNT_CLAIM_PURPOSE);
+    const staleClaim = window.sessionStorage.getItem(
+      "eliza.join.onboardingSession",
+    );
+    vi.advanceTimersByTime(1);
+    const newerLink = "bbbbbbbb-test-test-test-tokentoken02";
+    storePendingOnboardingSession(newerLink, "link");
+    if (!staleClaim) throw new Error("Expected stored claim fixture");
+    window.sessionStorage.setItem("eliza.join.onboardingSession", staleClaim);
+
+    expect(peekPendingOnboardingSession()).toBe(newerLink);
+    expect(
+      peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE),
+    ).toBeNull();
+  });
+
   it("never stores an invalid token", () => {
     storePendingOnboardingSession("platform:discord:123456789012");
     expect(peekPendingOnboardingSession()).toBeNull();
@@ -165,6 +183,22 @@ describe("completePendingOnboardingContinuation", () => {
       completePendingOnboardingContinuation(TOKEN, transport),
     ).rejects.toThrow("503");
     expect(peekPendingOnboardingSession()).toBe(TOKEN);
+  });
+
+  it("does not clear a newer Telegram claim when an older link succeeds", async () => {
+    vi.useFakeTimers();
+    storePendingOnboardingSession(TOKEN, "link");
+    vi.advanceTimersByTime(1);
+    const newerClaim = "cccccccc-test-test-test-tokentoken03";
+    storePendingOnboardingSession(newerClaim, TELEGRAM_ACCOUNT_CLAIM_PURPOSE);
+
+    await completePendingOnboardingContinuation(TOKEN, {
+      post: vi.fn().mockResolvedValue({}),
+    });
+
+    expect(peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE)).toBe(
+      newerClaim,
+    );
   });
 
   it("silently ignores an unsanitizable token", async () => {

--- a/packages/ui/src/cloud/join/lib/onboarding-continuation.ts
+++ b/packages/ui/src/cloud/join/lib/onboarding-continuation.ts
@@ -78,13 +78,29 @@ export function storePendingOnboardingSession(
 ): boolean {
   const sanitized = sanitizeOnboardingSessionToken(token);
   if (!sanitized) return false;
+  const storages = eachStorage();
+  let expiresAt = Date.now() + PENDING_ONBOARDING_SESSION_TTL_MS;
+  // The expiry also orders mirrored entries. Advance beyond either existing
+  // value so same-millisecond links and partial storage writes stay ordered.
+  for (const storage of storages) {
+    try {
+      const existing = parseStored(
+        storage.getItem(PENDING_ONBOARDING_SESSION_KEY),
+      );
+      if (existing && existing.expiresAt >= expiresAt) {
+        expiresAt = existing.expiresAt + 1;
+      }
+    } catch {
+      // error-policy:J3 unreadable storage cannot contribute ordering state.
+    }
+  }
   const stored = JSON.stringify({
     token: sanitized,
-    expiresAt: Date.now() + PENDING_ONBOARDING_SESSION_TTL_MS,
+    expiresAt,
     purpose,
   } satisfies StoredPendingOnboardingSession);
   let persisted = false;
-  for (const storage of eachStorage()) {
+  for (const storage of storages) {
     try {
       storage.setItem(PENDING_ONBOARDING_SESSION_KEY, stored);
       persisted = true;
@@ -122,19 +138,22 @@ function parseStored(
 export function peekPendingOnboardingSession(
   purpose?: PendingOnboardingPurpose,
 ): string | null {
+  let newest: StoredPendingOnboardingSession | null = null;
   for (const storage of eachStorage()) {
     try {
       const pending = parseStored(
         storage.getItem(PENDING_ONBOARDING_SESSION_KEY),
       );
-      if (pending && (!purpose || pending.purpose === purpose)) {
-        return pending.token;
+      if (pending && (!newest || pending.expiresAt >= newest.expiresAt)) {
+        newest = pending;
       }
     } catch {
       // error-policy:J3 unreadable storage reads as no pending token.
     }
   }
-  return null;
+  return newest && (!purpose || newest.purpose === purpose)
+    ? newest.token
+    : null;
 }
 
 /** Drop the pending token from every storage (post-success, single-use). */
@@ -228,5 +247,5 @@ export async function completePendingOnboardingContinuation(
     platform: "web",
     confirmPlatformLink: true,
   });
-  clearPendingOnboardingSession();
+  clearPendingOnboardingSessionIfMatches(sanitized, "link");
 }

--- a/packages/ui/src/cloud/join/lib/onboarding-continuation.ts
+++ b/packages/ui/src/cloud/join/lib/onboarding-continuation.ts
@@ -148,6 +148,35 @@ export function clearPendingOnboardingSession(): void {
   }
 }
 
+/**
+ * Drop only the exact continuation that just succeeded. A different claim may
+ * have been stored while the request was in flight (another tab or link); that
+ * newer authority must not be consumed by an older response.
+ */
+export function clearPendingOnboardingSessionIfMatches(
+  token: string,
+  purpose: PendingOnboardingPurpose,
+): boolean {
+  const sanitized = sanitizeOnboardingSessionToken(token);
+  if (!sanitized) return false;
+  let cleared = false;
+  for (const storage of eachStorage()) {
+    try {
+      const pending = parseStored(
+        storage.getItem(PENDING_ONBOARDING_SESSION_KEY),
+      );
+      if (pending?.token === sanitized && pending.purpose === purpose) {
+        storage.removeItem(PENDING_ONBOARDING_SESSION_KEY);
+        cleared = true;
+      }
+    } catch {
+      // error-policy:J6 best-effort post-success cleanup; the server remains
+      // authoritative and the leftover expires without granting new access.
+    }
+  }
+  return cleared;
+}
+
 /** The transport seam, injectable for tests. */
 export interface OnboardingContinuationTransport {
   post(path: string, body: Record<string, unknown>): Promise<unknown>;

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.telegram-claim.test.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.telegram-claim.test.ts
@@ -9,6 +9,7 @@ import {
   TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
 } from "../../join/lib/onboarding-continuation";
 import {
+  confirmTelegramAccountClaim,
   exchangeStewardCodeViaApi,
   syncStewardSessionCookie,
 } from "./steward-session";
@@ -23,7 +24,7 @@ afterEach(() => {
 });
 
 describe("Steward Telegram account claim handoff", () => {
-  it("sends the pending claim on JWT sync and consumes it only after success", async () => {
+  it("establishes a JWT session without sending or consuming a pending claim", async () => {
     storePendingOnboardingSession(TOKEN, TELEGRAM_ACCOUNT_CLAIM_PURPOSE);
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), {
@@ -38,45 +39,13 @@ describe("Steward Telegram account claim handoff", () => {
     expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
       token: "steward-token",
       refreshToken: "refresh-token",
-      telegramContinuation: TOKEN,
     });
-    expect(peekPendingOnboardingSession()).toBeNull();
+    expect(peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE)).toBe(
+      TOKEN,
+    );
   });
 
   it("accepts explicit claim authority when the landing page is already authenticated", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
-
-    await syncStewardSessionCookie("steward-token", undefined, {
-      telegramContinuation: TOKEN,
-    });
-
-    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
-      token: "steward-token",
-      telegramContinuation: TOKEN,
-    });
-  });
-
-  it("rejects a guessable explicit claim before making a request", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(
-      syncStewardSessionCookie("steward-token", undefined, {
-        telegramContinuation: "platform:telegram:123456789",
-      }),
-    ).rejects.toThrow("Invalid Telegram account claim");
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("never attaches the pending claim on a passive session recovery", async () => {
-    // The login page's stored-token recovery runs on page load with no user
-    // gesture. It must skip the pending claim entirely: not sent, not consumed.
     storePendingOnboardingSession(TOKEN, TELEGRAM_ACCOUNT_CLAIM_PURPOSE);
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), {
@@ -86,9 +55,40 @@ describe("Steward Telegram account claim handoff", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await syncStewardSessionCookie("steward-token", null, {
-      skipPendingTelegramClaim: true,
+    await confirmTelegramAccountClaim("steward-token", TOKEN);
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      token: "steward-token",
+      telegramContinuation: TOKEN,
+      telegramClaimConfirmation: "explicit",
     });
+    expect(peekPendingOnboardingSession()).toBeNull();
+  });
+
+  it("rejects a guessable explicit claim before making a request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      confirmTelegramAccountClaim(
+        "steward-token",
+        "platform:telegram:123456789",
+      ),
+    ).rejects.toThrow("Invalid Telegram account claim");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not require callers to opt out of claim consumption", async () => {
+    storePendingOnboardingSession(TOKEN, TELEGRAM_ACCOUNT_CLAIM_PURPOSE);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await syncStewardSessionCookie("steward-token", null);
 
     expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
       token: "steward-token",
@@ -113,13 +113,33 @@ describe("Steward Telegram account claim handoff", () => {
       ),
     );
 
-    await expect(syncStewardSessionCookie("steward-token")).rejects.toThrow(
-      "This Telegram chat cannot be linked automatically",
-    );
+    await expect(
+      confirmTelegramAccountClaim("steward-token", TOKEN),
+    ).rejects.toThrow("This Telegram chat cannot be linked automatically");
     expect(peekPendingOnboardingSession()).toBe(TOKEN);
   });
 
-  it("carries the same claim through the OAuth nonce exchange", async () => {
+  it("does not clear a newer claim when an older explicit claim succeeds", async () => {
+    const newerToken = "telegram-claim-test-token-00000002";
+    storePendingOnboardingSession(newerToken, TELEGRAM_ACCOUNT_CLAIM_PURPOSE);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await confirmTelegramAccountClaim("steward-token", TOKEN);
+
+    expect(peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE)).toBe(
+      newerToken,
+    );
+  });
+
+  it("exchanges an OAuth nonce without sending or consuming the claim", async () => {
     storePendingOnboardingSession(TOKEN, TELEGRAM_ACCOUNT_CLAIM_PURPOSE);
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
@@ -144,9 +164,10 @@ describe("Steward Telegram account claim handoff", () => {
       redirectUri: "https://cloud.eliza.app/login",
       tenantId: "elizacloud",
       codeVerifier: "verifier",
-      telegramContinuation: TOKEN,
     });
-    expect(peekPendingOnboardingSession()).toBeNull();
+    expect(peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE)).toBe(
+      TOKEN,
+    );
   });
 
   it("leaves ordinary Discord and phone continuations on their confirm flow", async () => {

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.ts
@@ -15,12 +15,13 @@ import {
   STEWARD_SESSION_ENDPOINT,
   type StewardNonceExchangeResponse,
   StewardSessionError,
+  type StewardSessionRequest,
+  type StewardTelegramClaimConfirmationRequest,
   sanitizeTelegramAccountClaimContinuation,
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
 import {
-  clearPendingOnboardingSession,
-  peekPendingOnboardingSession,
+  clearPendingOnboardingSessionIfMatches,
   TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
 } from "../../join/lib/onboarding-continuation";
 import { decodeJwtPayload } from "../../lib/jwt";
@@ -38,7 +39,7 @@ export function resolveStewardAuthEndpoint(
 
 async function postAuthJson(
   path: string,
-  body?: Record<string, unknown>,
+  body?: object,
   method: "POST" | "DELETE" = "POST",
   signal?: AbortSignal,
 ): Promise<Response> {
@@ -68,41 +69,23 @@ async function readSessionError(response: Response): Promise<{
  * Steward JWT → HttpOnly cookie sync. Production cloud hosts post directly to
  * api.eliza.app so auth callbacks do not depend on a same-origin redirect.
  *
- * A pending Telegram account claim rides this sync only on an explicit
- * gesture: an explicit `telegramContinuation`, or the pending continuation
- * peeked for a sign-in ceremony. Passive page-load callers (session recovery)
- * must pass `skipPendingTelegramClaim` so a stored claim can never fire
- * without the /get-started confirmation (W9-001).
+ * Authentication establishment never discovers account-link authority from
+ * browser storage. A Telegram claim rides this request only when the
+ * /get-started confirmation passes it explicitly after showing the preview.
  */
 export async function syncStewardSessionCookie(
   token: string,
   refreshToken?: string | null,
   options?: {
     verifiedPhone?: string;
-    telegramContinuation?: string;
-    skipPendingTelegramClaim?: boolean;
   },
 ): Promise<void> {
-  const explicitTelegramContinuation = sanitizeTelegramAccountClaimContinuation(
-    options?.telegramContinuation,
-  );
-  if (
-    options?.telegramContinuation !== undefined &&
-    !explicitTelegramContinuation
-  ) {
-    throw new Error("Invalid Telegram account claim.");
-  }
-  const telegramContinuation =
-    explicitTelegramContinuation ??
-    (options?.skipPendingTelegramClaim
-      ? null
-      : peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE));
-  const response = await postAuthJson(STEWARD_SESSION_ENDPOINT, {
+  const request: StewardSessionRequest = {
     token,
     ...(refreshToken ? { refreshToken } : {}),
     ...(options?.verifiedPhone ? { verifiedPhone: options.verifiedPhone } : {}),
-    ...(telegramContinuation ? { telegramContinuation } : {}),
-  });
+  };
+  const response = await postAuthJson(STEWARD_SESSION_ENDPOINT, request);
 
   if (!response.ok) {
     const body = await readSessionError(response);
@@ -111,12 +94,46 @@ export async function syncStewardSessionCookie(
     );
   }
 
-  if (telegramContinuation) clearPendingOnboardingSession();
-
   if (typeof window !== "undefined") {
     // The cookie boundary may be entered directly by an SDK callback or after
     // the login page already persisted the same token. Canonical storage is
     // idempotent, so both paths publish one authority transition in total.
+    writeStoredStewardToken(token);
+    window.dispatchEvent(
+      new CustomEvent("steward-token-sync", { detail: { token } }),
+    );
+  }
+}
+
+/**
+ * Confirms the exact Telegram identity previewed by /get-started. This is a
+ * separate API from session establishment so login, recovery, and SSO cannot
+ * acquire claim semantics by discovering browser storage.
+ */
+export async function confirmTelegramAccountClaim(
+  token: string,
+  continuation: string,
+): Promise<void> {
+  const telegramContinuation =
+    sanitizeTelegramAccountClaimContinuation(continuation);
+  if (!telegramContinuation) {
+    throw new Error("Invalid Telegram account claim.");
+  }
+  const request: StewardTelegramClaimConfirmationRequest = {
+    token,
+    telegramContinuation,
+    telegramClaimConfirmation: "explicit",
+  };
+  const response = await postAuthJson(STEWARD_SESSION_ENDPOINT, request);
+  if (!response.ok) {
+    const body = await readSessionError(response);
+    throw new Error(body.error || "Could not connect this Telegram account.");
+  }
+  clearPendingOnboardingSessionIfMatches(
+    telegramContinuation,
+    TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
+  );
+  if (typeof window !== "undefined") {
     writeStoredStewardToken(token);
     window.dispatchEvent(
       new CustomEvent("steward-token-sync", { detail: { token } }),
@@ -234,15 +251,11 @@ export async function exchangeStewardCodeViaApi(
   code: string,
   opts: { redirectUri?: string; tenantId?: string; codeVerifier?: string } = {},
 ): Promise<StewardNonceExchangeResponse> {
-  const telegramContinuation = peekPendingOnboardingSession(
-    TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
-  );
   const response = await postAuthJson(STEWARD_NONCE_EXCHANGE_ENDPOINT, {
     code,
     ...(opts.redirectUri ? { redirectUri: opts.redirectUri } : {}),
     ...(opts.tenantId ? { tenantId: opts.tenantId } : {}),
     ...(opts.codeVerifier ? { codeVerifier: opts.codeVerifier } : {}),
-    ...(telegramContinuation ? { telegramContinuation } : {}),
   });
 
   if (!response.ok) {
@@ -253,7 +266,6 @@ export async function exchangeStewardCodeViaApi(
       body.code ?? null,
     );
   }
-  if (telegramContinuation) clearPendingOnboardingSession();
   return (await response.json()) as StewardNonceExchangeResponse;
 }
 

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.phone-login.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.phone-login.test.tsx
@@ -195,7 +195,6 @@ describe("StewardLoginSection phone login", () => {
       expect(sessionSpies.sync).toHaveBeenCalledWith(
         "existing-session-token",
         null,
-        { skipPendingTelegramClaim: true },
       ),
     );
     expect(authSpies.refreshSession).not.toHaveBeenCalled();

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -782,13 +782,10 @@ export default function StewardLoginSection() {
         const storedToken = readStoredStewardToken();
         if (storedToken) {
           try {
-            // Passive recovery runs on page load with no user gesture, so it
-            // must not consume a pending Telegram account claim: only the
-            // /get-started confirmation or a sign-in ceremony may fire it
-            // (W9-001). The claim stays stored for those paths.
-            await syncStewardSessionCookie(storedToken, null, {
-              skipPendingTelegramClaim: true,
-            });
+            // Session recovery establishes auth only. A pending Telegram claim
+            // remains inert until /get-started previews it and the user
+            // confirms it explicitly.
+            await syncStewardSessionCookie(storedToken, null);
             if (!cancelled) {
               setRedirectTo(resolveLoginReturnTo(searchParams));
             }

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
@@ -137,9 +137,9 @@ afterEach(() => {
 describe("AuthTokenSync 401 handling", () => {
   it("never carries a pending Telegram account claim through the passive token sync", async () => {
     // The passive JWT → cookie mirror runs on any authenticated page load with
-    // no user gesture, so it must not execute the account-claim merge: only
-    // the /get-started confirmation click or a sign-in ceremony may consume
-    // the pending claim (W9-001).
+    // no user gesture, so it must not execute the account-claim merge. Login
+    // and SSO establish auth only; /get-started confirmation is the sole
+    // consumer.
     const token = makeJwt({
       sub: "u1",
       exp: Math.floor(Date.now() / 1000) + 3600,

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -120,10 +120,9 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
 
       // A pending Telegram account claim is deliberately NOT attached to this
       // passive mirror. The claim merges the DM-created account, so it must
-      // fire only on an explicit gesture: the /get-started confirmation, or a
-      // sign-in ceremony (nonce exchange, session sync, SSO exchange), each of
-      // which attaches the pending continuation itself. A clicked claim link
-      // landing on an authenticated session must never execute on page load.
+      // fire only when /get-started attaches the continuation after rendering
+      // its identity preview and receiving explicit confirmation. Login,
+      // nonce exchange, and SSO establish authentication only.
       fetch(configuredSessionEndpoint(), {
         method: "POST",
         credentials: "include",

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
@@ -408,7 +408,7 @@ describe("performSsoExchange", () => {
     expect(isSsoLoggedOut()).toBe(false);
   });
 
-  it("makes Telegram claim convergence authoritative before hydrating bridged storage", async () => {
+  it("establishes bridged auth without sending or consuming a Telegram claim", async () => {
     storePendingOnboardingSession(
       "opaque-telegram-claim-token",
       TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
@@ -426,13 +426,14 @@ describe("performSsoExchange", () => {
 
     expect(JSON.parse(String(calls[1]?.init?.body))).toEqual({
       token,
-      telegramContinuation: "opaque-telegram-claim-token",
     });
-    expect(peekPendingOnboardingSession()).toBeNull();
+    expect(peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE)).toBe(
+      "opaque-telegram-claim-token",
+    );
     expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(token);
   });
 
-  it("keeps Telegram claim authority and storage unhydrated when bridge sync rejects it", async () => {
+  it("keeps Telegram claim authority when best-effort cookie sync is rejected", async () => {
     storePendingOnboardingSession(
       "opaque-telegram-claim-token",
       TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
@@ -450,14 +451,11 @@ describe("performSsoExchange", () => {
       fn,
     );
 
-    expect(result).toEqual({
-      ok: false,
-      error: "Telegram account claim failed (HTTP 409)",
-    });
+    expect(result).toEqual({ ok: true });
     expect(peekPendingOnboardingSession(TELEGRAM_ACCOUNT_CLAIM_PURPOSE)).toBe(
       "opaque-telegram-claim-token",
     );
-    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeTruthy();
   });
 
   it("refuses a malformed verifier without calling out", async () => {

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
@@ -52,11 +52,6 @@ import {
 } from "@elizaos/shared/steward-session-client";
 import { shellLocalStorage } from "../../surface-realm-channel";
 import { appModeNavigation } from "../app-mode/app-mode";
-import {
-  clearPendingOnboardingSession,
-  peekPendingOnboardingSession,
-  TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
-} from "../join/lib/onboarding-continuation";
 import { decodeJwtPayload } from "../lib/jwt";
 import {
   clearStaleStewardSession,
@@ -532,42 +527,23 @@ export async function performSsoExchange(
       return { ok: false, error: "Exchange returned no usable session" };
     }
 
-    const telegramContinuation = peekPendingOnboardingSession(
-      TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
-    );
-    if (!telegramContinuation) writeStoredStewardToken(token);
+    writeStoredStewardToken(token);
 
     // Same call the login flow makes: sets the HttpOnly steward cookies + the
     // authed marker for this environment. It stays best-effort for an ordinary
-    // bridge because AuthTokenSync retries, but a Telegram account claim must
-    // win before storage hydration or an unhinted background sync could create
-    // a second account.
+    // bridge because AuthTokenSync retries. Account-link authority is never
+    // discovered here: a pending Telegram claim remains inert until the user
+    // returns to /get-started and confirms the preview explicitly.
     try {
-      const sessionResponse = await fetchFn(configuredSessionEndpoint(), {
+      await fetchFn(configuredSessionEndpoint(), {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          token,
-          ...(telegramContinuation ? { telegramContinuation } : {}),
-        }),
+        body: JSON.stringify({ token }),
       });
-      if (telegramContinuation && !sessionResponse.ok) {
-        return {
-          ok: false,
-          error: `Telegram account claim failed (HTTP ${sessionResponse.status})`,
-        };
-      }
     } catch {
-      if (telegramContinuation) {
-        return { ok: false, error: "Telegram account claim unavailable" };
-      }
       // error-policy:J6 best-effort cookie sync; the localStorage session is
       // established and AuthTokenSync re-syncs on its own cadence.
-    }
-    if (telegramContinuation) {
-      clearPendingOnboardingSession();
-      writeStoredStewardToken(token);
     }
 
     clearSsoBridgeAttempt();


### PR DESCRIPTION
Security fix-forward for merged #21770. Detailed authority analysis is tracked in the private repository advisory.

Authentication, token recovery, nonce exchange, email/phone session sync, and SSO now establish authentication only. Pending Telegram claim authority survives login and can be consumed only from `/get-started` after the signed-in user sees the identity preview and explicitly confirms it. The server accepts only canonical claim-purpose sessions; ordinary, legacy, and noncanonical Telegram sessions fail closed and require a fresh trusted `/connect`. Successful confirmation clears only the exact token/purpose so a newer concurrent claim is preserved.

Exact head: `c51132f1e6f59f3f8886f3943ff88cb4d6b5266c` rebased onto `d39df839991e5da1926d444a50248187dff13c61`.

Validation:

- post-rebase UI auth/claim: 53/53
- full focused UI set before final mechanical rebase: 66/66
- Cloud Shared onboarding: 85/85
- confirmation route: 8/8
- OAuth nonce rejection: 2/2
- onboarding platform route: 25/25
- Shared, UI, and Cloud API typechecks
- Cloud worker production dry-run bundle
- Biome and diff integrity
- core Node/browser/edge/testing artifacts built before an unrelated host bunx failure in a later capacitor package

Exact-head hosted Quality succeeded. Hosted Cloud lint/types, stack E2E, and E2E succeeded; its broad unit/integration aggregate failures are current unrelated baseline failures outside the changed Telegram/onboarding paths, whose focused contracts are green.

The repository-wide exact-head app audit completed 222/223 captures with zero broken views; its sole failure was the unrelated pre-existing minimalism ratchet for three built-in mobile-landscape views. The dedicated changed-route cloud audit passed 4/4 across desktop/mobile confirmation and success states with zero page/console errors, banned colors, hover violations, clipping, or screenshot-quality issues. Manual pixel and OCR review passed. An exact detached-base capture confirms the screen itself is intentionally unchanged: this fix moves claim authority from sign-in/session sync to the existing explicit confirmation action rather than redesigning the page.

Exact evidence, contribution attribution, and independent security review are complete. This candidate is ready for merge.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - independent security audit
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c51132f1e6f59f3f8886f3943ff88cb4d6b5266c -->
<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21925-before-base-d39df839-desktop.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21925-after-c51132-confirm-desktop.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21925-after-c51132-confirm-to-success-v2.mp4
<!-- evidence-row:backend-logs -->
- [x] [21925-backend-ci-review-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21925-backend-ci-review-v2.log)
<!-- evidence-row:frontend-logs -->
- [x] [21925-browser-review-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21925-browser-review-v2.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [21925-domain-contract-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21925-domain-contract-review.txt)
<!-- evidence-row:ocr-review -->
- [x] [21925-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/21925-ocr-review.txt)



