### PR TITLE
fix(personal-assistant): keep adaptive windows wake-relative

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/defaults.adaptive-window.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/defaults.adaptive-window.test.ts
@@ -110,7 +110,7 @@ describe("computeAdaptiveWindowPolicy", () => {
     for (
       let typicalWakeHour = 4;
       typicalWakeHour <= 27;
-      typicalWakeHour += 0.5
+      typicalWakeHour += 0.25
     ) {
       const policy = computeAdaptiveWindowPolicy(
         {
@@ -123,7 +123,9 @@ describe("computeAdaptiveWindowPolicy", () => {
       );
 
       for (const [index, window] of policy.windows.entries()) {
-        expect(window.endMinute).toBeGreaterThan(window.startMinute);
+        expect(window.endMinute - window.startMinute).toBeGreaterThanOrEqual(
+          60,
+        );
         if (index > 0) {
           expect(window.startMinute).toBe(policy.windows[index - 1]?.endMinute);
         }

--- a/plugins/plugin-personal-assistant/src/lifeops/defaults.adaptive-window.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/defaults.adaptive-window.test.ts
@@ -61,34 +61,55 @@ describe("computeAdaptiveWindowPolicy", () => {
   });
 
   it.each([
-    { wakeTime: "14:30", typicalWakeHour: 14.5 },
-    { wakeTime: "15:00", typicalWakeHour: 15 },
+    {
+      expectedEndMinute: 900,
+      expectedStartMinute: 840,
+      typicalWakeHour: 14.5,
+    },
+    {
+      expectedEndMinute: 930,
+      expectedStartMinute: 870,
+      typicalWakeHour: 15,
+    },
+    {
+      expectedEndMinute: 1410,
+      expectedStartMinute: 1350,
+      typicalWakeHour: 23,
+    },
+    {
+      expectedEndMinute: 1650,
+      expectedStartMinute: 1590,
+      typicalWakeHour: 27,
+    },
   ])(
-    "keeps the morning window non-empty for a $wakeTime wake rhythm",
-    ({ typicalWakeHour }) => {
+    "keeps a $typicalWakeHour wake inside its wake-relative morning window",
+    ({ expectedEndMinute, expectedStartMinute, typicalWakeHour }) => {
       const policy = computeAdaptiveWindowPolicy(
         {
           typicalWakeHour,
           typicalFirstActiveHour: null,
           typicalLastActiveHour: null,
-          typicalSleepHour: null,
+          typicalSleepHour: 28,
         },
         "UTC",
       );
 
       expect(policy.windows[0]).toMatchObject({
         name: "morning",
-        startMinute: 780,
-        endMinute: 840,
+        startMinute: expectedStartMinute,
+        endMinute: expectedEndMinute,
       });
-      expect(policy.windows[1]?.startMinute).toBe(840);
+      const wakeMinute = typicalWakeHour * 60;
+      expect(policy.windows[0]?.startMinute).toBeLessThanOrEqual(wakeMinute);
+      expect(policy.windows[0]?.endMinute).toBeGreaterThan(wakeMinute);
+      expect(policy.windows[1]?.startMinute).toBe(expectedEndMinute);
     },
   );
 
   it("keeps every adaptive daypart contiguous and non-empty across wake rhythms", () => {
     for (
-      let typicalWakeHour = 0;
-      typicalWakeHour < 24;
+      let typicalWakeHour = 4;
+      typicalWakeHour <= 27;
       typicalWakeHour += 0.5
     ) {
       const policy = computeAdaptiveWindowPolicy(
@@ -96,7 +117,7 @@ describe("computeAdaptiveWindowPolicy", () => {
           typicalWakeHour,
           typicalFirstActiveHour: null,
           typicalLastActiveHour: null,
-          typicalSleepHour: null,
+          typicalSleepHour: 28,
         },
         "UTC",
       );
@@ -107,6 +128,12 @@ describe("computeAdaptiveWindowPolicy", () => {
           expect(window.startMinute).toBe(policy.windows[index - 1]?.endMinute);
         }
       }
+      const morning = policy.windows[0];
+      expect(morning?.startMinute).toBe(
+        Math.max(Math.round((typicalWakeHour - 0.5) * 60), 4 * 60),
+      );
+      expect(morning?.startMinute).toBeLessThanOrEqual(typicalWakeHour * 60);
+      expect(morning?.endMinute).toBeGreaterThan(typicalWakeHour * 60);
     }
   });
 
@@ -136,7 +163,7 @@ describe("computeAdaptiveWindowPolicy", () => {
     ).toBe(true);
     expect(
       occurrences.every(
-        ({ scheduledAt }) => scheduledAt?.slice(11, 16) === "13:00",
+        ({ scheduledAt }) => scheduledAt?.slice(11, 16) === "14:30",
       ),
     ).toBe(true);
   });

--- a/plugins/plugin-personal-assistant/src/lifeops/defaults.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/defaults.ts
@@ -95,9 +95,6 @@ export function windowPolicyMatchesDefaults(
 const ADAPTIVE_MORNING_FLOOR_MINUTES = 4 * 60;
 /** Ceiling value for the morning window end (2:00 PM in minutes). */
 const ADAPTIVE_MORNING_END_CAP_MINUTES = 14 * 60;
-/** Latest morning start that preserves a one-hour window before the end cap. */
-const ADAPTIVE_MORNING_START_CAP_MINUTES =
-  ADAPTIVE_MORNING_END_CAP_MINUTES - 60;
 /** Ceiling value for the afternoon window end (8:00 PM in minutes). */
 const ADAPTIVE_AFTERNOON_END_CAP_MINUTES = 20 * 60;
 /** Ceiling value for the evening window end (4:00 AM next day in minutes). */
@@ -106,6 +103,8 @@ const ADAPTIVE_EVENING_END_CAP_MINUTES = 28 * 60;
 const ADAPTIVE_LEAD_HOURS = 0.5;
 /** Standard span of the morning and afternoon windows. */
 const ADAPTIVE_WINDOW_SPAN_HOURS = 5;
+/** Minimum positive span retained when a rhythm falls beyond a daypart cap. */
+const ADAPTIVE_MIN_WINDOW_MINUTES = 60;
 /** How long after typical last active to end the evening window. */
 const ADAPTIVE_LAST_ACTIVE_LAG_HOURS = 1;
 
@@ -138,23 +137,26 @@ export function computeAdaptiveWindowPolicy(
     };
   }
 
-  const morningStartMinute = Math.min(
-    Math.max(
-      Math.round((wakeSource - ADAPTIVE_LEAD_HOURS) * 60),
-      ADAPTIVE_MORNING_FLOOR_MINUTES,
-    ),
-    ADAPTIVE_MORNING_START_CAP_MINUTES,
+  const morningStartMinute = Math.max(
+    Math.round((wakeSource - ADAPTIVE_LEAD_HOURS) * 60),
+    ADAPTIVE_MORNING_FLOOR_MINUTES,
   );
 
-  const morningEndMinute = Math.min(
-    morningStartMinute + ADAPTIVE_WINDOW_SPAN_HOURS * 60,
-    ADAPTIVE_MORNING_END_CAP_MINUTES,
+  const morningEndMinute = Math.max(
+    morningStartMinute + ADAPTIVE_MIN_WINDOW_MINUTES,
+    Math.min(
+      morningStartMinute + ADAPTIVE_WINDOW_SPAN_HOURS * 60,
+      ADAPTIVE_MORNING_END_CAP_MINUTES,
+    ),
   );
 
   const afternoonStartMinute = morningEndMinute;
-  const afternoonEndMinute = Math.min(
-    afternoonStartMinute + ADAPTIVE_WINDOW_SPAN_HOURS * 60,
-    ADAPTIVE_AFTERNOON_END_CAP_MINUTES,
+  const afternoonEndMinute = Math.max(
+    afternoonStartMinute + ADAPTIVE_MIN_WINDOW_MINUTES,
+    Math.min(
+      afternoonStartMinute + ADAPTIVE_WINDOW_SPAN_HOURS * 60,
+      ADAPTIVE_AFTERNOON_END_CAP_MINUTES,
+    ),
   );
 
   const eveningStartMinute = afternoonEndMinute;
@@ -187,14 +189,18 @@ export function computeAdaptiveWindowPolicy(
     eveningEndMinute = defaultEveningWindow.endMinute;
   }
 
-  // Guard: evening end must be strictly after evening start.
-  if (eveningEndMinute <= eveningStartMinute) {
-    eveningEndMinute = eveningStartMinute + 60;
-  }
+  const nightEndMinute = morningStartMinute + 24 * 60;
+  // Preserve at least one hour for both evening and the following night.
+  eveningEndMinute = Math.min(
+    Math.max(
+      eveningEndMinute,
+      eveningStartMinute + ADAPTIVE_MIN_WINDOW_MINUTES,
+    ),
+    nightEndMinute - ADAPTIVE_MIN_WINDOW_MINUTES,
+  );
 
   // Night wraps from evening end to morning start + 24.
   const nightStartMinute = eveningEndMinute;
-  const nightEndMinute = morningStartMinute + 24 * 60;
 
   return {
     timezone: tz,


### PR DESCRIPTION
## Summary

- restore the adaptive morning start to the user's wake-relative lead band instead of forcing late wakes to 13:00
- allow morning and afternoon caps to move when necessary while preserving at least 60 minutes for every daypart, including evening and the following night
- add adversarial 4:00–27:00 rhythm coverage and real occurrence-materialization proof

Closes #22113. Corrects the late-wake regression merged by #22083.

## Why this is necessary

For `typicalWakeHour = 15`, the merged policy produced a 13:00–14:00 "morning" window that ended an hour before the user woke. The policy contract says windows shift to the user's actual rhythm, and the occurrence materializer therefore scheduled the routine before the intended wake lead band.

The corrected boundary is:

- morning start: `max(round((wake - 0.5h) * 60), 04:00)`
- morning/afternoon end: normal five-hour span capped at 14:00/20:00, but never less than 60 minutes after its start
- evening end: learned/default end clamped to leave at least 60 minutes for both evening and the following night

## Exact-head evidence

Evidence head: `a3f9f4a63f818cc5b74cfbce7ebc5ecb00ec689d`
Base tested: `92cd0ce3f46080aeadda62cf08dacf484102f046`

```
bunx vitest run --config plugins/plugin-personal-assistant/vitest.config.ts \
  plugins/plugin-personal-assistant/src/lifeops/defaults.adaptive-window.test.ts
# Test Files 1 passed (1)
# Tests      7 passed (7)

bunx biome check \
  plugins/plugin-personal-assistant/src/lifeops/defaults.ts \
  plugins/plugin-personal-assistant/src/lifeops/defaults.adaptive-window.test.ts
# Checked 2 files. No fixes applied.

git diff --check origin/develop...HEAD
# pass
```

The tests prove:

- ordinary wake hour 7 retains the existing 06:30–11:30 result
- wake hours 14.5, 15, 23, and 27 remain inside their wake-relative morning windows
- every quarter-hour wake rhythm from 4 through 27 yields four positive, contiguous dayparts
- the real occurrence materializer schedules a wake-15 morning routine at 14:30, not the regressed 13:00

## Evidence matrix

- Before/after screenshots: N/A — deterministic backend scheduling policy; no rendered surface changed.
- Video: N/A — no interactive UI path.
- Backend/domain artifact: exact focused test output above exercises the real policy and occurrence materializer.
- Frontend logs: N/A — no frontend code.
- Live model trajectory: N/A — no model behavior.
- Audio/OCR: N/A — no audio or visual artifact.

## Known gap

The package `typecheck` was attempted but the no-script/offline review install lacks built workspace links and generated package artifacts, producing broad pre-existing `TS2307` workspace-resolution failures across agent/core/plugin dependencies. The two changed files pass Biome and their exact behavior passes the focused Vitest suite. Independent review is required before merge.

## Provenance

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]

<!-- contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"6d2d20f26c725bed66c2988a1667f244b2cbc2c4","status":"self-reported","lane":"codex-open-issues"} -->

<!-- evidence-head:1f431b0f3dbc99a21ac258e32509f94927ec5697 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - deterministic backend scheduling policy; no rendered surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - deterministic backend scheduling policy; no rendered surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI path; focused occurrence proof is attached

<!-- evidence-row:backend-logs -->
- [x] [22121-pr22121-final-head-audit.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22121-pr22121-final-head-audit.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser runtime changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic scheduling policy with no model invocation

<!-- evidence-row:domain-artifacts -->
- [x] [22121-pr22121-final-domain-artifact.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22121-pr22121-final-domain-artifact.txt)
