### PR TITLE
fix(agent): canonical-decimal memory-feed cursors — close the residual coercion class

### DIFF
--- a/packages/agent/src/api/memory-feed-cursor.test.ts
+++ b/packages/agent/src/api/memory-feed-cursor.test.ts
@@ -53,47 +53,103 @@ describe("GET /api/memories/feed cursor", () => {
     });
   });
 
-  test("400s a malformed before cursor instead of silently emptying the feed", async () => {
-    // Number("abc") is NaN — a `number`, so it passes the undefined check in
-    // fetchMemoriesFromTables, and every `createdAt < NaN` comparison is
-    // false. Without the boundary guard this request returned 200 with an
-    // empty feed, indistinguishable from an agent that has no memories.
-    const getMemories = vi.fn(async () => []);
+  test.each([
+    ["abc", "non-numeric text"],
+    ["0x10", "hex form (Number coercion would read 16)"],
+    ["1e3", "exponent form"],
+    ["-5", "negative"],
+    ["1.5", "fractional"],
+    ["012", "non-canonical leading zero"],
+    ["9007199254740993", "beyond Number.isSafeInteger"],
+  ])(
+    "400s the non-canonical before cursor %j instead of silently mis-filtering the feed",
+    async (rawCursor) => {
+      const getMemories = vi.fn(async () => []);
+      const runtime = {
+        agentId: "11111111-1111-4111-8111-111111111111" as UUID,
+        character: { name: "Eliza" },
+        ensureConnection: vi.fn(async () => undefined),
+        getMemories,
+      } as unknown as AgentRuntime;
+      const errors: Array<{ message: string; status?: number }> = [];
+      const url = new URL("https://agent.test/api/memories/feed?type=messages");
+      url.searchParams.set("before", rawCursor);
+      const context: MemoryRouteContext = {
+        req: {} as never,
+        res: {} as never,
+        method: "GET",
+        pathname: "/api/memories/feed",
+        url,
+        runtime,
+        agentName: "Eliza",
+        json: () => {
+          throw new Error("unexpected 200");
+        },
+        error: (_res, message, status) => {
+          errors.push({ message, status });
+        },
+        readJsonBody: async <T extends object>() => ({}) as T,
+      };
+
+      expect(await handleMemoryRoutes(context)).toBe(true);
+      expect(errors).toEqual([
+        {
+          message: "before must be a Unix timestamp in milliseconds",
+          status: 400,
+        },
+      ]);
+      expect(getMemories).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([["", "empty"], [" ", "whitespace-only"]])(
+    "treats a blank before value (%j) as no cursor, not junk",
+    async (rawCursor) => {
+    // `?before=` templates naturally from clients interpolating an unset
+    // variable, and whitespace trims to the same blank. Both previously
+    // mis-coerced (whitespace became an epoch-0 cursor via Number(" ") === 0,
+    // silently emptying the feed); both now mean "no cursor" — unlike
+    // present junk, which 400s.
+    const response: { value?: unknown } = {};
     const runtime = {
       agentId: "11111111-1111-4111-8111-111111111111" as UUID,
       character: { name: "Eliza" },
       ensureConnection: vi.fn(async () => undefined),
-      getMemories,
+      getMemories: vi.fn(async () => [
+        {
+          id: "22222222-2222-4222-8222-222222222222" as UUID,
+          entityId: "33333333-3333-4333-8333-333333333333" as UUID,
+          roomId: "44444444-4444-4444-8444-444444444444" as UUID,
+          content: { text: "still visible without a cursor" },
+          createdAt: 1,
+        },
+      ]),
     } as unknown as AgentRuntime;
-    const errors: Array<{ message: string; status?: number }> = [];
     const context: MemoryRouteContext = {
       req: {} as never,
       res: {} as never,
       method: "GET",
       pathname: "/api/memories/feed",
-      url: new URL(
-        "https://agent.test/api/memories/feed?before=abc&type=messages",
-      ),
+      url: (() => {
+        const u = new URL("https://agent.test/api/memories/feed?type=messages");
+        u.searchParams.set("before", rawCursor);
+        return u;
+      })(),
       runtime,
       agentName: "Eliza",
-      json: () => {
-        throw new Error("unexpected 200");
+      json: (_res, value) => {
+        response.value = value;
       },
       error: (_res, message, status) => {
-        errors.push({ message, status });
+        throw new Error(`unexpected ${status}: ${message}`);
       },
       readJsonBody: async <T extends object>() => ({}) as T,
     };
 
     expect(await handleMemoryRoutes(context)).toBe(true);
-    expect(errors).toEqual([
-      {
-        message: "before must be a finite Unix timestamp in milliseconds",
-        status: 400,
-      },
-    ]);
-    expect(getMemories).not.toHaveBeenCalled();
-  });
+    expect((response.value as { count: number }).count).toBe(1);
+    },
+  );
 
   test("rejects an unknown type before scanning tables", async () => {
     const getMemories = vi.fn(async () => []);

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -29,6 +29,7 @@ import type { RouteRequestContext } from "@elizaos/shared";
 import {
   PatchMemoryRequestSchema,
   PostMemoryRememberRequestSchema,
+  parseCanonicalInteger,
   parsePositiveInteger,
 } from "@elizaos/shared";
 import {
@@ -574,14 +575,15 @@ export async function handleMemoryRoutes(
       MEMORY_FEED_DEFAULT_LIMIT,
     );
     const limit = Math.min(Math.max(requestedLimit, 1), MEMORY_FEED_MAX_LIMIT);
-    const beforeParam = url.searchParams.get("before");
-    const before = beforeParam ? Number(beforeParam) : undefined;
-    // Number("abc") is NaN, which is a `number` and so survives the
-    // `beforeTs !== undefined` cursor gate below — but every `< NaN`
-    // comparison is false, so a malformed cursor would silently empty the
-    // feed with a 200. Reject it here instead, mirroring the `type` guard.
-    if (before !== undefined && !Number.isFinite(before)) {
-      error(res, "before must be a finite Unix timestamp in milliseconds", 400);
+    // A cursor is a createdAt millisecond timestamp, so only its canonical
+    // decimal form is a valid value. Bare Number() coercion admitted
+    // whitespace (" " -> 0, silently emptying the feed as an epoch cursor)
+    // and hex/exponent forms; parseCanonicalInteger distinguishes an absent
+    // cursor (undefined) from junk ("invalid"), which 400s like the `type`
+    // guard below.
+    const before = parseCanonicalInteger(url.searchParams.get("before"));
+    if (before === "invalid") {
+      error(res, "before must be a Unix timestamp in milliseconds", 400);
       return true;
     }
     const tableFilter = parseMemoryTableFilter(url.searchParams.get("type"));


### PR DESCRIPTION
# Relates to

Follow-up to #21323, completing the malformed-cursor class its execution review identified. @HomunculusLabs's in-sandbox verification confirmed two residual same-class inputs the finite-guard still passed: whitespace-only `?before=%20` (`Number(" ") === 0` → treated as an epoch cursor → feed silently empties) and `0x10` (→ `16`, silently filtering by the wrong timestamp). Their review suggested exactly this follow-up.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched directly off the current `origin/develop` tip; zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync — exit 0 at this exact head, see Testing.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5` (fix, tests, verification)
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched directly off the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync at this head.

# Risks

Low. One route's cursor parsing swaps a bare `Number()` coercion for `parseCanonicalInteger` — the shared helper already parsing route integers in `health-routes.ts` and `connector-account-routes.ts`. Behaviour changes only for cursors no production client emits (audit below): hex/exponent/sign/fractional/leading-zero forms and beyond-`MAX_SAFE_INTEGER` values now 400; whitespace-only now means "no cursor" instead of silently acting as epoch 0. Canonical cursors, absent, and empty are byte-for-byte unchanged.

# Background

## What does this PR do?

#21323 rejected non-finite cursors, but `Number()` coercion still admits non-canonical finite forms:

| input | before this PR | after |
|---|---|---|
| `?before=%20` | `Number(" ") === 0` → epoch cursor → **feed silently empties** | no cursor (blank = absent) |
| `?before=0x10` | filters by `16` | 400 |
| `?before=1e3` | filters by `1000` | 400 |
| `?before=-5` | filters by `-5` (empties) | 400 |
| `?before=1.5` | fractional cursor | 400 |
| `?before=012` | filters by `12` | 400 |
| `?before=9007199254740993` | filters by the *neighbouring* representable integer | 400 |
| `?before=0` / canonical | epoch honored (#20521) / normal | unchanged |

Rather than growing the guard's regex in place, the cursor now goes through `parseCanonicalInteger` (`@elizaos/shared`), which is already how sibling route files parse integer params: trims, accepts only `/^(0|[1-9]\d*)$/` within `[0, MAX_SAFE_INTEGER]`, and — the part a fallback-style parser can't do — returns a distinct `"invalid"` sentinel so a *present but junk* cursor 400s while an *absent/blank* one scans unfiltered. The previous `Number.isFinite` guard is subsumed (every canonical integer is finite).

The 400 message drops the now-misleading word "finite": `before must be a Unix timestamp in milliseconds`. Nothing else in the tree asserts the old message (verified by grep).

**Same-class siblings, deliberately not touched here:** two parallel implementations of this route still carry the bare coercion — `packages/ui/src/api/ios-local-agent-kernel.ts:781` (local mock kernel) and `plugins/plugin-capacitor-bridge/src/ios/bridge.ts:1275` (iOS serving path). Different serving stacks with their own helpers and test surfaces, so aligning them belongs to a dedicated change; happy to follow up if wanted.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/memory-feed-cursor.test.ts` — the `test.each` matrix (7 junk forms → 400 + `getMemories` never called) and the blank-forms cases (`""`, `" "` → unfiltered 200).

## Detailed testing steps

None: Automated tests are acceptable.

Red→green against current `develop` (`08bb08c0f7`, which already contains #21323): **8 of the 14 cursor tests fail on develop's behaviour** — hex/exponent/sign/fractional/leading-zero/unsafe-int all pass through as 200s, whitespace silently empties the feed — and 14/14 pass with this change.

**Client audit** (why no legitimate caller can hit the new 400s): the only production emitter is `MemoryViewerView.loadFeed(last.createdAt)` → `getMemoryFeed`, which gates `typeof before === "number"` and sends `String(before)` where the value is a `Date.now()`-derived integer `createdAt` — always canonical decimal. `String(n)` produces exponent notation only at ≥1e21, unreachable for ms timestamps.

**Independent matrix** (expectations written before running, then executed against `handleMemoryRoutes` with a 2-memory fixture): absent/`""`/`" "` → 200 unfiltered; `0` → epoch honored; `6` → strict-`<` keeps exactly the `createdAt: 5` memory; `+5`, `٥` (arabic-indic digit), `9007199254740993` → 400 with no table scan; `9007199254740991` (`MAX_SAFE_INTEGER`) → 200; NBSP-prefixed and trailing-newline digits → trimmed then honored, the same trim policy every other integer param in the tree already applies.

# Evidence Gate

<!-- evidence-head:9054fd9950e44524c12c9d20339a5a53a5fb57b7 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - HTTP API cursor parsing; no rendered UI surface in the diff.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - HTTP API cursor parsing; no rendered UI surface in the diff.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-UI change; behaviour is fully captured by the 14-case route-handler suite below.`
<!-- evidence-row:backend-logs -->
- [x] `bunx vitest run src/api/memory-feed-cursor.test.ts` at this head: **14 passed (14)** — the 8-case junk matrix 400s with `getMemories` never called, blank forms scan unfiltered, epoch + strict-`<` cases intact. Same suite against develop's parse: **8 failed | 6 passed** (the red proof). Root `bun run verify`: exit 0 at this head.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend consumer changed; the memory viewer emits String(Date.now()-derived integer) cursors, which are unaffected (audit in Testing).`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; pure HTTP parameter validation.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows/memories/tasks created; junk cursors are rejected before any table scan (asserted: getMemories not called).`
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

<details><summary>Cursor suite at this head (14/14) and red control on develop (8 failed)</summary>

```
# this head
✓ honors a before cursor at the Unix epoch
✓ 400s the non-canonical before cursor "abc" …
✓ 400s the non-canonical before cursor "0x10" …
✓ 400s the non-canonical before cursor "1e3" …
✓ 400s the non-canonical before cursor "-5" …
✓ 400s the non-canonical before cursor "1.5" …
✓ 400s the non-canonical before cursor "012" …
✓ 400s the non-canonical before cursor "9007199254740993" …
✓ treats a blank before value ("") as no cursor, not junk
✓ treats a blank before value (" ") as no cursor, not junk
✓ rejects an unknown type before scanning tables
✓ parseMemoryTableFilter (3 cases)
Tests  14 passed (14)

# develop control (same suite, develop's memory-routes.ts)
× 0x10 / 1e3 / -5 / 1.5 / 012 / 9007199254740993 → 200 instead of 400
× " " → feed silently emptied (epoch-0 coercion)
× "abc" → 400 but with the pre-rename message
Tests  8 failed | 6 passed (14)
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`
