### PR TITLE
fix(ui): route unified-tasks hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/hooks/useUnifiedTasks-native.test.ts
+++ b/packages/ui/src/hooks/useUnifiedTasks-native.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves unified-task hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "../api/client-base";
+import type { AgentRequestTransport } from "../api/transport";
+import { setBootConfig } from "../config/boot-config";
+import {
+  fetchUnifiedAutomations,
+  fetchUnifiedScheduledTasks,
+  UNIFIED_AUTOMATIONS_FETCH_TIMEOUT_MS,
+  UNIFIED_SCHEDULED_TASKS_FETCH_TIMEOUT_MS,
+} from "./useUnifiedTasks";
+
+function makeClientWithTransport(request: AgentRequestTransport["request"]) {
+  const api = new ElizaClient("http://agent.example:2138", "token");
+  api.setRequestTransport({ request });
+  return api;
+}
+
+describe("useUnifiedTasks ElizaClient native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the automations deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({
+        automations: [],
+        summary: {
+          total: 0,
+          coordinatorCount: 0,
+          workflowCount: 0,
+          scheduledCount: 0,
+          draftCount: 0,
+        },
+        workflowStatus: null,
+        workflowFetchError: null,
+        executionFetchErrors: [],
+      }),
+    );
+    const api = makeClientWithTransport(request);
+    await fetchUnifiedAutomations(api);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/automations",
+      expect.any(Object),
+      { timeoutMs: UNIFIED_AUTOMATIONS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the scheduled-tasks deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ tasks: [] }),
+    );
+    const api = makeClientWithTransport(request);
+    await fetchUnifiedScheduledTasks(api, true);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/lifeops/scheduled-tasks?ownerVisibleOnly=1",
+      expect.any(Object),
+      { timeoutMs: UNIFIED_SCHEDULED_TASKS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled automations hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    const api = makeClientWithTransport(request);
+    await expect(fetchUnifiedAutomations(api, 10)).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/automations",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/hooks/useUnifiedTasks.test.tsx
+++ b/packages/ui/src/hooks/useUnifiedTasks.test.tsx
@@ -11,21 +11,28 @@ import type {
   ScheduledTaskView,
 } from "../api/client-types-core";
 
-// The hook reads the two list endpoints via the typed client — mock both. Each
-// is a spy so we can assert the parallel fetch, the per-source degrade, and the
-// ownerVisibleOnly default.
-const { listAutomationsMock, listScheduledTasksMock } = vi.hoisted(() => ({
-  listAutomationsMock: vi.fn(),
-  listScheduledTasksMock: vi.fn(),
+// Native-complete seam: automations go through workflowSurfaceClient.fetch,
+// scheduled tasks through the active client.fetch — each with its own timeoutMs.
+const { automationsFetchMock, scheduledFetchMock } = vi.hoisted(() => ({
+  automationsFetchMock: vi.fn(),
+  scheduledFetchMock: vi.fn(),
 }));
 vi.mock("../api", () => ({
   client: {
-    listAutomations: listAutomationsMock,
-    listScheduledTasks: listScheduledTasksMock,
+    fetch: scheduledFetchMock,
   },
 }));
+vi.mock("../api/workflow-surface-routing", () => ({
+  workflowSurfaceClient: () => ({ fetch: automationsFetchMock }),
+}));
 
-import { useUnifiedTasks } from "./useUnifiedTasks";
+import {
+  fetchUnifiedAutomations,
+  fetchUnifiedScheduledTasks,
+  UNIFIED_AUTOMATIONS_FETCH_TIMEOUT_MS,
+  UNIFIED_SCHEDULED_TASKS_FETCH_TIMEOUT_MS,
+  useUnifiedTasks,
+} from "./useUnifiedTasks";
 
 const automation: AutomationItem = {
   id: "workflow:w-1",
@@ -85,18 +92,16 @@ function scheduledResponse(
 
 describe("useUnifiedTasks", () => {
   beforeEach(() => {
-    listAutomationsMock.mockReset();
-    listScheduledTasksMock.mockReset();
+    automationsFetchMock.mockReset();
+    scheduledFetchMock.mockReset();
   });
   afterEach(() => {
     vi.useRealTimers();
   });
 
   it("merges automations + scheduled tasks into one list and settles loading", async () => {
-    listAutomationsMock.mockResolvedValue(automationsResponse([automation]));
-    listScheduledTasksMock.mockResolvedValue(
-      scheduledResponse([scheduledTask()]),
-    );
+    automationsFetchMock.mockResolvedValue(automationsResponse([automation]));
+    scheduledFetchMock.mockResolvedValue(scheduledResponse([scheduledTask()]));
 
     const { result } = renderHook(() => useUnifiedTasks());
     await waitFor(() => expect(result.current.state.loading).toBe(false));
@@ -105,21 +110,27 @@ describe("useUnifiedTasks", () => {
     expect(ids).toContain("workflow:w-1");
     expect(ids).toContain("scheduled:t-1");
     expect(result.current.state.error).toBeNull();
-    // Both sources fetched in parallel.
-    expect(listAutomationsMock).toHaveBeenCalledTimes(1);
-    expect(listScheduledTasksMock).toHaveBeenCalledTimes(1);
+    expect(automationsFetchMock).toHaveBeenCalledTimes(1);
+    expect(scheduledFetchMock).toHaveBeenCalledTimes(1);
+    expect(automationsFetchMock).toHaveBeenCalledWith(
+      "/api/automations",
+      undefined,
+      { timeoutMs: UNIFIED_AUTOMATIONS_FETCH_TIMEOUT_MS },
+    );
+    expect(scheduledFetchMock).toHaveBeenCalledWith(
+      "/api/lifeops/scheduled-tasks?ownerVisibleOnly=1",
+      undefined,
+      { timeoutMs: UNIFIED_SCHEDULED_TASKS_FETCH_TIMEOUT_MS },
+    );
   });
 
   it("degrades each source independently — one source failing yields empty for it, not an error", async () => {
-    listAutomationsMock.mockRejectedValue(new Error("automations not hosted"));
-    listScheduledTasksMock.mockResolvedValue(
-      scheduledResponse([scheduledTask()]),
-    );
+    automationsFetchMock.mockRejectedValue(new Error("automations not hosted"));
+    scheduledFetchMock.mockResolvedValue(scheduledResponse([scheduledTask()]));
 
     const { result } = renderHook(() => useUnifiedTasks());
     await waitFor(() => expect(result.current.state.loading).toBe(false));
 
-    // The whole hook still resolves; only the failed source is empty.
     expect(result.current.state.error).toBeNull();
     expect(result.current.state.items.map((i) => i.id)).toEqual([
       "scheduled:t-1",
@@ -127,8 +138,8 @@ describe("useUnifiedTasks", () => {
   });
 
   it("settles to empty (never throws) when BOTH sources fail", async () => {
-    listAutomationsMock.mockRejectedValue(new Error("down"));
-    listScheduledTasksMock.mockRejectedValue(new Error("down"));
+    automationsFetchMock.mockRejectedValue(new Error("down"));
+    scheduledFetchMock.mockRejectedValue(new Error("down"));
 
     const { result } = renderHook(() => useUnifiedTasks());
     await waitFor(() => expect(result.current.state.loading).toBe(false));
@@ -138,38 +149,107 @@ describe("useUnifiedTasks", () => {
   });
 
   it("requests owner-visible scheduled tasks by default", async () => {
-    listAutomationsMock.mockResolvedValue(automationsResponse([]));
-    listScheduledTasksMock.mockResolvedValue(scheduledResponse([]));
+    automationsFetchMock.mockResolvedValue(automationsResponse([]));
+    scheduledFetchMock.mockResolvedValue(scheduledResponse([]));
 
     renderHook(() => useUnifiedTasks());
     await waitFor(() =>
-      expect(listScheduledTasksMock).toHaveBeenCalledWith({
-        ownerVisibleOnly: true,
-      }),
+      expect(scheduledFetchMock).toHaveBeenCalledWith(
+        "/api/lifeops/scheduled-tasks?ownerVisibleOnly=1",
+        undefined,
+        { timeoutMs: UNIFIED_SCHEDULED_TASKS_FETCH_TIMEOUT_MS },
+      ),
     );
   });
 
   it("honors ownerVisibleOnly: false override", async () => {
-    listAutomationsMock.mockResolvedValue(automationsResponse([]));
-    listScheduledTasksMock.mockResolvedValue(scheduledResponse([]));
+    automationsFetchMock.mockResolvedValue(automationsResponse([]));
+    scheduledFetchMock.mockResolvedValue(scheduledResponse([]));
 
     renderHook(() => useUnifiedTasks({ ownerVisibleOnly: false }));
     await waitFor(() =>
-      expect(listScheduledTasksMock).toHaveBeenCalledWith({
-        ownerVisibleOnly: false,
-      }),
+      expect(scheduledFetchMock).toHaveBeenCalledWith(
+        "/api/lifeops/scheduled-tasks",
+        undefined,
+        { timeoutMs: UNIFIED_SCHEDULED_TASKS_FETCH_TIMEOUT_MS },
+      ),
     );
   });
 
   it("refresh() re-fetches both sources", async () => {
-    listAutomationsMock.mockResolvedValue(automationsResponse([]));
-    listScheduledTasksMock.mockResolvedValue(scheduledResponse([]));
+    automationsFetchMock.mockResolvedValue(automationsResponse([]));
+    scheduledFetchMock.mockResolvedValue(scheduledResponse([]));
 
     const { result } = renderHook(() => useUnifiedTasks());
     await waitFor(() => expect(result.current.state.loading).toBe(false));
 
-    const before = listAutomationsMock.mock.calls.length;
+    const before = automationsFetchMock.mock.calls.length;
     await result.current.refresh();
-    expect(listAutomationsMock.mock.calls.length).toBeGreaterThan(before);
+    expect(automationsFetchMock.mock.calls.length).toBeGreaterThan(before);
+  });
+});
+
+describe("unified-tasks native-complete deadlines", () => {
+  beforeEach(() => {
+    automationsFetchMock.mockReset();
+    scheduledFetchMock.mockReset();
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(UNIFIED_AUTOMATIONS_FETCH_TIMEOUT_MS).toBe(6_000);
+    expect(UNIFIED_SCHEDULED_TASKS_FETCH_TIMEOUT_MS).toBe(6_000);
+  });
+
+  it("passes automations timeoutMs through client.fetch", async () => {
+    automationsFetchMock.mockResolvedValue(automationsResponse([]));
+    await fetchUnifiedAutomations({ fetch: automationsFetchMock });
+    expect(automationsFetchMock).toHaveBeenCalledWith(
+      "/api/automations",
+      undefined,
+      { timeoutMs: UNIFIED_AUTOMATIONS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes scheduled timeoutMs through client.fetch", async () => {
+    scheduledFetchMock.mockResolvedValue(scheduledResponse([scheduledTask()]));
+    const listed = await fetchUnifiedScheduledTasks(
+      { fetch: scheduledFetchMock },
+      true,
+    );
+    expect(listed.tasks).toHaveLength(1);
+    expect(scheduledFetchMock).toHaveBeenCalledWith(
+      "/api/lifeops/scheduled-tasks?ownerVisibleOnly=1",
+      undefined,
+      { timeoutMs: UNIFIED_SCHEDULED_TASKS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled automations hop as TimeoutError", async () => {
+    const timeout = Object.assign(new Error("Request timed out after 10ms"), {
+      name: "ApiError",
+      kind: "timeout",
+    });
+    automationsFetchMock.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          setTimeout(() => reject(timeout), 10);
+        }),
+    );
+    await expect(
+      fetchUnifiedAutomations({ fetch: automationsFetchMock }, 10),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+  });
+
+  it("surfaces a provider error from a completed scheduled GET", async () => {
+    scheduledFetchMock.mockRejectedValue(
+      Object.assign(new Error("Scheduled tasks request failed (503)"), {
+        name: "ApiError",
+        kind: "http",
+        status: 503,
+      }),
+    );
+    await expect(
+      fetchUnifiedScheduledTasks({ fetch: scheduledFetchMock }, true),
+    ).rejects.toMatchObject({ status: 503 });
   });
 });

--- a/packages/ui/src/hooks/useUnifiedTasks.ts
+++ b/packages/ui/src/hooks/useUnifiedTasks.ts
@@ -7,14 +7,22 @@
  * second scheduler is introduced. Either source degrading (404 where the
  * runtime/runner isn't hosted, e.g. mobile) is treated as empty, mirroring the
  * existing self-hide behaviour of the automations surfaces.
+ *
+ * Each hop goes through ElizaClient `fetch` with its own `{ timeoutMs }` so
+ * Android/iOS `client.fetch` is actually bounded. Automations stay on
+ * `workflowSurfaceClient` (mobile Cloud routing). Scheduled tasks stay on the
+ * active client (plugin-scheduling is on-device).
  */
 
 import { useCallback, useEffect, useState } from "react";
 import { client } from "../api";
 import type { AutomationListResponse } from "../api/client-types-config";
-import type { ScheduledTaskListResponse } from "../api/client-types-core";
+import type {
+  ScheduledTaskListResponse,
+  ScheduledTaskView,
+} from "../api/client-types-core";
+import { workflowSurfaceClient } from "../api/workflow-surface-routing";
 import { mergeUnifiedTasks } from "../utils/merge-unified-tasks";
-import { withTimeout } from "../utils/with-timeout";
 
 export interface UnifiedTasksState {
   items: ReturnType<typeof mergeUnifiedTasks>;
@@ -55,7 +63,43 @@ export interface UseUnifiedTasksOptions {
   ownerVisibleOnly?: boolean;
 }
 
-const DEFAULT_TIMEOUT_MS = 6_000;
+/** Automations list hop — existing 6s glance budget, independent of scheduled. */
+export const UNIFIED_AUTOMATIONS_FETCH_TIMEOUT_MS = 6_000;
+/** Scheduled-tasks list hop — existing 6s glance budget, independent of automations. */
+export const UNIFIED_SCHEDULED_TASKS_FETCH_TIMEOUT_MS = 6_000;
+
+type UnifiedFetchClient = Pick<typeof client, "fetch">;
+
+function scheduledTasksPath(ownerVisibleOnly: boolean): string {
+  const params = new URLSearchParams();
+  if (ownerVisibleOnly) params.set("ownerVisibleOnly", "1");
+  const query = params.toString();
+  return `/api/lifeops/scheduled-tasks${query ? `?${query}` : ""}`;
+}
+
+export async function fetchUnifiedAutomations(
+  api: UnifiedFetchClient,
+  timeoutMs: number = UNIFIED_AUTOMATIONS_FETCH_TIMEOUT_MS,
+): Promise<AutomationListResponse> {
+  return api.fetch<AutomationListResponse>(
+    "/api/automations",
+    undefined,
+    { timeoutMs },
+  );
+}
+
+export async function fetchUnifiedScheduledTasks(
+  api: UnifiedFetchClient,
+  ownerVisibleOnly: boolean,
+  timeoutMs: number = UNIFIED_SCHEDULED_TASKS_FETCH_TIMEOUT_MS,
+): Promise<ScheduledTaskListResponse> {
+  const res = await api.fetch<{ tasks?: ScheduledTaskView[] }>(
+    scheduledTasksPath(ownerVisibleOnly),
+    undefined,
+    { timeoutMs },
+  );
+  return { tasks: Array.isArray(res?.tasks) ? res.tasks : [] };
+}
 
 async function settle<T>(promise: Promise<T>, fallback: T): Promise<T> {
   try {
@@ -71,21 +115,26 @@ export function useUnifiedTasks(options?: UseUnifiedTasksOptions): {
   state: UnifiedTasksState;
   refresh: () => Promise<void>;
 } {
-  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const automationsTimeoutMs =
+    options?.timeoutMs ?? UNIFIED_AUTOMATIONS_FETCH_TIMEOUT_MS;
+  const scheduledTimeoutMs =
+    options?.timeoutMs ?? UNIFIED_SCHEDULED_TASKS_FETCH_TIMEOUT_MS;
   const ownerVisibleOnly = options?.ownerVisibleOnly ?? true;
   const [state, setState] = useState<UnifiedTasksState>(INITIAL_STATE);
 
   const load = useCallback(
     async (signal: { cancelled: boolean }) => {
+      const automationsClient = workflowSurfaceClient(client);
       const [automations, scheduled] = await Promise.all([
         settle(
-          withTimeout(client.listAutomations(), timeoutMs),
+          fetchUnifiedAutomations(automationsClient, automationsTimeoutMs),
           EMPTY_AUTOMATIONS,
         ),
         settle(
-          withTimeout(
-            client.listScheduledTasks({ ownerVisibleOnly }),
-            timeoutMs,
+          fetchUnifiedScheduledTasks(
+            client,
+            ownerVisibleOnly,
+            scheduledTimeoutMs,
           ),
           EMPTY_SCHEDULED,
         ),
@@ -97,7 +146,7 @@ export function useUnifiedTasks(options?: UseUnifiedTasksOptions): {
       );
       setState({ items, automations, loading: false, error: null });
     },
-    [timeoutMs, ownerVisibleOnly],
+    [automationsTimeoutMs, scheduledTimeoutMs, ownerVisibleOnly],
   );
 
   useEffect(() => {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `useUnifiedTasks` wrapped `listAutomations` and `listScheduledTasks` in `withTimeout` (Promise.race). Those methods call `fetch(path)` with no `{ timeoutMs }`, so native never sees the 6s glance budget. This PR routes each hop through `client.fetch` / `{ timeoutMs }` with **separate** 6s deadlines. Automations stay on `workflowSurfaceClient` (mobile Cloud routing). Scheduled tasks stay on the active client. Native-complete: injected `client.fetch`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not test-only `*WithFetch`. Not the ten inbox CR files. Not `#21956` (calendar-upcoming, already posted). Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not Atlas video (`#19302`). Not Twilio. Not shared-runtime. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Merge/self-hide behaviour unchanged. Each hop keeps the existing 6s glance budget as an independent `timeoutMs`. Unfixed head: both hops called `fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(path, undefined, { timeoutMs })`; a 10ms stalled automations hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

`useUnifiedTasks` raced `client.listAutomations()` and `client.listScheduledTasks()` under `withTimeout`. Local-agent bridges discard `RequestInit.signal`, so Promise.race does not bound Android/iOS `client.fetch`. This PR exports `fetchUnifiedAutomations` / `fetchUnifiedScheduledTasks` that pass `{ timeoutMs }` and keeps automations on `workflowSurfaceClient`.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Hook merge rules unchanged. Optional `{ timeoutMs }` still overrides both hop defaults.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/hooks/useUnifiedTasks-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`. `useUnifiedTasks.test.tsx` — merge/degrade rules plus TimeoutError / provider-error / success on injected `client.fetch`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/hooks/useUnifiedTasks.test.tsx \
  src/hooks/useUnifiedTasks-native.test.ts
```

Unfixed head: both hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 14 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Unified-tasks hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Unified-tasks hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the unified-tasks hook + native-transport files (14 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: `fetch("/api/automations")` and `fetch("/api/lifeops/scheduled-tasks?ownerVisibleOnly=1")` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21810` not touched. `#21800` stays draft. `#21956` not restacked.

<!-- evidence-head:243d0955c5041a09e375004d31e1faa4234c9394 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
