### PR TITLE
fix(shared): guard non-string gpuName in matchGpuProfile and add unit test suite

### DIFF
--- a/packages/shared/src/local-inference/gpu-profiles.test.ts
+++ b/packages/shared/src/local-inference/gpu-profiles.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for GPU deployment profiles, card matching, and headroom calculation.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  GPU_PROFILE_IDS,
+  GPU_PROFILES,
+  type GpuProfile,
+  matchGpuProfile,
+  reservedHeadroomGb,
+} from "./gpu-profiles.ts";
+
+describe("matchGpuProfile", () => {
+  it("matches supported GPU models accurately", () => {
+    expect(matchGpuProfile("NVIDIA GeForce RTX 3090")).toBe("rtx-3090");
+    expect(matchGpuProfile("NVIDIA GeForce RTX 4090")).toBe("rtx-4090");
+    expect(matchGpuProfile("NVIDIA RTX4090 D")).toBe("rtx-4090");
+    expect(matchGpuProfile("NVIDIA GeForce RTX 5090")).toBe("rtx-5090");
+    expect(matchGpuProfile("NVIDIA H200 (SXM 141 GiB)")).toBe("h200");
+  });
+
+  it("returns null for unsupported GPUs or invalid inputs", () => {
+    expect(matchGpuProfile("NVIDIA GeForce RTX 3080")).toBeNull();
+    expect(matchGpuProfile("NVIDIA A100-SXM4-80GB")).toBeNull();
+    expect(matchGpuProfile("Apple M2 Max")).toBeNull();
+    expect(matchGpuProfile("")).toBeNull();
+    expect(matchGpuProfile(null)).toBeNull();
+    expect(matchGpuProfile(undefined)).toBeNull();
+  });
+});
+
+describe("reservedHeadroomGb", () => {
+  it("calculates reserved headroom correctly per profile", () => {
+    expect(reservedHeadroomGb(GPU_PROFILES["rtx-3090"])).toBe(3);
+    expect(reservedHeadroomGb(GPU_PROFILES["rtx-4090"])).toBe(3);
+    expect(reservedHeadroomGb(GPU_PROFILES["rtx-5090"])).toBe(4);
+    expect(reservedHeadroomGb(GPU_PROFILES.h200)).toBe(6);
+  });
+
+  it("returns default headroom for nullish or invalid profiles", () => {
+    expect(reservedHeadroomGb(null)).toBe(3);
+    expect(reservedHeadroomGb(undefined)).toBe(3);
+    expect(reservedHeadroomGb({} as GpuProfile)).toBe(3);
+  });
+});
+
+describe("GPU_PROFILES and GPU_PROFILE_IDS", () => {
+  it("contains all listed profile IDs with complete configuration properties", () => {
+    for (const id of GPU_PROFILE_IDS) {
+      const profile = GPU_PROFILES[id];
+      expect(profile).toBeDefined();
+      expect(profile.id).toBe(id);
+      expect(profile.vramGb).toBeGreaterThan(0);
+      expect(profile.computeCapability).toMatch(/^sm_\d+$/);
+      expect(profile.recommendedBundles.length).toBeGreaterThan(0);
+      expect(profile.parallel).toBeGreaterThan(0);
+      expect(profile.batchSize).toBeGreaterThan(0);
+      expect(profile.ubatchSize).toBeGreaterThan(0);
+      expect(profile.kvCacheTypeK).toBeDefined();
+      expect(profile.kvCacheTypeV).toBeDefined();
+    }
+  });
+});

--- a/packages/shared/src/local-inference/gpu-profiles.ts
+++ b/packages/shared/src/local-inference/gpu-profiles.ts
@@ -242,7 +242,10 @@ export const GPU_PROFILE_IDS: ReadonlyArray<GpuProfileId> = [
  * The patterns are intentionally strict to avoid mis-classifying a 3080
  * as a 3090, or an A100 as a 4090.
  */
-export function matchGpuProfile(gpuName: string): GpuProfileId | null {
+export function matchGpuProfile(
+  gpuName: string | null | undefined,
+): GpuProfileId | null {
+  if (typeof gpuName !== "string") return null;
   const n = gpuName.toLowerCase();
   if (n.includes("h200")) return "h200";
   if (n.includes("rtx 5090") || n.includes("rtx5090")) return "rtx-5090";
@@ -260,7 +263,10 @@ export function matchGpuProfile(gpuName: string): GpuProfileId | null {
  * cards have different driver overheads (Windows display drivers steal
  * ~1 GiB before workloads even start; H200 SXM has none).
  */
-export function reservedHeadroomGb(profile: GpuProfile): number {
+export function reservedHeadroomGb(
+  profile: GpuProfile | null | undefined,
+): number {
+  if (!profile || typeof profile !== "object") return 3;
   switch (profile.id) {
     case "rtx-3090":
       return 3;
@@ -270,5 +276,7 @@ export function reservedHeadroomGb(profile: GpuProfile): number {
       return 4;
     case "h200":
       return 6;
+    default:
+      return 3;
   }
 }


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `matchGpuProfile` against non-string and nullish `gpuName` parameters.
- Guard `reservedHeadroomGb` against nullish or malformed `GpuProfile` objects.
- Add a dedicated unit test suite in `packages/shared/src/local-inference/gpu-profiles.test.ts` testing GPU model matching, unsupported GPU rejection, headroom calculation, and profile completeness across all supported card profiles with 100% coverage.

## Related Issues

- Fixes #21947

## Testing

- Added `packages/shared/src/local-inference/gpu-profiles.test.ts` with 5 tests covering:
  - Exact GPU name matching for RTX 3090, 4090, 5090, and H200
  - Rejection of unsupported GPUs (e.g. RTX 3080, A100, M2 Max, empty string, null)
  - Reserved headroom calculation and fallback defaults
  - Profile ID dictionary completeness and property validation
- `bun test packages/shared/src/local-inference/gpu-profiles.test.ts` passes (5/5 tests, 58 assertions, 100% coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/local-inference/gpu-profiles.test.ts:
✓ matchGpuProfile > matches supported GPU models accurately [0.17ms]
✓ matchGpuProfile > returns null for unsupported GPUs or invalid inputs [0.06ms]
✓ reservedHeadroomGb > calculates reserved headroom correctly per profile [0.08ms]
✓ reservedHeadroomGb > returns default headroom for nullish or invalid profiles [0.03ms]
✓ GPU_PROFILES and GPU_PROFILE_IDS > contains all listed profile IDs with complete configuration properties [0.20ms]
-----------------------------------------------------|---------|---------|-------------------
File                                                 | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------------|---------|---------|-------------------
 packages/shared/src/local-inference/gpu-profiles.ts |  100.00 |  100.00 | 
-----------------------------------------------------|---------|---------|-------------------

 5 pass
 0 fail
 58 expect() calls
Ran 5 tests across 1 file. [124.00ms]
```
