### PR TITLE
fix(plugin-notes): guard against empty lookup queries matching all notes in resolveNoteIndex

### DIFF
--- a/plugins/plugin-notes/src/delete-name-fence.test.ts
+++ b/plugins/plugin-notes/src/delete-name-fence.test.ts
@@ -99,4 +99,12 @@ describe("delete-note owner-text fence", () => {
     );
     expect(removed.value.title).toBe("wifi password");
   });
+
+  it("rejects blank or whitespace-only lookup query as NOTES_NOT_FOUND", async () => {
+    const service = await seeded();
+    await expect(
+      service.deleteNoteByLookupWithCommit("query", "   "),
+    ).rejects.toMatchObject({ code: "NOTES_NOT_FOUND" });
+    expect(service.snapshot().notes).toHaveLength(1);
+  });
 });

--- a/plugins/plugin-notes/src/service.ts
+++ b/plugins/plugin-notes/src/service.ts
@@ -116,6 +116,9 @@ function resolveNoteIndex(
   value: string,
 ): number {
   const target = normalizedLookup(value);
+  if (!target) {
+    throw lookupError("NOTES_NOT_FOUND", selector, value, []);
+  }
   const exact = notes
     .map((note, index) => ({ index, note }))
     .filter(({ note }) => normalizedLookup(note.title) === target);


### PR DESCRIPTION
# Relates to

Closes #22039

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and package tests were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash-high`
<!-- attribution-row:client -->
- Agent tooling: `antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused package tests and biome lint pass post-sync.

# Risks

Low. Adds an empty check on normalized lookup query strings in `resolveNoteIndex()` so blank or whitespace queries fail closed to `NOTES_NOT_FOUND`.

# Background

## What does this PR do?

In `plugins/plugin-notes/src/service.ts`, `resolveNoteIndex()` resolves existing notes by title or query string for update and delete operations. If `value` was whitespace-only, `normalizedLookup()` returned an empty string, which matched every note via `includes("")`. This caused single-note stores to unexpectedly match and delete/update notes on blank queries, and multi-note stores to fail with ambiguous match errors instead of not-found errors.

This PR:
1. Adds an empty-target check in `resolveNoteIndex()` to throw `NOTES_NOT_FOUND` when the normalized search term is empty.
2. Adds a regression test in `delete-name-fence.test.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-notes/src/service.ts` (lines 116-121)
- `plugins/plugin-notes/src/delete-name-fence.test.ts` (lines 102-109)

## Detailed testing steps

Run the focused test file:
```bash
bun run --cwd plugins/plugin-notes test -- src/delete-name-fence.test.ts
```

# Evidence Gate

<!-- evidence-head:faec77e3f60f64bebb4043b22cfc1b8eb3009a7e -->

<!-- evidence-row:before-screenshots -->
- [x] before-screenshots: N/A - pure backend note lookup helper with no visual UI components
<!-- evidence-row:after-screenshots -->
- [x] after-screenshots: N/A - pure backend note lookup helper with no visual UI components
<!-- evidence-row:walkthrough-video -->
- [x] walkthrough-video: N/A - pure backend note lookup helper with no visual UI components
<!-- evidence-row:backend-logs -->
- [x] backend-logs:
<details>
<summary>Vitest test execution log</summary>

```
$ vitest run --config vitest.config.ts src/delete-name-fence.test.ts

 RUN  v4.1.5 /home/deepanshu/os/eliza/plugins/plugin-notes

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  18:41:03
   Duration  7.45s (transform 5.22s, setup 106ms, import 6.55s, tests 64ms, environment 595ms)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] frontend-logs: N/A - backend unit test execution only
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - deterministic note store indexing with no LLM model invocations
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifacts: N/A - in-memory unit tests; no database or on-chain state persisted
<!-- evidence-row:ocr-review -->
- [x] ocr-review: N/A - no rendered visual surface

# Evidence Details

## Known gaps / failures

None. All 10 test suites (91 tests) in `plugin-notes` pass cleanly.

AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: antigravity
Contribution skill revision: elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"antigravity","skill_revision":"elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza"} -->