### PR TITLE
fix(ui): route vault OverviewTab install hop through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/components/settings/vault-tabs/OverviewTab-native.test.ts
+++ b/packages/ui/src/components/settings/vault-tabs/OverviewTab-native.test.ts
@@ -67,7 +67,7 @@ describe("OverviewTab install rawRequest native transport", () => {
     const request = vi.fn<AgentRequestTransport["request"]>(
       async (_url, init, ctx) => {
         const ms = ctx?.timeoutMs ?? 10;
-        await new Promise<never>((_, reject) => {
+        return new Promise<never>((_, reject) => {
           const timer = setTimeout(() => {
             reject(
               Object.assign(new Error(`Request timed out after ${ms}ms`), {

--- a/packages/ui/src/components/settings/vault-tabs/OverviewTab-native.test.ts
+++ b/packages/ui/src/components/settings/vault-tabs/OverviewTab-native.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves the vault Overview tab install hop carries timeoutMs into
+ * Agent.request and keeps allowNonOk. Sign-in hop stays untouched.
+ * Not wallets. Not Finances.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "../../../api/client-base";
+import type { AgentRequestTransport } from "../../../api/transport";
+import { setBootConfig } from "../../../config/boot-config";
+import {
+  VAULT_OVERVIEW_INSTALL_RAW_REQUEST_TIMEOUT_MS,
+  rawRequestVaultOverviewInstall,
+} from "./OverviewTab";
+
+const METHOD = { kind: "brew" as const, package: "1password-cli", cask: false };
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("OverviewTab install rawRequest native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the POST /api/secrets/manager/install deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ jobId: "job-1" }),
+    );
+    const res = await rawRequestVaultOverviewInstall(
+      "1password",
+      METHOD,
+      VAULT_OVERVIEW_INSTALL_RAW_REQUEST_TIMEOUT_MS,
+      makeClient(request),
+    );
+    expect(res.ok).toBe(true);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/manager/install",
+      expect.objectContaining({ method: "POST" }),
+      { timeoutMs: VAULT_OVERVIEW_INSTALL_RAW_REQUEST_TIMEOUT_MS },
+    );
+  });
+
+  it("returns a non-ok install response instead of throwing", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () => new Response("nope", { status: 503 }),
+    );
+    const res = await rawRequestVaultOverviewInstall(
+      "1password",
+      METHOD,
+      VAULT_OVERVIEW_INSTALL_RAW_REQUEST_TIMEOUT_MS,
+      makeClient(request),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(503);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/manager/install",
+      expect.objectContaining({ method: "POST" }),
+      { timeoutMs: VAULT_OVERVIEW_INSTALL_RAW_REQUEST_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled install hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      rawRequestVaultOverviewInstall(
+        "1password",
+        METHOD,
+        10,
+        makeClient(request),
+      ),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/manager/install",
+      expect.objectContaining({ method: "POST" }),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from the install hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw Object.assign(new Error("vault install unavailable"), {
+        name: "TypeError",
+      });
+    });
+    await expect(
+      rawRequestVaultOverviewInstall(
+        "1password",
+        METHOD,
+        VAULT_OVERVIEW_INSTALL_RAW_REQUEST_TIMEOUT_MS,
+        makeClient(request),
+      ),
+    ).rejects.toMatchObject({ name: "ApiError" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/manager/install",
+      expect.objectContaining({ method: "POST" }),
+      { timeoutMs: VAULT_OVERVIEW_INSTALL_RAW_REQUEST_TIMEOUT_MS },
+    );
+  });
+});

--- a/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
@@ -30,6 +30,7 @@ import { useAgentElement } from "../../../agent-surface";
 // fetch targets the page origin unauthenticated, which breaks remote/token-
 // authed runtimes (e.g. the Android local agent).
 import { client } from "../../../api/client";
+import type { ElizaClient } from "../../../api/client-base";
 import { useTranslation } from "../../../state/TranslationContext.hooks";
 import { resolveApiUrl } from "../../../utils/asset-url";
 import { openEventSource } from "../../../utils/event-source";
@@ -51,6 +52,26 @@ const BACKEND_ORDER: BackendId[] = [
   "bitwarden",
   "protonpass",
 ];
+
+/** Ordinary REST budget for POST /api/secrets/manager/install. */
+export const VAULT_OVERVIEW_INSTALL_RAW_REQUEST_TIMEOUT_MS = 10_000;
+
+export async function rawRequestVaultOverviewInstall(
+  backendId: InstallableBackendId,
+  method: InstallMethod,
+  timeoutMs: number = VAULT_OVERVIEW_INSTALL_RAW_REQUEST_TIMEOUT_MS,
+  api: Pick<ElizaClient, "rawRequest"> = client,
+): Promise<Response> {
+  return api.rawRequest(
+    "/api/secrets/manager/install",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ backendId, method }),
+    },
+    { allowNonOk: true, timeoutMs },
+  );
+}
 
 export interface OverviewTabProps {
   backends: BackendStatus[];
@@ -643,15 +664,7 @@ export function InstallSheet({
       setError(null);
       setDone(false);
       try {
-        const res = await client.rawRequest(
-          "/api/secrets/manager/install",
-          {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({ backendId, method }),
-          },
-          { allowNonOk: true },
-        );
+        const res = await rawRequestVaultOverviewInstall(backendId, method);
         if (!res.ok) {
           const body = (await res.json().catch(() => ({}))) as {
             error?: string;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS hops are only bounded when they go through ElizaClient with `{ timeoutMs }`. Vault `OverviewTab` `InstallSheet` called `client.rawRequest("/api/secrets/manager/install", { method: "POST", … }, { allowNonOk: true })` with no `{ timeoutMs }`. This PR routes **that hop** through `rawRequest` / `{ timeoutMs }` with an explicit 10s REST budget and **keeps `allowNonOk`**. Sign-in hop stays untouched. Not `#22007` (RoutingTab). Not `#22006` (LoginsTab). Not `#21992`. Not wallets (byt61). Not Finances. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success / non-ok passthrough, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not extra-decode. Not payment. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. `allowNonOk` retained. Unfixed head: OverviewTab install called `rawRequest("/api/secrets/manager/install", { method: "POST" }, { allowNonOk: true })` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawAllowNonOk: true` / `argc: 3`). After: `rawRequest(..., { allowNonOk: true, timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

The vault Overview tab install hop omitted `{ timeoutMs }`. This PR passes `{ timeoutMs }` on that hop only and keeps `allowNonOk`.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Vault Overview tab UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/settings/vault-tabs/OverviewTab-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`, TimeoutError, provider-error, success, and non-ok passthrough.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/components/settings/vault-tabs/OverviewTab-native.test.ts
```

Unfixed head: hop hung (`HUNG` / `sawTimeoutMs: false` / `sawAllowNonOk: true`). After the fix: native suite passes.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. POST /api/secrets/manager/install now uses ElizaClient timeoutMs on rawRequest.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, success, and allowNonOk.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. POST /api/secrets/manager/install now carries ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the vault Overview tab install native-transport file. Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: OverviewTab install `rawRequest("/api/secrets/manager/install", { method: "POST" }, { allowNonOk: true })` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawAllowNonOk: true`. After: the hop forwards its deadline to `Agent.request` and keeps allowNonOk. Sign-in hop untouched. Not `#22007`. Not `#22006`. Not `#21992`. Not wallets.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`rawRequest` / `{ timeoutMs }`, keep `allowNonOk`), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#22007` / `#22006` / `#22005` / `#22004` / `#22002` / `#22001` / `#22000` / `#21998` / `#21997` / `#21992` and earlier owned hops not restacked. Sign-in hop not restacked.

<!-- evidence-head:6640132100820c24fa2c05c601550430c54e9bec -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
