### PR TITLE
fix(plugin-task-coordinator): route GitHub token-status hop through ElizaClient timeoutMs

### DIFF
--- a/plugins/plugin-task-coordinator/src/GitHubConnectionCard-native.test.ts
+++ b/plugins/plugin-task-coordinator/src/GitHubConnectionCard-native.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves the GitHub token status hop carries timeoutMs into Agent.request.
+ * Device poll/start, POST token, and DELETE stay untouched.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "../../../packages/ui/src/api/client-base";
+import type { AgentRequestTransport } from "../../../packages/ui/src/api/transport";
+import { setBootConfig } from "../../../packages/ui/src/config/boot-config";
+import {
+  fetchGitHubTokenStatus,
+  GITHUB_TOKEN_STATUS_FETCH_TIMEOUT_MS,
+} from "./GitHubConnectionCard";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("GitHubConnectionCard token-status native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the GET /api/github/token deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ connected: false, deviceFlowAvailable: false }),
+    );
+    await expect(
+      fetchGitHubTokenStatus(
+        GITHUB_TOKEN_STATUS_FETCH_TIMEOUT_MS,
+        makeClient(request),
+      ),
+    ).resolves.toEqual({ connected: false, deviceFlowAvailable: false });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/github/token",
+      expect.any(Object),
+      { timeoutMs: GITHUB_TOKEN_STATUS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled token-status hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      fetchGitHubTokenStatus(10, makeClient(request)),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/github/token",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from the token-status hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw Object.assign(new Error("github token status unavailable"), {
+        name: "TypeError",
+      });
+    });
+    await expect(
+      fetchGitHubTokenStatus(10_000, makeClient(request)),
+    ).rejects.toMatchObject({ name: "ApiError" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/github/token",
+      expect.any(Object),
+      { timeoutMs: 10_000 },
+    );
+  });
+});

--- a/plugins/plugin-task-coordinator/src/GitHubConnectionCard.tsx
+++ b/plugins/plugin-task-coordinator/src/GitHubConnectionCard.tsx
@@ -44,6 +44,20 @@ interface TokenStatus {
   savedAt?: number;
 }
 
+/** Ordinary REST budget for GET /api/github/token (status refresh). */
+export const GITHUB_TOKEN_STATUS_FETCH_TIMEOUT_MS = 10_000;
+
+export async function fetchGitHubTokenStatus(
+  timeoutMs: number = GITHUB_TOKEN_STATUS_FETCH_TIMEOUT_MS,
+  api: { fetch: typeof client.fetch } = client,
+): Promise<TokenStatus> {
+  return api.fetch<TokenStatus>(
+    "/api/github/token",
+    undefined,
+    { timeoutMs },
+  );
+}
+
 const TOKEN_GENERATE_URL =
   "https://github.com/settings/tokens/new?description=eliza-coding-agents&scopes=repo,read:user";
 
@@ -101,7 +115,7 @@ export function GitHubConnectionCard() {
   useEffect(() => stopPolling, [stopPolling]);
 
   const refreshStatus = useCallback(async () => {
-    const next = await client.fetch<TokenStatus>("/api/github/token");
+    const next = await fetchGitHubTokenStatus();
     setStatus(next);
   }, []);
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `GitHubConnectionCard` `refreshStatus` called `client.fetch("/api/github/token")` with no `{ timeoutMs }`. This PR routes **that hop** through `client.fetch` / `{ timeoutMs }` with an explicit 10s REST budget. Device poll/start, POST token, and DELETE stay untouched. Not `#21765` (closed GitHub OAuth). Not wallets. Not `#21964`. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not `#21997` / `#21996` / `#21995` / `#21994` / `#21993` / `#21992` / `#21991` / `#21989` / `#21988` / `#21987` / `#21986` / `#21983` / `#21982` / `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Validator path unchanged. Unfixed head: refreshStatus called `client.fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false` / `argc: 1`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

The GitHub connection card's token-status refresh hop omitted `{ timeoutMs }`. This PR passes `{ timeoutMs }` on that hop only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). GitHub connection card UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-task-coordinator/src/GitHubConnectionCard-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`, TimeoutError, provider-error, and success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-task-coordinator && bunx vitest run --config ./vitest.config.ts \
  src/GitHubConnectionCard-native.test.ts src/GitHubConnectionCard.test.tsx
```

Unfixed head: hop hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: native suite plus existing card tests pass.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. GET /api/github/token now uses ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. GET /api/github/token now carries ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the GitHub token-status native-transport file plus existing card tests. Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: refreshStatus `client.fetch("/api/github/token")` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: the hop forwards its deadline to `Agent.request`. Device poll/start, POST token, and DELETE untouched. Not wallets. Not `#21765`. Not `#21964`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21997` / `#21996` / `#21995` and earlier owned hops not restacked. Remaining GitHubConnectionCard hops not restacked.

<!-- evidence-head:c7c9d25fd76c4fb5500a0896af9d48545756c696 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
