### PR TITLE
fix(plugin-video): validate and forward yt-dlp download flags

### DIFF
--- a/plugins/plugin-video/src/services/binaries.ts
+++ b/plugins/plugin-video/src/services/binaries.ts
@@ -18,6 +18,7 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
 import { elizaLogger, resolveStateDir } from "@elizaos/core";
+import type { Flags as YtDlpFlags } from "youtube-dl-exec";
 import youtubeDl from "youtube-dl-exec";
 
 const require = createRequire(import.meta.url);
@@ -25,7 +26,7 @@ const execFileAsync = promisify(execFile);
 
 export type YtDlpRunner = (
   url: string,
-  flags?: Record<string, string | boolean | number | undefined>,
+  flags?: YtDlpFlags,
   opts?: object,
 ) => Promise<unknown>;
 
@@ -283,10 +284,7 @@ export class BinaryResolver {
    * Run yt-dlp with one auto-update + retry attempt on extractor-failure
    * patterns, when the active binary is the managed cache.
    */
-  async runYtDlp(
-    url: string,
-    flags: Record<string, string | boolean | number | undefined>,
-  ): Promise<unknown> {
+  async runYtDlp(url: string, flags: YtDlpFlags): Promise<unknown> {
     const runner = await this.getYtDlpRunner();
     try {
       return await runner(url, flags);

--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -321,7 +321,7 @@ describe("VideoService deterministic behavior", () => {
       output: outputPath,
       writeInfoJson: false,
       format: "bestvideo",
-      writeSubs: true,
+      writeSub: true,
       embedSubs: true,
     });
   });

--- a/plugins/plugin-video/src/services/video.ts
+++ b/plugins/plugin-video/src/services/video.ts
@@ -23,6 +23,7 @@ import {
   type VideoProcessingOptions,
 } from "@elizaos/core";
 import ffmpeg from "fluent-ffmpeg";
+import type { Flags as YtDlpFlags } from "youtube-dl-exec";
 import { BinaryResolver } from "./binaries";
 import { normalizeCaptionNewlines, parseYtDlpUploadDate } from "./video-parse";
 
@@ -237,7 +238,7 @@ export class VideoService extends IVideoService {
     }
 
     try {
-      const downloadOptions: Record<string, string | boolean> = {
+      const downloadOptions: YtDlpFlags = {
         verbose: true,
         output: outputFile,
         writeInfoJson: options?.writeInfoJson ?? true,
@@ -256,7 +257,7 @@ export class VideoService extends IVideoService {
         downloadOptions.format = "bestvideo[ext=mp4]/best[ext=mp4]/best";
       }
       if (options?.subtitles) {
-        downloadOptions.writeSubs = true;
+        downloadOptions.writeSub = true;
       }
       if (options?.embedSubs) {
         downloadOptions.embedSubs = true;


### PR DESCRIPTION
# Relates to

Closes #22046.
Supersedes #22047 while retaining its original option-forwarding commit and attribution.

## Review finding and repair

The submitted PR used `writeSubs`, but the installed `youtube-dl-exec` contract exposes `writeSub` (singular). The mocked assertion therefore proved the same invalid key and the real CLI would not receive `--write-subs`.

This replacement:

- forwards `subtitles` as the library-correct `writeSub`
- forwards `embedSubs` and caller-controlled `writeInfoJson`
- preserves explicit `format` precedence over `quality`
- types `BinaryResolver.runYtDlp`, its runner, and the download option object with upstream `Flags`, preventing future misspelled or unsupported flag names from compiling

## Exact-head evidence

Head: `1e9d02d97ab0e59a5ddb6bfeb76a47ec9fa9e374`

- plugin-video full unit lane: 40 passed, 4 integration-only skipped
- plugin-video typecheck: passed
- changed-file Biome: passed
- `git diff --check`: passed

The test double now asserts `writeSub: true`, matching the installed upstream declaration. No rendered UI, model behavior, or persistent domain artifact changes; visual and trajectory evidence are N/A.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@b5f0f27a706f82c132b97278e6342765461a9cae:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:1e9d02d97ab0e59a5ddb6bfeb76a47ec9fa9e374 -->