### PR TITLE
feat(shared): add unregister, clear, and direct lookup helpers to detail-extension-registry and add unit tests

### DIFF
--- a/packages/shared/src/apps/detail-extension-registry.test.ts
+++ b/packages/shared/src/apps/detail-extension-registry.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for app detail extension registry lifecycle and component lookup.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RegistryAppInfo } from "../contracts/apps.ts";
+import {
+  clearDetailExtensionRegistry,
+  getAppDetailExtension,
+  getDetailExtension,
+  registerDetailExtension,
+  unregisterDetailExtension,
+} from "./detail-extension-registry.ts";
+import type { AppDetailExtensionComponent } from "./detail-extension-types.ts";
+
+describe("detail-extension-registry", () => {
+  beforeEach(() => {
+    clearDetailExtensionRegistry();
+  });
+
+  afterEach(() => {
+    clearDetailExtensionRegistry();
+  });
+
+  const MockPanelComponent: AppDetailExtensionComponent = (() =>
+    null) as unknown as AppDetailExtensionComponent;
+
+  it("registers and retrieves detail extension components", () => {
+    expect(getDetailExtension("wallet-detail-panel")).toBeNull();
+
+    registerDetailExtension("wallet-detail-panel", MockPanelComponent);
+    expect(getDetailExtension("wallet-detail-panel")).toBe(MockPanelComponent);
+
+    const app: RegistryAppInfo = {
+      name: "wallet-app",
+      displayName: "Wallet",
+      description: "Crypto wallet",
+      category: "finance",
+      launchType: "tab",
+      launchUrl: null,
+      icon: "wallet",
+      heroImage: null,
+      capabilities: [],
+      stars: 0,
+      repository: "",
+      latestVersion: null,
+      supports: { v0: false, v1: false, v2: true },
+      npm: {
+        package: "wallet-app",
+        v0Version: null,
+        v1Version: null,
+        v2Version: null,
+      },
+      uiExtension: {
+        detailPanelId: "wallet-detail-panel",
+      },
+    };
+
+    expect(getAppDetailExtension(app)).toBe(MockPanelComponent);
+  });
+
+  it("unregisters detail extension components", () => {
+    registerDetailExtension("chat-detail-panel", MockPanelComponent);
+    expect(getDetailExtension("chat-detail-panel")).toBe(MockPanelComponent);
+
+    expect(unregisterDetailExtension("chat-detail-panel")).toBe(true);
+    expect(getDetailExtension("chat-detail-panel")).toBeNull();
+    expect(unregisterDetailExtension("chat-detail-panel")).toBe(false);
+  });
+
+  it("clears all detail extensions via clearDetailExtensionRegistry", () => {
+    registerDetailExtension("panel-1", MockPanelComponent);
+    registerDetailExtension("panel-2", MockPanelComponent);
+
+    expect(getDetailExtension("panel-1")).toBe(MockPanelComponent);
+    expect(getDetailExtension("panel-2")).toBe(MockPanelComponent);
+
+    clearDetailExtensionRegistry();
+    expect(getDetailExtension("panel-1")).toBeNull();
+    expect(getDetailExtension("panel-2")).toBeNull();
+  });
+
+  it("returns null when app lacks uiExtension or detailPanelId is unknown", () => {
+    const plainApp: RegistryAppInfo = {
+      name: "plain-app",
+      displayName: "Plain",
+      description: "No extension",
+      category: "tools",
+      launchType: "tab",
+      launchUrl: null,
+      icon: "tool",
+      heroImage: null,
+      capabilities: [],
+      stars: 0,
+      repository: "",
+      latestVersion: null,
+      supports: { v0: false, v1: false, v2: true },
+      npm: {
+        package: "plain-app",
+        v0Version: null,
+        v1Version: null,
+        v2Version: null,
+      },
+    };
+
+    expect(getAppDetailExtension(plainApp)).toBeNull();
+    expect(getAppDetailExtension(null)).toBeNull();
+    expect(getAppDetailExtension(undefined)).toBeNull();
+  });
+
+  it("guards against invalid or empty registration arguments", () => {
+    registerDetailExtension("", MockPanelComponent);
+    registerDetailExtension(null as unknown as string, MockPanelComponent);
+    registerDetailExtension(
+      "valid-id",
+      null as unknown as AppDetailExtensionComponent,
+    );
+
+    expect(getDetailExtension("")).toBeNull();
+    expect(getDetailExtension("valid-id")).toBeNull();
+    expect(unregisterDetailExtension(null as unknown as string)).toBe(false);
+  });
+});

--- a/packages/shared/src/apps/detail-extension-registry.ts
+++ b/packages/shared/src/apps/detail-extension-registry.ts
@@ -28,13 +28,40 @@ export function registerDetailExtension(
   detailPanelId: string,
   component: AppDetailExtensionComponent,
 ): void {
+  if (
+    typeof detailPanelId !== "string" ||
+    !detailPanelId.trim() ||
+    !component
+  ) {
+    return;
+  }
   DETAIL_EXTENSION_COMPONENTS.set(detailPanelId, component);
 }
 
-export function getAppDetailExtension(
-  app: RegistryAppInfo,
+/** Unregister a detail-panel extension component by panel id. */
+export function unregisterDetailExtension(detailPanelId: string): boolean {
+  if (typeof detailPanelId !== "string") return false;
+  return DETAIL_EXTENSION_COMPONENTS.delete(detailPanelId);
+}
+
+/** Clear all registered detail extension components. */
+export function clearDetailExtensionRegistry(): void {
+  DETAIL_EXTENSION_COMPONENTS.clear();
+}
+
+/** Directly retrieve a registered detail extension component by panel id. */
+export function getDetailExtension(
+  detailPanelId: string,
 ): AppDetailExtensionComponent | null {
+  if (typeof detailPanelId !== "string") return null;
+  return DETAIL_EXTENSION_COMPONENTS.get(detailPanelId) ?? null;
+}
+
+export function getAppDetailExtension(
+  app: RegistryAppInfo | null | undefined,
+): AppDetailExtensionComponent | null {
+  if (!app || typeof app !== "object") return null;
   const detailPanelId = app.uiExtension?.detailPanelId;
   if (!detailPanelId) return null;
-  return DETAIL_EXTENSION_COMPONENTS.get(detailPanelId) ?? null;
+  return getDetailExtension(detailPanelId);
 }


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Add and export `unregisterDetailExtension(detailPanelId: string): boolean`, `clearDetailExtensionRegistry(): void`, and `getDetailExtension(detailPanelId: string): AppDetailExtensionComponent | null` to support dynamic lifecycle operations and direct component lookup.
- Add input validation guards across `registerDetailExtension`, `unregisterDetailExtension`, `getDetailExtension`, and `getAppDetailExtension`.
- Add a comprehensive unit test suite in `packages/shared/src/apps/detail-extension-registry.test.ts` testing registration, lookup, removal, clearing, missing extension handling, and invalid inputs with 100% coverage.

## Related Issues

- Fixes #21939

## Testing

- Added `packages/shared/src/apps/detail-extension-registry.test.ts` with 5 tests covering:
  - Register and retrieve detail extension components
  - Unregister detail extension components
  - Clear entire detail extension registry
  - Safe null handling when app lacks `uiExtension` or `detailPanelId`
  - Input validation on empty or invalid registration arguments
- `bun test packages/shared/src/apps/detail-extension-registry.test.ts` passes (5/5 tests, 17 assertions, 100% coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/apps/detail-extension-registry.test.ts:
✓ detail-extension-registry > registers and retrieves detail extension components [0.53ms]
✓ detail-extension-registry > unregisters detail extension components [0.10ms]
✓ detail-extension-registry > clears all detail extensions via clearDetailExtensionRegistry [0.07ms]
✓ detail-extension-registry > returns null when app lacks uiExtension or detailPanelId is unknown [0.09ms]
✓ detail-extension-registry > guards against invalid or empty registration arguments [0.06ms]
-------------------------------------------------------|---------|---------|-------------------
File                                                   | % Funcs | % Lines | Uncovered Line #s
-------------------------------------------------------|---------|---------|-------------------
 packages/shared/src/apps/detail-extension-registry.ts |  100.00 |  100.00 | 
-------------------------------------------------------|---------|---------|-------------------

 5 pass
 0 fail
 17 expect() calls
Ran 5 tests across 1 file. [120.00ms]
```
