### PR TITLE
fix(ui): bound slash-command view-switch and shortcut fetches

### DIFF
--- a/packages/ui/src/chat/report-shortcut-fired.test.ts
+++ b/packages/ui/src/chat/report-shortcut-fired.test.ts
@@ -14,7 +14,14 @@ vi.mock("../utils/eliza-globals", () => ({
   getElizaApiToken: () => "test-token",
 }));
 
-import { reportShortcutFired } from "./useSlashCommandController";
+import {
+  postShortcutReportWithFetch,
+  postViewSwitchReportWithFetch,
+  reportShortcutFired,
+  reportUserViewSwitch,
+  SLASH_SHORTCUT_FETCH_TIMEOUT_MS,
+  SLASH_VIEW_SWITCH_FETCH_TIMEOUT_MS,
+} from "./useSlashCommandController";
 
 const fetchMock = vi.fn(() => Promise.resolve(new Response("{}")));
 
@@ -41,6 +48,23 @@ describe("reportShortcutFired (#8792)", () => {
       shortcutId: "open-command-palette",
       context: "command-palette",
     });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("POSTs a view switch to /api/views/:id/navigate with a deadline", () => {
+    reportUserViewSwitch("wallet", "/wallet");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("http://localhost:31337/api/views/wallet/navigate");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      source: "user",
+      path: "/wallet",
+    });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("omits context when not provided", () => {
@@ -57,5 +81,103 @@ describe("reportShortcutFired (#8792)", () => {
   it("is fire-and-forget — a rejected fetch never throws", () => {
     fetchMock.mockReturnValueOnce(Promise.reject(new Error("offline")));
     expect(() => reportShortcutFired("toggle-terminal")).not.toThrow();
+  });
+});
+
+function stallUntilAborted(label: string): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error(`expected ${label} abort signal`);
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+const viewArgs = {
+  base: "http://localhost:31337",
+  token: "test-token",
+  viewId: "wallet",
+};
+
+const shortcutArgs = {
+  base: "http://localhost:31337",
+  token: "test-token",
+  shortcutId: "open-command-palette",
+  context: "command-palette",
+};
+
+describe("slash-command report request deadlines", () => {
+  it("keeps a documented view-switch budget", () => {
+    expect(SLASH_VIEW_SWITCH_FETCH_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("keeps a documented shortcut budget", () => {
+    expect(SLASH_SHORTCUT_FETCH_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("aborts a stalled view-switch POST at the injected deadline", async () => {
+    await expect(
+      postViewSwitchReportWithFetch(
+        viewArgs,
+        stallUntilAborted("view-switch"),
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("aborts a stalled shortcut POST at the injected deadline", async () => {
+    await expect(
+      postShortcutReportWithFetch(
+        shortcutArgs,
+        stallUntilAborted("shortcut"),
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed view-switch POST", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 503, statusText: "Service Unavailable" });
+    await expect(
+      postViewSwitchReportWithFetch(viewArgs, fetchImpl, 1_000),
+    ).rejects.toThrow("POST /api/views/wallet/navigate returned HTTP 503");
+  });
+
+  it("surfaces a provider error from a completed shortcut POST", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 401, statusText: "Unauthorized" });
+    await expect(
+      postShortcutReportWithFetch(shortcutArgs, fetchImpl, 1_000),
+    ).rejects.toThrow("POST /api/interactions/shortcut returned HTTP 401");
+  });
+
+  it("uses the injected fetch for a successful view-switch POST", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response("{}", { status: 200 });
+    };
+    const res = await postViewSwitchReportWithFetch(viewArgs, fetchImpl, 1_000);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(res.ok).toBe(true);
+  });
+
+  it("uses the injected fetch for a successful shortcut POST", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response("{}", { status: 200 });
+    };
+    const res = await postShortcutReportWithFetch(
+      shortcutArgs,
+      fetchImpl,
+      1_000,
+    );
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(res.ok).toBe(true);
   });
 });

--- a/packages/ui/src/chat/useSlashCommandController.ts
+++ b/packages/ui/src/chat/useSlashCommandController.ts
@@ -72,6 +72,74 @@ function isModelCatalogProviders(
   );
 }
 
+/** View-switch report POST — same 15s Fal #21205 family. */
+export const SLASH_VIEW_SWITCH_FETCH_TIMEOUT_MS = 15_000;
+/** Shortcut report POST — independent hop, own 15s deadline. */
+export const SLASH_SHORTCUT_FETCH_TIMEOUT_MS = 15_000;
+
+export async function postViewSwitchReportWithFetch(
+  args: {
+    base: string;
+    token?: string | null;
+    viewId: string;
+    viewPath?: string;
+  },
+  fetchImpl: typeof fetch,
+  timeoutMs: number = SLASH_VIEW_SWITCH_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const res = await fetchImpl(
+    `${args.base}/api/views/${encodeURIComponent(args.viewId)}/navigate`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(args.token ? { Authorization: `Bearer ${args.token}` } : {}),
+      },
+      body: JSON.stringify({
+        source: "user",
+        ...(args.viewPath ? { path: args.viewPath } : {}),
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(
+      `POST /api/views/${args.viewId}/navigate returned HTTP ${res.status}`,
+    );
+  }
+  return res;
+}
+
+export async function postShortcutReportWithFetch(
+  args: {
+    base: string;
+    token?: string | null;
+    shortcutId: string;
+    context?: string;
+  },
+  fetchImpl: typeof fetch,
+  timeoutMs: number = SLASH_SHORTCUT_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const res = await fetchImpl(`${args.base}/api/interactions/shortcut`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(args.token ? { Authorization: `Bearer ${args.token}` } : {}),
+    },
+    body: JSON.stringify({
+      shortcutId: args.shortcutId,
+      ...(args.context ? { context: args.context } : {}),
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `POST /api/interactions/shortcut returned HTTP ${res.status}`,
+    );
+  }
+  return res;
+}
+
 /**
  * Report a user-initiated view switch to the agent (#8792). Fire-and-forget,
  * fully guarded: a failure here must never break navigation. `source: "user"`
@@ -84,17 +152,10 @@ export function reportUserViewSwitch(viewId: string, viewPath?: string): void {
     const base = getElizaApiBase();
     if (!base || typeof fetch === "undefined") return;
     const token = getElizaApiToken();
-    void fetch(`${base}/api/views/${encodeURIComponent(viewId)}/navigate`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      body: JSON.stringify({
-        source: "user",
-        ...(viewPath ? { path: viewPath } : {}),
-      }),
-    }).catch((err) => {
+    void postViewSwitchReportWithFetch(
+      { base, token, viewId, viewPath },
+      globalThis.fetch,
+    ).catch((err) => {
       // error-policy:J7 telemetry write must not break navigation; warn keeps
       // a dead reporting endpoint observable in the console.
       logger.warn(
@@ -122,17 +183,10 @@ export function reportShortcutFired(
     const base = getElizaApiBase();
     if (!base || typeof fetch === "undefined") return;
     const token = getElizaApiToken();
-    void fetch(`${base}/api/interactions/shortcut`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      body: JSON.stringify({
-        shortcutId,
-        ...(context ? { context } : {}),
-      }),
-    }).catch((err) => {
+    void postShortcutReportWithFetch(
+      { base, token, shortcutId, context },
+      globalThis.fetch,
+    ).catch((err) => {
       // error-policy:J7 telemetry write must not break the shortcut; warn keeps
       // a dead reporting endpoint observable in the console.
       logger.warn(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). View-manager sibling `#21871`. `reportUserViewSwitch` and `reportShortcutFired` used unbounded `fetch` on two independent hops — `POST /api/views/:id/navigate` and `POST /api/interactions/shortcut` — so a stalled hop never aborts. This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, **separate 15s deadlines per hop**. Tests execute the helpers under abort. Public reporters stay fire-and-forget (J7). Not extra-decode. Not list-limit. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Not Twilio. Not shared-runtime. Not GitHub OAuth (`#21765` closed). Not X OAuth `#21921` (already posted). Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Catalog load and slash-menu contracts unchanged. Public `reportUserViewSwitch` / `reportShortcutFired` stay void fire-and-forget. Unfixed head: both report `fetch` hops had **no signal** and a hung hop never settled (80ms race → `HUNG` / `sawSignal: false` on both). After: 10ms deadline → `TimeoutError` on each helper. Each hop has its own 15s constant.

# Background

## What does this PR do?

View-switch and shortcut reporters called `fetch` with no `signal`. A stalled hop never returns. This PR injects `postViewSwitchReportWithFetch` / `postShortcutReportWithFetch` (Fal `#21205` shape) and adds `AbortSignal.timeout` with a separate 15s constant per hop.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Slash catalog and settings navigation unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/chat/report-shortcut-fired.test.ts` — timeout, provider-error, and success on each hop.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts src/chat/report-shortcut-fired.test.ts
```

Unfixed head: navigate POST and shortcut POST `signal` was undefined and each hop hung (`HUNG` / `sawSignal: false`). After the fix: 12 passed in this file.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Slash-command report fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live view/shortcut hop. vitest asserts TimeoutError, provider 503/401, and success.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console change beyond existing J7 warn on failure.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no new rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - slash-command report transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no live hop. Unfixed hang: no signal, 80ms race `HUNG` / `sawSignal: false` on `POST /api/views/:id/navigate` and on `POST /api/interactions/shortcut`. After the fix, vitest asserts TimeoutError, `503`/`401` provider responses, and successful hops with 15s constants.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface change.

## Audio / voice walkthrough

N/A - report HTTP timeout only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`12 pass` in this file; catalog/models also green). Root verify is an unrelated full-repo cost. No `bun install`.

<!-- evidence-head:bf573b86cea6f4e5bd14bc923e5480518d150b7f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
