### PR TITLE
fix(plugin-inbox): sanitize LIMIT counts before raw SQL (bypassing sqlInteger)

### DIFF
--- a/plugins/plugin-inbox/src/inbox/repository.ts
+++ b/plugins/plugin-inbox/src/inbox/repository.ts
@@ -14,6 +14,7 @@ import {
   parseJsonArray,
   parseJsonRecord,
   sqlBoolean,
+  sqlInteger,
   sqlNumber,
   sqlQuote,
   sqlText,
@@ -150,6 +151,17 @@ function newId(): string {
   return crypto.randomUUID();
 }
 
+// Coerce a caller-supplied `LIMIT` count to a safe, bounded, positive integer
+// before it reaches raw SQL. Mirrors the clamp in unsubscribe-repository.ts.
+// A fractional value is truncated, a value below 1 is raised to 1, values are
+// capped at `max`, and a non-finite value (Infinity/NaN) falls back to
+// `fallback`. The result is still passed through `sqlInteger` at the call site
+// so a malformed literal can never be interpolated into a query.
+function resolveLimit(value?: number, fallback = 50, max = 500): number {
+  const base = Number.isFinite(value) ? (value as number) : fallback;
+  return Math.max(1, Math.min(max, Math.trunc(base)));
+}
+
 function isoNow(): string {
   return new Date().toISOString();
 }
@@ -263,7 +275,7 @@ export class InboxRepository {
        ORDER BY
          CASE urgency WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END,
          created_at DESC
-       LIMIT ${limit}`,
+       LIMIT ${sqlInteger(resolveLimit(limit))}`,
     );
     return rows.map(parseTriageEntry);
   }
@@ -310,7 +322,7 @@ export class InboxRepository {
        ORDER BY
          CASE urgency WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END,
          created_at DESC
-       LIMIT ${limit}`,
+       LIMIT ${sqlInteger(resolveLimit(limit))}`,
     );
     return rows.map(parseTriageEntry);
   }
@@ -338,7 +350,7 @@ export class InboxRepository {
          ${resolvedClause}
          ${snoozeClause}
        ORDER BY created_at DESC
-       LIMIT ${limit}`,
+       LIMIT ${sqlInteger(resolveLimit(limit))}`,
     );
     return rows.map(parseTriageEntry);
   }
@@ -461,7 +473,7 @@ export class InboxRepository {
        WHERE agent_id = ${sqlText(this.agentId)}
          AND auto_replied = TRUE
        ORDER BY created_at DESC
-       LIMIT ${limit}`,
+       LIMIT ${sqlInteger(resolveLimit(limit, 5))}`,
     );
     return rows.map(parseTriageEntry);
   }
@@ -536,7 +548,7 @@ export class InboxRepository {
       `SELECT * FROM app_inbox.life_inbox_triage_examples
        WHERE agent_id = ${sqlText(this.agentId)}
        ORDER BY created_at DESC
-       LIMIT ${limit}`,
+       LIMIT ${sqlInteger(resolveLimit(limit, 10))}`,
     );
     return rows.map(parseTriageExample);
   }

--- a/plugins/plugin-inbox/src/routes/inbox-routes.ts
+++ b/plugins/plugin-inbox/src/routes/inbox-routes.ts
@@ -51,6 +51,22 @@ function queryInt(value: unknown, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
 }
 
+/**
+ * Coerce a request-body `exampleLimit` to a positive integer. A missing value
+ * is accepted (the service applies its own default); a present-but-invalid
+ * value — non-number, non-finite, or non-positive — is rejected so the route
+ * returns a clean 400 rather than forwarding a malformed count into raw SQL.
+ */
+function parseExampleLimit(
+  value: unknown,
+): { ok: true; value?: number } | { ok: false } {
+  if (value === undefined) return { ok: true };
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return { ok: false };
+  }
+  return { ok: true, value: Math.floor(value) };
+}
+
 function firstQuery(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
@@ -146,14 +162,21 @@ async function handleTriageWrite(
   if (!Array.isArray(messages)) {
     return json(400, { ok: false, error: "messages array is required" });
   }
+  const exampleLimit = parseExampleLimit(body.exampleLimit);
+  if (!exampleLimit.ok) {
+    return json(400, {
+      ok: false,
+      error: "exampleLimit must be a positive number",
+    });
+  }
   const service = new InboxService(ctx.runtime);
   const result = await service.triage(messages as InboundMessage[], {
     classifyOnly: body.classifyOnly === true,
     ...(typeof body.ownerContext === "string"
       ? { ownerContext: body.ownerContext }
       : {}),
-    ...(typeof body.exampleLimit === "number"
-      ? { exampleLimit: body.exampleLimit }
+    ...(exampleLimit.value !== undefined
+      ? { exampleLimit: exampleLimit.value }
       : {}),
   });
   return json(200, { ok: true, ...result });

--- a/plugins/plugin-inbox/test/inbox-repository.test.ts
+++ b/plugins/plugin-inbox/test/inbox-repository.test.ts
@@ -251,6 +251,62 @@ describe("InboxRepository", () => {
     );
   });
 
+  describe("LIMIT sanitization (raw-SQL numeric guard)", () => {
+    // Regression for #22011: caller-supplied limits used to be interpolated
+    // verbatim (`LIMIT ${limit}`), so a fractional / negative / non-finite
+    // value emitted malformed SQL such as `LIMIT 1.5`, `LIMIT -5`, or
+    // `LIMIT Infinity` that Postgres rejects as an unhandled 500. Every LIMIT
+    // must now be a truncated, clamped, positive integer.
+    const limitOf = (sql: string): string | undefined =>
+      /LIMIT\s+(\S+)/.exec(sql)?.[1];
+
+    it("truncates a fractional getExamples limit to an integer", async () => {
+      const repo = new InboxRepository(env.runtime);
+      await repo.getExamples(1.5);
+      const sql = env.calls[0]?.sql ?? "";
+      expect(sql).not.toContain("LIMIT 1.5");
+      expect(limitOf(sql)).toBe("1");
+    });
+
+    it("clamps a negative getUnresolved limit up to 1", async () => {
+      const repo = new InboxRepository(env.runtime);
+      await repo.getUnresolved({ limit: -5 });
+      const sql = env.calls[0]?.sql ?? "";
+      expect(sql).not.toContain("LIMIT -5");
+      expect(limitOf(sql)).toBe("1");
+    });
+
+    it("falls back to a default for a non-finite getUnresolved limit", async () => {
+      const repo = new InboxRepository(env.runtime);
+      await repo.getUnresolved({ limit: Number.POSITIVE_INFINITY });
+      const sql = env.calls[0]?.sql ?? "";
+      expect(sql).not.toContain("LIMIT Infinity");
+      expect(limitOf(sql)).toBe("50");
+    });
+
+    it("caps an over-large getByClassification limit at 500", async () => {
+      env = makeRuntime((sql) =>
+        sql.includes("classification = 'urgent'") ? [] : [],
+      );
+      const repo = new InboxRepository(env.runtime);
+      await repo.getByClassification("urgent", { limit: 1_000_000 });
+      expect(limitOf(env.calls[0]?.sql ?? "")).toBe("500");
+    });
+
+    it("sanitizes getUnresolvedForSender and getRecentAutoReplies limits", async () => {
+      const repo = new InboxRepository(env.runtime);
+      await repo.getUnresolvedForSender({
+        sourceEntityId: "entity-1",
+        limit: 2.9,
+      });
+      expect(limitOf(env.calls[0]?.sql ?? "")).toBe("2");
+
+      const repo2 = new InboxRepository(env.runtime);
+      await repo2.getRecentAutoReplies(Number.NaN);
+      expect(limitOf(env.calls[1]?.sql ?? "")).toBe("5");
+    });
+  });
+
   it("throws on an invalid persisted classification rather than silently coercing", async () => {
     env = makeRuntime(() => [triageRow({ classification: "bogus" })]);
     const repo = new InboxRepository(env.runtime);

--- a/plugins/plugin-inbox/test/inbox-routes.test.ts
+++ b/plugins/plugin-inbox/test/inbox-routes.test.ts
@@ -6,16 +6,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const executeInboxQueueOperation = vi.fn();
+const triageMock = vi.fn(async () => ({ triaged: [] }));
 
 vi.mock("../src/actions/inbox.ts", () => ({
   executeInboxQueueOperation,
 }));
 
+// The reply/snooze/archive/approve paths never construct InboxService (they go
+// through executeInboxQueueOperation), while the triage-write path does. This
+// stub records the options the route forwards to `triage` so the tests can
+// assert the sanitized `exampleLimit` boundary without a live service.
 vi.mock("../src/inbox/service.ts", () => ({
   InboxService: class {
-    constructor() {
-      throw new Error("InboxService should not be constructed");
-    }
+    triage = triageMock;
   },
 }));
 
@@ -105,5 +108,69 @@ describe("inbox operation error mapping", () => {
     const result = await runReply();
     expect(result?.status).toBe(500);
     expect(result?.body?.error).toMatch(/database connection lost/);
+  });
+});
+
+describe("triage write exampleLimit validation", () => {
+  beforeEach(() => {
+    triageMock.mockClear();
+    triageMock.mockResolvedValue({ triaged: [] });
+  });
+
+  async function postTriage(
+    body: Record<string, unknown>,
+  ): Promise<
+    { status?: number; body?: { ok?: boolean; error?: string } } | undefined
+  > {
+    const { inboxRoutes } = await import("../src/routes/inbox-routes.ts");
+    const route = inboxRoutes.find(
+      (candidate) =>
+        candidate.type === "POST" &&
+        candidate.path === "/api/lifeops/inbox/triage",
+    );
+    return route?.routeHandler?.(
+      makeContext({
+        method: "POST",
+        path: "/api/lifeops/inbox/triage",
+        isTrustedLocal: true,
+        body,
+      }),
+    ) as Promise<
+      { status?: number; body?: { ok?: boolean; error?: string } } | undefined
+    >;
+  }
+
+  it("rejects a non-finite exampleLimit with a clean 400, never reaching the service", async () => {
+    // Regression for #22011: `Infinity` used to flow through the `typeof
+    // === number` guard into `getExamples(Infinity)` and emit `LIMIT
+    // Infinity`, which Postgres rejects as an unhandled 500.
+    const result = await postTriage({
+      messages: [],
+      exampleLimit: Number.POSITIVE_INFINITY,
+    });
+    expect(result?.status).toBe(400);
+    expect(result?.body?.error).toMatch(/exampleLimit/);
+    expect(triageMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive exampleLimit with a 400", async () => {
+    const result = await postTriage({ messages: [], exampleLimit: -5 });
+    expect(result?.status).toBe(400);
+    expect(triageMock).not.toHaveBeenCalled();
+  });
+
+  it("coerces a fractional exampleLimit to an integer before the service call", async () => {
+    const result = await postTriage({ messages: [], exampleLimit: 1.5 });
+    expect(result?.status).toBe(200);
+    expect(triageMock).toHaveBeenCalledTimes(1);
+    const opts = triageMock.mock.calls[0]?.[1] as { exampleLimit?: number };
+    expect(opts.exampleLimit).toBe(1);
+  });
+
+  it("omits exampleLimit entirely when the caller does not supply one", async () => {
+    const result = await postTriage({ messages: [] });
+    expect(result?.status).toBe(200);
+    const opts = triageMock.mock.calls[0]?.[1] as { exampleLimit?: number };
+    expect(opts.exampleLimit).toBeUndefined();
   });
 });


### PR DESCRIPTION
# Relates to

Closes #22011

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` was run after sync; `bun run verify` could not complete on this
      machine (unrelated blocker recorded under **Known gaps / failures**). Focused
      package gates (test/typecheck/lint) were run and are recorded below.
- [x] A reviewer can confirm the change works from the failing-then-passing
      reproduction and the real-PGLite integration run attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased by maintainer onto current `origin/develop` (`3bc23e51eade653ac72b9016d055e542caf6abc4`); zero conflicts.
- [x] Focused package gates pass post-sync; the repo-wide `bun run verify` blocker
      is documented in **Known gaps / failures** below.

# Risks

Low. The change is confined to one repository file and one route helper in
`plugins/plugin-inbox`, an owner-only HTTP surface. No public API, schema, or
export changes. Behavior only becomes *stricter* for previously-malformed input:
a fractional/negative/non-finite `LIMIT` count that used to emit invalid SQL is
now clamped to a valid integer, and an invalid `exampleLimit` on the triage-write
route now returns a clean `400` instead of an unhandled `500`. Valid callers are
unaffected.

# Background

## What does this PR do?

`InboxRepository` built every `LIMIT` clause by raw string interpolation of the
caller-supplied numeric limit (`LIMIT ${limit}`) in `getUnresolved`,
`getUnresolvedForSender`, `getByClassification`, `getExamples`, and
`getRecentAutoReplies`, bypassing the module's own `sqlInteger()` numeric guard
(`src/db/sql.ts`), which exists precisely to truncate and reject non-finite
numeric SQL literals.

The triage-write route (`handleTriageWrite` in `src/routes/inbox-routes.ts`)
forwarded `exampleLimit` from the request body with only a `typeof === "number"`
check, so a fractional, negative, or non-finite value flowed straight through
`InboxService.triage → repository.getExamples(exampleLimit)` and emitted
malformed SQL such as `LIMIT 1.5`, `LIMIT -5`, or `LIMIT Infinity`. Postgres
rejects all three, so a bad-input request that should be a clean `400` became an
unhandled DB error (`500`).

This PR:

- Adds a small `resolveLimit(value?, fallback, max)` helper in
  `src/inbox/repository.ts` — `Math.max(1, Math.min(max, Math.trunc(base)))`
  with a non-finite fallback — mirroring the existing clamp in
  `src/inbox/unsubscribe-repository.ts`, and applies
  `LIMIT ${sqlInteger(resolveLimit(limit))}` in all five methods (defense in
  depth: clamp + the `sqlInteger` encoder).
- Validates `exampleLimit` at the triage-write route via `parseExampleLimit`, so
  a present-but-invalid value (non-number, non-finite, or non-positive) returns a
  clean `400` and a fractional positive is floored before it reaches the service.

## What kind of change is this?

Bug fix (non-breaking change which fixes an error-policy / boundary-validation gap).

# Documentation changes needed?

No. Behavior is corrected to match the documented raw-SQL numeric-guard contract
(`sqlInteger`) already described in the package; no public surface changed.

# Testing

## Where should a reviewer start?

- `plugins/plugin-inbox/test/inbox-repository.test.ts` — new
  **"LIMIT sanitization (raw-SQL numeric guard)"** block asserts the emitted SQL
  now carries an integer `LIMIT` for fractional / negative / non-finite / oversize
  inputs across all affected methods.
- `plugins/plugin-inbox/test/inbox-routes.test.ts` — new
  **"triage write exampleLimit validation"** block asserts the route returns `400`
  (without constructing the service) for non-finite / non-positive `exampleLimit`,
  and floors a fractional positive before the service call.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-inbox test        # full package suite
# or focused:
cd plugins/plugin-inbox
bunx vitest run --config ./vitest.config.ts test/inbox-repository.test.ts test/inbox-routes.test.ts
```

# Evidence Gate

<!-- evidence-head:3c5ecc0987b39079896077eed2dfeb565fabad38 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface changed; this is a raw-SQL repository + owner-only HTTP route fix.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface changed.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the surface is a JSON HTTP endpoint and a DB repository.`
<!-- evidence-row:backend-logs -->
<details><summary>Failing-then-passing test logs (pre-fix malformed LIMIT -> post-fix integer LIMIT)</summary>

```
=== #22011 failing-then-passing reproduction (plugin-inbox LIMIT sanitization) ===

########## PRE-FIX (parent commit 2462c6e333 source, new regression tests present) ##########
 FAIL  test/inbox-repository.test.ts > InboxRepository > LIMIT sanitization (raw-SQL numeric guard) > truncates a fractional getExamples limit to an integer
AssertionError: expected 'SELECT * FROM app_inbox.life_inbox_tr…' not to contain 'LIMIT 1.5'
 FAIL  test/inbox-repository.test.ts > InboxRepository > LIMIT sanitization (raw-SQL numeric guard) > clamps a negative getUnresolved limit up to 1
AssertionError: expected 'SELECT * FROM app_inbox.life_inbox_tr…' not to contain 'LIMIT -5'
 FAIL  test/inbox-repository.test.ts > InboxRepository > LIMIT sanitization (raw-SQL numeric guard) > falls back to a default for a non-finite getUnresolved limit
AssertionError: expected 'SELECT * FROM app_inbox.life_inbox_tr…' not to contain 'LIMIT Infinity'
 FAIL  test/inbox-repository.test.ts > InboxRepository > LIMIT sanitization (raw-SQL numeric guard) > caps an over-large getByClassification limit at 500
AssertionError: expected '1000000' to be '500' // Object.is equality
 FAIL  test/inbox-repository.test.ts > InboxRepository > LIMIT sanitization (raw-SQL numeric guard) > sanitizes getUnresolvedForSender and getRecentAutoReplies limits
AssertionError: expected '2.9' to be '2' // Object.is equality
 FAIL  test/inbox-routes.test.ts > triage write exampleLimit validation > rejects a non-finite exampleLimit with a clean 400, never reaching the service
AssertionError: expected 200 to be 400 // Object.is equality
 FAIL  test/inbox-routes.test.ts > triage write exampleLimit validation > rejects a non-positive exampleLimit with a 400
AssertionError: expected 200 to be 400 // Object.is equality
 FAIL  test/inbox-routes.test.ts > triage write exampleLimit validation > coerces a fractional exampleLimit to an integer before the service call
AssertionError: expected 1.5 to be 1 // Object.is equality
 Test Files  2 failed (2)
      Tests  8 failed | 16 passed (24)

########## POST-FIX (this PR HEAD) ##########
 Test Files  2 passed (2)
      Tests  24 passed (24)
```

</details>

Mirror: https://gist.github.com/agent-cortex/593de7ec1237a3bc848643daaf929f59
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend; owner-only backend HTTP route.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changed; this is numeric-literal SQL sanitization + request validation.`
<!-- evidence-row:domain-artifacts -->
<details><summary>Full plugin-inbox suite incl real-PGLite integration + lint</summary>

```
=== #22011 domain artifacts: full plugin-inbox suite (incl real-PGLite integration) + lint ===

########## FULL PACKAGE SUITE (test/inbox.real-db.test.ts boots real PGLite AgentRuntime) ##########
 Test Files  21 passed | 1 skipped (22)
      Tests  186 passed | 2 skipped (188)

########## LINT ##########
Checked 60 files in 478ms. No fixes applied.
```

</details>

Mirror: https://gist.github.com/agent-cortex/d18a9383c1cfdb116aaea856f6c4167f
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model call path changed.` The classifier model is invoked deterministically
in the real-DB integration suite (a rule-based `TEXT_SMALL` stub), which is
sufficient to exercise the `triage → getExamples(limit) → SQL` path this PR fixes.

## Backend + frontend logs

**Failing-then-passing reproduction (the regression tests exercise the exact
changed contract).**

Pre-fix (parent commit `2462c6e333` source, new tests present) — the malformed
`LIMIT` strings are emitted verbatim and the route forwards invalid input:

```
########## PRE-FIX (parent commit source) ##########
AssertionError: expected 'SELECT * FROM app_inbox.life_inbox_tr…' not to contain 'LIMIT 1.5'
AssertionError: expected 'SELECT * FROM app_inbox.life_inbox_tr…' not to contain 'LIMIT -5'
AssertionError: expected 'SELECT * FROM app_inbox.life_inbox_tr…' not to contain 'LIMIT Infinity'
AssertionError: expected '1000000' to be '500' // Object.is equality
AssertionError: expected '2.9' to be '2' // Object.is equality
AssertionError: expected 200 to be 400 // Object.is equality   (Infinity exampleLimit)
AssertionError: expected 200 to be 400 // Object.is equality   (-5 exampleLimit)
AssertionError: expected 1.5 to be 1 // Object.is equality     (fractional exampleLimit forwarded raw)
 Test Files  2 failed (2)
      Tests  8 failed | 16 passed (24)
```

Post-fix (this PR's HEAD) — integer `LIMIT` emitted, route validated:

```
########## POST-FIX ##########
 Test Files  2 passed (2)
      Tests  24 passed (24)
```

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.` The diff touches `src/inbox/repository.ts` and
`src/routes/inbox-routes.ts` only.

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Domain artifacts — full package suite + real-PGLite integration

Full `plugins/plugin-inbox` suite green (includes `test/inbox.real-db.test.ts`,
which boots a real PGLite-backed `AgentRuntime` and exercises
`InboxService.triage → InboxRepository.getExamples(limit) → app_inbox` SQL — the
exact fixed path):

```
 Test Files  21 passed | 1 skipped (22)
      Tests  186 passed | 2 skipped (188)
```

Focused typecheck / lint on the package:

```
$ bun run --cwd plugins/plugin-inbox lint
Checked 60 files in 838ms. No fixes applied.

# typecheck: no errors reported for any plugin-inbox/src or plugin-inbox/test file
# (the only tsc errors are pre-existing, in packages/core, packages/shared, and
#  plugin-google-workspace, from missing generated/build artifacts — see gaps).
```

## Known gaps / failures

- **`bun run verify` (repo-wide) not run to completion on this machine.** The
  sandbox's global bun supply-chain guard (`minimumReleaseAge`) blocks a handful
  of unrelated, recently-published transitive deps pinned in the committed
  upstream lockfile (`viem`, `smthrs`, `kubernetes-fluent-client`, `pepr`), so a
  clean full-workspace `bun install` + `verify` cannot complete here. I installed
  the exact committed lockfile versions (`--frozen-lockfile`, no drift) and ran
  the owning-package gates instead. Not a blocker for this change: the diff is
  scoped to `plugins/plugin-inbox`.
- **`tsc` errors outside plugin-inbox** (`@elizaos/cloud-routing`,
  `./generated/validation-keyword-data.ts`, `plugin-google-workspace`) are
  pre-existing missing-generated-file / build-order artifacts in the sandbox,
  unrelated to this change; zero errors reference `plugin-inbox`.
- **2 skipped tests** in the package suite are the live-LLM tests
  (`inbox.live-llm.test.ts`) that require model credentials; `N/A` here.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza"} -->

