### PR TITLE
fix(plugin-google-genai): pin embedding output to the 768 probe width so memory writes stop failing (#22010)

### DIFF
--- a/plugins/plugin-google-genai/AGENTS.md
+++ b/plugins/plugin-google-genai/AGENTS.md
@@ -17,7 +17,7 @@ Registers model handlers for all elizaOS `ModelType` tiers (nano through mega, p
 | `TEXT_MEGA` | `handleTextMega` | falls back to large model |
 | `RESPONSE_HANDLER` | `handleResponseHandler` | falls back to nano model |
 | `ACTION_PLANNER` | `handleActionPlanner` | falls back to medium model |
-| `TEXT_EMBEDDING` | `handleTextEmbedding` | `text-embedding-004` (768-dim) |
+| `TEXT_EMBEDDING` | `handleTextEmbedding` | `gemini-embedding-001` (pinned to 768-dim, L2-normalized) |
 | `IMAGE_DESCRIPTION` | `handleImageDescription` | `gemini-2.5-pro-preview-03-25` |
 
 Event emitted after each model call: `MODEL_USED` (via `runtime.emitEvent`).
@@ -76,7 +76,7 @@ Settings are read first from `runtime.getSetting(key)`, then from `process.env`.
 | `GOOGLE_RESPONSE_HANDLER_MODEL` / `GOOGLE_SHOULD_RESPOND_MODEL` / `RESPONSE_HANDLER_MODEL` / `SHOULD_RESPOND_MODEL` | No | falls back to nano | |
 | `GOOGLE_ACTION_PLANNER_MODEL` / `GOOGLE_PLANNER_MODEL` / `ACTION_PLANNER_MODEL` / `PLANNER_MODEL` | No | falls back to medium | |
 | `GOOGLE_IMAGE_MODEL` / `IMAGE_MODEL` | No | `gemini-2.5-pro-preview-03-25` | |
-| `GOOGLE_EMBEDDING_MODEL` | No | `text-embedding-004` | 768-dimension output |
+| `GOOGLE_EMBEDDING_MODEL` | No | `gemini-embedding-001` | Output pinned to 768 dims via `outputDimensionality` and L2-normalized so writes match the runtime's probe-sized column (#22010) |
 
 ## How to extend
 

--- a/plugins/plugin-google-genai/CLAUDE.md
+++ b/plugins/plugin-google-genai/CLAUDE.md
@@ -17,7 +17,7 @@ Registers model handlers for all elizaOS `ModelType` tiers (nano through mega, p
 | `TEXT_MEGA` | `handleTextMega` | falls back to large model |
 | `RESPONSE_HANDLER` | `handleResponseHandler` | falls back to nano model |
 | `ACTION_PLANNER` | `handleActionPlanner` | falls back to medium model |
-| `TEXT_EMBEDDING` | `handleTextEmbedding` | `text-embedding-004` (768-dim) |
+| `TEXT_EMBEDDING` | `handleTextEmbedding` | `gemini-embedding-001` (pinned to 768-dim, L2-normalized) |
 | `IMAGE_DESCRIPTION` | `handleImageDescription` | `gemini-2.5-pro-preview-03-25` |
 
 Event emitted after each model call: `MODEL_USED` (via `runtime.emitEvent`).
@@ -76,7 +76,7 @@ Settings are read first from `runtime.getSetting(key)`, then from `process.env`.
 | `GOOGLE_RESPONSE_HANDLER_MODEL` / `GOOGLE_SHOULD_RESPOND_MODEL` / `RESPONSE_HANDLER_MODEL` / `SHOULD_RESPOND_MODEL` | No | falls back to nano | |
 | `GOOGLE_ACTION_PLANNER_MODEL` / `GOOGLE_PLANNER_MODEL` / `ACTION_PLANNER_MODEL` / `PLANNER_MODEL` | No | falls back to medium | |
 | `GOOGLE_IMAGE_MODEL` / `IMAGE_MODEL` | No | `gemini-2.5-pro-preview-03-25` | |
-| `GOOGLE_EMBEDDING_MODEL` | No | `text-embedding-004` | 768-dimension output |
+| `GOOGLE_EMBEDDING_MODEL` | No | `gemini-embedding-001` | Output pinned to 768 dims via `outputDimensionality` and L2-normalized so writes match the runtime's probe-sized column (#22010) |
 
 ## How to extend
 

--- a/plugins/plugin-google-genai/README.md
+++ b/plugins/plugin-google-genai/README.md
@@ -5,7 +5,7 @@ Google Generative AI (Gemini) model provider for [elizaOS](https://github.com/el
 ## Capabilities
 
 - **Text generation** across all model tiers: nano, small, medium, large, mega, response handler, action planner.
-- **Text embeddings** with `text-embedding-004` (768 dimensions).
+- **Text embeddings** with `gemini-embedding-001`, pinned to 768 dimensions (`outputDimensionality: 768`) and L2-normalized so writes match the runtime's probe-sized vector column.
 - **Image description** — fetch an image by URL, encode it inline, and return a `{ title, description }` object.
 - **Structured output** — pass a JSON Schema as `responseSchema` to any text handler to get `application/json` back from the model.
 - **Tool use** — pass function declarations via `tools` / `toolChoice` to enable function-calling on supported models.
@@ -44,7 +44,7 @@ Or register it explicitly in your agent character file:
 | `GOOGLE_MEGA_MODEL` | No | falls back to large | Mega text model |
 | `GOOGLE_RESPONSE_HANDLER_MODEL` | No | falls back to nano | Response handler model |
 | `GOOGLE_ACTION_PLANNER_MODEL` | No | falls back to medium | Action planner model |
-| `GOOGLE_EMBEDDING_MODEL` | No | `text-embedding-004` | Embedding model |
+| `GOOGLE_EMBEDDING_MODEL` | No | `gemini-embedding-001` | Embedding model. Output is pinned to 768 dimensions and L2-normalized regardless of the model's native default. |
 | `GOOGLE_IMAGE_MODEL` | No | `gemini-2.5-pro-preview-03-25` | Image description model |
 
 Generic fallbacks (`SMALL_MODEL`, `LARGE_MODEL`, `IMAGE_MODEL`, etc.) are also respected when the `GOOGLE_*` prefix variants are not set.
@@ -65,7 +65,7 @@ const text = await runtime.useModel(ModelType.TEXT_LARGE, {
 const embedding = await runtime.useModel(ModelType.TEXT_EMBEDDING, {
   text: "Hello, world!",
 });
-// embedding is number[] with 768 dimensions
+// embedding is a unit-length number[] with 768 dimensions
 
 // Image description
 const result = await runtime.useModel(
@@ -99,7 +99,7 @@ const person = await runtime.useModel(ModelType.TEXT_SMALL, {
 | `TEXT_MEGA` | falls back to large | |
 | `RESPONSE_HANDLER` | falls back to nano | |
 | `ACTION_PLANNER` | falls back to medium | |
-| `TEXT_EMBEDDING` | `text-embedding-004` | 768-dim vectors |
+| `TEXT_EMBEDDING` | `gemini-embedding-001` | 768-dim unit vectors (`outputDimensionality: 768`) |
 | `IMAGE_DESCRIPTION` | `gemini-2.5-pro-preview-03-25` | Multimodal; fetches image by URL |
 
 ## Development

--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -1,7 +1,10 @@
 /**
- * Unit tests for `handleTextEmbedding`: the null-probe marker vector, usage
- * emission, and the throw paths (empty input, empty API response). The config,
- * events, tokenization, and `@google/genai` layers are mocked — no live call.
+ * Unit tests for `handleTextEmbedding`: the null-probe marker vector, the
+ * probe/write width contract (#22010 — both pinned to 768 so the runtime's
+ * probe-sized pgvector column matches every write), L2 normalization, usage
+ * emission, and the throw paths (empty input, empty/oversized API response).
+ * The config, events, tokenization, and `@google/genai` layers are mocked — no
+ * live call.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -27,7 +30,7 @@ vi.mock("@elizaos/core", () => ({
 
 vi.mock("../utils/config", () => ({
   createGoogleGenAI: mocks.createGoogleGenAI,
-  getEmbeddingModel: vi.fn(() => "text-embedding-004"),
+  getEmbeddingModel: vi.fn(() => "gemini-embedding-001"),
 }));
 
 vi.mock("../utils/events", () => ({
@@ -51,8 +54,10 @@ describe("Google GenAI embeddings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.countTokens.mockResolvedValue(5);
+    // gemini-embedding-001 honours outputDimensionality:768 and returns a
+    // 768-length (un-normalized) vector for that request.
     mocks.embedContent.mockResolvedValue({
-      embeddings: [{ values: [0.1, 0.2, 0.3] }],
+      embeddings: [{ values: Array(768).fill(0.5) }],
     });
     mocks.createGoogleGenAI.mockReturnValue({
       models: {
@@ -76,11 +81,7 @@ describe("Google GenAI embeddings", () => {
 
     const embedding = await handleTextEmbedding(runtime, "hello");
 
-    expect(embedding).toEqual([0.1, 0.2, 0.3]);
-    expect(mocks.embedContent).toHaveBeenCalledWith({
-      model: "text-embedding-004",
-      contents: "hello",
-    });
+    expect(embedding).toHaveLength(768);
     expect(mocks.emitModelUsageEvent).toHaveBeenCalledWith(
       runtime,
       "TEXT_EMBEDDING",
@@ -90,6 +91,63 @@ describe("Google GenAI embeddings", () => {
         completionTokens: 0,
         totalTokens: 5,
       },
+    );
+  });
+
+  it("pins outputDimensionality to the probe width so the write matches the sized column (#22010)", async () => {
+    // Regression for #22010: the default model gemini-embedding-001 emits 3072
+    // dims by default, but the runtime sizes its pgvector column from the 768
+    // init probe. The real request MUST constrain the width to 768 or every
+    // memory write fails with "expected 768 dimensions, not 3072".
+    const probe = await handleTextEmbedding(createRuntime(), null);
+    const embedding = await handleTextEmbedding(createRuntime(), "hello");
+
+    expect(mocks.embedContent).toHaveBeenCalledWith({
+      model: "gemini-embedding-001",
+      contents: "hello",
+      config: { outputDimensionality: 768 },
+    });
+    // The probe (which sizes the column) and a real write agree on width.
+    expect(embedding).toHaveLength(probe.length);
+    expect(embedding).toHaveLength(768);
+  });
+
+  it("L2-normalizes the returned vector to unit length", async () => {
+    // Google does not pre-normalize sub-3072 outputs; the handler renormalizes
+    // so vectors stay cosine-comparable like the native 768-dim model did.
+    mocks.embedContent.mockResolvedValue({
+      embeddings: [{ values: Array(768).fill(2) }],
+    });
+
+    const embedding = await handleTextEmbedding(createRuntime(), "hello");
+
+    const norm = Math.sqrt(
+      embedding.reduce((acc, value) => acc + value * value, 0),
+    );
+    expect(norm).toBeCloseTo(1, 10);
+    // Every component of a uniform vector normalizes to 1/sqrt(768).
+    expect(embedding[0]).toBeCloseTo(1 / Math.sqrt(768), 10);
+  });
+
+  it("fails closed when the provider returns a width other than the probe (no mismatched write)", async () => {
+    // Adversarial: a provider ignoring outputDimensionality and returning 3072
+    // must not be written into the 768-sized column; the handler throws instead.
+    mocks.embedContent.mockResolvedValue({
+      embeddings: [{ values: Array(3072).fill(0.01) }],
+    });
+
+    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
+      "returned 3072 dimensions",
+    );
+  });
+
+  it("rejects a zero-magnitude embedding that cannot be normalized", async () => {
+    mocks.embedContent.mockResolvedValue({
+      embeddings: [{ values: Array(768).fill(0) }],
+    });
+
+    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
+      "zero-magnitude embedding",
     );
   });
 

--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -2,7 +2,8 @@
  * Unit tests for `handleTextEmbedding`: the null-probe marker vector, the
  * probe/write width contract (#22010 — both pinned to 768 so the runtime's
  * probe-sized pgvector column matches every write), L2 normalization, usage
- * emission, and the throw paths (empty input, empty/oversized API response).
+ * emission, and the typed fail-closed throw paths (empty input, empty API
+ * response, width mismatch, zero-magnitude, and non-finite components).
  * The config, events, tokenization, and `@google/genai` layers are mocked — no
  * live call.
  */
@@ -17,6 +18,23 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@elizaos/core", () => ({
+  ElizaError: class ElizaError extends Error {
+    code?: string;
+    context?: Record<string, unknown>;
+    constructor(
+      message: string,
+      options?: {
+        code?: string;
+        cause?: unknown;
+        context?: Record<string, unknown>;
+      },
+    ) {
+      super(message, { cause: options?.cause });
+      this.name = "ElizaError";
+      this.code = options?.code;
+      this.context = options?.context;
+    }
+  },
   logger: {
     debug: vi.fn(),
     error: vi.fn(),
@@ -148,6 +166,33 @@ describe("Google GenAI embeddings", () => {
 
     await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
       "zero-magnitude embedding",
+    );
+  });
+
+  it("fails closed on a non-finite component instead of returning an all-NaN unit vector", async () => {
+    // A NaN slipping through a transport/SDK bug would leave norm = NaN, so a
+    // bare `norm === 0` guard never fires and an all-NaN "unit" vector escapes.
+    // pgvector accepts NaN literals, so it would store silently and corrupt
+    // similarity ordering; the handler must reject the vector instead.
+    const poisoned = Array(768).fill(0.5);
+    poisoned[7] = Number.NaN;
+    mocks.embedContent.mockResolvedValue({
+      embeddings: [{ values: poisoned }],
+    });
+
+    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
+      "non-finite embedding component",
+    );
+
+    // Infinity is analogous (norm = Infinity), and must also fail closed.
+    const infinite = Array(768).fill(0.5);
+    infinite[7] = Number.POSITIVE_INFINITY;
+    mocks.embedContent.mockResolvedValue({
+      embeddings: [{ values: infinite }],
+    });
+
+    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
+      "non-finite embedding component",
     );
   });
 

--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -3,9 +3,11 @@
  * probe/write width contract (#22010 — both pinned to 768 so the runtime's
  * probe-sized pgvector column matches every write), L2 normalization, usage
  * emission, and the typed fail-closed throw paths (empty input, empty API
- * response, width mismatch, zero-magnitude, and non-finite components).
- * The config, events, tokenization, and `@google/genai` layers are mocked — no
- * live call.
+ * response, width mismatch, zero-magnitude, non-finite components, and a norm
+ * that overflows to a non-finite value). The real `ElizaError` is used via
+ * `importActual` so the typed `code`/`context` contract is asserted against the
+ * class the handler actually throws; the config, events, tokenization, and
+ * `@google/genai` layers are mocked — no live call.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,34 +19,24 @@ const mocks = vi.hoisted(() => ({
   emitModelUsageEvent: vi.fn(),
 }));
 
-vi.mock("@elizaos/core", () => ({
-  ElizaError: class ElizaError extends Error {
-    code?: string;
-    context?: Record<string, unknown>;
-    constructor(
-      message: string,
-      options?: {
-        code?: string;
-        cause?: unknown;
-        context?: Record<string, unknown>;
-      },
-    ) {
-      super(message, { cause: options?.cause });
-      this.name = "ElizaError";
-      this.code = options?.code;
-      this.context = options?.context;
-    }
-  },
-  logger: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    log: vi.fn(),
-    warn: vi.fn(),
-  },
-  ModelType: {
-    TEXT_EMBEDDING: "TEXT_EMBEDDING",
-  },
-}));
+vi.mock("@elizaos/core", async () => {
+  // Use the real ElizaError so `instanceof` and the typed code/context contract
+  // are exercised against the class the handler throws, not a drifting stub.
+  const actual =
+    await vi.importActual<typeof import("@elizaos/core")>("@elizaos/core");
+  return {
+    ElizaError: actual.ElizaError,
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    },
+    ModelType: {
+      TEXT_EMBEDDING: "TEXT_EMBEDDING",
+    },
+  };
+});
 
 vi.mock("../utils/config", () => ({
   createGoogleGenAI: mocks.createGoogleGenAI,
@@ -147,26 +139,71 @@ describe("Google GenAI embeddings", () => {
     expect(embedding[0]).toBeCloseTo(1 / Math.sqrt(768), 10);
   });
 
-  it("fails closed when the provider returns a width other than the probe (no mismatched write)", async () => {
+  it("fails closed with a typed width-mismatch error when the provider returns a width other than the probe (no mismatched write)", async () => {
     // Adversarial: a provider ignoring outputDimensionality and returning 3072
     // must not be written into the 768-sized column; the handler throws instead.
     mocks.embedContent.mockResolvedValue({
       embeddings: [{ values: Array(3072).fill(0.01) }],
     });
 
-    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
-      "returned 3072 dimensions",
-    );
+    await expect(
+      handleTextEmbedding(createRuntime(), "hello"),
+    ).rejects.toMatchObject({
+      code: "EMBEDDING_DIMENSION_MISMATCH",
+      context: {
+        model: "gemini-embedding-001",
+        returnedDimensions: 3072,
+        expectedDimensions: 768,
+      },
+    });
   });
 
-  it("rejects a zero-magnitude embedding that cannot be normalized", async () => {
+  it("rejects a zero-magnitude embedding with a typed error that cannot be normalized", async () => {
     mocks.embedContent.mockResolvedValue({
       embeddings: [{ values: Array(768).fill(0) }],
     });
 
-    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
-      "zero-magnitude embedding",
-    );
+    await expect(
+      handleTextEmbedding(createRuntime(), "hello"),
+    ).rejects.toMatchObject({
+      code: "EMBEDDING_ZERO_MAGNITUDE",
+      context: { dimensions: 768 },
+    });
+  });
+
+  it("fails closed when the norm overflows to a non-finite value (all components finite)", async () => {
+    // A single enormous component squares past Number.MAX_VALUE, so sumSquares
+    // (and thus the norm) is Infinity even though every component is finite and
+    // the per-component Number.isFinite guard passes. Dividing by an Infinity
+    // norm would return an all-zero "unit" vector — a silent corrupt embedding a
+    // store could persist — so the handler must fail closed instead.
+    const single = Array(768).fill(1e-10);
+    single[0] = 1e200;
+    mocks.embedContent.mockResolvedValue({
+      embeddings: [{ values: single }],
+    });
+
+    await expect(
+      handleTextEmbedding(createRuntime(), "hello"),
+    ).rejects.toMatchObject({
+      code: "EMBEDDING_NORM_OVERFLOW",
+      context: { dimensions: 768 },
+    });
+
+    // Accumulation variant: 768 finite components whose squares each fit the
+    // double range but whose sum overflows, even though the true norm
+    // (√768·10^154 ≈ 2.77e155) is perfectly representable. The naive sum can't
+    // see this, so guarding the norm — not just each component — is required.
+    mocks.embedContent.mockResolvedValue({
+      embeddings: [{ values: Array(768).fill(1e154) }],
+    });
+
+    await expect(
+      handleTextEmbedding(createRuntime(), "hello"),
+    ).rejects.toMatchObject({
+      code: "EMBEDDING_NORM_OVERFLOW",
+      context: { dimensions: 768 },
+    });
   });
 
   it("fails closed on a non-finite component instead of returning an all-NaN unit vector", async () => {
@@ -180,9 +217,12 @@ describe("Google GenAI embeddings", () => {
       embeddings: [{ values: poisoned }],
     });
 
-    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
-      "non-finite embedding component",
-    );
+    await expect(
+      handleTextEmbedding(createRuntime(), "hello"),
+    ).rejects.toMatchObject({
+      code: "EMBEDDING_NON_FINITE",
+      context: { dimensions: 768, index: 7 },
+    });
 
     // Infinity is analogous (norm = Infinity), and must also fail closed.
     const infinite = Array(768).fill(0.5);
@@ -191,9 +231,12 @@ describe("Google GenAI embeddings", () => {
       embeddings: [{ values: infinite }],
     });
 
-    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
-      "non-finite embedding component",
-    );
+    await expect(
+      handleTextEmbedding(createRuntime(), "hello"),
+    ).rejects.toMatchObject({
+      code: "EMBEDDING_NON_FINITE",
+      context: { dimensions: 768, index: 7 },
+    });
   });
 
   it("throws for empty embedding input before creating a client", async () => {

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -20,7 +20,7 @@
  */
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
 import * as ElizaCore from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { createGoogleGenAI, getEmbeddingModel } from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
 import { countTokens } from "../utils/tokenization";
@@ -49,18 +49,30 @@ function createInitProbeVector(): number[] {
  * L2-normalize an embedding so its Euclidean norm is 1. Google returns
  * sub-3072 `outputDimensionality` vectors un-normalized, so callers that expect
  * cosine-comparable unit vectors (as the native 768-dim `text-embedding-004`
- * produced) must renormalize. A zero vector cannot be normalized and is
- * rejected upstream as an empty/degenerate response.
+ * produced) must renormalize. A non-finite component (a `NaN`/`±Infinity`
+ * slipping through a transport/SDK bug) or a zero-magnitude vector cannot yield
+ * a unit vector, so each is rejected here with its own typed error rather than
+ * returning a silently-corrupt embedding a downstream store could persist.
  */
 function l2Normalize(vector: number[]): number[] {
   let sumSquares = 0;
   for (const value of vector) {
+    if (!Number.isFinite(value)) {
+      throw new ElizaError(
+        "Google GenAI API returned a non-finite embedding component that cannot be normalized",
+        {
+          code: "EMBEDDING_NON_FINITE",
+          context: { dimensions: vector.length },
+        },
+      );
+    }
     sumSquares += value * value;
   }
   const norm = Math.sqrt(sumSquares);
   if (norm === 0) {
-    throw new Error(
+    throw new ElizaError(
       "Google GenAI API returned a zero-magnitude embedding that cannot be normalized",
+      { code: "EMBEDDING_ZERO_MAGNITUDE" },
     );
   }
   return vector.map((value) => value / norm);
@@ -136,10 +148,18 @@ export async function handleTextEmbedding(
     // Fail CLOSED on a width that disagrees with the probe rather than writing a
     // mismatched vector into a column the runtime already sized from the probe.
     if (rawEmbedding.length !== EMBEDDING_DIMENSIONS) {
-      throw new Error(
+      throw new ElizaError(
         `Google embedding model "${embeddingModelName}" returned ${rawEmbedding.length} dimensions, ` +
-          `but the runtime sized its embedding column at ${EMBEDDING_DIMENSIONS} (the init-probe width). ` +
-          `Set GOOGLE_EMBEDDING_MODEL to a model whose output matches, or align the requested outputDimensionality.`,
+          `but the init probe pinned the embedding width to ${EMBEDDING_DIMENSIONS}. ` +
+          `Set GOOGLE_EMBEDDING_MODEL to a model whose output matches the ${EMBEDDING_DIMENSIONS}-dim probe.`,
+        {
+          code: "EMBEDDING_DIMENSION_MISMATCH",
+          context: {
+            model: embeddingModelName,
+            returnedDimensions: rawEmbedding.length,
+            expectedDimensions: EMBEDDING_DIMENSIONS,
+          },
+        },
       );
     }
 
@@ -160,6 +180,13 @@ export async function handleTextEmbedding(
   } catch (error) {
     // error-policy:J2 context-adding rethrow — never fabricate a vector; the
     // provider failure surfaces to the caller (#9324: throw, never fabricate).
+    // Our own typed failures (width mismatch, non-finite/zero magnitude) are
+    // already actionable — rethrow them as-is so a value like a "returned 404
+    // dimensions" mismatch is never re-bucketed by the 404 message probe below.
+    if (error instanceof ElizaError) {
+      logger.error(`Error generating embedding: ${error.message}`);
+      throw error;
+    }
     const message = error instanceof Error ? error.message : String(error);
     // Fail CLOSED on a 404 / NOT_FOUND with one clear, model-named error rather
     // than propagating the raw SDK 404 on every subsequent call. This is the

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -49,30 +49,49 @@ function createInitProbeVector(): number[] {
  * L2-normalize an embedding so its Euclidean norm is 1. Google returns
  * sub-3072 `outputDimensionality` vectors un-normalized, so callers that expect
  * cosine-comparable unit vectors (as the native 768-dim `text-embedding-004`
- * produced) must renormalize. A non-finite component (a `NaN`/`±Infinity`
- * slipping through a transport/SDK bug) or a zero-magnitude vector cannot yield
- * a unit vector, so each is rejected here with its own typed error rather than
- * returning a silently-corrupt embedding a downstream store could persist.
+ * produced) must renormalize. Three inputs cannot yield a unit vector and are
+ * each rejected here with a typed error rather than returning a silently-corrupt
+ * embedding a downstream store could persist: a non-finite component (a
+ * `NaN`/`±Infinity` slipping through a transport/SDK bug), a norm that overflows
+ * to a non-finite value (a huge or accumulating magnitude whose squares exceed
+ * `Number.MAX_VALUE` even though every component is finite — dividing by it
+ * would yield an all-zero "unit" vector), and a zero-magnitude vector.
  */
 function l2Normalize(vector: number[]): number[] {
   let sumSquares = 0;
-  for (const value of vector) {
+  for (let index = 0; index < vector.length; index++) {
+    const value = vector[index];
     if (!Number.isFinite(value)) {
       throw new ElizaError(
         "Google GenAI API returned a non-finite embedding component that cannot be normalized",
         {
           code: "EMBEDDING_NON_FINITE",
-          context: { dimensions: vector.length },
+          context: { dimensions: vector.length, index },
         },
       );
     }
     sumSquares += value * value;
   }
   const norm = Math.sqrt(sumSquares);
+  if (!Number.isFinite(norm)) {
+    // Every component is finite but their squared sum overflowed the double
+    // range, so `norm` is `Infinity` and `value / norm` would be all zeros —
+    // a silent all-zero "unit" vector. Fail closed like the other classes.
+    throw new ElizaError(
+      "Google GenAI API returned an embedding whose magnitude overflowed to a non-finite value and cannot be normalized",
+      {
+        code: "EMBEDDING_NORM_OVERFLOW",
+        context: { dimensions: vector.length },
+      },
+    );
+  }
   if (norm === 0) {
     throw new ElizaError(
       "Google GenAI API returned a zero-magnitude embedding that cannot be normalized",
-      { code: "EMBEDDING_ZERO_MAGNITUDE" },
+      {
+        code: "EMBEDDING_ZERO_MAGNITUDE",
+        context: { dimensions: vector.length },
+      },
     );
   }
   return vector.map((value) => value / norm);

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -4,8 +4,12 @@
  * A `null`/empty-object input is treated as an initialization probe and answered
  * with a fixed 768-length marker vector so the runtime can size its embedding
  * column without a network call; real text is truncated to the model's ~8192
- * token limit, embedded, and reported via `emitModelUsageEvent`. Throws on empty
- * text and on an empty API response rather than fabricating a vector.
+ * token limit, embedded, and reported via `emitModelUsageEvent`. Real requests
+ * pin `outputDimensionality` to the same 768 width as the probe and L2-normalize
+ * the result, because the default `gemini-embedding-001` otherwise emits its
+ * 3072-dim default and every write would fail the probe-sized column (#22010).
+ * Throws on empty text, on an empty API response, and on a width that disagrees
+ * with the probe rather than fabricating or misfitting a vector.
  *
  * A 404 / NOT_FOUND from the provider (e.g. a decommissioned model id like
  * `text-embedding-004` on the current `v1beta` route) fails CLOSED with one
@@ -25,10 +29,41 @@ const TEXT_EMBEDDING_MODEL_TYPE = ((
   ElizaCore as { ModelType?: Record<string, string> }
 ).ModelType?.TEXT_EMBEDDING ?? "TEXT_EMBEDDING") as string;
 
+/**
+ * Target embedding width for both the init probe and every real write. Chosen
+ * to match the historical/native default so an existing 768-wide pgvector
+ * column keeps working after the default model moved to `gemini-embedding-001`
+ * (which otherwise emits 3072). `gemini-embedding-001` accepts an
+ * `outputDimensionality` in {768, 1536, 3072}; 768 is Google's supported
+ * reduced width.
+ */
+const EMBEDDING_DIMENSIONS = 768;
+
 function createInitProbeVector(): number[] {
-  const vector = Array(768).fill(0);
+  const vector = Array(EMBEDDING_DIMENSIONS).fill(0);
   vector[0] = 0.1;
   return vector;
+}
+
+/**
+ * L2-normalize an embedding so its Euclidean norm is 1. Google returns
+ * sub-3072 `outputDimensionality` vectors un-normalized, so callers that expect
+ * cosine-comparable unit vectors (as the native 768-dim `text-embedding-004`
+ * produced) must renormalize. A zero vector cannot be normalized and is
+ * rejected upstream as an empty/degenerate response.
+ */
+function l2Normalize(vector: number[]): number[] {
+  let sumSquares = 0;
+  for (const value of vector) {
+    sumSquares += value * value;
+  }
+  const norm = Math.sqrt(sumSquares);
+  if (norm === 0) {
+    throw new Error(
+      "Google GenAI API returned a zero-magnitude embedding that cannot be normalized",
+    );
+  }
+  return vector.map((value) => value / norm);
 }
 
 function extractText(
@@ -86,12 +121,31 @@ export async function handleTextEmbedding(
     const response = await genAI.models.embedContent({
       model: embeddingModelName,
       contents: text,
+      // Pin the output width to the same size as the init probe so the value
+      // written matches the pgvector column the runtime sized from the probe.
+      // Without this, `gemini-embedding-001` returns its 3072-dim default and
+      // every write fails against the 768-wide column (#22010).
+      config: { outputDimensionality: EMBEDDING_DIMENSIONS },
     });
 
-    const embedding = response.embeddings?.[0]?.values || [];
-    if (embedding.length === 0) {
+    const rawEmbedding = response.embeddings?.[0]?.values || [];
+    if (rawEmbedding.length === 0) {
       throw new Error("Google GenAI API returned no embedding");
     }
+
+    // Fail CLOSED on a width that disagrees with the probe rather than writing a
+    // mismatched vector into a column the runtime already sized from the probe.
+    if (rawEmbedding.length !== EMBEDDING_DIMENSIONS) {
+      throw new Error(
+        `Google embedding model "${embeddingModelName}" returned ${rawEmbedding.length} dimensions, ` +
+          `but the runtime sized its embedding column at ${EMBEDDING_DIMENSIONS} (the init-probe width). ` +
+          `Set GOOGLE_EMBEDDING_MODEL to a model whose output matches, or align the requested outputDimensionality.`,
+      );
+    }
+
+    // Google does not pre-normalize sub-3072 outputs; renormalize so the vector
+    // is unit-length and cosine-comparable like the native 768-dim model.
+    const embedding = l2Normalize(rawEmbedding);
 
     const promptTokens = await countTokens(text);
 


### PR DESCRIPTION
# Relates to

Closes #22010

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package `test`, `typecheck`, and `lint` pass. Repo-wide `bun run verify` is not run to green here — see **Known gaps / failures** for the exact unrelated blocker.
- [x] A reviewer can confirm the change works from the evidence below without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`2462c6e333`); zero conflicts.
- [ ] `bun run verify` passes post-sync — not run to green; see **Known gaps / failures**.

# Risks

Low. The change is confined to `plugins/plugin-google-genai`'s embedding handler and its docs. It constrains the embedding request to a width the runtime already assumed (768) and normalizes the result; it cannot widen an existing column. The added fail-closed guard turns a silent pgvector write failure into an actionable typed error.

# Background

## What does this PR do?

`handleTextEmbedding` answers the runtime's `null` dimension probe with a hardcoded **768**-length marker vector. `AgentRuntime.ensureEmbeddingDimension` uses that probe width to size the adapter's pgvector column and pins the provider on the invariant that "the column width and the vectors written to it always come from the same provider width". But the real `embedContent` call sent only `{ model, contents }` with **no** `outputDimensionality`, and PR #16701 changed the default embedding model from `text-embedding-004` (native 768) to `gemini-embedding-001`, whose documented default output is **3072** dimensions. So the column was sized at 768 while every real write was 3072-dim, producing a pgvector `expected 768 dimensions, not 3072` failure on every memory embedding write / bundled-document seed — re-breaking the exact path #16701 set out to fix (it swapped a 404 for a silent dimension mismatch).

This PR:

- Pins the real request to `config: { outputDimensionality: 768 }` so the write matches the probe-sized column. (`EmbedContentConfig.outputDimensionality` is a first-class `@google/genai` field: *"Reduced dimension for the output embedding. If set, excessive values in the output embedding are truncated from the end."*)
- **L2-normalizes** the returned vector, because Google does not pre-normalize sub-3072 `outputDimensionality` outputs and cosine comparison expects unit vectors (as the native 768-dim model produced).
- **Fails closed** if the provider ever returns a width that disagrees with the probe, rather than writing a mismatched vector into the sized column.
- Updates the README and package guides that still advertised `text-embedding-004` / "768 dimensions".

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

Done — `README.md`, `AGENTS.md`, and `CLAUDE.md` in `plugins/plugin-google-genai` updated to describe the pinned-768, L2-normalized `gemini-embedding-001` embedding contract.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-genai/models/embedding.ts` (the fix) and `plugins/plugin-google-genai/__tests__/embedding.shape.test.ts` (the regression coverage).

## Detailed testing steps

```bash
cd plugins/plugin-google-genai
bun run test        # 61 passed | 2 skipped (embedding.shape: 11 passed)
bun run typecheck   # clean
bun run lint        # clean
```

The width contract is provable deterministically via the mocked `embedContent` path plus the documented Google default; no live credentials are required.

Google's official embeddings documentation (`ai.google.dev/gemini-api/docs/embeddings`) states `gemini-embedding-001` produces **"the default 3072-dimension embeddings"** and supports reduced `outputDimensionality` of 768 or 1536 (which then require renormalization).

# Evidence Gate

<!-- evidence-head:d3d0f30acde0984547508983fa36e38846c3354d -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - no rendered UI surface; this is a model-provider embedding-width fix.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no user-facing flow; the change is a server/runtime embedding-write contract.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — real failing-then-passing reproduction. Pre-fix: the runtime probe sizes the column at 768 while the real write is 3072 (the pgvector `expected 768 dimensions, not 3072` failure). Post-fix: `embedContent` is called with `outputDimensionality: 768`, the write width equals the probe width, and the vector is unit-norm. Mirror at https://gist.github.com/agent-cortex/6754c30f7508ae53b78388d9eb9a40d6

  <details><summary>pre-fix reproduction + post-fix run output</summary>

  ```
  stdout | REPRO #22010: gemini-embedding-001 probe/write width mismatch
  [REPRO] probe width=768 real width=3072
  [REPRO] embedContent called with: {"model":"gemini-embedding-001","contents":"hello"}
   ✓ REPRO #22010 > probe returns 768 but a real embed returns 3072 (breaks memory writes) 14ms
   Test Files  1 passed (1)
        Tests  1 passed (1)

  ===== POST-FIX: embedding.shape.test.ts =====
   ✓ returns a marker vector for null initialization probes without creating a client
   ✓ embeds non-empty input and emits usage
   ✓ pins outputDimensionality to the probe width so the write matches the sized column (#22010)
   ✓ L2-normalizes the returned vector to unit length
   ✓ fails closed when the provider returns a width other than the probe (no mismatched write)
   ✓ rejects a zero-magnitude embedding that cannot be normalized
   Test Files  1 passed (1)
        Tests  11 passed (11)
  $ tsc --noEmit -p tsconfig.json   # typecheck clean
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs `N/A - no frontend surface.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - the defect is a deterministic vector-width/normalization contract, provable without a live model; no GOOGLE_GENERATIVE_AI_API_KEY is available in this environment. The 3072 default is confirmed by Google's official docs quoted above.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact — the vector-width contract is the artifact: the probe (which sizes the pgvector column) and a real write now agree at 768, and the write is unit-norm. Mirror at https://gist.github.com/agent-cortex/bb681704d88ab359890824584be106fa

  <details><summary>post-fix width/normalization contract output</summary>

  ```
   ✓ pins outputDimensionality to the probe width so the write matches the sized column (#22010)
   ✓ L2-normalizes the returned vector to unit length
   ✓ fails closed when the provider returns a width other than the probe (no mismatched write)
   ✓ rejects a zero-magnitude embedding that cannot be normalized
   Test Files  1 passed (1)
        Tests  11 passed (11)
     Duration  523ms
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review `N/A - no rendered visual surface.`

# Evidence Details

## Known gaps / failures

- **`bun run verify` (repo-wide) not run to green:** this environment enforces a global bun `minimumReleaseAge` policy that blocks a handful of newly-published transitive deps in *unrelated* workspaces (`viem`, `pepr`, `kubernetes-fluent-client`, `smthrs`), and `/tmp` is a small RAM-backed tmpfs that cannot hold the full `@elizaos/core` edge-package build. Neither limitation touches `plugins/plugin-google-genai`; the owning package's `test`, `typecheck`, and `lint` all pass (shown above). No functional blocker for this scoped fix.
- **Evidence hosted as inline transcript + gist mirror:** an external fork contributor using the GitHub CLI cannot mint `github.com/user-attachments` URLs (that endpoint is browser-only), so the real logs are pasted inline per the CONTRIBUTING.md "long logs in a `<details>` block" standard, with a public gist mirror for convenience.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza"} -->
