### PR TITLE
fix(ui): route character random-name and history hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-agent-character-native.test.ts
+++ b/packages/ui/src/api/client-agent-character-native.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves character random-name and history hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  CHARACTER_HISTORY_FETCH_TIMEOUT_MS,
+  CHARACTER_RANDOM_NAME_FETCH_TIMEOUT_MS,
+} from "./client-agent";
+import "./client-agent";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient character-history native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the random-name deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ name: "Ada" }),
+    );
+    await makeClient(request).getRandomName();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/character/random-name",
+      expect.any(Object),
+      { timeoutMs: CHARACTER_RANDOM_NAME_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the history deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ history: [] }),
+    );
+    await makeClient(request).listCharacterHistory();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/character/history",
+      expect.any(Object),
+      { timeoutMs: CHARACTER_HISTORY_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled history hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).listCharacterHistory(undefined, 10),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/character/history",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/api/client-agent-character-timeout.test.ts
+++ b/packages/ui/src/api/client-agent-character-timeout.test.ts
@@ -1,0 +1,112 @@
+/** Verifies character random-name / history hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  CHARACTER_HISTORY_FETCH_TIMEOUT_MS,
+  CHARACTER_RANDOM_NAME_FETCH_TIMEOUT_MS,
+} from "./client-agent";
+import "./client-agent";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient character-history native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(CHARACTER_RANDOM_NAME_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(CHARACTER_HISTORY_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes random-name timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ name: "Ada" }),
+    );
+    await makeClient(request).getRandomName();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/character/random-name",
+      expect.any(Object),
+      { timeoutMs: CHARACTER_RANDOM_NAME_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes history timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ history: [] }),
+    );
+    await makeClient(request).listCharacterHistory();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/character/history",
+      expect.any(Object),
+      { timeoutMs: CHARACTER_HISTORY_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("keeps limit/offset and passes history timeoutMs on that hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ history: [] }),
+    );
+    await makeClient(request).listCharacterHistory({ limit: 20, offset: 5 });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/character/history?limit=20&offset=5",
+      expect.any(Object),
+      { timeoutMs: CHARACTER_HISTORY_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled random-name hop as TimeoutError", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(makeClient(request).getRandomName(10)).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+  });
+
+  it("surfaces a provider error from a completed history GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(
+      makeClient(request).listCharacterHistory(),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -269,6 +269,11 @@ function logSettingsClient(
 const SETTINGS_MUTATION_TIMEOUT_MS = 30_000;
 const DESKTOP_STATUS_RPC_TIMEOUT_MS = 1_500;
 
+/** Random-name GET — existing 10s REST budget, independent hop. */
+export const CHARACTER_RANDOM_NAME_FETCH_TIMEOUT_MS = 10_000;
+/** Character-history GET — existing 10s REST budget, independent hop. */
+export const CHARACTER_HISTORY_FETCH_TIMEOUT_MS = 10_000;
+
 async function getDesktopStatusRpc<T>(
   baseUrl: string,
   rpcMethod: string,
@@ -597,7 +602,7 @@ declare module "./client-base" {
       character: CharacterData;
       agentName: string;
     }>;
-    getRandomName(): Promise<{ name: string }>;
+    getRandomName(timeoutMs?: number): Promise<{ name: string }>;
     generateCharacterField(
       field: string,
       context: {
@@ -613,10 +618,13 @@ declare module "./client-base" {
     updateCharacter(
       character: CharacterData,
     ): Promise<{ ok: boolean; character: CharacterData; agentName: string }>;
-    listCharacterHistory(options?: {
-      limit?: number;
-      offset?: number;
-    }): Promise<CharacterHistoryResponse>;
+    listCharacterHistory(
+      options?: {
+        limit?: number;
+        offset?: number;
+      },
+      timeoutMs?: number,
+    ): Promise<CharacterHistoryResponse>;
     listExperiences(
       options?: ExperienceListQuery,
     ): Promise<ExperienceListResponse>;
@@ -2573,8 +2581,11 @@ ElizaClient.prototype.getCharacter = async function (this: ElizaClient) {
   return this.fetch("/api/character");
 };
 
-ElizaClient.prototype.getRandomName = async function (this: ElizaClient) {
-  return this.fetch("/api/character/random-name");
+ElizaClient.prototype.getRandomName = async function (
+  this: ElizaClient,
+  timeoutMs: number = CHARACTER_RANDOM_NAME_FETCH_TIMEOUT_MS,
+) {
+  return this.fetch("/api/character/random-name", undefined, { timeoutMs });
 };
 
 ElizaClient.prototype.generateCharacterField = async function (
@@ -2602,6 +2613,7 @@ ElizaClient.prototype.updateCharacter = async function (
 ElizaClient.prototype.listCharacterHistory = async function (
   this: ElizaClient,
   options,
+  timeoutMs: number = CHARACTER_HISTORY_FETCH_TIMEOUT_MS,
 ) {
   const params = new URLSearchParams();
   if (typeof options?.limit === "number") {
@@ -2611,7 +2623,9 @@ ElizaClient.prototype.listCharacterHistory = async function (
     params.set("offset", String(options.offset));
   }
   const qs = params.toString();
-  return this.fetch(`/api/character/history${qs ? `?${qs}` : ""}`);
+  return this.fetch(`/api/character/history${qs ? `?${qs}` : ""}`, undefined, {
+    timeoutMs,
+  });
 };
 
 function appendMultiQueryParam(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `getRandomName` and `listCharacterHistory` called `this.fetch(path)` with no `{ timeoutMs }`. This PR routes **only those two hops** through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (existing ordinary default, now explicit). `getCharacter` stays RPC-then-HTTP (not restacked). First-run / wallet / subscription / reset untouched. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not `*WithFetch`. Not wallets. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not remaining `client-skills.ts` hops. Not remaining `client-local-inference.ts` hops. Not `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. `listCharacterHistory` still emits `?limit=` / `?offset=` only when those numbers are passed (unchanged). `getCharacter` RPC-then-HTTP path is untouched. Unfixed head: random-name and history called `fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled history hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

Character random-name / history hops omitted `{ timeoutMs }`. This PR passes a separate `{ timeoutMs }` on each of those two hops only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Character editor UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-agent-character-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request` for getRandomName and listCharacterHistory. `client-agent-character-timeout.test.ts` — TimeoutError / provider-error / success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-agent-character-timeout.test.ts \
  src/api/client-agent-character-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 9 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Character random-name and history hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Character random-name and history hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of character-history timeout + native-transport files (9 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: random-name and history `this.fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`. Query params unchanged. getCharacter not restacked.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run. `getCharacter` stays RPC-then-HTTP. Remaining `client-agent.ts` hops stay unbounded this tick.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. `getCharacter` / first-run / wallet / subscription / reset not restacked. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:f75b5fc3456c7c9a6306ae76c67829763e246458 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
