### PR TITLE
fix(cloud): align the character credits test with the org attribution

### DIFF
--- a/packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts
+++ b/packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts
@@ -155,9 +155,10 @@ describe("default Eliza voice", () => {
     }
   });
 
-  test("credits the people who actually built it", () => {
+  test("credits its makers and stays open source", () => {
     const identity = `${character.system}\n${character.bio.join("\n")}`.toLowerCase();
-    for (const name of ["shaw", "nubs", "shad0w", "elizaos"]) {
+    // The persona now attributes the org rather than individual handles.
+    for (const name of ["eliza research", "elizaos"]) {
       expect(identity).toContain(name);
     }
     expect(identity).toContain("github.com/elizaos/eliza");


### PR DESCRIPTION
The default Eliza persona was rewritten to attribute 'eliza research' rather than individual handles; the credits test still pinned the old names (release candidate run 32158359495 — the only red in the full test lane). The test now pins the current attribution contract plus the open-source repo link. Suite 11/11; Biome clean.