### PR TITLE
fix(plugin-native-macosalarm): kill the helper child on runHelper timeout

### DIFF
--- a/plugins/plugin-native-macosalarm/__tests__/helper.test.ts
+++ b/plugins/plugin-native-macosalarm/__tests__/helper.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough, Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
@@ -89,13 +90,80 @@ describe("runHelper", () => {
   });
 
   it("rejects spawn errors without hanging", async () => {
-    const { spawn } = createFakeSpawn({ error: new Error("spawn denied") });
+    const { spawn: fakeSpawn } = createFakeSpawn({
+      error: new Error("spawn denied"),
+    });
 
     await expect(
       runHelper(
         { action: "list" },
-        { spawnImpl: spawn, binPathOverride: "/tmp/helper" },
+        { spawnImpl: fakeSpawn, binPathOverride: "/tmp/helper" },
       ),
     ).rejects.toThrow("spawn denied");
+  });
+
+  it("kills the spawned helper child when the timeout fires", async () => {
+    // Regression for #22021: the timeout path used to reject without killing
+    // the child, orphaning the real helper process and its stdio pipes. Use a
+    // real long-lived child so the assertion observes actual process teardown
+    // rather than a mock's bookkeeping.
+    let child: ReturnType<typeof spawn> | undefined;
+    const spawnImpl: HelperSpawn = () => {
+      child = spawn("sleep", ["30"]);
+      return child as never;
+    };
+
+    await expect(
+      runHelper(
+        { action: "list" },
+        { spawnImpl, binPathOverride: "/tmp/helper", timeoutMs: 200 },
+      ),
+    ).rejects.toThrow(/timed out after 200ms/);
+
+    // Let the SIGTERM be delivered and the process reaped.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(child).toBeDefined();
+    expect(child?.killed).toBe(true);
+    expect(child?.exitCode !== null || child?.signalCode !== null).toBe(true);
+  });
+
+  it("does not kill the child on the successful (non-timeout) path", async () => {
+    // The fix must only tear down the child on timeout; a fast-closing helper
+    // still resolves normally and is never signalled.
+    const proc = new EventEmitter() as ReturnType<HelperSpawn>;
+    const killed: string[] = [];
+    proc.stdout = new PassThrough() as never;
+    proc.stderr = new PassThrough() as never;
+    proc.kill = ((signal?: NodeJS.Signals | number) => {
+      killed.push(String(signal));
+      return true;
+    }) as never;
+    proc.stdin = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+      final(callback) {
+        queueMicrotask(() => {
+          proc.stdout.end('{"success":true}\n');
+          proc.stderr.end();
+          proc.emit("close", 0);
+        });
+        callback();
+      },
+    }) as never;
+
+    await expect(
+      runHelper(
+        { action: "list" },
+        {
+          spawnImpl: () => proc,
+          binPathOverride: "/tmp/helper",
+          timeoutMs: 5_000,
+        },
+      ),
+    ).resolves.toEqual({ success: true });
+
+    expect(killed).toEqual([]);
   });
 });

--- a/plugins/plugin-native-macosalarm/src/helper.ts
+++ b/plugins/plugin-native-macosalarm/src/helper.ts
@@ -78,8 +78,21 @@ export async function runHelper(
   const exitCode = await new Promise<number | null>(
     (resolvePromise, rejectPromise) => {
       let timer: ReturnType<typeof setTimeout> | undefined;
+      let killEscalation: ReturnType<typeof setTimeout> | undefined;
+      const clearTimers = () => {
+        if (timer) clearTimeout(timer);
+        if (killEscalation) clearTimeout(killEscalation);
+      };
       if (options.timeoutMs && options.timeoutMs > 0) {
         timer = setTimeout(() => {
+          // Abort the hung helper before rejecting so the child process and its
+          // stdin/stdout/stderr pipes are reclaimed instead of being orphaned.
+          // SIGTERM lets the helper exit cleanly; escalate to SIGKILL if it
+          // ignores the request. `proc.on("close")` still fires and clears the
+          // escalation timer, so this never keeps the event loop alive.
+          proc.kill("SIGTERM");
+          killEscalation = setTimeout(() => proc.kill("SIGKILL"), 2000);
+          killEscalation.unref?.();
           rejectPromise(
             new Error(
               `macosalarm helper timed out after ${options.timeoutMs}ms`,
@@ -88,11 +101,11 @@ export async function runHelper(
         }, options.timeoutMs);
       }
       proc.on("error", (err: Error) => {
-        if (timer) clearTimeout(timer);
+        clearTimers();
         rejectPromise(err);
       });
       proc.on("close", (code: number | null) => {
-        if (timer) clearTimeout(timer);
+        clearTimers();
         resolvePromise(code);
       });
     },


### PR DESCRIPTION
# Relates to

Closes #22021

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; `bun run verify` status is recorded under **Known gaps / failures** (focused package gates pass).
- [x] A reviewer can confirm the change works without reading the code, from the before/after vitest evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (branch is 0 commits behind `origin/develop`).
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures**; the repo-wide gate is not runnable to completion on this machine, focused package gates (test/typecheck/lint) all pass.

# Risks

Low. The change is confined to `runHelper`'s timeout branch in one plugin
(`plugins/plugin-native-macosalarm/src/helper.ts`). It only adds child-process
teardown on the already-failing timeout path; the success and spawn-error paths
are unchanged. No public type, export, or signature changes.

# Background

## What does this PR do?

Fixes a resource leak on the macOS alarm helper boundary. `runHelper`'s timeout
path rejected the promise with `macosalarm helper timed out after Nms` but never
terminated the spawned Swift helper child. When a caller set the public
`HelperRunOptions.timeoutMs` and the helper hung, every timed-out invocation left
an orphaned child process with its stdin/stdout/stderr pipes still attached —
leaking processes and keeping the Node event loop alive via the un-reaped child.

The timeout callback now aborts the child before rejecting: it sends `SIGTERM`,
then escalates to `SIGKILL` on a short `unref()`'d grace timer if the helper
ignores the request. The existing `close` handler clears the escalation timer, so
the fix never keeps the event loop alive on the normal path.

## What kind of change is this?

Bug fix (non-breaking change which fixes a teardown/resource-leak defect).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior of the
public `timeoutMs` option is corrected to match its documented intent (abort the
helper on timeout), not changed.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-macosalarm/__tests__/helper.test.ts` — the new
`kills the spawned helper child when the timeout fires` case spawns a real
`sleep 30` child through `spawnImpl`, runs `runHelper` with `timeoutMs: 200`,
asserts the rejection, then asserts `child.killed === true` and that the process
actually exited/was signalled. A companion case proves the success path never
signals the child.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-native-macosalarm test
bun run --cwd plugins/plugin-native-macosalarm typecheck
bun run --cwd plugins/plugin-native-macosalarm lint:check
```

# Evidence Gate

<!-- evidence-head:1c7c56d2a7dd507d620a608a09488905ebb7572c -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots — `N/A - non-UI change; this is a child-process teardown fix in a Node IPC helper with no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots — `N/A - non-UI change (see above).`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - non-UI change; the observable behavior is process teardown, captured as before/after vitest output below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — real child-process reproduction run with the package's own vitest; before the fix the timeout leaves `sleep 30` running, after the fix it is killed.

<details>
<summary>vitest reproduction (before fix fails, after fix passes)</summary>

```
########## BEFORE FIX: src/helper.ts at parent commit (no proc.kill in timeout path) ##########
$ node_modules/.bin/vitest run --config vitest.config.ts __tests__/helper.test.ts
 × kills the spawned helper child when the timeout fires 518ms
 FAIL  __tests__/helper.test.ts > runHelper > kills the spawned helper child when the timeout fires
AssertionError: expected false to be true // Object.is equality
- Expected  + Received
- true
+ false
 ❯ __tests__/helper.test.ts:127:27  expect(child?.killed).toBe(true);
 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)

########## AFTER FIX: proc.kill(SIGTERM)+SIGKILL escalation added to timeout path ##########
$ node_modules/.bin/vitest run --config vitest.config.ts __tests__/helper.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)

$ node_modules/.bin/vitest run --config vitest.config.ts   # full package
 Test Files  2 passed | 1 skipped (3)
      Tests  20 passed | 2 skipped (22)
```

Full raw log artifact: https://github.com/agent-cortex/eliza/releases/download/pr-evidence/22023-repro-before-after.txt

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs — `N/A - no frontend surface touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change; this is the helper IPC teardown boundary, no model is invoked.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the observable domain artifact is the spawned child process itself; the regression asserts it transitions from orphaned (`killed=false, exitCode=null, signalCode=null`) to reaped (`killed=true`, exit/signal set) after the timeout.

<details>
<summary>process-teardown assertions (real child, before vs after)</summary>

```
BEFORE fix — probe console.log from the timeout path:
  child.killed = false exitCode = null signalCode = null   (sleep 30 still running after reject)

AFTER fix — regression assertions pass:
  expect(child?.killed).toBe(true)                                  ✓
  expect(child?.exitCode !== null || child?.signalCode !== null)    ✓
```

Full raw log artifact: https://github.com/agent-cortex/eliza/releases/download/pr-evidence/22023-repro-before-after.txt

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Real child-process reproduction run with the package's own vitest
(`node_modules/.bin/vitest run --config vitest.config.ts __tests__/helper.test.ts`).
The regression test spawns a real `sleep 30` child; before the fix the timeout
rejects but leaves it running, after the fix it is terminated.

<details>
<summary>BEFORE fix (src/helper.ts at parent commit) — regression test fails</summary>

```
 × kills the spawned helper child when the timeout fires 517ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  __tests__/helper.test.ts > runHelper > kills the spawned helper child when the timeout fires
AssertionError: expected false to be true // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)
```

Direct probe output (`console.log` in the reproduction) confirmed the leak:
`child.killed = false exitCode = null signalCode = null` — the promise rejects
with the timeout error while `sleep 30` keeps running.

</details>

<details>
<summary>AFTER fix — full package suite passes</summary>

```
$ node_modules/.bin/vitest run --config vitest.config.ts __tests__/helper.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)

$ node_modules/.bin/vitest run --config vitest.config.ts   # full package
 Test Files  2 passed | 1 skipped (3)
      Tests  20 passed | 2 skipped (22)

$ bun run typecheck
$ tsc --noEmit -p tsconfig.json      # (no errors)

$ bun run lint:check
$ bunx @biomejs/biome check .
Checked 12 files in 63ms. No fixes applied.
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - non-UI change.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- `bun run verify` (repo-wide parity/dependency/type/lint/audit gate) is not
  runnable to completion in this environment: the full workspace `bun install`
  is blocked by a local minimum-release-age policy on unrelated freshly
  published transitive deps (`viem`, `kubernetes-fluent-client`, `pepr`,
  `smthrs`) in other workspaces. The install was completed against the
  committed, vetted `bun.lock`, and the owning package's focused gates
  (`test`, `typecheck`, `lint:check`) all pass, as shown above. No source in
  this PR touches those packages.
- The macOS-only integration suite (`integration.macos.test.ts`) is skipped on
  this non-darwin host, matching its existing platform guard. The changed
  timeout path is covered on any platform via the real-child regression test.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza"} -->
