### PR TITLE
fix(ui): route document stats and list hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-chat-documents-native.test.ts
+++ b/packages/ui/src/api/client-chat-documents-native.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves document stats and list hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  DOCUMENT_LIST_FETCH_TIMEOUT_MS,
+  DOCUMENT_STATS_FETCH_TIMEOUT_MS,
+} from "./client-chat";
+import "./client-chat";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const stats = { documentCount: 0, fragmentCount: 0, agentId: "a1" };
+const list = { documents: [], total: 0, limit: 20, offset: 0 };
+
+describe("ElizaClient document-list native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the stats deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(stats),
+    );
+    await makeClient(request).getDocumentStats();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/documents/stats",
+      expect.any(Object),
+      { timeoutMs: DOCUMENT_STATS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the list deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(list),
+    );
+    await makeClient(request).listDocuments();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/documents",
+      expect.any(Object),
+      { timeoutMs: DOCUMENT_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled list hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).listDocuments(undefined, 10),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/documents",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/api/client-chat-documents-timeout.test.ts
+++ b/packages/ui/src/api/client-chat-documents-timeout.test.ts
@@ -1,0 +1,115 @@
+/** Verifies document stats / list hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  DOCUMENT_LIST_FETCH_TIMEOUT_MS,
+  DOCUMENT_STATS_FETCH_TIMEOUT_MS,
+} from "./client-chat";
+import "./client-chat";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const stats = { documentCount: 0, fragmentCount: 0, agentId: "a1" };
+const list = { documents: [], total: 0, limit: 20, offset: 0 };
+
+describe("ElizaClient document-list native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(DOCUMENT_STATS_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(DOCUMENT_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes stats timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(stats),
+    );
+    await makeClient(request).getDocumentStats();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/documents/stats",
+      expect.any(Object),
+      { timeoutMs: DOCUMENT_STATS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes list timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(list),
+    );
+    await makeClient(request).listDocuments();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/documents",
+      expect.any(Object),
+      { timeoutMs: DOCUMENT_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("keeps ?q= and passes list timeoutMs on that hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(list),
+    );
+    await makeClient(request).listDocuments({ query: "x" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/documents?q=x",
+      expect.any(Object),
+      { timeoutMs: DOCUMENT_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled stats hop as TimeoutError", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(makeClient(request).getDocumentStats(10)).rejects.toMatchObject(
+      {
+        name: "ApiError",
+        kind: "timeout",
+      },
+    );
+  });
+
+  it("surfaces a provider error from a completed list GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(makeClient(request).listDocuments()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -576,11 +576,14 @@ declare module "./client-base" {
     cleanupEmptyConversations(options?: {
       keepId?: string;
     }): Promise<{ deleted: string[] }>;
-    getDocumentStats(): Promise<DocumentStats>;
+    getDocumentStats(timeoutMs?: number): Promise<DocumentStats>;
     getDocumentFacetCounts(
       options?: DocumentListOptions,
     ): Promise<DocumentFacetCountsResponse>;
-    listDocuments(options?: DocumentListOptions): Promise<DocumentsResponse>;
+    listDocuments(
+      options?: DocumentListOptions,
+      timeoutMs?: number,
+    ): Promise<DocumentsResponse>;
     getDocument(documentId: string): Promise<{ document: DocumentDetail }>;
     updateDocument(
       documentId: string,
@@ -1426,17 +1429,28 @@ ElizaClient.prototype.cleanupEmptyConversations = async function (
   });
 };
 
-ElizaClient.prototype.getDocumentStats = async function (this: ElizaClient) {
-  return this.fetch("/api/documents/stats");
+/** Document stats GET — existing 10s REST budget, independent hop. */
+export const DOCUMENT_STATS_FETCH_TIMEOUT_MS = 10_000;
+/** Document list GET — existing 10s REST budget, independent hop. */
+export const DOCUMENT_LIST_FETCH_TIMEOUT_MS = 10_000;
+
+ElizaClient.prototype.getDocumentStats = async function (
+  this: ElizaClient,
+  timeoutMs: number = DOCUMENT_STATS_FETCH_TIMEOUT_MS,
+) {
+  return this.fetch("/api/documents/stats", undefined, { timeoutMs });
 };
 
 ElizaClient.prototype.listDocuments = async function (
   this: ElizaClient,
   options?,
+  timeoutMs: number = DOCUMENT_LIST_FETCH_TIMEOUT_MS,
 ) {
   const params = buildDocumentListParams(options);
   const query = params.toString();
-  return this.fetch(`/api/documents${query ? `?${query}` : ""}`);
+  return this.fetch(`/api/documents${query ? `?${query}` : ""}`, undefined, {
+    timeoutMs,
+  });
 };
 
 ElizaClient.prototype.getDocumentFacetCounts = async function (


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `getDocumentStats` and `listDocuments` called `this.fetch(path)` with no `{ timeoutMs }`. This PR routes **only those two hops** through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (existing ordinary default, now explicit). Query construction (`?q=` / limit / offset / filters) is unchanged (`#21541` list-limit not restacked). Remaining `client-chat.ts` hops stay unbounded this tick. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not `*WithFetch`. Not wallets. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not remaining `client-agent.ts` / `client-skills.ts` / `client-local-inference.ts` hops. Not `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. `listDocuments` still builds the same query string via `buildDocumentListParams`. Facets / get / upload / search hops are untouched. Unfixed head: stats and list called `fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled list hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

Document stats / list hops omitted `{ timeoutMs }`. This PR passes a separate `{ timeoutMs }` on each of those two hops only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Knowledge hub UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-chat-documents-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request` for getDocumentStats and listDocuments. `client-chat-documents-timeout.test.ts` — TimeoutError / provider-error / success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-chat-documents-timeout.test.ts \
  src/api/client-chat-documents-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 9 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Document stats and list hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Document stats and list hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of document-list timeout + native-transport files (9 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: stats and list `this.fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`. Query params unchanged. `#21541` list-limit not restacked.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run. Remaining `client-chat.ts` hops (facets / get / upload / search / memory) stay unbounded this tick.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:007250832c79359218fa9d9ba10ebe23434f35f4 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
