### PR TITLE
fix(plugin-finances): parse date-only CSV values on a UTC base so postedAt and import idempotency stop depending on server timezone

### DIFF
--- a/plugins/plugin-finances/src/payment-csv-import.test.ts
+++ b/plugins/plugin-finances/src/payment-csv-import.test.ts
@@ -54,8 +54,6 @@ describe("parseTransactionsCsv", () => {
   });
 
   it("supports separate debit/credit columns and accounting negatives", () => {
-    // ISO dates parse to a deterministic UTC midnight (US/short formats go
-    // through Date.parse, which is timezone-dependent — not asserted here).
     const r = parseTransactionsCsv(
       "Posted Date,Payee,Debit,Credit\n2026-01-15,Coffee,(4.50),\n2026-01-16,Refund,,10.00\n",
     );
@@ -74,8 +72,68 @@ describe("parseTransactionsCsv", () => {
   it("normalizes US-format and 2-digit-year dates to a 2026 calendar date", () => {
     const r = parseTransactionsCsv("Date,Amount,Merchant\n1/16/26,-5,Gym\n");
     expect(r.transactions).toHaveLength(1);
-    // Exact time is timezone-dependent via Date.parse; assert the year only.
-    expect(r.transactions[0].postedAt).toMatch(/^2026-01-1[56]T/);
+    expect(r.transactions[0].postedAt).toBe("2026-01-16T00:00:00.000Z");
+  });
+
+  describe("timezone-deterministic date normalization", () => {
+    // postedAt feeds buildTransactionId, so a date-only value must map to the
+    // same UTC instant on every machine or re-imports from another timezone
+    // double-count. Expected instants are therefore always constructed via
+    // Date.UTC — never via `new Date(y, m, d)`, which would bake the test
+    // runner's local offset into the expectation and hide the regression.
+    const utcMidnight = (y: number, m: number, d: number) =>
+      new Date(Date.UTC(y, m - 1, d)).toISOString();
+
+    it("parses MM/DD/YYYY and ISO date-only values to the same UTC midnight", () => {
+      const r = parseTransactionsCsv(
+        "Date,Amount,Merchant\n01/02/2024,-12.34,Netflix\n2024-01-02,-9.99,Spotify\n",
+      );
+      expect(r.errors).toEqual([]);
+      expect(r.transactions[0].postedAt).toBe(utcMidnight(2024, 1, 2));
+      expect(r.transactions[0].postedAt).toBe("2024-01-02T00:00:00.000Z");
+      expect(r.transactions[1].postedAt).toBe(r.transactions[0].postedAt);
+    });
+
+    it("keeps mixed-format rows for the same day on one UTC base", () => {
+      const r = parseTransactionsCsv(
+        'Date,Amount,Merchant\n1-2-24,-1,Dash\n"Jan 2, 2024",-1,Prose\n2024-01-02,-1,Iso\n',
+      );
+      expect(r.errors).toEqual([]);
+      const stamps = new Set(r.transactions.map((t) => t.postedAt));
+      expect(stamps).toEqual(new Set([utcMidnight(2024, 1, 2)]));
+    });
+
+    it("preserves native semantics for datetimes carrying Z or an offset", () => {
+      const r = parseTransactionsCsv(
+        "Date,Amount,Merchant\n2024-01-02T10:00:00Z,-1,Zulu\n2024-01-02T10:00:00-05:00,-1,Offset\n",
+      );
+      expect(r.errors).toEqual([]);
+      expect(r.transactions[0].postedAt).toBe("2024-01-02T10:00:00.000Z");
+      expect(r.transactions[1].postedAt).toBe("2024-01-02T15:00:00.000Z");
+    });
+
+    it("still rejects unparseable dates", () => {
+      const r = parseTransactionsCsv(
+        "Date,Amount,Merchant\nnot-a-date,-1,Bad\n2024-99,-1,AlsoBad\n",
+      );
+      expect(r.transactions).toEqual([]);
+      expect(r.errors.filter((e) => /unparseable date/.test(e))).toHaveLength(
+        2,
+      );
+    });
+
+    it("yields a stable transaction-id key for a re-imported row", () => {
+      // Mirrors buildTransactionId's hash key recipe (finances-service.ts):
+      // postedAt is a hashed component, so determinism here is what keeps
+      // CSV re-imports idempotent across machines in different timezones.
+      const key = (t: { postedAt: string; amountUsd: number }) =>
+        ["agent", "source", t.postedAt, t.amountUsd.toFixed(2)].join("|");
+      const csv = "Date,Amount,Merchant\n01/02/2024,-12.34,Netflix\n";
+      const first = parseTransactionsCsv(csv).transactions[0];
+      const second = parseTransactionsCsv(csv).transactions[0];
+      expect(key(second)).toBe(key(first));
+      expect(first.postedAt).toBe(utcMidnight(2024, 1, 2));
+    });
   });
 
   it("strips currency symbols and thousands separators", () => {

--- a/plugins/plugin-finances/src/payment-csv-import.test.ts
+++ b/plugins/plugin-finances/src/payment-csv-import.test.ts
@@ -112,6 +112,14 @@ describe("parseTransactionsCsv", () => {
       expect(r.transactions[1].postedAt).toBe("2024-01-02T15:00:00.000Z");
     });
 
+    it("preserves explicit zones on date-only RFC spellings", () => {
+      const r = parseTransactionsCsv(
+        'Date,Amount,Merchant\n"02 Jan 2024 GMT",-1,Zone\n',
+      );
+      expect(r.errors).toEqual([]);
+      expect(r.transactions[0].postedAt).toBe("2024-01-02T00:00:00.000Z");
+    });
+
     it("still rejects unparseable dates", () => {
       const r = parseTransactionsCsv(
         "Date,Amount,Merchant\nnot-a-date,-1,Bad\n2024-99,-1,AlsoBad\n",

--- a/plugins/plugin-finances/src/payment-csv-import.ts
+++ b/plugins/plugin-finances/src/payment-csv-import.ts
@@ -169,12 +169,12 @@ function normalizeDate(raw: string): string | null {
   if (!trimmed) {
     return null;
   }
-  // Try native parse first. Falls back to YYYY-MM-DD and MM/DD/YYYY.
-  const native = Date.parse(trimmed);
-  if (Number.isFinite(native)) {
-    return new Date(native).toISOString();
-  }
-  const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  // Date-only values must map to the same UTC instant on every machine:
+  // buildTransactionId hashes postedAt, so a timezone-dependent parse would
+  // mint different ids for the same row and double-count re-imports. The
+  // explicit UTC-based branches therefore run BEFORE the native Date.parse
+  // fallback, which is reserved for strings carrying a time component.
+  const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
   if (isoMatch) {
     return new Date(
       Date.UTC(
@@ -184,7 +184,7 @@ function normalizeDate(raw: string): string | null {
       ),
     ).toISOString();
   }
-  const usMatch = trimmed.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{2,4})/);
+  const usMatch = trimmed.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{2,4})$/);
   if (usMatch) {
     const month = Number(usMatch[1]);
     const day = Number(usMatch[2]);
@@ -192,7 +192,21 @@ function normalizeDate(raw: string): string | null {
     const year = rawYear < 100 ? 2000 + rawYear : rawYear;
     return new Date(Date.UTC(year, month - 1, day)).toISOString();
   }
-  return null;
+  const native = Date.parse(trimmed);
+  if (!Number.isFinite(native)) {
+    return null;
+  }
+  // Strings with a time-of-day (e.g. "2024-01-02T10:00:00Z" or offset-bearing
+  // datetimes) keep native semantics. Remaining date-only spellings such as
+  // "Jan 2, 2024" parse as local midnight, so rebase the local calendar date
+  // onto UTC midnight to stay deterministic across timezones.
+  if (/\d:\d/.test(trimmed)) {
+    return new Date(native).toISOString();
+  }
+  const local = new Date(native);
+  return new Date(
+    Date.UTC(local.getFullYear(), local.getMonth(), local.getDate()),
+  ).toISOString();
 }
 
 export interface ParsedCsvTransaction

--- a/plugins/plugin-finances/src/payment-csv-import.ts
+++ b/plugins/plugin-finances/src/payment-csv-import.ts
@@ -196,11 +196,15 @@ function normalizeDate(raw: string): string | null {
   if (!Number.isFinite(native)) {
     return null;
   }
-  // Strings with a time-of-day (e.g. "2024-01-02T10:00:00Z" or offset-bearing
-  // datetimes) keep native semantics. Remaining date-only spellings such as
-  // "Jan 2, 2024" parse as local midnight, so rebase the local calendar date
-  // onto UTC midnight to stay deterministic across timezones.
-  if (/\d:\d/.test(trimmed)) {
+  // Strings with a time-of-day or an explicit timezone keep native semantics.
+  // The timezone guard also covers date-only RFC spellings such as
+  // "02 Jan 2024 GMT": rebasing that already-UTC instant through local calendar
+  // fields would move it to the prior day west of UTC. Remaining date-only
+  // spellings such as "Jan 2, 2024" parse as local midnight, so rebase their
+  // local calendar date onto UTC midnight for cross-machine determinism.
+  const hasExplicitTimezone =
+    /(?:\b(?:UTC|GMT|[ECMP][SD]T)|[+-]\d{2}:?\d{2})$/i.test(trimmed);
+  if (/\d:\d/.test(trimmed) || hasExplicitTimezone) {
     return new Date(native).toISOString();
   }
   const local = new Date(native);

--- a/plugins/plugin-finances/vitest.config.ts
+++ b/plugins/plugin-finances/vitest.config.ts
@@ -67,6 +67,10 @@ export default defineConfig({
   },
   test: {
     ...baseConfig.test,
+    // Date-only CSV normalization must stay distinguishable from local-time
+    // parsing on CI. UTC runners make the unfixed behavior look correct, so
+    // pin a non-UTC zone for the package test process.
+    env: { ...baseConfig.test?.env, TZ: "America/New_York" },
     // .test.ts run in the default node environment. View component tests live in
     // .test.tsx files and opt into jsdom via a `// @vitest-environment jsdom`
     // docblock at the top of each file.


### PR DESCRIPTION
# Relates to

Fixes #22063.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] Full plugin suite (run under `TZ=America/New_York`), typecheck, and Biome pass at the exact head; mutation check recorded in the evidence log.
- [x] A reviewer can confirm the behavior from the executed TZ × format matrix attached below.

# Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-fable-5
- Client / agent tooling: Claude Code
- Attribution status: self-reported

## What

`normalizeDate` ran native `Date.parse` first, which parses `MM/DD/YYYY` as **local** midnight — the `Date.UTC` fallback was dead for that format. The same CSV row `01/02/2024` produced `05:00Z` in New York, `00:00Z` under UTC, and `2024-01-01T15:00Z` in Tokyo — the previous calendar day, shifting `computeSpendingSummary` windows. And since `buildTransactionId` hashes `postedAt`, re-importing the same CSV from a different timezone minted different ids and **double-counted every row**. ISO rows in the same file parsed as UTC, so mixed-format files were internally inconsistent.

The explicit `Date.UTC` branches now run first — ISO date-only and US `M/D/Y` / `M-D-Y` (2/4-digit year), end-anchored so datetimes fall through — and the native path is kept only for strings with a time component; other natively-parseable date-only spellings ("Jan 2, 2024") are rebased from their local calendar date onto UTC midnight. Month/day interpretation is untouched; only the timezone base changed. Preserved format inventory: ISO date-only; `MM/DD/YYYY` and `M-D-YY(YY)` incl. pre-existing rollover acceptance; prose dates; datetimes with Z/offset unchanged; offset-less datetimes keep native local semantics; invalid strings still rejected.

## Verification (exact head `47ce07b41`)

- 5 new tests (~60 lines) in `payment-csv-import.test.ts`: `01/02/2024` and `2024-01-02` both land on the same UTC midnight (expectations constructed via `Date.UTC`, never `new Date(y,m,d)` — the invariant is documented in the test); mixed-format same-day rows share one base; offset-datetime passthrough; invalid rejection; transaction-id key stability mirroring `buildTransactionId`'s recipe. No existing test pinned local-time parsing; two pre-existing TZ-hedged assertions were tightened.
- **Mutation-checked** (commit-first): develop's source with the new tests kept → **4 failed | 12 passed** (e.g. received `2024-01-02T05:00:00.000Z`); restored from the commit and grep-verified before push.
- Full `plugin-finances` suite under `TZ=America/New_York`: **76/76 across 11 files**. Typecheck and Biome clean.
- Executed probes (real `parseTransactionsCsv` under three TZ values): before — NY `05:00Z` / UTC `00:00Z` / Tokyo `2024-01-01T15:00Z` with diverging sha1 txn-ids; after — identical `2024-01-02T00:00:00.000Z` and identical ids under all three.

# Evidence Gate

<!-- evidence-head:775ff21e425decfd0a7a820fb035f82d4bcb53b2 -->

Backend CSV date parsing with no rendered UI surface.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend parsing; no rendered visual surface exists to capture.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend parsing; no rendered visual surface exists to capture.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow; the wrong outputs are timestamps and transaction ids.
<!-- evidence-row:backend-logs -->
- [x] Executed TZ probes + mutation-check + test transcript: [csv-utc-repro.log](https://github.com/user-attachments/files/31184364/csv-utc-repro.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface parses CSV dates.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic date parsing; no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Executed TZ × format before/after matrix (JSON): [csv-utc-matrix.json](https://github.com/user-attachments/files/31184369/csv-utc-matrix.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
