### PR TITLE
fix(ui): route listScheduledTasks hop through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-scheduled-tasks-native.test.ts
+++ b/packages/ui/src/api/client-scheduled-tasks-native.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves listScheduledTasks carries timeoutMs into Agent.request.
+ * Query construction (#21541) is unchanged.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import { SCHEDULED_TASKS_LIST_FETCH_TIMEOUT_MS } from "./client-scheduled-tasks";
+import "./client-scheduled-tasks";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient scheduled-tasks native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget for the list hop", () => {
+    expect(SCHEDULED_TASKS_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("forwards the list deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ tasks: [] }),
+    );
+    await makeClient(request).listScheduledTasks();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/lifeops/scheduled-tasks",
+      expect.any(Object),
+      { timeoutMs: SCHEDULED_TASKS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("keeps ownerVisibleOnly query construction unchanged", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ tasks: [] }),
+    );
+    await makeClient(request).listScheduledTasks({ ownerVisibleOnly: true });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/lifeops/scheduled-tasks?ownerVisibleOnly=1",
+      expect.any(Object),
+      { timeoutMs: SCHEDULED_TASKS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled list hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).listScheduledTasks(undefined, 10),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/lifeops/scheduled-tasks",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from a completed list GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(makeClient(request).listScheduledTasks()).rejects.toMatchObject(
+      {
+        name: "ApiError",
+        status: 503,
+      },
+    );
+  });
+});

--- a/packages/ui/src/api/client-scheduled-tasks.ts
+++ b/packages/ui/src/api/client-scheduled-tasks.ts
@@ -9,6 +9,9 @@ import type {
   ScheduledTaskView,
 } from "./client-types-core";
 
+/** Scheduled-tasks list GET — existing 10s REST budget, independent hop. */
+export const SCHEDULED_TASKS_LIST_FETCH_TIMEOUT_MS = 10_000;
+
 /**
  * Owner-facing scheduled-task verbs (`POST /api/lifeops/scheduled-tasks/:id/<verb>`).
  * These are exactly the runner's frozen `ScheduledTaskVerb` set.
@@ -53,6 +56,7 @@ declare module "./client-base" {
      */
     listScheduledTasks(
       filter?: ScheduledTaskListFilter,
+      timeoutMs?: number,
     ): Promise<ScheduledTaskListResponse>;
 
     /**
@@ -104,9 +108,12 @@ function buildQuery(filter?: ScheduledTaskListFilter): string {
 ElizaClient.prototype.listScheduledTasks = async function (
   this: ElizaClient,
   filter?: ScheduledTaskListFilter,
+  timeoutMs: number = SCHEDULED_TASKS_LIST_FETCH_TIMEOUT_MS,
 ): Promise<ScheduledTaskListResponse> {
   const res = await this.fetch<{ tasks?: ScheduledTaskView[] }>(
     `/api/lifeops/scheduled-tasks${buildQuery(filter)}`,
+    undefined,
+    { timeoutMs },
   );
   return { tasks: Array.isArray(res?.tasks) ? res.tasks : [] };
 };


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `listScheduledTasks` called `this.fetch("/api/lifeops/scheduled-tasks…")` with no `{ timeoutMs }`. This PR routes **that hop** through `client.fetch` / `{ timeoutMs }` with an explicit 10s REST budget. `buildQuery` / `#21541` list-limit query construction is unchanged. Remaining scheduled-task hops (apply / fire / test-probe) are untouched. Not `#21964` (useUnifiedTasks already has timeoutMs). Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not wallets. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not remaining agent / skills / local-inference / chat / cloud / automations / approvals / background / notifications hops. Not `#21989` / `#21988` / `#21987` / `#21986` / `#21983` / `#21982` / `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. `buildQuery` unchanged. Unfixed head: listScheduledTasks called `fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

The scheduled-tasks list hop omitted `{ timeoutMs }`. This PR passes `{ timeoutMs }` on that hop only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). LifeOps scheduled-task list UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-scheduled-tasks-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`, TimeoutError, provider-error, and unchanged `ownerVisibleOnly=1` query construction.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-scheduled-tasks-native.test.ts
```

Unfixed head: hop hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: native suite passes.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. listScheduledTasks now uses ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. listScheduledTasks now carries ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the scheduled-tasks native-transport file. Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: listScheduledTasks `this.fetch("/api/lifeops/scheduled-tasks?ownerVisibleOnly=1")` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: the hop forwards its deadline to `Agent.request`. `buildQuery` unchanged. Not `#21964`. Not `#21541`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21989` / `#21988` / `#21987` / `#21986` / `#21983` / `#21982` / `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked. Remaining scheduled-task hops not restacked.

<!-- evidence-head:84a8809d816e52b04cf6445b93bd633dabb1512f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
