### PR TITLE
fix(ui): route meeting request, list, get, and stop hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-meetings-native.test.ts
+++ b/packages/ui/src/api/client-meetings-native.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves meeting hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  MEETINGS_GET_FETCH_TIMEOUT_MS,
+  MEETINGS_LIST_FETCH_TIMEOUT_MS,
+  MEETINGS_REQUEST_FETCH_TIMEOUT_MS,
+} from "./client-meetings";
+import "./client-meetings";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient meeting native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the request deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ session: { id: "m1" } }),
+    );
+    await makeClient(request).requestMeetingBot({
+      platform: "zoom",
+      meetingUrl: "https://zoom.example/j/1",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/meetings",
+      expect.any(Object),
+      { timeoutMs: MEETINGS_REQUEST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the list deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ sessions: [] }),
+    );
+    await makeClient(request).listMeetings();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/meetings",
+      expect.any(Object),
+      { timeoutMs: MEETINGS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the get deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ session: { id: "m1" } }),
+    );
+    await makeClient(request).getMeeting("m1");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/meetings/m1",
+      expect.any(Object),
+      { timeoutMs: MEETINGS_GET_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled get hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(makeClient(request).getMeeting("m1", 10)).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/meetings/m1",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/api/client-meetings-timeout.test.ts
+++ b/packages/ui/src/api/client-meetings-timeout.test.ts
@@ -1,0 +1,142 @@
+/** Verifies meeting hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  MEETINGS_GET_FETCH_TIMEOUT_MS,
+  MEETINGS_LIST_FETCH_TIMEOUT_MS,
+  MEETINGS_REQUEST_FETCH_TIMEOUT_MS,
+  MEETINGS_STOP_FETCH_TIMEOUT_MS,
+} from "./client-meetings";
+import "./client-meetings";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const join = {
+  platform: "zoom" as const,
+  meetingUrl: "https://zoom.example/j/1",
+};
+
+describe("ElizaClient meeting native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(MEETINGS_REQUEST_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(MEETINGS_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(MEETINGS_GET_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(MEETINGS_STOP_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes request timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ session: { id: "m1" } }),
+    );
+    await makeClient(request).requestMeetingBot(join);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/meetings",
+      expect.any(Object),
+      { timeoutMs: MEETINGS_REQUEST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes list timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ sessions: [] }),
+    );
+    await makeClient(request).listMeetings();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/meetings",
+      expect.any(Object),
+      { timeoutMs: MEETINGS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("keeps ?active=1 and passes list timeoutMs on that hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ sessions: [] }),
+    );
+    await makeClient(request).listMeetings({ active: true });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/meetings?active=1",
+      expect.any(Object),
+      { timeoutMs: MEETINGS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes get timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ session: { id: "m1" } }),
+    );
+    await makeClient(request).getMeeting("m1");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/meetings/m1",
+      expect.any(Object),
+      { timeoutMs: MEETINGS_GET_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes stop timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true }),
+    );
+    await makeClient(request).stopMeeting("m1");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/meetings/m1",
+      expect.any(Object),
+      { timeoutMs: MEETINGS_STOP_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled stop hop as TimeoutError", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(makeClient(request).stopMeeting("m1", 10)).rejects.toMatchObject(
+      { name: "ApiError", kind: "timeout" },
+    );
+  });
+
+  it("surfaces a provider error from a completed list GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(makeClient(request).listMeetings()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-meetings.ts
+++ b/packages/ui/src/api/client-meetings.ts
@@ -24,51 +24,79 @@ export interface ListMeetingsOptions {
   active?: boolean;
 }
 
+/** Request POST — existing 10s REST budget, independent hop. */
+export const MEETINGS_REQUEST_FETCH_TIMEOUT_MS = 10_000;
+/** List GET — existing 10s REST budget, independent hop. */
+export const MEETINGS_LIST_FETCH_TIMEOUT_MS = 10_000;
+/** Get GET — existing 10s REST budget, independent hop. */
+export const MEETINGS_GET_FETCH_TIMEOUT_MS = 10_000;
+/** Stop DELETE — existing 10s REST budget, independent hop. */
+export const MEETINGS_STOP_FETCH_TIMEOUT_MS = 10_000;
+
 declare module "./client-base" {
   interface ElizaClient {
     requestMeetingBot(
       input: MeetingJoinRequest,
+      timeoutMs?: number,
     ): Promise<{ session: MeetingSession }>;
     listMeetings(
       options?: ListMeetingsOptions,
+      timeoutMs?: number,
     ): Promise<{ sessions: MeetingSession[] }>;
-    getMeeting(id: string): Promise<{ session: MeetingSession }>;
-    stopMeeting(id: string): Promise<{ ok: boolean }>;
+    getMeeting(
+      id: string,
+      timeoutMs?: number,
+    ): Promise<{ session: MeetingSession }>;
+    stopMeeting(id: string, timeoutMs?: number): Promise<{ ok: boolean }>;
   }
 }
 
 ElizaClient.prototype.requestMeetingBot = async function (
   this: ElizaClient,
   input: MeetingJoinRequest,
+  timeoutMs: number = MEETINGS_REQUEST_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch("/api/meetings", {
-    method: "POST",
-    body: JSON.stringify(input),
-  });
+  return this.fetch(
+    "/api/meetings",
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+    { timeoutMs },
+  );
 };
 
 ElizaClient.prototype.listMeetings = async function (
   this: ElizaClient,
   options?: ListMeetingsOptions,
+  timeoutMs: number = MEETINGS_LIST_FETCH_TIMEOUT_MS,
 ) {
   const q = options?.active ? "?active=1" : "";
-  return this.fetch(`/api/meetings${q}`);
+  return this.fetch(`/api/meetings${q}`, undefined, { timeoutMs });
 };
 
 ElizaClient.prototype.getMeeting = async function (
   this: ElizaClient,
   id: string,
+  timeoutMs: number = MEETINGS_GET_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch(`/api/meetings/${encodeURIComponent(id)}`);
+  return this.fetch(`/api/meetings/${encodeURIComponent(id)}`, undefined, {
+    timeoutMs,
+  });
 };
 
 ElizaClient.prototype.stopMeeting = async function (
   this: ElizaClient,
   id: string,
+  timeoutMs: number = MEETINGS_STOP_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch(`/api/meetings/${encodeURIComponent(id)}`, {
-    method: "DELETE",
-  });
+  return this.fetch(
+    `/api/meetings/${encodeURIComponent(id)}`,
+    {
+      method: "DELETE",
+    },
+    { timeoutMs },
+  );
 };
 
 function isSegmentArray(value: unknown): value is TranscriptSegment[] {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `client-meetings.ts` called `this.fetch(path[, init])` for request / list / get / stop with no `{ timeoutMs }`. This PR routes each hop through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (existing ordinary default, now explicit). `?active=1` list query semantics are unchanged. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not `*WithFetch`. Not cloud JSON. Not wallets. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not Atlas video (`#19302`). Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Join payload, path ids, and `?active=1` list query unchanged. Unfixed head: request, list, list?active=1, get, and stop called `fetch(path[, init])` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled get hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

Meeting-bot request / list / get / stop hops omitted `{ timeoutMs }`. This PR passes a separate `{ timeoutMs }` on every adapter hop.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Meeting-bot UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-meetings-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request` for request, list, and get. `client-meetings-timeout.test.ts` — TimeoutError / provider-error / success plus `?active=1` list hop.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-meetings-timeout.test.ts \
  src/api/client-meetings-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 12 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Meeting hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Meeting hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of meeting timeout + native-transport files (12 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: request, list, list?active=1, get, and stop `this.fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`. `?active=1` query unchanged.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. `?active=1` list query not restacked as a list-limit. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:5650e1ab457eb4436617b4cb90d76ceae4fbbe05 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
