### PR TITLE
fix(cloud): give the Cartesia test sockets a removeEventListener

### DIFF
--- a/packages/cloud/api/v1/voice/tts/__tests__/cartesia-synthesis.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/cartesia-synthesis.test.ts
@@ -42,6 +42,9 @@ function scriptedFactory(
         else if (type === "close")
           close.push(l as (e: { readonly code?: number }) => void);
       },
+      // The adapter detaches listeners on every terminal path; a missing
+      // removeEventListener throws mid-cancel and hangs the suite.
+      removeEventListener() {},
     };
     queueMicrotask(() => {
       for (const l of open) l();
@@ -125,6 +128,7 @@ describe("synthesizeCartesiaWav", () => {
             );
           }
         },
+        removeEventListener() {},
       };
       queueMicrotask(() => {
         for (const listener of error) {
@@ -217,6 +221,7 @@ describe("synthesizeCartesiaWav", () => {
           else if (type === "close")
             close.push(l as (e: { readonly code?: number }) => void);
         },
+        removeEventListener() {},
       };
       queueMicrotask(() => {
         for (const l of open) l();


### PR DESCRIPTION
The adapter detaches socket listeners on every terminal path; the scripted in-memory sockets in cartesia-synthesis.test.ts lacked removeEventListener, so the no-audio and PCM-cap cancellations threw mid-detach, leaked the deadline timer, and HUNG the cloud test lane until the release candidate's job cap — run 32127233686 sat idle for 2.5 hours before being killed. Suite 8/8 and the test process exits cleanly. Biome clean.