### PR TITLE
fix(plugin-google-genai): enforce real embedding token limits

### DIFF
--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -2488,10 +2488,10 @@
           "type": "string",
           "required": false,
           "sensitive": false,
-          "default": "text-embedding-004",
+          "default": "gemini-embedding-001",
           "label": "Embedding Model",
           "help": "Overrides the default text embedding model used by Google Generative AI.",
-          "placeholder": "e.g., text-embedding-3-small",
+          "placeholder": "e.g., gemini-embedding-001, gemini-embedding-2",
           "advanced": false
         },
         "GOOGLE_IMAGE_MODEL": {

--- a/plugins/plugin-google-genai/AGENTS.md
+++ b/plugins/plugin-google-genai/AGENTS.md
@@ -99,7 +99,7 @@ Append a `TestCase` object to the `pluginTests[0].tests` array in `index.ts`. Te
 - **Structured output.** Pass a JSON Schema as `responseSchema` in `GenerateTextParams`. Text handlers internally set `responseMimeType: "application/json"` and `responseJsonSchema` on the Google SDK request. The model returns raw JSON text; no post-parse step is applied for text handlers (the caller owns parsing).
 - **Safety settings are hardcoded.** All four harm categories block at `BLOCK_MEDIUM_AND_ABOVE`. Adjust in `utils/config.ts → getSafetySettings()` if needed.
 - **Token counting is a heuristic.** `utils/tokenization.ts` estimates tokens as `Math.ceil(text.length / 4)`. It is used for telemetry only; do not rely on it for context-window management.
-- **Embedding truncation.** Inputs are truncated to the embedding model's documented input token limit before the request (`gemini-embedding-001` -> 2 048 tokens / ~8 192 chars; the larger-window `gemini-embedding-2` -> 8 192 tokens / ~32 768 chars), resolved via `getEmbeddingInputTokenLimit` in `utils/config.ts`. This is a real per-model constraint, not the telemetry-only `length / 4` estimate.
+- **Embedding truncation.** Inputs are measured with Google's model tokenizer and truncated by code-point-safe binary search to the documented input limit before embedding (`gemini-embedding-001` -> 2 048 tokens; `gemini-embedding-2` -> 8 192). The `length / 4` helper remains telemetry-only.
 - **No actions, providers, or evaluators.** If you need to add behavior beyond model inference, register it in a separate plugin or in the agent's character definition.
 
 ## Verification

--- a/plugins/plugin-google-genai/AGENTS.md
+++ b/plugins/plugin-google-genai/AGENTS.md
@@ -99,7 +99,7 @@ Append a `TestCase` object to the `pluginTests[0].tests` array in `index.ts`. Te
 - **Structured output.** Pass a JSON Schema as `responseSchema` in `GenerateTextParams`. Text handlers internally set `responseMimeType: "application/json"` and `responseJsonSchema` on the Google SDK request. The model returns raw JSON text; no post-parse step is applied for text handlers (the caller owns parsing).
 - **Safety settings are hardcoded.** All four harm categories block at `BLOCK_MEDIUM_AND_ABOVE`. Adjust in `utils/config.ts → getSafetySettings()` if needed.
 - **Token counting is a heuristic.** `utils/tokenization.ts` estimates tokens as `Math.ceil(text.length / 4)`. It is used for telemetry only; do not rely on it for context-window management.
-- **Embedding truncation.** Inputs longer than ~32 768 characters (~8 192 tokens) are truncated before being sent to the embedding model.
+- **Embedding truncation.** Inputs are truncated to the embedding model's documented input token limit before the request (`gemini-embedding-001` -> 2 048 tokens / ~8 192 chars; the larger-window `gemini-embedding-2` -> 8 192 tokens / ~32 768 chars), resolved via `getEmbeddingInputTokenLimit` in `utils/config.ts`. This is a real per-model constraint, not the telemetry-only `length / 4` estimate.
 - **No actions, providers, or evaluators.** If you need to add behavior beyond model inference, register it in a separate plugin or in the agent's character definition.
 
 ## Verification

--- a/plugins/plugin-google-genai/CLAUDE.md
+++ b/plugins/plugin-google-genai/CLAUDE.md
@@ -99,7 +99,7 @@ Append a `TestCase` object to the `pluginTests[0].tests` array in `index.ts`. Te
 - **Structured output.** Pass a JSON Schema as `responseSchema` in `GenerateTextParams`. Text handlers internally set `responseMimeType: "application/json"` and `responseJsonSchema` on the Google SDK request. The model returns raw JSON text; no post-parse step is applied for text handlers (the caller owns parsing).
 - **Safety settings are hardcoded.** All four harm categories block at `BLOCK_MEDIUM_AND_ABOVE`. Adjust in `utils/config.ts → getSafetySettings()` if needed.
 - **Token counting is a heuristic.** `utils/tokenization.ts` estimates tokens as `Math.ceil(text.length / 4)`. It is used for telemetry only; do not rely on it for context-window management.
-- **Embedding truncation.** Inputs are truncated to the embedding model's documented input token limit before the request (`gemini-embedding-001` -> 2 048 tokens / ~8 192 chars; the larger-window `gemini-embedding-2` -> 8 192 tokens / ~32 768 chars), resolved via `getEmbeddingInputTokenLimit` in `utils/config.ts`. This is a real per-model constraint, not the telemetry-only `length / 4` estimate.
+- **Embedding truncation.** Inputs are measured with Google's model tokenizer and truncated by code-point-safe binary search to the documented input limit before embedding (`gemini-embedding-001` -> 2 048 tokens; `gemini-embedding-2` -> 8 192). The `length / 4` helper remains telemetry-only.
 - **No actions, providers, or evaluators.** If you need to add behavior beyond model inference, register it in a separate plugin or in the agent's character definition.
 
 ## Verification

--- a/plugins/plugin-google-genai/CLAUDE.md
+++ b/plugins/plugin-google-genai/CLAUDE.md
@@ -99,7 +99,7 @@ Append a `TestCase` object to the `pluginTests[0].tests` array in `index.ts`. Te
 - **Structured output.** Pass a JSON Schema as `responseSchema` in `GenerateTextParams`. Text handlers internally set `responseMimeType: "application/json"` and `responseJsonSchema` on the Google SDK request. The model returns raw JSON text; no post-parse step is applied for text handlers (the caller owns parsing).
 - **Safety settings are hardcoded.** All four harm categories block at `BLOCK_MEDIUM_AND_ABOVE`. Adjust in `utils/config.ts → getSafetySettings()` if needed.
 - **Token counting is a heuristic.** `utils/tokenization.ts` estimates tokens as `Math.ceil(text.length / 4)`. It is used for telemetry only; do not rely on it for context-window management.
-- **Embedding truncation.** Inputs longer than ~32 768 characters (~8 192 tokens) are truncated before being sent to the embedding model.
+- **Embedding truncation.** Inputs are truncated to the embedding model's documented input token limit before the request (`gemini-embedding-001` -> 2 048 tokens / ~8 192 chars; the larger-window `gemini-embedding-2` -> 8 192 tokens / ~32 768 chars), resolved via `getEmbeddingInputTokenLimit` in `utils/config.ts`. This is a real per-model constraint, not the telemetry-only `length / 4` estimate.
 - **No actions, providers, or evaluators.** If you need to add behavior beyond model inference, register it in a separate plugin or in the agent's character definition.
 
 ## Verification

--- a/plugins/plugin-google-genai/__tests__/config.test.ts
+++ b/plugins/plugin-google-genai/__tests__/config.test.ts
@@ -3,6 +3,8 @@
  * env precedence, blank trimming, model-alias fallback, and client creation.
  * `@google/genai` and the logger are mocked; no network.
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -32,13 +34,23 @@ vi.mock("@google/genai", () => ({
 
 import {
   createGoogleGenAI,
+  DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT,
   DEFAULT_GOOGLE_EMBEDDING_MODEL,
   getApiKey,
+  getEmbeddingInputTokenLimit,
   getEmbeddingModel,
   getLargeModel,
   getResponseHandlerModel,
   getSmallModel,
 } from "../utils/config";
+
+const PLUGIN_ROOT = new URL("../", import.meta.url);
+
+function readPluginJson(relativePath: string): unknown {
+  return JSON.parse(
+    readFileSync(fileURLToPath(new URL(relativePath, PLUGIN_ROOT)), "utf-8"),
+  );
+}
 
 type Settings = Record<string, string | null | undefined>;
 
@@ -129,5 +141,49 @@ describe("Google GenAI config", () => {
         runtimeWith({ GOOGLE_EMBEDDING_MODEL: " text-embedding-004 " }),
       ),
     ).toBe("text-embedding-004");
+  });
+
+  it("resolves model-aware embedding input token limits with a safe default", () => {
+    // gemini-embedding-001 documents a 2,048-token input limit; the larger
+    // gemini-embedding-2 window accepts 8,192. Unmapped overrides must fall back
+    // to the safe default (2,048), never the larger window.
+    expect(getEmbeddingInputTokenLimit("gemini-embedding-001")).toBe(2_048);
+    expect(getEmbeddingInputTokenLimit("gemini-embedding-2")).toBe(8_192);
+    expect(getEmbeddingInputTokenLimit("some-unknown-model")).toBe(
+      DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT,
+    );
+    expect(DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT).toBe(2_048);
+    // The default model's limit must equal the safe fallback so an unknown id is
+    // never truncated to a window wider than the shipped default supports.
+    expect(getEmbeddingInputTokenLimit(DEFAULT_GOOGLE_EMBEDDING_MODEL)).toBe(
+      DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT,
+    );
+  });
+
+  it("keeps package.json and registry-entry.json embedding defaults in sync with DEFAULT_GOOGLE_EMBEDDING_MODEL", () => {
+    // Drift guard: both public config sources previously advertised the retired
+    // text-embedding-004 while the runtime default moved to gemini-embedding-001.
+    // Assert they derive from the same source of truth so they cannot drift again.
+    const pkg = readPluginJson("package.json") as {
+      agentConfig: {
+        pluginParameters: { GOOGLE_EMBEDDING_MODEL: { default: string } };
+      };
+    };
+    const registry = readPluginJson("registry-entry.json") as {
+      config: {
+        GOOGLE_EMBEDDING_MODEL: { default: string; placeholder: string };
+      };
+    };
+
+    expect(
+      pkg.agentConfig.pluginParameters.GOOGLE_EMBEDDING_MODEL.default,
+    ).toBe(DEFAULT_GOOGLE_EMBEDDING_MODEL);
+    expect(registry.config.GOOGLE_EMBEDDING_MODEL.default).toBe(
+      DEFAULT_GOOGLE_EMBEDDING_MODEL,
+    );
+    // The placeholder must name valid Google embedding ids, not an OpenAI model.
+    const placeholder = registry.config.GOOGLE_EMBEDDING_MODEL.placeholder;
+    expect(placeholder).toContain("gemini-embedding");
+    expect(placeholder).not.toMatch(/text-embedding-3|gpt-|openai/i);
   });
 });

--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -277,6 +277,59 @@ describe("Google GenAI embeddings", () => {
     expect(passed.contents).toBe("!".repeat(2_048));
   });
 
+  it("truncates only at Unicode code-point boundaries", async () => {
+    mocks.countEmbeddingTokens.mockImplementation(
+      async ({ contents }: { contents: string }) => ({
+        totalTokens: Array.from(contents).length,
+      }),
+    );
+    const oversized = "😀".repeat(3_000);
+
+    await handleTextEmbedding(createRuntime(), oversized);
+
+    const passed = mocks.embedContent.mock.calls[0][0] as { contents: string };
+    expect(Array.from(passed.contents)).toHaveLength(2_048);
+    expect(passed.contents).toBe("😀".repeat(2_048));
+    expect(passed.contents.endsWith("😀")).toBe(true);
+  });
+
+  it("stays safe when prefix token counts are non-monotone", async () => {
+    mocks.countEmbeddingTokens.mockImplementation(
+      async ({ contents }: { contents: string }) => ({
+        // A contrived merge discontinuity: the 1,500-character prefix costs
+        // more than longer neighboring prefixes. The search may conservatively
+        // stop early, but the exact prefix sent must still be measured <= 2,048.
+        totalTokens: contents.length === 1_500 ? 2_500 : contents.length,
+      }),
+    );
+
+    await handleTextEmbedding(createRuntime(), "n".repeat(3_000));
+
+    const passed = mocks.embedContent.mock.calls[0][0] as { contents: string };
+    expect(passed.contents).toBe("n".repeat(1_499));
+  });
+
+  it("fails closed if re-measuring the selected prefix exceeds the limit", async () => {
+    const callsByContents = new Map<string, number>();
+    mocks.countEmbeddingTokens.mockImplementation(
+      async ({ contents }: { contents: string }) => {
+        const calls = (callsByContents.get(contents) ?? 0) + 1;
+        callsByContents.set(contents, calls);
+        return {
+          totalTokens:
+            contents.length === 2_048 && calls > 1 ? 2_049 : contents.length,
+        };
+      },
+    );
+
+    await expect(
+      handleTextEmbedding(createRuntime(), "x".repeat(3_000)),
+    ).rejects.toMatchObject({
+      code: "EMBEDDING_TOKEN_LIMIT_UNSATISFIABLE",
+    });
+    expect(mocks.embedContent).not.toHaveBeenCalled();
+  });
+
   it("does NOT truncate a gemini-embedding-2 override to the smaller 2,048 limit for the same input", async () => {
     // The same provider-tokenized input that exceeds the default model's 2,048
     // limit remains below gemini-embedding-2's 8,192-token window.

--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   countTokens: vi.fn(),
+  countEmbeddingTokens: vi.fn(),
   createGoogleGenAI: vi.fn(),
   embedContent: vi.fn(),
   emitModelUsageEvent: vi.fn(),
@@ -74,6 +75,11 @@ describe("Google GenAI embeddings", () => {
     vi.clearAllMocks();
     mocks.getEmbeddingModel.mockReturnValue("gemini-embedding-001");
     mocks.countTokens.mockResolvedValue(5);
+    mocks.countEmbeddingTokens.mockImplementation(
+      async ({ contents }: { contents: string }) => ({
+        totalTokens: Math.ceil(contents.length / 4),
+      }),
+    );
     // gemini-embedding-001 honours outputDimensionality:768 and returns a
     // 768-length (un-normalized) vector for that request.
     mocks.embedContent.mockResolvedValue({
@@ -81,6 +87,7 @@ describe("Google GenAI embeddings", () => {
     });
     mocks.createGoogleGenAI.mockReturnValue({
       models: {
+        countTokens: mocks.countEmbeddingTokens,
         embedContent: mocks.embedContent,
       },
     });
@@ -249,12 +256,14 @@ describe("Google GenAI embeddings", () => {
     });
   });
 
-  it("truncates an oversized input to the default model's 2,048-token (~8,192-char) limit before the embedContent call", async () => {
-    // gemini-embedding-001 documents a 2,048-token input limit. The handler must
-    // slice the text to ~4 chars/token = 8,192 chars BEFORE the SDK call, so the
-    // mocked embedContent never sees more than 8,192 characters for this model.
+  it("uses the provider tokenizer to truncate adversarial one-character tokens to the default model limit", async () => {
     mocks.getEmbeddingModel.mockReturnValue("gemini-embedding-001");
-    const oversized = "a".repeat(20_000);
+    mocks.countEmbeddingTokens.mockImplementation(
+      async ({ contents }: { contents: string }) => ({
+        totalTokens: contents.length,
+      }),
+    );
+    const oversized = "!".repeat(3_000);
 
     await handleTextEmbedding(createRuntime(), oversized);
 
@@ -264,17 +273,20 @@ describe("Google GenAI embeddings", () => {
       contents: string;
     };
     expect(passed.model).toBe("gemini-embedding-001");
-    expect(passed.contents.length).toBe(8_192);
-    expect(passed.contents).toBe("a".repeat(8_192));
+    expect(passed.contents.length).toBe(2_048);
+    expect(passed.contents).toBe("!".repeat(2_048));
   });
 
   it("does NOT truncate a gemini-embedding-2 override to the smaller 2,048 limit for the same input", async () => {
-    // gemini-embedding-2 supports an 8,192-token window (~32,768 chars). The
-    // same 20,000-char input that is cut to 8,192 chars under the default model
-    // must pass through untouched here, proving the limit is model-aware and not
-    // pinned to the old hardcoded boundary.
+    // The same provider-tokenized input that exceeds the default model's 2,048
+    // limit remains below gemini-embedding-2's 8,192-token window.
     mocks.getEmbeddingModel.mockReturnValue("gemini-embedding-2");
-    const input = "a".repeat(20_000);
+    mocks.countEmbeddingTokens.mockImplementation(
+      async ({ contents }: { contents: string }) => ({
+        totalTokens: contents.length,
+      }),
+    );
+    const input = "a".repeat(3_000);
 
     await handleTextEmbedding(createRuntime(), input);
 
@@ -284,19 +296,33 @@ describe("Google GenAI embeddings", () => {
       contents: string;
     };
     expect(passed.model).toBe("gemini-embedding-2");
-    expect(passed.contents.length).toBe(20_000);
+    expect(passed.contents.length).toBe(3_000);
   });
 
   it("truncates an unmapped override to the safe 2,048-token default limit", async () => {
     // An override id not present in the limit map falls back to the safe 2,048
-    // limit (never the larger 8,192 window), so it is cut to 8,192 chars.
+    // limit rather than inheriting the larger model's window.
     mocks.getEmbeddingModel.mockReturnValue("some-unknown-embedding-model");
-    const oversized = "b".repeat(40_000);
+    mocks.countEmbeddingTokens.mockImplementation(
+      async ({ contents }: { contents: string }) => ({
+        totalTokens: contents.length,
+      }),
+    );
+    const oversized = "b".repeat(3_000);
 
     await handleTextEmbedding(createRuntime(), oversized);
 
     const passed = mocks.embedContent.mock.calls[0][0] as { contents: string };
-    expect(passed.contents.length).toBe(8_192);
+    expect(passed.contents.length).toBe(2_048);
+  });
+
+  it("fails closed when the provider tokenizer returns no valid token total", async () => {
+    mocks.countEmbeddingTokens.mockResolvedValue({});
+
+    await expect(
+      handleTextEmbedding(createRuntime(), "hello"),
+    ).rejects.toMatchObject({ code: "EMBEDDING_TOKEN_COUNT_INVALID" });
+    expect(mocks.embedContent).not.toHaveBeenCalled();
   });
 
   it("throws for empty embedding input before creating a client", async () => {

--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   createGoogleGenAI: vi.fn(),
   embedContent: vi.fn(),
   emitModelUsageEvent: vi.fn(),
+  getEmbeddingModel: vi.fn(() => "gemini-embedding-001"),
 }));
 
 vi.mock("@elizaos/core", async () => {
@@ -38,10 +39,18 @@ vi.mock("@elizaos/core", async () => {
   };
 });
 
-vi.mock("../utils/config", () => ({
-  createGoogleGenAI: mocks.createGoogleGenAI,
-  getEmbeddingModel: vi.fn(() => "gemini-embedding-001"),
-}));
+vi.mock("../utils/config", async () => {
+  // Use the real per-model input-token-limit resolver so the truncation
+  // boundary tests exercise the actual gemini-embedding-001 (2048) vs
+  // gemini-embedding-2 (8192) map, not a re-declared stub that could drift.
+  const actual =
+    await vi.importActual<typeof import("../utils/config")>("../utils/config");
+  return {
+    createGoogleGenAI: mocks.createGoogleGenAI,
+    getEmbeddingModel: mocks.getEmbeddingModel,
+    getEmbeddingInputTokenLimit: actual.getEmbeddingInputTokenLimit,
+  };
+});
 
 vi.mock("../utils/events", () => ({
   emitModelUsageEvent: mocks.emitModelUsageEvent,
@@ -63,6 +72,7 @@ function createRuntime(): IAgentRuntime {
 describe("Google GenAI embeddings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getEmbeddingModel.mockReturnValue("gemini-embedding-001");
     mocks.countTokens.mockResolvedValue(5);
     // gemini-embedding-001 honours outputDimensionality:768 and returns a
     // 768-length (un-normalized) vector for that request.
@@ -237,6 +247,56 @@ describe("Google GenAI embeddings", () => {
       code: "EMBEDDING_NON_FINITE",
       context: { dimensions: 768, index: 7 },
     });
+  });
+
+  it("truncates an oversized input to the default model's 2,048-token (~8,192-char) limit before the embedContent call", async () => {
+    // gemini-embedding-001 documents a 2,048-token input limit. The handler must
+    // slice the text to ~4 chars/token = 8,192 chars BEFORE the SDK call, so the
+    // mocked embedContent never sees more than 8,192 characters for this model.
+    mocks.getEmbeddingModel.mockReturnValue("gemini-embedding-001");
+    const oversized = "a".repeat(20_000);
+
+    await handleTextEmbedding(createRuntime(), oversized);
+
+    expect(mocks.embedContent).toHaveBeenCalledTimes(1);
+    const passed = mocks.embedContent.mock.calls[0][0] as {
+      model: string;
+      contents: string;
+    };
+    expect(passed.model).toBe("gemini-embedding-001");
+    expect(passed.contents.length).toBe(8_192);
+    expect(passed.contents).toBe("a".repeat(8_192));
+  });
+
+  it("does NOT truncate a gemini-embedding-2 override to the smaller 2,048 limit for the same input", async () => {
+    // gemini-embedding-2 supports an 8,192-token window (~32,768 chars). The
+    // same 20,000-char input that is cut to 8,192 chars under the default model
+    // must pass through untouched here, proving the limit is model-aware and not
+    // pinned to the old hardcoded boundary.
+    mocks.getEmbeddingModel.mockReturnValue("gemini-embedding-2");
+    const input = "a".repeat(20_000);
+
+    await handleTextEmbedding(createRuntime(), input);
+
+    expect(mocks.embedContent).toHaveBeenCalledTimes(1);
+    const passed = mocks.embedContent.mock.calls[0][0] as {
+      model: string;
+      contents: string;
+    };
+    expect(passed.model).toBe("gemini-embedding-2");
+    expect(passed.contents.length).toBe(20_000);
+  });
+
+  it("truncates an unmapped override to the safe 2,048-token default limit", async () => {
+    // An override id not present in the limit map falls back to the safe 2,048
+    // limit (never the larger 8,192 window), so it is cut to 8,192 chars.
+    mocks.getEmbeddingModel.mockReturnValue("some-unknown-embedding-model");
+    const oversized = "b".repeat(40_000);
+
+    await handleTextEmbedding(createRuntime(), oversized);
+
+    const passed = mocks.embedContent.mock.calls[0][0] as { contents: string };
+    expect(passed.contents.length).toBe(8_192);
   });
 
   it("throws for empty embedding input before creating a client", async () => {

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -159,24 +159,40 @@ async function truncateToEmbeddingTokenLimit(
 
   let low = 0;
   let high = boundaries.length - 1;
-  let acceptedTokens = 0;
   while (low < high) {
     const middle = Math.ceil((low + high) / 2);
     const candidate = text.slice(0, boundaries[middle]);
     const tokens = await providerTokenCount(genAI, model, candidate);
     if (tokens <= limit) {
       low = middle;
-      acceptedTokens = tokens;
     } else {
       high = middle - 1;
     }
   }
 
   const truncatedText = text.slice(0, boundaries[low]);
-  if (low > 0 && acceptedTokens === 0) {
-    acceptedTokens = await providerTokenCount(genAI, model, truncatedText);
+  // Prefix token counts are not a mathematically monotone contract for a
+  // subword tokenizer: appending text can retokenize the preceding suffix.
+  // Binary search is therefore only a fast way to find a conservative
+  // candidate, not proof of maximality. Re-measure the exact returned prefix
+  // so tokenizer changes or a non-monotone/mock implementation can never let
+  // an over-limit request reach embedContent.
+  const verifiedTokens = await providerTokenCount(genAI, model, truncatedText);
+  if (verifiedTokens > limit || !truncatedText.trim()) {
+    throw new ElizaError(
+      "Google tokenizer could not produce a non-empty embedding prefix within the model limit",
+      {
+        code: "EMBEDDING_TOKEN_LIMIT_UNSATISFIABLE",
+        context: {
+          model,
+          limit,
+          candidateTokens: verifiedTokens,
+          candidateCodePoints: low,
+        },
+      },
+    );
   }
-  return { text: truncatedText, tokens: acceptedTokens, truncated: true };
+  return { text: truncatedText, tokens: verifiedTokens, truncated: true };
 }
 
 export async function handleTextEmbedding(

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -21,9 +21,11 @@
  * to the next TEXT_EMBEDDING provider (or disables embedding generation), so a
  * misconfigured model id can no longer produce an infinite 404 retry spam.
  */
+
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
 import * as ElizaCore from "@elizaos/core";
 import { ElizaError, logger } from "@elizaos/core";
+import type { GoogleGenAI } from "@google/genai";
 import {
   createGoogleGenAI,
   getEmbeddingInputTokenLimit,
@@ -121,6 +123,62 @@ function extractText(
   );
 }
 
+async function providerTokenCount(
+  genAI: GoogleGenAI,
+  model: string,
+  contents: string,
+): Promise<number> {
+  const response = await genAI.models.countTokens({ model, contents });
+  const total = response.totalTokens;
+  if (typeof total !== "number" || !Number.isSafeInteger(total) || total < 0) {
+    throw new ElizaError("Google token counter returned an invalid total", {
+      code: "EMBEDDING_TOKEN_COUNT_INVALID",
+      context: { model, totalTokens: total },
+    });
+  }
+  return total;
+}
+
+async function truncateToEmbeddingTokenLimit(
+  genAI: GoogleGenAI,
+  model: string,
+  text: string,
+  limit: number,
+): Promise<{ text: string; tokens: number; truncated: boolean }> {
+  const fullTokens = await providerTokenCount(genAI, model, text);
+  if (fullTokens <= limit) {
+    return { text, tokens: fullTokens, truncated: false };
+  }
+
+  const boundaries = [0];
+  for (let index = 0; index < text.length; ) {
+    const point = text.codePointAt(index);
+    index += point !== undefined && point > 0xffff ? 2 : 1;
+    boundaries.push(index);
+  }
+
+  let low = 0;
+  let high = boundaries.length - 1;
+  let acceptedTokens = 0;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const candidate = text.slice(0, boundaries[middle]);
+    const tokens = await providerTokenCount(genAI, model, candidate);
+    if (tokens <= limit) {
+      low = middle;
+      acceptedTokens = tokens;
+    } else {
+      high = middle - 1;
+    }
+  }
+
+  const truncatedText = text.slice(0, boundaries[low]);
+  if (low > 0 && acceptedTokens === 0) {
+    acceptedTokens = await providerTokenCount(genAI, model, truncatedText);
+  }
+  return { text: truncatedText, tokens: acceptedTokens, truncated: true };
+}
+
 export async function handleTextEmbedding(
   runtime: IAgentRuntime,
   params: TextEmbeddingParams | string | null,
@@ -146,21 +204,22 @@ export async function handleTextEmbedding(
   const embeddingModelName = getEmbeddingModel(runtime);
   logger.debug(`[TEXT_EMBEDDING] Using model: ${embeddingModelName}`);
 
-  // Truncate to stay within the model's documented input token limit. The limit
-  // is model-aware (gemini-embedding-001 -> 2048, gemini-embedding-2 -> 8192,
-  // safe 2048 default for unmapped overrides); the ~4 chars/token factor only
-  // converts that token limit to a character slice. This boundary is a real
-  // provider constraint, not the telemetry-only `length / 4` estimate.
   const tokenLimit = getEmbeddingInputTokenLimit(embeddingModelName);
-  const maxChars = tokenLimit * 4;
-  if (text.length > maxChars) {
-    logger.warn(
-      `[Google GenAI] Embedding input too long (~${Math.ceil(text.length / 4)} tokens) for model "${embeddingModelName}", truncating to its ${tokenLimit}-token (~${maxChars}-char) input limit`,
-    );
-    text = text.slice(0, maxChars);
-  }
 
   try {
+    const bounded = await truncateToEmbeddingTokenLimit(
+      genAI,
+      embeddingModelName,
+      text,
+      tokenLimit,
+    );
+    if (bounded.truncated) {
+      logger.warn(
+        `[Google GenAI] Embedding input has more than ${tokenLimit} tokens for model "${embeddingModelName}"; truncated with the provider tokenizer to ${bounded.tokens} tokens`,
+      );
+    }
+    text = bounded.text;
+
     const response = await genAI.models.embedContent({
       model: embeddingModelName,
       contents: text,

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -3,8 +3,11 @@
  * `gemini-embedding-001`; overridable via `GOOGLE_EMBEDDING_MODEL`).
  * A `null`/empty-object input is treated as an initialization probe and answered
  * with a fixed 768-length marker vector so the runtime can size its embedding
- * column without a network call; real text is truncated to the model's ~8192
- * token limit, embedded, and reported via `emitModelUsageEvent`. Real requests
+ * column without a network call; real text is truncated to the model's
+ * documented input token limit (2,048 for the default `gemini-embedding-001`,
+ * 8,192 for the larger-window `gemini-embedding-2`) via
+ * `getEmbeddingInputTokenLimit`, embedded, and reported via
+ * `emitModelUsageEvent`. Real requests
  * pin `outputDimensionality` to the same 768 width as the probe and L2-normalize
  * the result, because the default `gemini-embedding-001` otherwise emits its
  * 3072-dim default and every write would fail the probe-sized column (#22010).
@@ -21,7 +24,11 @@
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
 import * as ElizaCore from "@elizaos/core";
 import { ElizaError, logger } from "@elizaos/core";
-import { createGoogleGenAI, getEmbeddingModel } from "../utils/config";
+import {
+  createGoogleGenAI,
+  getEmbeddingInputTokenLimit,
+  getEmbeddingModel,
+} from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
 import { countTokens } from "../utils/tokenization";
 
@@ -139,11 +146,16 @@ export async function handleTextEmbedding(
   const embeddingModelName = getEmbeddingModel(runtime);
   logger.debug(`[TEXT_EMBEDDING] Using model: ${embeddingModelName}`);
 
-  // Truncate to stay within embedding model token limits (~4 chars per token)
-  const maxChars = 8_192 * 4;
+  // Truncate to stay within the model's documented input token limit. The limit
+  // is model-aware (gemini-embedding-001 -> 2048, gemini-embedding-2 -> 8192,
+  // safe 2048 default for unmapped overrides); the ~4 chars/token factor only
+  // converts that token limit to a character slice. This boundary is a real
+  // provider constraint, not the telemetry-only `length / 4` estimate.
+  const tokenLimit = getEmbeddingInputTokenLimit(embeddingModelName);
+  const maxChars = tokenLimit * 4;
   if (text.length > maxChars) {
     logger.warn(
-      `[Google GenAI] Embedding input too long (~${Math.ceil(text.length / 4)} tokens), truncating to ~8192 tokens`,
+      `[Google GenAI] Embedding input too long (~${Math.ceil(text.length / 4)} tokens) for model "${embeddingModelName}", truncating to its ${tokenLimit}-token (~${maxChars}-char) input limit`,
     );
     text = text.slice(0, maxChars);
   }

--- a/plugins/plugin-google-genai/package.json
+++ b/plugins/plugin-google-genai/package.json
@@ -102,7 +102,7 @@
         "type": "string",
         "description": "Overrides the default text embedding model used by Google Generative AI.",
         "required": false,
-        "default": "text-embedding-004",
+        "default": "gemini-embedding-001",
         "sensitive": false
       },
       "GOOGLE_IMAGE_MODEL": {

--- a/plugins/plugin-google-genai/registry-entry.json
+++ b/plugins/plugin-google-genai/registry-entry.json
@@ -38,10 +38,10 @@
       "type": "string",
       "required": false,
       "sensitive": false,
-      "default": "text-embedding-004",
+      "default": "gemini-embedding-001",
       "label": "Embedding Model",
       "help": "Overrides the default text embedding model used by Google Generative AI.",
-      "placeholder": "e.g., text-embedding-3-small",
+      "placeholder": "e.g., gemini-embedding-001, gemini-embedding-2",
       "advanced": false
     },
     "GOOGLE_IMAGE_MODEL": {

--- a/plugins/plugin-google-genai/utils/config.ts
+++ b/plugins/plugin-google-genai/utils/config.ts
@@ -122,6 +122,39 @@ export function getImageModel(runtime: IAgentRuntime): string {
  */
 export const DEFAULT_GOOGLE_EMBEDDING_MODEL = "gemini-embedding-001";
 
+/**
+ * Per-model input token limit for the embedding endpoint. Google documents a
+ * 2,048-token input limit for `gemini-embedding-001`, while the larger-window
+ * `gemini-embedding-2` accepts 8,192 tokens. `handleTextEmbedding` derives its
+ * character truncation boundary from this map so the request never exceeds the
+ * model's real limit; an unmapped/override id falls back to the safe 2,048
+ * limit (`DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT`) rather than assuming the larger
+ * window. This is a hard model constraint — it must not be confused with the
+ * telemetry-only `length / 4` estimate in `utils/tokenization.ts`.
+ */
+export const EMBEDDING_INPUT_TOKEN_LIMITS: Readonly<Record<string, number>> = {
+  "gemini-embedding-001": 2_048,
+  "gemini-embedding-2": 8_192,
+};
+
+/**
+ * Safe default input token limit used when a `GOOGLE_EMBEDDING_MODEL` override
+ * names a model that is not in `EMBEDDING_INPUT_TOKEN_LIMITS`. Matches the
+ * current default model (`gemini-embedding-001`) so an unknown id can never be
+ * truncated to a window larger than it supports.
+ */
+export const DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT = 2_048;
+
+/**
+ * Resolve the documented input token limit for an embedding model id, falling
+ * back to the safe default for unmapped overrides.
+ */
+export function getEmbeddingInputTokenLimit(model: string): number {
+  return (
+    EMBEDDING_INPUT_TOKEN_LIMITS[model] ?? DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT
+  );
+}
+
 export function getEmbeddingModel(runtime: IAgentRuntime): string {
   return (
     getSetting(

--- a/plugins/plugin-google-genai/utils/config.ts
+++ b/plugins/plugin-google-genai/utils/config.ts
@@ -126,8 +126,8 @@ export const DEFAULT_GOOGLE_EMBEDDING_MODEL = "gemini-embedding-001";
  * Per-model input token limit for the embedding endpoint. Google documents a
  * 2,048-token input limit for `gemini-embedding-001`, while the larger-window
  * `gemini-embedding-2` accepts 8,192 tokens. `handleTextEmbedding` derives its
- * character truncation boundary from this map so the request never exceeds the
- * model's real limit; an unmapped/override id falls back to the safe 2,048
+ * provider-tokenized truncation boundary from this map so the request never
+ * exceeds the model's real limit; an unmapped/override id falls back to 2,048
  * limit (`DEFAULT_EMBEDDING_INPUT_TOKEN_LIMIT`) rather than assuming the larger
  * window. This is a hard model constraint — it must not be confused with the
  * telemetry-only `length / 4` estimate in `utils/tokenization.ts`.


### PR DESCRIPTION
## Summary

- retain the corrected Google embedding defaults and per-model limits from #22108
- measure embedding input with Google `models.countTokens` rather than the unsafe four-characters-per-token heuristic
- truncate oversized input at Unicode code-point boundaries
- re-measure the exact selected prefix before embedding, so nonmonotone or changed tokenizer responses fail closed rather than crossing the model limit

Fixes #22095. Supersedes #22108.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Contract review

The installed `@google/genai` 1.52.0 types expose `models.countTokens({ model, contents }) -> CountTokensResponse.totalTokens`. Google documents that endpoint as running the named model tokenizer. Current model documentation gives `gemini-embedding-001` a 2,048-token input limit and `gemini-embedding-2` an 8,192-token limit.

Prefix counts are not assumed mathematically monotone: a subword tokenizer may retokenize a suffix when text is appended. Binary search therefore selects a conservative code-point prefix, and the final exact prefix is counted again before `embedContent`; invalid, empty, or over-limit results throw a typed error.

## Exact-head verification

Head: `e6bd5a1ee91ee0123213cf7576452ff8779b5592`

- Full plugin tests: 8 files passed, 1 integration file skipped; 72 passed, 2 skipped.
- Focused embedding suite: 20/20 passed.
- Plugin typecheck: passed.
- Plugin lint: 30 files clean.
- Plugin build: Node, browser, CJS, and declarations passed.
- Package CLAUDE/AGENTS parity: passed.
- Diff check: passed.

Regressions cover adversarial one-character tokens, astral Unicode boundaries, a deliberately nonmonotone prefix counter, changed final-prefix counts, larger `gemini-embedding-2` limits, unknown-model fallback, and invalid provider totals.

## Evidence Gate

<!-- evidence-head:e6bd5a1ee91ee0123213cf7576452ff8779b5592 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend provider logic with no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend provider logic with no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head test/typecheck/lint/build evidence recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic pre-request token measurement; no generation trajectory.
<!-- evidence-row:domain-artifacts -->
- [x] Exact `embedContent.contents` and typed failure contracts are asserted by the focused suite.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.

AI provider/model: `openai / gpt-5.6-sol`
Client / agent tooling: `Codex Desktop`
Skill revision: `elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza`
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza"} -->