### PR TITLE
fix(cloud-api): enforce cookie-mutation CSRF guard on thin inference shells

### DIFF
--- a/packages/cloud/api/AGENTS.md
+++ b/packages/cloud/api/AGENTS.md
@@ -29,7 +29,8 @@ src/
   middleware/              auth.ts (global auth gate + public-path allowlist),
                            cookie-mutation-guard.ts (CSRF origin+marker gate for
                            cookie-authenticated mutations, mounted right after
-                           authMiddleware), org-membership.ts.
+                           authMiddleware and in the thin inference shell, which
+                           skips global auth), org-membership.ts.
   services/                audit/ (cloud-owned audit contract + dispatcher), audit-events.ts (required auth_events sink).
   queue/                   stripe-event.ts, types.ts (Cloudflare Queue consumers).
   steward/embedded.ts      Embedded Steward (auth provider) handler, mounted at /steward*.

--- a/packages/cloud/api/CLAUDE.md
+++ b/packages/cloud/api/CLAUDE.md
@@ -29,7 +29,8 @@ src/
   middleware/              auth.ts (global auth gate + public-path allowlist),
                            cookie-mutation-guard.ts (CSRF origin+marker gate for
                            cookie-authenticated mutations, mounted right after
-                           authMiddleware), org-membership.ts.
+                           authMiddleware and in the thin inference shell, which
+                           skips global auth), org-membership.ts.
   services/                audit/ (cloud-owned audit contract + dispatcher), audit-events.ts (required auth_events sink).
   queue/                   stripe-event.ts, types.ts (Cloudflare Queue consumers).
   steward/embedded.ts      Embedded Steward (auth provider) handler, mounted at /steward*.

--- a/packages/cloud/api/src/inference-app.test.ts
+++ b/packages/cloud/api/src/inference-app.test.ts
@@ -1,6 +1,7 @@
 /** Verifies the thin inference router's authentication and canonical route behavior. */
 import { describe, expect, test } from "bun:test";
 import { Hono, type ExecutionContext as HonoExecutionContext } from "hono";
+import { stewardCookieNames } from "@/lib/auth/steward-cookies";
 import { getRequestTaskDefer } from "@/lib/runtime/request-context";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import chatCompletionsRoute from "../v1/chat/completions/route";
@@ -207,5 +208,132 @@ describe("chat-only inference application", () => {
         code: "authentication_required",
       },
     });
+  });
+});
+
+/**
+ * W11-CLOUD-01: the thin inference shell must mount the same cookie-mutation
+ * CSRF guard as the full app. These requests go through the REAL
+ * createInferenceApp middleware chain into the REAL chat-completions route —
+ * the same shell index.ts dispatches /api/v1/chat and the fifteen other
+ * billable routes to, differing only in the mounted route module, which the
+ * guard never consults. The guard's 403 verdict body is a shape the route
+ * itself never emits, so a guard verdict unambiguously proves the shell
+ * rejected the request before routing.
+ */
+describe("thin inference shell cookie-mutation CSRF guard", () => {
+  const GUARD_REJECTION_CODES = new Set([
+    "forbidden_origin",
+    "csrf_marker_required",
+  ]);
+  const SESSION_COOKIE = `${stewardCookieNames(env.ENVIRONMENT).token}=attacker-replayed`;
+  const COMPLETIONS_URL = "https://api.elizacloud.ai/api/v1/chat/completions";
+  const FIRST_PARTY_ORIGIN = "https://cloud.eliza.app";
+  const HOSTED_USER_CONTENT_ORIGIN = "https://evil.sites.eliza.app";
+
+  function postCompletions(headers: Record<string, string>) {
+    return createChatInferenceApp().fetch(
+      new Request(COMPLETIONS_URL, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          model: "gemma-4-31b",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      }),
+      env,
+      executionCtx,
+    );
+  }
+
+  /** The guard's verdict code, or null when the guard let the request run. */
+  async function guardVerdict(res: Response): Promise<string | null> {
+    const body = (await res.json()) as { code?: unknown };
+    return res.status === 403 &&
+      typeof body.code === "string" &&
+      GUARD_REJECTION_CODES.has(body.code)
+      ? body.code
+      : null;
+  }
+
+  test("cookie-authed cross-site simple POST → 403 forbidden_origin", async () => {
+    // The finding's attack shape: same-site hosted user content fires a
+    // preflight-less text/plain POST and the browser attaches the cookie.
+    const res = await postCompletions({
+      cookie: SESSION_COOKIE,
+      origin: HOSTED_USER_CONTENT_ORIGIN,
+      "content-type": "text/plain",
+    });
+    expect(await guardVerdict(res)).toBe("forbidden_origin");
+  });
+
+  test("cookie-authed POST with no Origin/Referer → 403 forbidden_origin", async () => {
+    const res = await postCompletions({
+      cookie: SESSION_COOKIE,
+      "content-type": "application/json",
+    });
+    expect(await guardVerdict(res)).toBe("forbidden_origin");
+  });
+
+  test("cookie-authed simple POST from a first-party Origin → 403 csrf_marker_required", async () => {
+    const res = await postCompletions({
+      cookie: SESSION_COOKIE,
+      origin: FIRST_PARTY_ORIGIN,
+      "content-type": "text/plain",
+    });
+    expect(await guardVerdict(res)).toBe("csrf_marker_required");
+  });
+
+  test("first-party Origin + JSON marker → guard passes to route auth", async () => {
+    const res = await postCompletions({
+      cookie: SESSION_COOKIE,
+      origin: FIRST_PARTY_ORIGIN,
+      "content-type": "application/json",
+    });
+    expect(await guardVerdict(res)).toBeNull();
+    // The replayed cookie is not a valid session, so the route's own auth —
+    // which the guard must not bypass or short-circuit — answers instead.
+    expect(res.status).toBe(401);
+  });
+
+  test("first-party Origin + x-eliza-csrf header → guard passes to route auth", async () => {
+    const res = await postCompletions({
+      cookie: SESSION_COOKIE,
+      origin: FIRST_PARTY_ORIGIN,
+      "x-eliza-csrf": "1",
+      "content-type": "text/plain",
+    });
+    expect(await guardVerdict(res)).toBeNull();
+    expect(res.status).toBe(401);
+  });
+
+  test("Bearer programmatic auth skips the guard (no Origin needed)", async () => {
+    const res = await postCompletions({
+      authorization: "Bearer eliza_invalid_key",
+      "content-type": "text/plain",
+    });
+    expect(await guardVerdict(res)).toBeNull();
+  });
+
+  test("X-API-Key programmatic auth skips the guard (no Origin needed)", async () => {
+    const res = await postCompletions({
+      "x-api-key": "eliza_invalid_key",
+      "content-type": "text/plain",
+    });
+    expect(await guardVerdict(res)).toBeNull();
+  });
+
+  test("safe methods are exempt: cookie-authed GET with no Origin is not guard-rejected", async () => {
+    const res = await createChatInferenceApp().fetch(
+      new Request(COMPLETIONS_URL, {
+        method: "GET",
+        headers: { cookie: SESSION_COOKIE },
+      }),
+      env,
+      executionCtx,
+    );
+    // The completions route only defines POST, so the shell's own 404 proves
+    // the guard passed the request through to routing.
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/cloud/api/src/inference-app.ts
+++ b/packages/cloud/api/src/inference-app.ts
@@ -26,6 +26,7 @@ import { setRuntimeR2Bucket } from "@/lib/storage/r2-runtime-binding";
 import { logger } from "@/lib/utils/logger";
 import { describeUnhandledError } from "@/lib/utils/unhandled-error-detail";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { cookieMutationGuardMiddleware } from "./middleware/cookie-mutation-guard";
 
 /**
  * Chat-only application loaded by the thin Worker entrypoint.
@@ -35,6 +36,13 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * resolution, so mounting global auth here would only evaluate the unrelated
  * protected-route auth/audit tree. Billing and SSE remain wholly owned by the
  * canonical route module.
+ *
+ * The cookie-mutation CSRF guard is NOT optional the way global auth is: these
+ * routes authenticate the ambient session cookie, and the shell parses bodies
+ * content-type-agnostically, so a cross-origin "simple" request from same-site
+ * hosted user content would otherwise ride a victim's cookie into billable
+ * inference. The guard is lane-selecting — programmatic Bearer/API-key callers
+ * pass through untouched — and mirrors the full-app verdicts exactly.
  */
 export function createInferenceApp(
   mountPath: string,
@@ -140,6 +148,10 @@ export function createInferenceApp(
       { bindingName: "GLOBAL_RATE_LIMITER" },
     ),
   );
+
+  // CSRF: same mount point as bootstrap-app (immediately before the routes,
+  // after the global limiter). See middleware/cookie-mutation-guard.ts.
+  app.use("*", cookieMutationGuardMiddleware);
 
   app.route(mountPath, route);
   app.notFound((c) =>

--- a/packages/cloud/api/src/inference-chat-csrf.test.ts
+++ b/packages/cloud/api/src/inference-chat-csrf.test.ts
@@ -1,0 +1,123 @@
+/**
+ * W11-CLOUD-01 contract on the named endpoint: POST /api/v1/chat through the
+ * REAL createInferenceApp thin-shell middleware chain into the REAL chat route
+ * module — the exact pairing index.ts dispatches in production. A
+ * cookie-authenticated cross-site simple POST must die at the shell's
+ * cookie-mutation CSRF guard (403) before route auth or billing; programmatic
+ * Bearer/API-key callers and first-party browser mutations with a non-simple
+ * marker must pass the guard to the route's own auth.
+ *
+ * Harness: real shell + real route; only the drizzle schema edges are stubbed
+ * (`@/db/schemas` pulls @elizaos/plugin-sql, which is wrangler-aliased to a
+ * build stub and not importable in the unit lane). Guard rejections fire
+ * pre-route; pass-through cases reach route auth, which rejects the
+ * replayed/invalid credential (the api_keys lookup against the unreachable
+ * test DATABASE_URL included) before any billing or provider work.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { ExecutionContext as HonoExecutionContext } from "hono";
+
+process.env.NODE_ENV ||= "test";
+
+mock.module("@/db/schemas", () => ({}));
+mock.module("@/db/schemas/eliza", () => ({}));
+
+import { stewardCookieNames } from "@/lib/auth/steward-cookies";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import chatRoute from "../v1/chat/route";
+import { createInferenceApp } from "./inference-app";
+
+const executionCtx = {
+  waitUntil: () => undefined,
+  passThroughOnException: () => undefined,
+  props: undefined,
+} satisfies HonoExecutionContext;
+
+const env = {
+  ENVIRONMENT: "test",
+  NODE_ENV: "test",
+  REDIS_RATE_LIMITING: "false",
+  CACHE_ENABLED: "false",
+  DATABASE_URL: "postgres://test.invalid/eliza",
+  BLOB: {},
+} as AppEnv["Bindings"];
+
+const SESSION_COOKIE = `${stewardCookieNames(env.ENVIRONMENT).token}=attacker-replayed`;
+const CHAT_URL = "https://api.elizacloud.ai/api/v1/chat";
+const FIRST_PARTY_ORIGIN = "https://cloud.eliza.app";
+const HOSTED_USER_CONTENT_ORIGIN = "https://evil.sites.eliza.app";
+
+const GUARD_REJECTION_CODES = new Set([
+  "forbidden_origin",
+  "csrf_marker_required",
+]);
+
+function postChat(headers: Record<string, string>) {
+  return createInferenceApp("/api/v1/chat", chatRoute).fetch(
+    new Request(CHAT_URL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    }),
+    env,
+    executionCtx,
+  );
+}
+
+/** The guard's verdict code, or null when the guard let the request run. */
+async function guardVerdict(res: Response): Promise<string | null> {
+  const body = (await res.json()) as { code?: unknown };
+  return res.status === 403 &&
+    typeof body.code === "string" &&
+    GUARD_REJECTION_CODES.has(body.code)
+    ? body.code
+    : null;
+}
+
+describe("W11-CLOUD-01: /api/v1/chat thin-shell CSRF guard", () => {
+  test("cookie-authed cross-site simple POST → 403 before route auth or billing", async () => {
+    // The finding's attack shape: same-site hosted user content
+    // (<slug>.sites.eliza.app) fires a preflight-less text/plain POST and the
+    // browser attaches the victim's SameSite=Lax steward cookie.
+    const res = await postChat({
+      cookie: SESSION_COOKIE,
+      origin: HOSTED_USER_CONTENT_ORIGIN,
+      "content-type": "text/plain",
+    });
+    expect(res.status).toBe(403);
+    expect(await guardVerdict(res)).toBe("forbidden_origin");
+  });
+
+  test("Bearer and X-API-Key callers pass the guard lane", async () => {
+    const programmaticHeaders: Record<string, string>[] = [
+      { authorization: "Bearer eliza_invalid_key" },
+      { "x-api-key": "eliza_invalid_key" },
+    ];
+    for (const headers of programmaticHeaders) {
+      const res = await postChat({ ...headers, "content-type": "text/plain" });
+      expect(await guardVerdict(res)).toBeNull();
+      expect(res.status).not.toBe(403);
+    }
+  });
+
+  test("first-party Origin + non-simple marker passes the guard to route auth", async () => {
+    const markerHeaders: Record<string, string>[] = [
+      { "content-type": "application/json" },
+      { "content-type": "text/plain", "x-eliza-csrf": "1" },
+    ];
+    for (const headers of markerHeaders) {
+      const res = await postChat({
+        cookie: SESSION_COOKIE,
+        origin: FIRST_PARTY_ORIGIN,
+        ...headers,
+      });
+      expect(await guardVerdict(res)).toBeNull();
+      // The replayed cookie is invalid, so the route's own auth — which the
+      // guard must neither bypass nor short-circuit — answers, not the guard.
+      expect(res.status).not.toBe(403);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Security hardening (W11-CLOUD-01, medium): the thin inference entry path
(`THIN_INFERENCE_ENTRY_ENABLED`, enabled in production) dispatches the
billable `/api/v1` inference routes — including `/api/v1/chat` and
`/api/v1/chat/completions` — to lightweight Hono shells from
`createInferenceApp`. Those shells mounted CORS, secure headers, and the
global rate limiter, but not the cookie-mutation CSRF guard that the full app
runs right after `authMiddleware` (PR #21792). Since the thin routes
authenticate the ambient session cookie, cookie-authenticated mutations through
this lane did not get the full app's browser-origin + non-simple-marker
policy.

## Change

- `packages/cloud/api/src/inference-app.ts`: mount
  `cookieMutationGuardMiddleware` in `createInferenceApp`, at the same
  relative position as in `bootstrap-app` (after the global limiter,
  immediately before the route). Full-app semantics apply unchanged:
  - mutating `/api/*` requests carrying the ambient session cookie must
    present a first-party browser origin and a non-simple request marker, else
    403 with the same verdict codes/response shape as the full app;
  - safe methods, cookie-less requests, and programmatic credentials
    (`Authorization: Bearer`, `X-API-Key`, `X-Service-Key`) pass through
    untouched — programmatic clients are unaffected.
- `packages/cloud/api/AGENTS.md` / `CLAUDE.md`: note the guard's second
  mount point (pair kept byte-identical; `check:agents-claude` passes).

## Tests

New contract coverage drives requests through the real
`createInferenceApp` middleware chain into the real route modules (no shell
or guard mocking):

- `src/inference-chat-csrf.test.ts` — the named `/api/v1/chat` pairing:
  cookie-authed cross-origin simple POST → 403 `forbidden_origin` before
  route auth/billing; Bearer and `X-API-Key` callers pass the guard lane;
  first-party origin + JSON or `x-eliza-csrf` marker passes to route auth.
- `src/inference-app.test.ts` — full guard matrix on the shell with the real
  chat-completions route: cross-origin simple POST, missing Origin/Referer,
  first-party origin without marker (all 403 with the guard's verdict codes),
  marker/credential/safe-method pass-throughs.

## Validation

- `node test/run-unit-isolated.mjs inference` (package unit lane): all 8
  files pass, including the two suites above (17 new assertions green).
- `bun test` on neighboring affected suites: `src/index.test.ts` (44),
  `chat-completions-passthrough-streaming` (44), `embeddings-passthrough`
  (7), `cookie-mutation-guard` (11) — all green.
- `tsc --noEmit` clean for the package; `biome check src/` clean;
  `check:worker-bundle` (wrangler production dry-run) succeeds.