### PR TITLE
fix(agent): drain filtered memory browse until the page is satisfied — no more unreachable memories, lying totals, or false feed exhaustion

### DIFF
--- a/packages/agent/src/api/memory-browse-drain.test.ts
+++ b/packages/agent/src/api/memory-browse-drain.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Exercises the filtered-browse drain loop at the real handleMemoryRoutes
+ * boundary with a deterministic in-memory runtime that honors `limit` the way
+ * a real adapter does (newest-first prefix). Covers the three over-fetch
+ * defects from #22061: sparse keyword filters losing matches on deep pages,
+ * by-entity post-filter truncation, and the feed's post-filter hasMore
+ * false-negative — plus drain termination on true exhaustion and the
+ * MEMORY_BROWSE_SCAN_CAP safety cap.
+ */
+
+import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, test, vi } from "vitest";
+import type { MemoryRouteContext } from "./memory-routes.ts";
+import { handleMemoryRoutes } from "./memory-routes.ts";
+
+const AGENT_ID = "11111111-1111-4111-8111-111111111111" as UUID;
+const ENTITY = "22222222-2222-4222-8222-222222222222" as UUID;
+const OTHER = "33333333-3333-4333-8333-333333333333" as UUID;
+const ROOM = "44444444-4444-4444-8444-444444444444" as UUID;
+
+function makeRow(i: number, text: string, entityId: UUID = OTHER): Memory {
+  return {
+    id: `00000000-0000-4000-8000-${String(i).padStart(12, "0")}` as UUID,
+    entityId,
+    roomId: ROOM,
+    agentId: AGENT_ID,
+    createdAt: 2_000_000 - i, // strictly newest-first
+    content: { text },
+  } as Memory;
+}
+
+/** 1000 messages: every 10th contains "needle" (100), every 20th owned by ENTITY (50). */
+function buildDb(): Memory[] {
+  const db: Memory[] = [];
+  for (let i = 0; i < 1000; i++) {
+    db.push(
+      makeRow(
+        i,
+        i % 10 === 0 ? `needle row ${i}` : `hay row ${i}`,
+        i % 20 === 0 ? ENTITY : OTHER,
+      ),
+    );
+  }
+  return db;
+}
+
+function makeRuntime(db: Memory[]): {
+  runtime: AgentRuntime;
+  getMemories: ReturnType<typeof vi.fn>;
+} {
+  const getMemories = vi.fn(
+    async ({ tableName, limit }: { tableName: string; limit: number }) =>
+      tableName === "messages" ? db.slice(0, limit).map((r) => ({ ...r })) : [],
+  );
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    ensureConnection: vi.fn(async () => undefined),
+    getMemories,
+  } as unknown as AgentRuntime;
+  return { runtime, getMemories };
+}
+
+async function get(
+  runtime: AgentRuntime,
+  path: string,
+): Promise<Record<string, unknown>> {
+  const url = new URL(`https://agent.test${path}`);
+  let out: unknown;
+  const context: MemoryRouteContext = {
+    req: {} as never,
+    res: {} as never,
+    method: "GET",
+    pathname: url.pathname,
+    url,
+    runtime,
+    agentName: "Eliza",
+    json: (_res, value) => {
+      out = value;
+    },
+    error: (_res, message, status) => {
+      throw new Error(`unexpected ${status}: ${message}`);
+    },
+    readJsonBody: async <T extends object>() => ({}) as T,
+  };
+  expect(await handleMemoryRoutes(context)).toBe(true);
+  return out as Record<string, unknown>;
+}
+
+const ids = (res: Record<string, unknown>): string[] =>
+  (res.memories as Array<{ id: string }>).map((m) => m.id);
+
+describe("filtered browse drain (#22061)", () => {
+  test("sparse q filter reaches every match across pages with a consistent final total", async () => {
+    const { runtime } = makeRuntime(buildDb());
+    const union = new Set<string>();
+    let offset = 0;
+    let lastTotal = 0;
+    for (;;) {
+      const page = await get(
+        runtime,
+        `/api/memories/browse?type=messages&q=needle&limit=50&offset=${offset}`,
+      );
+      const pageIds = ids(page);
+      for (const id of pageIds) union.add(id);
+      lastTotal = page.total as number;
+      // Every page but the last must be full; total must never falsely
+      // report exhaustion while more matches remain reachable.
+      if (offset + 50 >= lastTotal) break;
+      expect(pageIds).toHaveLength(50);
+      offset += 50;
+    }
+    expect(union.size).toBe(100); // all 100 matching rows reachable
+    expect(lastTotal).toBe(100); // exact once the drain exhausted the table
+  });
+
+  test("first page total is at least a full page beyond the window, never a lying exhaustion", async () => {
+    const { runtime } = makeRuntime(buildDb());
+    const p0 = await get(
+      runtime,
+      "/api/memories/browse?type=messages&q=needle&limit=50&offset=0",
+    );
+    expect(ids(p0)).toHaveLength(50);
+    // total is either exact (100) or a lower bound > offset+limit so the
+    // UI's Next control stays enabled.
+    expect(p0.total as number).toBeGreaterThan(50);
+  });
+
+  test("by-entity returns all 50 rows for a sparsely represented entity", async () => {
+    const { runtime } = makeRuntime(buildDb());
+    const res = await get(
+      runtime,
+      `/api/memories/by-entity/${ENTITY}?type=messages&limit=50&offset=0`,
+    );
+    expect(ids(res)).toHaveLength(50);
+    expect(res.total).toBe(50);
+    expect(
+      (res.memories as Array<{ entityId: string }>).every(
+        (m) => m.entityId === ENTITY,
+      ),
+    ).toBe(true);
+  });
+
+  test("feed hasMore is true when later browsable rows exist past an empty-text run", async () => {
+    // Newest 30 rows with text, next 870 empty, oldest 100 with text:
+    // 130 browsable rows total, so a limit-50 feed has more.
+    const db: Memory[] = [];
+    for (let i = 0; i < 1000; i++) {
+      db.push(makeRow(i, i < 30 || i >= 900 ? `txt ${i}` : ""));
+    }
+    const { runtime } = makeRuntime(db);
+    const res = await get(runtime, "/api/memories/feed?type=messages&limit=50");
+    expect(res.count).toBe(50);
+    expect(res.hasMore).toBe(true);
+  });
+
+  test("true exhaustion (adapter returns fewer rows than requested) terminates the drain", async () => {
+    const db = [makeRow(0, "needle"), makeRow(1, "hay"), makeRow(2, "needle")];
+    const { runtime, getMemories } = makeRuntime(db);
+    const res = await get(
+      runtime,
+      "/api/memories/browse?type=messages&q=needle&limit=50&offset=0",
+    );
+    expect(ids(res)).toHaveLength(2);
+    expect(res.total).toBe(2); // exact — the whole table was scanned
+    expect(getMemories).toHaveBeenCalledTimes(1); // no futile refetch rounds
+  });
+
+  test("safety cap bounds the scan when nothing ever matches an endless table", async () => {
+    // Adapter always returns exactly `limit` rows (looks bottomless) and no
+    // row ever matches — without the cap the drain would double forever.
+    const requestedLimits: number[] = [];
+    const getMemories = vi.fn(
+      async ({ limit }: { tableName: string; limit: number }) => {
+        requestedLimits.push(limit);
+        return Array.from({ length: limit }, (_, i) => ({
+          ...makeRow(i, `hay ${i}`),
+        }));
+      },
+    );
+    const runtime = {
+      agentId: AGENT_ID,
+      character: { name: "Eliza" },
+      ensureConnection: vi.fn(async () => undefined),
+      getMemories,
+    } as unknown as AgentRuntime;
+    const res = await get(
+      runtime,
+      "/api/memories/browse?type=messages&q=absent-needle&limit=50&offset=0",
+    );
+    expect(ids(res)).toHaveLength(0);
+    expect(res.total).toBe(0);
+    // The per-table window is clamped to MEMORY_BROWSE_SCAN_CAP (10k rows).
+    expect(Math.max(...requestedLimits)).toBeLessThanOrEqual(10_000);
+    expect(getMemories.mock.calls.length).toBeLessThan(12);
+  });
+});

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -49,6 +49,14 @@ const QUICK_CONTEXT_DOCUMENTS_THRESHOLD = 0.2;
 
 const MEMORY_BROWSE_DEFAULT_LIMIT = 50;
 const MEMORY_BROWSE_MAX_LIMIT = 200;
+/**
+ * Hard per-table safety cap for the filtered-browse drain loop. The drain
+ * doubles its fetch window until the requested page (plus one sentinel row)
+ * is satisfied or the adapter is exhausted; this cap bounds the worst-case
+ * scan to 10k rows per table so a needle-in-a-haystack filter cannot turn a
+ * page request into an unbounded table scan.
+ */
+const MEMORY_BROWSE_SCAN_CAP = 10_000;
 const MEMORY_FEED_DEFAULT_LIMIT = 50;
 const MEMORY_FEED_MAX_LIMIT = 100;
 const MEMORY_TABLE_NAMES = [
@@ -360,11 +368,17 @@ async function fetchMemoriesFromTables(
     limit?: number;
     before?: number;
   },
-): Promise<TaggedMemory[]> {
+): Promise<{
+  memories: TaggedMemory[];
+  /** Every table returned fewer rows than requested — nothing deeper exists. */
+  exhausted: boolean;
+  /** The per-table fetch window hit MEMORY_BROWSE_SCAN_CAP. */
+  capped: boolean;
+}> {
   const tables = params.tables ?? MEMORY_TABLE_NAMES;
-  const perTableLimit = Math.max(
-    Math.ceil((params.limit ?? MEMORY_BROWSE_DEFAULT_LIMIT) * 2),
-    200,
+  const perTableLimit = Math.min(
+    Math.max(Math.ceil((params.limit ?? MEMORY_BROWSE_DEFAULT_LIMIT) * 2), 200),
+    MEMORY_BROWSE_SCAN_CAP,
   );
   // Read every table concurrently — they are independent queries, and a
   // sequential loop would make the feed's first paint wait on N round-trips.
@@ -382,6 +396,10 @@ async function fetchMemoriesFromTables(
     }),
   );
   const allMemories: TaggedMemory[] = perTableMemories.flat();
+  const exhausted = perTableMemories.every(
+    (rows) => rows.length < perTableLimit,
+  );
+  const capped = perTableLimit >= MEMORY_BROWSE_SCAN_CAP;
 
   // The DB adapter ignores entityId in getMemories (used only for RLS
   // context). Post-filter here so person-centric views actually work.
@@ -396,9 +414,54 @@ async function fetchMemoriesFromTables(
 
   const beforeTs = params.before;
   if (beforeTs !== undefined) {
-    return filtered.filter((m) => memoryCreatedAt(m) < beforeTs);
+    filtered = filtered.filter((m) => memoryCreatedAt(m) < beforeTs);
   }
-  return filtered;
+  return { memories: filtered, exhausted, capped };
+}
+
+/**
+ * Drain loop for filtered browse paths. Every filter here (entityId, empty
+ * text, `before`, keyword `q`) is applied *after* the adapter's `limit`, so a
+ * single fixed over-fetch window loses matches: a selective filter can leave
+ * the page short while thousands of deeper matching rows exist. Refetch with a
+ * doubling window until the caller's target (page end plus one sentinel row)
+ * is met, the adapter is truly exhausted (returned fewer rows than requested),
+ * or the MEMORY_BROWSE_SCAN_CAP safety cap is hit.
+ *
+ * Totals contract for callers: when `exhausted` is true the filtered array is
+ * the complete match set, so its length is an exact total. When the cap
+ * stopped the drain instead, the length is a lower bound — but it is then
+ * guaranteed to be >= the caller's target, so `total > offset + limit` and
+ * pagination controls stay enabled rather than falsely reporting exhaustion.
+ */
+async function drainFilteredMemories(
+  runtime: AgentRuntime,
+  params: {
+    entityIds?: UUID[];
+    roomId?: UUID;
+    tables?: readonly string[];
+    before?: number;
+  },
+  target: number,
+  keywordQuery?: string,
+): Promise<{ filtered: TaggedMemory[]; exhausted: boolean }> {
+  let requestLimit = Math.max(target + 100, MEMORY_BROWSE_DEFAULT_LIMIT);
+  for (;;) {
+    const { memories, exhausted, capped } = await fetchMemoriesFromTables(
+      runtime,
+      { ...params, limit: requestLimit },
+    );
+    const filtered = keywordQuery
+      ? memories.filter((m) => {
+          const text = (m.content as { text?: string } | undefined)?.text ?? "";
+          return matchesKeyword(text, keywordQuery);
+        })
+      : memories;
+    if (filtered.length >= target || exhausted || capped) {
+      return { filtered, exhausted };
+    }
+    requestLimit *= 2;
+  }
 }
 
 /**
@@ -591,11 +654,14 @@ export async function handleMemoryRoutes(
     }
     const tables = tableFilter.tables;
 
-    const allMemories = await fetchMemoriesFromTables(runtime, {
-      tables,
-      limit: limit * 2,
-      before,
-    });
+    // Drain until limit+1 browsable rows exist (the extra row is a sentinel
+    // proving there is a next page) or the tables are exhausted, so hasMore
+    // cannot false-negative just because empty-text rows padded the window.
+    const { filtered: allMemories } = await drainFilteredMemories(
+      runtime,
+      { tables, before },
+      limit + 1,
+    );
 
     allMemories.sort(byNewestFirst);
     const items = allMemories.slice(0, limit).map(memoryToBrowseItem);
@@ -639,23 +705,22 @@ export async function handleMemoryRoutes(
         ? [entityIdParam as UUID]
         : undefined;
 
-    const allMemories = await fetchMemoriesFromTables(runtime, {
-      tables,
-      entityIds,
-      roomId: roomIdParam ? (roomIdParam as UUID) : undefined,
-      limit: limit + offset + 100,
-    });
+    const { filtered } = await drainFilteredMemories(
+      runtime,
+      {
+        tables,
+        entityIds,
+        roomId: roomIdParam ? (roomIdParam as UUID) : undefined,
+      },
+      offset + limit + 1,
+      searchQuery || undefined,
+    );
 
-    allMemories.sort(byNewestFirst);
+    filtered.sort(byNewestFirst);
 
-    let filtered = allMemories;
-    if (searchQuery) {
-      filtered = allMemories.filter((m) => {
-        const text = (m.content as { text?: string } | undefined)?.text ?? "";
-        return matchesKeyword(text, searchQuery);
-      });
-    }
-
+    // Exact when the drain exhausted the tables; otherwise a lower bound that
+    // exceeds offset+limit, so paging controls never falsely disable (see
+    // drainFilteredMemories).
     const total = filtered.length;
     const page = filtered.slice(offset, offset + limit).map(memoryToBrowseItem);
 
@@ -706,11 +771,14 @@ export async function handleMemoryRoutes(
     }
     const tables = tableFilter.tables;
 
-    const allMemories = await fetchMemoriesFromTables(runtime, {
-      entityIds,
-      tables,
-      limit: limit + offset + 100,
-    });
+    // The adapter ignores entityId, so the entity filter is post-limit and can
+    // be extremely selective — drain until the page is satisfied (see
+    // drainFilteredMemories for the total semantics).
+    const { filtered: allMemories } = await drainFilteredMemories(
+      runtime,
+      { entityIds, tables },
+      offset + limit + 1,
+    );
 
     allMemories.sort(byNewestFirst);
     const total = allMemories.length;

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
@@ -224,6 +224,55 @@ describe("iOS bridge — memories view routes", () => {
 		expect(page.json).toMatchObject({ total: 3, limit: 1, offset: 1 });
 	});
 
+	it("browse drains a sparse q filter so deep pages reach every match (#22061)", async () => {
+		// 1000 rows, every 10th matches "needle" (100 matches). A fixed
+		// over-fetch window used to surface only the matches inside it and
+		// report a lying total.
+		for (let i = 0; i < 1000; i++) {
+			await seedMemory(
+				"messages",
+				i % 10 === 0 ? `needle row ${i}` : `hay row ${i}`,
+				2_000_000 - i,
+			);
+		}
+		const union = new Set<string>();
+		for (const offset of [0, 50]) {
+			const page = await call(
+				backend,
+				"GET",
+				`/api/memories/browse?type=messages&q=needle&limit=50&offset=${offset}`,
+			);
+			const memories = page.json.memories as Array<{ id: string }>;
+			expect(memories).toHaveLength(50);
+			for (const m of memories) union.add(m.id);
+		}
+		expect(union.size).toBe(100);
+		const last = await call(
+			backend,
+			"GET",
+			"/api/memories/browse?type=messages&q=needle&limit=50&offset=50",
+		);
+		expect(last.json.total).toBe(100); // exact after exhausting the table
+	});
+
+	it("feed hasMore survives an empty-text run padding the fetch window (#22061)", async () => {
+		// Newest 30 rows browsable, next 470 empty, oldest 100 browsable.
+		for (let i = 0; i < 600; i++) {
+			await seedMemory(
+				"messages",
+				i < 30 || i >= 500 ? `txt ${i}` : "",
+				2_000_000 - i,
+			);
+		}
+		const { json } = await call(
+			backend,
+			"GET",
+			"/api/memories/feed?type=messages&limit=50",
+		);
+		expect(json.count).toBe(50);
+		expect(json.hasMore).toBe(true);
+	});
+
 	it("stats totals per table", async () => {
 		await seedMemory("messages", "m1", 1_000);
 		await seedMemory("messages", "m2", 2_000);

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1138,6 +1138,8 @@ function parsePositiveInteger(value: string | null, fallback: number): number {
 
 const MEMORY_BROWSE_DEFAULT_LIMIT = 50;
 const MEMORY_BROWSE_MAX_LIMIT = 200;
+/** Per-table safety cap for the filtered-browse drain loop (see agent mirror). */
+const MEMORY_BROWSE_SCAN_CAP = 10_000;
 const MEMORY_FEED_DEFAULT_LIMIT = 50;
 const MEMORY_FEED_MAX_LIMIT = 100;
 const MEMORY_TABLE_NAMES = [
@@ -1226,11 +1228,17 @@ async function fetchMemoriesFromTables(
 		limit?: number;
 		before?: number;
 	},
-): Promise<TaggedMemory[]> {
+): Promise<{
+	memories: TaggedMemory[];
+	/** Every table returned fewer rows than requested — nothing deeper exists. */
+	exhausted: boolean;
+	/** The per-table fetch window hit MEMORY_BROWSE_SCAN_CAP. */
+	capped: boolean;
+}> {
 	const tables = params.tables ?? MEMORY_TABLE_NAMES;
-	const perTableLimit = Math.max(
-		Math.ceil((params.limit ?? MEMORY_BROWSE_DEFAULT_LIMIT) * 2),
-		200,
+	const perTableLimit = Math.min(
+		Math.max(Math.ceil((params.limit ?? MEMORY_BROWSE_DEFAULT_LIMIT) * 2), 200),
+		MEMORY_BROWSE_SCAN_CAP,
 	);
 	const perTableMemories = await Promise.all(
 		tables.map(async (tableName) => {
@@ -1245,6 +1253,10 @@ async function fetchMemoriesFromTables(
 		}),
 	);
 	const allMemories: TaggedMemory[] = perTableMemories.flat();
+	const exhausted = perTableMemories.every(
+		(rows) => rows.length < perTableLimit,
+	);
+	const capped = perTableLimit >= MEMORY_BROWSE_SCAN_CAP;
 
 	let filtered = allMemories;
 	const entitySet = params.entityIds;
@@ -1257,9 +1269,49 @@ async function fetchMemoriesFromTables(
 
 	const beforeTs = params.before;
 	if (beforeTs) {
-		return filtered.filter((m) => memoryCreatedAt(m) < beforeTs);
+		filtered = filtered.filter((m) => memoryCreatedAt(m) < beforeTs);
 	}
-	return filtered;
+	return { memories: filtered, exhausted, capped };
+}
+
+/**
+ * Drain loop for filtered browse paths, mirroring
+ * packages/agent/src/api/memory-routes.ts. Every filter (entityId, empty
+ * text, `before`, keyword `q`) is applied after the adapter's `limit`, so a
+ * fixed over-fetch window loses matches. Refetch with a doubling window until
+ * the target (page end plus one sentinel row) is met, the adapter is truly
+ * exhausted, or the MEMORY_BROWSE_SCAN_CAP safety cap is hit. When exhausted,
+ * filtered.length is an exact total; when capped it is a lower bound that is
+ * >= target, so pagination never falsely reports exhaustion.
+ */
+async function drainFilteredMemories(
+	runtime: IAgentRuntime,
+	params: {
+		entityIds?: UUID[];
+		roomId?: UUID;
+		tables?: readonly string[];
+		before?: number;
+	},
+	target: number,
+	keywordQuery?: string,
+): Promise<{ filtered: TaggedMemory[]; exhausted: boolean }> {
+	let requestLimit = Math.max(target + 100, MEMORY_BROWSE_DEFAULT_LIMIT);
+	for (;;) {
+		const { memories, exhausted, capped } = await fetchMemoriesFromTables(
+			runtime,
+			{ ...params, limit: requestLimit },
+		);
+		const filtered = keywordQuery
+			? memories.filter((m) => {
+					const text = (m.content as { text?: string } | undefined)?.text ?? "";
+					return matchesMemoryKeyword(text, keywordQuery);
+				})
+			: memories;
+		if (filtered.length >= target || exhausted || capped) {
+			return { filtered, exhausted };
+		}
+		requestLimit *= 2;
+	}
 }
 
 async function handleMemoriesFeedRoute(
@@ -1275,11 +1327,14 @@ async function handleMemoriesFeedRoute(
 	const before = beforeParam ? Number(beforeParam) : undefined;
 	const tables = resolveMemoryTableFilter(queryParam(query, "type"));
 
-	const allMemories = await fetchMemoriesFromTables(runtime, {
-		tables,
-		limit: limit * 2,
-		before,
-	});
+	// Drain until limit+1 browsable rows exist (the extra row is a sentinel
+	// proving there is a next page) or the tables are exhausted, so hasMore
+	// cannot false-negative just because empty-text rows padded the window.
+	const { filtered: allMemories } = await drainFilteredMemories(
+		runtime,
+		{ tables, before },
+		limit + 1,
+	);
 
 	allMemories.sort(byNewestFirst);
 	const items = allMemories.slice(0, limit).map(memoryToBrowseItem);
@@ -1317,23 +1372,21 @@ async function handleMemoriesBrowseRoute(
 			? [entityIdParam as UUID]
 			: undefined;
 
-	const allMemories = await fetchMemoriesFromTables(runtime, {
-		tables,
-		entityIds,
-		roomId: roomIdParam ? (roomIdParam as UUID) : undefined,
-		limit: limit + offset + 100,
-	});
+	const { filtered } = await drainFilteredMemories(
+		runtime,
+		{
+			tables,
+			entityIds,
+			roomId: roomIdParam ? (roomIdParam as UUID) : undefined,
+		},
+		offset + limit + 1,
+		searchQuery || undefined,
+	);
 
-	allMemories.sort(byNewestFirst);
+	filtered.sort(byNewestFirst);
 
-	let filtered = allMemories;
-	if (searchQuery) {
-		filtered = allMemories.filter((m) => {
-			const text = (m.content as { text?: string } | undefined)?.text ?? "";
-			return matchesMemoryKeyword(text, searchQuery);
-		});
-	}
-
+	// Exact when the drain exhausted the tables; otherwise a lower bound that
+	// exceeds offset+limit, so paging controls never falsely disable.
 	const total = filtered.length;
 	const page = filtered.slice(offset, offset + limit).map(memoryToBrowseItem);
 


### PR DESCRIPTION
# Relates to

Fixes #22061.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] Both packages' suites, typecheck, and Biome pass at the exact head; mutation check recorded in the evidence log.
- [x] A reviewer can confirm the behavior from the executed per-scenario matrix attached below.

# Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-fable-5
- Client / agent tooling: Claude Code
- Attribution status: self-reported

## What

The browse endpoints fetched a fixed over-fetch window (`limit + offset + 100`), applied filters *after* the DB limit (keyword `q`, entityId, empty-text, `before`), then sliced — so filter selectivity beyond the buffer silently lost items. Demonstrated on the real exported `handleMemoryRoutes`: a sparse keyword filter left **70 of 100 matching memories unreachable via any offset**, `total` changed between pages (30→40), by-entity returned 15 of 50, and the feed reported `hasMore: false` with 100 browsable rows remaining.

`drainFilteredMemories` now refetches with a doubling per-table window until `filtered.length >= offset + limit + 1` (the extra row is the next-page sentinel), the adapter returns fewer rows than requested (true exhaustion), or a hard safety cap of **10,000 rows per table** (`MEMORY_BROWSE_SCAN_CAP`). `fetchMemoriesFromTables` returns `{memories, exhausted, capped}`; browse, by-entity, and feed all route through the drain (feed `hasMore` from the drained sentinel).

**`total` semantics (documented in code):** exact whenever the drain reached exhaustion; a lower bound guaranteed `> offset + limit` when the cap stopped it first. Verified against the real consumer — `MemoryViewerView.tsx` renders "X–Y of Z" and gates Next on `offset + PAGE >= total`, so a lower bound exceeding the current window keeps paging enabled and the final page shows the exact count; nothing pinned the old lying total.

**Bridge mirror:** `plugins/plugin-capacitor-bridge/src/ios/bridge.ts` is a deliberate verbatim duplicate today (no shared code, no new cross-package dependency created); it received the identical drain, constant, and comments, plus mirror tests in its existing harness.

## Verification (exact head `16de0dfa7`)

- New suite `memory-browse-drain.test.ts` — **6/6**: sparse q-filter reaches all 100 matches across pages with exact final total; first-page total is a lower bound; by-entity returns all 50; feed `hasMore` true past an empty-text run; true exhaustion terminates in one adapter call; safety cap terminates with max request ≤ 10k in 7 rounds. Bridge harness (`bridge.routes.test.ts`): +2 mirror tests.
- **Mutation-checked** (commit-first): both source files reverted to develop with tests kept → agent **4/6 fail**, bridge **2 fail**; restored from the commit, grep-verified (`drainFilteredMemories`: 6 refs agent, 3 bridge), suites green before push.
- Suites: agent memory tests 13→19 passed; bridge 17→19 passed; typecheck and `lint:check` clean in both packages; zero regressions.
- Executed probe before/after: browse union **30/100 → 100/100**; by-entity **15 → 50**; feed `hasMore` **false → true**.

# Evidence Gate

<!-- evidence-head:16de0dfa79c9856b66532ee339533f2deff75ddd -->

Backend pagination with no rendered-UI code changes.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered-UI code changes; the wrong outputs are response counts and flags.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered-UI code changes; the wrong outputs are response counts and flags.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow changes; the memory viewer consumes the corrected DTO unchanged.
<!-- evidence-row:backend-logs -->
- [x] Executed probes + mutation-check + test transcript: [memory-drain-repro.log](https://github.com/user-attachments/files/31184333/memory-drain-repro.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - MemoryViewerView renders the corrected totals unchanged (consumer compatibility analyzed in the PR body).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic pagination; no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Executed per-scenario before/after matrix (JSON): [memory-drain-matrix.json](https://github.com/user-attachments/files/31184339/memory-drain-matrix.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
