### PR TITLE
fix(electrobun): run the tab-encoding suite under vitest on unique ports

### DIFF
--- a/packages/app-core/platforms/electrobun/src/browser-workspace-bridge-server.encoding.test.ts
+++ b/packages/app-core/platforms/electrobun/src/browser-workspace-bridge-server.encoding.test.ts
@@ -1,13 +1,13 @@
 /** Exercises malformed browser-workspace tab identifiers at the bridge boundary. */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import http from "node:http";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-const closeTab = mock(
-  async (options: { id: string }) => options.id === "tab-1",
+const closeTab = vi.hoisted(() =>
+  vi.fn(async (options: { id: string }) => options.id === "tab-1"),
 );
 
-mock.module("./native/browser-workspace", () => ({
+vi.mock("./native/browser-workspace", () => ({
   getBrowserWorkspaceManager: () => ({
     listTabs: async () => ({ tabs: [] }),
     closeTab,
@@ -74,9 +74,13 @@ async function request(
 }
 
 describe("electrobun browser-workspace tab id encoding", () => {
+  let nextPort = 31991;
   beforeEach(() => {
     closeTab.mockClear();
-    process.env.ELIZA_BROWSER_WORKSPACE_PORT = "31991";
+    // A fresh port per test: the previous server's close is asynchronous, and
+    // reusing its port races the shutdown into ECONNRESET under vitest.
+    nextPort += 1;
+    process.env.ELIZA_BROWSER_WORKSPACE_PORT = String(nextPort);
     process.env.ELIZA_BROWSER_WORKSPACE_TOKEN = "test-tab-encoding-token";
   });
 


### PR DESCRIPTION
The new browser-workspace-bridge-server.encoding.test.ts imported bun:test, which the electrobun vitest lane cannot resolve (release candidate run 32112706836 — the only red in the full test lane). Converted to vitest (mock.module → vi.mock with a hoisted fn) and gave each test a fresh port: the previous server's close is asynchronous and reusing its port races the shutdown into ECONNRESET. Suite 6/6; Biome clean.