### PR TITLE
fix(ui): route BrowserWorkspaceView bridge hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/components/pages/BrowserWorkspaceView-native.test.ts
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView-native.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves browser-bridge hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "../../api/client-base";
+import type { AgentRequestTransport } from "../../api/transport";
+import { setBootConfig } from "../../config/boot-config";
+import {
+  BROWSER_BRIDGE_OPEN_MANAGER_FETCH_TIMEOUT_MS,
+  BROWSER_BRIDGE_PACKAGES_FETCH_TIMEOUT_MS,
+  fetchBrowserBridgePackages,
+  openBrowserBridgeChromeManager,
+} from "./BrowserWorkspaceView";
+
+function makeClientWithTransport(request: AgentRequestTransport["request"]) {
+  const api = new ElizaClient("http://agent.example:2138", "token");
+  api.setRequestTransport({ request });
+  return api;
+}
+
+describe("BrowserWorkspaceView ElizaClient native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the packages deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ status: {} }),
+    );
+    const api = makeClientWithTransport(request);
+    await fetchBrowserBridgePackages(api);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/browser-bridge/packages",
+      expect.any(Object),
+      { timeoutMs: BROWSER_BRIDGE_PACKAGES_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the open-manager deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true }),
+    );
+    const api = makeClientWithTransport(request);
+    await openBrowserBridgeChromeManager(api);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/browser-bridge/packages/chrome/open-manager",
+      expect.any(Object),
+      { timeoutMs: BROWSER_BRIDGE_OPEN_MANAGER_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled open-manager hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    const api = makeClientWithTransport(request);
+    await expect(
+      openBrowserBridgeChromeManager(api, 10),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/browser-bridge/packages/chrome/open-manager",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/components/pages/BrowserWorkspaceView-timeout.test.ts
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView-timeout.test.ts
@@ -1,0 +1,121 @@
+/** Verifies BrowserWorkspaceView bridge hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BROWSER_BRIDGE_CHROME_BUILD_FETCH_TIMEOUT_MS,
+  BROWSER_BRIDGE_COMPANIONS_FETCH_TIMEOUT_MS,
+  BROWSER_BRIDGE_OPEN_MANAGER_FETCH_TIMEOUT_MS,
+  BROWSER_BRIDGE_OPEN_PATH_FETCH_TIMEOUT_MS,
+  BROWSER_BRIDGE_PACKAGES_FETCH_TIMEOUT_MS,
+  buildBrowserBridgeChromePackage,
+  fetchBrowserBridgeCompanions,
+  fetchBrowserBridgePackages,
+  openBrowserBridgeChromeManager,
+  revealBrowserBridgeOpenPath,
+} from "./BrowserWorkspaceView";
+
+const { fetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+}));
+
+describe("BrowserWorkspaceView native-complete deadlines", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(BROWSER_BRIDGE_COMPANIONS_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(BROWSER_BRIDGE_PACKAGES_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(BROWSER_BRIDGE_CHROME_BUILD_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(BROWSER_BRIDGE_OPEN_PATH_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(BROWSER_BRIDGE_OPEN_MANAGER_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes companions timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({ companions: [] });
+    await fetchBrowserBridgeCompanions({ fetch: fetchMock });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/browser-bridge/companions",
+      undefined,
+      { timeoutMs: BROWSER_BRIDGE_COMPANIONS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes packages timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({ status: { chromeBuildPath: "/tmp" } });
+    await fetchBrowserBridgePackages({ fetch: fetchMock });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/browser-bridge/packages",
+      undefined,
+      { timeoutMs: BROWSER_BRIDGE_PACKAGES_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes chrome-build timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({ status: { chromeBuildPath: "/tmp" } });
+    await buildBrowserBridgeChromePackage({ fetch: fetchMock });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/browser-bridge/packages/chrome/build",
+      { method: "POST" },
+      { timeoutMs: BROWSER_BRIDGE_CHROME_BUILD_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes open-path timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({
+      path: "/tmp/bridge",
+      target: "chrome_build",
+      revealOnly: true,
+    });
+    await revealBrowserBridgeOpenPath({ fetch: fetchMock });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/browser-bridge/packages/open-path",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          target: "chrome_build",
+          revealOnly: true,
+        }),
+      },
+      { timeoutMs: BROWSER_BRIDGE_OPEN_PATH_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes open-manager timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    await openBrowserBridgeChromeManager({ fetch: fetchMock });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/browser-bridge/packages/chrome/open-manager",
+      { method: "POST" },
+      { timeoutMs: BROWSER_BRIDGE_OPEN_MANAGER_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled open-manager hop as TimeoutError", async () => {
+    const timeout = Object.assign(new Error("Request timed out after 10ms"), {
+      name: "ApiError",
+      kind: "timeout",
+    });
+    fetchMock.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          setTimeout(() => reject(timeout), 10);
+        }),
+    );
+    await expect(
+      openBrowserBridgeChromeManager({ fetch: fetchMock }, 10),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+  });
+
+  it("surfaces a provider error from a completed companions GET", async () => {
+    fetchMock.mockRejectedValue(
+      Object.assign(new Error("Companions request failed (503)"), {
+        name: "ApiError",
+        kind: "http",
+        status: 503,
+      }),
+    );
+    await expect(
+      fetchBrowserBridgeCompanions({ fetch: fetchMock }),
+    ).rejects.toMatchObject({ status: 503 });
+  });
+});

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -76,6 +76,84 @@ import {
 } from "./browser-workspace-wallet";
 import { useBrowserWorkspaceWalletBridge } from "./useBrowserWorkspaceWalletBridge";
 
+/** Companions GET — existing 10s REST budget, independent hop. */
+export const BROWSER_BRIDGE_COMPANIONS_FETCH_TIMEOUT_MS = 10_000;
+/** Packages status GET — existing 10s REST budget, independent hop. */
+export const BROWSER_BRIDGE_PACKAGES_FETCH_TIMEOUT_MS = 10_000;
+/** Chrome build POST — existing 10s REST budget, independent hop. */
+export const BROWSER_BRIDGE_CHROME_BUILD_FETCH_TIMEOUT_MS = 10_000;
+/** Open-path POST — existing 10s REST budget, independent hop. */
+export const BROWSER_BRIDGE_OPEN_PATH_FETCH_TIMEOUT_MS = 10_000;
+/** Chrome extensions manager POST — existing 10s REST budget, independent hop. */
+export const BROWSER_BRIDGE_OPEN_MANAGER_FETCH_TIMEOUT_MS = 10_000;
+
+type BrowserFetchClient = Pick<typeof client, "fetch">;
+
+export async function fetchBrowserBridgeCompanions(
+  api: BrowserFetchClient,
+  timeoutMs: number = BROWSER_BRIDGE_COMPANIONS_FETCH_TIMEOUT_MS,
+) {
+  return api.fetch<{ companions: BrowserBridgeCompanionStatus[] }>(
+    "/api/browser-bridge/companions",
+    undefined,
+    { timeoutMs },
+  );
+}
+
+export async function fetchBrowserBridgePackages(
+  api: BrowserFetchClient,
+  timeoutMs: number = BROWSER_BRIDGE_PACKAGES_FETCH_TIMEOUT_MS,
+) {
+  return api.fetch<{ status: BrowserBridgeCompanionPackageStatus }>(
+    "/api/browser-bridge/packages",
+    undefined,
+    { timeoutMs },
+  );
+}
+
+export async function buildBrowserBridgeChromePackage(
+  api: BrowserFetchClient,
+  timeoutMs: number = BROWSER_BRIDGE_CHROME_BUILD_FETCH_TIMEOUT_MS,
+) {
+  return api.fetch<{ status: BrowserBridgeCompanionPackageStatus }>(
+    "/api/browser-bridge/packages/chrome/build",
+    { method: "POST" },
+    { timeoutMs },
+  );
+}
+
+export async function revealBrowserBridgeOpenPath(
+  api: BrowserFetchClient,
+  timeoutMs: number = BROWSER_BRIDGE_OPEN_PATH_FETCH_TIMEOUT_MS,
+) {
+  return api.fetch<{
+    path: string;
+    target: string;
+    revealOnly: boolean;
+  }>(
+    "/api/browser-bridge/packages/open-path",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        target: "chrome_build",
+        revealOnly: true,
+      }),
+    },
+    { timeoutMs },
+  );
+}
+
+export async function openBrowserBridgeChromeManager(
+  api: BrowserFetchClient,
+  timeoutMs: number = BROWSER_BRIDGE_OPEN_MANAGER_FETCH_TIMEOUT_MS,
+) {
+  return api.fetch(
+    "/api/browser-bridge/packages/chrome/open-manager",
+    { method: "POST" },
+    { timeoutMs },
+  );
+}
+
 const POLL_INTERVAL_MS = 2_500;
 const BROWSER_BRIDGE_POLL_INTERVAL_MS = 4_000;
 const BROWSER_WORKSPACE_AGENT_PARTITION = "persist:eliza-browser-agent";
@@ -820,12 +898,8 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         setBrowserBridgeLoading(true);
       }
       const [companionsResult, packageResult] = await Promise.allSettled([
-        client.fetch<{ companions: BrowserBridgeCompanionStatus[] }>(
-          "/api/browser-bridge/companions",
-        ),
-        client.fetch<{ status: BrowserBridgeCompanionPackageStatus }>(
-          "/api/browser-bridge/packages",
-        ),
+        fetchBrowserBridgeCompanions(client),
+        fetchBrowserBridgePackages(client),
       ]);
       if (companionsResult.status === "fulfilled") {
         setBrowserBridgeCompanions(companionsResult.value.companions);
@@ -2391,35 +2465,16 @@ export function BrowserWorkspaceView(): React.JSX.Element {
       async () => {
         let nextPackageStatus = browserBridgePackageStatus;
         if (!nextPackageStatus?.chromeBuildPath) {
-          const buildResponse = await client.fetch<{
-            status: BrowserBridgeCompanionPackageStatus;
-          }>("/api/browser-bridge/packages/chrome/build", {
-            method: "POST",
-          });
+          const buildResponse = await buildBrowserBridgeChromePackage(client);
           nextPackageStatus = buildResponse.status;
           setBrowserBridgePackageStatus(buildResponse.status);
         }
 
-        const revealResponse = await client.fetch<{
-          path: string;
-          target: string;
-          revealOnly: boolean;
-        }>("/api/browser-bridge/packages/open-path", {
-          method: "POST",
-          body: JSON.stringify({
-            target: "chrome_build",
-            revealOnly: true,
-          }),
-        });
+        const revealResponse = await revealBrowserBridgeOpenPath(client);
 
         let openedManager = true;
         try {
-          await client.fetch(
-            "/api/browser-bridge/packages/chrome/open-manager",
-            {
-              method: "POST",
-            },
-          );
+          await openBrowserBridgeChromeManager(client);
         } catch {
           openedManager = false;
         }
@@ -2456,17 +2511,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     await runBrowserWorkspaceAction(
       "browser-bridge:reveal-folder",
       async () => {
-        const response = await client.fetch<{
-          path: string;
-          target: string;
-          revealOnly: boolean;
-        }>("/api/browser-bridge/packages/open-path", {
-          method: "POST",
-          body: JSON.stringify({
-            target: "chrome_build",
-            revealOnly: true,
-          }),
-        });
+        const response = await revealBrowserBridgeOpenPath(client);
         setActionNoticeRef.current(
           t("browserworkspace.BrowserBridgeFolderRevealed", {
             defaultValue:
@@ -2488,9 +2533,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     await runBrowserWorkspaceAction(
       "browser-bridge:open-manager",
       async () => {
-        await client.fetch("/api/browser-bridge/packages/chrome/open-manager", {
-          method: "POST",
-        });
+        await openBrowserBridgeChromeManager(client);
         setActionNoticeRef.current(
           t("browserworkspace.BrowserBridgeOpenedChromeExtensions", {
             defaultValue:


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `BrowserWorkspaceView` called `client.fetch` for companions, packages, chrome/build, open-path, and chrome/open-manager with no `{ timeoutMs }`. This PR routes each hop through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (existing ordinary default, now explicit). Native-complete: injected `client.fetch`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not `*WithFetch`. Not `packages/browser-bridge-extension/**` (already owned). Not cloud launch-sessions / `browser-launch.ts`. Not the ten inbox CR files. Not `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not Atlas video (`#19302`). Not Twilio. Not shared-runtime. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Chrome fullscreen / wallet-origin behaviour unchanged. Each hop keeps the existing 10s ordinary REST budget as an independent `timeoutMs`. Unfixed head: all five hops called `fetch(path[, init])` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled open-manager hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

Browser workspace companion-bridge reads and chrome-extension install/reveal/open-manager POSTs omitted `{ timeoutMs }`. This PR exports per-hop helpers that pass separate `{ timeoutMs }` values.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Workspace chrome unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/pages/BrowserWorkspaceView-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`. `BrowserWorkspaceView-timeout.test.ts` — TimeoutError / provider-error / success on injected `client.fetch`. Existing chrome tests still pass.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/components/pages/BrowserWorkspaceView.chrome.test.tsx \
  src/components/pages/BrowserWorkspaceView-timeout.test.ts \
  src/components/pages/BrowserWorkspaceView-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 27 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Browser-bridge hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Browser-bridge hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of BrowserWorkspaceView chrome + timeout + native-transport files (27 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: companions, packages, chrome/build, open-path, and open-manager `client.fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. `packages/browser-bridge-extension/**` not touched. Cloud launch-sessions / `browser-launch.ts` not touched. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21810` not touched. `#21800` stays draft. `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:f7c05605ad9eaae99b662388fdddf59b3e08d1e1 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
