### PR TITLE
fix(ui): route AppsSection relaunch and edit hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/components/chat/AppsSection-native.test.ts
+++ b/packages/ui/src/components/chat/AppsSection-native.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves AppsSection kebab hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "../../api/client-base";
+import type { AgentRequestTransport } from "../../api/transport";
+import { setBootConfig } from "../../config/boot-config";
+import {
+  APPS_CREATE_EDIT_FETCH_TIMEOUT_MS,
+  APPS_RELAUNCH_FETCH_TIMEOUT_MS,
+  relaunchAppViaClient,
+  startAppEditViaClient,
+} from "./AppsSection";
+
+function makeClientWithTransport(request: AgentRequestTransport["request"]) {
+  const api = new ElizaClient("http://agent.example:2138", "token");
+  api.setRequestTransport({ request });
+  return api;
+}
+
+describe("AppsSection ElizaClient native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the relaunch deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true }),
+    );
+    const api = makeClientWithTransport(request);
+    await relaunchAppViaClient(api, "demo");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/apps/relaunch",
+      expect.any(Object),
+      { timeoutMs: APPS_RELAUNCH_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the create/edit deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true }),
+    );
+    const api = makeClientWithTransport(request);
+    await startAppEditViaClient(api, "demo");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/apps/create",
+      expect.any(Object),
+      { timeoutMs: APPS_CREATE_EDIT_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled relaunch hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    const api = makeClientWithTransport(request);
+    await expect(relaunchAppViaClient(api, "demo", 10)).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/apps/relaunch",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/components/chat/AppsSection-timeout.test.ts
+++ b/packages/ui/src/components/chat/AppsSection-timeout.test.ts
@@ -1,0 +1,82 @@
+/** Verifies AppsSection kebab hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  APPS_CREATE_EDIT_FETCH_TIMEOUT_MS,
+  APPS_RELAUNCH_FETCH_TIMEOUT_MS,
+  relaunchAppViaClient,
+  startAppEditViaClient,
+} from "./AppsSection";
+
+const { fetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+}));
+
+describe("AppsSection native-complete deadlines", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(APPS_RELAUNCH_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(APPS_CREATE_EDIT_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes relaunch timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    await expect(
+      relaunchAppViaClient({ fetch: fetchMock }, "demo"),
+    ).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/apps/relaunch",
+      {
+        method: "POST",
+        body: JSON.stringify({ name: "demo" }),
+      },
+      { timeoutMs: APPS_RELAUNCH_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes create/edit timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    await expect(
+      startAppEditViaClient({ fetch: fetchMock }, "demo"),
+    ).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/apps/create",
+      {
+        method: "POST",
+        body: JSON.stringify({ intent: "edit", editTarget: "demo" }),
+      },
+      { timeoutMs: APPS_CREATE_EDIT_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled relaunch hop as TimeoutError", async () => {
+    const timeout = Object.assign(new Error("Request timed out after 10ms"), {
+      name: "ApiError",
+      kind: "timeout",
+    });
+    fetchMock.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          setTimeout(() => reject(timeout), 10);
+        }),
+    );
+    await expect(
+      relaunchAppViaClient({ fetch: fetchMock }, "demo", 10),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+  });
+
+  it("surfaces a provider error from a completed create/edit POST", async () => {
+    fetchMock.mockRejectedValue(
+      Object.assign(new Error("Apps create failed (503)"), {
+        name: "ApiError",
+        kind: "http",
+        status: 503,
+      }),
+    );
+    await expect(
+      startAppEditViaClient({ fetch: fetchMock }, "demo"),
+    ).rejects.toMatchObject({ status: 503 });
+  });
+});

--- a/packages/ui/src/components/chat/AppsSection.tsx
+++ b/packages/ui/src/components/chat/AppsSection.tsx
@@ -26,6 +26,43 @@ import {
 } from "../ui/dropdown-menu";
 import { WidgetSection } from "./widgets/shared";
 
+/** Relaunch POST — existing 10s REST budget, independent of create/edit. */
+export const APPS_RELAUNCH_FETCH_TIMEOUT_MS = 10_000;
+/** Create/edit POST — existing 10s REST budget, independent of relaunch. */
+export const APPS_CREATE_EDIT_FETCH_TIMEOUT_MS = 10_000;
+
+type AppsFetchClient = Pick<typeof client, "fetch">;
+
+export async function relaunchAppViaClient(
+  api: AppsFetchClient,
+  name: string,
+  timeoutMs: number = APPS_RELAUNCH_FETCH_TIMEOUT_MS,
+): Promise<unknown> {
+  return api.fetch(
+    "/api/apps/relaunch",
+    {
+      method: "POST",
+      body: JSON.stringify({ name }),
+    },
+    { timeoutMs },
+  );
+}
+
+export async function startAppEditViaClient(
+  api: AppsFetchClient,
+  name: string,
+  timeoutMs: number = APPS_CREATE_EDIT_FETCH_TIMEOUT_MS,
+): Promise<unknown> {
+  return api.fetch(
+    "/api/apps/create",
+    {
+      method: "POST",
+      body: JSON.stringify({ intent: "edit", editTarget: name }),
+    },
+    { timeoutMs },
+  );
+}
+
 function getRunRingClass(_run: AppRunSummary): string {
   return "";
 }
@@ -124,10 +161,7 @@ export function AppsSection({ headerAction }: AppsSectionProps = {}) {
   const handleRelaunch = useCallback(
     async (app: RegistryAppInfo) => {
       try {
-        await client.fetch("/api/apps/relaunch", {
-          method: "POST",
-          body: JSON.stringify({ name: app.name }),
-        });
+        await relaunchAppViaClient(client, app.name);
         setActionNotice(
           `${app.displayName ?? app.name} relaunched.`,
           "success",
@@ -153,10 +187,7 @@ export function AppsSection({ headerAction }: AppsSectionProps = {}) {
   const handleEdit = useCallback(
     async (app: RegistryAppInfo) => {
       try {
-        await client.fetch("/api/apps/create", {
-          method: "POST",
-          body: JSON.stringify({ intent: "edit", editTarget: app.name }),
-        });
+        await startAppEditViaClient(client, app.name);
         setActionNotice(
           `Editing ${app.displayName ?? app.name}…`,
           "info",


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. AppsSection kebab actions called `client.fetch("/api/apps/relaunch")` and `client.fetch("/api/apps/create")` with no third argument. This PR routes each hop through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (the existing ordinary default, now explicit). Native-complete: injected `client.fetch`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not test-only `*WithFetch`. Not the ten inbox CR files. Not `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not Atlas video (`#19302`). Not Twilio. Not shared-runtime. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Kebab notice / catalog-load behaviour unchanged. Each hop keeps the existing 10s ordinary REST budget as an independent `timeoutMs`. Unfixed head: both hops called `fetch(path, init)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(path, init, { timeoutMs })`; a 10ms stalled relaunch hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

AppsSection relaunch and edit POSTs omitted `{ timeoutMs }`. Local-agent bridges discard `RequestInit.signal`, so the default is not a glance-explicit native deadline. This PR exports `relaunchAppViaClient` / `startAppEditViaClient` that pass separate `{ timeoutMs }` values.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Widget render and kebab copy unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/chat/AppsSection-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`. `AppsSection-timeout.test.ts` — TimeoutError / provider-error / success on injected `client.fetch`. Existing catalog-load-error tests still pass.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/components/chat/AppsSection.catalog-load-error.test.tsx \
  src/components/chat/AppsSection-timeout.test.ts \
  src/components/chat/AppsSection-native.test.ts
```

Unfixed head: both hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 10 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. AppsSection kebab hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. AppsSection hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of AppsSection catalog + timeout + native-transport files (10 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: `fetch("/api/apps/relaunch", { method: "POST", ... })` and `fetch("/api/apps/create", { method: "POST", ... })` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21810` not touched. `#21800` stays draft. `#21964` / `#21956` not restacked.

<!-- evidence-head:b66784bba86db456be35086cec719c43572d68cb -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
