### PR TITLE
fix(ui): route getOrchestratorWidgets hop through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-agent-orchestrator-timeline.test.ts
+++ b/packages/ui/src/api/client-agent-orchestrator-timeline.test.ts
@@ -4,6 +4,9 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import "./client-agent";
+import {
+  ORCHESTRATOR_WIDGETS_FETCH_TIMEOUT_MS,
+} from "./client-orchestrator-widgets";
 import "./client-orchestrator-widgets";
 import { ElizaClient } from "./client-base";
 
@@ -68,6 +71,8 @@ describe("ElizaClient.getOrchestratorWidgets", () => {
 
     expect(fetch).toHaveBeenCalledWith(
       "/api/orchestrator/widgets?includeArchived=true&projectId=project+%2F+alpha&limit=8",
+      undefined,
+      { timeoutMs: ORCHESTRATOR_WIDGETS_FETCH_TIMEOUT_MS },
     );
     expect(snapshot.totalTaskCount).toBe(0);
   });

--- a/packages/ui/src/api/client-orchestrator-widgets-native.test.ts
+++ b/packages/ui/src/api/client-orchestrator-widgets-native.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves getOrchestratorWidgets carries timeoutMs into Agent.request.
+ * widgetQuery / #21541 list-limit construction is unchanged.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import { ORCHESTRATOR_WIDGETS_FETCH_TIMEOUT_MS } from "./client-orchestrator-widgets";
+import "./client-orchestrator-widgets";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const snapshot = {
+  version: "orchestrator.widgets.v1" as const,
+  generatedAt: "2026-08-18T00:00:00.000Z",
+  totalTaskCount: 0,
+  tasks: [],
+};
+
+describe("ElizaClient orchestrator-widgets native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget for the widgets hop", () => {
+    expect(ORCHESTRATOR_WIDGETS_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("forwards the widgets deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(snapshot),
+    );
+    await makeClient(request).getOrchestratorWidgets();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/orchestrator/widgets",
+      expect.any(Object),
+      { timeoutMs: ORCHESTRATOR_WIDGETS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("keeps limit query construction unchanged", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(snapshot),
+    );
+    await makeClient(request).getOrchestratorWidgets({ limit: 8 });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/orchestrator/widgets?limit=8",
+      expect.any(Object),
+      { timeoutMs: ORCHESTRATOR_WIDGETS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled widgets hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).getOrchestratorWidgets(undefined, 10),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/orchestrator/widgets",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from a completed widgets GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(
+      makeClient(request).getOrchestratorWidgets(),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-orchestrator-widgets.ts
+++ b/packages/ui/src/api/client-orchestrator-widgets.ts
@@ -7,6 +7,9 @@
 import { openEventSource } from "../utils/event-source";
 import { ElizaClient } from "./client-base";
 
+/** Orchestrator widgets GET — existing 10s REST budget, independent hop. */
+export const ORCHESTRATOR_WIDGETS_FETCH_TIMEOUT_MS = 10_000;
+
 export type OrchestratorWidgetStatus =
   | "queued"
   | "running"
@@ -52,6 +55,7 @@ declare module "./client-base" {
   interface ElizaClient {
     getOrchestratorWidgets(
       options?: OrchestratorWidgetOptions,
+      timeoutMs?: number,
     ): Promise<OrchestratorWidgetSnapshot>;
     streamOrchestratorWidgets(
       options: OrchestratorWidgetOptions | undefined,
@@ -75,9 +79,12 @@ function widgetQuery(options?: OrchestratorWidgetOptions): string {
 ElizaClient.prototype.getOrchestratorWidgets = function (
   this: ElizaClient,
   options,
+  timeoutMs: number = ORCHESTRATOR_WIDGETS_FETCH_TIMEOUT_MS,
 ) {
   return this.fetch<OrchestratorWidgetSnapshot>(
     `/api/orchestrator/widgets${widgetQuery(options)}`,
+    undefined,
+    { timeoutMs },
   );
 };
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `getOrchestratorWidgets` called `this.fetch("/api/orchestrator/widgets…")` with no `{ timeoutMs }`. This PR routes **that hop** through `client.fetch` / `{ timeoutMs }` with an explicit 10s REST budget. `widgetQuery` / `#21541` list-limit construction is unchanged. Stream hop (`openEventSource`) is untouched. Not `#21964`. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not wallets. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not remaining agent / skills / local-inference / chat / cloud / automations / approvals / background / notifications / scheduled-tasks / vault / iMessage hops. Not `#21993` / `#21992` / `#21991` / `#21989` / `#21988` / `#21987` / `#21986` / `#21983` / `#21982` / `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. `widgetQuery` unchanged. Unfixed head: getOrchestratorWidgets called `fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

The orchestrator widgets snapshot hop omitted `{ timeoutMs }`. This PR passes `{ timeoutMs }` on that hop only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Task summary rail UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-orchestrator-widgets-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`, TimeoutError, provider-error, and unchanged `?limit=8` query construction. `client-agent-orchestrator-timeline.test.ts` — existing encoded-options contract now asserts the same `{ timeoutMs }`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-orchestrator-widgets-native.test.ts \
  src/api/client-agent-orchestrator-timeline.test.ts
```

Unfixed head: hop hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: native + existing contract suites pass.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. getOrchestratorWidgets now uses ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. getOrchestratorWidgets now carries ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the widgets native-transport + existing timeline contract files. Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: getOrchestratorWidgets `this.fetch("/api/orchestrator/widgets")` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: the hop forwards its deadline to `Agent.request`. `widgetQuery` unchanged. Not `#21964`. Not `#21541`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21993` / `#21992` / `#21991` / `#21989` / `#21988` / `#21987` / `#21986` / `#21983` / `#21982` / `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked. Stream hop not restacked.

<!-- evidence-head:25126e97fe7c76e4022db60c5efdfe35d0afa2bc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
