### PR TITLE
fix(plugin-trajectory-logger): bound list, detail, purge, and export fetches

### DIFF
--- a/plugins/plugin-trajectory-logger/src/api-client.contract.test.ts
+++ b/plugins/plugin-trajectory-logger/src/api-client.contract.test.ts
@@ -7,7 +7,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchTrajectoryDetail,
+  fetchTrajectoryExportWithFetch,
   fetchTrajectoryList,
+  fetchTrajectoryListWithFetch,
+  fetchTrajectoryDetailWithFetch,
+  purgeTrajectoryWithFetch,
+  TRAJECTORY_DETAIL_FETCH_TIMEOUT_MS,
+  TRAJECTORY_EXPORT_FETCH_TIMEOUT_MS,
+  TRAJECTORY_LIST_FETCH_TIMEOUT_MS,
+  TRAJECTORY_PURGE_FETCH_TIMEOUT_MS,
   type TrajectoryDetail,
   type TrajectoryListResult,
 } from "./api-client.js";
@@ -247,5 +255,108 @@ describe("readJson error path", () => {
     await expect(fetchTrajectoryList()).rejects.toThrow(
       "[trajectory-logger] 503 Service Unavailable: Trajectories service not available",
     );
+  });
+});
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected trajectory abort signal");
+      if (signal.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+describe("trajectory-logger request deadlines", () => {
+  it("keeps a documented budget per hop", () => {
+    expect(TRAJECTORY_LIST_FETCH_TIMEOUT_MS).toBe(15_000);
+    expect(TRAJECTORY_DETAIL_FETCH_TIMEOUT_MS).toBe(15_000);
+    expect(TRAJECTORY_PURGE_FETCH_TIMEOUT_MS).toBe(15_000);
+    expect(TRAJECTORY_EXPORT_FETCH_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("aborts a stalled list GET at the injected deadline", async () => {
+    await expect(
+      fetchTrajectoryListWithFetch({}, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("aborts a stalled detail GET at the injected deadline", async () => {
+    await expect(
+      fetchTrajectoryDetailWithFetch("traj-000", {}, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("aborts a stalled purge DELETE at the injected deadline", async () => {
+    await expect(
+      purgeTrajectoryWithFetch("traj-000", {}, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("aborts a stalled export GET at the injected deadline", async () => {
+    await expect(
+      fetchTrajectoryExportWithFetch("traj-000", {}, stallUntilAborted(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("still honors a caller abort signal on list", async () => {
+    const ctrl = new AbortController();
+    ctrl.abort();
+    await expect(
+      fetchTrajectoryListWithFetch(
+        { signal: ctrl.signal },
+        stallUntilAborted(),
+        1_000,
+      ),
+    ).rejects.toBeTruthy();
+  });
+
+  it("surfaces a provider error from a completed purge DELETE", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("nope", { status: 503, statusText: "Service Unavailable" });
+    await expect(
+      purgeTrajectoryWithFetch("traj-000", {}, fetchImpl, 1_000),
+    ).rejects.toThrow("purgeTrajectory failed: 503 Service Unavailable");
+  });
+
+  it("uses the injected fetch for a successful list GET", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response(JSON.stringify(LIST_PAYLOAD), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const result = await fetchTrajectoryListWithFetch({}, fetchImpl, 1_000);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(result.total).toBe(2);
+  });
+
+  it("uses the injected fetch for a successful export GET", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      });
+    };
+    const blob = await fetchTrajectoryExportWithFetch(
+      "traj-000",
+      {},
+      fetchImpl,
+      1_000,
+    );
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(blob.size).toBe(3);
   });
 });

--- a/plugins/plugin-trajectory-logger/src/api-client.ts
+++ b/plugins/plugin-trajectory-logger/src/api-client.ts
@@ -98,52 +98,77 @@ async function readJson<T>(res: Response): Promise<T> {
   return (await res.json()) as T;
 }
 
-export async function fetchTrajectoryList(
-  options: { limit?: number; signal?: AbortSignal } = {},
+/** List GET — same 15s Fal #21205 family. Independent hop. */
+export const TRAJECTORY_LIST_FETCH_TIMEOUT_MS = 15_000;
+/** Detail GET — independent hop, own 15s deadline. */
+export const TRAJECTORY_DETAIL_FETCH_TIMEOUT_MS = 15_000;
+/** Purge DELETE — independent hop, own 15s deadline. */
+export const TRAJECTORY_PURGE_FETCH_TIMEOUT_MS = 15_000;
+/** Export GET — independent hop, own 15s deadline. */
+export const TRAJECTORY_EXPORT_FETCH_TIMEOUT_MS = 15_000;
+
+export function composeTrajectoryFetchSignal(
+  caller: AbortSignal | undefined,
+  timeoutMs: number,
+): AbortSignal {
+  const deadline = AbortSignal.timeout(timeoutMs);
+  return caller ? AbortSignal.any([caller, deadline]) : deadline;
+}
+
+export async function fetchTrajectoryListWithFetch(
+  options: { limit?: number; signal?: AbortSignal },
+  fetchImpl: typeof fetch,
+  timeoutMs: number = TRAJECTORY_LIST_FETCH_TIMEOUT_MS,
 ): Promise<TrajectoryListResult> {
   const limit = options.limit ?? 10;
-  const res = await fetch(`/api/trajectories?limit=${limit}`, {
+  const res = await fetchImpl(`/api/trajectories?limit=${limit}`, {
     headers: { Accept: "application/json" },
-    signal: options.signal,
+    signal: composeTrajectoryFetchSignal(options.signal, timeoutMs),
   });
   return readJson<TrajectoryListResult>(res);
 }
 
-export async function fetchTrajectoryDetail(
+export async function fetchTrajectoryDetailWithFetch(
   id: string,
-  options: { signal?: AbortSignal } = {},
+  options: { signal?: AbortSignal },
+  fetchImpl: typeof fetch,
+  timeoutMs: number = TRAJECTORY_DETAIL_FETCH_TIMEOUT_MS,
 ): Promise<TrajectoryDetail> {
-  const res = await fetch(`/api/trajectories/${encodeURIComponent(id)}`, {
+  const res = await fetchImpl(`/api/trajectories/${encodeURIComponent(id)}`, {
     headers: { Accept: "application/json" },
-    signal: options.signal,
+    signal: composeTrajectoryFetchSignal(options.signal, timeoutMs),
   });
   return readJson<TrajectoryDetail>(res);
 }
 
-/**
- * Soft-purge a single trajectory. The server route is wired by the training
- * plugin; if it returns 404 the caller surfaces "not available" rather than
- * silently failing.
- */
-export async function purgeTrajectory(id: string): Promise<void> {
-  const res = await fetch(`/api/trajectories/${encodeURIComponent(id)}`, {
+export async function purgeTrajectoryWithFetch(
+  id: string,
+  options: { signal?: AbortSignal },
+  fetchImpl: typeof fetch,
+  timeoutMs: number = TRAJECTORY_PURGE_FETCH_TIMEOUT_MS,
+): Promise<void> {
+  const res = await fetchImpl(`/api/trajectories/${encodeURIComponent(id)}`, {
     method: "DELETE",
     headers: { Accept: "application/json" },
+    signal: composeTrajectoryFetchSignal(options.signal, timeoutMs),
   });
   if (!res.ok) {
     throw new Error(`purgeTrajectory failed: ${res.status} ${res.statusText}`);
   }
 }
 
-/**
- * Export a trajectory as a signed zip bundle. The server route returns the
- * archive as `application/zip` (with a `X-Eliza-Signature` header carrying the
- * detached signature). Caller is responsible for streaming the blob.
- */
-export async function fetchTrajectoryExport(id: string): Promise<Blob> {
-  const res = await fetch(
+export async function fetchTrajectoryExportWithFetch(
+  id: string,
+  options: { signal?: AbortSignal },
+  fetchImpl: typeof fetch,
+  timeoutMs: number = TRAJECTORY_EXPORT_FETCH_TIMEOUT_MS,
+): Promise<Blob> {
+  const res = await fetchImpl(
     `/api/trajectories/${encodeURIComponent(id)}/export`,
-    { headers: { Accept: "application/zip" } },
+    {
+      headers: { Accept: "application/zip" },
+      signal: composeTrajectoryFetchSignal(options.signal, timeoutMs),
+    },
   );
   if (!res.ok) {
     throw new Error(
@@ -151,4 +176,41 @@ export async function fetchTrajectoryExport(id: string): Promise<Blob> {
     );
   }
   return res.blob();
+}
+
+export async function fetchTrajectoryList(
+  options: { limit?: number; signal?: AbortSignal } = {},
+): Promise<TrajectoryListResult> {
+  return fetchTrajectoryListWithFetch(options, globalThis.fetch);
+}
+
+export async function fetchTrajectoryDetail(
+  id: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<TrajectoryDetail> {
+  return fetchTrajectoryDetailWithFetch(id, options, globalThis.fetch);
+}
+
+/**
+ * Soft-purge a single trajectory. The server route is wired by the training
+ * plugin; if it returns 404 the caller surfaces "not available" rather than
+ * silently failing.
+ */
+export async function purgeTrajectory(
+  id: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<void> {
+  return purgeTrajectoryWithFetch(id, options, globalThis.fetch);
+}
+
+/**
+ * Export a trajectory as a signed zip bundle. The server route returns the
+ * archive as `application/zip` (with a `X-Eliza-Signature` header carrying the
+ * detached signature). Caller is responsible for streaming the blob.
+ */
+export async function fetchTrajectoryExport(
+  id: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<Blob> {
+  return fetchTrajectoryExportWithFetch(id, options, globalThis.fetch);
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw-kept byt61 fetch-timeout family (`#21154` / `#21165` / `#21205` Fal). Composer-activity sibling `#21929`. Trajectory logger `api-client` used unbounded `fetch` on four independent hops — list GET, detail GET, purge DELETE, and export GET — so a stalled hop never aborts. List/detail accepted an optional caller `signal` but had no default deadline; purge/export had no `AbortSignal` at all. This PR is Fal `#21205` bar: injected fetch, TimeoutError, provider-error, success, **separate 15s deadlines per hop**. Default deadline when the caller does not pass a signal; `AbortSignal.any` when they do (polling unmount still works). Tests execute the helpers under abort. Not extra-decode. Not list-limit. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON reprints. Not Atlas video (`#19302`). Not Twilio. Not shared-runtime. Not GitHub OAuth (`#21765` closed). Not composer-activity `#21929` (already posted). Proof is vitest of this file only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport abort only. Trajectory list/detail/purge/export contract parsing unchanged. Callers that pass `{ signal }` (polling unmount) still abort via `AbortSignal.any`. Unfixed head: list/detail used caller `signal` only (undefined = no abort) and purge/export had **no signal**; hung hops never settled (`HUNG` / `sawSignal: false`). After: 10ms deadline → `TimeoutError`. Budget is 15s per hop.

# Background

## What does this PR do?

List and detail `fetch` used `signal: options.signal` with no default deadline. Purge and export called `fetch` with no `signal`. A stalled hop never returns. This PR injects `*WithFetch` helpers (Fal `#21205` shape) and adds `AbortSignal.timeout` with a separate 15s constant per hop. When a caller passes a signal, it is composed with the deadline via `AbortSignal.any`.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Optional `signal` on purge/export is backward-compatible. Contract parsing unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-trajectory-logger/src/api-client.contract.test.ts` — timeout, caller-abort, provider-error, and success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-trajectory-logger && bunx vitest run --config ./vitest.config.ts src/api-client.contract.test.ts
```

Unfixed head: four hops hung (`HUNG` / `sawSignal: false`). After the fix: 13 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Trajectory-logger fetch timeout only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected fetch proves abort, error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live trajectory hop. vitest asserts TimeoutError, provider 503, and success.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request-facing fetch timeout. No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / wallet change. Hung fetch never reaches a response body.
<!-- evidence-row:ocr-review -->
- [x] N/A - no new rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - trajectory-logger transport timeout. No agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no live hop. Unfixed hang: no default deadline, 80ms race `HUNG` / `sawSignal: false` on list GET, detail GET, purge DELETE, and export GET. After the fix, vitest asserts TimeoutError, `503` provider responses, caller abort, and successful hops with a 15s constant per hop.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface change.

## Audio / voice walkthrough

N/A - trajectory-logger HTTP timeout only.

## Known gaps / failures

`bun run verify` was not run. Focused package vitest is the proof (`13 pass`). Root verify is an unrelated full-repo cost. No `bun install`.

<!-- evidence-head:7dca6daceae357427ecf3a8b3f72650b96fd9dd0 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
