### PR TITLE
fix(shared): make diagnostic formatting failure-safe

### DIFF
--- a/packages/shared/src/diagnostic-error.test.ts
+++ b/packages/shared/src/diagnostic-error.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Exercises both shared diagnostic entry points with ordinary, serialized,
+ * cross-realm-like, and deliberately hostile unknown values.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  formatUncaughtError,
+  shouldIgnoreUnhandledRejection,
+} from "./error-classification.ts";
+import { formatErrorWithStack } from "./format-error.ts";
+
+const formatters = [formatErrorWithStack, formatUncaughtError] as const;
+
+describe.each(formatters)("safe diagnostic formatter", (formatDiagnostic) => {
+  it("prefers a nonblank stack, then a message", () => {
+    expect(formatDiagnostic({ stack: "stack trace", message: "message" })).toBe(
+      "stack trace",
+    );
+    expect(formatDiagnostic({ stack: "   ", message: "message" })).toBe(
+      "message",
+    );
+  });
+
+  it("preserves primitive and nullish diagnostics", () => {
+    expect(formatDiagnostic("failure")).toBe("failure");
+    expect(formatDiagnostic(null)).toBe("null");
+    expect(formatDiagnostic(undefined)).toBe("undefined");
+  });
+
+  it("does not throw for poisoned getters, proxies, or coercion", () => {
+    const poisonedGetter = {
+      get stack(): string {
+        throw new Error("poisoned stack getter");
+      },
+      message: "preserved message",
+    };
+    const hostileProxy = new Proxy(
+      {},
+      {
+        get(): never {
+          throw new Error("poisoned proxy");
+        },
+      },
+    );
+    const poisonedCoercion = {
+      [Symbol.toPrimitive](): never {
+        throw new Error("poisoned coercion");
+      },
+      toString(): never {
+        throw new Error("poisoned toString");
+      },
+    };
+
+    expect(formatDiagnostic(poisonedGetter)).toBe("preserved message");
+    expect(formatDiagnostic(hostileProxy)).toBe("[unstringifiable error]");
+    expect(formatDiagnostic(poisonedCoercion)).toBe("[object Object]");
+    expect(formatDiagnostic(Object.create(null))).toBe("[object Object]");
+  });
+});
+
+describe("shouldIgnoreUnhandledRejection", () => {
+  it("classifies serialized provider-credit errors through safe properties", () => {
+    expect(
+      shouldIgnoreUnhandledRejection({
+        message: "AI_APICallError",
+        statusCode: 402,
+      }),
+    ).toBe(true);
+    expect(
+      shouldIgnoreUnhandledRejection({
+        message: "wrapper",
+        cause: { message: "AI_RetryError: insufficient credits" },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not throw while traversing a hostile rejection", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        get(): never {
+          throw new Error("poisoned rejection");
+        },
+      },
+    );
+    expect(shouldIgnoreUnhandledRejection(hostile)).toBe(false);
+  });
+});

--- a/packages/shared/src/error-classification.ts
+++ b/packages/shared/src/error-classification.ts
@@ -6,11 +6,13 @@
  * Intentionally dependency-free — only string/object inspection.
  */
 
+import {
+  formatDiagnosticError,
+  readDiagnosticProperty,
+} from "./utils/safe-diagnostic-error.js";
+
 export function formatUncaughtError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.stack ?? error.message;
-  }
-  return String(error);
+  return formatDiagnosticError(error);
 }
 
 function hasInsufficientCreditsSignal(input: string): boolean {
@@ -42,14 +44,10 @@ export function shouldIgnoreUnhandledRejection(reason: unknown): boolean {
     if (isProviderError) {
       if (hasInsufficientCreditsSignal(formatted)) return true;
 
-      const statusCode = isObject
-        ? (current as { statusCode?: number }).statusCode
-        : undefined;
+      const statusCode = readDiagnosticProperty(current, "statusCode");
       if (statusCode === 402) return true;
 
-      const responseBody = isObject
-        ? (current as { responseBody?: unknown }).responseBody
-        : undefined;
+      const responseBody = readDiagnosticProperty(current, "responseBody");
       if (
         typeof responseBody === "string" &&
         hasInsufficientCreditsSignal(responseBody)
@@ -60,12 +58,12 @@ export function shouldIgnoreUnhandledRejection(reason: unknown): boolean {
 
     if (!isObject) continue;
 
-    const errors = (current as { errors?: unknown }).errors;
+    const errors = readDiagnosticProperty(current, "errors");
     if (Array.isArray(errors)) {
       pending.push(...errors);
     }
 
-    pending.push((current as { cause?: unknown }).cause);
+    pending.push(readDiagnosticProperty(current, "cause"));
   }
 
   return false;

--- a/packages/shared/src/format-error.ts
+++ b/packages/shared/src/format-error.ts
@@ -11,8 +11,10 @@
  * logs, plugin crash diagnostics).
  */
 
+import { formatDiagnosticError } from "./utils/safe-diagnostic-error.js";
+
 export { formatError } from "@elizaos/core/client-public";
 
 export function formatErrorWithStack(err: unknown): string {
-  return err instanceof Error ? (err.stack ?? err.message) : String(err);
+  return formatDiagnosticError(err);
 }

--- a/packages/shared/src/utils/safe-diagnostic-error.ts
+++ b/packages/shared/src/utils/safe-diagnostic-error.ts
@@ -1,0 +1,55 @@
+/**
+ * Formats unknown diagnostic values without invoking an untrusted getter,
+ * proxy trap, or coercion path that can mask the original runtime failure.
+ */
+
+function isPropertyContainer(
+  value: unknown,
+): value is Record<PropertyKey, unknown> | ((...args: never[]) => unknown) {
+  return (
+    value !== null && (typeof value === "object" || typeof value === "function")
+  );
+}
+
+export function readDiagnosticProperty(
+  value: unknown,
+  property: PropertyKey,
+): unknown {
+  if (!isPropertyContainer(value)) return undefined;
+  try {
+    return Reflect.get(value, property);
+  } catch {
+    // error-policy:J7 diagnostic inspection must not mask the original failure
+    return undefined;
+  }
+}
+
+function readNonBlankString(
+  value: unknown,
+  property: PropertyKey,
+): string | null {
+  const candidate = readDiagnosticProperty(value, property);
+  return typeof candidate === "string" && candidate.trim() ? candidate : null;
+}
+
+function safeString(value: unknown): string {
+  try {
+    return String(value);
+  } catch {
+    // error-policy:J7 diagnostic coercion must not mask the original failure
+    try {
+      return Object.prototype.toString.call(value);
+    } catch {
+      // error-policy:J7 hostile type-tag access still needs printable output
+      return "[unstringifiable error]";
+    }
+  }
+}
+
+export function formatDiagnosticError(value: unknown): string {
+  return (
+    readNonBlankString(value, "stack") ??
+    readNonBlankString(value, "message") ??
+    safeString(value)
+  );
+}


### PR DESCRIPTION
## Summary

- consolidates serialized error stack/message extraction behind one dependency-free helper
- prevents getters, proxies, Symbol.toPrimitive, null-prototype objects, and hostile type tags from masking the original failure
- safely traverses statusCode, responseBody, errors, and cause in unhandled-rejection classification
- supersedes closed #21889 and #21923; continues #21886 and #21922

Original contribution direction credited to Deepanshu Yadav in the commit trailer.

## Exact-head evidence

Head: 8ddc463a14210b8ff62e51dded87e25430b584d6
Base: 69bb5ba41fbb43fcd3f2946a9fd26637387d3c8c

- bun test packages/shared/src/diagnostic-error.test.ts packages/core/src/utils/format-error.test.ts: 17 passed, 0 failed
- bun run --cwd packages/shared typecheck: passed
- Biome on all four touched files: passed
- git diff --check: passed
- adversarial cases include throwing stack getter, throwing Proxy get trap, poisoned Symbol.toPrimitive/toString, null-prototype input, nested serialized cause, and hostile rejection traversal

## Evidence applicability

- UI screenshots/video: N/A - diagnostic string boundary only
- frontend/backend live logs: N/A - deterministic failure-path formatting; exact returned artifacts asserted
- model trajectory: N/A - no model/prompt behavior
- domain artifact: formatted diagnostics and classification booleans asserted at both shared entry points

## Contribution provenance

- AI assistance: yes
- Model(s) used: OpenAI/gpt-5.6-sol
- Agent tooling: Codex Desktop
- Skill path: elizaOS/eliza@69bb5ba41fbb43fcd3f2946a9fd26637387d3c8c:packages/skills/skills/contribute-to-eliza
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@69bb5ba41fbb43fcd3f2946a9fd26637387d3c8c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@69bb5ba41fbb43fcd3f2946a9fd26637387d3c8c:packages/skills/skills/contribute-to-eliza"} -->
