### PR TITLE
fix(auth): treat whitespace-only failure text as unknown in classifyAuthFailureReason

### DIFF
--- a/packages/auth/src/token-expiry.test.ts
+++ b/packages/auth/src/token-expiry.test.ts
@@ -52,5 +52,8 @@ describe("access-token expiry classification", () => {
   it("preserves missing provider detail as an unknown reason", () => {
     expect(isTokenExpiryText(undefined)).toBe(false);
     expect(classifyAuthFailureReason(undefined)).toBe("unknown");
+    expect(classifyAuthFailureReason(null)).toBe("unknown");
+    expect(classifyAuthFailureReason("")).toBe("unknown");
+    expect(classifyAuthFailureReason("   ")).toBe("unknown");
   });
 });

--- a/packages/auth/src/token-expiry.ts
+++ b/packages/auth/src/token-expiry.ts
@@ -43,7 +43,7 @@ export function isTokenExpiryText(text: string | null | undefined): boolean {
 export function classifyAuthFailureReason(
   text: string | null | undefined,
 ): CodingAuthFailureReason {
-  if (!text) return "unknown";
+  if (!text || text.trim().length === 0) return "unknown";
   if (isTokenExpiryText(text)) return "token_expired";
   return "needs_reauth";
 }


### PR DESCRIPTION
# Relates to

Closes #22051

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and package tests were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash-high`
<!-- attribution-row:client -->
- Agent tooling: `antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused package tests and biome lint pass post-sync.

# Risks

Low. Refines `classifyAuthFailureReason` to treat whitespace-only failure text as `"unknown"` rather than falling through to `"needs_reauth"`.

# Background

## What does this PR do?

In `packages/auth/src/token-expiry.ts`, `classifyAuthFailureReason` classifies provider failure strings into `CodingAuthFailureReason`. Missing error detail (`null`, `undefined`, `""`) returns `"unknown"`. However, whitespace-only strings (e.g. `"   "`) fell through to `"needs_reauth"` because `!text` evaluated to false.

This PR:
1. Updates `classifyAuthFailureReason()` to return `"unknown"` when `text.trim().length === 0`.
2. Adds test assertions in `packages/auth/src/token-expiry.test.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/auth/src/token-expiry.ts` (lines 43-48)
- `packages/auth/src/token-expiry.test.ts` (lines 52-57)

## Detailed testing steps

Run the focused test file:
```bash
bun run --cwd packages/auth test -- src/token-expiry.test.ts
```

# Evidence Gate

<!-- evidence-head:0835c66b42b6a22fdfbf9fc7ea7d1be7b11d615f -->

<!-- evidence-row:before-screenshots -->
- [x] before-screenshots: N/A - pure backend auth error classifier with no visual UI components
<!-- evidence-row:after-screenshots -->
- [x] after-screenshots: N/A - pure backend auth error classifier with no visual UI components
<!-- evidence-row:walkthrough-video -->
- [x] walkthrough-video: N/A - pure backend auth error classifier with no visual UI components
<!-- evidence-row:backend-logs -->
- [x] backend-logs:
<details>
<summary>Vitest test execution log</summary>

```
$ vitest run src/token-expiry.test.ts

 RUN  v4.1.5 /home/deepanshu/os/eliza/packages/auth

 Test Files  1 passed (1)
      Tests  31 passed (31)
   Start at  19:11:28
   Duration  200ms (transform 37ms, setup 0ms, import 50ms, tests 7ms, environment 0ms)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] frontend-logs: N/A - backend unit test execution only
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - deterministic error classifier with no LLM model invocations
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifacts: N/A - in-memory unit tests; no database or on-chain state persisted
<!-- evidence-row:ocr-review -->
- [x] ocr-review: N/A - no rendered visual surface

# Evidence Details

## Known gaps / failures

None. All 11 test suites (171 tests) in `packages/auth` pass cleanly.

AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: antigravity
Contribution skill revision: elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"antigravity","skill_revision":"elizaOS/eliza@2462c6e333872605c246208f3a5f4f5a6a3f8734:packages/skills/skills/contribute-to-eliza"} -->