### PR TITLE
fix(plugin-goals): handle null candidate successCriteria in scoreGoalSimilarity

### DIFF
--- a/plugins/plugin-goals/src/goals-service.ts
+++ b/plugins/plugin-goals/src/goals-service.ts
@@ -113,7 +113,7 @@ export function scoreGoalSimilarity(args: {
     buildGoalSimilarityTokens({
       title: args.candidate.title,
       description: args.candidate.description,
-      successCriteria: normalizeOptionalRecord(
+      successCriteria: normalizeNullableRecord(
         args.candidate.successCriteria,
         "successCriteria",
       ),

--- a/plugins/plugin-goals/test/goals-service.test.ts
+++ b/plugins/plugin-goals/test/goals-service.test.ts
@@ -253,6 +253,18 @@ describe("scoreGoalSimilarity", () => {
       candidate: base,
     });
     expect(unrelated).toBe(0);
+
+    const withNullCriteria = scoreGoalSimilarity({
+      reference: {
+        title: "Run a marathon this year",
+        description: "Train for a marathon",
+      },
+      candidate: {
+        ...base,
+        successCriteria: null,
+      },
+    });
+    expect(withNullCriteria).toBeGreaterThanOrEqual(0.85);
   });
 });
 


### PR DESCRIPTION
# Relates to

Closes #22028

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and package tests were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash-high`
<!-- attribution-row:client -->
- Agent tooling: `antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused package tests and biome lint pass post-sync.

# Risks

Low. Replaces `normalizeOptionalRecord` with `normalizeNullableRecord` when extracting `args.candidate.successCriteria` in `scoreGoalSimilarity()`, allowing `null` candidate criteria values to safely normalize without throwing `GoalsServiceError`. No public types, actions, or route interfaces are altered.

# Background

## What does this PR do?

In `plugins/plugin-goals/src/goals-service.ts`, `scoreGoalSimilarity()` calculates a similarity score between a reference goal and an existing `LifeOpsGoalDefinition` candidate. `args.candidate.successCriteria` was passed through `normalizeOptionalRecord()`, which throws `GoalsServiceError(400, "successCriteria must be an object")` when `successCriteria` is `null` (since `normalizeOptionalRecord` only treats `undefined` as optional).

Because `LifeOpsGoalDefinition.successCriteria` is nullable (`Record<string, unknown> | null | undefined`), candidate goals from the database frequently have `successCriteria: null`. When `GoalsService.createGoal()` evaluated near-duplicate similarity against existing goals, `scoreGoalSimilarity()` threw an error instead of calculating the score.

This PR:
1. Changes `normalizeOptionalRecord` to `normalizeNullableRecord` in `scoreGoalSimilarity()`.
2. Adds a unit test in `test/goals-service.test.ts` verifying that candidates with `null` `successCriteria` score similarity accurately without throwing.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-goals/src/goals-service.ts` (lines 112-120)
- `plugins/plugin-goals/test/goals-service.test.ts` (lines 255-268)

## Detailed testing steps

Run the focused test file:
```bash
bun run --cwd plugins/plugin-goals test -- test/goals-service.test.ts
```

# Evidence Gate

<!-- evidence-head:e7379dab2db5b6e68074d4715dc9223126f53676 -->

<!-- evidence-row:before-screenshots -->
- [x] before-screenshots: N/A - pure backend goal similarity scoring with no visual UI components
<!-- evidence-row:after-screenshots -->
- [x] after-screenshots: N/A - pure backend goal similarity scoring with no visual UI components
<!-- evidence-row:walkthrough-video -->
- [x] walkthrough-video: N/A - pure backend goal similarity scoring with no visual UI components
<!-- evidence-row:backend-logs -->
- [x] backend-logs:
<details>
<summary>Vitest test execution log</summary>

```
$ bunx vitest run --config ./vitest.config.ts test/goals-service.test.ts

 RUN  v4.1.5 /home/deepanshu/os/eliza/plugins/plugin-goals

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  18:03:32
   Duration  8.88s (transform 6.61s, setup 98ms, import 8.63s, tests 20ms, environment 0ms)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] frontend-logs: N/A - backend unit test execution only
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - deterministic similarity algorithm with no LLM model invocations
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifacts: N/A - in-memory unit tests; no database or on-chain state persisted
<!-- evidence-row:ocr-review -->
- [x] ocr-review: N/A - no rendered visual surface

# Evidence Details

## Known gaps / failures

None. `test/goals-service.test.ts` and `src/goal-normalize.test.ts` pass cleanly.

AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: antigravity
Contribution skill revision: elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"antigravity","skill_revision":"elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza"} -->