### PR TITLE
fix(plugin-personal-assistant): late wakers no longer lose every morning-routine occurrence to an inverted adaptive window

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/defaults.adaptive-morning.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/defaults.adaptive-morning.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Pins the adaptive morning window against inversion for late wakers: a wake
+ * source at or past the 14:00 end cap must yield a shortened-but-real morning
+ * window, never one that normalizeWindowPolicy would silently discard (which
+ * materialized zero occurrences for morning-routine definitions, #21938).
+ * Deterministic — computeAdaptiveWindowPolicy is a pure function.
+ */
+import { describe, expect, it } from "vitest";
+
+import { computeAdaptiveWindowPolicy, normalizeWindowPolicy } from "./defaults";
+
+function morningWindow(policy: ReturnType<typeof computeAdaptiveWindowPolicy>) {
+  const window = policy.windows.find((w) => w.name === "morning");
+  if (!window) throw new Error("expected a morning window");
+  return window;
+}
+
+describe("computeAdaptiveWindowPolicy morning inversion guard", () => {
+  it("keeps a real morning window for a 15:00 waker instead of inverting it", () => {
+    const policy = computeAdaptiveWindowPolicy({
+      typicalWakeHour: 15,
+      typicalFirstActiveHour: null,
+      typicalLastActiveHour: null,
+      typicalSleepHour: null,
+    });
+    const morning = morningWindow(policy);
+    expect(morning.endMinute).toBeGreaterThan(morning.startMinute);
+    expect(morning.endMinute - morning.startMinute).toBeGreaterThanOrEqual(60);
+  });
+
+  it("keeps a real morning window at the exact 14:30 zero-width boundary", () => {
+    const policy = computeAdaptiveWindowPolicy({
+      typicalWakeHour: 14.5,
+      typicalFirstActiveHour: null,
+      typicalLastActiveHour: null,
+      typicalSleepHour: null,
+    });
+    const morning = morningWindow(policy);
+    expect(morning.endMinute).toBeGreaterThan(morning.startMinute);
+  });
+
+  it("survives normalizeWindowPolicy for every wake hour from 4:00 to 27:00", () => {
+    for (let wake = 4; wake <= 27; wake += 0.5) {
+      const policy = computeAdaptiveWindowPolicy({
+        typicalWakeHour: wake,
+        typicalFirstActiveHour: null,
+        typicalLastActiveHour: null,
+        typicalSleepHour: null,
+      });
+      const normalized = normalizeWindowPolicy(policy);
+      const morning = normalized?.windows.find((w) => w.name === "morning");
+      expect(morning, `wake=${wake} must keep a morning window`).toBeDefined();
+    }
+  });
+
+  it("leaves ordinary wake hours unchanged", () => {
+    const policy = computeAdaptiveWindowPolicy({
+      typicalWakeHour: 7,
+      typicalFirstActiveHour: null,
+      typicalLastActiveHour: null,
+      typicalSleepHour: null,
+    });
+    const morning = morningWindow(policy);
+    expect(morning.startMinute).toBe(Math.round((7 - 0.5) * 60));
+    expect(morning.endMinute).toBe(Math.round((7 - 0.5) * 60) + 5 * 60);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/defaults.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/defaults.ts
@@ -135,9 +135,17 @@ export function computeAdaptiveWindowPolicy(
     };
   }
 
-  const morningStartMinute = Math.max(
-    Math.round((wakeSource - ADAPTIVE_LEAD_HOURS) * 60),
-    ADAPTIVE_MORNING_FLOOR_MINUTES,
+  // The start must clamp below the end cap (mirroring the evening inversion
+  // guard): the wake source is the owner's real wake instant, and a wake at or
+  // after 14:30 would otherwise produce an inverted/empty morning window that
+  // normalizeWindowPolicy silently discards — materializing zero occurrences
+  // for every morning-routine definition. Keep at least one real hour.
+  const morningStartMinute = Math.min(
+    Math.max(
+      Math.round((wakeSource - ADAPTIVE_LEAD_HOURS) * 60),
+      ADAPTIVE_MORNING_FLOOR_MINUTES,
+    ),
+    ADAPTIVE_MORNING_END_CAP_MINUTES - 60,
   );
 
   const morningEndMinute = Math.min(


### PR DESCRIPTION
# Relates to

Fixes #21938.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] Focused + lifeops-scoped suites, typecheck, and Biome pass at the exact head; mutation check recorded in the evidence log.
- [x] A reviewer can confirm the behavior from the executed window matrix and probe transcripts attached below.

# Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-fable-5
- Client / agent tooling: Claude Code
- Attribution status: self-reported

## What

`computeAdaptiveWindowPolicy` caps the adaptive morning window's **end** at 14:00 (`ADAPTIVE_MORNING_END_CAP_MINUTES`) but never clamped the **start** against that cap. The wake source is the owner's real wake instant (`typicalWakeHour` from `schedule.wakeAt`), so any wake ≥ 14:30 produced an inverted morning window (`start 870 > end 840`; exactly 14:30 gives a zero-width one) — only the evening window had an inversion guard. Downstream, `normalizeWindowPolicy` **silently discards** inverted windows, so a daily routine with `windows: ["morning"]` materialized **zero occurrences**: the reminder never fired, with no error anywhere, for as long as the late-wake rhythm (night-shift owner, jet lag) persisted.

The fix clamps the morning start to one hour below the end cap, mirroring the evening guard — a late waker gets a shortened-but-real morning window, and ordinary wake hours are byte-identical.

## Verification (exact head `6967f3020`)

- New suite `defaults.adaptive-morning.test.ts` — **4/4**: 15:00 waker keeps a ≥60-min window; the exact 14:30 zero-width boundary survives; a sweep of every wake hour 4:00–27:00 (half-hour steps) survives `normalizeWindowPolicy` with a morning window present; ordinary 7:00 waker output byte-identical to develop.
- **Mutation-checked:** with `defaults.ts` reverted to develop and the new tests kept, 3/4 fail (only the ordinary-waker pin passes); restored, 4/4.
- Lifeops-scoped suite (`src/lifeops`, 73 files): **655/655**. Typecheck (0 errors) and Biome clean, verified in a canonical develop checkout with the fix applied (the review worktree's symlinked type resolution produces 3 pre-existing unrelated cross-package errors with or without this change).
- Executed matrix (attached): on develop's math, wake hours {14.5, 15, 18, 24} all produce a discarded morning window (zero occurrences); on the fix, every wake hour keeps a ≥60-min morning window. The discovering probes additionally materialized occurrences end-to-end: 0 under the adaptive policy at wake 15:00 on develop vs 10 under defaults for the identical definition.

# Evidence Gate

<!-- evidence-head:6967f3020fae24ce7290bbbf7491309f9ab47e15 -->

Backend window-policy computation with no rendered UI surface.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend policy math; no rendered visual surface exists to capture.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend policy math; no rendered visual surface exists to capture.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow; the failure mode is a silently-discarded scheduling window.
<!-- evidence-row:backend-logs -->
- [x] Executed probes + mutation-check + test transcript: [adaptive-morning-repro.log](https://github.com/user-attachments/files/31181750/adaptive-morning-repro.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface computes window policies.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - pure-function policy math; no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Executed before/after window matrix per wake hour (JSON): [adaptive-morning-matrix.json](https://github.com/user-attachments/files/31181751/adaptive-morning-matrix.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
