### PR TITLE
fix(cloud): mock billFlatUsage in the shared-turn idempotency suite

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-turn-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-turn-idempotency.test.ts
@@ -111,6 +111,10 @@ mock.module("@/lib/services/ai-billing", () => ({
     return { totalCost: 0.004, inputTokens: 12, outputTokens: 4 };
   },
   recordUsageAnalytics: async () => null,
+  billFlatUsage: async () => {
+    billSettlements++;
+    return { totalCost: 0.004, inputTokens: 0, outputTokens: 0 };
+  },
   InsufficientCreditsError: class InsufficientCreditsError extends Error {
     required = 1;
     available = 0;


### PR DESCRIPTION
The shared-turn path now imports billFlatUsage from ai-billing; the idempotency suite's module mock predates it, so the file died on a missing-export link error (release candidate run 32152352572 — the only red across 457 cloud-api files). The mock now settles flat usage through the same counter. Suite 2/2; Biome clean.