### PR TITLE
fix(memory): enforce canonical feed cursors across local hosts

### DIFF
--- a/packages/agent/src/api/memory-feed-cursor.test.ts
+++ b/packages/agent/src/api/memory-feed-cursor.test.ts
@@ -102,52 +102,57 @@ describe("GET /api/memories/feed cursor", () => {
     },
   );
 
-  test.each([["", "empty"], [" ", "whitespace-only"]])(
+  test.each([
+    ["", "empty"],
+    [" ", "whitespace-only"],
+  ])(
     "treats a blank before value (%j) as no cursor, not junk",
     async (rawCursor) => {
-    // `?before=` templates naturally from clients interpolating an unset
-    // variable, and whitespace trims to the same blank. Both previously
-    // mis-coerced (whitespace became an epoch-0 cursor via Number(" ") === 0,
-    // silently emptying the feed); both now mean "no cursor" — unlike
-    // present junk, which 400s.
-    const response: { value?: unknown } = {};
-    const runtime = {
-      agentId: "11111111-1111-4111-8111-111111111111" as UUID,
-      character: { name: "Eliza" },
-      ensureConnection: vi.fn(async () => undefined),
-      getMemories: vi.fn(async () => [
-        {
-          id: "22222222-2222-4222-8222-222222222222" as UUID,
-          entityId: "33333333-3333-4333-8333-333333333333" as UUID,
-          roomId: "44444444-4444-4444-8444-444444444444" as UUID,
-          content: { text: "still visible without a cursor" },
-          createdAt: 1,
+      // `?before=` templates naturally from clients interpolating an unset
+      // variable, and whitespace trims to the same blank. Both previously
+      // mis-coerced (whitespace became an epoch-0 cursor via Number(" ") === 0,
+      // silently emptying the feed); both now mean "no cursor" — unlike
+      // present junk, which 400s.
+      const response: { value?: unknown } = {};
+      const runtime = {
+        agentId: "11111111-1111-4111-8111-111111111111" as UUID,
+        character: { name: "Eliza" },
+        ensureConnection: vi.fn(async () => undefined),
+        getMemories: vi.fn(async () => [
+          {
+            id: "22222222-2222-4222-8222-222222222222" as UUID,
+            entityId: "33333333-3333-4333-8333-333333333333" as UUID,
+            roomId: "44444444-4444-4444-8444-444444444444" as UUID,
+            content: { text: "still visible without a cursor" },
+            createdAt: 1,
+          },
+        ]),
+      } as unknown as AgentRuntime;
+      const context: MemoryRouteContext = {
+        req: {} as never,
+        res: {} as never,
+        method: "GET",
+        pathname: "/api/memories/feed",
+        url: (() => {
+          const u = new URL(
+            "https://agent.test/api/memories/feed?type=messages",
+          );
+          u.searchParams.set("before", rawCursor);
+          return u;
+        })(),
+        runtime,
+        agentName: "Eliza",
+        json: (_res, value) => {
+          response.value = value;
         },
-      ]),
-    } as unknown as AgentRuntime;
-    const context: MemoryRouteContext = {
-      req: {} as never,
-      res: {} as never,
-      method: "GET",
-      pathname: "/api/memories/feed",
-      url: (() => {
-        const u = new URL("https://agent.test/api/memories/feed?type=messages");
-        u.searchParams.set("before", rawCursor);
-        return u;
-      })(),
-      runtime,
-      agentName: "Eliza",
-      json: (_res, value) => {
-        response.value = value;
-      },
-      error: (_res, message, status) => {
-        throw new Error(`unexpected ${status}: ${message}`);
-      },
-      readJsonBody: async <T extends object>() => ({}) as T,
-    };
+        error: (_res, message, status) => {
+          throw new Error(`unexpected ${status}: ${message}`);
+        },
+        readJsonBody: async <T extends object>() => ({}) as T,
+      };
 
-    expect(await handleMemoryRoutes(context)).toBe(true);
-    expect((response.value as { count: number }).count).toBe(1);
+      expect(await handleMemoryRoutes(context)).toBe(true);
+      expect((response.value as { count: number }).count).toBe(1);
     },
   );
 

--- a/packages/agent/src/api/memory-feed-cursor.test.ts
+++ b/packages/agent/src/api/memory-feed-cursor.test.ts
@@ -53,47 +53,103 @@ describe("GET /api/memories/feed cursor", () => {
     });
   });
 
-  test("400s a malformed before cursor instead of silently emptying the feed", async () => {
-    // Number("abc") is NaN — a `number`, so it passes the undefined check in
-    // fetchMemoriesFromTables, and every `createdAt < NaN` comparison is
-    // false. Without the boundary guard this request returned 200 with an
-    // empty feed, indistinguishable from an agent that has no memories.
-    const getMemories = vi.fn(async () => []);
+  test.each([
+    ["abc", "non-numeric text"],
+    ["0x10", "hex form (Number coercion would read 16)"],
+    ["1e3", "exponent form"],
+    ["-5", "negative"],
+    ["1.5", "fractional"],
+    ["012", "non-canonical leading zero"],
+    ["9007199254740993", "beyond Number.isSafeInteger"],
+  ])(
+    "400s the non-canonical before cursor %j instead of silently mis-filtering the feed",
+    async (rawCursor) => {
+      const getMemories = vi.fn(async () => []);
+      const runtime = {
+        agentId: "11111111-1111-4111-8111-111111111111" as UUID,
+        character: { name: "Eliza" },
+        ensureConnection: vi.fn(async () => undefined),
+        getMemories,
+      } as unknown as AgentRuntime;
+      const errors: Array<{ message: string; status?: number }> = [];
+      const url = new URL("https://agent.test/api/memories/feed?type=messages");
+      url.searchParams.set("before", rawCursor);
+      const context: MemoryRouteContext = {
+        req: {} as never,
+        res: {} as never,
+        method: "GET",
+        pathname: "/api/memories/feed",
+        url,
+        runtime,
+        agentName: "Eliza",
+        json: () => {
+          throw new Error("unexpected 200");
+        },
+        error: (_res, message, status) => {
+          errors.push({ message, status });
+        },
+        readJsonBody: async <T extends object>() => ({}) as T,
+      };
+
+      expect(await handleMemoryRoutes(context)).toBe(true);
+      expect(errors).toEqual([
+        {
+          message: "before must be a Unix timestamp in milliseconds",
+          status: 400,
+        },
+      ]);
+      expect(getMemories).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([["", "empty"], [" ", "whitespace-only"]])(
+    "treats a blank before value (%j) as no cursor, not junk",
+    async (rawCursor) => {
+    // `?before=` templates naturally from clients interpolating an unset
+    // variable, and whitespace trims to the same blank. Both previously
+    // mis-coerced (whitespace became an epoch-0 cursor via Number(" ") === 0,
+    // silently emptying the feed); both now mean "no cursor" — unlike
+    // present junk, which 400s.
+    const response: { value?: unknown } = {};
     const runtime = {
       agentId: "11111111-1111-4111-8111-111111111111" as UUID,
       character: { name: "Eliza" },
       ensureConnection: vi.fn(async () => undefined),
-      getMemories,
+      getMemories: vi.fn(async () => [
+        {
+          id: "22222222-2222-4222-8222-222222222222" as UUID,
+          entityId: "33333333-3333-4333-8333-333333333333" as UUID,
+          roomId: "44444444-4444-4444-8444-444444444444" as UUID,
+          content: { text: "still visible without a cursor" },
+          createdAt: 1,
+        },
+      ]),
     } as unknown as AgentRuntime;
-    const errors: Array<{ message: string; status?: number }> = [];
     const context: MemoryRouteContext = {
       req: {} as never,
       res: {} as never,
       method: "GET",
       pathname: "/api/memories/feed",
-      url: new URL(
-        "https://agent.test/api/memories/feed?before=abc&type=messages",
-      ),
+      url: (() => {
+        const u = new URL("https://agent.test/api/memories/feed?type=messages");
+        u.searchParams.set("before", rawCursor);
+        return u;
+      })(),
       runtime,
       agentName: "Eliza",
-      json: () => {
-        throw new Error("unexpected 200");
+      json: (_res, value) => {
+        response.value = value;
       },
       error: (_res, message, status) => {
-        errors.push({ message, status });
+        throw new Error(`unexpected ${status}: ${message}`);
       },
       readJsonBody: async <T extends object>() => ({}) as T,
     };
 
     expect(await handleMemoryRoutes(context)).toBe(true);
-    expect(errors).toEqual([
-      {
-        message: "before must be a finite Unix timestamp in milliseconds",
-        status: 400,
-      },
-    ]);
-    expect(getMemories).not.toHaveBeenCalled();
-  });
+    expect((response.value as { count: number }).count).toBe(1);
+    },
+  );
 
   test("rejects an unknown type before scanning tables", async () => {
     const getMemories = vi.fn(async () => []);

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -29,6 +29,7 @@ import type { RouteRequestContext } from "@elizaos/shared";
 import {
   PatchMemoryRequestSchema,
   PostMemoryRememberRequestSchema,
+  parseCanonicalInteger,
   parsePositiveInteger,
 } from "@elizaos/shared";
 import {
@@ -574,14 +575,15 @@ export async function handleMemoryRoutes(
       MEMORY_FEED_DEFAULT_LIMIT,
     );
     const limit = Math.min(Math.max(requestedLimit, 1), MEMORY_FEED_MAX_LIMIT);
-    const beforeParam = url.searchParams.get("before");
-    const before = beforeParam ? Number(beforeParam) : undefined;
-    // Number("abc") is NaN, which is a `number` and so survives the
-    // `beforeTs !== undefined` cursor gate below — but every `< NaN`
-    // comparison is false, so a malformed cursor would silently empty the
-    // feed with a 200. Reject it here instead, mirroring the `type` guard.
-    if (before !== undefined && !Number.isFinite(before)) {
-      error(res, "before must be a finite Unix timestamp in milliseconds", 400);
+    // A cursor is a createdAt millisecond timestamp, so only its canonical
+    // decimal form is a valid value. Bare Number() coercion admitted
+    // whitespace (" " -> 0, silently emptying the feed as an epoch cursor)
+    // and hex/exponent forms; parseCanonicalInteger distinguishes an absent
+    // cursor (undefined) from junk ("invalid"), which 400s like the `type`
+    // guard below.
+    const before = parseCanonicalInteger(url.searchParams.get("before"));
+    if (before === "invalid") {
+      error(res, "before must be a Unix timestamp in milliseconds", 400);
       return true;
     }
     const tableFilter = parseMemoryTableFilter(url.searchParams.get("type"));

--- a/packages/ui/src/api/ios-local-agent-kernel.test.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.test.ts
@@ -561,6 +561,28 @@ describe("handleIosLocalAgentRequest", () => {
       hasMore: false,
     });
     await expect(
+      getJson("/api/memories/feed?before=%20"),
+    ).resolves.toMatchObject({ count: 2 });
+    for (const before of [
+      "abc",
+      "0x10",
+      "1e3",
+      "-5",
+      "1.5",
+      "012",
+      "9007199254740993",
+    ]) {
+      const response = await handleIosLocalAgentRequest(
+        new Request(
+          `http://127.0.0.1:31337/api/memories/feed?before=${before}`,
+        ),
+      );
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "before must be a Unix timestamp in milliseconds",
+      });
+    }
+    await expect(
       getJson("/api/memories/feed?limit=junk"),
     ).resolves.toMatchObject({ limit: 50 });
     await expect(

--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -11,6 +11,7 @@ import {
   COINGECKO_MARKET_PROVIDER,
   POLYMARKET_MARKET_PROVIDER,
   type ProviderStatus,
+  parseCanonicalInteger,
   parseCoinGeckoMarkets,
 } from "@elizaos/shared";
 import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
@@ -778,8 +779,13 @@ function handleLocalMemoriesRoute(
       ),
       MEMORY_FEED_MAX_LIMIT,
     );
-    const beforeParam = url.searchParams.get("before");
-    const before = beforeParam ? Number(beforeParam) : undefined;
+    const before = parseCanonicalInteger(url.searchParams.get("before"));
+    if (before === "invalid") {
+      return json(
+        { error: "before must be a Unix timestamp in milliseconds" },
+        400,
+      );
+    }
     let items = localMemoryTypeHasRows(url.searchParams.get("type"))
       ? localMemoryFeedItems()
       : [];

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
@@ -186,6 +186,34 @@ describe("iOS bridge — memories view routes", () => {
 			(m) => m.text,
 		);
 		expect(beforeTexts).toEqual(["m1", "m0"]);
+
+		const epoch = await call(backend, "GET", "/api/memories/feed?before=0");
+		expect(epoch.status).toBe(200);
+		expect(epoch.json.memories).toEqual([]);
+
+		const blank = await call(backend, "GET", "/api/memories/feed?before=%20");
+		expect(blank.status).toBe(200);
+		expect((blank.json.memories as unknown[]).length).toBe(5);
+
+		for (const cursor of [
+			"abc",
+			"0x10",
+			"1e3",
+			"-5",
+			"1.5",
+			"012",
+			"9007199254740993",
+		]) {
+			const invalid = await call(
+				backend,
+				"GET",
+				`/api/memories/feed?before=${cursor}`,
+			);
+			expect(invalid).toEqual({
+				status: 400,
+				json: { error: "before must be a Unix timestamp in milliseconds" },
+			});
+		}
 	});
 
 	it("feed type filter scopes to a single table", async () => {

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -27,6 +27,7 @@ import {
 import {
 	buildBrandEnvAliases,
 	getBootConfig,
+	parseCanonicalInteger,
 	readAliasedEnv,
 	setBootConfig,
 } from "@elizaos/shared";
@@ -1256,7 +1257,7 @@ async function fetchMemoriesFromTables(
 	filtered = filtered.filter(hasBrowsableContent);
 
 	const beforeTs = params.before;
-	if (beforeTs) {
+	if (beforeTs !== undefined) {
 		return filtered.filter((m) => memoryCreatedAt(m) < beforeTs);
 	}
 	return filtered;
@@ -1271,8 +1272,12 @@ async function handleMemoriesFeedRoute(
 		MEMORY_FEED_DEFAULT_LIMIT,
 	);
 	const limit = Math.min(Math.max(requestedLimit, 1), MEMORY_FEED_MAX_LIMIT);
-	const beforeParam = queryParam(query, "before");
-	const before = beforeParam ? Number(beforeParam) : undefined;
+	const before = parseCanonicalInteger(queryParam(query, "before"));
+	if (before === "invalid") {
+		return jsonResponse(400, {
+			error: "before must be a Unix timestamp in milliseconds",
+		});
+	}
 	const tables = resolveMemoryTableFilter(queryParam(query, "type"));
 
 	const allMemories = await fetchMemoriesFromTables(runtime, {


### PR DESCRIPTION
# Relates to

Closes #22105.
Supersedes #22044 while retaining its original standalone-agent commit and attribution.

## What changed

The three implementations of `GET /api/memories/feed` now share the canonical unsigned-decimal cursor contract through `parseCanonicalInteger`:

- standalone agent route
- iOS WebView compatibility kernel
- iOS Bun-host bridge

Blank/whitespace means absent, `0` remains an epoch cursor, and text/hex/exponent/sign/fraction/leading-zero/unsafe-integer values return 400 before a memory scan. The Bun-host filter also uses an explicit undefined check so epoch is no longer lost to truthiness.

## Why replace #22044

The submitted PR correctly fixes the standalone server but explicitly leaves the two iOS serving stacks on bare `Number()` coercion. Those are the same public API contract, and the Bun-host path additionally ignored a valid epoch cursor. This replacement rebases the original commit and completes the contract across all hosts.

## Exact-head evidence

Head: `c003b93ecf33c64581774c5142e17cd8602bfc37`

- standalone agent cursor suite: 14/14 passed
- iOS WebView kernel suite: 15/15 passed
- iOS Bun-host route suite: 17/17 passed
- plugin-capacitor-bridge typecheck: passed
- Biome on all six changed files: passed
- `git diff --check`: passed
- agent/UI package typechecks were attempted in the sparse review checkout; they were blocked by omitted unrelated workspace packages/stale generated package outputs and produced no diagnostic in the changed cursor files. The original standalone change had a full `bun run verify` pass before this cross-host repair.

No rendered UI or live-model behavior changes; screenshots, video, and model trajectories are N/A.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza"} -->