### PR TITLE
fix(auth): classify a reset-vacated root as the typed generation fence

### DIFF
--- a/packages/auth/src/account-storage.ts
+++ b/packages/auth/src/account-storage.ts
@@ -412,7 +412,23 @@ function acquireStorageLock(
       }
       return { lockDir, ownerFile, policy, token };
     } catch (cause) {
-      if ((cause as NodeJS.ErrnoException).code !== "EEXIST") throw cause;
+      const errorCode = (cause as NodeJS.ErrnoException).code;
+      if (errorCode === "ENOENT") {
+        // error-policy:J2 The auth root vanished between lock creation and
+        // the generation check — a concurrent full reset removed it. The
+        // fence held (nothing was written); surface the typed generation
+        // error the reset contract promises instead of the raw ENOENT.
+        throw storageError(
+          "AUTH_CREDENTIAL_STORAGE_GENERATION_CHANGED",
+          "Credential storage policy predates the latest reset",
+          {
+            operation,
+            policyGeneration: policy[ACCOUNT_STORAGE_ROOT_IDENTITY].generation,
+          },
+          cause,
+        );
+      }
+      if (errorCode !== "EEXIST") throw cause;
       if (removeStaleLock(policy, lockDir)) continue;
       if (Date.now() - startedAt >= STORAGE_LOCK_TIMEOUT_MS) {
         throw storageError(


### PR DESCRIPTION
A stale writer that races a full credential-storage reset can hit ENOENT inside the lock window when the reset deletes the auth root between lock creation and the generation check; the raw errno escaped instead of the typed AUTH_CREDENTIAL_STORAGE_GENERATION_CHANGED the reset contract promises (release candidate run 32122308997 — the subprocess fence suite was the only red in the full test lane). The vanished root is itself proof of a concurrent reset — the fence held; the lock path now maps ENOENT to the typed error with the errno preserved as cause (error-policy:J2). Auth lane 171/171; Biome clean.