### PR TITLE
fix(plugin-elizacloud): fail closed when IMAGE generation returns no url

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/image-generation.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/image-generation.test.ts
@@ -68,6 +68,14 @@ describe("handleImageGeneration fail-closed contract (#21985)", () => {
     ]);
   });
 
+  it("falls back to a valid base64 image when url is empty", async () => {
+    const b64 = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==";
+    generateImage.mockResolvedValue({ images: [{ url: "", image: b64 }] });
+    await expect(handleImageGeneration(runtime(), { prompt: "a cat" })).resolves.toEqual([
+      { url: b64 },
+    ]);
+  });
+
   it("rejects a mixed batch rather than returning an empty-url hole", async () => {
     generateImage.mockResolvedValue({
       images: [{}, { url: "https://cdn/ok.png" }],

--- a/plugins/plugin-elizacloud/__tests__/image-generation.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/image-generation.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression coverage for `handleImageGeneration`'s fail-closed contract
+ * (elizaOS/eliza#21985). The IMAGE slot must never fabricate a healthy-looking
+ * `{ url: "" }` for a cloud entry that carries neither `url` nor `image`
+ * (partial/failed/moderated generation). It must throw the same way the
+ * sibling `handleVideoGeneration`/`handleAudioGeneration`/
+ * `handleImageDescription` handlers in this package already fail closed, so the
+ * runtime reports the failure instead of storing an empty attachment
+ * reference. The cloud SDK client is mocked; no network.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const generateImage = vi.fn();
+vi.mock("../src/utils/sdk-client", () => ({
+  createElizaCloudClient: () => ({ generateImage }),
+}));
+vi.mock("../src/utils/config", async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getImageGenerationModel: () => "google/nano-banana-2/text-to-image",
+  };
+});
+
+const { handleImageGeneration } = await import("../src/models/image");
+
+function runtime(): IAgentRuntime {
+  return { getSetting: () => "", emitEvent: () => {} } as unknown as IAgentRuntime;
+}
+
+describe("handleImageGeneration fail-closed contract (#21985)", () => {
+  afterEach(() => generateImage.mockReset());
+
+  it("throws instead of fabricating { url: '' } when an entry has neither url nor image", async () => {
+    generateImage.mockResolvedValue({ images: [{}] });
+    await expect(handleImageGeneration(runtime(), { prompt: "a cat" })).rejects.toThrow(
+      /returned no image URL/i
+    );
+  });
+
+  it("throws when the cloud returns an empty images array for a >=1 image request", async () => {
+    generateImage.mockResolvedValue({ images: [] });
+    await expect(handleImageGeneration(runtime(), { prompt: "a cat" })).rejects.toThrow(
+      /returned no image/i
+    );
+  });
+
+  it("throws when the cloud omits the images field entirely", async () => {
+    generateImage.mockResolvedValue({});
+    await expect(handleImageGeneration(runtime(), { prompt: "a cat" })).rejects.toThrow(
+      /returned no image/i
+    );
+  });
+
+  it("resolves a single entry that carries only a url", async () => {
+    generateImage.mockResolvedValue({ images: [{ url: "https://cdn/ok.png" }] });
+    await expect(handleImageGeneration(runtime(), { prompt: "a cat" })).resolves.toEqual([
+      { url: "https://cdn/ok.png" },
+    ]);
+  });
+
+  it("preserves a base64 entry that carries only the image field", async () => {
+    const b64 = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==";
+    generateImage.mockResolvedValue({ images: [{ image: b64 }] });
+    await expect(handleImageGeneration(runtime(), { prompt: "a cat" })).resolves.toEqual([
+      { url: b64 },
+    ]);
+  });
+
+  it("rejects a mixed batch rather than returning an empty-url hole", async () => {
+    generateImage.mockResolvedValue({
+      images: [{}, { url: "https://cdn/ok.png" }],
+    });
+    await expect(handleImageGeneration(runtime(), { prompt: "a cat" })).rejects.toThrow(
+      /returned no image URL/i
+    );
+  });
+
+  it("rejects when an entry's url is an empty string", async () => {
+    generateImage.mockResolvedValue({ images: [{ url: "" }] });
+    await expect(handleImageGeneration(runtime(), { prompt: "a cat" })).rejects.toThrow(
+      /returned no image URL/i
+    );
+  });
+});

--- a/plugins/plugin-elizacloud/src/models/image.ts
+++ b/plugins/plugin-elizacloud/src/models/image.ts
@@ -62,9 +62,23 @@ export async function handleImageGeneration(
       }
     }
 
-    const result = typedData.images.map((img: { url?: string; image?: string }) => ({
-      url: img.url ?? img.image ?? "",
-    }));
+    // Fail closed, matching the sibling handlers in this package: video/audio
+    // throw "...returned no video/audio URL" and image-description throws on an
+    // empty completion. A request that asked for >=1 image but got back no
+    // entries, or an entry that carries neither a `url` nor a base64 `image`
+    // (partial/failed/moderated generation), is a failure — never fabricate a
+    // healthy-looking `{ url: "" }` for the IMAGE slot (elizaOS/eliza#21985).
+    const images = typedData.images;
+    if (!Array.isArray(images) || images.length === 0) {
+      throw new Error("Eliza Cloud image generation returned no images");
+    }
+    const result = images.map((img: { url?: string; image?: string }) => {
+      const url = img.url ?? img.image;
+      if (typeof url !== "string" || url.trim() === "") {
+        throw new Error("Eliza Cloud image generation returned no image URL");
+      }
+      return { url };
+    });
     return result;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/plugins/plugin-elizacloud/src/models/image.ts
+++ b/plugins/plugin-elizacloud/src/models/image.ts
@@ -73,8 +73,11 @@ export async function handleImageGeneration(
       throw new Error("Eliza Cloud image generation returned no images");
     }
     const result = images.map((img: { url?: string; image?: string }) => {
-      const url = img.url ?? img.image;
-      if (typeof url !== "string" || url.trim() === "") {
+      const url = [img.url, img.image].find(
+        (candidate): candidate is string =>
+          typeof candidate === "string" && candidate.trim() !== "",
+      );
+      if (!url) {
         throw new Error("Eliza Cloud image generation returned no image URL");
       }
       return { url };


### PR DESCRIPTION
## Summary

`handleImageGeneration` in `plugins/plugin-elizacloud/src/models/image.ts` mapped
each cloud result via `url: img.url ?? img.image ?? ""`. When the cloud returned
an image entry carrying neither `url` nor `image` (a partial / failed / moderated
generation), the handler returned a healthy-looking `{ url: "" }` for the
`ModelType.IMAGE` slot instead of surfacing the failure. Downstream consumers of
the IMAGE model then treated generation as successful and stored/posted an empty
attachment reference.

This is a J-policy / AGENTS.md violation ("`?? <literal>` used to disguise missing
required data"; DTO fields required by default) and was inconsistent with the rest
of the same package, which fails closed:

- `handleVideoGeneration` throws `"Eliza Cloud video generation returned no video URL"` (`src/models/media.ts`).
- `handleAudioGeneration` throws `"Eliza Cloud music generation returned no audio URL"` (`src/models/media.ts`).
- `handleImageDescription` throws `"ElizaOS Cloud image description returned an empty completion"` (`src/models/image.ts`).

## Change

Replace the `?? ""` fabrication with explicit validation that mirrors those
sibling handlers:

- Throw `"Eliza Cloud image generation returned no images"` when the cloud returns
  no entries for a request that asked for >=1 image.
- Throw `"Eliza Cloud image generation returned no image URL"` for any entry that
  carries neither a `url` nor a base64 `image`.
- Preserve the existing base64 `image` path.

Closes #21985

## Test plan

Added `plugins/plugin-elizacloud/__tests__/image-generation.test.ts` (mocks
`../src/utils/sdk-client`, no network), covering the changed contract:

1. entry with neither `url` nor `image` -> rejects with the no-URL error
2. empty `images: []` -> rejects
3. `images` field omitted entirely -> rejects
4. entry with only `url` -> resolves `[{ url }]`
5. entry with only base64 `image` -> resolves preserving it
6. mixed valid + invalid batch -> rejects rather than returning an empty-url hole
7. entry whose `url` is an empty string -> rejects

## Package gates

- `bun run typecheck` -> passes (`tsc --noEmit -p tsconfig.json`, no output).
- `bun run lint` -> `Checked 62 files in 331ms. No fixes applied.`
- `bunx vitest run` (full package) -> `491 passed | 5 skipped`. The single
  `__tests__/unit/research-retirement.test.ts` failure is a pre-existing
  environmental issue (an unbuilt self-referencing
  `@elizaos/plugin-elizacloud/endpoint-config` subpath export); it fails
  identically on the parent commit and is unrelated to this change.

# Evidence Gate

<!-- evidence-head:0c643c6b7b676eb329f74a72fc088bf1c4d1616e -->

### Evidence rows

- Before screenshots:
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface; this is a runtime model-handler bug fix

- After screenshots:
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface; this is a runtime model-handler bug fix

- Walkthrough video:
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI or interactive flow changed

- Backend logs (focused vitest output, failing-before then passing-after):
<!-- evidence-row:backend-logs -->
```text
FAILING BEFORE (parent commit's image.ts, new tests run against the pre-fix handler):
 × throws instead of fabricating { url: '' } when an entry has neither url nor image 17ms
   -> promise resolved "[ { url: '' } ]" instead of rejecting
 × throws when the cloud returns an empty images array for a >=1 image request 2ms
   -> promise resolved "[]" instead of rejecting
 × throws when the cloud omits the images field entirely 8ms
   -> expected [Function] to throw error matching /returned no image/i but got 'Cannot read properties of undefined (reading map)'
 ✓ resolves a single entry that carries only a url 2ms
 ✓ preserves a base64 entry that carries only the image field 1ms
 × rejects a mixed batch rather than returning an empty-url hole 3ms
   -> promise resolved "[ { url: '' }, ...(1) ]" instead of rejecting
 × rejects when an entry's url is an empty string 2ms
   -> promise resolved "[ { url: '' } ]" instead of rejecting
 Test Files  1 failed (1)
      Tests  5 failed | 2 passed (7)

PASSING AFTER (with the fail-closed fix applied):
 ✓ throws instead of fabricating { url: '' } when an entry has neither url nor image 8ms
 ✓ throws when the cloud returns an empty images array for a >=1 image request 2ms
 ✓ throws when the cloud omits the images field entirely 1ms
 ✓ resolves a single entry that carries only a url 2ms
 ✓ preserves a base64 entry that carries only the image field 1ms
 ✓ rejects a mixed batch rather than returning an empty-url hole 1ms
 ✓ rejects when an entry's url is an empty string 1ms
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Full run logs: https://gist.github.com/agent-cortex/6429fcb3aa58d635267415973e1c1db3

- Frontend logs:
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path touched

- Real-LLM trajectory:
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - response-shape validation of the IMAGE handler; the SDK client is mocked deterministically to reproduce a url-less/moderated cloud entry that a live model cannot emit on demand

- Domain artifacts (the failing-then-passing reproduction of the empty-url hole):
<!-- evidence-row:domain-artifacts -->
```text
The exact defect is the IMAGE handler resolving a malformed cloud entry to a
healthy-looking { url: "" }. Pre-fix the handler produces the hole; post-fix it rejects.
Observed vitest assertions against handleImageGeneration:

cloud response { images: [{}] }
  pre-fix  handleImageGeneration -> resolved "[ { url: '' } ]"   (the empty-url hole)
  post-fix handleImageGeneration -> rejects  "Eliza Cloud image generation returned no image URL"

cloud response { images: [] }
  pre-fix  -> resolved "[]"                                       (silent empty batch)
  post-fix -> rejects  "Eliza Cloud image generation returned no images"

cloud response { images: [{}, { url: 'https://cdn/ok.png' }] }
  pre-fix  -> resolved "[ { url: '' }, { url: 'https://cdn/ok.png' } ]"  (hole in a mixed batch)
  post-fix -> rejects  "Eliza Cloud image generation returned no image URL"
```

Full reproduction logs: https://gist.github.com/agent-cortex/54f1cb68100b56e4ca36ea869d157e6f

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza"} -->
