### PR TITLE
fix(plugin-calendar): route LifeOps calendar feed hop through ElizaClient timeoutMs

### DIFF
--- a/plugins/plugin-calendar/src/api/client-calendar-native.test.ts
+++ b/plugins/plugin-calendar/src/api/client-calendar-native.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves getLifeOpsCalendarFeed carries timeoutMs into Agent.request.
+ * Remaining calendar CRUD stays untouched. Not #21956. Query construction
+ * unchanged (#21541).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "@elizaos/ui/api/client-base";
+import type { AgentRequestTransport } from "@elizaos/ui/api/transport";
+import { setBootConfig } from "@elizaos/ui/config/boot-config";
+import {
+  LIFEOPS_CALENDAR_FEED_FETCH_TIMEOUT_MS,
+} from "./client-calendar";
+import "./client-calendar";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("getLifeOpsCalendarFeed native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the feed deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ events: [] }),
+    );
+    await makeClient(request).getLifeOpsCalendarFeed();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/lifeops/calendar/feed",
+      expect.any(Object),
+      { timeoutMs: LIFEOPS_CALENDAR_FEED_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled feed hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).getLifeOpsCalendarFeed({}, 10),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/lifeops/calendar/feed",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from the feed hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw Object.assign(new Error("calendar feed unavailable"), {
+        name: "TypeError",
+      });
+    });
+    await expect(
+      makeClient(request).getLifeOpsCalendarFeed(),
+    ).rejects.toMatchObject({ name: "ApiError" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/lifeops/calendar/feed",
+      expect.any(Object),
+      { timeoutMs: LIFEOPS_CALENDAR_FEED_FETCH_TIMEOUT_MS },
+    );
+  });
+});

--- a/plugins/plugin-calendar/src/api/client-calendar.ts
+++ b/plugins/plugin-calendar/src/api/client-calendar.ts
@@ -57,9 +57,13 @@ type CalendarEditorDeleteRequest = Partial<
     | "remove_private_copy";
 };
 
+/** Ordinary REST budget for GET /api/lifeops/calendar/feed. */
+export const LIFEOPS_CALENDAR_FEED_FETCH_TIMEOUT_MS = 10_000;
+
 export interface CalendarClientMethods {
   getLifeOpsCalendarFeed(
     options?: GetLifeOpsCalendarFeedRequest,
+    timeoutMs?: number,
   ): Promise<LifeOpsCalendarFeed>;
   getLifeOpsCalendars(
     options?: ListLifeOpsCalendarsRequest,
@@ -115,6 +119,7 @@ const calendarClientPrototype = ElizaClient.prototype as ElizaClient &
 calendarClientPrototype.getLifeOpsCalendarFeed = async function (
   this: ElizaClient,
   options: GetLifeOpsCalendarFeedRequest = {},
+  timeoutMs: number = LIFEOPS_CALENDAR_FEED_FETCH_TIMEOUT_MS,
 ) {
   const params = new URLSearchParams();
   if (options.mode) params.set("mode", options.mode);
@@ -136,6 +141,8 @@ calendarClientPrototype.getLifeOpsCalendarFeed = async function (
   const query = params.toString();
   return this.fetch<LifeOpsCalendarFeed>(
     `/api/lifeops/calendar/feed${query ? `?${query}` : ""}`,
+    undefined,
+    { timeoutMs },
   );
 };
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `getLifeOpsCalendarFeed` called `this.fetch("/api/lifeops/calendar/feed…")` with no `{ timeoutMs }`. This PR routes **that hop** through `client.fetch` / `{ timeoutMs }` with an explicit 10s REST budget. Remaining calendar CRUD stays untouched. **Not** `#21956` (calendar-upcoming UI, different file). Query construction unchanged (`#21541`). Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not wallets. Not the ten inbox CR files. Not `#22002` / `#22001` / `#22000` / `#21998` / `#21997` / `#21956` / `#21964`. Not extra-decode. Not payment. Not Finances. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Feed query construction unchanged. Unfixed head: getLifeOpsCalendarFeed called `this.fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false` / `argc: 1`). After: `this.fetch(..., { timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

The LifeOps calendar feed hop omitted `{ timeoutMs }`. This PR passes `{ timeoutMs }` on that hop only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Calendar UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-calendar/src/api/client-calendar-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`, TimeoutError, provider-error, and success.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd plugins/plugin-calendar && bunx vitest run --config ./vitest.config.ts \
  src/api/client-calendar-native.test.ts test/client-calendar.test.ts
```

Unfixed head: hop hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false`). After the fix: native suite plus existing calendar client tests pass.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. GET /api/lifeops/calendar/feed now uses ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. GET /api/lifeops/calendar/feed now carries ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the calendar feed native-transport file plus existing client-calendar tests. Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: getLifeOpsCalendarFeed `this.fetch("/api/lifeops/calendar/feed")` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false`. After: the hop forwards its deadline to `Agent.request`. Remaining calendar CRUD untouched. Query construction unchanged. Not `#21956`. Not wallets. Not `#21964`.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#22002` / `#22001` / `#22000` / `#21998` / `#21997` / `#21956` and earlier owned hops not restacked. Remaining calendar hops not restacked.

<!-- evidence-head:21ed83c691ed1446325ba98260006a0a49c6232e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
