### PR TITLE
fix(ui): route vault inventory list hop through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/components/settings/VaultInventoryPanel-native.test.ts
+++ b/packages/ui/src/components/settings/VaultInventoryPanel-native.test.ts
@@ -9,8 +9,8 @@ import { ElizaClient } from "../../api/client-base";
 import type { AgentRequestTransport } from "../../api/transport";
 import { setBootConfig } from "../../config/boot-config";
 import {
-  VAULT_INVENTORY_LIST_RAW_REQUEST_TIMEOUT_MS,
   rawRequestVaultInventoryList,
+  VAULT_INVENTORY_LIST_RAW_REQUEST_TIMEOUT_MS,
 } from "./VaultInventoryPanel";
 
 function makeClient(request: AgentRequestTransport["request"]) {
@@ -61,7 +61,7 @@ describe("VaultInventoryPanel list rawRequest native transport", () => {
     const request = vi.fn<AgentRequestTransport["request"]>(
       async (_url, init, ctx) => {
         const ms = ctx?.timeoutMs ?? 10;
-        await new Promise<never>((_, reject) => {
+        return new Promise<never>((_, reject) => {
           const timer = setTimeout(() => {
             reject(
               Object.assign(new Error(`Request timed out after ${ms}ms`), {

--- a/packages/ui/src/components/settings/VaultInventoryPanel-native.test.ts
+++ b/packages/ui/src/components/settings/VaultInventoryPanel-native.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves the vault inventory list hop carries timeoutMs into Agent.request
+ * and keeps allowNonOk. Reveal / mutate / profile hops stay untouched.
+ * Not wallets. Not Finances.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "../../api/client-base";
+import type { AgentRequestTransport } from "../../api/transport";
+import { setBootConfig } from "../../config/boot-config";
+import {
+  VAULT_INVENTORY_LIST_RAW_REQUEST_TIMEOUT_MS,
+  rawRequestVaultInventoryList,
+} from "./VaultInventoryPanel";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("VaultInventoryPanel list rawRequest native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards the GET /api/secrets/inventory deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ entries: [] }),
+    );
+    const res = await rawRequestVaultInventoryList(
+      VAULT_INVENTORY_LIST_RAW_REQUEST_TIMEOUT_MS,
+      makeClient(request),
+    );
+    expect(res.ok).toBe(true);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/inventory",
+      expect.any(Object),
+      { timeoutMs: VAULT_INVENTORY_LIST_RAW_REQUEST_TIMEOUT_MS },
+    );
+  });
+
+  it("returns a non-ok list response instead of throwing", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () => new Response("nope", { status: 503 }),
+    );
+    const res = await rawRequestVaultInventoryList(
+      VAULT_INVENTORY_LIST_RAW_REQUEST_TIMEOUT_MS,
+      makeClient(request),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(503);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/inventory",
+      expect.any(Object),
+      { timeoutMs: VAULT_INVENTORY_LIST_RAW_REQUEST_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled list hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      rawRequestVaultInventoryList(10, makeClient(request)),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/inventory",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from the list hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw Object.assign(new Error("vault inventory unavailable"), {
+        name: "TypeError",
+      });
+    });
+    await expect(
+      rawRequestVaultInventoryList(
+        VAULT_INVENTORY_LIST_RAW_REQUEST_TIMEOUT_MS,
+        makeClient(request),
+      ),
+    ).rejects.toMatchObject({ name: "ApiError" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/inventory",
+      expect.any(Object),
+      { timeoutMs: VAULT_INVENTORY_LIST_RAW_REQUEST_TIMEOUT_MS },
+    );
+  });
+});

--- a/packages/ui/src/components/settings/VaultInventoryPanel.tsx
+++ b/packages/ui/src/components/settings/VaultInventoryPanel.tsx
@@ -49,6 +49,7 @@ import { useAgentElement } from "../../agent-surface";
 // fetch targets the page origin unauthenticated, which breaks remote/token-
 // authed runtimes (e.g. the Android local agent).
 import { client } from "../../api/client";
+import type { ElizaClient } from "../../api/client-base";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -74,6 +75,19 @@ const CATEGORY_ORDER: VaultEntryCategory[] = [
   "session",
   "system",
 ];
+
+/** Ordinary REST budget for GET /api/secrets/inventory (vault inventory list). */
+export const VAULT_INVENTORY_LIST_RAW_REQUEST_TIMEOUT_MS = 10_000;
+
+export async function rawRequestVaultInventoryList(
+  timeoutMs: number = VAULT_INVENTORY_LIST_RAW_REQUEST_TIMEOUT_MS,
+  api: Pick<ElizaClient, "rawRequest"> = client,
+): Promise<Response> {
+  return api.rawRequest("/api/secrets/inventory", undefined, {
+    allowNonOk: true,
+    timeoutMs,
+  });
+}
 
 const CATEGORY_INPUT_OPTIONS: Array<{
   value: VaultEntryCategory;
@@ -178,9 +192,7 @@ export function VaultInventoryPanel(props: VaultInventoryPanelProps = {}) {
   const load = useCallback(async () => {
     setError(null);
     try {
-      const res = await client.rawRequest("/api/secrets/inventory", undefined, {
-        allowNonOk: true,
-      });
+      const res = await rawRequestVaultInventoryList();
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const body = (await res.json()) as { entries: VaultEntryMeta[] };
       setInternalEntries(body.entries);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS hops are only bounded when they go through ElizaClient with `{ timeoutMs }`. `VaultInventoryPanel` `load` called `client.rawRequest("/api/secrets/inventory", undefined, { allowNonOk: true })` with no `{ timeoutMs }`. This PR routes **that hop** through `rawRequest` / `{ timeoutMs }` with an explicit 10s REST budget and **keeps `allowNonOk`**. Reveal / mutate / profile hops stay untouched. Not `#22008` (OverviewTab). Not `#22007`. Not `#22006`. Not `#21992`. Not wallets (byt61). Not Finances. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success / non-ok passthrough, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not extra-decode. Not payment. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. `allowNonOk` retained. Unfixed head: VaultInventoryPanel load called `rawRequest("/api/secrets/inventory", undefined, { allowNonOk: true })` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawAllowNonOk: true` / `argc: 3`). After: `rawRequest(..., { allowNonOk: true, timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

The vault inventory list hop omitted `{ timeoutMs }`. This PR passes `{ timeoutMs }` on that hop only and keeps `allowNonOk`.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Vault inventory UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/settings/VaultInventoryPanel-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`, TimeoutError, provider-error, success, and non-ok passthrough.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/components/settings/VaultInventoryPanel-native.test.ts
```

Unfixed head: hop hung (`HUNG` / `sawTimeoutMs: false` / `sawAllowNonOk: true`). After the fix: native suite passes.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. GET /api/secrets/inventory now uses ElizaClient timeoutMs on rawRequest.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, success, and allowNonOk.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. GET /api/secrets/inventory now carries ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the vault inventory list native-transport file. Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: VaultInventoryPanel load `rawRequest("/api/secrets/inventory", undefined, { allowNonOk: true })` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawAllowNonOk: true`. After: the hop forwards its deadline to `Agent.request` and keeps allowNonOk. Reveal / mutate / profile hops untouched. Not `#22008`. Not `#21992`. Not wallets.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`rawRequest` / `{ timeoutMs }`, keep `allowNonOk`), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#22008` / `#22007` / `#22006` / `#22005` / `#22004` / `#22002` / `#22001` / `#22000` / `#21998` / `#21997` / `#21992` and earlier owned hops not restacked. Remaining inventory hops not restacked.

<!-- evidence-head:24c26e0319a6d39438e3c735c04747be2315d214 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
