### PR TITLE
fix(ui): route vault settings-row summary hops through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/components/settings/SecretsManagerSection-native.test.ts
+++ b/packages/ui/src/components/settings/SecretsManagerSection-native.test.ts
@@ -9,10 +9,10 @@ import { ElizaClient } from "../../api/client-base";
 import type { AgentRequestTransport } from "../../api/transport";
 import { setBootConfig } from "../../config/boot-config";
 import {
-  VAULT_SECRETS_BACKENDS_RAW_REQUEST_TIMEOUT_MS,
-  VAULT_SECRETS_PREFERENCES_RAW_REQUEST_TIMEOUT_MS,
   rawRequestVaultSecretsBackends,
   rawRequestVaultSecretsPreferences,
+  VAULT_SECRETS_BACKENDS_RAW_REQUEST_TIMEOUT_MS,
+  VAULT_SECRETS_PREFERENCES_RAW_REQUEST_TIMEOUT_MS,
 } from "./SecretsManagerSection";
 
 function makeClient(request: AgentRequestTransport["request"]) {
@@ -24,7 +24,7 @@ function makeClient(request: AgentRequestTransport["request"]) {
 function stallTransport(): AgentRequestTransport["request"] {
   return async (_url, init, ctx) => {
     const ms = ctx?.timeoutMs ?? 10;
-    await new Promise<never>((_, reject) => {
+    return new Promise<never>((_, reject) => {
       const timer = setTimeout(() => {
         reject(
           Object.assign(new Error(`Request timed out after ${ms}ms`), {

--- a/packages/ui/src/components/settings/SecretsManagerSection-native.test.ts
+++ b/packages/ui/src/components/settings/SecretsManagerSection-native.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves refreshSummary backends and preferences hops each carry their own
+ * timeoutMs into Agent.request and keep allowNonOk. Modal load / sign-out
+ * hops stay untouched. Not wallets. Not Finances.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "../../api/client-base";
+import type { AgentRequestTransport } from "../../api/transport";
+import { setBootConfig } from "../../config/boot-config";
+import {
+  VAULT_SECRETS_BACKENDS_RAW_REQUEST_TIMEOUT_MS,
+  VAULT_SECRETS_PREFERENCES_RAW_REQUEST_TIMEOUT_MS,
+  rawRequestVaultSecretsBackends,
+  rawRequestVaultSecretsPreferences,
+} from "./SecretsManagerSection";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+function stallTransport(): AgentRequestTransport["request"] {
+  return async (_url, init, ctx) => {
+    const ms = ctx?.timeoutMs ?? 10;
+    await new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => {
+        reject(
+          Object.assign(new Error(`Request timed out after ${ms}ms`), {
+            name: "TimeoutError",
+          }),
+        );
+      }, ms);
+      init.signal?.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(timer);
+          reject(
+            Object.assign(new Error("The operation was aborted"), {
+              name: "AbortError",
+            }),
+          );
+        },
+        { once: true },
+      );
+    });
+  };
+}
+
+describe("SecretsManagerSection refreshSummary native transport", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("forwards a separate backends deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ backends: [] }),
+    );
+    const res = await rawRequestVaultSecretsBackends(
+      VAULT_SECRETS_BACKENDS_RAW_REQUEST_TIMEOUT_MS,
+      makeClient(request),
+    );
+    expect(res.ok).toBe(true);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/manager/backends",
+      expect.any(Object),
+      { timeoutMs: VAULT_SECRETS_BACKENDS_RAW_REQUEST_TIMEOUT_MS },
+    );
+  });
+
+  it("forwards a separate preferences deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ preferences: { enabled: ["in-house"] } }),
+    );
+    const res = await rawRequestVaultSecretsPreferences(
+      VAULT_SECRETS_PREFERENCES_RAW_REQUEST_TIMEOUT_MS,
+      makeClient(request),
+    );
+    expect(res.ok).toBe(true);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/manager/preferences",
+      expect.any(Object),
+      { timeoutMs: VAULT_SECRETS_PREFERENCES_RAW_REQUEST_TIMEOUT_MS },
+    );
+  });
+
+  it("keeps independent deadlines when both hops run together", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json({ ok: true }),
+    );
+    const api = makeClient(request);
+    const [backends, prefs] = await Promise.all([
+      rawRequestVaultSecretsBackends(10, api),
+      rawRequestVaultSecretsPreferences(20, api),
+    ]);
+    expect(backends.ok).toBe(true);
+    expect(prefs.ok).toBe(true);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/manager/backends",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/manager/preferences",
+      expect.any(Object),
+      { timeoutMs: 20 },
+    );
+  });
+
+  it("returns a non-ok backends response instead of throwing", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () => new Response("nope", { status: 503 }),
+    );
+    const res = await rawRequestVaultSecretsBackends(
+      VAULT_SECRETS_BACKENDS_RAW_REQUEST_TIMEOUT_MS,
+      makeClient(request),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(503);
+  });
+
+  it("times out a stalled backends hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(stallTransport());
+    await expect(
+      rawRequestVaultSecretsBackends(10, makeClient(request)),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/manager/backends",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("times out a stalled preferences hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(stallTransport());
+    await expect(
+      rawRequestVaultSecretsPreferences(10, makeClient(request)),
+    ).rejects.toMatchObject({ name: "ApiError", kind: "timeout" });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/secrets/manager/preferences",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from the backends hop", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw Object.assign(new Error("vault backends unavailable"), {
+        name: "TypeError",
+      });
+    });
+    await expect(
+      rawRequestVaultSecretsBackends(
+        VAULT_SECRETS_BACKENDS_RAW_REQUEST_TIMEOUT_MS,
+        makeClient(request),
+      ),
+    ).rejects.toMatchObject({ name: "ApiError" });
+  });
+});

--- a/packages/ui/src/components/settings/SecretsManagerSection.tsx
+++ b/packages/ui/src/components/settings/SecretsManagerSection.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 // fetch targets the page origin unauthenticated, which breaks remote/token-
 // authed runtimes (e.g. the Android local agent).
 import { client } from "../../api/client";
+import type { ElizaClient } from "../../api/client-base";
 import {
   dispatchSecretsManagerOpen,
   useSecretsManagerModalState,
@@ -51,6 +52,31 @@ import type {
   VaultEntryMeta,
   VaultTabNavigate,
 } from "./vault-tabs/types";
+
+/** Ordinary REST budget for GET /api/secrets/manager/backends (settings row). */
+export const VAULT_SECRETS_BACKENDS_RAW_REQUEST_TIMEOUT_MS = 10_000;
+/** Ordinary REST budget for GET /api/secrets/manager/preferences (settings row). */
+export const VAULT_SECRETS_PREFERENCES_RAW_REQUEST_TIMEOUT_MS = 10_000;
+
+export async function rawRequestVaultSecretsBackends(
+  timeoutMs: number = VAULT_SECRETS_BACKENDS_RAW_REQUEST_TIMEOUT_MS,
+  api: Pick<ElizaClient, "rawRequest"> = client,
+): Promise<Response> {
+  return api.rawRequest("/api/secrets/manager/backends", undefined, {
+    allowNonOk: true,
+    timeoutMs,
+  });
+}
+
+export async function rawRequestVaultSecretsPreferences(
+  timeoutMs: number = VAULT_SECRETS_PREFERENCES_RAW_REQUEST_TIMEOUT_MS,
+  api: Pick<ElizaClient, "rawRequest"> = client,
+): Promise<Response> {
+  return api.rawRequest("/api/secrets/manager/preferences", undefined, {
+    allowNonOk: true,
+    timeoutMs,
+  });
+}
 
 const HASH_PREFIX = "vault";
 
@@ -89,12 +115,8 @@ export function SecretsManagerSection() {
 
   const refreshSummary = useCallback(async () => {
     const [bRes, pRes] = await Promise.all([
-      client.rawRequest("/api/secrets/manager/backends", undefined, {
-        allowNonOk: true,
-      }),
-      client.rawRequest("/api/secrets/manager/preferences", undefined, {
-        allowNonOk: true,
-      }),
+      rawRequestVaultSecretsBackends(),
+      rawRequestVaultSecretsPreferences(),
     ]);
     if (!bRes.ok || !pRes.ok) return;
     const bJson = (await bRes.json()) as { backends: BackendStatus[] };


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS hops are only bounded when they go through ElizaClient with `{ timeoutMs }`. `SecretsManagerSection` `refreshSummary` called `rawRequest("/api/secrets/manager/backends")` and `rawRequest("/api/secrets/manager/preferences")` in one `Promise.all` with `{ allowNonOk: true }` and no `{ timeoutMs }`. This PR routes **those two independent hops** through `rawRequest` / `{ timeoutMs }` with a 10s REST budget **each** (separate deadlines, not one shared budget) and **keeps `allowNonOk`**. Modal load / sign-out hops stay untouched. Not `#22013`. Not `#22008`. Not `#22007`. Not `#22006`. Not `#21992`. Not wallets (byt61). Not Finances. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success / non-ok passthrough, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not extra-decode. Not payment. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. `allowNonOk` retained. Unfixed head: both summary hops called `rawRequest(..., { allowNonOk: true })` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawAllowNonOk: true` / `argc: 3` on each path). After: each hop forwards its own `{ timeoutMs }`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and paired hops receive distinct deadlines (10 vs 20).

# Background

## What does this PR do?

The settings Vault summary hops omitted `{ timeoutMs }`. This PR passes a **separate** `{ timeoutMs }` on backends and preferences and keeps `allowNonOk`.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Vault settings-row UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/settings/SecretsManagerSection-native.test.ts` — real ElizaClient + `setRequestTransport` proves each hop's `timeoutMs` reaches `Agent.request`, TimeoutError, provider-error, success, non-ok passthrough, and independent paired deadlines.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/components/settings/SecretsManagerSection-native.test.ts
```

Unfixed head: both hops hung (`HUNG` / `sawTimeoutMs: false` / `sawAllowNonOk: true`). After the fix: native suite passes.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. GET /api/secrets/manager/backends and /preferences now use ElizaClient timeoutMs on rawRequest.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves separate timeoutMs, TimeoutError, provider-error, success, and allowNonOk.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. The two summary hops now carry ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the secrets-manager summary native-transport file. Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: backends and preferences `rawRequest(..., { allowNonOk: true })` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawAllowNonOk: true` on each path. After: each hop forwards its own deadline to `Agent.request`. Modal load / sign-out hops untouched. Not `#22013`. Not wallets.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`rawRequest` / `{ timeoutMs }`, keep `allowNonOk`, separate deadlines per independent hop), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#22013` / `#22008` / `#22007` / `#22006` and earlier owned hops not restacked. Remaining SecretsManagerSection / VaultModal hops not restacked.

<!-- evidence-head:e48630079ad8a3a1bbd7f8da8a6e98e925d53a6c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
