### PR TITLE
fix(cloud): keep sandbox secrets off Docker argv

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -47,13 +47,17 @@ import {
   BRIDGE_PORT_MAX,
   BRIDGE_PORT_MIN,
   buildAgentContainerLabelFlags,
+  buildDockerContainerEnvTransport,
+  buildDockerCreateWithSecretEnvCommand,
   buildEnsureNetworkCmd,
   CONTAINER_DURABLE_STATE_DIR,
   dockerPlatformFlag,
   ensureVolumeVaultPassphrase,
   extractDockerCreateContainerId,
   getContainerName,
+  getContainerSecretEnvPath,
   getVolumePath,
+  getVolumeVaultPassphrasePath,
   parseDockerNodes,
   requiresDockerHostGateway,
   resolveAgentContainerClass,
@@ -1037,6 +1041,12 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 1. Input validation
     validateAgentName(agentName);
     validateAgentId(agentId);
+    // Reject env-file record splitting before node allocation, SSH, volume, or
+    // vault setup can mutate remote state. Errors identify only the key.
+    for (const [key, value] of Object.entries(environmentVars)) {
+      validateEnvKey(key);
+      validateEnvValue(key, value);
+    }
     if (
       (config.onReplacementCreated || config.onReplacementVpnRegistered) &&
       !config.onReplacementCreateIntent
@@ -1322,8 +1332,8 @@ export class DockerSandboxProvider implements SandboxProvider {
       // that lifecycle: it seeds the persisted key on first provision and
       // must match it afterwards (fail-closed on mismatch), so a later
       // replacement launched without the override still reads the same key.
-      const vaultPassphrase = await ensureVolumeVaultPassphrase(
-        (cmd, timeoutMs) => ssh.exec(cmd, timeoutMs),
+      await ensureVolumeVaultPassphrase(
+        (cmd, input, timeoutMs) => ssh.execStdin(cmd, input, timeoutMs),
         volumePath,
         DOCKER_CMD_TIMEOUT_MS,
         environmentVars.ELIZA_VAULT_PASSPHRASE,
@@ -1425,14 +1435,6 @@ export class DockerSandboxProvider implements SandboxProvider {
         // provisioned containers (no token + cloud flag = 401).
         AGENT_DISABLE_AUTO_API_TOKEN: "1",
         ELIZA_DISABLE_AUTO_API_TOKEN: "1",
-        // V2 image refuses to boot on headless Linux without a passphrase
-        // (no D-Bus keychain). The key must be STABLE across container
-        // replacement over the same agent volume: the state-dir vault
-        // ciphertext survives on the mount, so a fresh per-launch key would
-        // orphan every stored credential (#18080 / #19225). Always the key
-        // persisted on the agent volume; a caller-injected value only seeds
-        // that key on first provision and must match it afterwards.
-        ELIZA_VAULT_PASSPHRASE: vaultPassphrase,
         // Durable state root on the `${volumePath}/eliza:/root/.eliza` mount.
         // Without it the runtime resolves state (including the vault) to
         // /root/.local/state/eliza in the container's writable layer, which
@@ -1458,6 +1460,11 @@ export class DockerSandboxProvider implements SandboxProvider {
           : {}),
       });
 
+      // The persisted vault value is appended to the stdin-backed env file on
+      // the Docker host; never retain the caller's override in the generic env
+      // map where it could accidentally return to command construction.
+      delete allEnv.ELIZA_VAULT_PASSPHRASE;
+
       // Validate env keys/values before they are interpolated into remote shell commands.
       // Internal env vars must also remain UPPER_SNAKE_CASE so validation stays
       // consistent across caller-supplied and provider-generated values.
@@ -1466,9 +1473,8 @@ export class DockerSandboxProvider implements SandboxProvider {
         validateEnvValue(key, value);
       }
 
-      const envFlags = Object.entries(allEnv)
-        .map(([key, value]) => `-e ${shellQuote(`${key}=${value}`)}`)
-        .join(" ");
+      const envTransport = buildDockerContainerEnvTransport(allEnv);
+      const secretEnvPath = getContainerSecretEnvPath(volumePath, replacementAttemptId);
 
       const dockerCreateCmd = [
         "docker create",
@@ -1522,9 +1528,15 @@ export class DockerSandboxProvider implements SandboxProvider {
         // nginx can reach /api/* via bridge_url and the UI via web_ui_port.
         `-p ${bridgePort}:${allEnv.PORT || DEFAULT_AGENT_PORT}`,
         `-p ${webUiPort}:${allEnv.PORT || DEFAULT_AGENT_PORT}`,
-        envFlags,
+        ...envTransport.commandFlags,
+        `--env-file ${shellQuote(secretEnvPath)}`,
         shellQuote(resolvedImage),
       ].join(" ");
+      const dockerCreateWithSecretEnvCmd = buildDockerCreateWithSecretEnvCommand({
+        dockerCreateCommand: dockerCreateCmd,
+        secretEnvPath,
+        vaultPassphrasePath: getVolumeVaultPassphrasePath(volumePath),
+      });
 
       const persistReplacementIntent = config.onReplacementCreateIntent;
 
@@ -1573,7 +1585,12 @@ export class DockerSandboxProvider implements SandboxProvider {
                 }
               }
             : undefined,
-          createContainer: () => ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),
+          createContainer: () =>
+            ssh.execStdin(
+              dockerCreateWithSecretEnvCmd,
+              envTransport.secretInput,
+              DOCKER_CMD_TIMEOUT_MS,
+            ),
         }),
       );
       createdContainerId = containerId;

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -1,21 +1,26 @@
-// Exercises docker sandbox utils behavior with deterministic cloud-shared lib fixtures.
-// bun:test, not vitest: this package runs unit lanes under bun
-// (scripts/run-bun-tests.mjs); its vitest config includes ONLY the
-// direct-wallet integration test.
+/**
+ * Exercises Docker sandbox utilities with deterministic cloud-shared fixtures.
+ * This is a bun:test lane because the package Vitest config owns only the
+ * direct-wallet integration surface.
+ */
 import { describe, expect, test } from "bun:test";
 import {
   allocatePort,
   buildAgentContainerLabelArgs,
   buildAgentContainerLabelFlags,
+  buildDockerContainerEnvTransport,
+  buildDockerCreateWithSecretEnvCommand,
   CONTAINER_DURABLE_STATE_DIR,
   dockerPlatformFlag,
   ensureVolumeVaultPassphrase,
   extractDockerCreateContainerId,
   getContainerName,
+  getContainerSecretEnvPath,
   getVolumePath,
   getVolumeVaultPassphrasePath,
   inferArchitectureFromHetznerServerType,
   isArchitectureCompatibleWithPlatform,
+  isSecretContainerEnvKey,
   normalizeDockerArchitecture,
   readDockerHostPortFromMetadata,
   requiredArchitectureForPlatform,
@@ -73,6 +78,184 @@ describe("validateEnvKey / validateEnvValue", () => {
   test("values reject control chars (newline-injected payloads)", () => {
     expect(() => validateEnvValue("K", "a normal value")).not.toThrow();
     expect(() => validateEnvValue("K", "line1\nline2")).toThrow(/contains control characters/);
+  });
+});
+
+describe("secret container environment transport (#22060)", () => {
+  test("classifies every current credential family conservatively", () => {
+    for (const key of [
+      "AGENT_SERVER_SHARED_SECRET",
+      "DATABASE_URL",
+      "DISCORD_API_TOKEN",
+      "ELIZAOS_CLOUD_API_KEY",
+      "ELIZA_API_TOKEN",
+      "ELIZA_LOCAL_ROOT_KEY",
+      "ELIZA_VAULT_PASSPHRASE",
+      "JWT_SECRET",
+      "OPENAI_API_KEY",
+      "SANDBOX_REGISTRY_REDIS_TOKEN",
+      "STEWARD_AGENT_TOKEN",
+      "STEWARD_JWT",
+      "STEWARD_REFRESH_SERVICE_TOKEN",
+      "TELEGRAM_BOT_TOKEN",
+      "TS_AUTHKEY",
+    ]) {
+      expect(isSecretContainerEnvKey(key)).toBe(true);
+    }
+    for (const key of [
+      "AGENT_DISABLE_AUTO_API_TOKEN",
+      "ELIZA_ALLOW_WS_QUERY_TOKEN",
+      "ELIZA_DISABLE_AUTO_API_TOKEN",
+      "ELIZA_STATE_DIR",
+      "PORT",
+    ]) {
+      expect(isSecretContainerEnvKey(key)).toBe(false);
+    }
+  });
+
+  test("serializes Docker env-file-safe bytes losslessly and rejects record splitting", () => {
+    const safeValues = {
+      API_KEY: "equals= spaces 'quotes' \\slashes\\ and trailing ",
+      PRIVATE_SETTING: " leading whitespace",
+    };
+    const transport = buildDockerContainerEnvTransport(safeValues);
+    for (const [key, value] of Object.entries(safeValues)) {
+      expect(transport.secretInput).toContain(`${key}=${value}\n`);
+    }
+    for (const invalidValue of ["line\nfeed", "carriage\rreturn", "nul\0byte"]) {
+      expect(() => buildDockerContainerEnvTransport({ API_KEY: invalidValue })).toThrow(
+        /contains control characters/,
+      );
+      try {
+        buildDockerContainerEnvTransport({ API_KEY: invalidValue });
+      } catch (error) {
+        expect(String(error)).not.toContain(invalidValue);
+      }
+    }
+  });
+
+  test("keeps secret keys and values out of the assembled Docker command", () => {
+    const secretValues = {
+      OPENAI_API_KEY: "openai-secret-value",
+      STEWARD_AGENT_TOKEN: "steward-secret-value",
+      DATABASE_URL: "postgres://user:password@example.invalid/db",
+      SANDBOX_REGISTRY_REDIS_TOKEN: "redis-secret-value",
+    };
+    const transport = buildDockerContainerEnvTransport({
+      PORT: "3000",
+      AGENT_DISABLE_AUTO_API_TOKEN: "1",
+      ...secretValues,
+    });
+    const secretEnvPath = getContainerSecretEnvPath(
+      "/data/agents/agent-a",
+      "12345678-1234-1234-1234-123456789abc",
+    );
+    const dockerCreate = [
+      "docker create",
+      ...transport.commandFlags,
+      `--env-file ${shellQuote(secretEnvPath)}`,
+      "image:latest",
+    ].join(" ");
+    const command = buildDockerCreateWithSecretEnvCommand({
+      dockerCreateCommand: dockerCreate,
+      secretEnvPath,
+      vaultPassphrasePath: "/data/agents/agent-a/.vault-passphrase",
+    });
+
+    expect(command).toContain("-e 'PORT=3000'");
+    expect(command).toContain("-e 'AGENT_DISABLE_AUTO_API_TOKEN=1'");
+    expect(command).toContain("--env-file");
+    expect(command).toContain("umask 077");
+    expect(command).toContain("chmod 600");
+    expect(command).toContain("trap");
+    expect(command).not.toContain("ELIZA_VAULT_PASSPHRASE");
+    for (const [key, value] of Object.entries(secretValues)) {
+      expect(command).not.toContain(key);
+      expect(command).not.toContain(value);
+      expect(transport.secretInput).toContain(`${key}=${value}`);
+    }
+  });
+
+  test("removes the restrictive env file after Docker success and failure", async () => {
+    const { spawn } = await import("node:child_process");
+    const fs = await import("node:fs");
+    const os = await import("node:os");
+    const path = await import("node:path");
+    const volume = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-secret-env-"));
+    const vaultPath = getVolumeVaultPassphrasePath(volume);
+    fs.writeFileSync(vaultPath, "persisted-vault-value", { mode: 0o600 });
+
+    for (const dockerCreateCommand of ["true", "false"]) {
+      const secretEnvPath = `${volume}/container.env`;
+      const command = buildDockerCreateWithSecretEnvCommand({
+        dockerCreateCommand,
+        secretEnvPath,
+        vaultPassphrasePath: vaultPath,
+      });
+      const secretInput = buildDockerContainerEnvTransport({ API_KEY: "stdin-only" }).secretInput;
+      await new Promise<void>((resolve) => {
+        const child = spawn("/bin/sh", ["-c", command]);
+        child.on("close", () => resolve());
+        child.stdin.end(secretInput);
+      });
+      expect(fs.existsSync(secretEnvPath)).toBe(false);
+    }
+    fs.rmSync(volume, { recursive: true, force: true });
+  });
+
+  test("fails closed and cleans up a truncated stdin stream without echoing secrets", async () => {
+    const { spawn } = await import("node:child_process");
+    const fs = await import("node:fs");
+    const os = await import("node:os");
+    const path = await import("node:path");
+    const volume = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-short-stdin-"));
+    const vaultPath = getVolumeVaultPassphrasePath(volume);
+    const secretEnvPath = `${volume}/container.env`;
+    fs.writeFileSync(vaultPath, "persisted-vault-value", { mode: 0o600 });
+    const command = buildDockerCreateWithSecretEnvCommand({
+      dockerCreateCommand: "true",
+      secretEnvPath,
+      vaultPassphrasePath: vaultPath,
+    });
+    const result = await new Promise<{ code: number | null; output: string }>((resolve) => {
+      const child = spawn("/bin/sh", ["-c", command]);
+      let output = "";
+      child.stdout.on("data", (chunk) => (output += chunk.toString()));
+      child.stderr.on("data", (chunk) => (output += chunk.toString()));
+      child.on("close", (code) => resolve({ code, output }));
+      child.stdin.end("API_KEY=must-not-echo\n");
+    });
+    expect(result.code).not.toBe(0);
+    expect(result.output).toBe("");
+    expect(result.output).not.toContain("must-not-echo");
+    expect(fs.existsSync(secretEnvPath)).toBe(false);
+    fs.rmSync(volume, { recursive: true, force: true });
+  });
+
+  test("signal interruption runs the env-file cleanup trap", async () => {
+    const { spawn } = await import("node:child_process");
+    const fs = await import("node:fs");
+    const os = await import("node:os");
+    const path = await import("node:path");
+    const volume = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-signal-cleanup-"));
+    const vaultPath = getVolumeVaultPassphrasePath(volume);
+    const secretEnvPath = `${volume}/container.env`;
+    fs.writeFileSync(vaultPath, "persisted-vault-value", { mode: 0o600 });
+    const command = buildDockerCreateWithSecretEnvCommand({
+      dockerCreateCommand: "sleep 30",
+      secretEnvPath,
+      vaultPassphrasePath: vaultPath,
+    });
+    const child = spawn("/bin/sh", ["-c", command], { detached: true });
+    child.stdin.end(buildDockerContainerEnvTransport({ API_KEY: "stdin-only" }).secretInput);
+    for (let attempt = 0; attempt < 100 && !fs.existsSync(secretEnvPath); attempt++) {
+      await Bun.sleep(10);
+    }
+    expect(fs.existsSync(secretEnvPath)).toBe(true);
+    process.kill(-child.pid!, "SIGTERM");
+    await new Promise<void>((resolve) => child.on("close", () => resolve()));
+    expect(fs.existsSync(secretEnvPath)).toBe(false);
+    fs.rmSync(volume, { recursive: true, force: true });
   });
 });
 
@@ -256,10 +439,20 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
   // Runs the EXACT shell command the provider sends over SSH, against a real
   // local /bin/sh and a real temp "agent volume" directory — the same
   // read-or-create the deployed node executes.
-  const shExec = async (cmd: string, _timeoutMs: number): Promise<string> => {
-    const { execFile } = await import("node:child_process");
+  const shExecStdin = async (cmd: string, input: string, _timeoutMs: number): Promise<string> => {
+    const { spawn } = await import("node:child_process");
     return await new Promise<string>((resolve, reject) => {
-      execFile("/bin/sh", ["-c", cmd], (err, stdout) => (err ? reject(err) : resolve(stdout)));
+      const child = spawn("/bin/sh", ["-c", cmd]);
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => (stdout += chunk.toString()));
+      child.stderr.on("data", (chunk) => (stderr += chunk.toString()));
+      child.on("error", reject);
+      child.on("close", (code) => {
+        if (code === 0) resolve(stdout);
+        else reject(Object.assign(new Error(stderr || `shell exited ${code}`), { code }));
+      });
+      child.stdin.end(input);
     });
   };
 
@@ -270,10 +463,32 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
     return fs.mkdtempSync(path.join(os.tmpdir(), "eliza-agent-volume-"));
   }
 
+  test("SSH setup failure preserves the transport error without exposing the override", async () => {
+    const volume = await makeVolume();
+    const override = "operator-secret-value";
+    let command = "";
+    let input = "";
+    const failedExec = async (cmd: string, stdin: string): Promise<string> => {
+      command = cmd;
+      input = stdin;
+      throw new Error("ssh transport unavailable");
+    };
+    await expect(ensureVolumeVaultPassphrase(failedExec, volume, 5_000, override)).rejects.toThrow(
+      "ssh transport unavailable",
+    );
+    expect(command).not.toContain(override);
+    expect(command).not.toContain("ELIZA_VAULT_PASSPHRASE");
+    expect(input).toBe(override);
+    expect("ssh transport unavailable").not.toContain(override);
+    const fs = await import("node:fs");
+    fs.rmSync(volume, { recursive: true, force: true });
+  });
+
   test("container A creates a 64-hex key file with 0600 on the volume", async () => {
     const fs = await import("node:fs");
     const volume = await makeVolume();
-    const key = await ensureVolumeVaultPassphrase(shExec, volume, 5_000);
+    await ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000);
+    const key = fs.readFileSync(getVolumeVaultPassphrasePath(volume), "utf-8");
     expect(key).toMatch(/^[0-9a-f]{64}$/);
     const keyPath = getVolumeVaultPassphrasePath(volume);
     expect(fs.readFileSync(keyPath, "utf-8")).toBe(key);
@@ -287,8 +502,10 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
     // Two independent provisions (A then its replacement B): each runs the
     // read-or-create against the shared agent volume, nothing is copied from
     // A's environment.
-    const keyA = await ensureVolumeVaultPassphrase(shExec, volume, 5_000);
-    const keyB = await ensureVolumeVaultPassphrase(shExec, volume, 5_000);
+    await ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000);
+    const keyA = fs.readFileSync(getVolumeVaultPassphrasePath(volume), "utf-8");
+    await ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000);
+    const keyB = fs.readFileSync(getVolumeVaultPassphrasePath(volume), "utf-8");
     expect(keyB).toBe(keyA);
     fs.rmSync(volume, { recursive: true, force: true });
   });
@@ -297,8 +514,10 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
     const fs = await import("node:fs");
     const volumeA = await makeVolume();
     const volumeB = await makeVolume();
-    const keyA = await ensureVolumeVaultPassphrase(shExec, volumeA, 5_000);
-    const keyB = await ensureVolumeVaultPassphrase(shExec, volumeB, 5_000);
+    await ensureVolumeVaultPassphrase(shExecStdin, volumeA, 5_000);
+    await ensureVolumeVaultPassphrase(shExecStdin, volumeB, 5_000);
+    const keyA = fs.readFileSync(getVolumeVaultPassphrasePath(volumeA), "utf-8");
+    const keyB = fs.readFileSync(getVolumeVaultPassphrasePath(volumeB), "utf-8");
     expect(keyA).not.toBe(keyB);
     fs.rmSync(volumeA, { recursive: true, force: true });
     fs.rmSync(volumeB, { recursive: true, force: true });
@@ -308,7 +527,8 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
     const fs = await import("node:fs");
     const volume = await makeVolume();
     fs.writeFileSync(getVolumeVaultPassphrasePath(volume), "operator-supplied-passphrase\n");
-    await expect(ensureVolumeVaultPassphrase(shExec, volume, 5_000)).resolves.toBe(
+    await expect(ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000)).resolves.toBeUndefined();
+    expect(fs.readFileSync(getVolumeVaultPassphrasePath(volume), "utf-8")).toBe(
       "operator-supplied-passphrase",
     );
     fs.rmSync(volume, { recursive: true, force: true });
@@ -319,25 +539,24 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
     const volume = await makeVolume();
     // Launch A injects ELIZA_VAULT_PASSPHRASE; the override must seed the
     // persisted key file instead of bypassing the volume lifecycle.
-    const keyA = await ensureVolumeVaultPassphrase(shExec, volume, 5_000, "dummy-operator-key-A");
-    expect(keyA).toBe("dummy-operator-key-A");
+    await ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000, "dummy-operator-key-A");
     const keyPath = getVolumeVaultPassphrasePath(volume);
     expect(fs.readFileSync(keyPath, "utf-8")).toBe("dummy-operator-key-A");
     expect(fs.statSync(keyPath).mode & 0o777).toBe(0o600);
     // Replacement B is launched over the same volume with NO override — the
     // regression: it must read A's key, not mint a fresh local fallback.
-    const keyB = await ensureVolumeVaultPassphrase(shExec, volume, 5_000);
-    expect(keyB).toBe(keyA);
+    await ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000);
+    expect(fs.readFileSync(keyPath, "utf-8")).toBe("dummy-operator-key-A");
     fs.rmSync(volume, { recursive: true, force: true });
   });
 
   test("relaunching with the same override over the seeded volume is idempotent", async () => {
     const fs = await import("node:fs");
     const volume = await makeVolume();
-    await ensureVolumeVaultPassphrase(shExec, volume, 5_000, "dummy-operator-key-A");
+    await ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000, "dummy-operator-key-A");
     await expect(
-      ensureVolumeVaultPassphrase(shExec, volume, 5_000, "dummy-operator-key-A"),
-    ).resolves.toBe("dummy-operator-key-A");
+      ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000, "dummy-operator-key-A"),
+    ).resolves.toBeUndefined();
     fs.rmSync(volume, { recursive: true, force: true });
   });
 
@@ -347,9 +566,10 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
     // The volume already has a durable key (e.g. generated by a prior
     // no-override launch); a different injected override must not silently
     // win OR silently lose — either guess can orphan ciphertext.
-    const persisted = await ensureVolumeVaultPassphrase(shExec, volume, 5_000);
+    await ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000);
+    const persisted = fs.readFileSync(getVolumeVaultPassphrasePath(volume), "utf-8");
     await expect(
-      ensureVolumeVaultPassphrase(shExec, volume, 5_000, "dummy-other-override"),
+      ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000, "dummy-other-override"),
     ).rejects.toThrow(/durable source of truth/);
     // The persisted key survives the refusal untouched.
     expect(fs.readFileSync(getVolumeVaultPassphrasePath(volume), "utf-8")).toBe(persisted);
@@ -359,7 +579,7 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
   test("fails closed on an unusable override BEFORE seeding the key file", async () => {
     const fs = await import("node:fs");
     const volume = await makeVolume();
-    await expect(ensureVolumeVaultPassphrase(shExec, volume, 5_000, "short")).rejects.toThrow(
+    await expect(ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000, "short")).rejects.toThrow(
       /refusing to seed/,
     );
     // Nothing was written — the next launch can still establish a good key.
@@ -370,7 +590,8 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
   test("an empty or whitespace-only override falls through to the volume lifecycle", async () => {
     const fs = await import("node:fs");
     const volume = await makeVolume();
-    const key = await ensureVolumeVaultPassphrase(shExec, volume, 5_000, "  ");
+    await ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000, "  ");
+    const key = fs.readFileSync(getVolumeVaultPassphrasePath(volume), "utf-8");
     expect(key).toMatch(/^[0-9a-f]{64}$/);
     fs.rmSync(volume, { recursive: true, force: true });
   });
@@ -379,7 +600,7 @@ describe("volume-persisted vault passphrase (#18080 / #19225)", () => {
     const fs = await import("node:fs");
     const volume = await makeVolume();
     fs.writeFileSync(getVolumeVaultPassphrasePath(volume), "short\n");
-    await expect(ensureVolumeVaultPassphrase(shExec, volume, 5_000)).rejects.toThrow(
+    await expect(ensureVolumeVaultPassphrase(shExecStdin, volume, 5_000)).rejects.toThrow(
       /refusing to mint a fresh per-launch key/,
     );
     fs.rmSync(volume, { recursive: true, force: true });

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -82,9 +82,11 @@ describe("validateEnvKey / validateEnvValue", () => {
 });
 
 describe("secret container environment transport (#22060)", () => {
-  test("classifies every current credential family conservatively", () => {
+  test("fails unknown and credential-like names closed to stdin", () => {
     for (const key of [
       "AGENT_SERVER_SHARED_SECRET",
+      "AWS_ACCESS_ID",
+      "CUSTOM_CREDENTIALS",
       "DATABASE_URL",
       "DISCORD_API_TOKEN",
       "ELIZAOS_CLOUD_API_KEY",
@@ -106,8 +108,6 @@ describe("secret container environment transport (#22060)", () => {
       "AGENT_DISABLE_AUTO_API_TOKEN",
       "ELIZA_ALLOW_WS_QUERY_TOKEN",
       "ELIZA_DISABLE_AUTO_API_TOKEN",
-      "ELIZA_STATE_DIR",
-      "PORT",
     ]) {
       expect(isSecretContainerEnvKey(key)).toBe(false);
     }
@@ -162,13 +162,14 @@ describe("secret container environment transport (#22060)", () => {
       vaultPassphrasePath: "/data/agents/agent-a/.vault-passphrase",
     });
 
-    expect(command).toContain("-e 'PORT=3000'");
     expect(command).toContain("-e 'AGENT_DISABLE_AUTO_API_TOKEN=1'");
     expect(command).toContain("--env-file");
     expect(command).toContain("umask 077");
     expect(command).toContain("chmod 600");
     expect(command).toContain("trap");
     expect(command).not.toContain("ELIZA_VAULT_PASSPHRASE");
+    expect(command).not.toContain("PORT=3000");
+    expect(transport.secretInput).toContain("PORT=3000");
     for (const [key, value] of Object.entries(secretValues)) {
       expect(command).not.toContain(key);
       expect(command).not.toContain(value);

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
@@ -267,24 +267,20 @@ export function validateEnvValue(key: string, value: string): void {
   }
 }
 
-const NON_SECRET_ENV_KEY_EXCEPTIONS = new Set([
+const PUBLIC_CONTAINER_ENV_KEY_ALLOWLIST = new Set([
   "AGENT_DISABLE_AUTO_API_TOKEN",
   "ELIZA_ALLOW_WS_QUERY_TOKEN",
   "ELIZA_DISABLE_AUTO_API_TOKEN",
 ]);
 
 /**
- * Classify container environment values that must travel over SSH stdin rather
- * than in the remotely logged `docker create` command. URL-shaped values are
- * included because provider and database URLs commonly carry credentials.
+ * Keep only fixed, non-secret feature flags on the Docker command line.
+ * Caller-provided environment keys are arbitrary BYO-secret material, so an
+ * unknown name must fail closed to the stdin-backed env file rather than rely
+ * on a credential-name heuristic.
  */
 export function isSecretContainerEnvKey(key: string): boolean {
-  if (NON_SECRET_ENV_KEY_EXCEPTIONS.has(key)) return false;
-  return (
-    /(?:^|_)(?:AUTH|CERT|COOKIE|CREDENTIAL|JWT|KEY|MNEMONIC|PASS(?:WORD|WD|PHRASE)?|PEM|PRIVATE|SEED|SECRET|SESSION|SIGNING|TOKEN|URI|URL)(?:_|$)/i.test(
-      key,
-    ) || /(?:AUTH|JWT|KEY|PASS(?:WORD|WD|PHRASE)?|SECRET|TOKEN)$/i.test(key)
-  );
+  return !PUBLIC_CONTAINER_ENV_KEY_ALLOWLIST.has(key);
 }
 
 export interface DockerContainerEnvTransport {

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
@@ -267,6 +267,54 @@ export function validateEnvValue(key: string, value: string): void {
   }
 }
 
+const NON_SECRET_ENV_KEY_EXCEPTIONS = new Set([
+  "AGENT_DISABLE_AUTO_API_TOKEN",
+  "ELIZA_ALLOW_WS_QUERY_TOKEN",
+  "ELIZA_DISABLE_AUTO_API_TOKEN",
+]);
+
+/**
+ * Classify container environment values that must travel over SSH stdin rather
+ * than in the remotely logged `docker create` command. URL-shaped values are
+ * included because provider and database URLs commonly carry credentials.
+ */
+export function isSecretContainerEnvKey(key: string): boolean {
+  if (NON_SECRET_ENV_KEY_EXCEPTIONS.has(key)) return false;
+  return (
+    /(?:^|_)(?:AUTH|CERT|COOKIE|CREDENTIAL|JWT|KEY|MNEMONIC|PASS(?:WORD|WD|PHRASE)?|PEM|PRIVATE|SEED|SECRET|SESSION|SIGNING|TOKEN|URI|URL)(?:_|$)/i.test(
+      key,
+    ) || /(?:AUTH|JWT|KEY|PASS(?:WORD|WD|PHRASE)?|SECRET|TOKEN)$/i.test(key)
+  );
+}
+
+export interface DockerContainerEnvTransport {
+  commandFlags: string[];
+  secretInput: string;
+}
+
+const CONTAINER_SECRET_ENV_STDIN_SENTINEL = "ELIZA_SECRET_ENV_STDIN_V1_END";
+
+/** Split validated container env into visible flags and stdin-only entries. */
+export function buildDockerContainerEnvTransport(
+  environment: Readonly<Record<string, string>>,
+): DockerContainerEnvTransport {
+  const commandFlags: string[] = [];
+  const secretLines: string[] = [];
+  for (const [key, value] of Object.entries(environment)) {
+    validateEnvKey(key);
+    validateEnvValue(key, value);
+    if (isSecretContainerEnvKey(key)) {
+      secretLines.push(`${key}=${value}`);
+    } else {
+      commandFlags.push(`-e ${shellQuote(`${key}=${value}`)}`);
+    }
+  }
+  return {
+    commandFlags,
+    secretInput: `${secretLines.length > 0 ? `${secretLines.join("\n")}\n` : ""}ELIZA_VAULT_PASSPHRASE=\n${CONTAINER_SECRET_ENV_STDIN_SENTINEL}\n`,
+  };
+}
+
 /** Docker container names must be simple shell-safe identifiers. */
 export function validateContainerName(containerName: string): void {
   if (hasControlChars(containerName) || !/^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/.test(containerName)) {
@@ -454,32 +502,42 @@ export function getVolumeVaultPassphrasePath(volumePath: string): string {
 }
 
 /**
- * Shell command that reads the per-agent vault master passphrase persisted on
- * the agent's host volume, creating it once (mode 0600 via umask, tmp+rename)
- * when absent — from `seedValue` when the operator injected one, otherwise 64
- * hex chars from /dev/urandom. Replacement container B over the same volume
- * therefore derives the same vault master key container A used — the key is
- * per agent, never derived from agent/org identifiers. A generated key never
- * transits a shell argument; an operator seed does, over the same ssh.exec
- * channel that already carries it inside `docker create -e`.
+ * Shell command that establishes and validates the per-agent vault master
+ * passphrase persisted on the host volume. An optional operator seed arrives
+ * only on stdin; the command emits no passphrase bytes. Replacement containers
+ * therefore derive the same per-volume key without exposing it to the caller.
  */
-export function buildVolumeVaultPassphraseCommand(volumePath: string, seedValue?: string): string {
-  const keyFile = shellQuote(getVolumeVaultPassphrasePath(volumePath));
-  const tmpFile = shellQuote(`${getVolumeVaultPassphrasePath(volumePath)}.tmp`);
-  const writeKey =
-    seedValue !== undefined
-      ? `printf %s ${shellQuote(seedValue)} > ${tmpFile}`
-      : `head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \\n' > ${tmpFile}`;
-  // ponytail: tmp+mv is last-writer-wins on a concurrent FIRST provision;
-  // upstream lifecycle locks serialize per-agent provisioning, and once the
-  // file exists every later provision only reads it.
-  return `test -s ${keyFile} || { umask 077; ${writeKey} && mv ${tmpFile} ${keyFile}; }; cat ${keyFile}`;
+export function buildVolumeVaultPassphraseCommand(volumePath: string): string {
+  const keyPath = getVolumeVaultPassphrasePath(volumePath);
+  const keyFile = shellQuote(keyPath);
+  const overrideFile = `${shellQuote(`${keyPath}.override`)}.$$`;
+  const generatedFile = `${shellQuote(`${keyPath}.generated`)}.$$`;
+  const normalizedFile = `${shellQuote(`${keyPath}.normalized`)}.$$`;
+  return [
+    "set -eu",
+    `override_file=${overrideFile}`,
+    `generated_file=${generatedFile}`,
+    `normalized_file=${normalizedFile}`,
+    'trap \'rm -f "$override_file" "$generated_file" "$normalized_file"\' EXIT',
+    "trap 'exit 1' HUP INT TERM",
+    "umask 077",
+    'cat > "$override_file"',
+    `if test ! -s ${keyFile}; then if test -s "$override_file"; then mv "$override_file" ${keyFile}; else head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \\n' > "$generated_file" && mv "$generated_file" ${keyFile}; fi; fi`,
+    `normalized=$(cat ${keyFile})`,
+    'printf %s "$normalized" > "$normalized_file"',
+    `key_length=$(wc -c < "$normalized_file" | tr -d ' ')`,
+    `nonspace_length=$(tr -d '[:space:]' < "$normalized_file" | wc -c | tr -d ' ')`,
+    'if test "$key_length" -lt 12 || test "$key_length" != "$nonspace_length"; then exit 43; fi',
+    `if ! cmp -s "$normalized_file" ${keyFile}; then mv "$normalized_file" ${keyFile}; fi`,
+    `chmod 600 ${keyFile}`,
+    `if test -s "$override_file" && ! cmp -s "$override_file" ${keyFile}; then exit 42; fi`,
+  ].join("; ");
 }
 
 /**
- * Run {@link buildVolumeVaultPassphraseCommand} through `exec` (the node's
- * shell, e.g. over SSH) and validate the result. Fails closed on a short or
- * empty read — a fresh random per-launch key would silently orphan every
+ * Run {@link buildVolumeVaultPassphraseCommand} through an stdin-capable node
+ * shell and validate the result remotely. Fails closed on a short or empty
+ * key — a fresh random per-launch key would silently orphan every
  * credential already encrypted on the volume.
  *
  * `operatorOverride` (an injected `ELIZA_VAULT_PASSPHRASE`) is not allowed to
@@ -492,11 +550,11 @@ export function buildVolumeVaultPassphraseCommand(volumePath: string, seedValue?
  * the ciphertext.
  */
 export async function ensureVolumeVaultPassphrase(
-  exec: (cmd: string, timeoutMs: number) => Promise<string>,
+  execStdin: (cmd: string, input: string, timeoutMs: number) => Promise<string>,
   volumePath: string,
   timeoutMs: number,
   operatorOverride?: string,
-): Promise<string> {
+): Promise<void> {
   // Empty/whitespace-only override means "not set" — same as the historical
   // `environmentVars.ELIZA_VAULT_PASSPHRASE?.trim() ||` fallthrough.
   const override = operatorOverride?.trim() || undefined;
@@ -504,36 +562,86 @@ export async function ensureVolumeVaultPassphrase(
     // Validate BEFORE seeding: persisting an unusable override would brick
     // every subsequent launch on the post-write length check below.
     throw new ElizaError(
-      `[docker-sandbox] injected ELIZA_VAULT_PASSPHRASE is unusable (length ${override.length}); refusing to seed ${getVolumeVaultPassphrasePath(volumePath)} with a key the vault would reject`,
+      `[docker-sandbox] injected vault override is unusable (length ${override.length}); refusing to seed ${getVolumeVaultPassphrasePath(volumePath)} with a key the vault would reject`,
       {
         code: "SANDBOX_VAULT_PASSPHRASE_OVERRIDE_UNUSABLE",
         context: { volumePath, passphraseLength: override.length },
       },
     );
   }
-  const output = await exec(buildVolumeVaultPassphraseCommand(volumePath, override), timeoutMs);
-  const passphrase = output.trim();
-  // 12 chars is the vault's own passphraseMasterKey minimum; generated keys
-  // are 64 hex chars, but an operator-provisioned key file is honored as-is.
-  if (passphrase.length < 12 || /\s/.test(passphrase)) {
-    throw new ElizaError(
-      `[docker-sandbox] persisted vault passphrase at ${getVolumeVaultPassphrasePath(volumePath)} is unusable (length ${passphrase.length}); refusing to mint a fresh per-launch key that would orphan the volume's vault ciphertext`,
-      {
-        code: "SANDBOX_VAULT_PASSPHRASE_UNUSABLE",
-        context: { volumePath, passphraseLength: passphrase.length },
-      },
-    );
+  try {
+    await execStdin(buildVolumeVaultPassphraseCommand(volumePath), override ?? "", timeoutMs);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    const exitCode =
+      typeof cause === "object" && cause !== null && "code" in cause
+        ? (cause as { code?: unknown }).code
+        : undefined;
+    if (exitCode === 42 || message.includes("exited with code 42")) {
+      throw new ElizaError(
+        `[docker-sandbox] injected vault override does not match the key persisted at ${getVolumeVaultPassphrasePath(volumePath)}; that file remains the durable source of truth`,
+        {
+          code: "SANDBOX_VAULT_PASSPHRASE_OVERRIDE_MISMATCH",
+          context: { volumePath },
+          cause,
+        },
+      );
+    }
+    if (exitCode === 43 || message.includes("exited with code 43")) {
+      throw new ElizaError(
+        `[docker-sandbox] persisted vault passphrase at ${getVolumeVaultPassphrasePath(volumePath)} is unusable; refusing to mint a fresh per-launch key`,
+        {
+          code: "SANDBOX_VAULT_PASSPHRASE_UNUSABLE",
+          context: { volumePath },
+          cause,
+        },
+      );
+    }
+    throw cause;
   }
-  if (override !== undefined && passphrase !== override) {
-    throw new ElizaError(
-      `[docker-sandbox] injected ELIZA_VAULT_PASSPHRASE does not match the key persisted at ${getVolumeVaultPassphrasePath(volumePath)}; that file is the durable source of truth for the volume's vault ciphertext — remove the override or rotate the key file deliberately`,
-      {
-        code: "SANDBOX_VAULT_PASSPHRASE_OVERRIDE_MISMATCH",
-        context: { volumePath },
-      },
-    );
+}
+
+/** Unique restrictive env file used only for one remote `docker create`. */
+export function getContainerSecretEnvPath(
+  volumePath: string,
+  replacementAttemptId: string,
+): string {
+  if (!/^[a-f0-9-]{36}$/i.test(replacementAttemptId)) {
+    throw new Error("Invalid replacement attempt ID for container secret environment file.");
   }
-  return passphrase;
+  return `${volumePath}/.container-env-${replacementAttemptId}`;
+}
+
+/**
+ * Wrap `docker create` so stdin becomes a 0600 env file, the persisted vault
+ * value is appended without being read by the caller, and every shell exit
+ * removes the file.
+ */
+export function buildDockerCreateWithSecretEnvCommand(options: {
+  dockerCreateCommand: string;
+  secretEnvPath: string;
+  vaultPassphrasePath: string;
+}): string {
+  const envFile = shellQuote(options.secretEnvPath);
+  const envBodyFile = shellQuote(`${options.secretEnvPath}.body`);
+  const vaultFile = shellQuote(options.vaultPassphrasePath);
+  return [
+    "set -eu",
+    `env_file=${envFile}`,
+    `env_body_file=${envBodyFile}`,
+    'trap \'rm -f "$env_file" "$env_body_file"\' EXIT',
+    "trap 'exit 1' HUP INT TERM",
+    "umask 077",
+    'cat > "$env_file"',
+    `test "$(tail -n 1 "$env_file")" = ${shellQuote(CONTAINER_SECRET_ENV_STDIN_SENTINEL)}`,
+    'sed \'$d\' "$env_file" > "$env_body_file"',
+    'mv "$env_body_file" "$env_file"',
+    'truncate -s -1 "$env_file"',
+    `cat ${vaultFile} >> "$env_file"`,
+    "printf '\\n' >> \"$env_file\"",
+    'chmod 600 "$env_file"',
+    options.dockerCreateCommand,
+  ].join("; ");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Relates to

Closes #22060

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated verification blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `develop` at `bfea19e5a7b0`; zero conflicts.
- [x] `bun run verify` was run post-sync. It reached 345/356 successful Turbo tasks, then stopped on unrelated pre-existing `@elizaos/ui` test-export type errors listed below; exact focused and package-owner gates are green.

# Risks

Medium. This changes the production Docker provisioning transport for all cloud agent environment variables. It preserves non-secret `-e` flags, moves credential-like and potentially credential-bearing URL values to a restrictive stdin-fed env file, and preserves durable vault mismatch behavior. The fail-closed classifier can move additional non-secret values to the env file, which is compatible with Docker but intentionally conservative.

# Background

## What does this PR do?

- Splits validated container env into explicit non-secret command flags and stdin-only secret records.
- Seeds and validates the per-volume vault key remotely without returning it on stdout or placing it in an SSH/Docker command.
- Runs `docker create` inside the same stdin-fed shell that creates the mode-0600 env file, with EXIT and signal cleanup on every shell path.
- Detects truncated stdin with a non-secret sentinel before Docker can run.
- Rejects CR, LF, NUL, and other control bytes before node allocation or remote mutation; preserves Docker-safe `=`, spaces, quotes, backslashes, and leading/trailing whitespace.

## What kind of change is this?

Bug fix / security hardening (non-breaking).

# Documentation changes needed?

No user-facing documentation change is needed; this is an internal provisioning transport hardening with executable contract tests.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts`, especially `secret container environment transport (#22060)` and `volume-persisted vault passphrase`.

## Detailed testing steps

At exact head `ec0eb0f0c49666c5ad46ed596319eb7b247aac3e`:

1. `bun install --frozen-lockfile`
2. `bun test packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts` — 41 pass, 0 fail.
3. `bun test packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-provider-lane.test.ts` — 112 pass, 0 fail.
4. `bun run --cwd packages/cloud/shared typecheck` — pass.
5. `bunx biome check` on all three changed files — pass.
6. Real Docker 26.1.5 in disposable Lima VM: `--env-file /dev/stdin` preserved accepted values containing `=`, spaces, single quotes, backslashes, and leading/trailing whitespace byte-for-byte.

# Evidence Gate

<!-- evidence-head:ec0eb0f0c49666c5ad46ed596319eb7b247aac3e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Docker provisioning change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Docker provisioning change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual user flow.
<!-- evidence-row:backend-logs -->
- [x] [22104-22060-backend-evidence.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22104-22060-backend-evidence.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the security invariant requires the temporary env file to be absent after both success and failure; real-shell tests assert that absence.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or UI surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior changed.

## Backend + frontend logs

<details>
<summary>Exact-head backend/security evidence</summary>

```text
Docker sandbox utils: 41 pass, 0 fail, 204 assertions
Docker provider composite lane: 112 pass, 0 fail, 269 assertions
@elizaos/cloud-shared typecheck: pass
Changed-file Biome: pass
Frozen install: pass
Real Docker env-file parser: Docker 26.1.5, accepted-value byte comparison pass
```

The real-shell suite verifies 0600 mode, durable replacement derivation, override mismatch refusal, SSH failure propagation, truncated-stdin refusal with empty stdout/stderr, Docker-create failure cleanup, success cleanup, and signal cleanup.

</details>

Frontend logs: N/A - backend-only.

## Screenshots (before / after) + video walkthrough

N/A - backend-only Docker provisioning change.

## Audio / voice walkthrough

N/A - no audio or voice behavior.

## Known gaps / failures

- The first frozen install attempt encountered a corrupted transient `ffmpeg-static` download; a clean retry at exact head completed successfully.
- Full `bun run verify` reached 345/356 successful Turbo tasks and failed in unchanged `@elizaos/ui` files: `BuildBadge-timeout.test.ts` imports three non-exported symbols from `BuildBadge.tsx`, and `load-pack-timeout.test.ts` imports two non-exported symbols from `load-pack.ts`. This PR changes only cloud sandbox files; its owning typecheck and focused suites pass.
- Real Docker evidence uses non-secret deterministic test values in the disposable Lima VM; production secrets were neither accessed nor emitted.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza"} -->






