### PR TITLE
fix(shared): guard non-string inputs and non-TTY environments in terminal links and add unit tests

### DIFF
--- a/packages/shared/src/terminal/links.test.ts
+++ b/packages/shared/src/terminal/links.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for OSC-8 terminal hyperlinks and docs link formatting.
+ */
+import { describe, expect, it } from "vitest";
+import { formatDocsLink, formatTerminalLink } from "./links.ts";
+
+describe("formatTerminalLink", () => {
+  it("formats OSC-8 hyperlink sequence when force is enabled", () => {
+    const result = formatTerminalLink(
+      "Eliza Documentation",
+      "https://docs.eliza.ai",
+      {
+        force: true,
+      },
+    );
+    expect(result).toBe(
+      "\u001b]8;;https://docs.eliza.ai\u0007Eliza Documentation\u001b]8;;\u0007",
+    );
+  });
+
+  it("returns fallback format when force is disabled and not in TTY", () => {
+    const result = formatTerminalLink("Eliza", "https://eliza.ai", {
+      force: false,
+    });
+    expect(result).toBe("Eliza (https://eliza.ai)");
+  });
+
+  it("uses custom fallback option when provided and not in TTY", () => {
+    const result = formatTerminalLink("Eliza", "https://eliza.ai", {
+      force: false,
+      fallback: "custom fallback text",
+    });
+    expect(result).toBe("custom fallback text");
+  });
+
+  it("strips ESC characters from label and url to prevent ANSI injection", () => {
+    const maliciousLabel = "Click\u001b[31m Here";
+    const maliciousUrl = "https://evil.com/\u001b[0m";
+    const result = formatTerminalLink(maliciousLabel, maliciousUrl, {
+      force: true,
+    });
+    expect(result).not.toContain("\u001b[31m");
+    expect(result).not.toContain("\u001b[0m");
+    expect(result).toBe(
+      "\u001b]8;;https://evil.com/[0m\u0007Click[31m Here\u001b]8;;\u0007",
+    );
+  });
+
+  it("handles non-string inputs safely without throwing", () => {
+    const result = formatTerminalLink(
+      null as unknown as string,
+      undefined as unknown as string,
+      { force: false },
+    );
+    expect(result).toBe(" ()");
+  });
+});
+
+describe("formatDocsLink", () => {
+  it("resolves relative paths with and without leading slash to docs.eliza.ai", () => {
+    const withSlash = formatDocsLink("/cli/start", undefined, { force: false });
+    expect(withSlash).toBe("https://docs.eliza.ai/cli/start");
+
+    const withoutSlash = formatDocsLink("cli/start", "Start CLI", {
+      force: false,
+    });
+    expect(withoutSlash).toBe("Start CLI (https://docs.eliza.ai/cli/start)");
+  });
+
+  it("preserves external HTTP/HTTPS URLs", () => {
+    const external = formatDocsLink(
+      "https://github.com/elizaOS/eliza",
+      "GitHub Repo",
+      { force: false },
+    );
+    expect(external).toBe("GitHub Repo (https://github.com/elizaOS/eliza)");
+  });
+
+  it("handles nullish or non-string paths safely", () => {
+    const result = formatDocsLink(null as unknown as string, undefined, {
+      force: false,
+    });
+    expect(result).toBe("https://docs.eliza.ai/");
+  });
+});

--- a/packages/shared/src/terminal/links.ts
+++ b/packages/shared/src/terminal/links.ts
@@ -10,9 +10,15 @@ export function formatTerminalLink(
   url: string,
   opts?: { fallback?: string; force?: boolean },
 ): string {
-  const safeLabel = label.replaceAll("\u001b", "");
-  const safeUrl = url.replaceAll("\u001b", "");
-  const allow = opts?.force ?? Boolean(process.stdout.isTTY);
+  const safeLabel =
+    typeof label === "string"
+      ? label.replaceAll("\u001b", "")
+      : String(label ?? "");
+  const safeUrl =
+    typeof url === "string" ? url.replaceAll("\u001b", "") : String(url ?? "");
+  const isTty =
+    typeof process !== "undefined" && Boolean(process.stdout?.isTTY);
+  const allow = opts?.force ?? isTty;
   if (!allow) {
     return opts?.fallback ?? `${safeLabel} (${safeUrl})`;
   }
@@ -24,12 +30,13 @@ export function formatDocsLink(
   label?: string,
   opts?: { fallback?: string; force?: boolean },
 ): string {
-  const trimmed = path.trim();
+  const rawPath = typeof path === "string" ? path : String(path ?? "");
+  const trimmed = rawPath.trim();
   const url = trimmed.startsWith("http")
     ? trimmed
     : `${DOCS_ROOT}${trimmed.startsWith("/") ? trimmed : `/${trimmed}`}`;
   return formatTerminalLink(label ?? url, url, {
-    fallback: opts?.fallback ?? url,
+    fallback: opts?.fallback ?? (label ? undefined : url),
     force: opts?.force,
   });
 }


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `label` and `url` inputs in `formatTerminalLink` and `path` in `formatDocsLink` against non-string and nullish values.
- Safely check `process?.stdout?.isTTY` without assuming `process.stdout` is always defined across non-Node environments.
- Correct fallback behavior in `formatDocsLink` when a custom label is provided.
- Add a dedicated unit test suite in `packages/shared/src/terminal/links.test.ts` testing OSC-8 sequence formatting, non-TTY fallbacks, ANSI injection escaping, docs URL resolution, and non-string inputs with 100% coverage.

## Related Issues

- Fixes #21924

## Testing

- Added `packages/shared/src/terminal/links.test.ts` with 8 tests covering:
  - OSC-8 formatting with `force: true`
  - Non-TTY fallback `label (url)` with `force: false`
  - Custom fallback override
  - Stripping ESC (`\u001b`) characters from label and url
  - Non-string / nullish input safety
  - Relative docs paths with and without leading slash
  - Full external HTTP/HTTPS URLs
  - Nullish / non-string docs path safety
- `bun test packages/shared/src/terminal/links.test.ts` passes (8/8 tests, 11 assertions, 100% coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/terminal/links.test.ts:
✓ formatTerminalLink > formats OSC-8 hyperlink sequence when force is enabled [13.83ms]
✓ formatTerminalLink > returns fallback format when force is disabled and not in TTY [0.07ms]
✓ formatTerminalLink > uses custom fallback option when provided and not in TTY [0.03ms]
✓ formatTerminalLink > strips ESC characters from label and url to prevent ANSI injection [0.06ms]
✓ formatTerminalLink > handles non-string inputs safely without throwing [0.03ms]
✓ formatDocsLink > resolves relative paths with and without leading slash to docs.eliza.ai [0.13ms]
✓ formatDocsLink > preserves external HTTP/HTTPS URLs [0.03ms]
✓ formatDocsLink > handles nullish or non-string paths safely [0.03ms]
---------------------------------------|---------|---------|-------------------
File                                   | % Funcs | % Lines | Uncovered Line #s
---------------------------------------|---------|---------|-------------------
 packages/shared/src/terminal/links.ts |  100.00 |  100.00 | 
---------------------------------------|---------|---------|-------------------

 8 pass
 0 fail
 11 expect() calls
Ran 8 tests across 1 file. [141.00ms]
```
