### PR TITLE
fix(ui): route sandbox platform and browser hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-cloud-sandbox-native.test.ts
+++ b/packages/ui/src/api/client-cloud-sandbox-native.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves sandbox platform and browser hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  SANDBOX_BROWSER_FETCH_TIMEOUT_MS,
+  SANDBOX_PLATFORM_FETCH_TIMEOUT_MS,
+} from "./client-cloud";
+import "./client-cloud";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const platform = {
+  platform: "darwin",
+  arch: "arm64",
+  dockerInstalled: true,
+  dockerAvailable: true,
+  dockerRunning: true,
+  recommended: "docker",
+};
+
+const browser = {
+  cdpEndpoint: "http://127.0.0.1:9222",
+  wsEndpoint: null,
+  noVncEndpoint: null,
+};
+
+describe("ElizaClient sandbox native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the platform deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(platform),
+    );
+    await makeClient(request).getSandboxPlatform();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/sandbox/platform",
+      expect.any(Object),
+      { timeoutMs: SANDBOX_PLATFORM_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the browser deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(browser),
+    );
+    await makeClient(request).getSandboxBrowser();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/sandbox/browser",
+      expect.any(Object),
+      { timeoutMs: SANDBOX_BROWSER_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled browser hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(makeClient(request).getSandboxBrowser(10)).rejects.toMatchObject(
+      {
+        name: "ApiError",
+        kind: "timeout",
+      },
+    );
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/sandbox/browser",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/api/client-cloud-sandbox-timeout.test.ts
+++ b/packages/ui/src/api/client-cloud-sandbox-timeout.test.ts
@@ -1,0 +1,115 @@
+/** Verifies sandbox platform / browser hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  SANDBOX_BROWSER_FETCH_TIMEOUT_MS,
+  SANDBOX_PLATFORM_FETCH_TIMEOUT_MS,
+} from "./client-cloud";
+import "./client-cloud";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const platform = {
+  platform: "darwin",
+  arch: "arm64",
+  dockerInstalled: true,
+  dockerAvailable: true,
+  dockerRunning: true,
+  recommended: "docker",
+};
+
+const browser = {
+  cdpEndpoint: "http://127.0.0.1:9222",
+  wsEndpoint: null,
+  noVncEndpoint: null,
+};
+
+describe("ElizaClient sandbox native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(SANDBOX_PLATFORM_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(SANDBOX_BROWSER_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes platform timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(platform),
+    );
+    await makeClient(request).getSandboxPlatform();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/sandbox/platform",
+      expect.any(Object),
+      { timeoutMs: SANDBOX_PLATFORM_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes browser timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(browser),
+    );
+    await makeClient(request).getSandboxBrowser();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/sandbox/browser",
+      expect.any(Object),
+      { timeoutMs: SANDBOX_BROWSER_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled platform hop as TimeoutError", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).getSandboxPlatform(10),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+  });
+
+  it("surfaces a provider error from a completed browser GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(makeClient(request).getSandboxBrowser()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -1657,8 +1657,8 @@ declare module "./client-base" {
       restored: true;
       requiresRestart: true;
     }>;
-    getSandboxPlatform(): Promise<SandboxPlatformStatus>;
-    getSandboxBrowser(): Promise<SandboxBrowserEndpoints>;
+    getSandboxPlatform(timeoutMs?: number): Promise<SandboxPlatformStatus>;
+    getSandboxBrowser(timeoutMs?: number): Promise<SandboxBrowserEndpoints>;
     getSandboxScreenshot(
       region?: SandboxScreenshotRegion,
     ): Promise<SandboxScreenshotPayload>;
@@ -3164,12 +3164,23 @@ ElizaClient.prototype.restoreLocalAgentBackup = async function (
   );
 };
 
-ElizaClient.prototype.getSandboxPlatform = async function (this: ElizaClient) {
-  return this.fetch("/api/sandbox/platform");
+/** Sandbox platform GET — existing 10s REST budget, independent hop. */
+export const SANDBOX_PLATFORM_FETCH_TIMEOUT_MS = 10_000;
+/** Sandbox browser GET — existing 10s REST budget, independent hop. */
+export const SANDBOX_BROWSER_FETCH_TIMEOUT_MS = 10_000;
+
+ElizaClient.prototype.getSandboxPlatform = async function (
+  this: ElizaClient,
+  timeoutMs: number = SANDBOX_PLATFORM_FETCH_TIMEOUT_MS,
+) {
+  return this.fetch("/api/sandbox/platform", undefined, { timeoutMs });
 };
 
-ElizaClient.prototype.getSandboxBrowser = async function (this: ElizaClient) {
-  return this.fetch("/api/sandbox/browser");
+ElizaClient.prototype.getSandboxBrowser = async function (
+  this: ElizaClient,
+  timeoutMs: number = SANDBOX_BROWSER_FETCH_TIMEOUT_MS,
+) {
+  return this.fetch("/api/sandbox/browser", undefined, { timeoutMs });
 };
 
 ElizaClient.prototype.getSandboxScreenshot = async function (


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `getSandboxPlatform` and `getSandboxBrowser` called `this.fetch(path)` with no `{ timeoutMs }`. These are **UI ElizaClient hops** to local `plugin-computeruse` `/api/sandbox/platform` and `/api/sandbox/browser` — not `packages/cloud/api/**` JSON 500-series, not grok-owned cloud persist, not `browser-launch.ts` launch-sessions, not billing / credits / x402. This PR routes **only those two hops** through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets. Screenshot / windows / docker / cloud login-persist / billing stay unbounded. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not wallets. Not Twilio. Not TelegramBotSetupPanel. Not the ten inbox CR files. Not remaining agent / skills / local-inference / chat hops. Not `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Server routes live in `plugins/plugin-computeruse/src/routes/sandbox-routes.ts` (local sandbox status), not cloud JSON. Billing / credits / `cloudLoginDirect` untouched. Unfixed head: platform and browser called `fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

Sandbox platform / browser hops omitted `{ timeoutMs }`. This PR passes a separate `{ timeoutMs }` on each of those two hops only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Sandbox UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-cloud-sandbox-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request` for getSandboxPlatform and getSandboxBrowser. `client-cloud-sandbox-timeout.test.ts` — TimeoutError / provider-error / success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-cloud-sandbox-timeout.test.ts \
  src/api/client-cloud-sandbox-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 8 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Sandbox platform and browser hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Sandbox platform and browser hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of sandbox timeout + native-transport files (8 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: platform and browser `this.fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`. Not cloud JSON 500-series. Not billing.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run. Remaining `client-cloud.ts` hops (screenshot / windows / docker / billing / login) stay unbounded this tick.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. Cloud JSON / billing / `browser-launch.ts` not restacked. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:35a37af426814e18205447ec3866f9c59e74cc56 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
