### PR TITLE
fix(shared): guard non-array evidence and borrowed device conflict in speaker-name-inference

### DIFF
--- a/packages/shared/src/speaker-name-inference.test.ts
+++ b/packages/shared/src/speaker-name-inference.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for speaker-name inference engine and attribution mapping.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type InferSpeakerNameInput,
+  inferSpeakerName,
+  toSpeakerNameAttribution,
+} from "./speaker-name-inference.ts";
+
+describe("inferSpeakerName", () => {
+  it("returns unknown resolution when no evidence is provided", () => {
+    const result = inferSpeakerName({
+      speakerId: "spk-1",
+      evidence: [],
+    });
+
+    expect(result.speakerId).toBe("spk-1");
+    expect(result.resolution).toBe("unknown");
+    expect(result.confidence).toBe(0);
+    expect(result.reasonCodes).toContain("no_name_evidence");
+    expect(result.requiresReview).toBe(true);
+    expect(result.bindingPlan.action).toBe("none");
+  });
+
+  it("confirms identity from high-confidence user correction and creates entity", () => {
+    const input: InferSpeakerNameInput = {
+      speakerId: "spk-1",
+      evidence: [
+        {
+          source: "user_correction",
+          confidence: 0.95,
+          name: "Alice Johnson",
+        },
+      ],
+    };
+
+    const result = inferSpeakerName(input);
+    expect(result.resolution).toBe("confirmed");
+    expect(result.displayName).toBe("Alice Johnson");
+    expect(result.reasonCodes).toContain("user_correction_applied");
+    expect(result.reasonCodes).toContain("high_confidence_name");
+    expect(result.bindingPlan.action).toBe("create_entity");
+    expect(result.bindingPlan.displayName).toBe("Alice Johnson");
+  });
+
+  it("binds existing entity when single matching entity is found", () => {
+    const input: InferSpeakerNameInput = {
+      speakerId: "spk-2",
+      evidence: [
+        {
+          source: "voice_profile",
+          confidence: 0.92,
+          name: "Bob Smith",
+          profileId: "vp-bob",
+        },
+      ],
+      existingEntities: [
+        {
+          entityId: "ent-bob-1",
+          displayName: "Bob Smith",
+        },
+      ],
+    };
+
+    const result = inferSpeakerName(input);
+    expect(result.resolution).toBe("confirmed");
+    expect(result.displayName).toBe("Bob Smith");
+    expect(result.entityId).toBe("ent-bob-1");
+    expect(result.profileId).toBe("vp-bob");
+    expect(result.bindingPlan.action).toBe("bind_existing_entity");
+    expect(result.bindingPlan.entityId).toBe("ent-bob-1");
+  });
+
+  it("plans entity merge when multiple existing entities share normalized name", () => {
+    const input: InferSpeakerNameInput = {
+      speakerId: "spk-3",
+      evidence: [
+        {
+          source: "voice_profile",
+          confidence: 0.9,
+          name: "Charlie Brown",
+        },
+      ],
+      existingEntities: [
+        { entityId: "ent-cb-1", displayName: "Charlie Brown" },
+        { entityId: "ent-cb-2", displayName: "charlie brown" },
+      ],
+    };
+
+    const result = inferSpeakerName(input);
+    expect(result.resolution).toBe("confirmed");
+    expect(result.bindingPlan.action).toBe("merge_duplicate_entities");
+    expect(result.bindingPlan.mergeEntityIds).toEqual(["ent-cb-1", "ent-cb-2"]);
+    expect(result.bindingPlan.reasonCodes).toContain(
+      "duplicate_entity_merge_required",
+    );
+    expect(result.requiresReview).toBe(true);
+  });
+
+  it("withholds identity when borrowed device conflict is detected", () => {
+    const input: InferSpeakerNameInput = {
+      speakerId: "spk-4",
+      evidence: [
+        {
+          source: "platform_roster",
+          confidence: 0.74,
+          name: "Dave's Laptop",
+        },
+        {
+          source: "self_introduction",
+          confidence: 0.88,
+          name: "Eve Adams",
+        },
+      ],
+    };
+
+    const result = inferSpeakerName(input);
+    expect(result.resolution).toBe("withheld");
+    expect(result.reasonCodes).toContain("borrowed_device_guardrail");
+  });
+
+  it("withholds identity when same first name ambiguity exists", () => {
+    const input: InferSpeakerNameInput = {
+      speakerId: "spk-5",
+      evidence: [
+        { source: "calendar_attendee", confidence: 0.7, name: "John Doe" },
+        { source: "platform_roster", confidence: 0.74, name: "John Smith" },
+      ],
+    };
+
+    const result = inferSpeakerName(input);
+    expect(result.resolution).toBe("withheld");
+    expect(result.reasonCodes).toContain("same_first_name_ambiguity");
+  });
+
+  it("withholds identity when sensitiveAttributeGuardrail is enabled", () => {
+    const input: InferSpeakerNameInput = {
+      speakerId: "spk-6",
+      evidence: [
+        { source: "voice_profile", confidence: 0.95, name: "Grace Hopper" },
+      ],
+      sensitiveAttributeGuardrail: true,
+    };
+
+    const result = inferSpeakerName(input);
+    expect(result.resolution).toBe("withheld");
+    expect(result.reasonCodes).toContain("sensitive_attribute_guardrail");
+  });
+
+  it("throws for invalid confidence ratio values", () => {
+    expect(() =>
+      inferSpeakerName({
+        speakerId: "spk-7",
+        evidence: [
+          { source: "platform_roster", confidence: 1.5, name: "Invalid" },
+        ],
+      }),
+    ).toThrow(/must be between 0 and 1/);
+  });
+});
+
+describe("toSpeakerNameAttribution", () => {
+  it("converts inference to attribution by stripping mutation plans", () => {
+    const inference = inferSpeakerName({
+      speakerId: "spk-1",
+      evidence: [
+        {
+          source: "user_correction",
+          confidence: 0.95,
+          name: "Alice",
+        },
+      ],
+    });
+
+    const attribution = toSpeakerNameAttribution(inference);
+    expect(attribution.resolution).toBe("confirmed");
+    expect(attribution.displayName).toBe("Alice");
+    expect(attribution.confidence).toBe(0.95);
+    expect("bindingPlan" in attribution).toBe(false);
+    expect("voiceTurnBindingPlan" in attribution).toBe(false);
+  });
+
+  it("handles nullish inference safely", () => {
+    const attribution = toSpeakerNameAttribution(null);
+    expect(attribution.resolution).toBe("unknown");
+    expect(attribution.confidence).toBe(0);
+  });
+});

--- a/packages/shared/src/speaker-name-inference.ts
+++ b/packages/shared/src/speaker-name-inference.ts
@@ -129,8 +129,18 @@ export interface SpeakerNameAttribution {
 
 /** Drop identity-graph mutation instructions before transporting attribution. */
 export function toSpeakerNameAttribution(
-  inference: SpeakerNameInference,
+  inference: SpeakerNameInference | null | undefined,
 ): SpeakerNameAttribution {
+  if (!inference || typeof inference !== "object") {
+    return {
+      resolution: "unknown",
+      confidence: 0,
+      candidateNames: [],
+      provenance: [],
+      reasonCodes: ["no_name_evidence"],
+      requiresReview: true,
+    };
+  }
   return {
     resolution: inference.resolution,
     ...(inference.displayName ? { displayName: inference.displayName } : {}),
@@ -197,8 +207,9 @@ function uniqueReasonCodes(
 }
 
 function groupCandidates(
-  evidence: readonly SpeakerNameEvidence[],
+  evidence: readonly SpeakerNameEvidence[] | null | undefined,
 ): MutableCandidate[] {
+  if (!Array.isArray(evidence)) return [];
   const candidates = new Map<string, MutableCandidate>();
   for (const item of evidence) {
     assertRatio(`${item.source}.confidence`, item.confidence);
@@ -217,10 +228,14 @@ function groupCandidates(
         provenance: [],
         score: 0,
       } satisfies MutableCandidate);
+    const sourcePriority =
+      item.source in SOURCE_PRIORITY
+        ? SOURCE_PRIORITY[item.source as SpeakerNameEvidenceSource]
+        : 0.5;
     candidate.confidence = Math.max(candidate.confidence, item.confidence);
     candidate.score = Math.max(
       candidate.score,
-      item.confidence * SOURCE_PRIORITY[item.source],
+      item.confidence * sourcePriority,
     );
     if (!candidate.sources.includes(item.source)) {
       candidate.sources.push(item.source);
@@ -240,7 +255,9 @@ function groupCandidates(
       ...candidate,
       sources: [...candidate.sources].sort(),
       provenance: [...candidate.provenance].sort(
-        (a, b) => SOURCE_PRIORITY[b.source] - SOURCE_PRIORITY[a.source],
+        (a, b) =>
+          (SOURCE_PRIORITY[b.source as SpeakerNameEvidenceSource] ?? 0.5) -
+          (SOURCE_PRIORITY[a.source as SpeakerNameEvidenceSource] ?? 0.5),
       ),
     }))
     .sort((a, b) => b.score - a.score || b.confidence - a.confidence);
@@ -445,6 +462,7 @@ export function inferSpeakerName(
     (hasStrongSource(chosen) || chosen.sources.length > 1) &&
     !sameFirstNameAmbiguity &&
     !unresolvedConflict &&
+    !borrowedDeviceConflict &&
     input.sensitiveAttributeGuardrail !== true;
   if (canConfirm) reasonCodes.push("high_confidence_name");
   if (chosen && !canConfirm) reasonCodes.push("low_confidence_name");


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `evidence` in `groupCandidates` to handle non-array and nullish values safely.
- Guard input in `toSpeakerNameAttribution` against nullish values.
- Enforce `!borrowedDeviceConflict` in `canConfirm` so high-confidence voice profile / self-introduction evidence does not bypass borrowed device conflict guardrails.
- Add a comprehensive unit test suite in `packages/shared/src/speaker-name-inference.test.ts` testing identity confirmation, entity creation/binding, duplicate entity merge planning, borrowed device guardrails, same first name ambiguities, sensitive attribute guardrails, and attribution serialization with 97%+ coverage.

## Related Issues

- Fixes #21928

## Testing

- Added `packages/shared/src/speaker-name-inference.test.ts` with 10 tests covering:
  - Empty evidence handling
  - High-confidence user correction and entity creation
  - Single matching entity binding
  - Duplicate entity merge planning and review flagging
  - Borrowed device conflict detection and resolution withholding
  - First-name ambiguity detection and resolution withholding
  - Sensitive attribute guardrail withholding
  - Ratio validation checks
  - Attribution conversion stripping mutation plans
  - Nullish input safety
- `bun test packages/shared/src/speaker-name-inference.test.ts` passes (10/10 tests, 37 assertions).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/speaker-name-inference.test.ts:
✓ inferSpeakerName > returns unknown resolution when no evidence is provided [0.79ms]
✓ inferSpeakerName > confirms identity from high-confidence user correction and creates entity [0.81ms]
✓ inferSpeakerName > binds existing entity when single matching entity is found [0.37ms]
✓ inferSpeakerName > plans entity merge when multiple existing entities share normalized name [0.17ms]
✓ inferSpeakerName > withholds identity when borrowed device conflict is detected [0.24ms]
✓ inferSpeakerName > withholds identity when same first name ambiguity exists [0.12ms]
✓ inferSpeakerName > withholds identity when sensitiveAttributeGuardrail is enabled [0.08ms]
✓ inferSpeakerName > throws for invalid confidence ratio values [0.23ms]
✓ toSpeakerNameAttribution > converts inference to attribution by stripping mutation plans [0.15ms]
✓ toSpeakerNameAttribution > handles nullish inference safely [0.03ms]
-----------------------------------------------|---------|---------|-------------------
File                                           | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------|---------|---------|-------------------
 packages/shared/src/speaker-name-inference.ts |   96.67 |   97.09 | 
-----------------------------------------------|---------|---------|-------------------

 10 pass
 0 fail
 37 expect() calls
Ran 10 tests across 1 file. [117.00ms]
```
