### PR TITLE
fix(mcp): preserve zero-valued schema bounds in Google tool-description fixups

### DIFF
--- a/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
+++ b/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression coverage for provider-specific MCP schema transformations using
+ * deterministic JSON Schema inputs and no external MCP server.
+ */
+import { describe, expect, it } from "vitest";
+import { GoogleMcpCompatibility } from "../src/tool-compatibility/providers/google.ts";
+
+describe("MCP tool compatibility", () => {
+  it("preserves zero upper bounds in Google descriptions", () => {
+    const compatibility = new GoogleMcpCompatibility({
+      provider: "google",
+      modelId: "gemini-pro",
+    });
+
+    // minLength/minItems are set alongside the zero upper bound so a
+    // fallback path that only fires when every constraint is skipped
+    // can't mask a truthy-check regression on maxLength/maxItems.
+    const transformed = compatibility.transformToolSchema({
+      type: "object",
+      properties: {
+        boundedText: { type: "string", minLength: 1, maxLength: 0 },
+        boundedList: {
+          type: "array",
+          minItems: 1,
+          maxItems: 0,
+          items: { type: "string" },
+        },
+      },
+    });
+
+    expect(transformed.properties?.boundedText).toMatchObject({
+      type: "string",
+      description: expect.stringContaining("0"),
+    });
+    expect(transformed.properties?.boundedList).toMatchObject({
+      type: "array",
+      description: expect.stringContaining("0"),
+    });
+  });
+});

--- a/plugins/plugin-mcp/src/tool-compatibility/providers/google.ts
+++ b/plugins/plugin-mcp/src/tool-compatibility/providers/google.ts
@@ -62,10 +62,10 @@ export class GoogleMcpCompatibility extends McpToolCompatibility {
   private formatConstraintsForGoogle(constraints: GoogleConstraints): string {
     const rules: string[] = [];
 
-    if (constraints.minLength) {
+    if (constraints.minLength !== undefined) {
       rules.push(`text must be at least ${constraints.minLength} characters long`);
     }
-    if (constraints.maxLength) {
+    if (constraints.maxLength !== undefined) {
       rules.push(`text must be no more than ${constraints.maxLength} characters long`);
     }
     if (constraints.minimum !== undefined) {
@@ -80,7 +80,7 @@ export class GoogleMcpCompatibility extends McpToolCompatibility {
     if (constraints.exclusiveMaximum !== undefined) {
       rules.push(`number must be less than ${constraints.exclusiveMaximum}`);
     }
-    if (constraints.multipleOf) {
+    if (constraints.multipleOf !== undefined) {
       rules.push(`number must be a multiple of ${constraints.multipleOf}`);
     }
     if (constraints.format === "email") {
@@ -101,19 +101,19 @@ export class GoogleMcpCompatibility extends McpToolCompatibility {
     if (constraints.enum && Array.isArray(constraints.enum)) {
       rules.push(`must be exactly one of these values: ${constraints.enum.join(", ")}`);
     }
-    if (constraints.minItems) {
+    if (constraints.minItems !== undefined) {
       rules.push(`array must contain at least ${constraints.minItems} items`);
     }
-    if (constraints.maxItems) {
+    if (constraints.maxItems !== undefined) {
       rules.push(`array must contain no more than ${constraints.maxItems} items`);
     }
     if (constraints.uniqueItems === true) {
       rules.push(`array items must all be unique (no duplicates)`);
     }
-    if (constraints.minProperties) {
+    if (constraints.minProperties !== undefined) {
       rules.push(`object must have at least ${constraints.minProperties} properties`);
     }
-    if (constraints.maxProperties) {
+    if (constraints.maxProperties !== undefined) {
       rules.push(`object must have no more than ${constraints.maxProperties} properties`);
     }
     if (constraints.additionalProperties === false) {


### PR DESCRIPTION
# Relates to

Fixes #22112.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`; original contributor also reports AgentRouter
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@08a091a4d0f4da15d9aa6c9c5c75510f2d079052:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

The original contribution and subsequent reviews were AI-assisted. Independent review found and removed an earlier unreachable OpenAI-code change, strengthened the regression so a raw-dump fallback cannot mask failure, and validated the remaining Google-only production path.

# Sync with develop

- [x] Rebased onto `develop` at `08a091a4d0f4da15d9aa6c9c5c75510f2d079052`; zero conflicts.
- [x] Owning plugin test, typecheck, and lint gates pass post-sync. Root `bun run verify` was not rerun for this isolated two-file plugin fix.

# Risks

Low. Presence checks change from truthiness to `!== undefined`; existing positive constraints are unchanged, while zero-valued bounds are no longer silently omitted.

# Background

## What does this PR do?

`GoogleMcpCompatibility` now preserves zero-valued JSON Schema length, item-count, property-count, and numeric constraints when folding them into Google tool descriptions. This is a live path through the MCP compatibility factories.

A prior draft also touched `OpenAIReasoningMcpCompatibility`, but review established that class is not constructed by this plugin factory. Those unreachable changes were removed; this PR is intentionally Google-only.

## What kind of change is this?

Bug fix with no schema or public API change.

# Documentation changes needed?

No.

# Testing

Exact reviewed head: `66f3305414b9a87f1c588b7896c820781b5b937b`.

- `bun run --cwd plugins/plugin-mcp test`: 14 files passed; 82 tests passed, 3 skipped.
- `bun run --cwd plugins/plugin-mcp typecheck`: passed.
- `bun run --cwd plugins/plugin-mcp lint:check`: 53 files checked, no errors.
- The regression uses positive sibling constraints with zero upper bounds, preventing the no-rules fallback from producing a false positive.

# Evidence Gate

<!-- evidence-head:66f3305414b9a87f1c588b7896c820781b5b937b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only deterministic schema transformation; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only deterministic schema transformation; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head automated evidence above; mutation review confirmed the regression fails when the Google source fix is reverted.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic preprocessing defect occurs before model invocation.
<!-- evidence-row:domain-artifacts -->
- [x] Generated descriptions are asserted directly by the regression test.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.

AI provider/model: `openai / gpt-5.6-sol`
Client / agent tooling: `Codex Desktop`
Skill revision: `elizaOS/eliza@08a091a4d0f4da15d9aa6c9c5c75510f2d079052:packages/skills/skills/contribute-to-eliza`
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@08a091a4d0f4da15d9aa6c9c5c75510f2d079052:packages/skills/skills/contribute-to-eliza"} -->