### PR TITLE
fix(ui): route file list and delete hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-files-native.test.ts
+++ b/packages/ui/src/api/client-files-native.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves file list/delete hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  FILES_DELETE_FETCH_TIMEOUT_MS,
+  FILES_LIST_FETCH_TIMEOUT_MS,
+} from "./client-files";
+import "./client-files";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient files native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the list deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ files: [] }),
+    );
+    await makeClient(request).listFiles();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/files",
+      expect.any(Object),
+      { timeoutMs: FILES_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the delete deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ deleted: true }),
+    );
+    await makeClient(request).deleteFile("note.pdf");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/files/note.pdf",
+      expect.any(Object),
+      { timeoutMs: FILES_DELETE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled list hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(makeClient(request).listFiles(10)).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/files",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/api/client-files-timeout.test.ts
+++ b/packages/ui/src/api/client-files-timeout.test.ts
@@ -1,0 +1,97 @@
+/** Verifies file list/delete hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  FILES_DELETE_FETCH_TIMEOUT_MS,
+  FILES_LIST_FETCH_TIMEOUT_MS,
+} from "./client-files";
+import "./client-files";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient files native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(FILES_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(FILES_DELETE_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes list timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ files: [], restricted: false }),
+    );
+    await makeClient(request).listFiles();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/files",
+      expect.any(Object),
+      { timeoutMs: FILES_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes delete timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ deleted: true }),
+    );
+    await makeClient(request).deleteFile("note.pdf");
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/files/note.pdf",
+      expect.any(Object),
+      { timeoutMs: FILES_DELETE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled delete hop as TimeoutError", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).deleteFile("note.pdf", 10),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+  });
+
+  it("surfaces a provider error from a completed list GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(makeClient(request).listFiles()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-files.ts
+++ b/packages/ui/src/api/client-files.ts
@@ -30,22 +30,40 @@ export interface StoredFile {
   createdAt: number;
 }
 
+/** List GET — existing 10s REST budget, independent hop. */
+export const FILES_LIST_FETCH_TIMEOUT_MS = 10_000;
+/** Delete DELETE — existing 10s REST budget, independent hop. */
+export const FILES_DELETE_FETCH_TIMEOUT_MS = 10_000;
+
 declare module "./client-base" {
   interface ElizaClient {
-    listFiles(): Promise<{ files: StoredFile[]; restricted?: boolean }>;
-    deleteFile(fileName: string): Promise<{ deleted: boolean }>;
+    listFiles(
+      timeoutMs?: number,
+    ): Promise<{ files: StoredFile[]; restricted?: boolean }>;
+    deleteFile(
+      fileName: string,
+      timeoutMs?: number,
+    ): Promise<{ deleted: boolean }>;
   }
 }
 
-ElizaClient.prototype.listFiles = async function (this: ElizaClient) {
-  return this.fetch("/api/files");
+ElizaClient.prototype.listFiles = async function (
+  this: ElizaClient,
+  timeoutMs: number = FILES_LIST_FETCH_TIMEOUT_MS,
+) {
+  return this.fetch("/api/files", undefined, { timeoutMs });
 };
 
 ElizaClient.prototype.deleteFile = async function (
   this: ElizaClient,
   fileName: string,
+  timeoutMs: number = FILES_DELETE_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch(`/api/files/${encodeURIComponent(fileName)}`, {
-    method: "DELETE",
-  });
+  return this.fetch(
+    `/api/files/${encodeURIComponent(fileName)}`,
+    {
+      method: "DELETE",
+    },
+    { timeoutMs },
+  );
 };


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `client-files.ts` called `this.fetch(path[, init])` for list / delete with no `{ timeoutMs }`. This PR routes each hop through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (existing ordinary default, now explicit). Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not `*WithFetch`. Not cloud `packages/cloud/api/v1/files/route.ts` (HARD_SKIP). Not wallets. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not Atlas video (`#19302`). Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Filename path encoding and `{ files, restricted }` list contract unchanged. Unfixed head: list and delete called `fetch(path[, init])` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled list hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

Local-agent file list / delete hops omitted `{ timeoutMs }`. This PR passes a separate `{ timeoutMs }` on each adapter hop.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Attachments UI unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-files-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request` for list and delete. `client-files-timeout.test.ts` — TimeoutError / provider-error / success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-files-timeout.test.ts \
  src/api/client-files-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 8 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. File hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. File hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of files timeout + native-transport files (8 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: list and delete `this.fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. Cloud `packages/cloud/api/v1/files/route.ts` not touched. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:a46ea5c37a259a5b9cff9079972e5f8315230e58 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
