### PR TITLE
fix(shared): contain OSC-8 terminal control bytes

### DIFF
--- a/packages/shared/src/terminal/links.test.ts
+++ b/packages/shared/src/terminal/links.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Exercises OSC-8 terminal link formatting against control-byte injection and
+ * verifies the non-TTY and documentation-link fallbacks.
+ */
+import { describe, expect, it } from "vitest";
+import { formatDocsLink, formatTerminalLink } from "./links.ts";
+
+describe("formatTerminalLink", () => {
+  it("formats an OSC-8 hyperlink when forced", () => {
+    expect(
+      formatTerminalLink("Documentation", "https://docs.eliza.ai", {
+        force: true,
+      }),
+    ).toBe(
+      "\u001b]8;;https://docs.eliza.ai\u0007Documentation\u001b]8;;\u0007",
+    );
+  });
+
+  it("removes ESC, BEL, remaining C0 bytes, and DEL from untrusted values", () => {
+    const result = formatTerminalLink(
+      "safe\u0007\u001b\n\u007f-label",
+      "https://example.test/\u0007\u001b\r\u007f-path",
+      { force: true },
+    );
+
+    expect(result).toBe(
+      "\u001b]8;;https://example.test/-path\u0007safe-label\u001b]8;;\u0007",
+    );
+    expect(
+      [...result]
+        .map((character) => character.codePointAt(0))
+        .filter((codePoint) => codePoint !== undefined && codePoint < 0x20),
+    ).toEqual([0x1b, 0x07, 0x1b, 0x07]);
+  });
+
+  it("uses a readable non-TTY fallback", () => {
+    expect(
+      formatTerminalLink("Docs", "https://docs.eliza.ai", { force: false }),
+    ).toBe("Docs (https://docs.eliza.ai)");
+  });
+});
+
+describe("formatDocsLink", () => {
+  it("resolves relative documentation paths", () => {
+    expect(formatDocsLink("/guides/setup", undefined, { force: false })).toBe(
+      "https://docs.eliza.ai/guides/setup",
+    );
+  });
+});

--- a/packages/shared/src/terminal/links.ts
+++ b/packages/shared/src/terminal/links.ts
@@ -1,17 +1,25 @@
 /**
  * Formats OSC-8 terminal hyperlinks for CLI output, falling back to `label
- * (url)` when stdout is not a TTY. Strips ESC bytes from label/url so untrusted
- * values cannot inject escape sequences.
+ * (url)` when stdout is not a TTY. Removes C0/DEL control bytes from label and
+ * URL values so untrusted text cannot terminate or inject terminal sequences.
  */
 const DOCS_ROOT = "https://docs.eliza.ai";
+function stripTerminalControlBytes(value: string): string {
+  return [...value]
+    .filter((character) => {
+      const codePoint = character.codePointAt(0);
+      return codePoint !== undefined && codePoint > 0x1f && codePoint !== 0x7f;
+    })
+    .join("");
+}
 
 export function formatTerminalLink(
   label: string,
   url: string,
   opts?: { fallback?: string; force?: boolean },
 ): string {
-  const safeLabel = label.replaceAll("\u001b", "");
-  const safeUrl = url.replaceAll("\u001b", "");
+  const safeLabel = stripTerminalControlBytes(label);
+  const safeUrl = stripTerminalControlBytes(url);
   const allow = opts?.force ?? Boolean(process.stdout.isTTY);
   if (!allow) {
     return opts?.fallback ?? `${safeLabel} (${safeUrl})`;


### PR DESCRIPTION
## Summary

- removes C0 and DEL bytes from untrusted OSC-8 labels and URLs
- specifically prevents BEL from terminating the hyperlink envelope
- preserves required typed inputs and existing non-TTY behavior
- supersedes closed #21927 and continues #21924

Original contribution direction credited to Deepanshu Yadav in the commit trailer.

## Exact-head evidence

Head: 4591ed606bf8ab32e06c359ba04e377ba1f3ddfe
Base: 8dd1512174954dcf268b99fa6612325211bce788

- bun test packages/shared/src/terminal/links.test.ts: 4 passed, 0 failed
- bun run --cwd packages/shared typecheck: passed
- Biome on both touched files: passed
- git diff --check: passed
- adversarial assertion verifies that only the two intended OSC-8 ESC/BEL pairs remain after sanitizing injected ESC, BEL, other C0 bytes, and DEL

## Evidence applicability

- UI screenshots/video: N/A - terminal string protocol only
- frontend/backend logs: N/A - deterministic formatter
- model trajectory: N/A - no model behavior
- domain artifact: exact OSC-8 output asserted in the focused test

## Contribution provenance

- AI assistance: yes
- Model(s) used: OpenAI/gpt-5.6-sol
- Agent tooling: Codex Desktop
- Skill path: elizaOS/eliza@8dd1512174954dcf268b99fa6612325211bce788:packages/skills/skills/contribute-to-eliza
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@8dd1512174954dcf268b99fa6612325211bce788:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8dd1512174954dcf268b99fa6612325211bce788:packages/skills/skills/contribute-to-eliza"} -->
