### PR TITLE
fix(plugin-form): give filled session fields precedence over context in buildTemplateValues

### DIFF
--- a/plugins/plugin-form/src/template.test.ts
+++ b/plugins/plugin-form/src/template.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for form template resolution, asserting that filled session fields
+ * take precedence over initial session context, and template strings interpolate
+ * placeholders across controls and subfields.
+ */
+import type { UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  buildTemplateValues,
+  renderTemplate,
+  resolveControlTemplates,
+} from "./template";
+import type { FormControl, FormSession } from "./types";
+
+function makeSession(overrides: Partial<FormSession> = {}): FormSession {
+  const now = Date.now();
+  return {
+    id: "session-1",
+    formId: "test_form",
+    formVersion: 1,
+    entityId: "00000000-0000-4000-8000-000000000001" as UUID,
+    roomId: "00000000-0000-4000-8000-000000000002" as UUID,
+    status: "active",
+    fields: {
+      name: {
+        status: "filled",
+        value: "Alice",
+        source: "manual",
+        updatedAt: now,
+      },
+      count: { status: "filled", value: 3, source: "manual", updatedAt: now },
+      active: {
+        status: "filled",
+        value: true,
+        source: "manual",
+        updatedAt: now,
+      },
+      missing: { status: "empty" },
+    },
+    context: {
+      tier: "pro",
+      name: "DefaultUser",
+    },
+    history: [],
+    effort: {
+      interactionCount: 1,
+      timeSpentMs: 1000,
+      firstInteractionAt: now,
+      lastInteractionAt: now,
+    },
+    expiresAt: now + 86_400_000,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe("buildTemplateValues", () => {
+  it("gives filled session fields precedence over initial session context on key collision", () => {
+    const session = makeSession();
+    const values = buildTemplateValues(session);
+
+    expect(values.tier).toBe("pro");
+    expect(values.name).toBe("Alice");
+    expect(values.count).toBe("3");
+    expect(values.active).toBe("true");
+    expect(values.missing).toBeUndefined();
+  });
+});
+
+describe("renderTemplate and resolveControlTemplates", () => {
+  it("interpolates template placeholders and preserves unmatched keys", () => {
+    const values = { name: "Alice", count: "3" };
+    expect(
+      renderTemplate(
+        "Hello {{name}}, you have {{count}} items ({{other}})",
+        values,
+      ),
+    ).toBe("Hello Alice, you have 3 items ({{other}})");
+    expect(renderTemplate(undefined, values)).toBeUndefined();
+  });
+
+  it("resolves placeholders across control labels, askPrompts, and subfields", () => {
+    const control: FormControl = {
+      key: "delivery",
+      label: "Delivery for {{name}}",
+      type: "text",
+      askPrompt: "Where should we send your {{count}} items, {{name}}?",
+      options: [{ value: "standard", label: "Standard for {{name}}" }],
+      fields: [
+        {
+          key: "sub",
+          label: "Sub field for {{name}}",
+          type: "text",
+        },
+      ],
+    };
+
+    const resolved = resolveControlTemplates(control, {
+      name: "Alice",
+      count: "3",
+    });
+    expect(resolved.label).toBe("Delivery for Alice");
+    expect(resolved.askPrompt).toBe(
+      "Where should we send your 3 items, Alice?",
+    );
+    expect(resolved.options?.[0].label).toBe("Standard for Alice");
+    expect(resolved.fields?.[0].label).toBe("Sub field for Alice");
+  });
+});

--- a/plugins/plugin-form/src/template.ts
+++ b/plugins/plugin-form/src/template.ts
@@ -12,15 +12,6 @@ const TEMPLATE_PATTERN = /\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}/g;
 export function buildTemplateValues(session: FormSession): TemplateValues {
   const values: TemplateValues = {};
 
-  for (const [key, state] of Object.entries(session.fields)) {
-    const value = state.value;
-    if (typeof value === "string") {
-      values[key] = value;
-    } else if (typeof value === "number" || typeof value === "boolean") {
-      values[key] = String(value);
-    }
-  }
-
   const context = session.context;
   if (context && typeof context === "object" && !Array.isArray(context)) {
     for (const [key, value] of Object.entries(context)) {
@@ -29,6 +20,15 @@ export function buildTemplateValues(session: FormSession): TemplateValues {
       } else if (typeof value === "number" || typeof value === "boolean") {
         values[key] = String(value);
       }
+    }
+  }
+
+  for (const [key, state] of Object.entries(session.fields)) {
+    const value = state.value;
+    if (typeof value === "string") {
+      values[key] = value;
+    } else if (typeof value === "number" || typeof value === "boolean") {
+      values[key] = String(value);
     }
   }
 


### PR DESCRIPTION
# Relates to

Closes #22034

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and package tests were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash-high`
<!-- attribution-row:client -->
- Agent tooling: `antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused package tests and biome lint pass post-sync.

# Risks

Low. Reorders dictionary assignment in `buildTemplateValues` so user-filled form fields take precedence over static initial session context on key collisions.

# Background

## What does this PR do?

In `plugins/plugin-form/src/template.ts`, `buildTemplateValues(session)` constructs the template values map used to interpolate prompt and label placeholders. Previously, `session.fields` was processed first and `session.context` was processed second. When a field key collided with an initial context key, the static context value wiped out the user's filled field response.

This PR:
1. Updates `buildTemplateValues()` to process `session.context` before `session.fields` so filled form responses take precedence.
2. Adds unit tests in `src/template.test.ts` covering field precedence and template placeholder rendering.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-form/src/template.ts` (lines 12-36)
- `plugins/plugin-form/src/template.test.ts`

## Detailed testing steps

Run the focused test file:
```bash
bun run --cwd plugins/plugin-form test -- src/template.test.ts
```

# Evidence Gate

<!-- evidence-head:ec639fc41ff056157147b3be6171b3e8e24c5bb2 -->

<!-- evidence-row:before-screenshots -->
- [x] before-screenshots: N/A - pure backend template interpolation helper with no visual UI components
<!-- evidence-row:after-screenshots -->
- [x] after-screenshots: N/A - pure backend template interpolation helper with no visual UI components
<!-- evidence-row:walkthrough-video -->
- [x] walkthrough-video: N/A - pure backend template interpolation helper with no visual UI components
<!-- evidence-row:backend-logs -->
- [x] backend-logs:
<details>
<summary>Vitest test execution log</summary>

```
$ vitest run --config vitest.config.ts src/template.test.ts

 RUN  v4.1.5 /home/deepanshu/os/eliza/plugins/plugin-form


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  18:24:33
   Duration  233ms (transform 53ms, setup 0ms, import 67ms, tests 5ms, environment 0ms)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] frontend-logs: N/A - backend unit test execution only
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - deterministic template helper with no LLM model invocations
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifacts: N/A - in-memory unit tests; no database or on-chain state persisted
<!-- evidence-row:ocr-review -->
- [x] ocr-review: N/A - no rendered visual surface

# Evidence Details

## Known gaps / failures

None. All 5 test suites (29 tests) in `plugin-form` pass cleanly.

AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: antigravity
Contribution skill revision: elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"antigravity","skill_revision":"elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza"} -->