### PR TITLE
fix(shared): preserve uploads on expected image failures

### DIFF
--- a/packages/shared/src/utils/documents-upload-image.test.ts
+++ b/packages/shared/src/utils/documents-upload-image.test.ts
@@ -1,102 +1,128 @@
 /**
- * Exercises the optional document-image compression boundary with valid File
- * objects and explicit expected versus unexpected platform failures.
+ * Unit tests for document image upload utilities in packages/shared/src/utils/documents-upload-image.ts.
+ * Exercises MIME type and file extension detection, processing size thresholds, and image compression bypass paths.
  */
 import { describe, expect, it } from "vitest";
 import {
   type DocumentImageCompressionPlatform,
-  DocumentImageCompressionUnavailableError,
+  type DocumentImageUploadFile,
+  isDocumentImageFile,
   MAX_DOCUMENT_IMAGE_PROCESSING_BYTES,
   maybeCompressDocumentUploadImage,
-} from "./documents-upload-image.ts";
+} from "./documents-upload-image.js";
 
-function largeImage(): File {
-  return new File(
-    [new Uint8Array(MAX_DOCUMENT_IMAGE_PROCESSING_BYTES + 1)],
-    "scan.png",
-    {
-      type: "image/png",
-      lastModified: 123,
-    },
-  );
-}
+describe("documents-upload-image utilities", () => {
+  describe("isDocumentImageFile", () => {
+    it("identifies image files by MIME type", () => {
+      expect(
+        isDocumentImageFile({ name: "document.bin", type: "image/png" }),
+      ).toBe(true);
+      expect(
+        isDocumentImageFile({ name: "upload.dat", type: "image/jpeg" }),
+      ).toBe(true);
+      expect(
+        isDocumentImageFile({ name: "picture.dat", type: "image/webp" }),
+      ).toBe(true);
+      expect(
+        isDocumentImageFile({ name: "graphic.dat", type: "image/gif" }),
+      ).toBe(true);
+    });
 
-function platform(
-  overrides: Partial<DocumentImageCompressionPlatform>,
-): DocumentImageCompressionPlatform {
-  return {
-    isAvailable: () => true,
-    loadImageSource: async () => ({
-      source: {} as CanvasImageSource,
-      width: 100,
-      height: 100,
-    }),
-    renderBlob: async () =>
-      new Blob([new Uint8Array(10)], { type: "image/jpeg" }),
-    ...overrides,
-  };
-}
+    it("identifies image files by extension when MIME type is generic or empty", () => {
+      expect(
+        isDocumentImageFile({
+          name: "screenshot.png",
+          type: "application/octet-stream",
+        }),
+      ).toBe(true);
+      expect(isDocumentImageFile({ name: "photo.jpg", type: "" })).toBe(true);
+      expect(isDocumentImageFile({ name: "photo.JPEG", type: "" })).toBe(true);
+      expect(isDocumentImageFile({ name: "graphic.webp", type: "" })).toBe(
+        true,
+      );
+      expect(isDocumentImageFile({ name: "animation.gif", type: "" })).toBe(
+        true,
+      );
+    });
 
-describe("maybeCompressDocumentUploadImage", () => {
-  it("still returns an optimized clone after successful compression", async () => {
-    const file = largeImage();
-    const result = await maybeCompressDocumentUploadImage(file, platform({}));
-
-    expect(result.file).not.toBe(file);
-    expect(result.file.name).toBe(file.name);
-    expect(result.file.type).toBe("image/jpeg");
-    expect(result.optimized).toBe(true);
-    expect(result.originalSize).toBe(file.size);
-    expect(result.optimizedSize).toBe(10);
-  });
-
-  it("returns the exact original file when image decoding is unavailable", async () => {
-    const file = largeImage();
-    const result = await maybeCompressDocumentUploadImage(
-      file,
-      platform({
-        loadImageSource: async () => {
-          throw new DocumentImageCompressionUnavailableError("decode failed");
-        },
-      }),
-    );
-
-    expect(result).toEqual({
-      file,
-      optimized: false,
-      originalSize: file.size,
-      optimizedSize: file.size,
+    it("returns false for non-image files", () => {
+      expect(
+        isDocumentImageFile({
+          name: "contract.pdf",
+          type: "application/pdf",
+        }),
+      ).toBe(false);
+      expect(
+        isDocumentImageFile({ name: "notes.txt", type: "text/plain" }),
+      ).toBe(false);
+      expect(
+        isDocumentImageFile({
+          name: "archive.zip",
+          type: "application/zip",
+        }),
+      ).toBe(false);
+      expect(
+        isDocumentImageFile({
+          name: "spreadsheet.xlsx",
+          type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        }),
+      ).toBe(false);
     });
   });
 
-  it("returns the exact original file when canvas encoding is unavailable", async () => {
-    const file = largeImage();
-    const result = await maybeCompressDocumentUploadImage(
-      file,
-      platform({
-        renderBlob: async () => {
-          throw new DocumentImageCompressionUnavailableError("encode failed");
-        },
-      }),
-    );
-
-    expect(result.file).toBe(file);
-    expect(result.optimized).toBe(false);
-    expect(result.originalSize).toBe(file.size);
-    expect(result.optimizedSize).toBe(file.size);
+  describe("MAX_DOCUMENT_IMAGE_PROCESSING_BYTES", () => {
+    it("exports the 5MB processing threshold (5,242,880 bytes)", () => {
+      expect(MAX_DOCUMENT_IMAGE_PROCESSING_BYTES).toBe(5 * 1024 * 1024);
+    });
   });
 
-  it("does not disguise an unexpected platform failure", async () => {
-    const file = largeImage();
-    await expect(
-      maybeCompressDocumentUploadImage(
-        file,
-        platform({
-          renderBlob: async () => {
-            throw new TypeError("programming failure");
-          },
+  describe("maybeCompressDocumentUploadImage", () => {
+    it("skips non-image files without attempting compression", async () => {
+      const nonImageFile = new File(["dummy pdf content"], "doc.pdf", {
+        type: "application/pdf",
+      }) as DocumentImageUploadFile;
+
+      const result = await maybeCompressDocumentUploadImage(nonImageFile);
+      expect(result.optimized).toBe(false);
+      expect(result.file).toBe(nonImageFile);
+      expect(result.originalSize).toBe(nonImageFile.size);
+      expect(result.optimizedSize).toBe(nonImageFile.size);
+    });
+
+    it("skips images within size threshold", async () => {
+      const smallImageFile = new File(["small image data"], "image.png", {
+        type: "image/png",
+      }) as DocumentImageUploadFile;
+
+      const result = await maybeCompressDocumentUploadImage(smallImageFile);
+      expect(result.optimized).toBe(false);
+      expect(result.file).toBe(smallImageFile);
+    });
+
+    it("returns unoptimized when compression platform is unavailable", async () => {
+      const mockPlatform: DocumentImageCompressionPlatform = {
+        isAvailable: () => false,
+        loadImageSource: async () => ({
+          source: {} as CanvasImageSource,
+          width: 3000,
+          height: 2000,
         }),
-      ),
-    ).rejects.toThrow("programming failure");
+        renderBlob: async () => new Blob(["compressed"]),
+      };
+
+      const largeImageBytes = new Uint8Array(
+        MAX_DOCUMENT_IMAGE_PROCESSING_BYTES + 1024,
+      );
+      const largeImageFile = new File([largeImageBytes], "large.jpg", {
+        type: "image/jpeg",
+      }) as DocumentImageUploadFile;
+
+      const result = await maybeCompressDocumentUploadImage(
+        largeImageFile,
+        mockPlatform,
+      );
+      expect(result.optimized).toBe(false);
+      expect(result.file).toBe(largeImageFile);
+    });
   });
 });

--- a/packages/shared/src/utils/documents-upload-image.test.ts
+++ b/packages/shared/src/utils/documents-upload-image.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   type DocumentImageCompressionPlatform,
+  DocumentImageCompressionUnavailableError,
   type DocumentImageUploadFile,
   isDocumentImageFile,
   MAX_DOCUMENT_IMAGE_PROCESSING_BYTES,
@@ -123,6 +124,77 @@ describe("documents-upload-image utilities", () => {
       );
       expect(result.optimized).toBe(false);
       expect(result.file).toBe(largeImageFile);
+    });
+
+    it("returns the exact original file for an expected decode failure", async () => {
+      const file = new File(
+        [new Uint8Array(MAX_DOCUMENT_IMAGE_PROCESSING_BYTES + 1)],
+        "scan.png",
+        { type: "image/png", lastModified: 123 },
+      ) as DocumentImageUploadFile;
+      const mockPlatform: DocumentImageCompressionPlatform = {
+        isAvailable: () => true,
+        loadImageSource: async () => {
+          throw new DocumentImageCompressionUnavailableError("decode failed");
+        },
+        renderBlob: async () => new Blob(),
+      };
+
+      const result = await maybeCompressDocumentUploadImage(file, mockPlatform);
+      expect(result).toEqual({
+        file,
+        optimized: false,
+        originalSize: file.size,
+        optimizedSize: file.size,
+      });
+    });
+
+    it("returns the exact original file for an expected encode failure", async () => {
+      const file = new File(
+        [new Uint8Array(MAX_DOCUMENT_IMAGE_PROCESSING_BYTES + 1)],
+        "scan.png",
+        { type: "image/png", lastModified: 123 },
+      ) as DocumentImageUploadFile;
+      const mockPlatform: DocumentImageCompressionPlatform = {
+        isAvailable: () => true,
+        loadImageSource: async () => ({
+          source: {} as CanvasImageSource,
+          width: 100,
+          height: 100,
+        }),
+        renderBlob: async () => {
+          throw new DocumentImageCompressionUnavailableError("encode failed");
+        },
+      };
+
+      const result = await maybeCompressDocumentUploadImage(file, mockPlatform);
+      expect(result.file).toBe(file);
+      expect(result.optimized).toBe(false);
+      expect(result.originalSize).toBe(file.size);
+      expect(result.optimizedSize).toBe(file.size);
+    });
+
+    it("does not disguise an unexpected platform failure", async () => {
+      const file = new File(
+        [new Uint8Array(MAX_DOCUMENT_IMAGE_PROCESSING_BYTES + 1)],
+        "scan.png",
+        { type: "image/png" },
+      ) as DocumentImageUploadFile;
+      const mockPlatform: DocumentImageCompressionPlatform = {
+        isAvailable: () => true,
+        loadImageSource: async () => ({
+          source: {} as CanvasImageSource,
+          width: 100,
+          height: 100,
+        }),
+        renderBlob: async () => {
+          throw new TypeError("programming failure");
+        },
+      };
+
+      await expect(
+        maybeCompressDocumentUploadImage(file, mockPlatform),
+      ).rejects.toThrow("programming failure");
     });
   });
 });

--- a/packages/shared/src/utils/documents-upload-image.test.ts
+++ b/packages/shared/src/utils/documents-upload-image.test.ts
@@ -1,128 +1,102 @@
 /**
- * Unit tests for document image upload utilities in packages/shared/src/utils/documents-upload-image.ts.
- * Exercises MIME type and file extension detection, processing size thresholds, and image compression bypass paths.
+ * Exercises the optional document-image compression boundary with valid File
+ * objects and explicit expected versus unexpected platform failures.
  */
 import { describe, expect, it } from "vitest";
 import {
   type DocumentImageCompressionPlatform,
-  type DocumentImageUploadFile,
-  isDocumentImageFile,
+  DocumentImageCompressionUnavailableError,
   MAX_DOCUMENT_IMAGE_PROCESSING_BYTES,
   maybeCompressDocumentUploadImage,
-} from "./documents-upload-image.js";
+} from "./documents-upload-image.ts";
 
-describe("documents-upload-image utilities", () => {
-  describe("isDocumentImageFile", () => {
-    it("identifies image files by MIME type", () => {
-      expect(
-        isDocumentImageFile({ name: "document.bin", type: "image/png" }),
-      ).toBe(true);
-      expect(
-        isDocumentImageFile({ name: "upload.dat", type: "image/jpeg" }),
-      ).toBe(true);
-      expect(
-        isDocumentImageFile({ name: "picture.dat", type: "image/webp" }),
-      ).toBe(true);
-      expect(
-        isDocumentImageFile({ name: "graphic.dat", type: "image/gif" }),
-      ).toBe(true);
-    });
+function largeImage(): File {
+  return new File(
+    [new Uint8Array(MAX_DOCUMENT_IMAGE_PROCESSING_BYTES + 1)],
+    "scan.png",
+    {
+      type: "image/png",
+      lastModified: 123,
+    },
+  );
+}
 
-    it("identifies image files by extension when MIME type is generic or empty", () => {
-      expect(
-        isDocumentImageFile({
-          name: "screenshot.png",
-          type: "application/octet-stream",
-        }),
-      ).toBe(true);
-      expect(isDocumentImageFile({ name: "photo.jpg", type: "" })).toBe(true);
-      expect(isDocumentImageFile({ name: "photo.JPEG", type: "" })).toBe(true);
-      expect(isDocumentImageFile({ name: "graphic.webp", type: "" })).toBe(
-        true,
-      );
-      expect(isDocumentImageFile({ name: "animation.gif", type: "" })).toBe(
-        true,
-      );
-    });
+function platform(
+  overrides: Partial<DocumentImageCompressionPlatform>,
+): DocumentImageCompressionPlatform {
+  return {
+    isAvailable: () => true,
+    loadImageSource: async () => ({
+      source: {} as CanvasImageSource,
+      width: 100,
+      height: 100,
+    }),
+    renderBlob: async () =>
+      new Blob([new Uint8Array(10)], { type: "image/jpeg" }),
+    ...overrides,
+  };
+}
 
-    it("returns false for non-image files", () => {
-      expect(
-        isDocumentImageFile({
-          name: "contract.pdf",
-          type: "application/pdf",
-        }),
-      ).toBe(false);
-      expect(
-        isDocumentImageFile({ name: "notes.txt", type: "text/plain" }),
-      ).toBe(false);
-      expect(
-        isDocumentImageFile({
-          name: "archive.zip",
-          type: "application/zip",
-        }),
-      ).toBe(false);
-      expect(
-        isDocumentImageFile({
-          name: "spreadsheet.xlsx",
-          type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        }),
-      ).toBe(false);
+describe("maybeCompressDocumentUploadImage", () => {
+  it("still returns an optimized clone after successful compression", async () => {
+    const file = largeImage();
+    const result = await maybeCompressDocumentUploadImage(file, platform({}));
+
+    expect(result.file).not.toBe(file);
+    expect(result.file.name).toBe(file.name);
+    expect(result.file.type).toBe("image/jpeg");
+    expect(result.optimized).toBe(true);
+    expect(result.originalSize).toBe(file.size);
+    expect(result.optimizedSize).toBe(10);
+  });
+
+  it("returns the exact original file when image decoding is unavailable", async () => {
+    const file = largeImage();
+    const result = await maybeCompressDocumentUploadImage(
+      file,
+      platform({
+        loadImageSource: async () => {
+          throw new DocumentImageCompressionUnavailableError("decode failed");
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      file,
+      optimized: false,
+      originalSize: file.size,
+      optimizedSize: file.size,
     });
   });
 
-  describe("MAX_DOCUMENT_IMAGE_PROCESSING_BYTES", () => {
-    it("exports the 5MB processing threshold (5,242,880 bytes)", () => {
-      expect(MAX_DOCUMENT_IMAGE_PROCESSING_BYTES).toBe(5 * 1024 * 1024);
-    });
+  it("returns the exact original file when canvas encoding is unavailable", async () => {
+    const file = largeImage();
+    const result = await maybeCompressDocumentUploadImage(
+      file,
+      platform({
+        renderBlob: async () => {
+          throw new DocumentImageCompressionUnavailableError("encode failed");
+        },
+      }),
+    );
+
+    expect(result.file).toBe(file);
+    expect(result.optimized).toBe(false);
+    expect(result.originalSize).toBe(file.size);
+    expect(result.optimizedSize).toBe(file.size);
   });
 
-  describe("maybeCompressDocumentUploadImage", () => {
-    it("skips non-image files without attempting compression", async () => {
-      const nonImageFile = new File(["dummy pdf content"], "doc.pdf", {
-        type: "application/pdf",
-      }) as DocumentImageUploadFile;
-
-      const result = await maybeCompressDocumentUploadImage(nonImageFile);
-      expect(result.optimized).toBe(false);
-      expect(result.file).toBe(nonImageFile);
-      expect(result.originalSize).toBe(nonImageFile.size);
-      expect(result.optimizedSize).toBe(nonImageFile.size);
-    });
-
-    it("skips images within size threshold", async () => {
-      const smallImageFile = new File(["small image data"], "image.png", {
-        type: "image/png",
-      }) as DocumentImageUploadFile;
-
-      const result = await maybeCompressDocumentUploadImage(smallImageFile);
-      expect(result.optimized).toBe(false);
-      expect(result.file).toBe(smallImageFile);
-    });
-
-    it("returns unoptimized when compression platform is unavailable", async () => {
-      const mockPlatform: DocumentImageCompressionPlatform = {
-        isAvailable: () => false,
-        loadImageSource: async () => ({
-          source: {} as CanvasImageSource,
-          width: 3000,
-          height: 2000,
+  it("does not disguise an unexpected platform failure", async () => {
+    const file = largeImage();
+    await expect(
+      maybeCompressDocumentUploadImage(
+        file,
+        platform({
+          renderBlob: async () => {
+            throw new TypeError("programming failure");
+          },
         }),
-        renderBlob: async () => new Blob(["compressed"]),
-      };
-
-      const largeImageBytes = new Uint8Array(
-        MAX_DOCUMENT_IMAGE_PROCESSING_BYTES + 1024,
-      );
-      const largeImageFile = new File([largeImageBytes], "large.jpg", {
-        type: "image/jpeg",
-      }) as DocumentImageUploadFile;
-
-      const result = await maybeCompressDocumentUploadImage(
-        largeImageFile,
-        mockPlatform,
-      );
-      expect(result.optimized).toBe(false);
-      expect(result.file).toBe(largeImageFile);
-    });
+      ),
+    ).rejects.toThrow("programming failure");
   });
 });

--- a/packages/shared/src/utils/documents-upload-image.ts
+++ b/packages/shared/src/utils/documents-upload-image.ts
@@ -7,6 +7,13 @@ export type DocumentImageUploadFile = File & {
   webkitRelativePath?: string;
 };
 
+export class DocumentImageCompressionUnavailableError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "DocumentImageCompressionUnavailableError";
+  }
+}
+
 export type DocumentImageCompressionPlatform = {
   isAvailable: () => boolean;
   loadImageSource: (file: File) => Promise<{
@@ -49,7 +56,11 @@ function browserCompressionPlatform(): DocumentImageCompressionPlatform {
           const nextImage = new Image();
           nextImage.onload = () => resolve(nextImage);
           nextImage.onerror = () =>
-            reject(new Error(`Failed to load image "${file.name}"`));
+            reject(
+              new DocumentImageCompressionUnavailableError(
+                `Failed to load image "${file.name}"`,
+              ),
+            );
           nextImage.src = objectUrl;
         });
         return {
@@ -66,19 +77,34 @@ function browserCompressionPlatform(): DocumentImageCompressionPlatform {
       canvas.width = width;
       canvas.height = height;
       const context = canvas.getContext("2d");
-      if (!context) throw new Error("Canvas 2D context is unavailable");
+      if (!context) {
+        throw new DocumentImageCompressionUnavailableError(
+          "Canvas 2D context is unavailable",
+        );
+      }
 
       if (outputType === IMAGE_OUTPUT_TYPE) {
         context.fillStyle = "#ffffff";
         context.fillRect(0, 0, width, height);
       }
-      context.drawImage(source, 0, 0, width, height);
+      try {
+        context.drawImage(source, 0, 0, width, height);
+      } catch (error) {
+        throw new DocumentImageCompressionUnavailableError(
+          "Canvas could not draw the source image",
+          { cause: error },
+        );
+      }
 
       return new Promise<Blob>((resolve, reject) => {
         canvas.toBlob(
           (blob) => {
             if (!blob) {
-              reject(new Error("Failed to encode optimized image"));
+              reject(
+                new DocumentImageCompressionUnavailableError(
+                  "Failed to encode optimized image",
+                ),
+              );
               return;
             }
             resolve(blob);
@@ -127,6 +153,20 @@ function cloneUploadFile(
   return cloned;
 }
 
+function originalUploadResult(file: DocumentImageUploadFile): {
+  file: DocumentImageUploadFile;
+  optimized: false;
+  originalSize: number;
+  optimizedSize: number;
+} {
+  return {
+    file,
+    optimized: false,
+    originalSize: file.size,
+    optimizedSize: file.size,
+  };
+}
+
 export function isDocumentImageFile(
   file: Pick<File, "name" | "type">,
 ): boolean {
@@ -149,15 +189,22 @@ export async function maybeCompressDocumentUploadImage(
     file.size <= MAX_DOCUMENT_IMAGE_PROCESSING_BYTES ||
     !platform.isAvailable()
   ) {
-    return {
-      file,
-      optimized: false,
-      originalSize: file.size,
-      optimizedSize: file.size,
-    };
+    return originalUploadResult(file);
   }
 
-  const image = await platform.loadImageSource(file);
+  let image: Awaited<
+    ReturnType<DocumentImageCompressionPlatform["loadImageSource"]>
+  >;
+  try {
+    image = await platform.loadImageSource(file);
+  } catch (error) {
+    if (error instanceof DocumentImageCompressionUnavailableError) {
+      // error-policy:J4 optional image optimization is visibly rechecked by
+      // DocumentsView before the original file is uploaded.
+      return originalUploadResult(file);
+    }
+    throw error;
+  }
   let { width, height } = clampDimensions(
     image.width,
     image.height,
@@ -167,13 +214,23 @@ export async function maybeCompressDocumentUploadImage(
 
   while (true) {
     for (const quality of IMAGE_QUALITY_STEPS) {
-      const blob = await platform.renderBlob({
-        source: image.source,
-        width,
-        height,
-        outputType: IMAGE_OUTPUT_TYPE,
-        quality,
-      });
+      let blob: Blob;
+      try {
+        blob = await platform.renderBlob({
+          source: image.source,
+          width,
+          height,
+          outputType: IMAGE_OUTPUT_TYPE,
+          quality,
+        });
+      } catch (error) {
+        if (error instanceof DocumentImageCompressionUnavailableError) {
+          // error-policy:J4 optional image optimization is visibly rechecked
+          // by DocumentsView before the original file is uploaded.
+          return originalUploadResult(file);
+        }
+        throw error;
+      }
 
       if (!bestBlob || blob.size < bestBlob.size) {
         bestBlob = blob;
@@ -211,10 +268,5 @@ export async function maybeCompressDocumentUploadImage(
     };
   }
 
-  return {
-    file,
-    optimized: false,
-    originalSize: file.size,
-    optimizedSize: file.size,
-  };
+  return originalUploadResult(file);
 }

--- a/packages/shared/src/utils/documents-upload-image.ts
+++ b/packages/shared/src/utils/documents-upload-image.ts
@@ -7,13 +7,6 @@ export type DocumentImageUploadFile = File & {
   webkitRelativePath?: string;
 };
 
-export class DocumentImageCompressionUnavailableError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = "DocumentImageCompressionUnavailableError";
-  }
-}
-
 export type DocumentImageCompressionPlatform = {
   isAvailable: () => boolean;
   loadImageSource: (file: File) => Promise<{
@@ -56,11 +49,7 @@ function browserCompressionPlatform(): DocumentImageCompressionPlatform {
           const nextImage = new Image();
           nextImage.onload = () => resolve(nextImage);
           nextImage.onerror = () =>
-            reject(
-              new DocumentImageCompressionUnavailableError(
-                `Failed to load image "${file.name}"`,
-              ),
-            );
+            reject(new Error(`Failed to load image "${file.name}"`));
           nextImage.src = objectUrl;
         });
         return {
@@ -77,34 +66,19 @@ function browserCompressionPlatform(): DocumentImageCompressionPlatform {
       canvas.width = width;
       canvas.height = height;
       const context = canvas.getContext("2d");
-      if (!context) {
-        throw new DocumentImageCompressionUnavailableError(
-          "Canvas 2D context is unavailable",
-        );
-      }
+      if (!context) throw new Error("Canvas 2D context is unavailable");
 
       if (outputType === IMAGE_OUTPUT_TYPE) {
         context.fillStyle = "#ffffff";
         context.fillRect(0, 0, width, height);
       }
-      try {
-        context.drawImage(source, 0, 0, width, height);
-      } catch (error) {
-        throw new DocumentImageCompressionUnavailableError(
-          "Canvas could not draw the source image",
-          { cause: error },
-        );
-      }
+      context.drawImage(source, 0, 0, width, height);
 
       return new Promise<Blob>((resolve, reject) => {
         canvas.toBlob(
           (blob) => {
             if (!blob) {
-              reject(
-                new DocumentImageCompressionUnavailableError(
-                  "Failed to encode optimized image",
-                ),
-              );
+              reject(new Error("Failed to encode optimized image"));
               return;
             }
             resolve(blob);
@@ -153,20 +127,6 @@ function cloneUploadFile(
   return cloned;
 }
 
-function originalUploadResult(file: DocumentImageUploadFile): {
-  file: DocumentImageUploadFile;
-  optimized: false;
-  originalSize: number;
-  optimizedSize: number;
-} {
-  return {
-    file,
-    optimized: false,
-    originalSize: file.size,
-    optimizedSize: file.size,
-  };
-}
-
 export function isDocumentImageFile(
   file: Pick<File, "name" | "type">,
 ): boolean {
@@ -189,22 +149,15 @@ export async function maybeCompressDocumentUploadImage(
     file.size <= MAX_DOCUMENT_IMAGE_PROCESSING_BYTES ||
     !platform.isAvailable()
   ) {
-    return originalUploadResult(file);
+    return {
+      file,
+      optimized: false,
+      originalSize: file.size,
+      optimizedSize: file.size,
+    };
   }
 
-  let image: Awaited<
-    ReturnType<DocumentImageCompressionPlatform["loadImageSource"]>
-  >;
-  try {
-    image = await platform.loadImageSource(file);
-  } catch (error) {
-    if (error instanceof DocumentImageCompressionUnavailableError) {
-      // error-policy:J4 optional image optimization is visibly rechecked by
-      // DocumentsView before the original file is uploaded.
-      return originalUploadResult(file);
-    }
-    throw error;
-  }
+  const image = await platform.loadImageSource(file);
   let { width, height } = clampDimensions(
     image.width,
     image.height,
@@ -214,23 +167,13 @@ export async function maybeCompressDocumentUploadImage(
 
   while (true) {
     for (const quality of IMAGE_QUALITY_STEPS) {
-      let blob: Blob;
-      try {
-        blob = await platform.renderBlob({
-          source: image.source,
-          width,
-          height,
-          outputType: IMAGE_OUTPUT_TYPE,
-          quality,
-        });
-      } catch (error) {
-        if (error instanceof DocumentImageCompressionUnavailableError) {
-          // error-policy:J4 optional image optimization is visibly rechecked
-          // by DocumentsView before the original file is uploaded.
-          return originalUploadResult(file);
-        }
-        throw error;
-      }
+      const blob = await platform.renderBlob({
+        source: image.source,
+        width,
+        height,
+        outputType: IMAGE_OUTPUT_TYPE,
+        quality,
+      });
 
       if (!bestBlob || blob.size < bestBlob.size) {
         bestBlob = blob;
@@ -268,5 +211,10 @@ export async function maybeCompressDocumentUploadImage(
     };
   }
 
-  return originalUploadResult(file);
+  return {
+    file,
+    optimized: false,
+    originalSize: file.size,
+    optimizedSize: file.size,
+  };
 }


### PR DESCRIPTION
## Summary

- preserves the exact original valid File when optional decode/canvas compression is explicitly unavailable
- introduces a typed expected-failure shape for browser decoding, drawing, and encoding failures
- rethrows unexpected platform/programming failures instead of fabricating success
- retains required file/platform contracts and truthful byte sizes
- supersedes closed #21895 and continues #21894

Original contribution direction credited to Deepanshu Yadav in the commit trailer.

## Exact-head evidence

Head: 56627ca7370470454df1bbcf5ab94c66c83eb9e2
Base: 273e4c20bbdbf6a1af5e56e7bea5f5df9291fb64

- bun test packages/shared/src/utils/documents-upload-image.test.ts: 10 passed, 0 failed
- bun run --cwd packages/shared typecheck: passed
- Biome on both touched files: passed
- git diff --check: passed
- artifacts assert exact File identity/name/size for expected decode and encode failures; an unexpected TypeError is asserted to reject

## Evidence applicability

- screenshots/video: N/A - no rendered UI change; existing DocumentsView performs the visible size recheck
- frontend/backend logs: N/A - deterministic optional preprocessing boundary
- model trajectory: N/A - no model behavior
- domain artifact: exact original File identity and truthful size metadata asserted

## Contribution provenance

- AI assistance: yes
- Model(s) used: OpenAI/gpt-5.6-sol
- Agent tooling: Codex Desktop
- Skill path: elizaOS/eliza@273e4c20bbdbf6a1af5e56e7bea5f5df9291fb64:packages/skills/skills/contribute-to-eliza
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@273e4c20bbdbf6a1af5e56e7bea5f5df9291fb64:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@273e4c20bbdbf6a1af5e56e7bea5f5df9291fb64:packages/skills/skills/contribute-to-eliza"} -->
