### PR TITLE
fix(plugin-inbox): X DMs the owner already read or replied to no longer count as unread

### DIFF
--- a/plugins/plugin-inbox/src/inbox/aggregate.ts
+++ b/plugins/plugin-inbox/src/inbox/aggregate.ts
@@ -160,17 +160,22 @@ export function toInboxMessage(
         : message.channelName
       : null;
 
-  // Gmail triage exposes `likelyReplyNeeded`/`isImportant` but the shared
-  // `InboundMessage` shape does not carry a per-channel read flag yet. Until
-  // the chat fetcher tracks read state per memory, mark chat messages as
-  // unread so the inbox surfaces them for triage.
+  // Gmail triage exposes `likelyReplyNeeded`/`isImportant`. X DMs carry real
+  // read state (the fetcher maps dm.readAt -> lastSeenAt and dm.repliedAt ->
+  // repliedAt), so a read-or-replied DM must not inflate unread counts. Chat
+  // memories still lack a read flag, so they stay unread for triage.
+  const hasSeenState =
+    (typeof message.lastSeenAt === "string" && message.lastSeenAt.length > 0) ||
+    (typeof message.repliedAt === "string" && message.repliedAt.length > 0);
   const unread =
     channel === "gmail"
       ? Boolean(
           message.gmailLikelyReplyNeeded === true ||
             message.gmailIsImportant === true,
         )
-      : true;
+      : channel === "x_dm"
+        ? !hasSeenState
+        : true;
 
   const threadId = deriveThreadId(message, channel, externalId);
   const chatType: InboxChatType =

--- a/plugins/plugin-inbox/src/inbox/aggregate.xdm-unread.test.ts
+++ b/plugins/plugin-inbox/src/inbox/aggregate.xdm-unread.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Pins X DM unread derivation in toInboxMessage/buildInbox: DMs the fetcher
+ * already marked read (dm.readAt -> lastSeenAt) or replied (dm.repliedAt) must
+ * not inflate x_dm unread counts, while never-seen DMs stay unread and chat
+ * channels keep their unread-for-triage fallback (#22055). Deterministic —
+ * pure aggregation over literal InboundMessage fixtures.
+ */
+import { describe, expect, it } from "vitest";
+
+import { buildInbox } from "./aggregate";
+import type { InboundMessage } from "./types";
+
+const NOW = Date.parse("2026-08-18T12:00:00.000Z");
+
+function xDm(overrides: Partial<InboundMessage>): InboundMessage {
+  return {
+    id: "dm1",
+    source: "x_dm",
+    senderName: "@friend",
+    channelName: "X DM from @friend",
+    channelType: "dm",
+    text: "hey",
+    snippet: "hey",
+    timestamp: NOW - 60_000,
+    threadId: "conv1",
+    chatType: "dm",
+    ...overrides,
+  } as InboundMessage;
+}
+
+function build(messages: InboundMessage[]) {
+  return buildInbox(messages, {
+    limit: 100,
+    allowed: new Set(["x_dm", "discord"]),
+    sources: [],
+    groupByThread: true,
+  } as never);
+}
+
+describe("x_dm unread derivation", () => {
+  it("counts a read-and-replied DM as read everywhere", () => {
+    const inbox = build([
+      xDm({
+        lastSeenAt: new Date(NOW - 30_000).toISOString(),
+        repliedAt: new Date(NOW - 20_000).toISOString(),
+      }),
+    ]);
+    expect(inbox.messages[0]?.unread).toBe(false);
+    expect(inbox.channelCounts.x_dm).toMatchObject({ total: 1, unread: 0 });
+    expect(inbox.threadGroups?.[0]?.unreadCount).toBe(0);
+  });
+
+  it("read-only and replied-only DMs each count as read", () => {
+    const readOnly = build([
+      xDm({ lastSeenAt: new Date(NOW - 30_000).toISOString() }),
+    ]);
+    expect(readOnly.messages[0]?.unread).toBe(false);
+
+    const repliedOnly = build([
+      xDm({ id: "dm2", repliedAt: new Date(NOW - 20_000).toISOString() }),
+    ]);
+    expect(repliedOnly.messages[0]?.unread).toBe(false);
+  });
+
+  it("a never-seen DM stays unread", () => {
+    const inbox = build([xDm({ id: "dm3" })]);
+    expect(inbox.messages[0]?.unread).toBe(true);
+    expect(inbox.channelCounts.x_dm).toMatchObject({ total: 1, unread: 1 });
+  });
+
+  it("chat channels keep the unread-for-triage fallback even with seen state", () => {
+    const inbox = build([
+      xDm({
+        id: "c1",
+        source: "discord",
+        channelName: "general",
+        lastSeenAt: new Date(NOW - 30_000).toISOString(),
+      }),
+    ]);
+    expect(inbox.messages[0]?.unread).toBe(true);
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #22055.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] New suite + full plugin suite, typecheck, and Biome pass at the exact head; mutation check recorded in the evidence log.
- [x] A reviewer can confirm the behavior from the executed count matrix attached below.

# Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-fable-5
- Client / agent tooling: Claude Code
- Attribution status: self-reported

## What

`toInboxMessage` hardcoded `unread: true` for every non-gmail channel. The justifying comment covers only chat memories — but X DMs carry real read state: the fetcher maps `dm.readAt` → `lastSeenAt` and `dm.repliedAt` → `repliedAt`, and `isMissedMessage` in the same module already consumes `repliedAt`. A DM the owner had read *and replied to* still incremented `channelCounts.x_dm.unread` and its thread group's `unreadCount` — a permanently wrong unread badge for the X channel.

For `x_dm`, `unread` now derives from the seen state (no `lastSeenAt` and no `repliedAt`); chat channels keep the unread-for-triage fallback, since their fetcher genuinely lacks a read flag — pinned by a test giving a discord message an incidental `lastSeenAt`.

## Verification (exact head `417d97b38`)

- New suite `aggregate.xdm-unread.test.ts` — **4/4**: read+replied DM reads as read across the message flag, `channelCounts.x_dm`, and thread-group `unreadCount`; read-only and replied-only each count as read; a never-seen DM stays unread; discord keeps the triage fallback.
- **Mutation-checked** (commit-first order): with `aggregate.ts` reverted to develop and the tests kept, 2/4 fail (the read-state tests); restored from the commit, 4/4 — fix presence re-verified by grep before push.
- Full `plugin-inbox` suite: **181 passed | 2 skipped** across 23 files. Typecheck and Biome clean.
- The discovering probe (real `buildInbox` export, pre-fix): `unread: true`, `channelCounts.x_dm {total:1, unread:1}`, `threadGroup unreadCount: 1` for an already-read-and-replied DM.
- App-audit note: this changes backend aggregation counts only; `InboxView` rendering code is untouched.

# Evidence Gate

<!-- evidence-head:417d97b3817c042208dc85a81d28c6279461f4ac -->

Backend inbox aggregation with no rendered-UI code changes.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered-UI code changes; the wrong outputs are aggregation counters.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered-UI code changes; the wrong outputs are aggregation counters.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow changes; the fix is a count derivation.
<!-- evidence-row:backend-logs -->
- [x] Executed probe + mutation-check + test transcript: [xdm-unread-repro.log](https://github.com/user-attachments/files/31183276/xdm-unread-repro.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - the view consumes the corrected DTO unchanged.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Executed before/after unread-count matrix (JSON): [xdm-unread-matrix.json](https://github.com/user-attachments/files/31183278/xdm-unread-matrix.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
