### PR TITLE
fix(ui): route calendar-upcoming hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/components/chat/widgets/calendar-upcoming-native.test.ts
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming-native.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves calendar glance hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../../../config/boot-config";
+import { ElizaClient } from "../../../api/client-base";
+import type { AgentRequestTransport } from "../../../api/transport";
+import {
+  CALENDAR_FEED_FETCH_TIMEOUT_MS,
+  CALENDAR_PROBE_FETCH_TIMEOUT_MS,
+  fetchCalendarConnectorAccounts,
+  fetchCalendarUpcomingFeed,
+} from "./calendar-upcoming";
+
+function makeClientWithTransport(request: AgentRequestTransport["request"]) {
+  const api = new ElizaClient("http://agent.example:2138", "token");
+  api.setRequestTransport({ request });
+  return api;
+}
+
+describe("calendar-upcoming ElizaClient native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the probe deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ accounts: [{ status: "connected" }] }),
+    );
+    const api = makeClientWithTransport(request);
+    await fetchCalendarConnectorAccounts(api);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/connectors/google/accounts",
+      expect.any(Object),
+      { timeoutMs: CALENDAR_PROBE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the feed deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ events: [] }),
+    );
+    const api = makeClientWithTransport(request);
+    await fetchCalendarUpcomingFeed(api, new URLSearchParams({ side: "owner" }));
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/lifeops/calendar/feed?side=owner",
+      expect.any(Object),
+      { timeoutMs: CALENDAR_FEED_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled feed hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    const api = makeClientWithTransport(request);
+    await expect(
+      fetchCalendarUpcomingFeed(
+        api,
+        new URLSearchParams({ side: "owner" }),
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/lifeops/calendar/feed?side=owner",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
@@ -25,20 +25,18 @@ vi.mock("../../../hooks/useAuthStatus", () => ({
 
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 
-const { getBaseUrlMock, publishMock, listConnectorAccountsMock } = vi.hoisted(
-  () => ({
-    getBaseUrlMock: vi.fn(() => "http://localhost"),
-    publishMock: vi.fn(),
-    listConnectorAccountsMock: vi.fn(),
-  }),
-);
+const { getBaseUrlMock, publishMock, fetchMock } = vi.hoisted(() => ({
+  getBaseUrlMock: vi.fn(() => "http://localhost"),
+  publishMock: vi.fn(),
+  fetchMock: vi.fn(),
+}));
 
 // Mock the client: getBaseUrl resolves without booting the real ElizaClient,
-// and listConnectorAccounts is the connection probe driven per-test.
+// and fetch is the native-complete seam for probe + feed hops.
 vi.mock("../../../api", () => ({
   client: {
     getBaseUrl: getBaseUrlMock,
-    listConnectorAccounts: listConnectorAccountsMock,
+    fetch: fetchMock,
   },
 }));
 
@@ -54,7 +52,13 @@ vi.mock("../../../chat/useSlashCommandController", () => ({
 }));
 
 import type { WidgetProps } from "../../../widgets/types";
-import { CalendarUpcomingWidget } from "./calendar-upcoming";
+import {
+  CALENDAR_FEED_FETCH_TIMEOUT_MS,
+  CALENDAR_PROBE_FETCH_TIMEOUT_MS,
+  CalendarUpcomingWidget,
+  fetchCalendarConnectorAccounts,
+  fetchCalendarUpcomingFeed,
+} from "./calendar-upcoming";
 
 // Minimal wire event matching LifeOpsCalendarEvent (@elizaos/shared
 // contracts/calendar.ts), only the fields the widget reads.
@@ -79,39 +83,35 @@ function event(
   };
 }
 
-function mockFeed(events: ReturnType<typeof event>[]) {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ events }),
-    })),
-  );
-}
-
-/** A linked Google account makes the connection probe resolve "connected". */
-function connectedGoogle() {
-  listConnectorAccountsMock.mockResolvedValue({
-    provider: "google",
-    connectorId: "google",
-    accounts: [
-      {
-        id: "g1",
-        provider: "google",
-        connectorId: "google",
-        label: "Work",
-        status: "connected",
-      },
-    ],
+function connectedGoogleWithFeed(events: ReturnType<typeof event>[]) {
+  fetchMock.mockImplementation(async (path: string) => {
+    if (String(path).includes("/api/connectors/")) {
+      return {
+        accounts: [
+          {
+            id: "g1",
+            provider: "google",
+            connectorId: "google",
+            label: "Work",
+            status: "connected",
+          },
+        ],
+      };
+    }
+    if (String(path).includes("/api/lifeops/calendar/feed")) {
+      return { events };
+    }
+    return { events: [] };
   });
 }
 
 /** No accounts → the probe resolves "disconnected" (connect affordance). */
 function disconnectedGoogle() {
-  listConnectorAccountsMock.mockResolvedValue({
-    provider: "google",
-    connectorId: "google",
-    accounts: [],
+  fetchMock.mockImplementation(async (path: string) => {
+    if (String(path).includes("/api/connectors/")) {
+      return { accounts: [] };
+    }
+    return { events: [] };
   });
 }
 
@@ -131,7 +131,7 @@ beforeEach(() => {
   getBaseUrlMock.mockReset();
   getBaseUrlMock.mockReturnValue("http://localhost");
   publishMock.mockReset();
-  listConnectorAccountsMock.mockReset();
+  fetchMock.mockReset();
 });
 
 describe("CalendarUpcomingWidget", () => {
@@ -144,19 +144,17 @@ describe("CalendarUpcomingWidget", () => {
     await waitFor(() => {
       expect(container.firstChild).toBeNull();
     });
-    expect(listConnectorAccountsMock).not.toHaveBeenCalled();
-    expect(globalThis.fetch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("renders NOTHING when no Google account is linked, no connect-CTA tile", async () => {
     disconnectedGoogle();
-    mockFeed([]);
     const { container } = render(<CalendarUpcomingWidget {...homeProps} />);
 
     // The probe settles to "disconnected" and the widget self-hides; the
     // connect flow lives in Settings → Connectors, not the home grid.
     await waitFor(() => {
-      expect(listConnectorAccountsMock).toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalled();
     });
     await waitFor(() => {
       expect(container.firstChild).toBeNull();
@@ -167,9 +165,7 @@ describe("CalendarUpcomingWidget", () => {
   });
 
   it("renders NOTHING when connected but no upcoming events, the row must earn its place", async () => {
-    connectedGoogle();
-    // A past event only, filtered out (startAt < now).
-    mockFeed([
+    connectedGoogleWithFeed([
       event({
         id: "past",
         startAt: new Date(Date.now() - 60 * 60_000).toISOString(),
@@ -178,7 +174,7 @@ describe("CalendarUpcomingWidget", () => {
     const { container } = render(<CalendarUpcomingWidget {...homeProps} />);
 
     await waitFor(() => {
-      expect(listConnectorAccountsMock).toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalled();
     });
     await waitFor(() => {
       expect(container.firstChild).toBeNull();
@@ -187,8 +183,7 @@ describe("CalendarUpcomingWidget", () => {
   });
 
   it("shows ONE high-priority datum, the soonest event, with a +N more badge", async () => {
-    connectedGoogle();
-    mockFeed([
+    connectedGoogleWithFeed([
       event({
         id: "a",
         title: "Standup",
@@ -220,8 +215,7 @@ describe("CalendarUpcomingWidget", () => {
   // is the narrower 18h window.
 
   it("renders the card when the next event is just inside the 18h gate (17h59m)", async () => {
-    connectedGoogle();
-    mockFeed([
+    connectedGoogleWithFeed([
       event({
         id: "soon",
         title: "Design sync",
@@ -235,10 +229,7 @@ describe("CalendarUpcomingWidget", () => {
   });
 
   it("yields its slot (renders null) when the next event is just past the 18h gate (18h01m)", async () => {
-    connectedGoogle();
-    // A real upcoming event, but beyond the 18h glance window: the feed returns
-    // it (14d query) yet the render gate holds the card null.
-    mockFeed([
+    connectedGoogleWithFeed([
       event({
         id: "far",
         title: "Next Tuesday",
@@ -250,10 +241,10 @@ describe("CalendarUpcomingWidget", () => {
     // The connector probe + feed both run (the event exists), but the card is
     // gated out, no tile occupies the home grid.
     await waitFor(() => {
-      expect(listConnectorAccountsMock).toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalled();
     });
     await waitFor(() => {
-      expect(globalThis.fetch as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalled();
     });
     await waitFor(() => {
       expect(container.firstChild).toBeNull();
@@ -262,8 +253,7 @@ describe("CalendarUpcomingWidget", () => {
   });
 
   it("does not publish home attention for a beyond-18h event (no card = no signal)", async () => {
-    connectedGoogle();
-    mockFeed([
+    connectedGoogleWithFeed([
       event({
         id: "far",
         title: "Next Tuesday",
@@ -273,7 +263,7 @@ describe("CalendarUpcomingWidget", () => {
     render(<CalendarUpcomingWidget {...homeProps} />);
 
     await waitFor(() => {
-      expect(globalThis.fetch as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalled();
     });
     // A gated-out card must never float the tile up; every publish call is null.
     await waitFor(() => {
@@ -290,8 +280,7 @@ describe("CalendarUpcomingWidget", () => {
     // render must still be null (the `now === 0` guard), the card only appears
     // after the effect installs the live clock. We assert the pre-effect frame,
     // then let the async probe/feed settle so nothing leaks past the test.
-    connectedGoogle();
-    mockFeed([
+    connectedGoogleWithFeed([
       event({
         id: "soon",
         title: "Design sync",
@@ -310,8 +299,7 @@ describe("CalendarUpcomingWidget", () => {
   });
 
   it("publishes the reminder weight when the next event starts within 2 hours (home slot)", async () => {
-    connectedGoogle();
-    mockFeed([
+    connectedGoogleWithFeed([
       event({
         id: "imminent",
         title: "Call",
@@ -327,8 +315,7 @@ describe("CalendarUpcomingWidget", () => {
   });
 
   it("navigates to the Calendar view when the populated card is clicked", async () => {
-    connectedGoogle();
-    mockFeed([event({ id: "a", title: "Standup" })]);
+    connectedGoogleWithFeed([event({ id: "a", title: "Standup" })]);
     const navEvents: string[] = [];
     const onNav = (e: Event) => {
       const detail = (e as CustomEvent<{ viewPath?: string }>).detail;
@@ -347,31 +334,109 @@ describe("CalendarUpcomingWidget", () => {
   // probe and the calendar feed must stay dormant while unauthenticated.
   it("does not probe the connector or fetch the feed while unauthenticated", async () => {
     authMock.authenticated = false;
-    connectedGoogle();
-    mockFeed([event({ id: "a", title: "Standup" })]);
+    connectedGoogleWithFeed([event({ id: "a", title: "Standup" })]);
 
     render(<CalendarUpcomingWidget {...homeProps} />);
 
     await Promise.resolve();
-    expect(listConnectorAccountsMock).not.toHaveBeenCalled();
-    expect(globalThis.fetch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("starts the probe + feed once the session flips to authenticated", async () => {
     authMock.authenticated = false;
-    connectedGoogle();
-    mockFeed([event({ id: "a", title: "Standup" })]);
+    connectedGoogleWithFeed([event({ id: "a", title: "Standup" })]);
 
     const { rerender } = render(<CalendarUpcomingWidget {...homeProps} />);
     await Promise.resolve();
-    expect(listConnectorAccountsMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
 
     authMock.authenticated = true;
     rerender(<CalendarUpcomingWidget {...homeProps} />);
 
     const card = await screen.findByTestId("chat-widget-calendar-upcoming");
     expect(card.textContent).toContain("Standup");
-    expect(listConnectorAccountsMock).toHaveBeenCalled();
-    expect(globalThis.fetch as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});
+
+describe("calendar-upcoming native-complete deadlines", () => {
+  it("keeps a documented budget per hop", () => {
+    expect(CALENDAR_PROBE_FETCH_TIMEOUT_MS).toBe(6_000);
+    expect(CALENDAR_FEED_FETCH_TIMEOUT_MS).toBe(8_000);
+  });
+
+  it("passes probe timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({ accounts: [{ status: "connected" }] });
+    const accounts = await fetchCalendarConnectorAccounts({
+      fetch: fetchMock,
+    });
+    expect(accounts).toEqual([{ status: "connected" }]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/connectors/google/accounts",
+      undefined,
+      { timeoutMs: CALENDAR_PROBE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes feed timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({
+      events: [
+        {
+          id: "evt-1",
+          title: "Standup",
+          startAt: "2026-08-18T10:00:00.000Z",
+          endAt: "2026-08-18T10:30:00.000Z",
+          isAllDay: false,
+          location: "",
+        },
+      ],
+    });
+    const events = await fetchCalendarUpcomingFeed(
+      { fetch: fetchMock },
+      new URLSearchParams({ side: "owner" }),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.title).toBe("Standup");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/lifeops/calendar/feed?side=owner",
+      undefined,
+      { timeoutMs: CALENDAR_FEED_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled feed hop as TimeoutError", async () => {
+    const timeout = Object.assign(new Error("Request timed out after 10ms"), {
+      name: "ApiError",
+      kind: "timeout",
+    });
+    fetchMock.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          setTimeout(() => reject(timeout), 10);
+        }),
+    );
+    await expect(
+      fetchCalendarUpcomingFeed(
+        { fetch: fetchMock },
+        new URLSearchParams({ side: "owner" }),
+        10,
+      ),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+  });
+
+  it("surfaces a provider error from a completed feed GET", async () => {
+    fetchMock.mockRejectedValue(
+      Object.assign(new Error("Goals request failed (503)"), {
+        name: "ApiError",
+        kind: "http",
+        status: 503,
+      }),
+    );
+    await expect(
+      fetchCalendarUpcomingFeed(
+        { fetch: fetchMock },
+        new URLSearchParams({ side: "owner" }),
+      ),
+    ).rejects.toMatchObject({ status: 503 });
   });
 });

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
@@ -19,7 +19,6 @@ import {
   useIntervalWhenDocumentVisible,
 } from "../../../hooks";
 import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
-import { withTimeout } from "../../../utils/with-timeout";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import type { WidgetProps } from "../../../widgets/types";
@@ -31,8 +30,10 @@ const GOOGLE_PROVIDER = "google";
 const DEFAULT_SPAN = "col-span-4 row-span-1";
 // Bound the bridge/feed calls so a hung agent channel settles the tile (connect
 // CTA / "No events today") instead of spinning on "Loading…" forever.
-const PROBE_TIMEOUT_MS = 6_000;
-const FEED_TIMEOUT_MS = 8_000;
+/** Connector-accounts probe — existing 6s glance budget, native timeoutMs. */
+export const CALENDAR_PROBE_FETCH_TIMEOUT_MS = 6_000;
+/** Calendar feed GET — existing 8s glance budget, independent hop. */
+export const CALENDAR_FEED_FETCH_TIMEOUT_MS = 8_000;
 
 // The home glanceable widget refreshes on a calm 60s cadence, the calendar
 // feed is far less volatile than the todo list.
@@ -88,6 +89,39 @@ function parseCalendarFeed(value: unknown): CalendarFeedEventWire[] {
   const events = (value as Record<string, unknown>).events;
   if (!Array.isArray(events)) return [];
   return events.filter(isCalendarFeedEvent);
+}
+
+type CalendarApi = Pick<typeof client, "fetch">;
+
+export async function fetchCalendarConnectorAccounts(
+  api: CalendarApi = client,
+  timeoutMs: number = CALENDAR_PROBE_FETCH_TIMEOUT_MS,
+): Promise<Array<{ status?: string }>> {
+  const body = await api.fetch<unknown>(
+    `/api/connectors/${encodeURIComponent(GOOGLE_PROVIDER)}/accounts`,
+    undefined,
+    { timeoutMs },
+  );
+  if (typeof body !== "object" || body === null) return [];
+  const accounts = (body as { accounts?: unknown }).accounts;
+  if (!Array.isArray(accounts)) return [];
+  return accounts.filter(
+    (account): account is { status?: string } =>
+      typeof account === "object" && account !== null,
+  );
+}
+
+export async function fetchCalendarUpcomingFeed(
+  api: CalendarApi = client,
+  params: URLSearchParams,
+  timeoutMs: number = CALENDAR_FEED_FETCH_TIMEOUT_MS,
+): Promise<CalendarFeedEventWire[]> {
+  const body = await api.fetch<unknown>(
+    `/api/lifeops/calendar/feed?${params.toString()}`,
+    undefined,
+    { timeoutMs },
+  );
+  return parseCalendarFeed(body);
 }
 
 /** Upcoming events (start >= now), soonest first. */
@@ -222,15 +256,12 @@ export function CalendarUpcomingWidget({
     if (!authenticated) return false;
 
     try {
-      const res = await withTimeout(
-        client.listConnectorAccounts(GOOGLE_PROVIDER),
-        PROBE_TIMEOUT_MS,
-      );
+      const accounts = await fetchCalendarConnectorAccounts();
       // Linked ONLY when an account is actually connected, a "needs-reauth" /
       // "pending" account is NOT usable, and treating it as linked left the tile
       // stuck on "Loading…" forever (the feed never returns), instead of showing
       // the "Connect calendar" affordance (matching the connectors strip).
-      const linked = res.accounts.some(
+      const linked = accounts.some(
         (account) => account.status === "connected",
       );
       setConnection(linked ? "connected" : "disconnected");
@@ -257,15 +288,7 @@ export function CalendarUpcomingWidget({
       timeZone,
     });
     try {
-      const res = await withTimeout(
-        fetch(
-          `${client.getBaseUrl()}/api/lifeops/calendar/feed?${params.toString()}`,
-        ),
-        FEED_TIMEOUT_MS,
-      );
-      if (!res.ok) return;
-      const json: unknown = await res.json();
-      const next = parseCalendarFeed(json);
+      const next = await fetchCalendarUpcomingFeed(client, params);
       // Skip the state update (and the re-render) when the poll is unchanged.
       setEvents((prev) => (eventsEqual(prev, next) ? prev : next));
     } catch {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. Calendar glance used `withTimeout(listConnectorAccounts)` (Promise.race, no explicit `timeoutMs`) and raw `fetch(\`${client.getBaseUrl()}/api/lifeops/calendar/feed\`)` (never reaches native `client.fetch`). This PR routes both hops through `client.fetch` / injected ElizaClient transport with the existing 6s probe and 8s feed budgets. Native-complete: injected `client.fetch`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not test-only `*WithFetch`. Not the ten inbox CR files. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not Atlas video (`#19302`). Not Twilio. Not shared-runtime. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Calendar event mapping and the 18h glance gate are unchanged. Probe stays 6s and feed stays 8s (sibling budgets, independent hops). Unfixed head: feed `fetch` had **no signal and no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: each hop calls `client.fetch(path, undefined, { timeoutMs })`; a 10ms stalled feed hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

`CalendarUpcomingWidget` probed Google via `withTimeout(client.listConnectorAccounts("google"), 6000)` and loaded the feed via raw `fetch` under `withTimeout`. Local-agent bridges discard `RequestInit.signal`, so Promise.race does not bound Android/iOS `client.fetch`. This PR exports `fetchCalendarConnectorAccounts` / `fetchCalendarUpcomingFeed` that call `client.fetch` with `{ timeoutMs }` and keeps the existing 6s / 8s glance budgets as separate deadlines.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Widget render rules unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/chat/widgets/calendar-upcoming-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`. `calendar-upcoming.test.tsx` — widget self-hide rules plus TimeoutError / provider-error / success on injected `client.fetch`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/components/chat/widgets/calendar-upcoming.test.tsx \
  src/components/chat/widgets/calendar-upcoming-native.test.ts
```

Unfixed head: feed GET hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 20 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Calendar glance hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Calendar glance hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the calendar-upcoming widget + native-transport files (20 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop feed hop: raw `fetch(\`${base}/api/lifeops/calendar/feed\`)` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: `client.fetch(..., { timeoutMs })` forwards the deadline to `Agent.request`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21810` not touched. `#21800` stays draft.

<!-- evidence-head:6a8fce8e09fffa091008b08d6358bdff3fde6515 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
