### PR TITLE
fix(cloud-shared): re-express zero-valued and unruled MCP schema bounds

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/base.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/base.ts
@@ -60,6 +60,8 @@ export abstract class McpToolCompatibility {
       "minItems",
       "maxItems",
       "uniqueItems",
+      "minProperties",
+      "maxProperties",
     ]) {
       if (schema[prop as keyof JSONSchema7] !== undefined) {
         constraints[prop] = schema[prop as keyof JSONSchema7];

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/google.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/google.ts
@@ -31,16 +31,16 @@ export class GoogleMcpCompatibility extends McpToolCompatibility {
     constraints: Record<string, unknown>,
   ): string {
     const rules: string[] = [];
-    if (constraints.minLength) rules.push(`at least ${constraints.minLength} chars`);
-    if (constraints.maxLength) rules.push(`at most ${constraints.maxLength} chars`);
+    if (constraints.minLength !== undefined) rules.push(`at least ${constraints.minLength} chars`);
+    if (constraints.maxLength !== undefined) rules.push(`at most ${constraints.maxLength} chars`);
     if (constraints.minimum !== undefined) rules.push(`>= ${constraints.minimum}`);
     if (constraints.maximum !== undefined) rules.push(`<= ${constraints.maximum}`);
     if (constraints.format === "email") rules.push(`valid email`);
     if (constraints.format === "uri" || constraints.format === "url") rules.push(`valid URL`);
     if (constraints.pattern) rules.push(`matches ${constraints.pattern}`);
     if (constraints.enum) rules.push(`one of: ${(constraints.enum as string[]).join(", ")}`);
-    if (constraints.minItems) rules.push(`>= ${constraints.minItems} items`);
-    if (constraints.maxItems) rules.push(`<= ${constraints.maxItems} items`);
+    if (constraints.minItems !== undefined) rules.push(`>= ${constraints.minItems} items`);
+    if (constraints.maxItems !== undefined) rules.push(`<= ${constraints.maxItems} items`);
     if (constraints.uniqueItems) rules.push(`unique items`);
 
     const text = rules.length > 0 ? `Constraints: ${rules.join("; ")}` : "";

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
@@ -102,7 +102,7 @@ export class OpenAIReasoningMcpCompatibility extends McpToolCompatibility {
       rule("minItems", `at least ${constraints.minItems} items`);
     if (constraints.maxItems !== undefined)
       rule("maxItems", `at most ${constraints.maxItems} items`);
-    if (constraints.uniqueItems !== undefined) rule("uniqueItems", `items must be unique`);
+    if (constraints.uniqueItems === true) rule("uniqueItems", `items must be unique`);
     if (constraints.minProperties !== undefined)
       rule("minProperties", `at least ${constraints.minProperties} properties`);
     if (constraints.maxProperties !== undefined)

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
@@ -59,25 +59,65 @@ export class OpenAIReasoningMcpCompatibility extends McpToolCompatibility {
     return ["minProperties", "maxProperties", "additionalProperties"];
   }
 
+  /**
+   * Reasoning models reject the constraint keywords stripped above, so every
+   * stripped bound has to survive as prose or the model is never told about a
+   * rule it must still satisfy. Two failure modes are guarded here: a bound of
+   * zero is a legitimate constraint and must not be dropped by a truthy test,
+   * and a collected keyword with no rule of its own must still reach the
+   * description rather than vanishing because some *other* keyword happened to
+   * render (the previous all-or-nothing fallback only fired when zero rules
+   * matched, which silently lost `multipleOf` from `{minimum, multipleOf}`).
+   */
   protected mergeDescription(
     original: string | undefined,
     constraints: Record<string, unknown>,
   ): string {
     const rules: string[] = [];
-    if (constraints.minLength) rules.push(`minimum ${constraints.minLength} characters`);
-    if (constraints.maxLength) rules.push(`maximum ${constraints.maxLength} characters`);
-    if (constraints.minimum !== undefined) rules.push(`must be >= ${constraints.minimum}`);
-    if (constraints.maximum !== undefined) rules.push(`must be <= ${constraints.maximum}`);
-    if (constraints.format === "email") rules.push(`must be a valid email`);
-    if (constraints.format === "uri" || constraints.format === "url")
-      rules.push(`must be a valid URL`);
-    if (constraints.pattern) rules.push(`must match: ${constraints.pattern}`);
-    if (constraints.enum)
-      rules.push(`must be one of: ${(constraints.enum as string[]).join(", ")}`);
-    if (constraints.minItems) rules.push(`at least ${constraints.minItems} items`);
-    if (constraints.maxItems) rules.push(`at most ${constraints.maxItems} items`);
+    const rendered = new Set<string>();
+    const rule = (key: string, text: string): void => {
+      rules.push(text);
+      rendered.add(key);
+    };
 
-    const text = rules.length > 0 ? `IMPORTANT: ${rules.join(", ")}` : JSON.stringify(constraints);
+    if (constraints.minLength !== undefined)
+      rule("minLength", `minimum ${constraints.minLength} characters`);
+    if (constraints.maxLength !== undefined)
+      rule("maxLength", `maximum ${constraints.maxLength} characters`);
+    if (constraints.minimum !== undefined) rule("minimum", `must be >= ${constraints.minimum}`);
+    if (constraints.maximum !== undefined) rule("maximum", `must be <= ${constraints.maximum}`);
+    if (constraints.exclusiveMinimum !== undefined)
+      rule("exclusiveMinimum", `must be > ${constraints.exclusiveMinimum}`);
+    if (constraints.exclusiveMaximum !== undefined)
+      rule("exclusiveMaximum", `must be < ${constraints.exclusiveMaximum}`);
+    if (constraints.multipleOf !== undefined)
+      rule("multipleOf", `must be a multiple of ${constraints.multipleOf}`);
+    if (constraints.format === "email") rule("format", `must be a valid email`);
+    if (constraints.format === "uri" || constraints.format === "url")
+      rule("format", `must be a valid URL`);
+    if (constraints.pattern !== undefined) rule("pattern", `must match: ${constraints.pattern}`);
+    if (constraints.enum !== undefined)
+      rule("enum", `must be one of: ${(constraints.enum as string[]).join(", ")}`);
+    if (constraints.minItems !== undefined)
+      rule("minItems", `at least ${constraints.minItems} items`);
+    if (constraints.maxItems !== undefined)
+      rule("maxItems", `at most ${constraints.maxItems} items`);
+    if (constraints.uniqueItems !== undefined) rule("uniqueItems", `items must be unique`);
+    if (constraints.minProperties !== undefined)
+      rule("minProperties", `at least ${constraints.minProperties} properties`);
+    if (constraints.maxProperties !== undefined)
+      rule("maxProperties", `at most ${constraints.maxProperties} properties`);
+
+    const unrendered = Object.keys(constraints).filter((key) => !rendered.has(key));
+    const parts: string[] = [];
+    if (rules.length > 0) parts.push(`IMPORTANT: ${rules.join(", ")}`);
+    if (unrendered.length > 0) {
+      parts.push(
+        JSON.stringify(Object.fromEntries(unrendered.map((key) => [key, constraints[key]]))),
+      );
+    }
+
+    const text = parts.join(" ");
     return original ? `${original}\n\n${text}` : text;
   }
 }

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
@@ -80,6 +80,16 @@ describe("cloud MCP tool-compatibility zero-valued bounds (#22068)", () => {
       expect(text).toContain("must be < 10");
     });
 
+    it("does not turn uniqueItems false into a uniqueness requirement", () => {
+      const out = reasoning().transformToolSchema({
+        type: "array",
+        uniqueItems: false,
+      });
+      expect(out.uniqueItems).toBeUndefined();
+      expect(out.description).toContain('"uniqueItems":false');
+      expect(out.description).not.toContain("items must be unique");
+    });
+
     it("surfaces a collected keyword that has no rule instead of dropping it", () => {
       const text = describeOf(reasoning(), {
         type: "string",

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Pins constraint re-expression in the cloud-vendored MCP tool-compatibility
+ * formatters, which strip keywords from the schema and must therefore restate
+ * every stripped bound in the description the hosted model reads (#22068).
+ * Deterministic: the compat objects come from the real
+ * `createMcpToolCompatibilitySync` factory over a literal runtime shape, and
+ * assertions run against the real `transformToolSchema` output.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import type { JSONSchema7 } from "json-schema";
+import { describe, expect, it } from "vitest";
+
+import { createMcpToolCompatibilitySync } from "./index";
+
+/** The factory reads only `model`/`modelProvider` off the runtime. */
+function compatFor(model: string) {
+  const compat = createMcpToolCompatibilitySync({ model } as unknown as IAgentRuntime);
+  if (!compat) throw new Error(`no compatibility layer for model ${model}`);
+  return compat;
+}
+
+const describeOf = (compat: ReturnType<typeof compatFor>, schema: JSONSchema7): string =>
+  String(compat.transformToolSchema(schema).description ?? "");
+
+describe("cloud MCP tool-compatibility zero-valued bounds (#22068)", () => {
+  describe("google formatter", () => {
+    const google = () => compatFor("gemini-2.0-flash");
+
+    it("keeps a zero-valued maxLength alongside a positive minLength", () => {
+      const text = describeOf(google(), { type: "string", minLength: 1, maxLength: 0 });
+      expect(text).toContain("at least 1 chars");
+      expect(text).toContain("at most 0 chars");
+    });
+
+    it("keeps a zero-valued maxItems alongside a positive minItems", () => {
+      const text = describeOf(google(), { type: "array", minItems: 1, maxItems: 0 });
+      expect(text).toContain(">= 1 items");
+      expect(text).toContain("<= 0 items");
+    });
+
+    it("renders positive bounds unchanged", () => {
+      const text = describeOf(google(), { type: "string", minLength: 2, maxLength: 8 });
+      expect(text).toBe("Constraints: at least 2 chars; at most 8 chars");
+    });
+  });
+
+  describe("openai reasoning formatter", () => {
+    // `o3` is what makes detectModelProvider set isReasoningModel, which is the
+    // only way the factory constructs OpenAIReasoningMcpCompatibility.
+    const reasoning = () => compatFor("o3-mini");
+
+    it("is the class the factory builds for a reasoning model", () => {
+      expect(reasoning().constructor.name).toBe("OpenAIReasoningMcpCompatibility");
+    });
+
+    it("keeps a zero-valued maxLength alongside a positive minLength", () => {
+      const text = describeOf(reasoning(), { type: "string", minLength: 1, maxLength: 0 });
+      expect(text).toContain("minimum 1 characters");
+      expect(text).toContain("maximum 0 characters");
+    });
+
+    it("restates multipleOf when another numeric rule also matched", () => {
+      const schema: JSONSchema7 = { type: "number", minimum: 1, multipleOf: 0.5 };
+      const out = reasoning().transformToolSchema(schema);
+      const text = String(out.description ?? "");
+      expect(text).toContain("must be >= 1");
+      expect(text).toContain("0.5");
+      // The keyword is still stripped from the schema, which is why the
+      // description is the only place the model can learn about it.
+      expect(out.multipleOf).toBeUndefined();
+    });
+
+    it("restates exclusive bounds that the schema strips", () => {
+      const text = describeOf(reasoning(), {
+        type: "number",
+        exclusiveMinimum: 0,
+        exclusiveMaximum: 10,
+      });
+      expect(text).toContain("must be > 0");
+      expect(text).toContain("must be < 10");
+    });
+
+    it("surfaces a collected keyword that has no rule instead of dropping it", () => {
+      const text = describeOf(reasoning(), {
+        type: "string",
+        minLength: 1,
+        format: "date-time",
+      });
+      expect(text).toContain("minimum 1 characters");
+      expect(text).toContain("date-time");
+    });
+
+    it("renders a fully-ruled positive constraint set without a raw json tail", () => {
+      const text = describeOf(reasoning(), { type: "string", minLength: 2, maxLength: 8 });
+      expect(text).toBe("IMPORTANT: minimum 2 characters, maximum 8 characters");
+    });
+  });
+});


### PR DESCRIPTION
Closes #22068.

## What was wrong

`packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/` is the vendored copy of the plugin's tool-schema fixup layer, wired into the hosted agent path. These formatters **strip** constraint keywords from the JSON schema, so a stripped bound survives only as prose in the tool description the model reads. Two paths dropped bounds silently.

**Zero is a legitimate bound.** Eight truthy checks across `google.ts` and `openai.ts` treated `maxLength: 0` / `maxItems: 0` as absent, so the keyword was removed from the schema *and* omitted from the description. #22050 fixed the plugin-side copy; as the issue notes, the cloud copy is the one whose factory actually constructs `OpenAIReasoningMcpCompatibility` in production.

**The fallback was all-or-nothing.** The reasoning formatter's raw-dump fallback fired only when *zero* rules matched, so a collected keyword with no rule of its own vanished whenever some other keyword happened to render. `{minimum: 1, multipleOf: 0.5}` rendered `IMPORTANT: must be >= 1` and lost `multipleOf` entirely.

## What changed

- `google.ts`, `openai.ts`: the 8 numeric-keyword truthy checks are now `!== undefined`.
- `openai.ts`: tracks which constraint keys actually rendered and appends any that did not, instead of dumping raw JSON only when nothing rendered. Adds rules for `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `uniqueItems`, `minProperties`, `maxProperties` — so the JSON tail is a backstop for genuinely unknown keywords rather than the primary path.
- `base.ts`: collects `minProperties`/`maxProperties`. They were listed as unsupported (and therefore deleted) but never collected, so no rule could ever re-express them. Adding rules without this would have been dead code.

Per the issue's acceptance criteria I **kept the vendored copy** rather than collapsing it into an import of `plugins/plugin-mcp`: de-duplication changes the cloud package's dependency surface, and the issue itself notes the two factories deliberately disagree today. That belongs in a maintainer-owned PR. The two "out of scope" items (factory disagreement, `detectModelProvider` precedence) are untouched.

## Verification

Fails-before is real, not asserted — 6 of 9 new tests fail on unfixed source. The 3 that pass are the ones asserting *unchanged* behavior, which is the correct outcome.

# Evidence Gate

<!-- evidence-head:8dd09c5a5b2d1d0ceafeb13768802d3d6468d41b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend schema-transformation code with no rendered UI surface. The observable output is the tool-description string, attached under domain artifacts.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend schema-transformation code with no rendered UI surface. The observable output is the tool-description string, attached under domain artifacts.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the change alters text passed to a model, not any screen.
<!-- evidence-row:backend-logs -->
- [x] Real code path firing end to end, through the factory-constructed compat objects.

```text
# BEFORE (fix reverted, new suite kept) — bun test, packages/cloud/shared
(fail) ... google formatter > keeps a zero-valued maxLength alongside a positive minLength
(fail) ... google formatter > keeps a zero-valued maxItems alongside a positive minItems
(fail) ... openai reasoning formatter > keeps a zero-valued maxLength alongside a positive minLength
(fail) ... openai reasoning formatter > restates multipleOf when another numeric rule also matched
(fail) ... openai reasoning formatter > restates exclusive bounds that the schema strips
(fail) ... openai reasoning formatter > surfaces a collected keyword that has no rule instead of dropping it
 3 pass, 6 fail, 14 expect() calls

# AFTER (this head)
 10 pass, 0 fail, 19 expect() calls
Ran 10 tests across 1 file.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser surface is exercised by this change; there is no request/response or client state involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no hosted-cloud credentials are available here to drive the live reasoning path. Worth stating plainly rather than hiding behind the N/A: this IS a model-facing prompt surface, because it changes the tool description a hosted model reads. Rather than claim a live run I did not do, the deterministic transformation output is attached under domain artifacts — the exact strings a model would receive, produced by the real factory-built compat objects — plus the regression comparison below.

```text
Regression check against develop baseline (bun test src/lib/eliza/, packages/cloud/shared)
  baseline (this branch stashed): 63 pass / 1 fail / 1 error across 8 files
  this head:                      72 pass / 1 fail / 1 error across 9 files
The 1 fail + 1 error are pre-existing on develop (plugin-web-search keyless-search,
network-dependent; passes 8/8 in isolation on both revisions). This branch adds 9
passing tests and changes neither number.
```

<!-- evidence-row:domain-artifacts -->
- [x] The produced tool-description strings, which are the artifact this code exists to emit.

```text
Google, {type:"string", minLength:1, maxLength:0}
  before: "Constraints: at least 1 chars"                       <- maxLength:0 lost
  after:  "Constraints: at least 1 chars; at most 0 chars"

OpenAI reasoning, {type:"number", minimum:1, multipleOf:0.5}
  before: "IMPORTANT: must be >= 1"                             <- multipleOf lost
  after:  "IMPORTANT: must be >= 1, must be a multiple of 0.5"
  (schema still has multipleOf stripped, which is why the text is the only channel)

OpenAI reasoning, {type:"string", minLength:2, maxLength:8}     positive-bound control
  before: "IMPORTANT: minimum 2 characters, maximum 8 characters"
  after:  "IMPORTANT: minimum 2 characters, maximum 8 characters"   <- unchanged
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Gates

```text
bun run --cwd packages/cloud/shared lint:check   -> Checked 2051 files. No fixes applied. (clean)
bun run --cwd packages/cloud/shared typecheck    -> tsc --noEmit, no errors
bun test src/lib/eliza/plugin-mcp/...zero-bounds -> 9 pass / 0 fail
bun test src/lib/eliza/ (subtree regression)     -> 72 pass vs 63 baseline, same 1 pre-existing fail
```

One disclosure: Slop's `terms-preflight` currently reports "new runs are paused until repository authority is verified", so I could not produce a signed run receipt for this work. The contribution stands on the evidence above; I would rather flag the missing receipt than quietly omit the footer.

---
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza
Attribution status: self-reported
— [kenjohnscreates]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza"} -->