### PR TITLE
fix(plugin-scheduling): support midnight-crossing morning/afternoon/evening windows

### DIFF
--- a/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
@@ -442,3 +442,109 @@ describe("during_window night wrap-around — no double-fire across midnight (#1
     });
   });
 });
+
+describe("during_window midnight-crossing evening — wrapping windows other than night (#22053)", () => {
+  // Evening runs 18:00-00:30, i.e. `end <= start`. Before the fix,
+  // windowBoundsMinutes modeled evening as the single (empty) range
+  // [18:00, 00:30), so it could never be due, and derived night as
+  // [00:30, 24:00) union [00:00, 06:00) — nearly the entire day.
+  const WRAP_EVENING_FACTS = {
+    timezone: "UTC",
+    morningWindow: { start: "06:00", end: "11:00" },
+    eveningWindow: { start: "18:00", end: "00:30" },
+  };
+  const eveningTask = (overrides: Partial<ScheduledTask> = {}): ScheduledTask =>
+    task({
+      trigger: { kind: "during_window", windowKey: "evening" },
+      ...overrides,
+    });
+  const nightTask = (overrides: Partial<ScheduledTask> = {}): ScheduledTask =>
+    task({
+      trigger: { kind: "during_window", windowKey: "night" },
+      ...overrides,
+    });
+
+  it("fires a during_window:evening task at 20:00, squarely inside the stated 18:00-00:30 window", async () => {
+    const decision = await isScheduledTaskDue(eveningTask(), {
+      now: new Date("2026-05-10T20:00:00.000Z"),
+      ownerFacts: WRAP_EVENING_FACTS,
+    });
+    expect(decision).toMatchObject({ due: true, reason: "window_due" });
+  });
+
+  it("fires a during_window:evening task at 00:15, the after-midnight tail of the same evening", async () => {
+    const decision = await isScheduledTaskDue(eveningTask(), {
+      now: new Date("2026-05-11T00:15:00.000Z"),
+      ownerFacts: WRAP_EVENING_FACTS,
+    });
+    expect(decision).toMatchObject({ due: true, reason: "window_due" });
+  });
+
+  it("does not double-fire evening across the midnight it now wraps", async () => {
+    const preMidnight = eveningTask();
+    const first = await isScheduledTaskDue(preMidnight, {
+      now: new Date("2026-05-10T20:00:00.000Z"),
+      ownerFacts: WRAP_EVENING_FACTS,
+    });
+    expect(first).toMatchObject({ due: true, reason: "window_due" });
+
+    const stamped = markWindowFireIfNeeded(preMidnight, {
+      now: new Date("2026-05-10T20:00:00.000Z"),
+      ownerFacts: WRAP_EVENING_FACTS,
+    });
+    expect(stamped?.lastWindowFireKey).toBe("2026-05-10:evening:evening");
+
+    const afterMidnight = await isScheduledTaskDue(
+      eveningTask({
+        metadata: { lastWindowFireKey: stamped?.lastWindowFireKey as string },
+      }),
+      {
+        now: new Date("2026-05-11T00:15:00.000Z"),
+        ownerFacts: WRAP_EVENING_FACTS,
+      },
+    );
+    expect(afterMidnight).toMatchObject({
+      due: false,
+      reason: "window_already_fired",
+    });
+  });
+
+  it("shrinks night to [eveningEnd, morningStart) instead of invading the daytime", async () => {
+    // Previously night == [00:30, 24:00) union [0, 06:00), so it was
+    // (wrongly) active at 13:00 local.
+    const atNoon = await isScheduledTaskDue(nightTask(), {
+      now: new Date("2026-05-10T13:00:00.000Z"),
+      ownerFacts: WRAP_EVENING_FACTS,
+    });
+    expect(atNoon).toMatchObject({ due: false, reason: "window_inactive" });
+
+    // Night is now the plain (non-wrapping) range 00:30-06:00.
+    const atOneAm = await isScheduledTaskDue(nightTask(), {
+      now: new Date("2026-05-11T01:00:00.000Z"),
+      ownerFacts: WRAP_EVENING_FACTS,
+    });
+    expect(atOneAm).toMatchObject({ due: true, reason: "window_due" });
+
+    // Still inactive during evening's own (wrapped) active minutes.
+    const duringEvening = await isScheduledTaskDue(nightTask(), {
+      now: new Date("2026-05-10T20:00:00.000Z"),
+      ownerFacts: WRAP_EVENING_FACTS,
+    });
+    expect(duringEvening).toMatchObject({
+      due: false,
+      reason: "window_inactive",
+    });
+  });
+
+  it("leaves a non-wrapping evening (end > start) unaffected", async () => {
+    const decision = await isScheduledTaskDue(eveningTask(), {
+      now: new Date("2026-05-10T19:00:00.000Z"),
+      ownerFacts: {
+        timezone: "UTC",
+        morningWindow: { start: "06:00", end: "11:00" },
+        eveningWindow: { start: "18:00", end: "22:00" },
+      },
+    });
+    expect(decision).toMatchObject({ due: true, reason: "window_due" });
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/due.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.ts
@@ -320,6 +320,25 @@ async function relativeAnchorDue(
   };
 }
 
+/**
+ * Bounds for one named window, splitting a wraparound range (`end <= start`,
+ * e.g. an evening of 18:00-00:30) into the same two-segment shape `night`
+ * already used: `[start, 24:00)` and `[0, end)`. A zero-width range
+ * (`start === end`) stays empty rather than wrapping to "active all day".
+ */
+function wrappingRange(
+  name: string,
+  start: number,
+  end: number,
+): Array<{ name: string; start: number; end: number }> {
+  if (start === end) return [];
+  if (start < end) return [{ name, start, end }];
+  return [
+    { name, start, end: 24 * 60 },
+    { name, start: 0, end },
+  ];
+}
+
 function windowBoundsMinutes(
   windowKey: string,
   ownerFacts: OwnerFactsView,
@@ -328,28 +347,23 @@ function windowBoundsMinutes(
     resolveOwnerWindowBoundsMinutes(ownerFacts);
   const afternoonStart = morningEnd;
   const afternoonEnd = eveningStart;
+  const morning = wrappingRange("morning", morningStart, morningEnd);
+  const afternoon = wrappingRange("afternoon", afternoonStart, afternoonEnd);
+  const evening = wrappingRange("evening", eveningStart, eveningEnd);
+  // Night is whatever's left between evening's end and morning's start; when
+  // evening itself wraps past midnight (consuming the midnight-crossing
+  // minutes), night no longer needs to, and vice versa.
+  const night = wrappingRange("night", eveningEnd, morningStart);
   const windows: Record<
     string,
     Array<{ name: string; start: number; end: number }>
   > = {
-    morning: [{ name: "morning", start: morningStart, end: morningEnd }],
-    afternoon: [
-      { name: "afternoon", start: afternoonStart, end: afternoonEnd },
-    ],
-    evening: [{ name: "evening", start: eveningStart, end: eveningEnd }],
-    night: [
-      { name: "night", start: eveningEnd, end: 24 * 60 },
-      { name: "night", start: 0, end: morningStart },
-    ],
-    morning_or_night: [
-      { name: "morning", start: morningStart, end: morningEnd },
-      { name: "night", start: eveningEnd, end: 24 * 60 },
-      { name: "night", start: 0, end: morningStart },
-    ],
-    morning_or_evening: [
-      { name: "morning", start: morningStart, end: morningEnd },
-      { name: "evening", start: eveningStart, end: eveningEnd },
-    ],
+    morning,
+    afternoon,
+    evening,
+    night,
+    morning_or_night: [...morning, ...night],
+    morning_or_evening: [...morning, ...evening],
   };
   return windows[windowKey] ?? [];
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22053.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low, additive for realistic configs. `wrappingRange` only changes behavior
for a window whose `end <= start`; every currently-valid (non-wrapping)
`morning`/`afternoon`/`evening` config produces the exact same single
segment as before. `night`'s own definition is now derived from
`wrappingRange("night", eveningEnd, morningStart)` instead of a hardcoded
two-segment literal — verified byte-identical output for the existing
non-wrapping-evening case (`due.test.ts`'s pre-existing 5-test "night
wrap-around" suite still passes unmodified).

One behavior change worth flagging: a *degenerate* zero-width window
(`start === end`, e.g. `eveningStart === eveningEnd`) now resolves to zero
active minutes for `night` too — previously `night: [{eveningEnd,1440},{0,
morningStart}]` with `eveningEnd === morningStart` covered the **entire day**
(a pre-existing latent bug this fix incidentally also closes, not something
I went looking for separately).

# Background

## What does this PR do?

`windowBoundsMinutes` (`plugins/plugin-scheduling/src/scheduled-task/due.ts`)
modeled `morning`/`afternoon`/`evening` as single `[start, end)` segments
with no wraparound handling — only `night` was hand-split across midnight.
An owner evening window of `18:00-00:30` (`end <= start`) therefore had
**zero active minutes in the entire day** (`[1080, 30)` is empty), so a
`during_window: "evening"` task evaluated at 20:00 local — squarely inside
the stated window — returned `window_inactive` and never fired. Worse, the
derived `night` window (`[eveningEnd, 24:00) ∪ [0, morningStart)`, computed
from the raw `eveningEnd` marker) became `[00:30, 24:00) ∪ [0, 06:00)` —
active essentially the entire day, so a "night" reminder fired at 1pm.

Added `wrappingRange(name, start, end)`, generalizing the pattern `night`
already used: when `end <= start`, split into `[start, 24:00)` and `[0,
end)` (both segments keep the same `name`, which `windowOccurrenceKey`'s
existing after-midnight-tail collapse already keys off of — no changes
needed there). Applied it to `morning`/`afternoon`/`evening`. `night` is now
itself `wrappingRange("night", eveningEnd, morningStart)` — whatever's left
between evening's end and morning's start — so it automatically stops
wrapping once evening's own wrap has already consumed the midnight-crossing
minutes, and automatically starts wrapping again for a normal
(non-wrapping) evening, matching the pre-existing hardcoded behavior exactly
for that case.

Did not touch `nextWindowStartIso` (`next-fire-at.ts`) — it only computes
window *start* minutes as `next_fire_at` scan-scheduling candidates,
unaffected by whether the window's active range wraps. Did not touch
`isWindow` in `fact-store.ts` (owner-fact patch validation) either: it
already accepts any two valid `HH:MM` values with no ordering constraint,
which is now the *correct* leniency since the resolver handles wrapping
windows properly. `window-learning.ts`'s own conservative refusal to emit
inverted windows, and first-run's `startLocal < endLocal` enforcement, are
still safe (just more conservative than strictly necessary now) — loosening
those is a separate follow-up, not part of this bug fix.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-scheduling/src/scheduled-task/due.test.ts` — new `describe`
block `"during_window midnight-crossing evening — wrapping windows other
than night (#22053)"`, added directly after the existing `"during_window
night wrap-around"` suite it mirrors.

## Detailed testing steps

None: Automated tests are acceptable. All five new tests drive the real
exported `isScheduledTaskDue`/`markWindowFireIfNeeded` against a deterministic
clock, exactly like every other test in this file — no test reads or matches
implementation source text.

- `cd plugins/plugin-scheduling && bunx vitest run --config ./vitest.config.ts src/scheduled-task/due.test.ts`
- Full `scheduled-task` suite (346 tests, no regressions): `bunx vitest run --config ./vitest.config.ts src/scheduled-task/`
- `bunx tsc --noEmit -p tsconfig.json`
- `bunx biome check src/scheduled-task/due.ts src/scheduled-task/due.test.ts`

I confirmed these tests are load-bearing: reverting just `due.ts` (keeping
the tests) makes 4 of the 5 new tests fail against the original code, with
exactly the two symptoms the issue reports (evening never due at 20:00;
night wrongly due at 13:00).

# Evidence Gate

<!-- evidence-head:0738113dd83fb0cc6320e529bdce996e0b05f3f0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change (plugin-scheduling due-evaluation math), no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change (plugin-scheduling due-evaluation math), no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change, no user-facing flow to walk through
<!-- evidence-row:backend-logs -->
- [x] Real Vitest run through the actual exported `isScheduledTaskDue` /
      `markWindowFireIfNeeded` with a deterministic clock, plus the full
      `scheduled-task` suite (no regressions).

<details>
<summary>Backend logs — real Vitest run, new tests + full scheduled-task suite</summary>

```
$ cd plugins/plugin-scheduling && bunx vitest run --config ./vitest.config.ts src/scheduled-task/due.test.ts --reporter=verbose

 ✓ during_window midnight-crossing evening — wrapping windows other than night (#22053) > fires a during_window:evening task at 20:00, squarely inside the stated 18:00-00:30 window 0ms
 ✓ during_window midnight-crossing evening — wrapping windows other than night (#22053) > fires a during_window:evening task at 00:15, the after-midnight tail of the same evening 0ms
 ✓ during_window midnight-crossing evening — wrapping windows other than night (#22053) > does not double-fire evening across the midnight it now wraps 0ms
 ✓ during_window midnight-crossing evening — wrapping windows other than night (#22053) > shrinks night to [eveningEnd, morningStart) instead of invading the daytime 0ms
 ✓ during_window midnight-crossing evening — wrapping windows other than night (#22053) > leaves a non-wrapping evening (end > start) unaffected 0ms

 Test Files  1 passed (1)
      Tests  22 passed (22)

$ bunx vitest run --config ./vitest.config.ts src/scheduled-task/

 Test Files  23 passed (23)
      Tests  346 passed (346)

$ bunx tsc --noEmit -p tsconfig.json
(no output — clean)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] Real due-decision objects from `isScheduledTaskDue`, executed against
      the exact `ownerFacts.eveningWindow = {start: "18:00", end: "00:30"}`
      config from the issue report — the two symptoms it named, fixed.

<details>
<summary>Domain artifact — real isScheduledTaskDue() output for the reported config</summary>

```
ownerFacts.eveningWindow = { start: "18:00", end: "00:30" }

PROBE evening@20:00 = {"due":true,"reason":"window_due","occurrenceAtIso":"2026-05-10T20:00:00.000Z"}
PROBE night@13:00   = {"due":false,"reason":"window_inactive"}
PROBE night@01:00   = {"due":true,"reason":"window_due","occurrenceAtIso":"2026-05-11T01:00:00.000Z"}
```

Before this fix (current `develop`): `evening@20:00` returns
`{"due":false,"reason":"window_inactive"}` (bug #1 — evening task
permanently wedged) and `night@13:00` returns
`{"due":true,"reason":"window_due"}` (bug #2 — night firing at 1pm).

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-manual]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza"} -->
