### PR TITLE
fix(ui): route workflow status and list hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-workflow-native.test.ts
+++ b/packages/ui/src/api/client-workflow-native.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves workflow status and list hops carry timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  WORKFLOW_LIST_FETCH_TIMEOUT_MS,
+  WORKFLOW_STATUS_FETCH_TIMEOUT_MS,
+} from "./client-workflow";
+import "./client-workflow";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const status = {
+  mode: "disabled",
+  host: null,
+  status: "ready",
+  cloudConnected: false,
+  localEnabled: true,
+  engine: "smthrs",
+};
+
+describe("ElizaClient workflow native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the status deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(status),
+    );
+    await makeClient(request).getWorkflowStatus();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/workflow/status",
+      expect.any(Object),
+      { timeoutMs: WORKFLOW_STATUS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards the list deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ workflows: [] }),
+    );
+    await makeClient(request).listWorkflowDefinitions();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/workflow/workflows",
+      expect.any(Object),
+      { timeoutMs: WORKFLOW_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled list hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).listWorkflowDefinitions(10),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/workflow/workflows",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+});

--- a/packages/ui/src/api/client-workflow-timeout.test.ts
+++ b/packages/ui/src/api/client-workflow-timeout.test.ts
@@ -1,0 +1,111 @@
+/** Verifies workflow status / list hops pass timeoutMs through ElizaClient.fetch. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import {
+  WORKFLOW_LIST_FETCH_TIMEOUT_MS,
+  WORKFLOW_STATUS_FETCH_TIMEOUT_MS,
+} from "./client-workflow";
+import "./client-workflow";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const status = {
+  mode: "disabled",
+  host: null,
+  status: "ready",
+  cloudConnected: false,
+  localEnabled: true,
+  engine: "smthrs",
+};
+
+describe("ElizaClient workflow native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget per hop", () => {
+    expect(WORKFLOW_STATUS_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(WORKFLOW_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes status timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(status),
+    );
+    await makeClient(request).getWorkflowStatus();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/workflow/status",
+      expect.any(Object),
+      { timeoutMs: WORKFLOW_STATUS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("passes list timeoutMs through client.fetch", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ workflows: [] }),
+    );
+    await makeClient(request).listWorkflowDefinitions();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/workflow/workflows",
+      expect.any(Object),
+      { timeoutMs: WORKFLOW_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("aborts a stalled status hop as TimeoutError", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(makeClient(request).getWorkflowStatus(10)).rejects.toMatchObject(
+      {
+        name: "ApiError",
+        kind: "timeout",
+      },
+    );
+  });
+
+  it("surfaces a provider error from a completed list GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(
+      makeClient(request).listWorkflowDefinitions(),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-workflow.ts
+++ b/packages/ui/src/api/client-workflow.ts
@@ -24,9 +24,9 @@ import { workflowSurfaceClient } from "./workflow-surface-routing";
 
 declare module "./client-base" {
   interface ElizaClient {
-    getWorkflowStatus(): Promise<WorkflowStatusResponse>;
+    getWorkflowStatus(timeoutMs?: number): Promise<WorkflowStatusResponse>;
     getWorkflowDefinition(id: string): Promise<WorkflowDefinition>;
-    listWorkflowDefinitions(): Promise<WorkflowDefinition[]>;
+    listWorkflowDefinitions(timeoutMs?: number): Promise<WorkflowDefinition[]>;
     createWorkflowDefinition(
       request: WorkflowDefinitionWriteRequest,
     ): Promise<WorkflowDefinition>;
@@ -81,11 +81,19 @@ declare module "./client-base" {
 // Implementations
 // ---------------------------------------------------------------------------
 
+/** Workflow status GET — existing 10s REST budget, independent hop. */
+export const WORKFLOW_STATUS_FETCH_TIMEOUT_MS = 10_000;
+/** Workflow list GET — existing 10s REST budget, independent hop. */
+export const WORKFLOW_LIST_FETCH_TIMEOUT_MS = 10_000;
+
 ElizaClient.prototype.getWorkflowStatus = async function (
   this: ElizaClient,
+  timeoutMs: number = WORKFLOW_STATUS_FETCH_TIMEOUT_MS,
 ): Promise<WorkflowStatusResponse> {
   return workflowSurfaceClient(this).fetch<WorkflowStatusResponse>(
     "/api/workflow/status",
+    undefined,
+    { timeoutMs },
   );
 };
 
@@ -100,10 +108,11 @@ ElizaClient.prototype.getWorkflowDefinition = async function (
 
 ElizaClient.prototype.listWorkflowDefinitions = async function (
   this: ElizaClient,
+  timeoutMs: number = WORKFLOW_LIST_FETCH_TIMEOUT_MS,
 ): Promise<WorkflowDefinition[]> {
   const res = await workflowSurfaceClient(this).fetch<{
     workflows: WorkflowDefinition[];
-  }>("/api/workflow/workflows");
+  }>("/api/workflow/workflows", undefined, { timeoutMs });
   return res.workflows ?? [];
 };
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `getWorkflowStatus` and `listWorkflowDefinitions` called `workflowSurfaceClient(this).fetch(path)` with no `{ timeoutMs }`. This PR routes **only those two hops** through `client.fetch` / `{ timeoutMs }` with **separate** 10s REST budgets (existing ordinary default, now explicit). `runWorkflowDefinition` stays 30s + `skipResume`. Remaining CRUD / execution hops stay unbounded this tick. `#21541` list-limit not restacked (`getWorkflowExecutions` `?limit=` untouched). Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not wallets. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not remaining agent / skills / local-inference / chat / cloud hops. Not `#21982` / `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. `workflowSurfaceClient` routing unchanged. Run hop still 30s + `skipResume`. Unfixed head: status and list called `fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

Workflow status / list hops omitted `{ timeoutMs }`. This PR passes a separate `{ timeoutMs }` on each of those two hops only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Workflow UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-workflow-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request` for getWorkflowStatus and listWorkflowDefinitions. `client-workflow-timeout.test.ts` — TimeoutError / provider-error / success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-workflow-timeout.test.ts \
  src/api/client-workflow-native.test.ts
```

Unfixed head: hops hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: 8 passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. Workflow status and list hops now use ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. Workflow status and list hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of workflow timeout + native-transport files (8 passed). Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: status and list `workflowSurfaceClient(this).fetch` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: each hop forwards its own deadline to `Agent.request`. Run hop 30s unchanged.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run. Remaining `client-workflow.ts` hops (get/create/update/run/executions) stay unbounded this tick except the existing run 30s.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Separate deadlines per hop. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21982` / `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked.

<!-- evidence-head:b43b002979afc757c355f8da685aeca54ea36b13 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
