### PR TITLE
fix(plugin-finances): parse thousands-separated subscription amounts ($1,234.56 no longer truncates to $1)

### DIFF
--- a/plugins/plugin-finances/src/services/subscriptions-service.ts
+++ b/plugins/plugin-finances/src/services/subscriptions-service.ts
@@ -371,11 +371,14 @@ function parseUsdAmount(
   message: Pick<LifeOpsGmailMessageSummary, "subject" | "snippet">,
 ): number | null {
   const blob = `${message.subject} ${message.snippet}`;
-  const match = blob.match(/\$([0-9]+(?:\.[0-9]{1,2})?)/);
+  // Allow thousands separators inside the integer part so grouped amounts like
+  // "$1,234.56" are captured whole, then strip the commas before Number() —
+  // matching the CSV importer's readNumber normalization in payment-csv-import.ts.
+  const match = blob.match(/\$\s*([0-9][0-9,]*(?:\.[0-9]{1,2})?)/);
   if (!match) {
     return null;
   }
-  const value = Number(match[1]);
+  const value = Number(match[1].replace(/,/g, ""));
   return Number.isFinite(value) ? value : null;
 }
 

--- a/plugins/plugin-finances/test/subscriptions-service.real-db.test.ts
+++ b/plugins/plugin-finances/test/subscriptions-service.real-db.test.ts
@@ -213,6 +213,47 @@ describe("SubscriptionsService — real PGLite", () => {
     ).toBe(true);
   });
 
+  it("annualizes thousands-separated dollar amounts without comma truncation (#22009)", async () => {
+    // Regression: parseUsdAmount() previously used /\$([0-9]+(?:\.[0-9]{1,2})?)/,
+    // which stopped at the first comma, so "$1,234.56" parsed to 1 and the
+    // monthly annualCostEstimateUsd collapsed to $12/yr instead of $14,814.72.
+    const gmail: SubscriptionsGmailGateway = {
+      async searchSubscriptionMessages() {
+        return [
+          gmailMessage({
+            id: "msg-grouped",
+            subject: "Fixture Streaming monthly plan receipt",
+            snippet:
+              "Your plan renews for $1,234.56 monthly from fixture-streaming.example",
+            from: "fixture streaming <billing@fixture-streaming.example>",
+            fromEmail: "billing@fixture-streaming.example",
+          }),
+        ];
+      },
+    };
+    const service = new SubscriptionsService(runtime, {
+      gmailGateway: gmail,
+      browserGateway: noCompanionBrowser,
+    });
+
+    const summary = await service.auditSubscriptions({ queryWindowDays: 90 });
+    const fixture = summary.candidates.find(
+      (c) => c.serviceSlug === "fixture_streaming",
+    );
+    expect(fixture).toBeTruthy();
+    expect(fixture?.cadence).toBe("monthly");
+    // The monthly base amount must be the full $1,234.56, not the truncated $1.
+    expect(fixture?.annualCostEstimateUsd).toBeCloseTo(14814.72, 2);
+    expect(fixture?.annualCostEstimateUsd).not.toBe(12);
+
+    // The DTO round-trips through the real DB with the corrected estimate.
+    const latest = await service.getLatestSubscriptionAudit();
+    const persisted = latest?.candidates.find(
+      (c) => c.serviceSlug === "fixture_streaming",
+    );
+    expect(persisted?.annualCostEstimateUsd).toBeCloseTo(14814.72, 2);
+  });
+
   it("falls back to a manual audit when Gmail throws and a serviceQuery is given", async () => {
     const gmail: SubscriptionsGmailGateway = {
       async searchSubscriptionMessages() {


### PR DESCRIPTION
# Relates to

Closes #22009

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and package checks were run after sync; unrelated blockers
      are recorded under **Known gaps / failures** below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`2462c6e333`); zero conflicts.
- [x] Package tests/lint pass post-sync; the unrelated `bun run verify` blocker
      is documented under **Known gaps / failures**.

# Risks

Low. Single-function change to `parseUsdAmount()` in
`plugins/plugin-finances/src/services/subscriptions-service.ts`. The regex is
widened to admit thousands separators inside the integer part and commas are
stripped before `Number()`. Amounts without separators (the previously-working
case) are unaffected — verified by the `$15.99` row below and the existing
`$9.99` audit test.

# Background

## What does this PR do?

Fixes a systematic ~1000x under-estimate in subscription cost detection.
`parseUsdAmount()` used `/\$([0-9]+(?:\.[0-9]{1,2})?)/`, whose integer class
stops at the first comma, so any thousands-separated amount was truncated at
the separator: `$1,234.56` parsed to `1` and `$2,499.00` to `2`. That value
feeds `annualizeAmount()` and becomes the candidate `annualCostEstimateUsd` DTO
field (`subscriptions-service.ts:865`) and the user-facing `est $X/yr` summary
line (`:1323`), so a `$1,234.56`/mo plan was reported as `$12/yr` — precisely
for the expensive 4-figure plans the audit exists to surface.

The fix widens the integer part to `[0-9][0-9,]*` and strips commas before
`Number()`, exactly matching the sibling CSV importer's `readNumber`
normalization (`plugins/plugin-finances/src/payment-csv-import.ts:129`,
`raw.replace(/[$,]/g, "")`). This makes the two amount parsers consistent.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The behavior
change is a bug fix aligning an internal parser with its already-documented
sibling; no public surface, route, or DTO shape changed.

# Testing

## Where should a reviewer start?

`plugins/plugin-finances/test/subscriptions-service.real-db.test.ts` — the new
regression test `annualizes thousands-separated dollar amounts without comma
truncation (#22009)` drives the real public `auditSubscriptions()` path against
a live PGLite-backed runtime, so it exercises the exact contract boundary
(Gmail evidence → candidate `annualCostEstimateUsd` DTO → DB round-trip) rather
than a privatized helper.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-finances test        # focused package lane
# or the single regression file:
bunx vitest run test/subscriptions-service.real-db.test.ts --root plugins/plugin-finances
```

The new test asserts a monthly `$1,234.56` candidate annualizes to `14814.72`
(not `12`) and that the value round-trips through the real database.

# Evidence Gate

<!-- evidence-head:f3f79c7d897c0f3d73861bb030f7cc5514461676 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface changed`. This PR edits an internal string parser in a
      service file; no rendered `.tsx`/`.css`/`.svg` under `packages/app` or
      `packages/ui` is touched.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface changed` (see above).
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-interactive flow changed`; the fix is a pure back-end parser
      correction covered by the automated regression test.
<!-- evidence-row:backend-logs -->
- [x] Backend proof: failing-then-passing vitest run on the real PGLite runtime
      (service back-end code path fires end to end).

<details><summary>vitest output / logs — subscriptions-service.real-db.test.ts</summary>

```
 ✓ SubscriptionsService — real PGLite > audits subscriptions from mocked Gmail evidence and persists the audit 24ms
 ✓ SubscriptionsService — real PGLite > annualizes thousands-separated dollar amounts without comma truncation (#22009) 13ms
 ✓ SubscriptionsService — real PGLite > falls back to a manual audit when Gmail throws and a serviceQuery is given 11ms
 ✓ SubscriptionsService — real PGLite > returns unsupported_surface for an unknown service (no playbook) 9ms
 ✓ SubscriptionsService — real PGLite > drives an agent_browser cancellation through a mocked computeruse service 10ms
 ✓ SubscriptionsService — real PGLite > drives an agent_browser cancellation through BrowserService workspace when computeruse is absent 1089ms
 ✓ SubscriptionsService — real PGLite > creates a user_browser session via the mocked browser gateway 6ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response path changed`.
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changed`; this is a
      deterministic numeric parser fix with no LLM call on the path.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: before/after parser+annualize table and the persisted
      `annualCostEstimateUsd` DB round-trip asserted by the test.

```
# parseUsdAmount before/after + persisted DTO (issue #22009)

## Before (pre-fix regex, truncates at first comma)
"Your plan renews for $1,234.56 monthly" -> parsed 1        annual(monthly) 12
"Receipt: $2,499.00 charged annually"    -> parsed 2        annual(monthly) 24
"Netflix $15.99/mo"                       -> parsed 15.99    annual(monthly) 191.88
"Enterprise $1,000,000.00 per year"       -> parsed 1        annual(monthly) 12

## After (fixed regex, strips thousands separators)
"Your plan renews for $1,234.56 monthly" -> parsed 1234.56  annual(monthly) 14814.72
"Receipt: $2,499.00 charged annually"    -> parsed 2499     annual(monthly) 29988
"Netflix $15.99/mo"                       -> parsed 15.99    annual(monthly) 191.88
"Enterprise $1,000,000.00 per year"       -> parsed 1000000 annual(monthly) 12000000

## Persisted DTO (asserted by regression test, round-trips via getLatestSubscriptionAudit)
candidate.serviceSlug=fixture_streaming cadence=monthly annualCostEstimateUsd=14814.72 (was 12)
```
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change`. `parseUsdAmount` is a
deterministic regex parser with no model on its path.

## Backend + frontend logs

Failing-then-passing evidence for the changed contract.

**Before the fix** — standalone repro of the exact pre-fix regex + `annualize`
logic (`Number((amount * 12).toFixed(2))`), reproducing the issue:

```
"Your plan renews for $1,234.56 monthly" -> parsed 1        annual(monthly) 12
"Receipt: $2,499.00 charged annually"    -> parsed 2        annual(monthly) 24
"Netflix $15.99/mo"                       -> parsed 15.99    annual(monthly) 191.88
"Enterprise $1,000,000.00 per year"       -> parsed 1        annual(monthly) 12
```

**After the fix** — same inputs through the corrected parser:

```
"Your plan renews for $1,234.56 monthly" -> parsed 1234.56  annual(monthly) 14814.72
"Receipt: $2,499.00 charged annually"    -> parsed 2499     annual(monthly) 29988
"Netflix $15.99/mo"                       -> parsed 15.99    annual(monthly) 191.88  (unchanged)
"Enterprise $1,000,000.00 per year"       -> parsed 1000000 annual(monthly) 12000000
```

`1 → 1234.56` and `2 → 2499`; the under-3-digit `$15.99` row is unchanged,
confirming the defect and its fix are specific to comma-grouped amounts.

**Passing regression test** on the real PGLite-backed runtime:

<details><summary>vitest run — subscriptions-service.real-db.test.ts (7 passed)</summary>

```
 ✓ SubscriptionsService — real PGLite > audits subscriptions from mocked Gmail evidence and persists the audit
 ✓ SubscriptionsService — real PGLite > annualizes thousands-separated dollar amounts without comma truncation (#22009)
 ✓ SubscriptionsService — real PGLite > falls back to a manual audit when Gmail throws and a serviceQuery is given
 ✓ SubscriptionsService — real PGLite > returns unsupported_surface for an unknown service (no playbook)
 ✓ SubscriptionsService — real PGLite > drives an agent_browser cancellation through a mocked computeruse service
 ✓ SubscriptionsService — real PGLite > drives an agent_browser cancellation through BrowserService workspace when computeruse is absent
 ✓ SubscriptionsService — real PGLite > creates a user_browser session via the mocked browser gateway

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

</details>

The new test drives `auditSubscriptions()` end to end: a Gmail message snippet
`"Your plan renews for $1,234.56 monthly …"` produces a `fixture_streaming`
candidate whose `annualCostEstimateUsd` is asserted `toBeCloseTo(14814.72, 2)`
and `not.toBe(12)`, then re-read from the database via
`getLatestSubscriptionAudit()` to prove the corrected estimate persists.

**Biome lint** on both touched files:

```
Checked 2 files in 115ms. No fixes applied.
```

Frontend: `N/A - no frontend path changed`.

## Screenshots (before / after) + video walkthrough

`N/A - no UI change`. No rendered surface under `packages/app`/`packages/ui` is
touched; the diff is limited to a service parser and its test.

### Before

`N/A - no UI change`.

### After

`N/A - no UI change`.

### Walkthrough video

`N/A - no UI change`.

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change`.

## Known gaps / failures

- `bun install` on this machine required `--minimum-release-age=0` against the
  committed frozen lockfile because the host's global `~/.bunfig.toml` sets a
  7-day supply-chain age gate that blocks a few already-vetted lockfile versions
  (viem, etc.). This does not affect the changed source; the lockfile is
  unmodified.
- Repo-wide `bun run verify` / package `typecheck` could not fully complete on
  this machine: pre-existing, change-independent failures exist on the base
  commit `2462c6e333` before my edit — `packages/core` needs the generated
  `src/i18n/generated/validation-keyword-data.ts` (regenerated locally via
  `node packages/shared/scripts/generate-keywords.mjs`), and
  `plugins/plugin-finances` `typecheck` reports errors only in unrelated files
  (`finances-service.ts`, `gmail-seam.ts`, incl. an unbuilt
  `@elizaos/plugin-google-workspace` workspace dep). Zero typecheck errors
  reference my edited `subscriptions-service.ts`; I confirmed the same errors on
  `git stash` of my change.
- Two package UI tests (`format-minor.test.ts`, `FinancesView.test.tsx`) fail on
  this host due to an ICU/Node currency-symbol locale difference
  (`JP¥1,500` vs `¥1,500`) — reproduced on the base commit with my change
  stashed, so they are environmental and unrelated to this fix.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza"} -->
