### PR TITLE
fix(shared): guard non-string inputs in matchViewCommand and add unit test suite

### DIFF
--- a/packages/shared/src/views/view-command-matcher.test.ts
+++ b/packages/shared/src/views/view-command-matcher.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for deterministic multilingual view-command matcher.
+ */
+import { describe, expect, it } from "vitest";
+import { MATCHER_VIEW_IDS, matchViewCommand } from "./view-command-matcher.ts";
+
+describe("matchViewCommand", () => {
+  it("matches English view navigation commands", () => {
+    expect(matchViewCommand("open settings")).toBe("settings");
+    expect(matchViewCommand("go to calendar")).toBe("calendar");
+    expect(matchViewCommand("show me my wallet")).toBe("wallet");
+    expect(matchViewCommand("my todos")).toBe("todos");
+    expect(matchViewCommand("notes page")).toBe("notes");
+    expect(matchViewCommand("go back")).toBe("chat");
+  });
+
+  it("matches Spanish view navigation commands", () => {
+    expect(matchViewCommand("abre ajustes")).toBe("settings");
+    expect(matchViewCommand("ir a billetera")).toBe("wallet");
+    expect(matchViewCommand("muéstrame el calendario")).toBe("calendar");
+  });
+
+  it("matches Portuguese view navigation commands", () => {
+    expect(matchViewCommand("abra configurações")).toBe("settings");
+    expect(matchViewCommand("mostra minhas tarefas")).toBe("todos");
+  });
+
+  it("matches French view navigation commands", () => {
+    expect(matchViewCommand("ouvre les paramètres")).toBe("settings");
+    expect(matchViewCommand("affiche mon calendrier")).toBe("calendar");
+  });
+
+  it("matches German view navigation commands", () => {
+    expect(matchViewCommand("öffne einstellungen")).toBe("settings");
+    expect(matchViewCommand("zeige meinen kalender")).toBe("calendar");
+  });
+
+  it("matches Chinese view navigation commands", () => {
+    expect(matchViewCommand("打开设置")).toBe("settings");
+    expect(matchViewCommand("查看日历")).toBe("calendar");
+    expect(matchViewCommand("切换到钱包")).toBe("wallet");
+  });
+
+  it("matches Japanese view navigation commands", () => {
+    expect(matchViewCommand("設定を開いて")).toBe("settings");
+    expect(matchViewCommand("カレンダーを表示")).toBe("calendar");
+  });
+
+  it("matches Korean view navigation commands", () => {
+    expect(matchViewCommand("설정 열기")).toBe("settings");
+    expect(matchViewCommand("캘린더 보여줘")).toBe("calendar");
+  });
+
+  it("rejects negated navigation commands", () => {
+    expect(matchViewCommand("don't open settings")).toBeNull();
+    expect(matchViewCommand("do not go to calendar")).toBeNull();
+    expect(matchViewCommand("no abras ajustes")).toBeNull();
+  });
+
+  it("rejects companion action requests", () => {
+    expect(matchViewCommand("draw avatar dance")).toBeNull();
+    expect(matchViewCommand("generate companion emote")).toBeNull();
+  });
+
+  it("rejects oversized inputs and nullish values", () => {
+    expect(matchViewCommand("a".repeat(161))).toBeNull();
+    expect(matchViewCommand("")).toBeNull();
+    expect(matchViewCommand("   ")).toBeNull();
+    expect(matchViewCommand(null)).toBeNull();
+    expect(matchViewCommand(undefined)).toBeNull();
+    expect(matchViewCommand(123 as unknown as string)).toBeNull();
+  });
+});
+
+describe("MATCHER_VIEW_IDS", () => {
+  it("contains core platform view identifiers", () => {
+    expect(MATCHER_VIEW_IDS).toContain("settings");
+    expect(MATCHER_VIEW_IDS).toContain("calendar");
+    expect(MATCHER_VIEW_IDS).toContain("inbox");
+    expect(MATCHER_VIEW_IDS).toContain("wallet");
+    expect(MATCHER_VIEW_IDS).toContain("chat");
+  });
+});

--- a/packages/shared/src/views/view-command-matcher.ts
+++ b/packages/shared/src/views/view-command-matcher.ts
@@ -1225,8 +1225,11 @@ function stripDiacritics(s: string): string {
  * or null. No LLM. Precision-first: a bare noun never matches without a nav
  * signal (verb / possessive / view-word / whole-message).
  */
-export function matchViewCommand(text: string | undefined): string | null {
-  const raw = (text ?? "").trim();
+export function matchViewCommand(
+  text: string | undefined | null,
+): string | null {
+  if (typeof text !== "string") return null;
+  const raw = text.trim();
   if (!raw || raw.length > 160) return null; // commands are short
   const lower = raw.toLowerCase();
   if (looksLikeCompanionActionRequest(lower)) return null;


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `matchViewCommand` to ensure `text` is a string (`typeof text !== "string"` returns `null`).
- Add a dedicated unit test suite in `packages/shared/src/views/view-command-matcher.test.ts` testing multilingual view matching (English, Spanish, Portuguese, French, German, Chinese, Japanese, Korean), home navigation ("go back"), negated navigation commands, companion action rejections, length thresholds, and nullish inputs with 99.9%+ coverage.

## Related Issues

- Fixes #21931

## Testing

- Added `packages/shared/src/views/view-command-matcher.test.ts` with 12 tests covering:
  - English commands (`open settings`, `go to calendar`, `show me my wallet`, `my todos`, `notes page`, `go back`)
  - Spanish commands (`abre ajustes`, `ir a billetera`, `muéstrame el calendario`)
  - Portuguese commands (`abra configurações`, `mostra minhas tarefas`)
  - French commands (`ouvre les paramètres`, `affiche mon calendrier`)
  - German commands (`öffne einstellungen`, `zeige meinen kalender`)
  - Chinese commands (`打开设置`, `查看日历`, `切换到钱包`)
  - Japanese commands (`設定を開いて`, `カレンダーを表示`)
  - Korean commands (`설정 열기`, `캘린더 보여줘`)
  - Negated command rejection (`don't open settings`, `no abras ajustes`)
  - Companion action rejection (`draw avatar dance`)
  - Oversized, empty, and nullish inputs
  - `MATCHER_VIEW_IDS` content integrity
- `bun test packages/shared/src/views/view-command-matcher.test.ts` passes (12/12 tests, 38 assertions).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/views/view-command-matcher.test.ts:
✓ matchViewCommand > matches English view navigation commands [94.97ms]
✓ matchViewCommand > matches Spanish view navigation commands [5.55ms]
✓ matchViewCommand > matches Portuguese view navigation commands [6.09ms]
✓ matchViewCommand > matches French view navigation commands [4.57ms]
✓ matchViewCommand > matches German view navigation commands [3.20ms]
✓ matchViewCommand > matches Chinese view navigation commands [1.86ms]
✓ matchViewCommand > matches Japanese view navigation commands [1.65ms]
✓ matchViewCommand > matches Korean view navigation commands [2.27ms]
✓ matchViewCommand > rejects negated navigation commands [25.91ms]
✓ matchViewCommand > rejects companion action requests [0.21ms]
✓ matchViewCommand > rejects oversized inputs and nullish values [0.09ms]
✓ MATCHER_VIEW_IDS > contains core platform view identifiers [0.06ms]
---------------------------------------------------|---------|---------|-------------------
File                                               | % Funcs | % Lines | Uncovered Line #s
---------------------------------------------------|---------|---------|-------------------
 packages/shared/src/views/shared-nav-targets.ts   |  100.00 |  100.00 | 
 packages/shared/src/views/view-command-matcher.ts |  100.00 |   99.91 | 
---------------------------------------------------|---------|---------|-------------------

 12 pass
 0 fail
 38 expect() calls
Ran 12 tests across 1 file. [352.00ms]
```
