### PR TITLE
fix(shared): guard isWithinElizaRoot inputs, export paths from index, and add unit tests

### DIFF
--- a/packages/shared/src/local-inference/index.ts
+++ b/packages/shared/src/local-inference/index.ts
@@ -85,6 +85,13 @@ export {
   type NetworkPolicyReason,
   type RawNetworkState,
 } from "./network-policy.js";
+export {
+  downloadsStagingDir,
+  elizaModelsDir,
+  isWithinElizaRoot,
+  localInferenceRoot,
+  registryPath,
+} from "./paths.js";
 export type {
   ProviderEnableState,
   ProviderId,

--- a/packages/shared/src/local-inference/paths.test.ts
+++ b/packages/shared/src/local-inference/paths.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for local inference root paths and path confinement helpers.
+ */
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  downloadsStagingDir,
+  elizaModelsDir,
+  isWithinElizaRoot,
+  localInferenceRoot,
+  registryPath,
+} from "./paths.ts";
+
+describe("local-inference paths", () => {
+  it("resolves the local inference root directory", () => {
+    const root = localInferenceRoot();
+    expect(root).toBeDefined();
+    expect(root.endsWith("local-inference")).toBe(true);
+  });
+
+  it("resolves specific subdirectories and files relative to root", () => {
+    const root = localInferenceRoot();
+
+    expect(elizaModelsDir()).toBe(path.join(root, "models"));
+    expect(registryPath()).toBe(path.join(root, "registry.json"));
+    expect(downloadsStagingDir()).toBe(path.join(root, "downloads"));
+  });
+
+  it("checks whether paths are confined within the Eliza local-inference root", () => {
+    const root = localInferenceRoot();
+    const modelPath = path.join(root, "models", "eliza-1-9b.gguf");
+    const downloadPath = path.join(root, "downloads", "temp-part-001");
+
+    expect(isWithinElizaRoot(modelPath)).toBe(true);
+    expect(isWithinElizaRoot(downloadPath)).toBe(true);
+
+    // Exact root itself is not considered "within" (confinement check for sub-items)
+    expect(isWithinElizaRoot(root)).toBe(false);
+
+    // External paths and traversal attempts
+    expect(isWithinElizaRoot("/etc/passwd")).toBe(false);
+    expect(isWithinElizaRoot(path.join(root, "..", "other-dir"))).toBe(false);
+    expect(isWithinElizaRoot("")).toBe(false);
+    expect(isWithinElizaRoot("   ")).toBe(false);
+    expect(isWithinElizaRoot(null)).toBe(false);
+    expect(isWithinElizaRoot(undefined)).toBe(false);
+  });
+});

--- a/packages/shared/src/local-inference/paths.ts
+++ b/packages/shared/src/local-inference/paths.ts
@@ -36,7 +36,8 @@ export function downloadsStagingDir(): string {
 }
 
 /** True when `target` is inside Eliza's local-inference root. */
-export function isWithinElizaRoot(target: string): boolean {
+export function isWithinElizaRoot(target: string | null | undefined): boolean {
+  if (typeof target !== "string" || !target.trim()) return false;
   const root = path.resolve(localInferenceRoot());
   const resolved = path.resolve(target);
   if (resolved === root) return false;


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Guard `isWithinElizaRoot` against non-string, empty, and nullish `target` inputs.
- Re-export `paths.ts` path helpers (`downloadsStagingDir`, `elizaModelsDir`, `isWithinElizaRoot`, `localInferenceRoot`, `registryPath`) from the `@elizaos/shared/local-inference` barrel.
- Add a dedicated unit test suite in `packages/shared/src/local-inference/paths.test.ts` testing root resolution, model/download directory structures, registry file path, and confinement boundaries with 100% coverage.

## Related Issues

- Fixes #21949

## Testing

- Added `packages/shared/src/local-inference/paths.test.ts` with 3 tests covering:
  - Root directory resolution
  - Subdirectory and registry path calculations
  - Inside-root boundary checks and path traversal rejection
  - Guarding against nullish / empty inputs
- `bun test packages/shared/src/local-inference/paths.test.ts` passes (3/3 tests, 14 assertions, 100% coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/local-inference/paths.test.ts:
✓ local-inference paths > resolves the local inference root directory
✓ local-inference paths > resolves specific subdirectories and files relative to root
✓ local-inference paths > checks whether paths are confined within the Eliza local-inference root
----------------------------------------------|---------|---------|-------------------
File                                          | % Funcs | % Lines | Uncovered Line #s
----------------------------------------------|---------|---------|-------------------
 packages/shared/src/local-inference/paths.ts |  100.00 |  100.00 | 
----------------------------------------------|---------|---------|-------------------

 3 pass
 0 fail
 14 expect() calls
Ran 3 tests across 1 file. [930.00ms]
```
