### PR TITLE
fix(ui): route glance getSkills and refreshSkills hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-skills-native.test.ts
+++ b/packages/ui/src/api/client-skills-native.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves glance skills hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  SKILLS_LIST_FETCH_TIMEOUT_MS,
+  SKILLS_REFRESH_FETCH_TIMEOUT_MS,
+} from "./client-skills";
+import "./client-skills";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient skills glance native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the getSkills deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ skills: [] }),
+    );
+    await makeClient(request).getSkills();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/skills",
+      expect.any(Object),
+      { timeoutMs: SKILLS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the refreshSkills deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true, skills: [] }),
+    );
+    await makeClient(request).refreshSkills();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/skills/refresh",
+      expect.any(Object),
+      { timeoutMs: SKILLS_REFRESH_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled getSkills hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(makeClient(request).getSkills(10)).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/skills",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/api/client-skills-timeout.test.ts
+++ b/packages/ui/src/api/client-skills-timeout.test.ts
@@ -1,0 +1,98 @@
+/** Verifies glance skills list/refresh hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  SKILLS_LIST_FETCH_TIMEOUT_MS,
+  SKILLS_REFRESH_FETCH_TIMEOUT_MS,
+} from "./client-skills";
+import "./client-skills";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient skills glance native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(SKILLS_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(SKILLS_REFRESH_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes getSkills timeoutMs through client.fetch with no query", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ skills: [] }),
+    );
+    await makeClient(request).getSkills();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/skills",
+      expect.any(Object),
+      { timeoutMs: SKILLS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes refreshSkills timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true, skills: [] }),
+    );
+    await makeClient(request).refreshSkills();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/skills/refresh",
+      expect.any(Object),
+      { timeoutMs: SKILLS_REFRESH_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled refresh hop as TimeoutError", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(makeClient(request).refreshSkills(10)).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+  });
+
+  it("surfaces a provider error from a completed getSkills GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(makeClient(request).getSkills()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-skills.ts
+++ b/packages/ui/src/api/client-skills.ts
@@ -85,8 +85,10 @@ export interface TelegramAccountSetupStatus {
 
 declare module "./client-base" {
   interface ElizaClient {
-    getSkills(): Promise<{ skills: SkillInfo[] }>;
-    refreshSkills(): Promise<{ ok: boolean; skills: SkillInfo[] }>;
+    getSkills(timeoutMs?: number): Promise<{ skills: SkillInfo[] }>;
+    refreshSkills(
+      timeoutMs?: number,
+    ): Promise<{ ok: boolean; skills: SkillInfo[] }>;
     installSkillFromGitHub(githubUrl: string): Promise<{
       ok: boolean;
       message: string;
@@ -398,12 +400,27 @@ declare module "./client-base" {
 // Prototype augmentation
 // ---------------------------------------------------------------------------
 
-ElizaClient.prototype.getSkills = async function (this: ElizaClient) {
-  return this.fetch("/api/skills");
+/** Skills list GET — existing 10s REST budget, independent hop. */
+export const SKILLS_LIST_FETCH_TIMEOUT_MS = 10_000;
+/** Skills refresh POST — existing 10s REST budget, independent hop. */
+export const SKILLS_REFRESH_FETCH_TIMEOUT_MS = 10_000;
+
+ElizaClient.prototype.getSkills = async function (
+  this: ElizaClient,
+  timeoutMs: number = SKILLS_LIST_FETCH_TIMEOUT_MS,
+) {
+  return this.fetch("/api/skills", undefined, { timeoutMs });
 };
 
-ElizaClient.prototype.refreshSkills = async function (this: ElizaClient) {
-  return this.fetch("/api/skills/refresh", { method: "POST" });
+ElizaClient.prototype.refreshSkills = async function (
+  this: ElizaClient,
+  timeoutMs: number = SKILLS_REFRESH_FETCH_TIMEOUT_MS,
+) {
+  return this.fetch(
+    "/api/skills/refresh",
+    { method: "POST" },
+    { timeoutMs },
+  );
 };
 
 ElizaClient.prototype.installSkillFromGitHub = async function (


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `getSkills` / `refreshSkills` called `this.fetch(path[, init])` with no `{ timeoutMs }`. This PR routes **only those two glance hops** through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (existing ordinary default, now explicit). No query params added or changed (`#21541` list-limit not restacked). Other `client-skills.ts` hops stay unbounded this tick. Not `#21966` CharacterLearnedSkills. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not `*WithFetch`. Not wallets. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. `GET /api/skills` has no query string (unchanged). Other skills/apps/connector hops in this file are untouched. Unfixed head: getSkills and refreshSkills called `fetch(path[, init])` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled getSkills hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

Glance skills list / refresh hops omitted `{ timeoutMs }`. This PR passes a separate `{ timeoutMs }` on each of those two hops only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Skills catalog UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-skills-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request` for getSkills and refreshSkills. `client-skills-timeout.test.ts` — TimeoutError / provider-error / success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-skills-timeout.test.ts \
  src/api/client-skills-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 8 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Glance skills hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Glance skills hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of skills glance timeout + native-transport files (8 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: getSkills and refreshSkills `this.fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`. No query params added.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run. Remaining `client-skills.ts` hops stay unbounded this tick.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. `#21541` list-limit not restacked. `#21966` CharacterLearnedSkills not touched. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:e386ec5c20a0238b901ca86791d647fe08acb28a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
