### PR TITLE
fix(core): scope worldId's || fallback to ?? without breaking roomId/entityId readability

### DIFF
--- a/packages/core/src/features/documents/__tests__/documents-empty-scope-nullish-coalescing.test.ts
+++ b/packages/core/src/features/documents/__tests__/documents-empty-scope-nullish-coalescing.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Regression coverage for the worldId `|| agentId` → `?? agentId` hardening
+ * across docs-loader.ts, document-processor.ts, and service.ts.
+ *
+ * `||` collapses an explicit empty-string worldId (a real sentinel used
+ * elsewhere in this codebase, e.g. `clientDocumentId: "" as UUID`) into the
+ * agent's own id, silently widening a document's tenant scope. `??` only
+ * falls back when the caller omitted the value (`undefined`).
+ *
+ * roomId and entityId deliberately keep `||`: every persisted document must
+ * satisfy `readDocumentMutationSnapshot`'s `isUuid(roomId)` / `isUuid(entityId)`
+ * gate (`database/document-list-query.ts`) to stay listable/mutable/visible at
+ * all, and "" is never a valid UUID. Switching those two to `??` was verified
+ * against a real `DocumentService.addDocument` call below: it makes
+ * `addDocument` itself throw `DOCUMENT_INGESTION_IN_PROGRESS` (the freshly
+ * written document fails its own post-write readability check), which is
+ * worse than the tenant-scope concern it would have "fixed". worldId carries
+ * no such gate, so preserving "" there is safe.
+ *
+ * These tests drive real persistence through `DocumentService.addDocument`
+ * (both the auto-fragmentation and pre-chunked-fragments paths) and the real
+ * `addDocumentFromFilePath` call boundary.
+ */
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../../runtime";
+import type { Character, Memory, UUID } from "../../../types";
+import { addDocumentFromFilePath } from "../docs-loader";
+import { DocumentService } from "../service";
+import type { AddDocumentOptions } from "../types";
+
+const AGENT_ID = "00000000-0000-0000-0000-00000000f00d" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-00000000d00d" as UUID;
+const ENTITY_ID = "00000000-0000-0000-0000-00000000c0de" as UUID;
+const EMPTY = "" as UUID;
+
+async function makeHarness(): Promise<{
+	runtime: AgentRuntime;
+	service: DocumentService;
+}> {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.initialize();
+	const runtime = new AgentRuntime({
+		agentId: AGENT_ID,
+		character: {
+			name: "DocumentScopeIntegrationAgent",
+			bio: "Exercises document/fragment scope-id fallback semantics.",
+			settings: {},
+		} as Character,
+		adapter,
+		logLevel: "fatal",
+	});
+	return { runtime, service: new DocumentService(runtime) };
+}
+
+async function fragmentsFor(
+	runtime: AgentRuntime,
+	documentId: UUID,
+): Promise<Memory[]> {
+	const fragments = await runtime.getMemories({
+		tableName: "document_fragments",
+		agentId: AGENT_ID,
+		count: 50,
+	});
+	return fragments.filter(
+		(fragment) =>
+			(fragment.metadata as { documentId?: string } | undefined)?.documentId ===
+			documentId,
+	);
+}
+
+describe("document worldId preserves an explicit empty-string sentinel", () => {
+	it("auto-fragmentation path: addDocument keeps worldId as '' end to end", async () => {
+		const { runtime, service } = await makeHarness();
+
+		const { storedDocumentMemoryId } = await service.addDocument({
+			agentId: AGENT_ID,
+			worldId: EMPTY,
+			roomId: ROOM_ID,
+			entityId: ENTITY_ID,
+			clientDocumentId: EMPTY,
+			contentType: "text/plain",
+			originalFilename: "scope-sentinel.txt",
+			content: "Empty-string worldId sentinel must survive persistence.",
+			addedBy: AGENT_ID,
+			addedByRole: "RUNTIME",
+			addedFrom: "runtime-internal",
+		} satisfies AddDocumentOptions);
+
+		const fragments = await fragmentsFor(runtime, storedDocumentMemoryId);
+		expect(fragments.length).toBeGreaterThan(0);
+		for (const fragment of fragments) {
+			expect(fragment.worldId).toBe("");
+		}
+	});
+
+	it("pre-chunked-fragments path: addDocument keeps worldId as '' end to end", async () => {
+		const { runtime, service } = await makeHarness();
+
+		const { storedDocumentMemoryId } = await service.addDocument({
+			agentId: AGENT_ID,
+			worldId: EMPTY,
+			roomId: ROOM_ID,
+			entityId: ENTITY_ID,
+			clientDocumentId: EMPTY,
+			contentType: "text/plain",
+			originalFilename: "scope-sentinel-prechunked.txt",
+			content: "unused when fragments are pre-chunked",
+			addedBy: AGENT_ID,
+			addedByRole: "RUNTIME",
+			addedFrom: "runtime-internal",
+			fragments: [
+				{
+					text: "First pre-chunked fragment body.",
+					metadata: { startMs: 0, endMs: 100, segmentIds: ["seg-1"] },
+				},
+				{
+					text: "Second pre-chunked fragment body.",
+					metadata: { startMs: 100, endMs: 200, segmentIds: ["seg-2"] },
+				},
+			],
+		} satisfies AddDocumentOptions);
+
+		const fragments = await fragmentsFor(runtime, storedDocumentMemoryId);
+		expect(fragments).toHaveLength(2);
+		for (const fragment of fragments) {
+			expect(fragment.worldId).toBe("");
+		}
+	});
+
+	it("an explicit empty roomId is coerced to agentId, keeping the document readable", async () => {
+		const { runtime, service } = await makeHarness();
+
+		const { storedDocumentMemoryId } = await service.addDocument({
+			agentId: AGENT_ID,
+			worldId: AGENT_ID,
+			roomId: EMPTY,
+			entityId: ENTITY_ID,
+			clientDocumentId: EMPTY,
+			contentType: "text/plain",
+			originalFilename: "empty-room-coerced.txt",
+			content: "roomId '' must still resolve to a valid, readable document",
+			addedBy: AGENT_ID,
+			addedByRole: "RUNTIME",
+			addedFrom: "runtime-internal",
+		} satisfies AddDocumentOptions);
+
+		const persisted = await runtime.getMemoryById(storedDocumentMemoryId);
+		expect(persisted?.roomId).toBe(AGENT_ID);
+	});
+
+	it("addDocumentFromFilePath forwards an explicit worldId '' unchanged, but still normalizes roomId/entityId", async () => {
+		const calls: AddDocumentOptions[] = [];
+		const stubService = {
+			reportError: () => undefined,
+			addDocument: async (options: AddDocumentOptions) => {
+				calls.push(options);
+				return {
+					clientDocumentId: options.clientDocumentId,
+					storedDocumentMemoryId: "doc-1" as UUID,
+					fragmentCount: 1,
+				};
+			},
+		};
+
+		const fs = await import("node:fs");
+		const os = await import("node:os");
+		const path = await import("node:path");
+		const filePath = path.join(
+			fs.mkdtempSync(path.join(os.tmpdir(), "eliza-docs-loader-")),
+			"scope-sentinel.txt",
+		);
+		fs.writeFileSync(filePath, "fixture body");
+
+		try {
+			await addDocumentFromFilePath({
+				service: stubService,
+				agentId: AGENT_ID,
+				worldId: EMPTY,
+				roomId: EMPTY,
+				entityId: EMPTY,
+				filePath,
+			});
+			await addDocumentFromFilePath({
+				service: stubService,
+				agentId: AGENT_ID,
+				filePath,
+			});
+		} finally {
+			fs.rmSync(filePath, { force: true });
+		}
+
+		expect(calls).toHaveLength(2);
+		expect(calls[0]).toMatchObject({
+			worldId: "",
+			roomId: AGENT_ID,
+			entityId: AGENT_ID,
+		});
+		expect(calls[1]).toMatchObject({
+			worldId: AGENT_ID,
+			roomId: AGENT_ID,
+			entityId: AGENT_ID,
+		});
+	});
+});

--- a/packages/core/src/features/documents/docs-loader.ts
+++ b/packages/core/src/features/documents/docs-loader.ts
@@ -201,7 +201,14 @@ export async function addDocumentFromFilePath({
 		clientDocumentId: "" as UUID,
 		contentType,
 		originalFilename: fileName,
-		worldId: worldId || agentId,
+		// worldId has no downstream UUID-format requirement, so an explicit ""
+		// is a meaningful scope value and only an omitted worldId should default
+		// to agentId. roomId/entityId cannot make the same distinction: every
+		// persisted document must satisfy readDocumentMutationSnapshot's
+		// isUuid(roomId)/isUuid(entityId) gate (database/document-list-query.ts)
+		// or the write is immediately unreadable, so "" is coerced like a
+		// missing value here too.
+		worldId: worldId ?? agentId,
 		content,
 		roomId: roomId || agentId,
 		entityId: entityId || agentId,

--- a/packages/core/src/features/documents/document-processor.ts
+++ b/packages/core/src/features/documents/document-processor.ts
@@ -230,9 +230,12 @@ export async function processFragmentsSynchronously({
 		fullDocumentText,
 		contentType,
 		agentId,
+		// roomId/entityId must satisfy readDocumentMutationSnapshot's isUuid gate
+		// (database/document-list-query.ts) to stay readable, so "" is coerced
+		// like a missing value; worldId has no such gate and keeps "" verbatim.
 		roomId: roomId || agentId,
 		entityId: entityId || agentId,
-		worldId: worldId || agentId,
+		worldId: worldId ?? agentId,
 		concurrencyLimit: CONCURRENCY_LIMIT,
 		rateLimiter,
 		documentTitle,
@@ -607,7 +610,7 @@ async function processAndSaveFragments({
 					id: uuidv4() as UUID,
 					agentId,
 					roomId: roomId || agentId,
-					worldId: worldId || agentId,
+					worldId: worldId ?? agentId,
 					entityId: entityId || agentId,
 					embedding,
 					content: { text: contextualizedChunkText },

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -1173,6 +1173,9 @@ export class DocumentService extends Service {
 				...documentMemory,
 				id: clientDocumentId,
 				agentId: agentId,
+				// roomId must satisfy readDocumentMutationSnapshot's isUuid gate
+				// (database/document-list-query.ts) to stay readable, so "" is
+				// coerced like a missing value.
 				roomId: roomId || agentId,
 				entityId: targetEntityId,
 			};
@@ -1227,9 +1230,12 @@ export class DocumentService extends Service {
 						documentId: clientDocumentId,
 						fragments,
 						agentId,
+						// roomId must satisfy readDocumentMutationSnapshot's isUuid gate
+						// (database/document-list-query.ts) to stay readable, so "" is
+						// coerced like a missing value; worldId has no such gate.
 						roomId: roomId || agentId,
 						entityId: targetEntityId,
-						worldId: worldId || agentId,
+						worldId: worldId ?? agentId,
 						documentTitle: originalFilename,
 						documentMetadata:
 							(documentMemory.metadata as Record<string, unknown>) ?? undefined,
@@ -1251,7 +1257,7 @@ export class DocumentService extends Service {
 						contentType,
 						roomId: roomId || agentId,
 						entityId: targetEntityId,
-						worldId: worldId || agentId,
+						worldId: worldId ?? agentId,
 						documentTitle: originalFilename,
 						documentMetadata:
 							(documentMemory.metadata as Record<string, unknown>) ?? undefined,


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Reworks the scope raised (and closed) in #21160. That PR blanket-swapped all
14 `worldId/roomId/entityId || agentId` sites in the documents feature to
`??`. It was closed with: "The `||` to `??` hardening is defensible, but
merging it without an executable behavioral contract would leave fourteen
scope sites protected only by text matching."

Building that real contract surfaced something the original PR (and my own
first pass) missed: a blanket swap is not actually safe for `roomId`/`entityId`
— see below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@284be6b7efc8dbea87f778723137e588b0313e17:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Narrower than the closed #21160: only `worldId` fallback semantics
change (5 call sites). `roomId`/`entityId` behavior is byte-for-byte
unchanged from current `develop` (still `|| agentId`), so no existing caller
of `addDocument`/`addDocumentFromFilePath`/`processFragmentsSynchronously`/
`preparePreChunkedFragmentMemories` sees a behavior change there.

# Background

## What does this PR do?

Fixes the same bug #21160 targeted — an explicit empty-string `worldId`
(a real sentinel already used in this codebase, e.g. `clientDocumentId: ""
as UUID`) was silently collapsed into `agentId` by `worldId || agentId`,
because `||` treats `""` the same as `undefined`/`null`. Switched to `??`
across all 5 `worldId` fallback sites in `docs-loader.ts`,
`document-processor.ts`, and `service.ts` so only a truly omitted `worldId`
defaults to `agentId`.

**Did not** apply the same change to `roomId`/`entityId` (6 + 3 = 9 sites),
even though the original PR did and this repo's own reviewer called that
"defensible." Investigating what "defensible" actually meant in practice
turned up a real problem: `readDocumentMutationSnapshot`
(`packages/core/src/database/document-list-query.ts:172-178`) requires
`isUuid(memory.roomId)` and `isUuid(memory.entityId)` — `""` is never a valid
UUID — as the gate for whether a document is listable, mutable, or visible
at all. I verified this against a real `DocumentService.addDocument()` call:
switching `roomId`/`entityId` to `??` and passing an explicit `""` makes
`addDocument` throw `DOCUMENT_INGESTION_IN_PROGRESS` on its own post-write
readability check, because the write it just made can no longer be read back
through that gate. `worldId` isn't part of that gate, so it doesn't have this
problem. Left `roomId`/`entityId` on `||` with a comment at each site
explaining why, so the next person doesn't repeat this exact mistake.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/features/documents/__tests__/documents-empty-scope-nullish-coalescing.test.ts`

## Detailed testing steps

None: Automated tests are acceptable. All four tests drive real persistence
through `DocumentService.addDocument` (both the auto-fragmentation and
pre-chunked-fragments paths) and the real `addDocumentFromFilePath` call
boundary — no test reads or matches implementation source text.

- `bun run --cwd packages/core test -- src/features/documents/__tests__/documents-empty-scope-nullish-coalescing.test.ts`
- Full documents suite (248 tests, no regressions): `bun run --cwd packages/core test -- src/features/documents`
- `bun run --cwd packages/core typecheck`
- `bunx biome check packages/core/src/features/documents/...`

I also confirmed these tests are load-bearing, not tautological: reverting
just the implementation (`git stash` on the 3 source files, keeping the
tests) makes 3 of the 4 tests fail against the original `||` code, and
re-applying a *naive* blanket `roomId`/`entityId` `??` swap makes
`addDocument` throw `DOCUMENT_INGESTION_IN_PROGRESS` — that failure mode is
exactly what test 3 guards against.

# Evidence Gate

<!-- evidence-head:82552798983c8490d180d9c3704030867910507c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change (packages/core), no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change (packages/core), no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change, no user-facing flow to walk through
<!-- evidence-row:backend-logs -->
- [x] Real Vitest run through the actual
      `DocumentService`/`AgentRuntime`/`InMemoryDatabaseAdapter` path.

<details>
<summary>Backend logs — real Vitest run, plus the full documents suite (no regressions)</summary>

```
$ bun run --cwd packages/core test -- src/features/documents/__tests__/documents-empty-scope-nullish-coalescing.test.ts --reporter=verbose

 ✓ document worldId preserves an explicit empty-string sentinel > auto-fragmentation path: addDocument keeps worldId as '' end to end 5ms
 ✓ document worldId preserves an explicit empty-string sentinel > pre-chunked-fragments path: addDocument keeps worldId as '' end to end 6ms
 ✓ document worldId preserves an explicit empty-string sentinel > an explicit empty roomId is coerced to agentId, keeping the document readable 1ms
 ✓ document worldId preserves an explicit empty-string sentinel > addDocumentFromFilePath forwards an explicit worldId '' unchanged, but still normalizes roomId/entityId 1ms

 Test Files  1 passed (1)
      Tests  4 passed (4)

$ bun run --cwd packages/core test -- src/features/documents

 Test Files  17 passed (17)
      Tests  248 passed (248)

$ bun run --cwd packages/core typecheck
(no output — clean)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] Actual persisted `document_fragments` row from a real
      `addDocument({worldId: "", roomId: <real-uuid>, entityId: <real-uuid>})`
      call, read back through `runtime.getMemories` — `worldId` preserved as
      `""` end to end.

<details>
<summary>Persisted fragment memory (domain artifact, worldId preserved as "")</summary>

```json
{
  "id": "8535dd7c-da7c-42fc-b8d6-df3e74da2bef",
  "agentId": "00000000-0000-0000-0000-00000000f00d",
  "roomId": "00000000-0000-0000-0000-00000000d00d",
  "entityId": "00000000-0000-0000-0000-00000000c0de",
  "worldId": "",
  "content": { "text": "Artifact capture for PR evidence." },
  "metadata": {
    "type": "fragment",
    "documentId": "a2c921fa-07aa-5bee-894a-7f16f49d9be3",
    "scope": "user-private",
    "scopedToEntityId": "00000000-0000-0000-0000-00000000c0de",
    "ingestionState": "pending",
    "position": 0,
    "documentTitle": "artifact-capture.txt"
  },
  "unique": true
}
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

I also confirmed the new tests are load-bearing, not tautological: reverting
just the implementation (`git stash` on the 3 source files, keeping the
tests) makes 3 of the 4 tests fail against the original `||` code, and
re-applying a *naive* blanket `roomId`/`entityId` `??` swap makes
`addDocument` throw `DOCUMENT_INGESTION_IN_PROGRESS` — that failure mode is
exactly what the third test guards against.

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@284be6b7efc8dbea87f778723137e588b0313e17:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-manual]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@284be6b7efc8dbea87f778723137e588b0313e17:packages/skills/skills/contribute-to-eliza"} -->
