### PR TITLE
fix(ui): bound consumer-key list transport

### DIFF
--- a/packages/ui/src/api/client-agent-consumer-keys-native.test.ts
+++ b/packages/ui/src/api/client-agent-consumer-keys-native.test.ts
@@ -4,11 +4,11 @@
  * Create / update / rotate hops stay untouched.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ElizaClient } from "./client-base";
 import { CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS } from "./client-agent-consumer-keys";
+import { ElizaClient } from "./client-base";
 import "./client-agent-consumer-keys";
-import type { AgentRequestTransport } from "./transport";
 import { setBootConfig } from "../config/boot-config";
+import type { AgentRequestTransport } from "./transport";
 
 function makeClient(request: AgentRequestTransport["request"]) {
   const client = new ElizaClient("http://agent.example:2138", "token");
@@ -55,7 +55,7 @@ describe("ElizaClient consumer-keys native-complete deadlines", () => {
     const request = vi.fn<AgentRequestTransport["request"]>(
       async (_url, init, ctx) => {
         const ms = ctx?.timeoutMs ?? 10;
-        await new Promise<never>((_, reject) => {
+        return new Promise<never>((_, reject) => {
           const timer = setTimeout(() => {
             reject(
               Object.assign(new Error(`Request timed out after ${ms}ms`), {

--- a/packages/ui/src/api/client-agent-consumer-keys-native.test.ts
+++ b/packages/ui/src/api/client-agent-consumer-keys-native.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Native-complete bar: real ElizaClient + request transport context.
+ * Proves listConsumerKeys carries timeoutMs into Agent.request.
+ * Create / update / rotate hops stay untouched.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import { CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS } from "./client-agent-consumer-keys";
+import "./client-agent-consumer-keys";
+import type { AgentRequestTransport } from "./transport";
+import { setBootConfig } from "../config/boot-config";
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+const list = {
+  keys: [
+    {
+      id: "ck_1",
+      label: "CI runner",
+      enabled: true,
+      dailyTokenQuota: null,
+      keyPrefix: "elizack_ab",
+      createdAt: 1,
+      updatedAt: 2,
+    },
+  ],
+};
+
+describe("ElizaClient consumer-keys native-complete deadlines", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+  });
+
+  it("keeps a documented budget for the list hop", () => {
+    expect(CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("forwards the list deadline to Agent.request", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () =>
+      Response.json(list),
+    );
+    await makeClient(request).listConsumerKeys();
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/accounts/consumer-keys",
+      expect.any(Object),
+      { timeoutMs: CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS },
+    );
+  });
+
+  it("times out a stalled list hop through ElizaClient", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async (_url, init, ctx) => {
+        const ms = ctx?.timeoutMs ?? 10;
+        await new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              Object.assign(new Error(`Request timed out after ${ms}ms`), {
+                name: "TimeoutError",
+              }),
+            );
+          }, ms);
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    await expect(
+      makeClient(request).listConsumerKeys(10),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "timeout",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/accounts/consumer-keys",
+      expect.any(Object),
+      { timeoutMs: 10 },
+    );
+  });
+
+  it("surfaces a provider error from a completed list GET", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () =>
+        new Response(JSON.stringify({ error: "unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(makeClient(request).listConsumerKeys()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+  });
+});

--- a/packages/ui/src/api/client-agent-consumer-keys.ts
+++ b/packages/ui/src/api/client-agent-consumer-keys.ts
@@ -9,6 +9,9 @@
 
 import { ElizaClient } from "./client-base";
 
+/** Consumer-key list GET — existing 10s REST budget, independent hop. */
+export const CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS = 10_000;
+
 export interface ConsumerKeySummary {
   id: string;
   label: string;
@@ -73,7 +76,7 @@ function parseCreated(value: unknown): ConsumerKeyCreated {
 
 declare module "./client-base" {
   interface ElizaClient {
-    listConsumerKeys(): Promise<ConsumerKeySummary[]>;
+    listConsumerKeys(timeoutMs?: number): Promise<ConsumerKeySummary[]>;
     createConsumerKey(body: ConsumerKeyPatch): Promise<ConsumerKeyCreated>;
     updateConsumerKey(
       id: string,
@@ -83,8 +86,15 @@ declare module "./client-base" {
   }
 }
 
-ElizaClient.prototype.listConsumerKeys = async function (this: ElizaClient) {
-  const response = await this.fetch<unknown>("/api/accounts/consumer-keys");
+ElizaClient.prototype.listConsumerKeys = async function (
+  this: ElizaClient,
+  timeoutMs: number = CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS,
+) {
+  const response = await this.fetch<unknown>(
+    "/api/accounts/consumer-keys",
+    undefined,
+    { timeoutMs },
+  );
   if (!isRecord(response) || !Array.isArray(response.keys)) {
     throw new Error("Malformed consumer-key list from agent");
   }


### PR DESCRIPTION
Replaces #22016, whose fork does not allow maintainer edits.

This keeps the original narrow production change: `listConsumerKeys` now forwards a 10-second deadline through `ElizaClient`, so native transports cannot hang indefinitely. It also repairs the original test's deterministic type error by returning the stalled `Promise<never>` and applies the repository import ordering.

Exact-head evidence (`c42a4e29a62e583bcbba4d3e7c3a6dba0228bc83`):

- focused native transport suite: 4/4 passed
- changed-file Biome: passed
- diff check: passed
- `packages/ui` typecheck: no diagnostics in either changed file; the lane remains baseline-red only in unrelated `BuildBadge-timeout.test.ts` and `load-pack-timeout.test.ts` imports on current `develop`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@69bb5ba41fbb43fcd3f2946a9fd26637387d3c8c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- codex-review -->
