### PR TITLE
fix(plugin-google-genai): align declared model defaults and input-limit handling

### DIFF
--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -2488,10 +2488,10 @@
           "type": "string",
           "required": false,
           "sensitive": false,
-          "default": "text-embedding-004",
+          "default": "gemini-embedding-001",
           "label": "Embedding Model",
           "help": "Overrides the default text embedding model used by Google Generative AI.",
-          "placeholder": "e.g., text-embedding-3-small",
+          "placeholder": "e.g., gemini-embedding-001, gemini-embedding-2",
           "advanced": false
         },
         "GOOGLE_IMAGE_MODEL": {

--- a/plugins/plugin-google-genai/AGENTS.md
+++ b/plugins/plugin-google-genai/AGENTS.md
@@ -99,7 +99,7 @@ Append a `TestCase` object to the `pluginTests[0].tests` array in `index.ts`. Te
 - **Structured output.** Pass a JSON Schema as `responseSchema` in `GenerateTextParams`. Text handlers internally set `responseMimeType: "application/json"` and `responseJsonSchema` on the Google SDK request. The model returns raw JSON text; no post-parse step is applied for text handlers (the caller owns parsing).
 - **Safety settings are hardcoded.** All four harm categories block at `BLOCK_MEDIUM_AND_ABOVE`. Adjust in `utils/config.ts → getSafetySettings()` if needed.
 - **Token counting is a heuristic.** `utils/tokenization.ts` estimates tokens as `Math.ceil(text.length / 4)`. It is used for telemetry only; do not rely on it for context-window management.
-- **Embedding truncation.** Inputs longer than ~32 768 characters (~8 192 tokens) are truncated before being sent to the embedding model.
+- **Embedding truncation.** Inputs are truncated to the embedding model's documented input token limit before the request (`gemini-embedding-001` -> 2 048 tokens / ~8 192 chars; the larger-window `gemini-embedding-2` -> 8 192 tokens / ~32 768 chars), resolved via `getEmbeddingInputTokenLimit` in `utils/config.ts`. This is a real per-model constraint, not the telemetry-only `length / 4` estimate.
 - **No actions, providers, or evaluators.** If you need to add behavior beyond model inference, register it in a separate plugin or in the agent's character definition.
 
 ## Verification

--- a/plugins/plugin-google-genai/CLAUDE.md
+++ b/plugins/plugin-google-genai/CLAUDE.md
@@ -99,7 +99,7 @@ Append a `TestCase` object to the `pluginTests[0].tests` array in `index.ts`. Te
 - **Structured output.** Pass a JSON Schema as `responseSchema` in `GenerateTextParams`. Text handlers internally set `responseMimeType: "application/json"` and `responseJsonSchema` on the Google SDK request. The model returns raw JSON text; no post-parse step is applied for text handlers (the caller owns parsing).
 - **Safety settings are hardcoded.** All four harm categories block at `BLOCK_MEDIUM_AND_ABOVE`. Adjust in `utils/config.ts → getSafetySettings()` if needed.
 - **Token counting is a heuristic.** `utils/tokenization.ts` estimates tokens as `Math.ceil(text.length / 4)`. It is used for telemetry only; do not rely on it for context-window management.
-- **Embedding truncation.** Inputs longer than ~32 768 characters (~8 192 tokens) are truncated before being sent to the embedding model.
+- **Embedding truncation.** Inputs are truncated to the embedding model's documented input token limit before the request (`gemini-embedding-001` -> 2 048 tokens / ~8 192 chars; the larger-window `gemini-embedding-2` -> 8 192 tokens / ~32 768 chars), resolved via `getEmbeddingInputTokenLimit` in `utils/config.ts`. This is a real per-model constraint, not the telemetry-only `length / 4` estimate.
 - **No actions, providers, or evaluators.** If you need to add behavior beyond model inference, register it in a separate plugin or in the agent's character definition.
 
 ## Verification

--- a/plugins/plugin-google-genai/__tests__/config.test.ts
+++ b/plugins/plugin-google-genai/__tests__/config.test.ts
@@ -3,6 +3,8 @@
  * env precedence, blank trimming, model-alias fallback, and client creation.
  * `@google/genai` and the logger are mocked; no network.
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -32,13 +34,23 @@ vi.mock("@google/genai", () => ({
 
 import {
   createGoogleGenAI,
+  DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT,
   DEFAULT_GOOGLE_EMBEDDING_MODEL,
   getApiKey,
+  getEmbeddingInputTokenLimit,
   getEmbeddingModel,
   getLargeModel,
   getResponseHandlerModel,
   getSmallModel,
 } from "../utils/config";
+
+const PLUGIN_ROOT = new URL("../", import.meta.url);
+
+function readPluginJson(relativePath: string): unknown {
+  return JSON.parse(
+    readFileSync(fileURLToPath(new URL(relativePath, PLUGIN_ROOT)), "utf-8"),
+  );
+}
 
 type Settings = Record<string, string | null | undefined>;
 
@@ -129,5 +141,49 @@ describe("Google GenAI config", () => {
         runtimeWith({ GOOGLE_EMBEDDING_MODEL: " text-embedding-004 " }),
       ),
     ).toBe("text-embedding-004");
+  });
+
+  it("resolves model-aware embedding input token limits with a safe default", () => {
+    // gemini-embedding-001 documents a 2,048-token input limit; the larger
+    // gemini-embedding-2 window accepts 8,192. Unmapped overrides must fall back
+    // to the safe default (2,048), never the larger window.
+    expect(getEmbeddingInputTokenLimit("gemini-embedding-001")).toBe(2_048);
+    expect(getEmbeddingInputTokenLimit("gemini-embedding-2")).toBe(8_192);
+    expect(getEmbeddingInputTokenLimit("some-unknown-model")).toBe(
+      DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT,
+    );
+    expect(DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT).toBe(2_048);
+    // The default model's limit must equal the safe fallback so an unknown id is
+    // never truncated to a window wider than the shipped default supports.
+    expect(getEmbeddingInputTokenLimit(DEFAULT_GOOGLE_EMBEDDING_MODEL)).toBe(
+      DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT,
+    );
+  });
+
+  it("keeps package.json and registry-entry.json embedding defaults in sync with DEFAULT_GOOGLE_EMBEDDING_MODEL", () => {
+    // Drift guard: both public config sources previously advertised the retired
+    // text-embedding-004 while the runtime default moved to gemini-embedding-001.
+    // Assert they derive from the same source of truth so they cannot drift again.
+    const pkg = readPluginJson("package.json") as {
+      agentConfig: {
+        pluginParameters: { GOOGLE_EMBEDDING_MODEL: { default: string } };
+      };
+    };
+    const registry = readPluginJson("registry-entry.json") as {
+      config: {
+        GOOGLE_EMBEDDING_MODEL: { default: string; placeholder: string };
+      };
+    };
+
+    expect(
+      pkg.agentConfig.pluginParameters.GOOGLE_EMBEDDING_MODEL.default,
+    ).toBe(DEFAULT_GOOGLE_EMBEDDING_MODEL);
+    expect(registry.config.GOOGLE_EMBEDDING_MODEL.default).toBe(
+      DEFAULT_GOOGLE_EMBEDDING_MODEL,
+    );
+    // The placeholder must name valid Google embedding ids, not an OpenAI model.
+    const placeholder = registry.config.GOOGLE_EMBEDDING_MODEL.placeholder;
+    expect(placeholder).toContain("gemini-embedding");
+    expect(placeholder).not.toMatch(/text-embedding-3|gpt-|openai/i);
   });
 });

--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   createGoogleGenAI: vi.fn(),
   embedContent: vi.fn(),
   emitModelUsageEvent: vi.fn(),
+  getEmbeddingModel: vi.fn(() => "gemini-embedding-001"),
 }));
 
 vi.mock("@elizaos/core", async () => {
@@ -38,10 +39,18 @@ vi.mock("@elizaos/core", async () => {
   };
 });
 
-vi.mock("../utils/config", () => ({
-  createGoogleGenAI: mocks.createGoogleGenAI,
-  getEmbeddingModel: vi.fn(() => "gemini-embedding-001"),
-}));
+vi.mock("../utils/config", async () => {
+  // Use the real per-model input-token-limit resolver so the truncation
+  // boundary tests exercise the actual gemini-embedding-001 (2048) vs
+  // gemini-embedding-2 (8192) map, not a re-declared stub that could drift.
+  const actual =
+    await vi.importActual<typeof import("../utils/config")>("../utils/config");
+  return {
+    createGoogleGenAI: mocks.createGoogleGenAI,
+    getEmbeddingModel: mocks.getEmbeddingModel,
+    getEmbeddingInputTokenLimit: actual.getEmbeddingInputTokenLimit,
+  };
+});
 
 vi.mock("../utils/events", () => ({
   emitModelUsageEvent: mocks.emitModelUsageEvent,
@@ -63,6 +72,7 @@ function createRuntime(): IAgentRuntime {
 describe("Google GenAI embeddings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getEmbeddingModel.mockReturnValue("gemini-embedding-001");
     mocks.countTokens.mockResolvedValue(5);
     // gemini-embedding-001 honours outputDimensionality:768 and returns a
     // 768-length (un-normalized) vector for that request.
@@ -237,6 +247,56 @@ describe("Google GenAI embeddings", () => {
       code: "EMBEDDING_NON_FINITE",
       context: { dimensions: 768, index: 7 },
     });
+  });
+
+  it("truncates an oversized input to the default model's 2,048-token (~8,192-char) limit before the embedContent call", async () => {
+    // gemini-embedding-001 documents a 2,048-token input limit. The handler must
+    // slice the text to ~4 chars/token = 8,192 chars BEFORE the SDK call, so the
+    // mocked embedContent never sees more than 8,192 characters for this model.
+    mocks.getEmbeddingModel.mockReturnValue("gemini-embedding-001");
+    const oversized = "a".repeat(20_000);
+
+    await handleTextEmbedding(createRuntime(), oversized);
+
+    expect(mocks.embedContent).toHaveBeenCalledTimes(1);
+    const passed = mocks.embedContent.mock.calls[0][0] as {
+      model: string;
+      contents: string;
+    };
+    expect(passed.model).toBe("gemini-embedding-001");
+    expect(passed.contents.length).toBe(8_192);
+    expect(passed.contents).toBe("a".repeat(8_192));
+  });
+
+  it("does NOT truncate a gemini-embedding-2 override to the smaller 2,048 limit for the same input", async () => {
+    // gemini-embedding-2 supports an 8,192-token window (~32,768 chars). The
+    // same 20,000-char input that is cut to 8,192 chars under the default model
+    // must pass through untouched here, proving the limit is model-aware and not
+    // pinned to the old hardcoded boundary.
+    mocks.getEmbeddingModel.mockReturnValue("gemini-embedding-2");
+    const input = "a".repeat(20_000);
+
+    await handleTextEmbedding(createRuntime(), input);
+
+    expect(mocks.embedContent).toHaveBeenCalledTimes(1);
+    const passed = mocks.embedContent.mock.calls[0][0] as {
+      model: string;
+      contents: string;
+    };
+    expect(passed.model).toBe("gemini-embedding-2");
+    expect(passed.contents.length).toBe(20_000);
+  });
+
+  it("truncates an unmapped override to the safe 2,048-token default limit", async () => {
+    // An override id not present in the limit map falls back to the safe 2,048
+    // limit (never the larger 8,192 window), so it is cut to 8,192 chars.
+    mocks.getEmbeddingModel.mockReturnValue("some-unknown-embedding-model");
+    const oversized = "b".repeat(40_000);
+
+    await handleTextEmbedding(createRuntime(), oversized);
+
+    const passed = mocks.embedContent.mock.calls[0][0] as { contents: string };
+    expect(passed.contents.length).toBe(8_192);
   });
 
   it("throws for empty embedding input before creating a client", async () => {

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -3,8 +3,11 @@
  * `gemini-embedding-001`; overridable via `GOOGLE_EMBEDDING_MODEL`).
  * A `null`/empty-object input is treated as an initialization probe and answered
  * with a fixed 768-length marker vector so the runtime can size its embedding
- * column without a network call; real text is truncated to the model's ~8192
- * token limit, embedded, and reported via `emitModelUsageEvent`. Real requests
+ * column without a network call; real text is truncated to the model's
+ * documented input token limit (2,048 for the default `gemini-embedding-001`,
+ * 8,192 for the larger-window `gemini-embedding-2`) via
+ * `getEmbeddingInputTokenLimit`, embedded, and reported via
+ * `emitModelUsageEvent`. Real requests
  * pin `outputDimensionality` to the same 768 width as the probe and L2-normalize
  * the result, because the default `gemini-embedding-001` otherwise emits its
  * 3072-dim default and every write would fail the probe-sized column (#22010).
@@ -21,7 +24,11 @@
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
 import * as ElizaCore from "@elizaos/core";
 import { ElizaError, logger } from "@elizaos/core";
-import { createGoogleGenAI, getEmbeddingModel } from "../utils/config";
+import {
+  createGoogleGenAI,
+  getEmbeddingInputTokenLimit,
+  getEmbeddingModel,
+} from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
 import { countTokens } from "../utils/tokenization";
 
@@ -139,11 +146,16 @@ export async function handleTextEmbedding(
   const embeddingModelName = getEmbeddingModel(runtime);
   logger.debug(`[TEXT_EMBEDDING] Using model: ${embeddingModelName}`);
 
-  // Truncate to stay within embedding model token limits (~4 chars per token)
-  const maxChars = 8_192 * 4;
+  // Truncate to stay within the model's documented input token limit. The limit
+  // is model-aware (gemini-embedding-001 -> 2048, gemini-embedding-2 -> 8192,
+  // safe 2048 default for unmapped overrides); the ~4 chars/token factor only
+  // converts that token limit to a character slice. This boundary is a real
+  // provider constraint, not the telemetry-only `length / 4` estimate.
+  const tokenLimit = getEmbeddingInputTokenLimit(embeddingModelName);
+  const maxChars = tokenLimit * 4;
   if (text.length > maxChars) {
     logger.warn(
-      `[Google GenAI] Embedding input too long (~${Math.ceil(text.length / 4)} tokens), truncating to ~8192 tokens`,
+      `[Google GenAI] Embedding input too long (~${Math.ceil(text.length / 4)} tokens) for model "${embeddingModelName}", truncating to its ${tokenLimit}-token (~${maxChars}-char) input limit`,
     );
     text = text.slice(0, maxChars);
   }

--- a/plugins/plugin-google-genai/package.json
+++ b/plugins/plugin-google-genai/package.json
@@ -102,7 +102,7 @@
         "type": "string",
         "description": "Overrides the default text embedding model used by Google Generative AI.",
         "required": false,
-        "default": "text-embedding-004",
+        "default": "gemini-embedding-001",
         "sensitive": false
       },
       "GOOGLE_IMAGE_MODEL": {

--- a/plugins/plugin-google-genai/registry-entry.json
+++ b/plugins/plugin-google-genai/registry-entry.json
@@ -38,10 +38,10 @@
       "type": "string",
       "required": false,
       "sensitive": false,
-      "default": "text-embedding-004",
+      "default": "gemini-embedding-001",
       "label": "Embedding Model",
       "help": "Overrides the default text embedding model used by Google Generative AI.",
-      "placeholder": "e.g., text-embedding-3-small",
+      "placeholder": "e.g., gemini-embedding-001, gemini-embedding-2",
       "advanced": false
     },
     "GOOGLE_IMAGE_MODEL": {

--- a/plugins/plugin-google-genai/utils/config.ts
+++ b/plugins/plugin-google-genai/utils/config.ts
@@ -122,6 +122,39 @@ export function getImageModel(runtime: IAgentRuntime): string {
  */
 export const DEFAULT_GOOGLE_EMBEDDING_MODEL = "gemini-embedding-001";
 
+/**
+ * Per-model input token limit for the embedding endpoint. Google documents a
+ * 2,048-token input limit for `gemini-embedding-001`, while the larger-window
+ * `gemini-embedding-2` accepts 8,192 tokens. `handleTextEmbedding` derives its
+ * character truncation boundary from this map so the request never exceeds the
+ * model's real limit; an unmapped/override id falls back to the safe 2,048
+ * limit (`DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT`) rather than assuming the larger
+ * window. This is a hard model constraint — it must not be confused with the
+ * telemetry-only `length / 4` estimate in `utils/tokenization.ts`.
+ */
+export const EMBEDDING_INPUT_TOKEN_LIMITS: Readonly<Record<string, number>> = {
+  "gemini-embedding-001": 2_048,
+  "gemini-embedding-2": 8_192,
+};
+
+/**
+ * Safe default input token limit used when a `GOOGLE_EMBEDDING_MODEL` override
+ * names a model that is not in `EMBEDDING_INPUT_TOKEN_LIMITS`. Matches the
+ * current default model (`gemini-embedding-001`) so an unknown id can never be
+ * truncated to a window larger than it supports.
+ */
+export const DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT = 2_048;
+
+/**
+ * Resolve the documented input token limit for an embedding model id, falling
+ * back to the safe default for unmapped overrides.
+ */
+export function getEmbeddingInputTokenLimit(model: string): number {
+  return (
+    EMBEDDING_INPUT_TOKEN_LIMITS[model] ?? DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT
+  );
+}
+
 export function getEmbeddingModel(runtime: IAgentRuntime): string {
   return (
     getSetting(


### PR DESCRIPTION
# Relates to

Closes #22095

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; package test/typecheck/lint pass (see Known gaps for the repo-wide `verify` note).
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@06616b65c0da27ba99a517237ea2bd2bab5b5733:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` — see **Known gaps** (documented unrelated blocker); package-scoped gates pass.

# Risks

Low. The change is bounded to `plugins/plugin-google-genai` plus its regenerated first-party registry entry. It corrects declared config defaults (no runtime default changed — the runtime already defaulted to `gemini-embedding-001`) and makes the embedding input-truncation boundary model-aware. Worst case for the truncation change is that a very long input under the default model is now cut to 8,192 chars (the model's real 2,048-token limit) instead of 32,768 chars — i.e. it stops sending inputs the model would reject.

# Background

## What does this PR do?

- **Declared-default sync.** `package.json` (`agentConfig.pluginParameters.GOOGLE_EMBEDDING_MODEL.default`) and the plugin-owned `registry-entry.json` (`config.GOOGLE_EMBEDDING_MODEL.default`) both advertised the retired `text-embedding-004` while the runtime default (`DEFAULT_GOOGLE_EMBEDDING_MODEL`) is `gemini-embedding-001`. Both now declare `gemini-embedding-001`. The registry placeholder previously named an OpenAI model (`text-embedding-3-small`) and now names valid Google ids (`gemini-embedding-001, gemini-embedding-2`). The first-party `packages/registry/src/first-party/generated.json` entry is regenerated to match (only the two google-genai lines; unrelated pre-existing drift left untouched).
- **Model-aware input limit.** Added `EMBEDDING_INPUT_TOKEN_LIMITS` + `getEmbeddingInputTokenLimit()` in `utils/config.ts` (`gemini-embedding-001` → 2048, `gemini-embedding-2` → 8192, safe 2048 default for unmapped overrides). `handleTextEmbedding` now computes `maxChars` from the resolved per-model token limit instead of the hardcoded `8_192 * 4`, and the warn log interpolates the actual per-model limit.
- **Docs/comments.** Updated the `models/embedding.ts` header (the old "~8192 token" wording) and the plugin `AGENTS.md`/`CLAUDE.md` truncation note. The telemetry-only `length / 4` estimate is explicitly not used as the correctness boundary.
- **Tests.** Added drift-guard and model-aware-truncation regression tests (details below).

## What kind of change is this?

Bug fix (non-breaking; corrects declared metadata and per-model input handling).

# Documentation changes needed?

Updated in-package: `AGENTS.md`, `CLAUDE.md` (byte-identical), and the `embedding.ts` header comment. No site-docs surface references the old default/limit.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-genai/__tests__/embedding.shape.test.ts` (truncation boundary) and `__tests__/config.test.ts` (limit resolver + default-sync drift guards).

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-google-genai test        # 68 passed | 2 skipped
bun run --cwd plugins/plugin-google-genai typecheck   # clean
bun run --cwd plugins/plugin-google-genai lint:check  # no fixes applied
```

Added tests prove:
- (a) an oversized input under the default `gemini-embedding-001` is truncated to the 2,048-token (~8,192-char) boundary **before** the mocked `embedContent` call (asserts on `contents.length`);
- (b) a `gemini-embedding-2` (8,192-token) override is **not** truncated to the smaller 2,048 limit for the same 20,000-char input;
- an unmapped override falls back to the safe 2,048 limit;
- `getEmbeddingInputTokenLimit` resolves the documented per-model limits with a safe default;
- `package.json` and `registry-entry.json` embedding defaults equal `DEFAULT_GOOGLE_EMBEDDING_MODEL`, and the placeholder names a Google (not OpenAI) model — a drift guard so this cannot regress.

# Evidence Gate

<!-- evidence-head:b2345c11b7920d97b1bd7bf71c750d3bb2560840 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - no UI surface; this plugin registers only model handlers (no actions/providers/routes/views).`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - no UI surface (see above).`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no UI/user flow; change is config metadata + a pure truncation-boundary function exercised by unit tests.`
<!-- evidence-row:backend-logs -->
- [x] Failing-then-passing reproduction, inline below (also mirrored at https://gist.github.com/agent-cortex/10763a2594ffc1df8218c1ed9baa95ae):

<details><summary>backend test output — the new tests fail on the OLD code and pass with the fix</summary>

```
Step 1 — new tests run against the OLD code (hardcoded maxChars = 8_192 * 4; text-embedding-004 declared defaults):
     x keeps package.json and registry-entry.json embedding defaults in sync with DEFAULT_GOOGLE_EMBEDDING_MODEL
     x truncates an oversized input to the default model's 2,048-token (~8,192-char) limit before the embedContent call
     x truncates an unmapped override to the safe 2,048-token default limit
 Test Files  2 failed (2)
      Tests  3 failed | 21 passed (24)

Step 2 — the same tests PASS with the fix (model-aware limit + synced defaults):
 + resolves model-aware embedding input token limits with a safe default
 + keeps package.json and registry-entry.json embedding defaults in sync with DEFAULT_GOOGLE_EMBEDDING_MODEL
 + truncates an oversized input to the default model's 2,048-token (~8,192-char) limit before the embedContent call
 + does NOT truncate a gemini-embedding-2 override to the smaller 2,048 limit for the same input
 + truncates an unmapped override to the safe 2,048-token default limit
 Test Files  8 passed | 1 skipped (9)
      Tests  68 passed | 2 skipped (70)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend surface.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no prompt/model-call behavior changed; the truncation and default-sync paths are deterministic and asserted against the mocked embedContent contract. A live embedding call would only echo the same char-slice boundary.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact inline below (also mirrored at https://gist.github.com/agent-cortex/40444f53ba75e44003360d94ed009750):

<details><summary>output — actual contents length passed to the SDK embedContent call per model</summary>

```
Driving the real handleTextEmbedding() and printing the length of the text the
SDK actually receives, for a fixed 20,000-character input string per model:

ARTIFACT model=gemini-embedding-001   inputChars=20000 -> contents.length sent to embedContent=8192    (2,048-token limit * ~4 chars/token => truncated)
ARTIFACT model=gemini-embedding-2     inputChars=20000 -> contents.length sent to embedContent=20000   (8,192-token window => NOT truncated for this input)
ARTIFACT model=some-unknown-model     inputChars=20000 -> contents.length sent to embedContent=8192    (unmapped override => safe 2,048-token default)

This is the behavioral contract the fix establishes: the truncation boundary is
model-aware (per EMBEDDING_INPUT_TOKEN_LIMITS), not the previous hardcoded 8_192 * 4.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no live-model behavior changed; deterministic truncation/config paths (see Evidence Gate rationale).`

## Backend + frontend logs

Failing-then-passing reproduction — the new tests FAIL against the old hardcoded `maxChars = 8_192 * 4` and old `text-embedding-004` defaults, and PASS with the fix.

<details><summary>New tests fail against OLD code (hardcoded 8192*4 boundary + text-embedding-004 defaults)</summary>

```
 ❯ __tests__/embedding.shape.test.ts (16 tests | 2 failed)
     × truncates an oversized input to the default model's 2,048-token (~8,192-char) limit before the embedContent call
     × truncates an unmapped override to the safe 2,048-token default limit
 ❯ __tests__/config.test.ts (8 tests | 1 failed)
     × keeps package.json and registry-entry.json embedding defaults in sync with DEFAULT_GOOGLE_EMBEDDING_MODEL
 Test Files  2 failed | 6 passed | 1 skipped (9)
      Tests  3 failed | 65 passed | 2 skipped (70)
```
</details>

<details><summary>All tests PASS with the fix (verbose, new tests highlighted)</summary>

```
 ✓ __tests__/config.test.ts > resolves model-aware embedding input token limits with a safe default
 ✓ __tests__/config.test.ts > keeps package.json and registry-entry.json embedding defaults in sync with DEFAULT_GOOGLE_EMBEDDING_MODEL
 ✓ __tests__/embedding.shape.test.ts > truncates an oversized input to the default model's 2,048-token (~8,192-char) limit before the embedContent call
 ✓ __tests__/embedding.shape.test.ts > does NOT truncate a gemini-embedding-2 override to the smaller 2,048 limit for the same input
 ✓ __tests__/embedding.shape.test.ts > truncates an unmapped override to the safe 2,048-token default limit

 Test Files  8 passed | 1 skipped (9)
      Tests  68 passed | 2 skipped (70)
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface in this plugin (model handlers only).`

## Audio / voice walkthrough

`N/A - no voice/audio path touched.`

## Known gaps / failures

- **Full `bun run verify` not run to completion on this machine.** `bun install` is gated by a global `minimumReleaseAge` supply-chain policy on the build host; the workspace was installed from the frozen lockfile (pinned versions). Package-scoped gates (`test`, `typecheck`, `lint:check`, `build`) all pass. This is an environment limitation, not a code blocker.
- **Registry `generate:first-party:check` reports pre-existing unrelated drift** in the `plugin-twitter` entry (present on `develop` before this PR). This PR intentionally does **not** touch that entry to keep scope proportionate; only the two google-genai lines in `generated.json` were updated, and they exactly match generator output for the google-genai entry.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@06616b65c0da27ba99a517237ea2bd2bab5b5733:packages/skills/skills/contribute-to-eliza"} -->


