### PR TITLE
fix(ui): route voice-profile first-run and profile hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-voice-profiles-native.test.ts
+++ b/packages/ui/src/api/client-voice-profiles-native.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves voice-profile first-run and profile hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  VOICE_PROFILES_APPEND_FETCH_TIMEOUT_MS,
+  VOICE_PROFILES_FINALIZE_FETCH_TIMEOUT_MS,
+  VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS,
+  VoiceProfilesClient,
+  VoiceProfilesUnavailableError,
+} from "./client-voice-profiles";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeVoices(request: AgentRequestTransport["request"]) {
+  const api = new ElizaClient("http://agent.example:2138", "token");
+  api.setRequestTransport({ request });
+  return new VoiceProfilesClient(api);
+}
+
+describe("VoiceProfilesClient ElizaClient native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the append deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({}),
+    );
+    const voices = makeVoices(request);
+    await voices.appendOwnerCapture("s1", {
+      promptId: "p1",
+      audioBase64: "YQ==",
+      durationMs: 1,
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/voice/first-run/profile/append?id=s1",
+      expect.any(Object),
+      { timeoutMs: VOICE_PROFILES_APPEND_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the finalize deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({
+        profileId: "p1",
+        entityId: "e1",
+        isOwner: true,
+      }),
+    );
+    const voices = makeVoices(request);
+    await voices.finalizeOwnerCapture("s1", { displayName: "Shaw" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/voice/first-run/profile/finalize?id=s1",
+      expect.any(Object),
+      { timeoutMs: VOICE_PROFILES_FINALIZE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the profile patch deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({}),
+    );
+    const voices = makeVoices(request);
+    await voices.patch("p1", { displayName: "Shaw" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/voice/profiles/p1",
+      expect.any(Object),
+      { timeoutMs: VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled finalize hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    const voices = makeVoices(request);
+    await expect(
+      voices.finalizeOwnerCapture("s1", { displayName: "Shaw" }, 10),
+    ).rejects.toBeInstanceOf(VoiceProfilesUnavailableError);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/voice/first-run/profile/finalize?id=s1",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/api/client-voice-profiles-timeout.test.ts
+++ b/packages/ui/src/api/client-voice-profiles-timeout.test.ts
@@ -1,0 +1,171 @@
+/** Verifies VoiceProfilesClient hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  VOICE_PROFILES_APPEND_FETCH_TIMEOUT_MS,
+  VOICE_PROFILES_FAMILY_FETCH_TIMEOUT_MS,
+  VOICE_PROFILES_FINALIZE_FETCH_TIMEOUT_MS,
+  VOICE_PROFILES_LIST_FETCH_TIMEOUT_MS,
+  VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS,
+  VOICE_PROFILES_START_FETCH_TIMEOUT_MS,
+  VoiceProfilesClient,
+  VoiceProfilesUnavailableError,
+} from "./client-voice-profiles";
+
+const { fetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+}));
+
+function makeClient() {
+  return new VoiceProfilesClient({ fetch: fetchMock });
+}
+
+describe("VoiceProfilesClient native-complete deadlines", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(VOICE_PROFILES_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(VOICE_PROFILES_START_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(VOICE_PROFILES_APPEND_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(VOICE_PROFILES_FINALIZE_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(VOICE_PROFILES_FAMILY_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes list timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({ profiles: [] });
+    await makeClient().list();
+    expect(fetchMock).toHaveBeenCalledWith("/api/voice/profiles", undefined, {
+      timeoutMs: VOICE_PROFILES_LIST_FETCH_TIMEOUT_MS,
+    });
+  });
+
+  it("passes first-run start timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({
+      sessionId: "s1",
+      prompts: [{ id: "p1", text: "Say hi", targetSeconds: 5 }],
+    });
+    await makeClient().startOwnerCapture();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/voice/first-run/profile/start",
+      { method: "POST" },
+      { timeoutMs: VOICE_PROFILES_START_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes first-run append timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({});
+    await makeClient().appendOwnerCapture("s1", {
+      promptId: "p1",
+      audioBase64: "YQ==",
+      durationMs: 1,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/voice/first-run/profile/append?id=s1",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          promptId: "p1",
+          audioBase64: "YQ==",
+          durationMs: 1,
+        }),
+      },
+      { timeoutMs: VOICE_PROFILES_APPEND_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes first-run finalize timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({
+      profileId: "p1",
+      entityId: "e1",
+      isOwner: true,
+    });
+    await makeClient().finalizeOwnerCapture("s1", { displayName: "Shaw" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/voice/first-run/profile/finalize?id=s1",
+      {
+        method: "POST",
+        body: JSON.stringify({ displayName: "Shaw" }),
+      },
+      { timeoutMs: VOICE_PROFILES_FINALIZE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes family-member timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({
+      profileId: "vp_1",
+      entityId: "ent-fam",
+      displayName: "Alex",
+      relationship: "spouse",
+      relationshipTag: "family_of",
+      ownerEntityId: null,
+    });
+    await makeClient().captureFamilyMember({
+      audioBase64: "dGVzdA==",
+      durationMs: 5000,
+      displayName: "Alex",
+      relationship: "spouse",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/voice/first-run/family-member",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          audioBase64: "dGVzdA==",
+          durationMs: 5000,
+          displayName: "Alex",
+          relationship: "spouse",
+        }),
+        headers: { "content-type": "application/json" },
+      },
+      { timeoutMs: VOICE_PROFILES_FAMILY_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes profile patch timeoutMs through client.fetch", async () => {
+    fetchMock.mockResolvedValue({});
+    await makeClient().patch("p1", { displayName: "Shaw" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/voice/profiles/p1",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ displayName: "Shaw" }),
+      },
+      { timeoutMs: VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled append hop as TimeoutError", async () => {
+    const timeout = Object.assign(new Error("Request timed out after 10ms"), {
+      name: "ApiError",
+      kind: "timeout",
+    });
+    fetchMock.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          setTimeout(() => reject(timeout), 10);
+        }),
+    );
+    await expect(
+      makeClient().appendOwnerCapture(
+        "s1",
+        { promptId: "p1", audioBase64: "YQ==", durationMs: 1 },
+        10,
+      ),
+    ).rejects.toBeInstanceOf(VoiceProfilesUnavailableError);
+  });
+
+  it("surfaces a provider error from a completed list GET", async () => {
+    fetchMock.mockRejectedValue(
+      Object.assign(new Error("Voice profiles request failed (503)"), {
+        name: "ApiError",
+        kind: "http",
+        status: 503,
+      }),
+    );
+    await expect(makeClient().list()).rejects.toMatchObject({
+      name: "VoiceProfilesUnavailableError",
+    });
+  });
+});

--- a/packages/ui/src/api/client-voice-profiles.ts
+++ b/packages/ui/src/api/client-voice-profiles.ts
@@ -114,6 +114,19 @@ export interface FamilyMemberCaptureResult {
  * Single failure context used by every adapter call so the UI can render a
  * stable empty state instead of a generic toast/spinner.
  */
+/** List GET — existing 10s REST budget, independent hop. */
+export const VOICE_PROFILES_LIST_FETCH_TIMEOUT_MS = 10_000;
+/** First-run start POST — existing 10s REST budget, independent hop. */
+export const VOICE_PROFILES_START_FETCH_TIMEOUT_MS = 10_000;
+/** First-run append POST — existing 10s REST budget, independent hop. */
+export const VOICE_PROFILES_APPEND_FETCH_TIMEOUT_MS = 10_000;
+/** First-run finalize POST — existing 10s REST budget, independent hop. */
+export const VOICE_PROFILES_FINALIZE_FETCH_TIMEOUT_MS = 10_000;
+/** First-run family-member POST — existing 10s REST budget, independent hop. */
+export const VOICE_PROFILES_FAMILY_FETCH_TIMEOUT_MS = 10_000;
+/** Profile mutation hops — existing 10s REST budget, independent per call. */
+export const VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS = 10_000;
+
 export class VoiceProfilesUnavailableError extends Error {
   constructor(
     readonly endpoint: string,
@@ -130,7 +143,11 @@ export class VoiceProfilesUnavailableError extends Error {
 }
 
 interface VoiceProfilesClientLike {
-  fetch<T>(path: string, init?: RequestInit): Promise<T>;
+  fetch<T>(
+    path: string,
+    init?: RequestInit,
+    options?: { timeoutMs?: number },
+  ): Promise<T>;
 }
 
 /**
@@ -141,10 +158,14 @@ export class VoiceProfilesClient {
   constructor(private readonly client: VoiceProfilesClientLike) {}
 
   /** List all known profiles. */
-  async list(): Promise<VoiceProfile[]> {
+  async list(
+    timeoutMs: number = VOICE_PROFILES_LIST_FETCH_TIMEOUT_MS,
+  ): Promise<VoiceProfile[]> {
     try {
       const raw = await this.client.fetch<{ profiles?: unknown[] } | unknown[]>(
         "/api/voice/profiles",
+        undefined,
+        { timeoutMs },
       );
       const items = Array.isArray(raw)
         ? raw
@@ -158,11 +179,14 @@ export class VoiceProfilesClient {
   }
 
   /** Start first-run capture for the OWNER profile. */
-  async startOwnerCapture(): Promise<VoiceCaptureSession> {
+  async startOwnerCapture(
+    timeoutMs: number = VOICE_PROFILES_START_FETCH_TIMEOUT_MS,
+  ): Promise<VoiceCaptureSession> {
     try {
       const raw = await this.client.fetch<unknown>(
         "/api/voice/first-run/profile/start",
         { method: "POST" },
+        { timeoutMs },
       );
       return normaliseCaptureSession(raw);
     } catch (err) {
@@ -177,11 +201,13 @@ export class VoiceProfilesClient {
   async appendOwnerCapture(
     sessionId: string,
     payload: { promptId: string; audioBase64: string; durationMs: number },
+    timeoutMs: number = VOICE_PROFILES_APPEND_FETCH_TIMEOUT_MS,
   ): Promise<void> {
     try {
       await this.client.fetch(
         `/api/voice/first-run/profile/append?id=${encodeURIComponent(sessionId)}`,
         { method: "POST", body: JSON.stringify(payload) },
+        { timeoutMs },
       );
     } catch (err) {
       throw new VoiceProfilesUnavailableError(
@@ -195,11 +221,13 @@ export class VoiceProfilesClient {
   async finalizeOwnerCapture(
     sessionId: string,
     payload: { displayName: string },
+    timeoutMs: number = VOICE_PROFILES_FINALIZE_FETCH_TIMEOUT_MS,
   ): Promise<VoiceCaptureSubmitResult> {
     try {
       return await this.client.fetch<VoiceCaptureSubmitResult>(
         `/api/voice/first-run/profile/finalize?id=${encodeURIComponent(sessionId)}`,
         { method: "POST", body: JSON.stringify(payload) },
+        { timeoutMs },
       );
     } catch (err) {
       throw new VoiceProfilesUnavailableError(
@@ -217,6 +245,7 @@ export class VoiceProfilesClient {
    */
   async captureFamilyMember(
     payload: FamilyMemberCapturePayload,
+    timeoutMs: number = VOICE_PROFILES_FAMILY_FETCH_TIMEOUT_MS,
   ): Promise<FamilyMemberCaptureResult> {
     try {
       return await this.client.fetch<FamilyMemberCaptureResult>(
@@ -226,6 +255,7 @@ export class VoiceProfilesClient {
           body: JSON.stringify(payload),
           headers: { "content-type": "application/json" },
         },
+        { timeoutMs },
       );
     } catch (err) {
       throw new VoiceProfilesUnavailableError(
@@ -236,12 +266,20 @@ export class VoiceProfilesClient {
   }
 
   /** Patch profile metadata (rename / relationship / retention). */
-  async patch(id: string, patch: VoiceProfilePatch): Promise<void> {
+  async patch(
+    id: string,
+    patch: VoiceProfilePatch,
+    timeoutMs: number = VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS,
+  ): Promise<void> {
     try {
-      await this.client.fetch(`/api/voice/profiles/${encodeURIComponent(id)}`, {
-        method: "PATCH",
-        body: JSON.stringify(patch),
-      });
+      await this.client.fetch(
+        `/api/voice/profiles/${encodeURIComponent(id)}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify(patch),
+        },
+        { timeoutMs },
+      );
     } catch (err) {
       throw new VoiceProfilesUnavailableError(`/api/voice/profiles/${id}`, err);
     }
@@ -251,11 +289,13 @@ export class VoiceProfilesClient {
   async merge(
     id: string,
     into: VoiceProfileMergeRequest,
+    timeoutMs: number = VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS,
   ): Promise<VoiceProfile> {
     try {
       const raw = await this.client.fetch<unknown>(
         `/api/voice/profiles/${encodeURIComponent(id)}/merge`,
         { method: "POST", body: JSON.stringify(into) },
+        { timeoutMs },
       );
       const profile = normaliseProfile(raw);
       if (!profile)
@@ -273,11 +313,13 @@ export class VoiceProfilesClient {
   async split(
     id: string,
     payload: VoiceProfileSplitRequest,
+    timeoutMs: number = VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS,
   ): Promise<{ original: VoiceProfile; split: VoiceProfile }> {
     try {
       const raw = await this.client.fetch<unknown>(
         `/api/voice/profiles/${encodeURIComponent(id)}/split`,
         { method: "POST", body: JSON.stringify(payload) },
+        { timeoutMs },
       );
       if (!raw || typeof raw !== "object") {
         throw new Error("Voice profile split returned an invalid response.");
@@ -301,11 +343,13 @@ export class VoiceProfilesClient {
   async bind(
     id: string,
     payload: { entityId: string; label?: string },
+    timeoutMs: number = VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS,
   ): Promise<VoiceProfile> {
     try {
       const raw = await this.client.fetch<unknown>(
         `/api/voice/profiles/${encodeURIComponent(id)}/bind`,
         { method: "POST", body: JSON.stringify(payload) },
+        { timeoutMs },
       );
       const profile = normaliseProfile(raw);
       if (!profile)
@@ -320,11 +364,15 @@ export class VoiceProfilesClient {
   }
 
   /** Remove a non-owner profile's entity binding. */
-  async unbind(id: string): Promise<VoiceProfile> {
+  async unbind(
+    id: string,
+    timeoutMs: number = VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS,
+  ): Promise<VoiceProfile> {
     try {
       const raw = await this.client.fetch<unknown>(
         `/api/voice/profiles/${encodeURIComponent(id)}/unbind`,
         { method: "POST" },
+        { timeoutMs },
       );
       const profile = normaliseProfile(raw);
       if (!profile)
@@ -339,22 +387,32 @@ export class VoiceProfilesClient {
   }
 
   /** Delete a profile (OWNER cannot be deleted via UI). */
-  async delete(id: string): Promise<void> {
+  async delete(
+    id: string,
+    timeoutMs: number = VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS,
+  ): Promise<void> {
     try {
-      await this.client.fetch(`/api/voice/profiles/${encodeURIComponent(id)}`, {
-        method: "DELETE",
-      });
+      await this.client.fetch(
+        `/api/voice/profiles/${encodeURIComponent(id)}`,
+        {
+          method: "DELETE",
+        },
+        { timeoutMs },
+      );
     } catch (err) {
       throw new VoiceProfilesUnavailableError(`/api/voice/profiles/${id}`, err);
     }
   }
 
   /** Bulk export (metadata only). Returns a server-signed download URL. */
-  async exportAll(): Promise<{ downloadUrl: string | null }> {
+  async exportAll(
+    timeoutMs: number = VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS,
+  ): Promise<{ downloadUrl: string | null }> {
     try {
       return await this.client.fetch<{ downloadUrl: string | null }>(
         "/api/voice/profiles/export",
         { method: "POST" },
+        { timeoutMs },
       );
     } catch (err) {
       throw new VoiceProfilesUnavailableError(
@@ -365,12 +423,19 @@ export class VoiceProfilesClient {
   }
 
   /** Delete all profiles. `includeOwner` is opt-in; default keeps OWNER. */
-  async deleteAll(options?: { includeOwner?: boolean }): Promise<void> {
+  async deleteAll(
+    options?: { includeOwner?: boolean },
+    timeoutMs: number = VOICE_PROFILES_MUTATION_FETCH_TIMEOUT_MS,
+  ): Promise<void> {
     const query = options?.includeOwner ? "?includeOwner=true" : "";
     try {
-      await this.client.fetch(`/api/voice/profiles${query}`, {
-        method: "DELETE",
-      });
+      await this.client.fetch(
+        `/api/voice/profiles${query}`,
+        {
+          method: "DELETE",
+        },
+        { timeoutMs },
+      );
     } catch (err) {
       throw new VoiceProfilesUnavailableError("/api/voice/profiles", err);
     }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `VoiceProfilesClient` called `this.client.fetch(path[, init])` for first-run append / finalize / start / family-member plus list and profile mutations with no `{ timeoutMs }`. This PR routes each hop through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (existing ordinary default, now explicit). Native-complete: injected `client.fetch`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not `*WithFetch`. Not `#21202` includeOwner list-limit (query semantics unchanged). Not wallets. Not Twilio. Not Nubs shared-runtime voice. Not TelegramBotSetupPanel. Not `browser-bridge-extension` / `browser-launch.ts`. Not the ten inbox CR files. Not `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not Atlas video (`#19302`). Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Voice-profile list / first-run / mutation payloads and `#21202` `includeOwner` query semantics unchanged. Each hop keeps the existing 10s ordinary REST budget as an independent `timeoutMs`. Unfixed head: list, start, append, finalize, and patch called `fetch(path[, init])` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled finalize hop throws `VoiceProfilesUnavailableError` wrapping ElizaClient timeout and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

First-run voice-profile append / finalize / start / family-member plus list and profile mutations omitted `{ timeoutMs }`. This PR passes a separate `{ timeoutMs }` on every adapter hop.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Capture UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-voice-profiles-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request` for append, finalize, and profile patch. `client-voice-profiles-timeout.test.ts` — TimeoutError / provider-error / success on injected `client.fetch`. Existing adapter tests still pass.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-voice-profiles.test.ts \
  src/api/client-voice-profiles-timeout.test.ts \
  src/api/client-voice-profiles-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 50 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Voice-profile hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. Injected ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Voice-profile hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of VoiceProfilesClient adapter + timeout + native-transport files (50 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: list, start, append, finalize, and patch `client.fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. `#21202` includeOwner query not restacked. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:7cb4bd36989b1c392785046c8584b7c595fc8a07 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
