### PR TITLE
fix(ui): bound composer-activity report fetch

### DIFF
--- a/packages/ui/src/chat/report-composer-activity.test.ts
+++ b/packages/ui/src/chat/report-composer-activity.test.ts
@@ -19,7 +19,11 @@ vi.mock("../utils/eliza-globals", () => ({
   getElizaApiToken: () => elizaGlobalsMock.token,
 }));
 
-import { reportComposerActivity } from "./report-composer-activity";
+import {
+  COMPOSER_ACTIVITY_FETCH_TIMEOUT_MS,
+  postComposerActivityWithFetch,
+  reportComposerActivity,
+} from "./report-composer-activity";
 
 const fetchMock = vi.fn(() => Promise.resolve(new Response("{}")));
 
@@ -63,6 +67,7 @@ describe("reportComposerActivity (#14679)", () => {
     });
     expect(body).not.toHaveProperty("text");
     expect(body).not.toHaveProperty("draft");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("reports a cleared draft reason", () => {
@@ -108,5 +113,65 @@ describe("reportComposerActivity (#14679)", () => {
     });
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected composer abort signal");
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+const composerArgs = {
+  base: "http://localhost:31337",
+  token: "test-token",
+  report: {
+    activity: "typing_paused" as const,
+    surface: "chat_overlay",
+    conversationId: "conversation-1",
+    draftLength: 17,
+    idleForMs: 2000,
+    occurredAt: "2026-06-01T12:00:02.000Z",
+  },
+};
+
+describe("composer-activity request deadline", () => {
+  it("keeps a documented composer-report budget", () => {
+    expect(COMPOSER_ACTIVITY_FETCH_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("aborts a stalled composer POST at the injected deadline", async () => {
+    await expect(
+      postComposerActivityWithFetch(composerArgs, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("surfaces a provider error from a completed composer POST", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 503, statusText: "Service Unavailable" });
+    await expect(
+      postComposerActivityWithFetch(composerArgs, fetchImpl, 1_000),
+    ).rejects.toThrow("POST /api/interactions/composer returned HTTP 503");
+  });
+
+  it("uses the injected fetch for a successful composer POST", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response("{}", { status: 200 });
+    };
+    const res = await postComposerActivityWithFetch(
+      composerArgs,
+      fetchImpl,
+      1_000,
+    );
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(res.ok).toBe(true);
   });
 });

--- a/packages/ui/src/chat/report-composer-activity.ts
+++ b/packages/ui/src/chat/report-composer-activity.ts
@@ -22,6 +22,48 @@ export interface ComposerActivityReport {
   occurredAt?: string;
 }
 
+/** Composer-activity report POST — same 15s Fal #21205 family. */
+export const COMPOSER_ACTIVITY_FETCH_TIMEOUT_MS = 15_000;
+
+export async function postComposerActivityWithFetch(
+  args: {
+    base: string;
+    token?: string | null;
+    report: ComposerActivityReport;
+  },
+  fetchImpl: typeof fetch,
+  timeoutMs: number = COMPOSER_ACTIVITY_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const report = args.report;
+  const res = await fetchImpl(`${args.base}/api/interactions/composer`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(args.token ? { Authorization: `Bearer ${args.token}` } : {}),
+    },
+    body: JSON.stringify({
+      activity: report.activity,
+      surface: report.surface,
+      ...(report.conversationId
+        ? { conversationId: report.conversationId }
+        : {}),
+      draftLength: report.draftLength,
+      ...(report.idleForMs !== undefined
+        ? { idleForMs: report.idleForMs }
+        : {}),
+      ...(report.reason ? { reason: report.reason } : {}),
+      occurredAt: report.occurredAt ?? new Date().toISOString(),
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `POST /api/interactions/composer returned HTTP ${res.status}`,
+    );
+  }
+  return res;
+}
+
 /** Report composer lifecycle metadata to the agent without blocking input. */
 export function reportComposerActivity(report: ComposerActivityReport): void {
   try {
@@ -29,26 +71,10 @@ export function reportComposerActivity(report: ComposerActivityReport): void {
     if (!base || typeof fetch === "undefined") return;
     if (!supportsFullAppShellRoutes(base)) return;
     const token = getElizaApiToken();
-    void fetch(`${base}/api/interactions/composer`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      body: JSON.stringify({
-        activity: report.activity,
-        surface: report.surface,
-        ...(report.conversationId
-          ? { conversationId: report.conversationId }
-          : {}),
-        draftLength: report.draftLength,
-        ...(report.idleForMs !== undefined
-          ? { idleForMs: report.idleForMs }
-          : {}),
-        ...(report.reason ? { reason: report.reason } : {}),
-        occurredAt: report.occurredAt ?? new Date().toISOString(),
-      }),
-    }).catch((err) => {
+    void postComposerActivityWithFetch(
+      { base, token, report },
+      globalThis.fetch,
+    ).catch((err) => {
       // error-policy:J7 telemetry write must not break typing; warn keeps a dead
       // reporting endpoint observable in the browser console.
       logger.warn(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). Slash-command sibling `#21926`. `reportComposerActivity` used unbounded `fetch` on `POST /api/interactions/composer`, so a stalled hop never aborts. This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, 15s deadline. Tests execute the helper under abort. Public reporter stays fire-and-forget (J7). Cloud-agent bases still skip. Not extra-decode. Not list-limit. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Not Twilio. Not shared-runtime. Not GitHub OAuth (`#21765` closed). Not slash-command `#21926` (already posted). Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Composer contract unchanged (no draft text). Public `reportComposerActivity` stays void fire-and-forget. Cloud-agent bases still skip. Unfixed head: composer `fetch` had **no signal** and a hung hop never settled (80ms race → `HUNG` / `sawSignal: false`). After: 10ms deadline → `TimeoutError`. Budget is 15s.

# Background

## What does this PR do?

`reportComposerActivity` called `fetch` with no `signal`. A stalled hop never returns. This PR injects `postComposerActivityWithFetch` (Fal `#21205` shape) and adds `AbortSignal.timeout` with a 15s constant.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Composer metadata body unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/chat/report-composer-activity.test.ts` — timeout, provider-error, and success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts src/chat/report-composer-activity.test.ts
```

Unfixed head: composer POST `signal` was undefined and the hop hung (`HUNG` / `sawSignal: false`). After the fix: 8 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Composer-activity fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live composer hop. vitest asserts TimeoutError, provider 503, and success.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console change beyond existing J7 warn on failure.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no new rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - composer-activity transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no live hop. Unfixed hang: no signal, 80ms race `HUNG` / `sawSignal: false` on `POST /api/interactions/composer`. After the fix, vitest asserts TimeoutError, `503` provider responses, and a successful hop with a 15s constant.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface change.

## Audio / voice walkthrough

N/A - composer report HTTP timeout only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`8 pass`). Root verify is an unrelated full-repo cost. No `bun install`.

<!-- evidence-head:272ee1897ee828bcba0a6f17be4cfe126f1c32f6 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
