### PR TITLE
fix(ui): route voice-model list, check, pin, and preferences hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-voice-models-native.test.ts
+++ b/packages/ui/src/api/client-voice-models-native.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves voice-model list/check/pin/preferences hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  VOICE_MODELS_CHECK_FETCH_TIMEOUT_MS,
+  VOICE_MODELS_LIST_FETCH_TIMEOUT_MS,
+  VOICE_MODELS_PIN_FETCH_TIMEOUT_MS,
+} from "./client-voice-models";
+import "./client-voice-models";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient voice-model native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the list deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ installations: [] }),
+    );
+    await makeClient(request).listVoiceModels();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/voice-models",
+      expect.any(Object),
+      { timeoutMs: VOICE_MODELS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the check deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ lastCheckedAt: "now", statuses: [] }),
+    );
+    await makeClient(request).checkVoiceModelUpdates();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/voice-models/check",
+      expect.any(Object),
+      { timeoutMs: VOICE_MODELS_CHECK_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the pin deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true, id: "kokoro", pinned: false }),
+    );
+    await makeClient(request).pinVoiceModel("kokoro", false);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/voice-models/kokoro/pin",
+      expect.any(Object),
+      { timeoutMs: VOICE_MODELS_PIN_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled check hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).checkVoiceModelUpdates(undefined, 10),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/voice-models/check",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/api/client-voice-models-timeout.test.ts
+++ b/packages/ui/src/api/client-voice-models-timeout.test.ts
@@ -1,0 +1,174 @@
+/** Verifies voice-model list/check/pin/preferences hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  VOICE_MODELS_CHECK_FETCH_TIMEOUT_MS,
+  VOICE_MODELS_GET_PREFERENCES_FETCH_TIMEOUT_MS,
+  VOICE_MODELS_LIST_FETCH_TIMEOUT_MS,
+  VOICE_MODELS_PIN_FETCH_TIMEOUT_MS,
+  VOICE_MODELS_SET_PREFERENCES_FETCH_TIMEOUT_MS,
+} from "./client-voice-models";
+import "./client-voice-models";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClientWithTransport(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient voice-model native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(VOICE_MODELS_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(VOICE_MODELS_CHECK_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(VOICE_MODELS_PIN_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(VOICE_MODELS_GET_PREFERENCES_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(VOICE_MODELS_SET_PREFERENCES_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes list timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ installations: [] }),
+    );
+    const client = makeClientWithTransport(request);
+    await client.listVoiceModels();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/voice-models",
+      expect.any(Object),
+      { timeoutMs: VOICE_MODELS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes check timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ lastCheckedAt: "now", statuses: [] }),
+    );
+    const client = makeClientWithTransport(request);
+    await client.checkVoiceModelUpdates();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/voice-models/check",
+      expect.any(Object),
+      { timeoutMs: VOICE_MODELS_CHECK_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes force-check timeoutMs on its own hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ lastCheckedAt: "now", statuses: [] }),
+    );
+    const client = makeClientWithTransport(request);
+    await client.checkVoiceModelUpdates({ force: true });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/voice-models/check?force=1",
+      expect.any(Object),
+      { timeoutMs: VOICE_MODELS_CHECK_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes pin timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true, id: "kokoro", pinned: true }),
+    );
+    const client = makeClientWithTransport(request);
+    await client.pinVoiceModel("kokoro", true);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/voice-models/kokoro/pin",
+      expect.any(Object),
+      { timeoutMs: VOICE_MODELS_PIN_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes preferences GET timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({
+        preferences: {
+          autoUpdateOnWifi: true,
+          autoUpdateOnCellular: false,
+          autoUpdateOnMetered: false,
+          quietHours: [],
+        },
+      }),
+    );
+    const client = makeClientWithTransport(request);
+    await client.getVoiceModelPreferences();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/voice-models/preferences",
+      expect.any(Object),
+      { timeoutMs: VOICE_MODELS_GET_PREFERENCES_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes preferences POST timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({
+        ok: true,
+        preferences: {
+          autoUpdateOnWifi: false,
+          autoUpdateOnCellular: false,
+          autoUpdateOnMetered: false,
+          quietHours: [],
+        },
+      }),
+    );
+    const client = makeClientWithTransport(request);
+    await client.setVoiceModelPreferences({ autoUpdateOnWifi: false });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/voice-models/preferences",
+      expect.any(Object),
+      { timeoutMs: VOICE_MODELS_SET_PREFERENCES_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled pin hop as TimeoutError", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    const client = makeClientWithTransport(request);
+    await expect(client.pinVoiceModel("kokoro", true, 10)).rejects.toMatchObject(
+      { name: "ApiError", kind: "timeout" },
+    );
+  });
+
+  it("surfaces a provider error from a completed list GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const client = makeClientWithTransport(request);
+    await expect(client.listVoiceModels()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-voice-models.ts
+++ b/packages/ui/src/api/client-voice-models.ts
@@ -76,42 +76,72 @@ export interface VoiceModelsSetPreferencesResponse {
   readonly preferences: NetworkPolicyPreferences;
 }
 
+/** List GET — existing 10s REST budget, independent hop. */
+export const VOICE_MODELS_LIST_FETCH_TIMEOUT_MS = 10_000;
+/** Check GET — existing 10s REST budget, independent hop. */
+export const VOICE_MODELS_CHECK_FETCH_TIMEOUT_MS = 10_000;
+/** Pin POST — existing 10s REST budget, independent hop. */
+export const VOICE_MODELS_PIN_FETCH_TIMEOUT_MS = 10_000;
+/** Preferences GET — existing 10s REST budget, independent hop. */
+export const VOICE_MODELS_GET_PREFERENCES_FETCH_TIMEOUT_MS = 10_000;
+/** Preferences POST — existing 10s REST budget, independent hop. */
+export const VOICE_MODELS_SET_PREFERENCES_FETCH_TIMEOUT_MS = 10_000;
+
 declare module "./client-base" {
   interface ElizaClient {
-    listVoiceModels(): Promise<VoiceModelsListResponse>;
-    checkVoiceModelUpdates(options?: {
-      force?: boolean;
-    }): Promise<VoiceModelsCheckResponse>;
+    listVoiceModels(
+      timeoutMs?: number,
+    ): Promise<VoiceModelsListResponse>;
+    checkVoiceModelUpdates(
+      options?: {
+        force?: boolean;
+      },
+      timeoutMs?: number,
+    ): Promise<VoiceModelsCheckResponse>;
     triggerVoiceModelUpdate(
       id: VoiceModelId,
     ): Promise<VoiceModelsUpdateResponse>;
     pinVoiceModel(
       id: VoiceModelId,
       pinned: boolean,
+      timeoutMs?: number,
     ): Promise<VoiceModelsPinResponse>;
-    getVoiceModelPreferences(): Promise<VoiceModelsPreferencesResponse>;
+    getVoiceModelPreferences(
+      timeoutMs?: number,
+    ): Promise<VoiceModelsPreferencesResponse>;
     setVoiceModelPreferences(
       patch: Partial<NetworkPolicyPreferences>,
+      timeoutMs?: number,
     ): Promise<VoiceModelsSetPreferencesResponse>;
   }
 }
 
-ElizaClient.prototype.listVoiceModels = async function (this: ElizaClient) {
-  return this.fetch("/api/local-inference/voice-models");
+ElizaClient.prototype.listVoiceModels = async function (
+  this: ElizaClient,
+  timeoutMs: number = VOICE_MODELS_LIST_FETCH_TIMEOUT_MS,
+) {
+  return this.fetch("/api/local-inference/voice-models", undefined, {
+    timeoutMs,
+  });
 };
 
 ElizaClient.prototype.checkVoiceModelUpdates = async function (
   this: ElizaClient,
   options,
+  timeoutMs: number = VOICE_MODELS_CHECK_FETCH_TIMEOUT_MS,
 ) {
   const query = options?.force ? "?force=1" : "";
-  return this.fetch(`/api/local-inference/voice-models/check${query}`);
+  return this.fetch(`/api/local-inference/voice-models/check${query}`, undefined, {
+    timeoutMs,
+  });
 };
 
 ElizaClient.prototype.triggerVoiceModelUpdate = async function (
   this: ElizaClient,
   id: VoiceModelId,
 ) {
+  // Model-download stay-off: this hop writes a GGUF/ONNX payload (version,
+  // finalPath, sha256, sizeBytes). Do not attach a 10s REST timeout here.
   return this.fetch(
     `/api/local-inference/voice-models/${encodeURIComponent(id)}/update`,
     { method: "POST", body: JSON.stringify({}) },
@@ -122,25 +152,35 @@ ElizaClient.prototype.pinVoiceModel = async function (
   this: ElizaClient,
   id: VoiceModelId,
   pinned: boolean,
+  timeoutMs: number = VOICE_MODELS_PIN_FETCH_TIMEOUT_MS,
 ) {
   return this.fetch(
     `/api/local-inference/voice-models/${encodeURIComponent(id)}/pin`,
     { method: "POST", body: JSON.stringify({ pinned }) },
+    { timeoutMs },
   );
 };
 
 ElizaClient.prototype.getVoiceModelPreferences = async function (
   this: ElizaClient,
+  timeoutMs: number = VOICE_MODELS_GET_PREFERENCES_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch("/api/local-inference/voice-models/preferences");
+  return this.fetch("/api/local-inference/voice-models/preferences", undefined, {
+    timeoutMs,
+  });
 };
 
 ElizaClient.prototype.setVoiceModelPreferences = async function (
   this: ElizaClient,
   patch: Partial<NetworkPolicyPreferences>,
+  timeoutMs: number = VOICE_MODELS_SET_PREFERENCES_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch("/api/local-inference/voice-models/preferences", {
-    method: "POST",
-    body: JSON.stringify(patch),
-  });
+  return this.fetch(
+    "/api/local-inference/voice-models/preferences",
+    {
+      method: "POST",
+      body: JSON.stringify(patch),
+    },
+    { timeoutMs },
+  );
 };


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `client-voice-models.ts` called `this.fetch(path[, init])` for list / check / pin / preferences with no `{ timeoutMs }`. This PR routes each of those hops through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (existing ordinary default, now explicit). `triggerVoiceModelUpdate` is left unbounded — that hop is model-download (version / finalPath / sha256 / sizeBytes). Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not `*WithFetch`. Not `getLocalInferenceHub` (already 30s). Not wallets. Not Twilio. Not Nubs shared-runtime voice. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not Atlas video (`#19302`). Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Voice-model ids, `?force=1` check query, and pin/preferences payloads unchanged. `triggerVoiceModelUpdate` (model-download) is not given a 10s REST timeout. Unfixed head: list, check, pin, and preferences called `fetch(path[, init])` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled check hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

Voice-model catalog list / update-check / pin / preferences hops omitted `{ timeoutMs }`. This PR passes a separate `{ timeoutMs }` on each of those adapter hops. The download/update POST stays unbounded.

## What kind of change is this?

Bug fix (non-breaking I/O bound). ModelUpdatesPanel UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-voice-models-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request` for list, check, and pin. `client-voice-models-timeout.test.ts` — TimeoutError / provider-error / success plus preferences hops.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-voice-models-timeout.test.ts \
  src/api/client-voice-models-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 13 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Voice-model hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Voice-model hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of voice-model timeout + native-transport files (13 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: list, check, check?force=1, pin, preferences GET, and preferences POST `this.fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each of those hops forwards its own deadline to `Agent.request`. `triggerVoiceModelUpdate` left unbounded (model-download).

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. `triggerVoiceModelUpdate` stay-off (model-download). Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:0186a2613f246fd5533b447e7c8df9543e8359cc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
