### PR TITLE
fix(plugin-anthropic-proxy): make proxy shutdown deterministic

### DIFF
--- a/plugins/plugin-anthropic-proxy/__tests__/proxy-server.shutdown.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/proxy-server.shutdown.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Verifies that ProxyServer.stop() terminates deterministically even when the
+ * local HTTP server has an active keep-alive connection. Before the fix,
+ * server.close() only stopped accepting new connections but never fired its
+ * callback until every existing socket closed on its own — causing teardown
+ * to hang until the test runner timed out.
+ */
+
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("ProxyServer.stop() determinism", () => {
+  let stoppedServer: { stop: () => Promise<void>; getUrl: () => string } | null = null;
+
+  afterEach(async () => {
+    if (stoppedServer) {
+      await stoppedServer.stop().catch(() => undefined);
+      stoppedServer = null;
+    }
+  });
+
+  it("resolves stop() promptly while a keep-alive connection is open", async () => {
+    const { ProxyServer } = await import("../src/proxy/server.js");
+    const server = new ProxyServer({
+      port: 0,
+      bindHost: "127.0.0.1",
+      envToken: "test-token",
+    });
+    await server.start();
+    stoppedServer = null;
+
+    // Open a keep-alive connection but do not close it.
+    const agent = new http.Agent({ keepAlive: true });
+    await new Promise<void>((resolve, reject) => {
+      const req = http.request(`${server.getUrl()}/health`, { agent }, (res) => {
+        res.resume();
+        res.on("end", resolve);
+      });
+      req.on("error", reject);
+      req.end();
+    });
+
+    // stop() must resolve within 2 s even though the keep-alive socket is
+    // still technically open from the agent's perspective.
+    await expect(
+      Promise.race([
+        server.stop(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("stop() timed out")), 2000)
+        ),
+      ])
+    ).resolves.toBeUndefined();
+
+    agent.destroy();
+  });
+});

--- a/plugins/plugin-anthropic-proxy/src/proxy/server.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/server.ts
@@ -76,6 +76,7 @@ export class ProxyServer {
   private requestCount = 0;
   private startedAt = 0;
   private listening = false;
+  private readonly sockets = new Set<import("node:net").Socket>();
 
   private readonly port: number;
   private readonly bindHost: string;
@@ -149,6 +150,10 @@ export class ProxyServer {
     }
 
     this.server = createServer((req, res) => this.handleRequest(req, res));
+    this.server.on("connection", (socket) => {
+      this.sockets.add(socket);
+      socket.once("close", () => this.sockets.delete(socket));
+    });
     const server = this.server;
     this.startedAt = Date.now();
     await new Promise<void>((resolve, reject) => {
@@ -167,6 +172,12 @@ export class ProxyServer {
   async stop(): Promise<void> {
     if (!this.server || !this.listening) return;
     const server = this.server;
+    // Destroy tracked open connections so server.close() callback fires immediately
+    // rather than waiting for keep-alive or in-flight connections to drain.
+    for (const socket of this.sockets) {
+      socket.destroy();
+    }
+    this.sockets.clear();
     await new Promise<void>((resolve) => {
       server.close(() => {
         this.listening = false;


### PR DESCRIPTION
# Relates to

Fixes #21654.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] New regression test (`proxy-server.shutdown.test.ts`) is RED on `develop` without the fix and GREEN with it — verified by restoring the original `stop()` and running the suite.
- [x] Pre-existing `proxy-server.routing.test.ts` remains green at this head.
- [x] `bun x biome check` passes on both changed files.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- AI provider/model: Google / Gemini
<!-- attribution-row:client -->
- Client / agent tooling: Antigravity IDE
<!-- attribution-row:skill-revision -->
- Contribution skill revision: elizaOS/eliza@8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

## What

`ProxyServer.stop()` called `server.close()` which stops accepting new connections
but **never fires its callback** while an existing keep-alive or in-flight
connection remains open. The result is an indefinite stall in test teardown
and in any service that calls `stop()` after a request with `Connection: keep-alive`.

**Fix:** Track every socket opened on the server via a `connection` listener on `this.server`.
When `stop()` is called, destroy all tracked sockets before invoking `server.close()`,
so the close callback fires immediately.

```ts
// Added to ProxyServer:
private readonly sockets = new Set<import("node:net").Socket>();

// In start() after createServer():
this.server.on("connection", (socket) => {
  this.sockets.add(socket);
  socket.once("close", () => this.sockets.delete(socket));
});

// In stop() before server.close():
for (const socket of this.sockets) socket.destroy();
this.sockets.clear();
```

## Verification (exact head `8518a8d935422f172d6429f8c649c86b6c6892d5`)

**New test `proxy-server.shutdown.test.ts`:**

1. Starts `ProxyServer` on `port: 0`
2. Opens a keep-alive connection via `http.Agent({ keepAlive: true })`, waits for the `/health` response
3. Calls `stop()` in a `Promise.race` against a 2-second timeout

**Mutation check (RED control):** Reverted `stop()` to `server.close(...)` without the socket-destroy loop → test **fails** with `stop() timed out` after 2 s. Restored fix → test **passes in 54ms**.

```
✓ __tests__/proxy-server.shutdown.test.ts (1 test) 54ms
✓ __tests__/proxy-server.routing.test.ts (1 test) 67ms
```

# Evidence Gate

<!-- evidence-head:8518a8d935422f172d6429f8c649c86b6c6892d5 -->

Server lifecycle change — no UI surface.

<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered UI surface; the failure is a hanging process.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no interactive user flow; the fix is a server lifecycle change.
<!-- evidence-row:backend-logs -->
- [x] Test output: `✓ proxy-server.shutdown.test.ts (1 test) 54ms` and `✓ proxy-server.routing.test.ts (1 test) 67ms`; mutation-check: reverted fix → timeout in 2s.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend surface involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no DB rows, generated files, or evidence artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered text or visual surface changes.

AI provider/model: Google / Gemini
Client / agent tooling: Antigravity IDE
Contribution skill revision: elizaOS/eliza@8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini","client":"Antigravity IDE","skill_revision":"elizaOS/eliza@8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->