### PR TITLE
feat(shared): add store/unrestricted predicates, export env key, and add unit tests for distribution-profile

### DIFF
--- a/packages/shared/src/config/__tests__/distribution-profile.test.ts
+++ b/packages/shared/src/config/__tests__/distribution-profile.test.ts
@@ -9,8 +9,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DISTRIBUTION_PROFILE_ENV_KEY,
   DISTRIBUTION_PROFILES,
   isDistributionProfile,
+  isStoreDistributionProfile,
+  isUnrestrictedDistributionProfile,
   resolveDistributionProfile,
 } from "../distribution-profile";
 
@@ -52,7 +55,24 @@ describe("distribution profile", () => {
     expect(isDistributionProfile(undefined)).toBe(false);
   });
 
-  it("exposes the canonical profile list", () => {
+  it("exposes the canonical profile list and env key", () => {
     expect([...DISTRIBUTION_PROFILES]).toEqual(["store", "unrestricted"]);
+    expect(DISTRIBUTION_PROFILE_ENV_KEY).toBe("ELIZA_DISTRIBUTION_PROFILE");
+  });
+
+  it("checks isStoreDistributionProfile and isUnrestrictedDistributionProfile", () => {
+    expect(isStoreDistributionProfile("store")).toBe(true);
+    expect(isStoreDistributionProfile("unrestricted")).toBe(false);
+    expect(isStoreDistributionProfile("other")).toBe(false);
+
+    expect(isUnrestrictedDistributionProfile("unrestricted")).toBe(true);
+    expect(isUnrestrictedDistributionProfile("store")).toBe(false);
+    expect(isUnrestrictedDistributionProfile(null)).toBe(false);
+  });
+
+  it("falls back to process.env when env argument is nullish", () => {
+    expect(
+      resolveDistributionProfile(null as unknown as NodeJS.ProcessEnv),
+    ).toBeDefined();
   });
 });

--- a/packages/shared/src/config/distribution-profile.ts
+++ b/packages/shared/src/config/distribution-profile.ts
@@ -14,7 +14,7 @@ export const DISTRIBUTION_PROFILES = ["store", "unrestricted"] as const;
 
 export type DistributionProfile = (typeof DISTRIBUTION_PROFILES)[number];
 
-const DISTRIBUTION_PROFILE_ENV_KEY = "ELIZA_DISTRIBUTION_PROFILE";
+export const DISTRIBUTION_PROFILE_ENV_KEY = "ELIZA_DISTRIBUTION_PROFILE";
 
 export function isDistributionProfile(
   value: unknown,
@@ -25,10 +25,19 @@ export function isDistributionProfile(
   );
 }
 
+export function isStoreDistributionProfile(value: unknown): boolean {
+  return isDistributionProfile(value) && value === "store";
+}
+
+export function isUnrestrictedDistributionProfile(value: unknown): boolean {
+  return isDistributionProfile(value) && value === "unrestricted";
+}
+
 export function resolveDistributionProfile(
   env: NodeJS.ProcessEnv = process.env,
 ): DistributionProfile {
-  const raw = env[DISTRIBUTION_PROFILE_ENV_KEY];
+  const safeEnv = env && typeof env === "object" ? env : process.env;
+  const raw = safeEnv[DISTRIBUTION_PROFILE_ENV_KEY];
   if (typeof raw !== "string") return "unrestricted";
   const trimmed = raw.trim().toLowerCase();
   if (!trimmed) return "unrestricted";


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Export `DISTRIBUTION_PROFILE_ENV_KEY = "ELIZA_DISTRIBUTION_PROFILE"`.
- Add and export `isStoreDistributionProfile(value: unknown): boolean` and `isUnrestrictedDistributionProfile(value: unknown): boolean` convenience predicates.
- Guard `resolveDistributionProfile` against non-object or nullish `env` parameters.
- Expand unit tests in `packages/shared/src/config/__tests__/distribution-profile.test.ts` covering predicates, exported constants, and fallback behaviors with 100% coverage.

## Related Issues

- Fixes #21951

## Testing

- Updated `packages/shared/src/config/__tests__/distribution-profile.test.ts` with 7 tests covering:
  - Defaulting to `"unrestricted"` on empty/unset inputs
  - Case-insensitive profile resolution
  - Explicit errors on unknown profiles
  - `isDistributionProfile` canonical checks
  - Canonical profile list and `DISTRIBUTION_PROFILE_ENV_KEY` constant
  - `isStoreDistributionProfile` and `isUnrestrictedDistributionProfile` predicates
  - Fallback on nullish `env` objects
- `bun test packages/shared/src/config/__tests__/distribution-profile.test.ts` passes (7/7 tests, 20 assertions, 100% coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/config/__tests__/distribution-profile.test.ts:
✓ distribution profile > defaults to unrestricted when env is unset or empty [0.18ms]
✓ distribution profile > accepts known profiles case-insensitively [0.08ms]
✓ distribution profile > throws on unknown profiles rather than silently defaulting [0.27ms]
✓ distribution profile > isDistributionProfile only accepts canonical values [0.06ms]
✓ distribution profile > exposes the canonical profile list and env key [0.10ms]
✓ distribution profile > checks isStoreDistributionProfile and isUnrestrictedDistributionProfile [0.10ms]
✓ distribution profile > falls back to process.env when env argument is nullish [0.13ms]
----------------------------------------------------|---------|---------|-------------------
File                                                | % Funcs | % Lines | Uncovered Line #s
----------------------------------------------------|---------|---------|-------------------
 packages/shared/src/config/distribution-profile.ts |  100.00 |  100.00 | 
----------------------------------------------------|---------|---------|-------------------

 7 pass
 0 fail
 20 expect() calls
Ran 7 tests across 1 file. [106.00ms]
```
