### PR TITLE
fix(plugin-health): read only the average from Google Fit heart-rate summary points — and revive the dead mock seam

### DIFF
--- a/plugins/plugin-health/src/health-bridge/health-bridge.google-fit-heart-rate.test.ts
+++ b/plugins/plugin-health/src/health-bridge/health-bridge.google-fit-heart-rate.test.ts
@@ -42,21 +42,28 @@ beforeAll(async () => {
         bucket = { dataset: [{ point: [] }] };
       } else if (types.length === 1) {
         // getDataPoints path: one hourly bucket for the requested metric.
-        const point =
+        const points =
           types[0] === "com.google.heart_rate.bpm"
-            ? hrPoint
-            : { value: [{ intVal: 8000 }] };
+            ? [hrPoint]
+            : [{ value: [{ intVal: 3000 }] }, { value: [{ intVal: 5000 }] }];
         bucket = {
           startTimeMillis: String(parsed.startTimeMillis),
           endTimeMillis: String(Number(parsed.startTimeMillis) + 3_600_000),
-          dataset: [{ point: [point] }],
+          dataset: [{ point: points }],
         };
       } else {
         // daily summary: steps, active_minutes, calories, distance, heart_rate
         bucket = {
           dataset: [
-            { point: [{ value: [{ intVal: 8000 }] }] },
-            { point: [{ value: [{ intVal: 30 }] }] },
+            {
+              point: [
+                { value: [{ intVal: 3000 }] },
+                { value: [{ intVal: 5000 }] },
+              ],
+            },
+            {
+              point: [{ value: [{ intVal: 10 }] }, { value: [{ intVal: 20 }] }],
+            },
             { point: [] },
             { point: [] },
             { point: [hrPoint] },

--- a/plugins/plugin-health/src/health-bridge/health-bridge.google-fit-heart-rate.test.ts
+++ b/plugins/plugin-health/src/health-bridge/health-bridge.google-fit-heart-rate.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression coverage for #22062: Google Fit heart-rate aggregation returns
+ * `com.google.heart_rate.summary` points whose value array is
+ * [average, max, min]. Previously the daily summary averaged all three
+ * (heartRateAvg 80 for avg=70/max=120/min=50) and getDataPoints summed them
+ * (240 bpm). Only the first value — the average — is a heart-rate reading.
+ *
+ * These tests exercise the real request path through the documented
+ * `ELIZA_MOCK_GOOGLE_BASE` loopback seam, which was itself dead for Google
+ * Fit (the rewrite regex matched only fitness.googleapis.com while the
+ * aggregate URL uses www.googleapis.com) — same fix.
+ */
+import http from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { getDailySummary, getDataPoints } from "./health-bridge.js";
+
+const GOOGLE_FIT_CONFIG = {
+  preferredBackend: "google-fit" as const,
+  googleFitAccessToken: "test-token",
+};
+
+// One heart-rate summary point: average=70, max=120, min=50 bpm.
+const hrPoint = { value: [{ fpVal: 70 }, { fpVal: 120 }, { fpVal: 50 }] };
+
+let server: http.Server;
+const seenUrls: string[] = [];
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    seenUrls.push(`http://${req.headers.host}${req.url}`);
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      const parsed = JSON.parse(body) as {
+        aggregateBy?: { dataTypeName: string }[];
+        startTimeMillis?: number;
+      };
+      const types = (parsed.aggregateBy ?? []).map((a) => a.dataTypeName);
+      let bucket: unknown;
+      if (types.includes("com.google.sleep.segment")) {
+        bucket = { dataset: [{ point: [] }] };
+      } else if (types.length === 1) {
+        // getDataPoints path: one hourly bucket for the requested metric.
+        const point =
+          types[0] === "com.google.heart_rate.bpm"
+            ? hrPoint
+            : { value: [{ intVal: 8000 }] };
+        bucket = {
+          startTimeMillis: String(parsed.startTimeMillis),
+          endTimeMillis: String(Number(parsed.startTimeMillis) + 3_600_000),
+          dataset: [{ point: [point] }],
+        };
+      } else {
+        // daily summary: steps, active_minutes, calories, distance, heart_rate
+        bucket = {
+          dataset: [
+            { point: [{ value: [{ intVal: 8000 }] }] },
+            { point: [{ value: [{ intVal: 30 }] }] },
+            { point: [] },
+            { point: [] },
+            { point: [hrPoint] },
+          ],
+        };
+      }
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ bucket: [bucket] }));
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as { port: number }).port;
+  process.env.ELIZA_MOCK_GOOGLE_BASE = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  delete process.env.ELIZA_MOCK_GOOGLE_BASE;
+  await new Promise<void>((r) => server.close(() => r()));
+});
+
+describe("Google Fit heart-rate summary aggregation (#22062)", () => {
+  it("routes the Google Fit aggregate URL through ELIZA_MOCK_GOOGLE_BASE", async () => {
+    seenUrls.length = 0;
+    await getDailySummary("2026-08-10", GOOGLE_FIT_CONFIG);
+    expect(seenUrls.length).toBeGreaterThan(0);
+    for (const url of seenUrls) {
+      expect(url).toContain("127.0.0.1");
+      expect(url).toContain("/fitness/v1/users/me/dataset:aggregate");
+    }
+  });
+
+  it("reports heartRateAvg as the summary point's average, not the mean of [avg,max,min]", async () => {
+    const summary = await getDailySummary("2026-08-10", GOOGLE_FIT_CONFIG);
+    expect(summary.heartRateAvg).toBe(70);
+  });
+
+  it("keeps sum semantics for the other daily-summary metrics", async () => {
+    const summary = await getDailySummary("2026-08-10", GOOGLE_FIT_CONFIG);
+    expect(summary.steps).toBe(8000);
+    expect(summary.activeMinutes).toBe(30);
+  });
+
+  it("emits heart_rate data points as bucket averages, not sums (70 bpm, not 240)", async () => {
+    const points = await getDataPoints(
+      {
+        metric: "heart_rate",
+        startAt: "2026-08-10T00:00:00Z",
+        endAt: "2026-08-10T01:00:00Z",
+      },
+      GOOGLE_FIT_CONFIG,
+    );
+    expect(points).toHaveLength(1);
+    expect(points[0]?.value).toBe(70);
+  });
+
+  it("leaves steps data points summed as before", async () => {
+    const points = await getDataPoints(
+      {
+        metric: "steps",
+        startAt: "2026-08-10T00:00:00Z",
+        endAt: "2026-08-10T01:00:00Z",
+      },
+      GOOGLE_FIT_CONFIG,
+    );
+    expect(points).toHaveLength(1);
+    expect(points[0]?.value).toBe(8000);
+  });
+});

--- a/plugins/plugin-health/src/health-bridge/health-bridge.ts
+++ b/plugins/plugin-health/src/health-bridge/health-bridge.ts
@@ -33,7 +33,7 @@ function rewriteGoogleUrlForMock(url: string): string {
     );
   }
   return url.replace(
-    /^https:\/\/(?:fitness)\.googleapis\.com/,
+    /^https:\/\/(?:www|fitness)\.googleapis\.com/,
     mockUrl.toString().replace(/\/+$/, ""),
   );
 }
@@ -523,14 +523,25 @@ function sumBucketValues(
   return total;
 }
 
+/**
+ * Average the values in a bucket. With `firstValueOnly`, only each point's
+ * first value contributes: Google Fit heart-rate aggregation returns
+ * `com.google.heart_rate.summary` points whose value array is
+ * `[average, max, min]`, so averaging (or summing) all three wholesale
+ * corrupts the result — only value[0] (the average) is a heart-rate reading.
+ */
 function avgBucketValues(
   bucket: NonNullable<GoogleFitAggregateResponse["bucket"]>[number],
+  opts?: { firstValueOnly?: boolean },
 ): number | undefined {
   let total = 0;
   let count = 0;
   for (const ds of bucket.dataset ?? []) {
     for (const point of ds.point ?? []) {
-      for (const v of point.value ?? []) {
+      const values = opts?.firstValueOnly
+        ? (point.value ?? []).slice(0, 1)
+        : (point.value ?? []);
+      for (const v of values) {
         const num =
           typeof v.fpVal === "number"
             ? v.fpVal
@@ -633,7 +644,9 @@ async function googleFitDailySummary(
   summary.calories = sumBucketValues(byType(2) as typeof bucket) || undefined;
   summary.distanceMeters =
     sumBucketValues(byType(3) as typeof bucket) || undefined;
-  summary.heartRateAvg = avgBucketValues(byType(4) as typeof bucket);
+  summary.heartRateAvg = avgBucketValues(byType(4) as typeof bucket, {
+    firstValueOnly: true,
+  });
 
   // Google Fit sleep lives in a separate dataset; fetch it with a dedicated call.
   try {
@@ -745,7 +758,13 @@ async function googleFitDataPoints(
 
   const points: HealthDataPoint[] = [];
   for (const bucket of response.bucket ?? []) {
-    const value = sumBucketValues(bucket);
+    // Heart rate is a rate, not an accumulating quantity: its summary points
+    // carry [average, max, min], so a bucket's data point is the average of
+    // the point averages — never a sum (summing [70,120,50] yields 240 bpm).
+    const value =
+      opts.metric === "heart_rate"
+        ? (avgBucketValues(bucket, { firstValueOnly: true }) ?? 0)
+        : sumBucketValues(bucket);
     if (value === 0) continue;
     const bucketStart = Number(bucket.startTimeMillis ?? "0");
     const bucketEnd = Number(bucket.endTimeMillis ?? "0");


### PR DESCRIPTION
# Relates to

Fixes #22062.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] Full plugin suite, typecheck, and Biome pass at the exact head; mutation check recorded in the evidence log.
- [x] A reviewer can confirm the behavior from the executed metric × payload matrix attached below.

# Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-fable-5
- Client / agent tooling: Claude Code
- Attribution status: self-reported

## What

Google Fit's aggregate API answers `com.google.heart_rate.bpm` with `com.google.heart_rate.summary` points whose `value` array is `[average, max, min]`. The bridge treated those as independent samples: `avgBucketValues` averaged all three (daily `heartRateAvg` **80** instead of 70 for a [70,120,50] payload), and `googleFitDataPoints` routed `heart_rate` through `sumBucketValues` — reporting **240 bpm**. Bundled second defect, exposed by the discovering probe: the documented `ELIZA_MOCK_GOOGLE_BASE` loopback seam never matched the Fit URL (`rewriteGoogleUrlForMock` matched only `fitness.googleapis.com`; the aggregate URL uses `www.googleapis.com`), so "mock" runs silently hit the real API (observed live 401).

`avgBucketValues` gains a `firstValueOnly` mode so heart-rate summary points contribute only `value[0]` (the average); `heart_rate` data points route through the first-value average — documented in-code that a rate aggregates as an average, never a sum. The mock rewrite now matches `^https://(?:www|fitness).googleapis.com`, and the new tests exercise the real request path *through* that revived seam via a loopback server. Sum semantics verified unchanged for steps, active_minutes, calories, and distance.

## Verification (exact head `567c876be`)

- New suite `health-bridge.google-fit-heart-rate.test.ts` — **5/5**: seam interception, `heartRateAvg` 70 (was 80), heart-rate data point 70 (was 240), summary steps/activeMinutes unchanged, steps data point 8000 unchanged.
- **Mutation-checked** (commit-first): with `health-bridge.ts` reverted to develop and tests kept, **all 5 fail**; restored from the commit and grep-verified before push.
- Full `plugin-health` suite: **35 files / 191 passed / 4 skipped → 36 / 196 / 4** — zero regressions. Typecheck and `lint:check` clean.
- Executed probes (loopback server + real exported `getDailySummary`/`getDataPoints`): before — heartRateAvg 80, heart-rate point 240 bpm, mock-base set yet request hit `www.googleapis.com` (401); after — 70 / 70 / intercepted.

# Evidence Gate

<!-- evidence-head:9ec900645c7d78e43ba4fc780fb4e43542ba77ab -->

Backend metric aggregation with no rendered UI surface.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend aggregation; no rendered visual surface exists to capture.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend aggregation; no rendered visual surface exists to capture.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow; the wrong outputs are numeric metric values.
<!-- evidence-row:backend-logs -->
- [x] Executed probes + mutation-check + test transcript: [gfit-hr-repro.log](https://github.com/user-attachments/files/31184353/gfit-hr-repro.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface computes these aggregates.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic aggregation; no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Executed metric × payload before/after matrix (JSON): [gfit-hr-matrix.json](https://github.com/user-attachments/files/31184356/gfit-hr-matrix.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
