### PR TITLE
fix(ui): route weather approximate-location hop through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/hooks/useWeather-native.test.ts
+++ b/packages/ui/src/hooks/useWeather-native.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves the weather approximate-location hop carries timeoutMs into Agent.request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "../api/client-base";
+import type { AgentRequestTransport } from "../api/transport";
+import { setBootConfig } from "../config/boot-config";
+import {
+  fetchApproximateCoords,
+  WEATHER_APPROXIMATE_LOCATION_FETCH_TIMEOUT_MS,
+} from "./useWeather";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("useWeather approximate-location native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the approximate-location deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ lat: 40.71, lon: -74.01 }),
+    );
+    await expect(
+      fetchApproximateCoords(
+        WEATHER_APPROXIMATE_LOCATION_FETCH_TIMEOUT_MS,
+        makeClient(request),
+      ),
+    ).resolves.toEqual({
+      lat: 40.71,
+      lon: -74.01,
+      approximate: true,
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/location/approximate",
+      expect.any(Object),
+      { timeoutMs: WEATHER_APPROXIMATE_LOCATION_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled approximate-location hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      fetchApproximateCoords(10, makeClient(request)),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/location/approximate",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from the approximate-location hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw Object.assign(new Error("upstream geo provider unavailable"), {
+        name: "TypeError",
+      });
+    });
+    await expect(
+      fetchApproximateCoords(10_000, makeClient(request)),
+    ).rejects.toMatchObject({ name: "ApiError" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/location/approximate",
+      expect.any(Object),
+      { timeoutMs: 10_000 },
+    );
+  });
+});

--- a/packages/ui/src/hooks/useWeather.ts
+++ b/packages/ui/src/hooks/useWeather.ts
@@ -195,11 +195,19 @@ interface ResolvedCoords extends Coords {
   approximate: boolean;
 }
 
+/** Ordinary REST budget for GET /api/location/approximate. */
+export const WEATHER_APPROXIMATE_LOCATION_FETCH_TIMEOUT_MS = 10_000;
+
 /** Server-side coarse IP-geolocation (city centroid). Same-origin/agent-API
  *  call, so it works on hosted origins where a browser-side lookup CORS-fails. */
-async function fetchApproximateCoords(): Promise<ResolvedCoords> {
-  const data = await client.fetch<{ lat: number; lon: number }>(
+export async function fetchApproximateCoords(
+  timeoutMs: number = WEATHER_APPROXIMATE_LOCATION_FETCH_TIMEOUT_MS,
+  api: { fetch: typeof client.fetch } = client,
+): Promise<ResolvedCoords> {
+  const data = await api.fetch<{ lat: number; lon: number }>(
     "/api/location/approximate",
+    undefined,
+    { timeoutMs },
   );
   if (
     typeof data.lat !== "number" ||


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `useWeather` `fetchApproximateCoords` called `client.fetch("/api/location/approximate")` with no `{ timeoutMs }`. This PR routes **that hop** through `client.fetch` / `{ timeoutMs }` with an explicit 10s REST budget. Open-Meteo `globalThis.fetch`, geolocation, and the approximate-location notification stay untouched. Not `#21964`. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not wallets. Not the ten inbox CR files. Not remaining `client-*` hops. Not `#21996` / `#21995` / `#21994` / `#21993` / `#21992` / `#21991` / `#21989` / `#21988` / `#21987` / `#21986` / `#21983` / `#21982` / `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Validator path unchanged. Unfixed head: fetchApproximateCoords called `client.fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false` / `argc: 1`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

The weather widget's approximate-location hop omitted `{ timeoutMs }`. This PR passes `{ timeoutMs }` on that hop only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Weather widget UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/hooks/useWeather-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`, TimeoutError, provider-error, and success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/hooks/useWeather-native.test.ts src/hooks/useWeather.test.ts
```

Unfixed head: hop hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: native suite passes.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. fetchApproximateCoords now uses ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. fetchApproximateCoords now carries ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the weather native-transport file plus existing useWeather tests. Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: fetchApproximateCoords `client.fetch("/api/location/approximate")` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: the hop forwards its deadline to `Agent.request`. Open-Meteo / geolocation / notification hops untouched. Not wallets. Not `#21964`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21996` / `#21995` / `#21994` / `#21993` / `#21992` / `#21991` / `#21989` / `#21988` / `#21987` / `#21986` / `#21983` / `#21982` / `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956` not restacked. Open-Meteo and remaining weather hops not restacked.

<!-- evidence-head:91c65a610f0b069604a1c3b5599cad60290d734f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
