### PR TITLE
fix(cloud): expect the typed 400 for malformed domain-search JSON

### DIFF
--- a/packages/cloud/api/__tests__/domains-search-validation.test.ts
+++ b/packages/cloud/api/__tests__/domains-search-validation.test.ts
@@ -64,10 +64,10 @@ describe("POST /api/v1/domains/search validation", () => {
     expect(searchDomains).toHaveBeenCalledWith("example", 7);
   });
 
-  test("preserves malformed JSON failure handling without calling the registrar", async () => {
+  test("rejects malformed JSON with a typed 400 without calling the registrar", async () => {
     const response = await search("{");
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(400);
     expect(await response.json()).toMatchObject({ success: false });
     expect(searchDomains).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
The domains/search route now rejects malformed JSON with a typed 400 (the repo-wide body-guard contract) instead of the legacy unguarded 500; the validation suite still pinned the 500 (release candidate run 32146860878 — the only red in the full test lane). Suite 7/7; Biome clean.