### PR TITLE
fix(ui): route startup cloud-passthrough status hop through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/state/startup-phase-runtime-native.test.ts
+++ b/packages/ui/src/state/startup-phase-runtime-native.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves the startup cloud-passthrough GET /api/status hop carries timeoutMs
+ * into Agent.request. listConversations and remaining startup hops stay
+ * untouched. Not packages/cloud JSON. Not browser-launch.ts.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "../api/client-base";
+import type { AgentRequestTransport } from "../api/transport";
+import { setBootConfig } from "../config/boot-config";
+import {
+  fetchCloudProxyAgentStatus,
+  STARTUP_CLOUD_PROXY_STATUS_FETCH_TIMEOUT_MS,
+} from "./startup-phase-runtime";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("startup-phase-runtime cloud-proxy status native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the GET /api/status deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ state: "running", canRespond: true }),
+    );
+    await expect(
+      fetchCloudProxyAgentStatus(
+        STARTUP_CLOUD_PROXY_STATUS_FETCH_TIMEOUT_MS,
+        makeClient(request),
+      ),
+    ).resolves.toEqual({ state: "running", canRespond: true });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/status",
+      expect.any(Object),
+      { timeoutMs: STARTUP_CLOUD_PROXY_STATUS_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled status hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      fetchCloudProxyAgentStatus(10, makeClient(request)),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/status",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from the status hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw Object.assign(new Error("status passthrough unavailable"), {
+        name: "TypeError",
+      });
+    });
+    await expect(
+      fetchCloudProxyAgentStatus(10_000, makeClient(request)),
+    ).rejects.toMatchObject({ name: "ApiError" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/status",
+      expect.any(Object),
+      { timeoutMs: 10_000 },
+    );
+  });
+});

--- a/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
+++ b/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
@@ -1,6 +1,9 @@
 /** Verifies runStartingRuntime — managed cloud cold-boot warmup through the package's configured test harness. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { runStartingRuntime } from "./startup-phase-runtime";
+import {
+  runStartingRuntime,
+  STARTUP_CLOUD_PROXY_STATUS_FETCH_TIMEOUT_MS,
+} from "./startup-phase-runtime";
 
 /**
  * Cold-boot routing regression for Eliza-MANAGED cloud agents.
@@ -303,7 +306,11 @@ describe("runStartingRuntime — managed cloud cold-boot warmup", () => {
     );
 
     // We fell back to /api/status once the 5xx streak crossed threshold.
-    expect(clientMock.fetch).toHaveBeenCalledWith("/api/status");
+    expect(clientMock.fetch).toHaveBeenCalledWith(
+      "/api/status",
+      undefined,
+      { timeoutMs: STARTUP_CLOUD_PROXY_STATUS_FETCH_TIMEOUT_MS },
+    );
     // And advanced to chat exactly once instead of stranding on the boot screen.
     const runningDispatches = dispatch.mock.calls.filter(
       ([e]) => e.type === "AGENT_RUNNING",

--- a/packages/ui/src/state/startup-phase-runtime.ts
+++ b/packages/ui/src/state/startup-phase-runtime.ts
@@ -222,9 +222,19 @@ async function probeCloudProxyPassthrough(): Promise<PassthroughProbe> {
  * genuinely-serving agent on the boot screen — if status says `canRespond`, the
  * agent is ready and the user should be let into chat (CONVERSATIONS-500).
  */
+/** Ordinary REST budget for GET /api/status (cloud-passthrough readiness). */
+export const STARTUP_CLOUD_PROXY_STATUS_FETCH_TIMEOUT_MS = 10_000;
+
+export async function fetchCloudProxyAgentStatus(
+  timeoutMs: number = STARTUP_CLOUD_PROXY_STATUS_FETCH_TIMEOUT_MS,
+  api: { fetch: typeof client.fetch } = client,
+): Promise<AgentStatus> {
+  return api.fetch<AgentStatus>("/api/status", undefined, { timeoutMs });
+}
+
 async function isCloudProxyStatusReady(): Promise<boolean> {
   try {
-    const status = await client.fetch<AgentStatus>("/api/status");
+    const status = await fetchCloudProxyAgentStatus();
     return status?.state === "running" && status?.canRespond === true;
   } catch {
     return false;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `startup-phase-runtime` `isCloudProxyStatusReady` called `client.fetch("/api/status")` with no `{ timeoutMs }`. This is a **UI ElizaClient hop** (passthrough readiness), not packages/cloud JSON 500-series, not grok-owned cloud routes, not `browser-launch.ts`. This PR routes **that hop** through `client.fetch` / `{ timeoutMs }` with an explicit 10s REST budget. `listConversations` and remaining startup hops stay untouched. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not Twilio. Not TelegramBotSetupPanel. Not wallets. Not the ten inbox CR files. Not `#22000` / `#21998` / `#21997` / `#21996` / `#21995` / `#21965` / `#21964`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Readiness predicate unchanged. Unfixed head: isCloudProxyStatusReady called `client.fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false` / `argc: 1`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

The startup cloud-passthrough `/api/status` hop omitted `{ timeoutMs }`. This PR passes `{ timeoutMs }` on that hop only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Startup UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/state/startup-phase-runtime-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`, TimeoutError, provider-error, and success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/state/startup-phase-runtime-native.test.ts \
  src/state/startup-phase-runtime.cloud-warm.test.ts \
  src/state/startup-phase-runtime.test.ts
```

Unfixed head: hop hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: native suite plus existing startup tests pass.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. GET /api/status now uses ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. GET /api/status now carries ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the startup status native-transport file plus existing startup tests. Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: isCloudProxyStatusReady `client.fetch("/api/status")` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: the hop forwards its deadline to `Agent.request`. Stay-off decision: UI ElizaClient hop, not cloud JSON. listConversations untouched. Not wallets. Not `#21964`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#22000` / `#21998` / `#21997` and earlier owned hops not restacked. Remaining startup hops not restacked.

<!-- evidence-head:3ce59ce79615de97c0b494f981738350ded2a7bd -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
