### PR TITLE
test(cloud): prove legacy decoder failures propagate

### DIFF
--- a/packages/cloud/api/v1/referrals/apply/route.decoder-failure.test.ts
+++ b/packages/cloud/api/v1/referrals/apply/route.decoder-failure.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Exercises the referral-application JSON decoder with real request bodies.
+ * Mocked auth and services isolate syntax failures from body-stream failures at the route boundary.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const USER_ID = "00000000-0000-4000-8000-0000000000aa";
+const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
+
+const requireUserOrApiKeyWithOrg =
+  mock<
+    (context: unknown) => Promise<{ id: string; organization_id: string }>
+  >();
+const applyReferralCode = mock<() => Promise<never>>();
+const failureResponse = mock(
+  (c: { json: (body: unknown, status: number) => unknown }) =>
+    c.json({ success: false, error: "An unexpected error occurred" }, 500),
+);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/services/referrals", () => ({
+  referralsService: { applyReferralCode },
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({ failureResponse }));
+mock.module("@/lib/utils/cors", () => ({ getCorsHeaders: () => ({}) }));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+const { default: app } = await import("./route");
+
+describe("POST /api/v1/referrals/apply decoder failures", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    applyReferralCode.mockClear();
+    failureResponse.mockClear();
+    requireUserOrApiKeyWithOrg.mockImplementation(async () => ({
+      id: USER_ID,
+      organization_id: ORG_ID,
+    }));
+    applyReferralCode.mockImplementation(async () => {
+      throw new Error("applyReferralCode must not run");
+    });
+  });
+
+  test("propagates a non-syntax body-read failure to the 500 boundary", async () => {
+    const request = new Request("http://test.local/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer eliza_test_key",
+      },
+      body: "{}",
+    });
+    Object.defineProperty(request, "text", {
+      value: () => Promise.reject(new TypeError("terminated")),
+    });
+
+    const response = await app.fetch(request);
+
+    expect(response.status).toBe(500);
+    expect(failureResponse).toHaveBeenCalledTimes(1);
+    expect(applyReferralCode).not.toHaveBeenCalled();
+  });
+
+  test("keeps malformed JSON at the caller-facing 400 boundary", async () => {
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer eliza_test_key",
+        },
+        body: "{",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+    });
+    expect(failureResponse).not.toHaveBeenCalled();
+    expect(applyReferralCode).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Relates to #21758. Follow-up evidence repair for merged #21850.

## Summary

- adds a route-level regression on a genuinely migrated legacy broad-catch route;
- proves malformed JSON remains the existing caller-facing 400;
- proves a non-`SyntaxError` body-stream failure reaches the existing 500 boundary without calling the referral service; and
- changes no production code.

The regression was preserved from closed, independently authored companion #21857 after #21850 won the implementation race. #21850's cited domains/buy regression is useful behavior coverage but is not mutation-sensitive to #21850: reversing that route hunk still leaves it green because the parent route already propagated non-syntax errors. This corrective test fails against the pre-#21850 referrals route (`expected 500, received 400`) and passes against the merged helper migration.

## Exact-head evidence

<!-- evidence-head:bb7ff193161924fe805fe2a9b36b2b009e56ed01 -->

- referral decoder/body suites: 12/12 pass, 42 assertions;
- mutation against the pre-#21850 broad catch: expected failure (`500` expected, `400` received);
- Cloud API `tsc --noEmit`: pass;
- Wrangler production Worker dry bundle: pass (24,133.72 KiB; gzip 5,720.40 KiB);
- changed-file Biome and `git diff --check`: pass;
- screenshots/video/live provider evidence: N/A — deterministic server request-boundary test only.

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex desktop
- Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported
— [/root/issue_20153]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->
