### PR TITLE
fix(ui): route listConsumerKeys hop through ElizaClient timeoutMs

### DIFF
--- a/packages/ui/src/api/client-agent-consumer-keys-native.test.ts
+++ b/packages/ui/src/api/client-agent-consumer-keys-native.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves listConsumerKeys carries timeoutMs into Agent.request.
+ * Create / update / rotate hops stay untouched.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import { CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS } from "./client-agent-consumer-keys";
+import "./client-agent-consumer-keys";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const list = {
+  keys: [
+    {
+      id: "ck_1",
+      label: "CI runner",
+      enabled: true,
+      dailyTokenQuota: null,
+      keyPrefix: "elizack_ab",
+      createdAt: 1,
+      updatedAt: 2,
+    },
+  ],
+};
+
+describe("ElizaClient consumer-keys native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget for the list hop", () => {
+    expect(CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("forwards the list deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(list),
+    );
+    await makeClient(request).listConsumerKeys();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/accounts/consumer-keys",
+      expect.any(Object),
+      { timeoutMs: CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled list hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).listConsumerKeys(10),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/accounts/consumer-keys",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from a completed list GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(makeClient(request).listConsumerKeys()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-agent-consumer-keys.ts
+++ b/packages/ui/src/api/client-agent-consumer-keys.ts
@@ -9,6 +9,9 @@
 
 import { ElizaClient } from "./client-base";
 
+/** Consumer-key list GET — existing 10s REST budget, independent hop. */
+export const CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS = 10_000;
+
 export interface ConsumerKeySummary {
   id: string;
   label: string;
@@ -73,7 +76,7 @@ function parseCreated(value: unknown): ConsumerKeyCreated {
 
 declare module "./client-base" {
   interface ElizaClient {
-    listConsumerKeys(): Promise<ConsumerKeySummary[]>;
+    listConsumerKeys(timeoutMs?: number): Promise<ConsumerKeySummary[]>;
     createConsumerKey(body: ConsumerKeyPatch): Promise<ConsumerKeyCreated>;
     updateConsumerKey(
       id: string,
@@ -83,8 +86,15 @@ declare module "./client-base" {
   }
 }
 
-ElizaClient.prototype.listConsumerKeys = async function (this: ElizaClient) {
-  const response = await this.fetch<unknown>("/api/accounts/consumer-keys");
+ElizaClient.prototype.listConsumerKeys = async function (
+  this: ElizaClient,
+  timeoutMs: number = CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS,
+) {
+  const response = await this.fetch<unknown>(
+    "/api/accounts/consumer-keys",
+    undefined,
+    { timeoutMs },
+  );
   if (!isRecord(response) || !Array.isArray(response.keys)) {
     throw new Error("Malformed consumer-key list from agent");
   }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Shaw CR bar on `#21864` / `#21800` / `#21795` (and siblings): Android/iOS `client.fetch` is only bounded when the hop goes through ElizaClient with `{ timeoutMs }`. `listConsumerKeys` called `this.fetch("/api/accounts/consumer-keys")` with no `{ timeoutMs }`. This PR routes **that hop** through `client.fetch` / `{ timeoutMs }` with an explicit 10s REST budget. Create / update / rotate hops stay untouched. Account-pool consumer keys, not byt61 wallets. Not `#21995` (`listAccounts`). Not `#22014`. Not Finances. Native-complete: ElizaClient + `setRequestTransport`, TimeoutError / provider-error / success, `timeoutMs` forwarded to `Agent.request`. Not AbortSignal.timeout. Not Twilio. Not TelegramBotSetupPanel. Not `browser-launch.ts`. Not the ten inbox CR files. Not extra-decode. Not payment. Not `#21385`. Not grok JSON. Not cloud JSON. Not `#21810`. Proof is vitest of these files only — does not `bun install`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Transport deadline only. Validator path unchanged. Unfixed head: listConsumerKeys called `fetch(path)` with **no timeoutMs** (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false` / `argc: 1`). After: `client.fetch(..., { timeoutMs })`; a 10ms stalled hop throws `ApiError` `{ kind: "timeout" }` and the transport receives `{ timeoutMs: 10 }`.

# Background

## What does this PR do?

The account-pool consumer-key list hop omitted `{ timeoutMs }`. This PR passes `{ timeoutMs }` on that hop only.

## What kind of change is this?

Bug fix (non-breaking I/O bound). Consumer-key panel UX unchanged.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-agent-consumer-keys-native.test.ts` — real ElizaClient + `setRequestTransport` proves `timeoutMs` reaches `Agent.request`, TimeoutError, and provider-error.

## Detailed testing steps

None: automated tests are acceptable.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts \
  src/api/client-agent-consumer-keys-native.test.ts
```

Unfixed head: hop hung (`HUNG` / `sawTimeoutMs: false` / `sawSignal: false` / `argc: 1`). After the fix: native suite passes.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no new rendered UI surface. listConsumerKeys now uses ElizaClient timeoutMs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow. ElizaClient transport proves timeoutMs, TimeoutError, provider-error, and success.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-side fetch deadline only; no server log required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser console claim. Hang-prove and vitest are the evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no new agent/LLM trajectory. listConsumerKeys now carries ElizaClient timeoutMs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no immutable domain artifact. Transport deadline only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot OCR. No rendered UI change.
<!-- evidence-row:ci-checks -->
- [x] Targeted vitest of the consumer-keys native-transport file. Full `bun run verify` not run; scoped I/O-bound timeout fix.
<!-- evidence-row:benchmarks -->
- [x] N/A - no performance claim.
<!-- evidence-row:repro-script -->
- [x] Hang-prove on origin/develop: listConsumerKeys `this.fetch("/api/accounts/consumer-keys")` with no `{ timeoutMs }` → `HUNG` / `sawTimeoutMs: false` / `sawSignal: false` / `argc: 1`. After: the hop forwards its deadline to `Agent.request`. Create / update / rotate hops untouched. Not `#21995`. Not wallets.

# Known gaps / failures

Full-repo `bun run verify` not run. Proof is the scoped vitest above. `bun install` not run.

# Notes for reviewers

Native-complete bar (`client.fetch` / `{ timeoutMs }`), not raw `AbortSignal.timeout`. Inbox CR siblings `#21864` `#21800` `#21795` `#21791` `#21789` `#21778` `#21777` `#21773` `#21762` `#21760` are not restacked. `#21800` stays draft. `#21810` not touched. `#22014` / `#22013` / `#22008` / `#22007` / `#22006` / `#22005` / `#22004` / `#22002` / `#22001` / `#22000` / `#21998` / `#21997` / `#21995` and earlier owned hops not restacked. Remaining consumer-key hops not restacked.

<!-- evidence-head:8c0ac851f9ee6594a9d88b4391fdd433e0020b42 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
