### PR TITLE
fix(plugin-inbox): guard against empty Telegram chatId and non-digit WhatsApp number in buildDeepLink

### DIFF
--- a/plugins/plugin-inbox/src/inbox/channel-deep-links.test.ts
+++ b/plugins/plugin-inbox/src/inbox/channel-deep-links.test.ts
@@ -49,6 +49,9 @@ describe("buildDeepLink — Telegram", () => {
     expect(
       buildDeepLink("telegram-account", { roomMeta: { chatId: "-100123" } }),
     ).toBe("https://t.me/c/123");
+    expect(
+      buildDeepLink("telegram-account", { roomMeta: { chatId: "-100" } }),
+    ).toBeNull();
     expect(buildDeepLink("telegram", { roomMeta: {} })).toBeNull();
   });
 });
@@ -82,6 +85,12 @@ describe("buildDeepLink — Signal / iMessage / WhatsApp", () => {
         roomMeta: { jid: "15551234@s.whatsapp.net" },
       }),
     ).toBe("https://wa.me/15551234");
+    expect(
+      buildDeepLink("whatsapp", { roomMeta: { phoneNumber: "non-digits" } }),
+    ).toBeNull();
+    expect(
+      buildDeepLink("whatsapp", { roomMeta: { jid: "@s.whatsapp.net" } }),
+    ).toBeNull();
     expect(buildDeepLink("whatsapp", { roomMeta: {} })).toBeNull();
   });
 });

--- a/plugins/plugin-inbox/src/inbox/channel-deep-links.ts
+++ b/plugins/plugin-inbox/src/inbox/channel-deep-links.ts
@@ -67,9 +67,11 @@ function buildTelegramLink(
   }
   if (chatId) {
     const normalized = chatId.replace(/^-100/, "");
-    return messageId
-      ? `https://t.me/c/${normalized}/${messageId}`
-      : `https://t.me/c/${normalized}`;
+    if (normalized.length > 0) {
+      return messageId
+        ? `https://t.me/c/${normalized}/${messageId}`
+        : `https://t.me/c/${normalized}`;
+    }
   }
   return null;
 }
@@ -92,10 +94,12 @@ function buildIMessageLink(room: Record<string, unknown>): string | null {
 }
 
 function buildWhatsAppLink(room: Record<string, unknown>): string | null {
-  const phoneNumber =
-    str(room.phoneNumber) || str(room.jid)?.replace(/@.*$/, "");
-  if (phoneNumber) {
-    return `https://wa.me/${phoneNumber.replace(/\D/g, "")}`;
+  const raw = str(room.phoneNumber) || str(room.jid)?.replace(/@.*$/, "");
+  if (raw) {
+    const digits = raw.replace(/\D/g, "");
+    if (digits.length > 0) {
+      return `https://wa.me/${digits}`;
+    }
   }
   return null;
 }


### PR DESCRIPTION
# Relates to

Closes #22037

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and package tests were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash-high`
<!-- attribution-row:client -->
- Agent tooling: `antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused package tests and biome lint pass post-sync.

# Risks

Low. Adds non-empty string checks in `buildTelegramLink` and `buildWhatsAppLink` so malformed or empty metadata fails closed to `null` instead of generating invalid URL prefixes.

# Background

## What does this PR do?

In `plugins/plugin-inbox/src/inbox/channel-deep-links.ts`:
1. `buildTelegramLink()` strips `-100` from `chatId`. If `chatId` was `"-100"`, the normalized string was empty and produced `"https://t.me/c/"`.
2. `buildWhatsAppLink()` strips non-digits from `phoneNumber`/`jid`. If no digits existed, it produced `"https://wa.me/"`.

This PR:
1. Validates that normalized Telegram chat IDs and WhatsApp digit strings have `length > 0` before returning a deep link URL, returning `null` otherwise.
2. Adds unit test cases in `channel-deep-links.test.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-inbox/src/inbox/channel-deep-links.ts` (lines 66-77, 93-104)
- `plugins/plugin-inbox/src/inbox/channel-deep-links.test.ts`

## Detailed testing steps

Run the focused test file:
```bash
bun run --cwd plugins/plugin-inbox test -- src/inbox/channel-deep-links.test.ts
```

# Evidence Gate

<!-- evidence-head:7cd256760ce5bf3cb10a2f5f1ae09a562479679f -->

<!-- evidence-row:before-screenshots -->
- [x] before-screenshots: N/A - pure backend deep-link URL helper with no visual UI components
<!-- evidence-row:after-screenshots -->
- [x] after-screenshots: N/A - pure backend deep-link URL helper with no visual UI components
<!-- evidence-row:walkthrough-video -->
- [x] walkthrough-video: N/A - pure backend deep-link URL helper with no visual UI components
<!-- evidence-row:backend-logs -->
- [x] backend-logs:
<details>
<summary>Vitest test execution log</summary>

```
$ bunx vitest run --config ./vitest.config.ts src/inbox/channel-deep-links.test.ts

 RUN  v4.1.5 /home/deepanshu/os/eliza/plugins/plugin-inbox

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  18:29:33
   Duration  287ms (transform 107ms, setup 107ms, import 38ms, tests 8ms, environment 0ms)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] frontend-logs: N/A - backend unit test execution only
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - deterministic URL builder with no LLM model invocations
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifacts: N/A - in-memory unit tests; no database or on-chain state persisted
<!-- evidence-row:ocr-review -->
- [x] ocr-review: N/A - no rendered visual surface

# Evidence Details

## Known gaps / failures

None. All 13 tests in `src/inbox/channel-deep-links.test.ts` pass cleanly.

AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: antigravity
Contribution skill revision: elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"antigravity","skill_revision":"elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza"} -->