### PR TITLE
test(shared): add comprehensive unit test suite for runtime-mode resolvers and predicates

### DIFF
--- a/packages/shared/src/config/runtime-mode.test.ts
+++ b/packages/shared/src/config/runtime-mode.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for runtime execution mode normalization, configuration reading, and environment resolvers.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isCloudExecutionMode,
+  isCloudRuntimeMode,
+  isLocalRuntimeMode,
+  isSafeLocalMode,
+  isYoloLocalMode,
+  normalizeRuntimeExecutionMode,
+  RUNTIME_EXECUTION_MODE_DEFINITIONS,
+  RUNTIME_EXECUTION_MODES,
+  readRuntimeExecutionModeConfig,
+  resolveLocalExecutionMode,
+  resolveRuntimeExecutionMode,
+  runtimeExecutionModeForDeploymentTarget,
+  shouldUseSandboxExecution,
+} from "./runtime-mode.ts";
+
+describe("runtime-mode normalization and predicates", () => {
+  it("normalizes valid mode strings case-insensitively and trims whitespace", () => {
+    expect(normalizeRuntimeExecutionMode("cloud")).toBe("cloud");
+    expect(normalizeRuntimeExecutionMode("  CLOUD  ")).toBe("cloud");
+    expect(normalizeRuntimeExecutionMode("local-safe")).toBe("local-safe");
+    expect(normalizeRuntimeExecutionMode("LOCAL-YOLO")).toBe("local-yolo");
+  });
+
+  it("returns null for invalid or non-string mode values", () => {
+    expect(normalizeRuntimeExecutionMode("invalid-mode")).toBeNull();
+    expect(normalizeRuntimeExecutionMode("")).toBeNull();
+    expect(normalizeRuntimeExecutionMode(null)).toBeNull();
+    expect(normalizeRuntimeExecutionMode(undefined)).toBeNull();
+    expect(normalizeRuntimeExecutionMode(42)).toBeNull();
+  });
+
+  it("evaluates mode predicates correctly", () => {
+    expect(isCloudRuntimeMode("cloud")).toBe(true);
+    expect(isCloudRuntimeMode("local-safe")).toBe(false);
+
+    expect(isLocalRuntimeMode("local-safe")).toBe(true);
+    expect(isLocalRuntimeMode("local-yolo")).toBe(true);
+    expect(isLocalRuntimeMode("cloud")).toBe(false);
+
+    expect(isSafeLocalMode("local-safe")).toBe(true);
+    expect(isSafeLocalMode("local-yolo")).toBe(false);
+
+    expect(isYoloLocalMode("local-yolo")).toBe(true);
+    expect(isYoloLocalMode("local-safe")).toBe(false);
+  });
+});
+
+describe("deployment target and config resolution", () => {
+  it("resolves execution mode for deployment target", () => {
+    expect(runtimeExecutionModeForDeploymentTarget({ runtime: "cloud" })).toBe(
+      "cloud",
+    );
+    expect(runtimeExecutionModeForDeploymentTarget({ runtime: "local" })).toBe(
+      "local-safe",
+    );
+    expect(runtimeExecutionModeForDeploymentTarget(null)).toBe("local-safe");
+    expect(runtimeExecutionModeForDeploymentTarget(undefined)).toBe(
+      "local-safe",
+    );
+  });
+
+  it("reads explicit executionMode from config or falls back to deploymentTarget", () => {
+    expect(
+      readRuntimeExecutionModeConfig({
+        runtime: { executionMode: "cloud" },
+      }),
+    ).toBe("cloud");
+
+    expect(
+      readRuntimeExecutionModeConfig({
+        runtime: { executionMode: "local-safe" },
+      }),
+    ).toBe("local-safe");
+
+    expect(
+      readRuntimeExecutionModeConfig({
+        deploymentTarget: { runtime: "cloud" },
+      }),
+    ).toBe("cloud");
+
+    expect(readRuntimeExecutionModeConfig(null)).toBe("local-safe");
+  });
+});
+
+describe("resolveRuntimeExecutionMode and helpers", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.ELIZA_RUNTIME_MODE;
+    delete process.env.RUNTIME_MODE;
+    delete process.env.LOCAL_RUNTIME_MODE;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("prioritizes source getSetting over environment variables", () => {
+    process.env.ELIZA_RUNTIME_MODE = "cloud";
+    const source = {
+      getSetting: (key: string) =>
+        key === "ELIZA_RUNTIME_MODE" ? "local-safe" : undefined,
+    };
+
+    expect(resolveRuntimeExecutionMode(source)).toBe("local-safe");
+  });
+
+  it("falls back to process.env when setting is absent", () => {
+    process.env.ELIZA_RUNTIME_MODE = "cloud";
+    expect(resolveRuntimeExecutionMode(null)).toBe("cloud");
+  });
+
+  it("defaults to local-yolo when no setting or env var is present", () => {
+    expect(resolveRuntimeExecutionMode(null)).toBe("local-yolo");
+  });
+
+  it("correctly evaluates sandbox, local, and cloud helpers", () => {
+    const safeSource = { getSetting: () => "local-safe" };
+    const yoloSource = { getSetting: () => "local-yolo" };
+    const cloudSource = { getSetting: () => "cloud" };
+
+    expect(resolveLocalExecutionMode(safeSource)).toBe("local-safe");
+    expect(resolveLocalExecutionMode(yoloSource)).toBe("local-yolo");
+    expect(resolveLocalExecutionMode(cloudSource)).toBe("local-yolo");
+
+    expect(shouldUseSandboxExecution(safeSource)).toBe(true);
+    expect(shouldUseSandboxExecution(yoloSource)).toBe(false);
+    expect(shouldUseSandboxExecution(cloudSource)).toBe(false);
+
+    expect(isCloudExecutionMode(cloudSource)).toBe(true);
+    expect(isCloudExecutionMode(safeSource)).toBe(false);
+  });
+});
+
+describe("RUNTIME_EXECUTION_MODE_DEFINITIONS", () => {
+  it("defines flags accurately for all modes", () => {
+    for (const mode of RUNTIME_EXECUTION_MODES) {
+      const def = RUNTIME_EXECUTION_MODE_DEFINITIONS[mode];
+      expect(def.mode).toBe(mode);
+      if (mode === "cloud") {
+        expect(def.cloud).toBe(true);
+        expect(def.local).toBe(false);
+      } else {
+        expect(def.cloud).toBe(false);
+        expect(def.local).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Add a comprehensive unit test suite in `packages/shared/src/config/runtime-mode.test.ts` covering:
  - `normalizeRuntimeExecutionMode` case insensitivity and whitespace trimming
  - Execution mode predicates (`isCloudRuntimeMode`, `isLocalRuntimeMode`, `isSafeLocalMode`, `isYoloLocalMode`)
  - Deployment target mapping in `runtimeExecutionModeForDeploymentTarget` and `readRuntimeExecutionModeConfig`
  - `resolveRuntimeExecutionMode` setting resolution precedence, environment variable fallback, and default selection
  - Local mode narrowing (`resolveLocalExecutionMode`), sandbox determination (`shouldUseSandboxExecution`), and cloud checks (`isCloudExecutionMode`)
  - `RUNTIME_EXECUTION_MODE_DEFINITIONS` flag validation

## Related Issues

- Fixes #21945

## Testing

- Added `packages/shared/src/config/runtime-mode.test.ts` with 10 tests and 46 assertions achieving 100% code coverage.
- `bun test packages/shared/src/config/runtime-mode.test.ts` passes.
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/config/runtime-mode.test.ts:
✓ runtime-mode normalization and predicates > normalizes valid mode strings case-insensitively and trims whitespace [0.12ms]
✓ runtime-mode normalization and predicates > returns null for invalid or non-string mode values [0.04ms]
✓ runtime-mode normalization and predicates > evaluates mode predicates correctly [0.10ms]
✓ deployment target and config resolution > resolves execution mode for deployment target [0.08ms]
✓ deployment target and config resolution > reads explicit executionMode from config or falls back to deploymentTarget [0.28ms]
✓ resolveRuntimeExecutionMode and helpers > prioritizes source getSetting over environment variables [0.71ms]
✓ resolveRuntimeExecutionMode and helpers > falls back to process.env when setting is absent [0.11ms]
✓ resolveRuntimeExecutionMode and helpers > defaults to local-yolo when no setting or env var is present [0.05ms]
✓ resolveRuntimeExecutionMode and helpers > correctly evaluates sandbox, local, and cloud helpers [0.42ms]
✓ RUNTIME_EXECUTION_MODE_DEFINITIONS > defines flags accurately for all modes [0.14ms]
--------------------------------------------------|---------|---------|-------------------
File                                              | % Funcs | % Lines | Uncovered Line #s
--------------------------------------------------|---------|---------|-------------------
 packages/shared/src/config/runtime-mode.ts       |  100.00 |  100.00 | 
--------------------------------------------------|---------|---------|-------------------

 10 pass
 0 fail
 46 expect() calls
Ran 10 tests across 1 file. [131.00ms]
```
