### PR TITLE
fix(plugin-calendar): stop bare time ranges like "friday 3-5" parsing as month/day dates

### DIFF
--- a/plugins/plugin-calendar/src/actions/calendar-handler.explicit-date.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.explicit-date.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Deterministic coverage for parseExplicitLocalDate's numeric branch: a bare
+ * dash time range beside a named weekday ("friday 3-5") must resolve through
+ * the weekday branch instead of being read as month/day, and impossible
+ * month/day pairs (month 25, Feb 30) must fall through rather than roll over
+ * (#21941). Real parser, no mocks; weekday expectations are computed relative
+ * to the current date so the suite stays green on any day.
+ */
+import { describe, expect, it } from "vitest";
+import { parseExplicitLocalDate } from "./calendar-handler.js";
+
+const TZ = "America/New_York";
+
+function weekdayOf(parts: { year: number; month: number; day: number }) {
+  return new Date(
+    Date.UTC(parts.year, parts.month - 1, parts.day, 12),
+  ).getUTCDay();
+}
+
+describe("parseExplicitLocalDate numeric branch (#21941)", () => {
+  it("resolves 'friday 3-5' via the weekday branch, not as March 5", () => {
+    const result = parseExplicitLocalDate("schedule review friday 3-5", TZ);
+    expect(result).toEqual(parseExplicitLocalDate("friday", TZ));
+    if (result === null) throw new Error("expected a weekday-branch result");
+    expect(weekdayOf(result)).toBe(5);
+  });
+
+  it("resolves 'friday 4-6' via the weekday branch, not as April 6", () => {
+    const result = parseExplicitLocalDate("what do I have friday 4-6", TZ);
+    expect(result).toEqual(parseExplicitLocalDate("friday", TZ));
+    if (result === null) throw new Error("expected a weekday-branch result");
+    expect(weekdayOf(result)).toBe(5);
+  });
+
+  it("rejects month 25 instead of rolling it over", () => {
+    expect(parseExplicitLocalDate("lunch on 25/12", TZ)).toBeNull();
+  });
+
+  it("rejects Feb 30 rollover", () => {
+    expect(parseExplicitLocalDate("review on 2/30/2026", TZ)).toBeNull();
+  });
+
+  it("still parses valid slash and dashed dates", () => {
+    const year = new Date().getFullYear();
+    expect(parseExplicitLocalDate("dinner on 12/25", TZ)).toMatchObject({
+      month: 12,
+      day: 25,
+    });
+    expect(parseExplicitLocalDate("meet on 3/5", TZ)).toMatchObject({
+      year,
+      month: 3,
+      day: 5,
+    });
+    expect(parseExplicitLocalDate("party 3-5-2026", TZ)).toEqual({
+      year: 2026,
+      month: 3,
+      day: 5,
+    });
+    expect(parseExplicitLocalDate("party 12/25/2026", TZ)).toEqual({
+      year: 2026,
+      month: 12,
+      day: 25,
+    });
+  });
+
+  it("keeps year-qualified dash dates winning even beside a weekday name", () => {
+    expect(parseExplicitLocalDate("friday 3-5-2026", TZ)).toEqual({
+      year: 2026,
+      month: 3,
+      day: 5,
+    });
+  });
+});

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -1716,21 +1716,44 @@ export function parseExplicitLocalDate(
   }
 
   const numericMatch = normalized.match(
-    /\b(\d{1,2})[/-](\d{1,2})(?:[/-](\d{2,4}))?\b/,
+    /\b(\d{1,2})([/-])(\d{1,2})(?:[/-](\d{2,4}))?\b/,
   );
   if (numericMatch) {
-    const yearRaw = numericMatch[3];
+    const yearRaw = numericMatch[4];
     const parsedYear =
       yearRaw === undefined
         ? localToday.year
         : yearRaw.length === 2
           ? 2000 + Number(yearRaw)
           : Number(yearRaw);
-    return {
-      year: parsedYear,
-      month: Number(numericMatch[1]),
-      day: Number(numericMatch[2]),
-    };
+    const month = Number(numericMatch[1]);
+    const day = Number(numericMatch[3]);
+    // A year-less dash pair alongside a named weekday ("friday 3-5") is a
+    // wall-clock time range, not a date — let the weekday branch below win
+    // (#21941).
+    const yearlessDashTimeRange =
+      yearRaw === undefined &&
+      numericMatch[2] === "-" &&
+      WEEKDAY_NAME_PATTERN.test(normalized);
+    // Range-check and round-trip through Date.UTC so impossible dates
+    // (month 25, Feb 30) fall through to the later branches instead of
+    // rolling over (#21941).
+    const candidate = new Date(Date.UTC(parsedYear, month - 1, day));
+    const isRealDate =
+      month >= 1 &&
+      month <= 12 &&
+      day >= 1 &&
+      day <= 31 &&
+      candidate.getUTCFullYear() === parsedYear &&
+      candidate.getUTCMonth() + 1 === month &&
+      candidate.getUTCDate() === day;
+    if (isRealDate && !yearlessDashTimeRange) {
+      return {
+        year: parsedYear,
+        month,
+        day,
+      };
+    }
   }
 
   const weekdayMatch = normalized.match(WEEKDAY_NAME_PATTERN);


### PR DESCRIPTION
# Relates to

Fixes #21941.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] Full plugin suite, typecheck, and Biome pass at the exact head; mutation check recorded in the evidence log.
- [x] A reviewer can confirm the behavior from the executed before/after parse matrix attached below.

# Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-fable-5
- Client / agent tooling: Claude Code
- Attribution status: self-reported

## What

`parseExplicitLocalDate`'s numeric branch ran before the weekday branch and accepted any `N-M` digit pair as month/day with no range validation — so "friday 3-5" parsed as **March 5**, and since this parser is the "user's stated date outranks the planner" authority (#19815), `applyStatedDateToCreateRequest` rewrote a correctly-planned next-Friday event onto March 5 (five months in the past), with the same parse steering update/delete target-day filtering and explicit-date read windows. "lunch on 25/12" produced `month: 25`, silently rolling into the following January.

The numeric branch now (a) range-checks month 1-12 / day 1-31 and round-trips the parts through `Date.UTC` (mirroring the ICS parser's `validateDateParts`, so Feb-30-style rollovers are rejected), and (b) treats a year-less dash-separated pair as a wall-clock range whenever the text names a weekday — falling through so "friday 3-5" resolves via the weekday branch to the actual next Friday. Narrowest-change trade-offs: a bare "3-5" with no weekday still parses as March 5 (existing behavior preserved), and year-qualified "friday 3-5-2026" still parses as the explicit date (intended).

## Verification (exact head `0c0ed7cf5`)

- New suite `calendar-handler.explicit-date.test.ts` — **6/6**: "friday 3-5"/"friday 4-6" resolve via the weekday branch (Friday asserted), "25/12" and "2/30/2026" rejected, "12/25", "3/5", "3-5-2026", "12/25/2026" unchanged.
- **Mutation-checked:** with the handler reverted to develop, 4/6 new tests fail; restored, 6/6.
- Full `plugin-calendar` suite: **610 passed | 4 skipped** (develop baseline: 604 | 4 — no regressions, +6 new). Typecheck and Biome clean. No existing tests exercised `parseExplicitLocalDate`, so no pinned behavior was changed.
- Executed probes: before — "friday 3-5" → `{month:3, day:5}`, "25/12" → `{month:25, day:12}`, "2/30/2026" accepted; after — weekday inputs → 2026-08-21 (next Friday), impossible dates → null, valid dates unchanged.

# Evidence Gate

<!-- evidence-head:9e2781ce1e9289664746509977b47e9226b83f00 -->

Backend date-parsing authority change with no rendered UI surface.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend parser; no rendered visual surface exists to capture.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend parser; no rendered visual surface exists to capture.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow; the wrong output is a UTC timestamp.
<!-- evidence-row:backend-logs -->
- [x] Executed probe + mutation-check + test transcript: [calendar-misparse-repro.log](https://github.com/user-attachments/files/31181747/calendar-misparse-repro.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface parses these strings.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic parser change; the planner's model output is untouched — the fix stops the parser overriding it wrongly.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - deterministic parser output is captured in the attached backend transcript; no separate persisted domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


