### PR TITLE
fix(cloud-shared): validate MCP constraints before rendering

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
@@ -79,34 +79,30 @@ export class OpenAIReasoningMcpCompatibility extends McpToolCompatibility {
       rules.push(text);
       rendered.add(key);
     };
+    const numericRule = (key: string, text: (value: number) => string): void => {
+      const value = constraints[key];
+      if (typeof value === "number") rule(key, text(value));
+    };
 
-    if (constraints.minLength !== undefined)
-      rule("minLength", `minimum ${constraints.minLength} characters`);
-    if (constraints.maxLength !== undefined)
-      rule("maxLength", `maximum ${constraints.maxLength} characters`);
-    if (constraints.minimum !== undefined) rule("minimum", `must be >= ${constraints.minimum}`);
-    if (constraints.maximum !== undefined) rule("maximum", `must be <= ${constraints.maximum}`);
-    if (constraints.exclusiveMinimum !== undefined)
-      rule("exclusiveMinimum", `must be > ${constraints.exclusiveMinimum}`);
-    if (constraints.exclusiveMaximum !== undefined)
-      rule("exclusiveMaximum", `must be < ${constraints.exclusiveMaximum}`);
-    if (constraints.multipleOf !== undefined)
-      rule("multipleOf", `must be a multiple of ${constraints.multipleOf}`);
+    numericRule("minLength", (value) => `minimum ${value} characters`);
+    numericRule("maxLength", (value) => `maximum ${value} characters`);
+    numericRule("minimum", (value) => `must be >= ${value}`);
+    numericRule("maximum", (value) => `must be <= ${value}`);
+    numericRule("exclusiveMinimum", (value) => `must be > ${value}`);
+    numericRule("exclusiveMaximum", (value) => `must be < ${value}`);
+    numericRule("multipleOf", (value) => `must be a multiple of ${value}`);
     if (constraints.format === "email") rule("format", `must be a valid email`);
     if (constraints.format === "uri" || constraints.format === "url")
       rule("format", `must be a valid URL`);
-    if (constraints.pattern !== undefined) rule("pattern", `must match: ${constraints.pattern}`);
-    if (constraints.enum !== undefined)
+    if (typeof constraints.pattern === "string")
+      rule("pattern", `must match: ${constraints.pattern}`);
+    if (Array.isArray(constraints.enum))
       rule("enum", `must be one of: ${(constraints.enum as string[]).join(", ")}`);
-    if (constraints.minItems !== undefined)
-      rule("minItems", `at least ${constraints.minItems} items`);
-    if (constraints.maxItems !== undefined)
-      rule("maxItems", `at most ${constraints.maxItems} items`);
+    numericRule("minItems", (value) => `at least ${value} items`);
+    numericRule("maxItems", (value) => `at most ${value} items`);
     if (constraints.uniqueItems === true) rule("uniqueItems", `items must be unique`);
-    if (constraints.minProperties !== undefined)
-      rule("minProperties", `at least ${constraints.minProperties} properties`);
-    if (constraints.maxProperties !== undefined)
-      rule("maxProperties", `at most ${constraints.maxProperties} properties`);
+    numericRule("minProperties", (value) => `at least ${value} properties`);
+    numericRule("maxProperties", (value) => `at most ${value} properties`);
 
     const unrendered = Object.keys(constraints).filter((key) => !rendered.has(key));
     const parts: string[] = [];

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
@@ -104,5 +104,29 @@ describe("cloud MCP tool-compatibility zero-valued bounds (#22068)", () => {
       const text = describeOf(reasoning(), { type: "string", minLength: 2, maxLength: 8 });
       expect(text).toBe("IMPORTANT: minimum 2 characters, maximum 8 characters");
     });
+
+    it("renders a uniqueness requirement when uniqueItems is true", () => {
+      expect(describeOf(reasoning(), { type: "array", uniqueItems: true })).toContain(
+        "items must be unique",
+      );
+    });
+
+    it("does not throw when an untrusted schema supplies a non-array enum", () => {
+      const malformed = { type: "string", enum: null } as unknown as JSONSchema7;
+      expect(() => describeOf(reasoning(), malformed)).not.toThrow();
+      expect(describeOf(reasoning(), malformed)).toContain('"enum":null');
+    });
+
+    it("restates and strips object property bounds", () => {
+      const out = reasoning().transformToolSchema({
+        type: "object",
+        minProperties: 0,
+        maxProperties: 2,
+      });
+      expect(out.description).toContain("at least 0 properties");
+      expect(out.description).toContain("at most 2 properties");
+      expect(out.minProperties).toBeUndefined();
+      expect(out.maxProperties).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- follow up on #22069 by value-checking collected third-party MCP schema constraints before rendering them as prose
- preserve zero-valued numeric bounds while preventing malformed `enum`, `pattern`, and numeric values from throwing or producing misleading descriptions
- pin `uniqueItems` true/false semantics, malformed `enum: null`, and stripped zero-valued object-property bounds

This is intentionally cloud-only. #22050 correctly fixed the separate standalone `plugin-mcp` Google path, while #22069 fixed the production cloud-vendored Google and OpenAI reasoning paths. Both have already merged; this closes the two concrete unsafe-input gaps identified during exact-head review of #22069 without changing either runtime's ownership boundary.

## Validation

- `bun test packages/cloud/shared/src/lib/eliza/plugin-mcp` — 13 pass, 0 fail
- `bun run --cwd packages/cloud/shared typecheck` — pass
- Biome check on both changed files — pass
- `git diff --check` against exact base `79b9bca13907fb4ab63113ca8613336525a74a69` — pass

AI provider/model: OpenAI / gpt-5.6-sol
Client: Codex Desktop
Skill revision: elizaOS/eliza@79b9bca13907fb4ab63113ca8613336525a74a69:packages/skills/skills/contribute-to-eliza
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@79b9bca13907fb4ab63113ca8613336525a74a69:packages/skills/skills/contribute-to-eliza"} -->
