### PR TITLE
fix(ui): route transcript list, get, share, and mutation hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-transcripts-native.test.ts
+++ b/packages/ui/src/api/client-transcripts-native.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves transcript hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  TRANSCRIPTS_GET_FETCH_TIMEOUT_MS,
+  TRANSCRIPTS_LIST_FETCH_TIMEOUT_MS,
+  TRANSCRIPTS_SHARE_FETCH_TIMEOUT_MS,
+} from "./client-transcripts";
+import "./client-transcripts";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient transcript native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the list deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ transcripts: [] }),
+    );
+    await makeClient(request).listTranscripts();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the get deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ transcript: { id: "t1" } }),
+    );
+    await makeClient(request).getTranscript("t1");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts/t1",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_GET_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the share deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({
+        ok: true,
+        transcriptId: "t1",
+        entityId: "e1",
+        mode: "full",
+      }),
+    );
+    await makeClient(request).shareTranscript("t1", {
+      entityId: "e1",
+      mode: "full",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts/t1/share",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_SHARE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled get hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).getTranscript("t1", 10),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts/t1",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/api/client-transcripts-timeout.test.ts
+++ b/packages/ui/src/api/client-transcripts-timeout.test.ts
@@ -1,0 +1,217 @@
+/** Verifies transcript hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  TRANSCRIPTS_CREATE_FETCH_TIMEOUT_MS,
+  TRANSCRIPTS_DELETE_FETCH_TIMEOUT_MS,
+  TRANSCRIPTS_GET_FETCH_TIMEOUT_MS,
+  TRANSCRIPTS_LIST_FETCH_TIMEOUT_MS,
+  TRANSCRIPTS_PRIVACY_FETCH_TIMEOUT_MS,
+  TRANSCRIPTS_REVOKE_SHARE_FETCH_TIMEOUT_MS,
+  TRANSCRIPTS_SHARE_FETCH_TIMEOUT_MS,
+  TRANSCRIPTS_SOURCE_AUDIO_FETCH_TIMEOUT_MS,
+  TRANSCRIPTS_UPDATE_FETCH_TIMEOUT_MS,
+} from "./client-transcripts";
+import "./client-transcripts";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient transcript native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(TRANSCRIPTS_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(TRANSCRIPTS_GET_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(TRANSCRIPTS_CREATE_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(TRANSCRIPTS_UPDATE_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(TRANSCRIPTS_DELETE_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(TRANSCRIPTS_SHARE_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(TRANSCRIPTS_REVOKE_SHARE_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(TRANSCRIPTS_PRIVACY_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(TRANSCRIPTS_SOURCE_AUDIO_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes list timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ transcripts: [] }),
+    );
+    await makeClient(request).listTranscripts();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes list-by-room timeoutMs on its own hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ transcripts: [] }),
+    );
+    await makeClient(request).listTranscripts("room-1");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts?roomId=room-1",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes get timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ transcript: { id: "t1" } }),
+    );
+    await makeClient(request).getTranscript("t1");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts/t1",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_GET_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes create timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ transcript: { id: "t1" } }),
+    );
+    await makeClient(request).createTranscript({ segments: [] });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_CREATE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes update timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ transcript: { id: "t1" } }),
+    );
+    await makeClient(request).updateTranscript("t1", { title: "Edited" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts/t1",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_UPDATE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes delete timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true }),
+    );
+    await makeClient(request).deleteTranscript("t1");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts/t1",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_DELETE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes share timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({
+        ok: true,
+        transcriptId: "t1",
+        entityId: "e1",
+        mode: "full",
+      }),
+    );
+    await makeClient(request).shareTranscript("t1", {
+      entityId: "e1",
+      mode: "full",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts/t1/share",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_SHARE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes revoke-share timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true, transcriptId: "t1", entityId: "e1" }),
+    );
+    await makeClient(request).revokeTranscriptShare("t1", "e1");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts/t1/share/e1",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_REVOKE_SHARE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes privacy timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ transcript: { id: "t1" } }),
+    );
+    await makeClient(request).updateTranscriptPrivacy("t1", {
+      sharing: {},
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts/t1/privacy",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_PRIVACY_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes source-audio timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ deleted: true, transcript: { id: "t1" } }),
+    );
+    await makeClient(request).deleteTranscriptSourceAudio("t1");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/transcripts/t1/source-audio",
+      expect.any(Object),
+      { timeoutMs: TRANSCRIPTS_SOURCE_AUDIO_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled delete hop as TimeoutError", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).deleteTranscript("t1", 10),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+  });
+
+  it("surfaces a provider error from a completed list GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(makeClient(request).listTranscripts()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-transcripts.ts
+++ b/packages/ui/src/api/client-transcripts.ts
@@ -64,34 +64,66 @@ export interface TranscriptPrivacyUpdateInput {
   sharing: Partial<TranscriptCaptureSharingState>;
 }
 
+/** List GET — existing 10s REST budget, independent hop. */
+export const TRANSCRIPTS_LIST_FETCH_TIMEOUT_MS = 10_000;
+/** Get GET — existing 10s REST budget, independent hop. */
+export const TRANSCRIPTS_GET_FETCH_TIMEOUT_MS = 10_000;
+/** Create POST — existing 10s REST budget, independent hop. */
+export const TRANSCRIPTS_CREATE_FETCH_TIMEOUT_MS = 10_000;
+/** Update PUT — existing 10s REST budget, independent hop. */
+export const TRANSCRIPTS_UPDATE_FETCH_TIMEOUT_MS = 10_000;
+/** Delete DELETE — existing 10s REST budget, independent hop. */
+export const TRANSCRIPTS_DELETE_FETCH_TIMEOUT_MS = 10_000;
+/** Share POST — existing 10s REST budget, independent hop. */
+export const TRANSCRIPTS_SHARE_FETCH_TIMEOUT_MS = 10_000;
+/** Revoke-share DELETE — existing 10s REST budget, independent hop. */
+export const TRANSCRIPTS_REVOKE_SHARE_FETCH_TIMEOUT_MS = 10_000;
+/** Privacy PATCH — existing 10s REST budget, independent hop. */
+export const TRANSCRIPTS_PRIVACY_FETCH_TIMEOUT_MS = 10_000;
+/** Source-audio DELETE — existing 10s REST budget, independent hop. */
+export const TRANSCRIPTS_SOURCE_AUDIO_FETCH_TIMEOUT_MS = 10_000;
+
 declare module "./client-base" {
   interface ElizaClient {
     listTranscripts(
       roomId?: string,
+      timeoutMs?: number,
     ): Promise<{ transcripts: TranscriptSummary[] }>;
-    getTranscript(id: string): Promise<{ transcript: Transcript }>;
+    getTranscript(
+      id: string,
+      timeoutMs?: number,
+    ): Promise<{ transcript: Transcript }>;
     createTranscript(
       input: TranscriptCreateInput,
+      timeoutMs?: number,
     ): Promise<{ transcript: Transcript }>;
     updateTranscript(
       id: string,
       input: TranscriptUpdateInput,
+      timeoutMs?: number,
     ): Promise<{ transcript: Transcript }>;
-    deleteTranscript(id: string): Promise<{ ok: boolean }>;
+    deleteTranscript(
+      id: string,
+      timeoutMs?: number,
+    ): Promise<{ ok: boolean }>;
     shareTranscript(
       id: string,
       input: TranscriptShareInput,
+      timeoutMs?: number,
     ): Promise<TranscriptShareResult>;
     revokeTranscriptShare(
       id: string,
       entityId: string,
+      timeoutMs?: number,
     ): Promise<TranscriptRevokeShareResult>;
     updateTranscriptPrivacy(
       id: string,
       input: TranscriptPrivacyUpdateInput,
+      timeoutMs?: number,
     ): Promise<{ transcript: Transcript }>;
     deleteTranscriptSourceAudio(
       id: string,
+      timeoutMs?: number,
     ): Promise<{ deleted: boolean; transcript: Transcript }>;
   }
 }
@@ -99,69 +131,95 @@ declare module "./client-base" {
 ElizaClient.prototype.listTranscripts = async function (
   this: ElizaClient,
   roomId?: string,
+  timeoutMs: number = TRANSCRIPTS_LIST_FETCH_TIMEOUT_MS,
 ) {
   const q = roomId ? `?roomId=${encodeURIComponent(roomId)}` : "";
-  return this.fetch(`/api/transcripts${q}`);
+  return this.fetch(`/api/transcripts${q}`, undefined, { timeoutMs });
 };
 
 ElizaClient.prototype.getTranscript = async function (
   this: ElizaClient,
   id: string,
+  timeoutMs: number = TRANSCRIPTS_GET_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch(`/api/transcripts/${encodeURIComponent(id)}`);
+  return this.fetch(`/api/transcripts/${encodeURIComponent(id)}`, undefined, {
+    timeoutMs,
+  });
 };
 
 ElizaClient.prototype.createTranscript = async function (
   this: ElizaClient,
   input: TranscriptCreateInput,
+  timeoutMs: number = TRANSCRIPTS_CREATE_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch("/api/transcripts", {
-    method: "POST",
-    body: JSON.stringify(input),
-  });
+  return this.fetch(
+    "/api/transcripts",
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+    { timeoutMs },
+  );
 };
 
 ElizaClient.prototype.updateTranscript = async function (
   this: ElizaClient,
   id: string,
   input: TranscriptUpdateInput,
+  timeoutMs: number = TRANSCRIPTS_UPDATE_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch(`/api/transcripts/${encodeURIComponent(id)}`, {
-    method: "PUT",
-    body: JSON.stringify(input),
-  });
+  return this.fetch(
+    `/api/transcripts/${encodeURIComponent(id)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify(input),
+    },
+    { timeoutMs },
+  );
 };
 
 ElizaClient.prototype.deleteTranscript = async function (
   this: ElizaClient,
   id: string,
+  timeoutMs: number = TRANSCRIPTS_DELETE_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch(`/api/transcripts/${encodeURIComponent(id)}`, {
-    method: "DELETE",
-  });
+  return this.fetch(
+    `/api/transcripts/${encodeURIComponent(id)}`,
+    {
+      method: "DELETE",
+    },
+    { timeoutMs },
+  );
 };
 
 ElizaClient.prototype.shareTranscript = async function (
   this: ElizaClient,
   id: string,
   input: TranscriptShareInput,
+  timeoutMs: number = TRANSCRIPTS_SHARE_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch(`/api/transcripts/${encodeURIComponent(id)}/share`, {
-    method: "POST",
-    body: JSON.stringify(input),
-  });
+  return this.fetch(
+    `/api/transcripts/${encodeURIComponent(id)}/share`,
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+    { timeoutMs },
+  );
 };
 
 ElizaClient.prototype.revokeTranscriptShare = async function (
   this: ElizaClient,
   id: string,
   entityId: string,
+  timeoutMs: number = TRANSCRIPTS_REVOKE_SHARE_FETCH_TIMEOUT_MS,
 ) {
   return this.fetch(
     `/api/transcripts/${encodeURIComponent(id)}/share/${encodeURIComponent(
       entityId,
     )}`,
     { method: "DELETE" },
+    { timeoutMs },
   );
 };
 
@@ -169,18 +227,28 @@ ElizaClient.prototype.updateTranscriptPrivacy = async function (
   this: ElizaClient,
   id: string,
   input: TranscriptPrivacyUpdateInput,
+  timeoutMs: number = TRANSCRIPTS_PRIVACY_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch(`/api/transcripts/${encodeURIComponent(id)}/privacy`, {
-    method: "PATCH",
-    body: JSON.stringify(input),
-  });
+  return this.fetch(
+    `/api/transcripts/${encodeURIComponent(id)}/privacy`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(input),
+    },
+    { timeoutMs },
+  );
 };
 
 ElizaClient.prototype.deleteTranscriptSourceAudio = async function (
   this: ElizaClient,
   id: string,
+  timeoutMs: number = TRANSCRIPTS_SOURCE_AUDIO_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch(`/api/transcripts/${encodeURIComponent(id)}/source-audio`, {
-    method: "DELETE",
-  });
+  return this.fetch(
+    `/api/transcripts/${encodeURIComponent(id)}/source-audio`,
+    {
+      method: "DELETE",
+    },
+    { timeoutMs },
+  );
 };


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `client-transcripts.ts` called `this.fetch(path[, init])` for list / get / create / update / delete / share / revoke / privacy / source-audio with no `{ timeoutMs }`. This PR routes each hop through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (existing ordinary default, now explicit). Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not `*WithFetch`. Not `#21810` `TranscriptViewerOverlay.tsx` (watch only; different file). Not wallets. Not Twilio. Not Nubs shared-runtime. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not Atlas video (`#19302`). Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. `roomId` query encoding, share/privacy payloads, and path ids unchanged. Unfixed head: list, get, create, update, delete, share, revoke, privacy, and source-audio called `fetch(path[, init])` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled get hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

Transcript list / get / create / update / delete / share / privacy / source-audio hops omitted `{ timeoutMs }`. This PR passes a separate `{ timeoutMs }` on every adapter hop.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Transcript UI unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-transcripts-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request` for list, get, and share. `client-transcripts-timeout.test.ts` — TimeoutError / provider-error / success on every hop.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-transcripts-timeout.test.ts \
  src/api/client-transcripts-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 17 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Transcript hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Transcript hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of transcript timeout + native-transport files (17 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: list, list?roomId, get, create, update, delete, share, revoke, privacy, and source-audio `this.fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. `#21810` TranscriptViewerOverlay not touched. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:ef7310d94ff728fa09fa42119314555f2a8dffb4 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
