### PR TITLE
feat(shared): add type guards and converters for LifeOpsServiceError and add unit tests

### DIFF
--- a/packages/shared/src/lifeops-normalize/service-error.test.ts
+++ b/packages/shared/src/lifeops-normalize/service-error.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for LifeOpsServiceError construction, type guards, and error conversion.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isLifeOpsServiceError,
+  LifeOpsServiceError,
+  toLifeOpsServiceError,
+} from "./service-error.ts";
+
+describe("LifeOpsServiceError", () => {
+  it("constructs an error with status, message, and optional error code", () => {
+    const error = new LifeOpsServiceError(404, "Task not found", "NOT_FOUND");
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(LifeOpsServiceError);
+    expect(error.name).toBe("LifeOpsServiceError");
+    expect(error.status).toBe(404);
+    expect(error.message).toBe("Task not found");
+    expect(error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("isLifeOpsServiceError", () => {
+  it("returns true for instances of LifeOpsServiceError and matching shapes", () => {
+    const err = new LifeOpsServiceError(400, "Invalid payload");
+    expect(isLifeOpsServiceError(err)).toBe(true);
+
+    const crossRealmErr = new Error("Cross realm error");
+    crossRealmErr.name = "LifeOpsServiceError";
+    (crossRealmErr as unknown as { status: number }).status = 403;
+    expect(isLifeOpsServiceError(crossRealmErr)).toBe(true);
+  });
+
+  it("returns false for non-matching errors and primitives", () => {
+    expect(isLifeOpsServiceError(new Error("Generic error"))).toBe(false);
+    expect(isLifeOpsServiceError("String error")).toBe(false);
+    expect(isLifeOpsServiceError(404)).toBe(false);
+    expect(isLifeOpsServiceError(null)).toBe(false);
+    expect(isLifeOpsServiceError(undefined)).toBe(false);
+    expect(isLifeOpsServiceError({ status: 500 })).toBe(false);
+  });
+});
+
+describe("toLifeOpsServiceError", () => {
+  it("returns existing LifeOpsServiceError instance unchanged", () => {
+    const original = new LifeOpsServiceError(
+      401,
+      "Unauthorized",
+      "UNAUTHORIZED",
+    );
+    const converted = toLifeOpsServiceError(original);
+
+    expect(converted).toBe(original);
+    expect(converted.status).toBe(401);
+  });
+
+  it("converts standard Error instances using fallback status", () => {
+    const standardErr = new Error("Connection failed");
+    const converted = toLifeOpsServiceError(standardErr, 502);
+
+    expect(converted).toBeInstanceOf(LifeOpsServiceError);
+    expect(converted.status).toBe(502);
+    expect(converted.message).toBe("Connection failed");
+  });
+
+  it("converts string errors and unknown values", () => {
+    const fromString = toLifeOpsServiceError("Bad gateway", 502);
+    expect(fromString).toBeInstanceOf(LifeOpsServiceError);
+    expect(fromString.status).toBe(502);
+    expect(fromString.message).toBe("Bad gateway");
+
+    const fromNull = toLifeOpsServiceError(null);
+    expect(fromNull).toBeInstanceOf(LifeOpsServiceError);
+    expect(fromNull.status).toBe(500);
+    expect(fromNull.message).toBe("An unknown error occurred");
+  });
+});

--- a/packages/shared/src/lifeops-normalize/service-error.ts
+++ b/packages/shared/src/lifeops-normalize/service-error.ts
@@ -17,3 +17,28 @@ export class LifeOpsServiceError extends Error {
     this.name = "LifeOpsServiceError";
   }
 }
+
+export function isLifeOpsServiceError(
+  error: unknown,
+): error is LifeOpsServiceError {
+  return (
+    error instanceof LifeOpsServiceError ||
+    (error instanceof Error &&
+      error.name === "LifeOpsServiceError" &&
+      typeof (error as unknown as { status: unknown }).status === "number")
+  );
+}
+
+export function toLifeOpsServiceError(
+  error: unknown,
+  fallbackStatus = 500,
+): LifeOpsServiceError {
+  if (isLifeOpsServiceError(error)) return error;
+  if (error instanceof Error) {
+    return new LifeOpsServiceError(fallbackStatus, error.message);
+  }
+  if (typeof error === "string") {
+    return new LifeOpsServiceError(fallbackStatus, error);
+  }
+  return new LifeOpsServiceError(fallbackStatus, "An unknown error occurred");
+}


### PR DESCRIPTION
<!--
  elizaOS pull request template
-->

## Proposed Changes

- Add and export `isLifeOpsServiceError(error: unknown): error is LifeOpsServiceError` type guard supporting cross-realm error matching.
- Add and export `toLifeOpsServiceError(error: unknown, fallbackStatus?: number): LifeOpsServiceError` converting errors, strings, or unknown values into typed `LifeOpsServiceError` instances.
- Add a dedicated unit test suite in `packages/shared/src/lifeops-normalize/service-error.test.ts` testing error construction, type guard evaluation, and error conversions with 100% coverage.

## Related Issues

- Fixes #21953

## Testing

- Added `packages/shared/src/lifeops-normalize/service-error.test.ts` with 6 tests covering:
  - Error instance construction with status, message, and error codes
  - Type guard validation on real and cross-realm error shapes
  - False returns for primitive and generic errors
  - Error conversion preserving existing `LifeOpsServiceError` instances
  - Fallback status mapping for standard `Error` and string messages
  - Fallback defaults on nullish / unknown inputs
- `bun test packages/shared/src/lifeops-normalize/service-error.test.ts` passes (6/6 tests, 25 assertions, 100% coverage).
- `bun run --cwd packages/shared typecheck` and `bun run --cwd packages/shared lint` pass cleanly.

## Evidence Details

```
bun test v1.3.14 (0d9b296a)

packages/shared/src/lifeops-normalize/service-error.test.ts:
✓ LifeOpsServiceError > constructs an error with status, message, and optional error code [0.19ms]
✓ isLifeOpsServiceError > returns true for instances of LifeOpsServiceError and matching shapes [0.09ms]
✓ isLifeOpsServiceError > returns false for non-matching errors and primitives [0.07ms]
✓ toLifeOpsServiceError > returns existing LifeOpsServiceError instance unchanged [0.07ms]
✓ toLifeOpsServiceError > converts standard Error instances using fallback status [0.04ms]
✓ toLifeOpsServiceError > converts string errors and unknown values [0.04ms]
--------------------------------------------------------|---------|---------|-------------------
File                                                    | % Funcs | % Lines | Uncovered Line #s
--------------------------------------------------------|---------|---------|-------------------
 packages/shared/src/lifeops-normalize/service-error.ts |  100.00 |  100.00 | 
--------------------------------------------------------|---------|---------|-------------------

 6 pass
 0 fail
 25 expect() calls
Ran 6 tests across 1 file. [107.00ms]
```
