### PR TITLE
fix(shared): preserve explicit speaker corrections

### DIFF
--- a/packages/shared/src/speaker-name-inference.test.ts
+++ b/packages/shared/src/speaker-name-inference.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Exercises borrowed-device identity conflicts with deterministic typed
+ * evidence, including the explicit user-correction escape hatch.
+ */
+import { describe, expect, it } from "vitest";
+import { inferSpeakerName } from "./speaker-name-inference.ts";
+
+describe("inferSpeakerName borrowed-device precedence", () => {
+  it("withholds automatic identity evidence that conflicts with the device roster", () => {
+    const result = inferSpeakerName({
+      speakerId: "speaker-1",
+      evidence: [
+        {
+          source: "platform_roster",
+          confidence: 0.74,
+          name: "Device Owner",
+        },
+        {
+          source: "voice_profile",
+          confidence: 0.99,
+          name: "Guest Speaker",
+          profileId: "voice-guest",
+        },
+      ],
+    });
+
+    expect(result.resolution).toBe("withheld");
+    expect(result.reasonCodes).toContain("borrowed_device_guardrail");
+    expect(result.bindingPlan.action).toBe("none");
+  });
+
+  it("lets an explicit user correction resolve a borrowed-device conflict", () => {
+    const result = inferSpeakerName({
+      speakerId: "speaker-1",
+      evidence: [
+        {
+          source: "platform_roster",
+          confidence: 0.74,
+          name: "Device Owner",
+        },
+        {
+          source: "user_correction",
+          confidence: 0.99,
+          name: "Actual Speaker",
+        },
+      ],
+    });
+
+    expect(result.resolution).toBe("confirmed");
+    expect(result.displayName).toBe("Actual Speaker");
+    expect(result.reasonCodes).toContain("user_correction_applied");
+    expect(result.bindingPlan.action).toBe("create_entity");
+  });
+});

--- a/packages/shared/src/speaker-name-inference.ts
+++ b/packages/shared/src/speaker-name-inference.ts
@@ -445,6 +445,7 @@ export function inferSpeakerName(
     (hasStrongSource(chosen) || chosen.sources.length > 1) &&
     !sameFirstNameAmbiguity &&
     !unresolvedConflict &&
+    (!borrowedDeviceConflict || correction !== undefined) &&
     input.sensitiveAttributeGuardrail !== true;
   if (canConfirm) reasonCodes.push("high_confidence_name");
   if (chosen && !canConfirm) reasonCodes.push("low_confidence_name");


### PR DESCRIPTION
## Summary

- withholds automatic voice/self-identification when it conflicts with a borrowed device roster
- preserves explicit user correction as the authoritative escape hatch
- keeps the required typed evidence contract and removes the unrelated guards/defaults from closed #21930
- continues #21928 and supersedes #21930

Original contribution direction credited to Deepanshu Yadav in the commit trailer.

## Exact-head evidence

Head: 7b9b94b4d4ffd1237f69e8721c65ff03aeb433d1
Base: 06616b65c0da27ba99a517237ea2bd2bab5b5733

- bun test packages/shared/src/speaker-name-inference.test.ts: 2 passed, 0 failed
- bun run --cwd packages/shared typecheck: passed
- Biome on both touched files: passed
- git diff --check: passed
- deterministic identity artifacts assert withheld/no mutation for voice evidence and confirmed/create_entity for explicit correction

## Evidence applicability

- UI screenshots/video: N/A - no rendered surface
- frontend/backend logs: N/A - deterministic shared identity policy
- live model trajectory: N/A - no model/prompt change
- domain artifact: exact inference resolution, reasons, and binding plan asserted

## Contribution provenance

- AI assistance: yes
- Model(s) used: OpenAI/gpt-5.6-sol
- Agent tooling: Codex Desktop
- Skill path: elizaOS/eliza@06616b65c0da27ba99a517237ea2bd2bab5b5733:packages/skills/skills/contribute-to-eliza
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@06616b65c0da27ba99a517237ea2bd2bab5b5733:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@06616b65c0da27ba99a517237ea2bd2bab5b5733:packages/skills/skills/contribute-to-eliza"} -->
