### PR TITLE
fix(plugin-video): forward subtitles, embedSubs, and writeInfoJson options in downloadVideo

### DIFF
--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -1,5 +1,8 @@
 /** Exercises VideoService metadata and parsing boundaries with deterministic binary doubles. */
 
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { ElizaError, IAgentRuntime, Media } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { BinaryResolver } from "./binaries";
@@ -295,5 +298,31 @@ describe("VideoService deterministic behavior", () => {
     const { service } = createServiceWithYtDlp([]);
     expect(service.isVideoUrl(null as unknown as string)).toBe(false);
     expect(service.isVideoUrl({} as unknown as string)).toBe(false);
+  });
+
+  it("forwards VideoDownloadOptions (format precedence, subtitles, embedSubs, writeInfoJson) to yt-dlp", async () => {
+    const { service, runYtDlp } = createServiceWithYtDlp([{}]);
+    const outputPath = path.join(
+      tmpdir(),
+      `eliza-video-options-${randomUUID()}.mp4`,
+    );
+
+    await service.downloadVideo("https://youtu.be/options-test", {
+      outputPath,
+      format: "bestvideo",
+      quality: "720p",
+      subtitles: true,
+      embedSubs: true,
+      writeInfoJson: false,
+    });
+
+    expect(runYtDlp).toHaveBeenCalledWith("https://youtu.be/options-test", {
+      verbose: true,
+      output: outputPath,
+      writeInfoJson: false,
+      format: "bestvideo",
+      writeSubs: true,
+      embedSubs: true,
+    });
   });
 });

--- a/plugins/plugin-video/src/services/video.ts
+++ b/plugins/plugin-video/src/services/video.ts
@@ -240,13 +240,12 @@ export class VideoService extends IVideoService {
       const downloadOptions: Record<string, string | boolean> = {
         verbose: true,
         output: outputFile,
-        writeInfoJson: true,
+        writeInfoJson: options?.writeInfoJson ?? true,
       };
 
       if (options?.format) {
         downloadOptions.format = options.format;
-      }
-      if (options?.quality) {
+      } else if (options?.quality) {
         downloadOptions.format = options.quality;
       }
       if (options?.audioOnly) {
@@ -255,6 +254,12 @@ export class VideoService extends IVideoService {
       }
       if (options?.videoOnly) {
         downloadOptions.format = "bestvideo[ext=mp4]/best[ext=mp4]/best";
+      }
+      if (options?.subtitles) {
+        downloadOptions.writeSubs = true;
+      }
+      if (options?.embedSubs) {
+        downloadOptions.embedSubs = true;
       }
 
       await this.binaries.runYtDlp(url, downloadOptions);


### PR DESCRIPTION
# Relates to

Closes #22046

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and package tests were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash-high`
<!-- attribution-row:client -->
- Agent tooling: `antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused package tests and biome lint pass post-sync.

# Risks

Low. Forwards existing `VideoDownloadOptions` fields (`subtitles`, `embedSubs`, `writeInfoJson`, format/quality precedence) to the underlying yt-dlp execution options.

# Background

## What does this PR do?

In `plugins/plugin-video/src/services/video.ts`:
1. `options.subtitles` and `options.embedSubs` were declared on `VideoDownloadOptions` in core but not mapped to yt-dlp arguments (`writeSubs` and `embedSubs`).
2. `writeInfoJson` was hardcoded to `true` on every download call, ignoring caller overrides.
3. `options.quality` unconditionally overwrote `options.format` when both were passed.

This PR:
1. Translates `subtitles` to `downloadOptions.writeSubs = true`.
2. Translates `embedSubs` to `downloadOptions.embedSubs = true`.
3. Respects `options.writeInfoJson ?? true`.
4. Prioritizes `options.format` over `options.quality`.
5. Adds unit tests in `src/services/video.test.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-video/src/services/video.ts` (lines 240-264)
- `plugins/plugin-video/src/services/video.test.ts` (lines 299-322)

## Detailed testing steps

Run the focused test file:
```bash
bun run --cwd plugins/plugin-video test -- src/services/video.test.ts
```

# Evidence Gate

<!-- evidence-head:2748356e64c39ca9ff920bb3b371bbff03bb8be8 -->

<!-- evidence-row:before-screenshots -->
- [x] before-screenshots: N/A - pure backend video download helper with no visual UI components
<!-- evidence-row:after-screenshots -->
- [x] after-screenshots: N/A - pure backend video download helper with no visual UI components
<!-- evidence-row:walkthrough-video -->
- [x] walkthrough-video: N/A - pure backend video download helper with no visual UI components
<!-- evidence-row:backend-logs -->
- [x] backend-logs:
<details>
<summary>Vitest test execution log</summary>

```
$ vitest run --config vitest.config.ts src/services/video.test.ts

 RUN  v4.1.5 /home/deepanshu/os/eliza/plugins/plugin-video

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  18:51:15
   Duration  6.99s (transform 5.76s, setup 0ms, import 6.84s, tests 16ms, environment 0ms)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] frontend-logs: N/A - backend unit test execution only
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - deterministic video option translation with no LLM model invocations
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifacts: N/A - in-memory unit tests; no database or on-chain state persisted
<!-- evidence-row:ocr-review -->
- [x] ocr-review: N/A - no rendered visual surface

# Evidence Details

## Known gaps / failures

None. All 4 test suites (40 tests) in `plugin-video` pass cleanly.

AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: antigravity
Contribution skill revision: elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"antigravity","skill_revision":"elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza"} -->