### PR TITLE
fix(ui): route Apps Management relaunch hop through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/components/settings/AppsManagementSection-native.test.ts
+++ b/packages/ui/src/components/settings/AppsManagementSection-native.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves the Apps Management relaunch hop carries timeoutMs into Agent.request.
+ * Create / load-from-directory stay untouched. Not AppsSection (#21965).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "../../api/client-base";
+import type { AgentRequestTransport } from "../../api/transport";
+import { setBootConfig } from "../../config/boot-config";
+import {
+  APPS_MANAGEMENT_RELAUNCH_FETCH_TIMEOUT_MS,
+  fetchAppsManagementRelaunch,
+} from "./AppsManagementSection";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("AppsManagementSection relaunch native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the POST /api/apps/relaunch deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true, message: "relaunching" }),
+    );
+    await expect(
+      fetchAppsManagementRelaunch(
+        { name: "demo", verify: true },
+        APPS_MANAGEMENT_RELAUNCH_FETCH_TIMEOUT_MS,
+        makeClient(request),
+      ),
+    ).resolves.toEqual({ ok: true, message: "relaunching" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/apps/relaunch",
+      expect.objectContaining({ method: "POST" }),
+      { timeoutMs: APPS_MANAGEMENT_RELAUNCH_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled relaunch hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      fetchAppsManagementRelaunch(
+        { name: "demo", verify: false },
+        10,
+        makeClient(request),
+      ),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/apps/relaunch",
+      expect.objectContaining({ method: "POST" }),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from the relaunch hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw Object.assign(new Error("apps relaunch unavailable"), {
+        name: "TypeError",
+      });
+    });
+    await expect(
+      fetchAppsManagementRelaunch(
+        { name: "demo", verify: true },
+        10_000,
+        makeClient(request),
+      ),
+    ).rejects.toMatchObject({ name: "ApiError" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/apps/relaunch",
+      expect.objectContaining({ method: "POST" }),
+      { timeoutMs: 10_000 },
+    );
+  });
+});

--- a/packages/ui/src/components/settings/AppsManagementSection.tsx
+++ b/packages/ui/src/components/settings/AppsManagementSection.tsx
@@ -94,6 +94,24 @@ interface RelaunchResponse {
   message?: string;
 }
 
+/** Ordinary REST budget for POST /api/apps/relaunch (settings inventory). */
+export const APPS_MANAGEMENT_RELAUNCH_FETCH_TIMEOUT_MS = 10_000;
+
+export async function fetchAppsManagementRelaunch(
+  body: { name: string; verify: boolean },
+  timeoutMs: number = APPS_MANAGEMENT_RELAUNCH_FETCH_TIMEOUT_MS,
+  api: { fetch: typeof client.fetch } = client,
+): Promise<RelaunchResponse> {
+  return api.fetch<RelaunchResponse>(
+    "/api/apps/relaunch",
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+    },
+    { timeoutMs },
+  );
+}
+
 type AsyncStatus =
   | { state: "idle" }
   | { state: "loading"; message?: string }
@@ -195,16 +213,10 @@ export function AppsManagementSection() {
     async (app: InstalledAppInfo) => {
       setBusyApp(app.name);
       try {
-        const response = await client.fetch<RelaunchResponse>(
-          "/api/apps/relaunch",
-          {
-            method: "POST",
-            body: JSON.stringify({
-              name: app.name,
-              verify: verifyOnRelaunch,
-            }),
-          },
-        );
+        const response = await fetchAppsManagementRelaunch({
+          name: app.name,
+          verify: verifyOnRelaunch,
+        });
         setActionNotice(
           response.message ?? `${app.displayName} relaunched.`,
           response.ok === false ? "error" : "success",


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `AppsManagementSection` `handleRelaunch` called `client.fetch("/api/apps/relaunch", { method: "POST", ... })` with no `{ timeoutMs }`. This PR routes **that hop** through `client.fetch` / `{ timeoutMs }` with an explicit 10s REST budget. Create / load-from-directory stay untouched. **Not** `#21965` `AppsSection` (different file). Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not wallets. Not the ten inbox CR files. Not `#21998` / `#21997` / `#21996` / `#21995` / `#21994` / `#21993` / `#21992` / `#21991` / `#21989` / `#21988` / `#21987` / `#21986` / `#21983` / `#21982` / `#21981` / `#21980` / `#21979` / `#21976` / `#21975` / `#21974` / `#21973` / `#21972` / `#21971` / `#21970` / `#21969` / `#21966` / `#21965` / `#21964` / `#21956`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Validator path unchanged. Unfixed head: handleRelaunch called `client.fetch(path, init)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false` / `argc: 2`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

The Apps Management settings relaunch hop omitted `{ timeoutMs }`. This PR passes `{ timeoutMs }` on that hop only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Apps Management UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/settings/AppsManagementSection-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`, TimeoutError, provider-error, and success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/components/settings/AppsManagementSection-native.test.ts \
  src/components/settings/AppsManagementSection.test.tsx
```

Unfixed head: hop hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: native suite plus existing section tests pass.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. POST /api/apps/relaunch now uses ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. POST /api/apps/relaunch now carries ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the Apps Management relaunch native-transport file plus existing section tests. Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: handleRelaunch `client.fetch("/api/apps/relaunch", { method: "POST" })` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: the hop forwards its deadline to `Agent.request`. Create / load-from-directory untouched. Not `#21965` AppsSection. Not wallets. Not `#21964`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#21998` / `#21997` / `#21996` / `#21995` / `#21965` and earlier owned hops not restacked. Remaining AppsManagementSection hops not restacked.

<!-- evidence-head:e59017be205304d4b063a5cd8f8d90af49808f26 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
