### PR TITLE
fix(ui): route local-inference hardware and device-tier hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-local-inference-native.test.ts
+++ b/packages/ui/src/api/client-local-inference-native.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves hardware and device-tier hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  LOCAL_INFERENCE_DEVICE_TIER_FETCH_TIMEOUT_MS,
+  LOCAL_INFERENCE_HARDWARE_FETCH_TIMEOUT_MS,
+} from "./client-local-inference";
+import "./client-local-inference";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const hardwareProbe = {
+  totalRamGb: 16,
+  freeRamGb: 8,
+  gpu: null,
+  cpuCores: 8,
+  platform: "linux",
+  arch: "x64",
+  appleSilicon: false,
+  recommendedBucket: "mid",
+  source: "os-fallback",
+};
+
+const deviceTierPayload = {
+  tier: {
+    tier: "GOOD",
+    reasons: ["16 GB RAM"],
+    canRunLocalLm: true,
+    canRunLocalVoice: true,
+    recommendedMode: "local",
+    recommendedFit: null,
+    numericContext: { vramGb: null, appleSilicon: false, mobile: false },
+  },
+};
+
+describe("ElizaClient local-inference hardware native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the hardware deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(hardwareProbe),
+    );
+    await makeClient(request).getLocalInferenceHardware();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/hardware",
+      expect.any(Object),
+      { timeoutMs: LOCAL_INFERENCE_HARDWARE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the device-tier deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(deviceTierPayload),
+    );
+    await makeClient(request).getLocalInferenceDeviceTier();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/device-tier",
+      expect.any(Object),
+      { timeoutMs: LOCAL_INFERENCE_DEVICE_TIER_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled hardware hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).getLocalInferenceHardware(10),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/hardware",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/api/client-local-inference-timeout.test.ts
+++ b/packages/ui/src/api/client-local-inference-timeout.test.ts
@@ -1,0 +1,127 @@
+/** Verifies local-inference hardware / device-tier hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  LOCAL_INFERENCE_DEVICE_TIER_FETCH_TIMEOUT_MS,
+  LOCAL_INFERENCE_HARDWARE_FETCH_TIMEOUT_MS,
+} from "./client-local-inference";
+import "./client-local-inference";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const hardwareProbe = {
+  totalRamGb: 16,
+  freeRamGb: 8,
+  gpu: null,
+  cpuCores: 8,
+  platform: "linux",
+  arch: "x64",
+  appleSilicon: false,
+  recommendedBucket: "mid",
+  source: "os-fallback",
+};
+
+const deviceTierPayload = {
+  tier: {
+    tier: "GOOD",
+    reasons: ["16 GB RAM"],
+    canRunLocalLm: true,
+    canRunLocalVoice: true,
+    recommendedMode: "local",
+    recommendedFit: null,
+    numericContext: { vramGb: null, appleSilicon: false, mobile: false },
+  },
+};
+
+describe("ElizaClient local-inference hardware native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(LOCAL_INFERENCE_HARDWARE_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(LOCAL_INFERENCE_DEVICE_TIER_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes hardware timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(hardwareProbe),
+    );
+    await makeClient(request).getLocalInferenceHardware();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/hardware",
+      expect.any(Object),
+      { timeoutMs: LOCAL_INFERENCE_HARDWARE_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes device-tier timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(deviceTierPayload),
+    );
+    await makeClient(request).getLocalInferenceDeviceTier();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/device-tier",
+      expect.any(Object),
+      { timeoutMs: LOCAL_INFERENCE_DEVICE_TIER_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled hardware hop as TimeoutError", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).getLocalInferenceHardware(10),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+  });
+
+  it("surfaces a provider error from a completed hardware GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(
+      makeClient(request).getLocalInferenceHardware(),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-local-inference.ts
+++ b/packages/ui/src/api/client-local-inference.ts
@@ -132,16 +132,21 @@ export function classifyDeviceTierFromProbe(
   return { tier, reason, cpuOnly, mobile };
 }
 
+/** Hardware GET — existing 10s REST budget, independent hop. */
+export const LOCAL_INFERENCE_HARDWARE_FETCH_TIMEOUT_MS = 10_000;
+/** Device-tier GET — existing 10s REST budget, independent hop. */
+export const LOCAL_INFERENCE_DEVICE_TIER_FETCH_TIMEOUT_MS = 10_000;
+
 declare module "./client-base" {
   interface ElizaClient {
     getLocalInferenceHub(): Promise<ModelHubSnapshot>;
-    getLocalInferenceHardware(): Promise<HardwareProbe>;
+    getLocalInferenceHardware(timeoutMs?: number): Promise<HardwareProbe>;
     /**
      * Resolve the live device tier by probing hardware and classifying it.
      * Backs the Settings → Voice tier banner and the per-slot "Auto"
      * resolution in the routing matrix.
      */
-    getLocalInferenceDeviceTier(): Promise<DeviceTierResult>;
+    getLocalInferenceDeviceTier(timeoutMs?: number): Promise<DeviceTierResult>;
     getLocalInferenceCatalog(): Promise<{ models: CatalogModel[] }>;
     getLocalInferenceInstalled(): Promise<{ models: InstalledModel[] }>;
     startLocalInferenceDownload(modelId: string): Promise<{ job: DownloadJob }>;
@@ -201,19 +206,23 @@ ElizaClient.prototype.getLocalInferenceHub = async function (
 
 ElizaClient.prototype.getLocalInferenceHardware = async function (
   this: ElizaClient,
+  timeoutMs: number = LOCAL_INFERENCE_HARDWARE_FETCH_TIMEOUT_MS,
 ) {
-  return this.fetch("/api/local-inference/hardware");
+  return this.fetch("/api/local-inference/hardware", undefined, { timeoutMs });
 };
 
 ElizaClient.prototype.getLocalInferenceDeviceTier = async function (
   this: ElizaClient,
+  timeoutMs: number = LOCAL_INFERENCE_DEVICE_TIER_FETCH_TIMEOUT_MS,
 ) {
   // Prefer the authoritative server assessment (same one the router's AUTO policy
   // consumes) so the UI's tier/recommendedMode/recommendedFit cannot disagree with
   // the actual routing decision. Fall back to the coarse client estimate only when
   // the endpoint is unavailable (older agent, transient error).
   try {
-    const res = (await this.fetch("/api/local-inference/device-tier")) as {
+    const res = (await this.fetch("/api/local-inference/device-tier", undefined, {
+      timeoutMs,
+    })) as {
       tier?: {
         tier?: DeviceTier;
         reasons?: string[];


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `getLocalInferenceHardware` and the device-tier hop inside `getLocalInferenceDeviceTier` called `this.fetch(path)` with no `{ timeoutMs }`. This PR routes **only those two hops** through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (existing ordinary default, now explicit). `getLocalInferenceHub` stays 30s (model-download stay-off). Downloads / catalog / installed / routing hops stay unbounded this tick. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not `*WithFetch`. Not wallets. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not remaining `client-skills.ts` hops. Not `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Hub stays 30s. Downloads untouched. Unfixed head: hardware and device-tier called `fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled hardware hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`. Device-tier failure still falls back to hardware, which now carries its own independent 10s budget.

# Background

## What does this PR do?

Local-inference hardware / device-tier hops omitted `{ timeoutMs }`. This PR passes a separate `{ timeoutMs }` on each of those two hops only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Local-inference UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-local-inference-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request` for hardware and device-tier. `client-local-inference-timeout.test.ts` — TimeoutError / provider-error / success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-local-inference-timeout.test.ts \
  src/api/client-local-inference-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 8 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Hardware and device-tier hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Hardware and device-tier hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of local-inference hardware timeout + native-transport files (8 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: hardware and device-tier `this.fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`. Hub 30s and downloads unchanged.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run. Remaining local-inference hops (catalog / installed / routing / downloads) stay unbounded this tick. `getLocalInferenceHub` stays 30s.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. Hub / downloads not restacked. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:f1ad893ad57280b73a914be9a62e6055d26ee084 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
