### PR TITLE
fix(cloud-mcp): validate stripped schema constraints

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/base.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/base.ts
@@ -62,6 +62,7 @@ export abstract class McpToolCompatibility {
       "uniqueItems",
       "minProperties",
       "maxProperties",
+      "additionalProperties",
     ]) {
       if (schema[prop as keyof JSONSchema7] !== undefined) {
         constraints[prop] = schema[prop as keyof JSONSchema7];

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/base.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/base.ts
@@ -62,11 +62,17 @@ export abstract class McpToolCompatibility {
       "uniqueItems",
       "minProperties",
       "maxProperties",
-      "additionalProperties",
     ]) {
       if (schema[prop as keyof JSONSchema7] !== undefined) {
         constraints[prop] = schema[prop as keyof JSONSchema7];
       }
+    }
+
+    // `additionalProperties` is useful diagnostic input only when this
+    // provider strips it. Collecting it for providers that preserve the
+    // keyword duplicates every closed-object schema in model-facing prose.
+    if (unsupported.includes("additionalProperties") && schema.additionalProperties !== undefined) {
+      constraints.additionalProperties = schema.additionalProperties;
     }
 
     for (const prop of unsupported) {
@@ -125,8 +131,17 @@ export abstract class McpToolCompatibility {
     original: string | undefined,
     constraints: Record<string, unknown>,
   ): string {
-    const json = JSON.stringify(constraints);
+    const json = this.stringifyConstraints(constraints);
     return original ? `${original}\n${json}` : json;
+  }
+
+  /** Preserve invalid JavaScript-only numbers instead of JSON-coercing them to null. */
+  protected stringifyConstraints(constraints: Record<string, unknown>): string {
+    return JSON.stringify(constraints, (_key, value) =>
+      typeof value === "number" && !Number.isFinite(value)
+        ? `[non-finite number: ${String(value)}]`
+        : value,
+    );
   }
 
   protected abstract getUnsupportedStringProperties(): string[];

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/anthropic.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/anthropic.ts
@@ -28,9 +28,18 @@ export class AnthropicMcpCompatibility extends McpToolCompatibility {
     constraints: Record<string, unknown>,
   ): string {
     const hints: string[] = [];
-    if (constraints.additionalProperties === false) hints.push("Only use the specified properties");
+    const rendered = new Set<string>();
+    if (constraints.additionalProperties === false) {
+      hints.push("Only use the specified properties");
+      rendered.add("additionalProperties");
+    }
     if (constraints.format === "date-time") hints.push("Use ISO 8601 format");
-    if (constraints.pattern) hints.push(`Must match: ${constraints.pattern}`);
+    if (typeof constraints.pattern === "string") hints.push(`Must match: ${constraints.pattern}`);
+
+    const additionalProperties = constraints.additionalProperties;
+    if (additionalProperties !== undefined && !rendered.has("additionalProperties")) {
+      hints.push(this.stringifyConstraints({ additionalProperties }));
+    }
 
     const text = hints.join(". ");
     return original && text ? `${original}. ${text}` : original || text || "";

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/google.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/google.ts
@@ -38,10 +38,13 @@ export class GoogleMcpCompatibility extends McpToolCompatibility {
     };
     const finiteNumber = (value: unknown): value is number =>
       typeof value === "number" && Number.isFinite(value);
+    const nonNegativeInteger = (value: unknown): value is number =>
+      finiteNumber(value) && Number.isInteger(value) && value >= 0;
+    const positiveNumber = (value: unknown): value is number => finiteNumber(value) && value > 0;
 
-    if (finiteNumber(constraints.minLength))
+    if (nonNegativeInteger(constraints.minLength))
       rule("minLength", `at least ${constraints.minLength} chars`);
-    if (finiteNumber(constraints.maxLength))
+    if (nonNegativeInteger(constraints.maxLength))
       rule("maxLength", `at most ${constraints.maxLength} chars`);
     if (finiteNumber(constraints.minimum)) rule("minimum", `>= ${constraints.minimum}`);
     if (finiteNumber(constraints.maximum)) rule("maximum", `<= ${constraints.maximum}`);
@@ -49,19 +52,21 @@ export class GoogleMcpCompatibility extends McpToolCompatibility {
       rule("exclusiveMinimum", `> ${constraints.exclusiveMinimum}`);
     if (finiteNumber(constraints.exclusiveMaximum))
       rule("exclusiveMaximum", `< ${constraints.exclusiveMaximum}`);
-    if (finiteNumber(constraints.multipleOf))
+    if (positiveNumber(constraints.multipleOf))
       rule("multipleOf", `multiple of ${constraints.multipleOf}`);
     if (constraints.format === "email") rule("format", "valid email");
     if (constraints.format === "uri" || constraints.format === "url") rule("format", "valid URL");
     if (typeof constraints.pattern === "string") rule("pattern", `matches ${constraints.pattern}`);
     if (Array.isArray(constraints.enum) && constraints.enum.length > 0)
       rule("enum", `one of: ${constraints.enum.map((value) => JSON.stringify(value)).join(", ")}`);
-    if (finiteNumber(constraints.minItems)) rule("minItems", `>= ${constraints.minItems} items`);
-    if (finiteNumber(constraints.maxItems)) rule("maxItems", `<= ${constraints.maxItems} items`);
+    if (nonNegativeInteger(constraints.minItems))
+      rule("minItems", `>= ${constraints.minItems} items`);
+    if (nonNegativeInteger(constraints.maxItems))
+      rule("maxItems", `<= ${constraints.maxItems} items`);
     if (constraints.uniqueItems === true) rule("uniqueItems", "unique items");
-    if (finiteNumber(constraints.minProperties))
+    if (nonNegativeInteger(constraints.minProperties))
       rule("minProperties", `>= ${constraints.minProperties} properties`);
-    if (finiteNumber(constraints.maxProperties))
+    if (nonNegativeInteger(constraints.maxProperties))
       rule("maxProperties", `<= ${constraints.maxProperties} properties`);
     if (constraints.additionalProperties === false)
       rule("additionalProperties", "no additional properties");

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/google.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/google.ts
@@ -76,7 +76,9 @@ export class GoogleMcpCompatibility extends McpToolCompatibility {
     if (rules.length > 0) parts.push(`Constraints: ${rules.join("; ")}`);
     if (unrendered.length > 0) {
       parts.push(
-        JSON.stringify(Object.fromEntries(unrendered.map((key) => [key, constraints[key]]))),
+        this.stringifyConstraints(
+          Object.fromEntries(unrendered.map((key) => [key, constraints[key]])),
+        ),
       );
     }
 

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/google.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/google.ts
@@ -31,19 +31,51 @@ export class GoogleMcpCompatibility extends McpToolCompatibility {
     constraints: Record<string, unknown>,
   ): string {
     const rules: string[] = [];
-    if (constraints.minLength !== undefined) rules.push(`at least ${constraints.minLength} chars`);
-    if (constraints.maxLength !== undefined) rules.push(`at most ${constraints.maxLength} chars`);
-    if (constraints.minimum !== undefined) rules.push(`>= ${constraints.minimum}`);
-    if (constraints.maximum !== undefined) rules.push(`<= ${constraints.maximum}`);
-    if (constraints.format === "email") rules.push(`valid email`);
-    if (constraints.format === "uri" || constraints.format === "url") rules.push(`valid URL`);
-    if (constraints.pattern) rules.push(`matches ${constraints.pattern}`);
-    if (constraints.enum) rules.push(`one of: ${(constraints.enum as string[]).join(", ")}`);
-    if (constraints.minItems !== undefined) rules.push(`>= ${constraints.minItems} items`);
-    if (constraints.maxItems !== undefined) rules.push(`<= ${constraints.maxItems} items`);
-    if (constraints.uniqueItems) rules.push(`unique items`);
+    const rendered = new Set<string>();
+    const rule = (key: string, text: string): void => {
+      rules.push(text);
+      rendered.add(key);
+    };
+    const finiteNumber = (value: unknown): value is number =>
+      typeof value === "number" && Number.isFinite(value);
 
-    const text = rules.length > 0 ? `Constraints: ${rules.join("; ")}` : "";
+    if (finiteNumber(constraints.minLength))
+      rule("minLength", `at least ${constraints.minLength} chars`);
+    if (finiteNumber(constraints.maxLength))
+      rule("maxLength", `at most ${constraints.maxLength} chars`);
+    if (finiteNumber(constraints.minimum)) rule("minimum", `>= ${constraints.minimum}`);
+    if (finiteNumber(constraints.maximum)) rule("maximum", `<= ${constraints.maximum}`);
+    if (finiteNumber(constraints.exclusiveMinimum))
+      rule("exclusiveMinimum", `> ${constraints.exclusiveMinimum}`);
+    if (finiteNumber(constraints.exclusiveMaximum))
+      rule("exclusiveMaximum", `< ${constraints.exclusiveMaximum}`);
+    if (finiteNumber(constraints.multipleOf))
+      rule("multipleOf", `multiple of ${constraints.multipleOf}`);
+    if (constraints.format === "email") rule("format", "valid email");
+    if (constraints.format === "uri" || constraints.format === "url") rule("format", "valid URL");
+    if (typeof constraints.pattern === "string") rule("pattern", `matches ${constraints.pattern}`);
+    if (Array.isArray(constraints.enum) && constraints.enum.length > 0)
+      rule("enum", `one of: ${constraints.enum.map((value) => JSON.stringify(value)).join(", ")}`);
+    if (finiteNumber(constraints.minItems)) rule("minItems", `>= ${constraints.minItems} items`);
+    if (finiteNumber(constraints.maxItems)) rule("maxItems", `<= ${constraints.maxItems} items`);
+    if (constraints.uniqueItems === true) rule("uniqueItems", "unique items");
+    if (finiteNumber(constraints.minProperties))
+      rule("minProperties", `>= ${constraints.minProperties} properties`);
+    if (finiteNumber(constraints.maxProperties))
+      rule("maxProperties", `<= ${constraints.maxProperties} properties`);
+    if (constraints.additionalProperties === false)
+      rule("additionalProperties", "no additional properties");
+
+    const unrendered = Object.keys(constraints).filter((key) => !rendered.has(key));
+    const parts: string[] = [];
+    if (rules.length > 0) parts.push(`Constraints: ${rules.join("; ")}`);
+    if (unrendered.length > 0) {
+      parts.push(
+        JSON.stringify(Object.fromEntries(unrendered.map((key) => [key, constraints[key]]))),
+      );
+    }
+
+    const text = parts.join(" ");
     return original && text ? `${original}\n\n${text}` : original || text;
   }
 }

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
@@ -81,10 +81,13 @@ export class OpenAIReasoningMcpCompatibility extends McpToolCompatibility {
     };
     const finiteNumber = (value: unknown): value is number =>
       typeof value === "number" && Number.isFinite(value);
+    const nonNegativeInteger = (value: unknown): value is number =>
+      finiteNumber(value) && Number.isInteger(value) && value >= 0;
+    const positiveNumber = (value: unknown): value is number => finiteNumber(value) && value > 0;
 
-    if (finiteNumber(constraints.minLength))
+    if (nonNegativeInteger(constraints.minLength))
       rule("minLength", `minimum ${constraints.minLength} characters`);
-    if (finiteNumber(constraints.maxLength))
+    if (nonNegativeInteger(constraints.maxLength))
       rule("maxLength", `maximum ${constraints.maxLength} characters`);
     if (finiteNumber(constraints.minimum)) rule("minimum", `must be >= ${constraints.minimum}`);
     if (finiteNumber(constraints.maximum)) rule("maximum", `must be <= ${constraints.maximum}`);
@@ -92,7 +95,7 @@ export class OpenAIReasoningMcpCompatibility extends McpToolCompatibility {
       rule("exclusiveMinimum", `must be > ${constraints.exclusiveMinimum}`);
     if (finiteNumber(constraints.exclusiveMaximum))
       rule("exclusiveMaximum", `must be < ${constraints.exclusiveMaximum}`);
-    if (finiteNumber(constraints.multipleOf))
+    if (positiveNumber(constraints.multipleOf))
       rule("multipleOf", `must be a multiple of ${constraints.multipleOf}`);
     if (constraints.format === "email") rule("format", `must be a valid email`);
     if (constraints.format === "uri" || constraints.format === "url")
@@ -104,14 +107,14 @@ export class OpenAIReasoningMcpCompatibility extends McpToolCompatibility {
         "enum",
         `must be one of: ${constraints.enum.map((value) => JSON.stringify(value)).join(", ")}`,
       );
-    if (finiteNumber(constraints.minItems))
+    if (nonNegativeInteger(constraints.minItems))
       rule("minItems", `at least ${constraints.minItems} items`);
-    if (finiteNumber(constraints.maxItems))
+    if (nonNegativeInteger(constraints.maxItems))
       rule("maxItems", `at most ${constraints.maxItems} items`);
     if (constraints.uniqueItems === true) rule("uniqueItems", `items must be unique`);
-    if (finiteNumber(constraints.minProperties))
+    if (nonNegativeInteger(constraints.minProperties))
       rule("minProperties", `at least ${constraints.minProperties} properties`);
-    if (finiteNumber(constraints.maxProperties))
+    if (nonNegativeInteger(constraints.maxProperties))
       rule("maxProperties", `at most ${constraints.maxProperties} properties`);
     if (constraints.additionalProperties === false)
       rule("additionalProperties", "must not contain additional properties");

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
@@ -124,7 +124,9 @@ export class OpenAIReasoningMcpCompatibility extends McpToolCompatibility {
     if (rules.length > 0) parts.push(`IMPORTANT: ${rules.join(", ")}`);
     if (unrendered.length > 0) {
       parts.push(
-        JSON.stringify(Object.fromEntries(unrendered.map((key) => [key, constraints[key]]))),
+        this.stringifyConstraints(
+          Object.fromEntries(unrendered.map((key) => [key, constraints[key]])),
+        ),
       );
     }
 

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/providers/openai.ts
@@ -79,30 +79,42 @@ export class OpenAIReasoningMcpCompatibility extends McpToolCompatibility {
       rules.push(text);
       rendered.add(key);
     };
-    const numericRule = (key: string, text: (value: number) => string): void => {
-      const value = constraints[key];
-      if (typeof value === "number") rule(key, text(value));
-    };
+    const finiteNumber = (value: unknown): value is number =>
+      typeof value === "number" && Number.isFinite(value);
 
-    numericRule("minLength", (value) => `minimum ${value} characters`);
-    numericRule("maxLength", (value) => `maximum ${value} characters`);
-    numericRule("minimum", (value) => `must be >= ${value}`);
-    numericRule("maximum", (value) => `must be <= ${value}`);
-    numericRule("exclusiveMinimum", (value) => `must be > ${value}`);
-    numericRule("exclusiveMaximum", (value) => `must be < ${value}`);
-    numericRule("multipleOf", (value) => `must be a multiple of ${value}`);
+    if (finiteNumber(constraints.minLength))
+      rule("minLength", `minimum ${constraints.minLength} characters`);
+    if (finiteNumber(constraints.maxLength))
+      rule("maxLength", `maximum ${constraints.maxLength} characters`);
+    if (finiteNumber(constraints.minimum)) rule("minimum", `must be >= ${constraints.minimum}`);
+    if (finiteNumber(constraints.maximum)) rule("maximum", `must be <= ${constraints.maximum}`);
+    if (finiteNumber(constraints.exclusiveMinimum))
+      rule("exclusiveMinimum", `must be > ${constraints.exclusiveMinimum}`);
+    if (finiteNumber(constraints.exclusiveMaximum))
+      rule("exclusiveMaximum", `must be < ${constraints.exclusiveMaximum}`);
+    if (finiteNumber(constraints.multipleOf))
+      rule("multipleOf", `must be a multiple of ${constraints.multipleOf}`);
     if (constraints.format === "email") rule("format", `must be a valid email`);
     if (constraints.format === "uri" || constraints.format === "url")
       rule("format", `must be a valid URL`);
     if (typeof constraints.pattern === "string")
       rule("pattern", `must match: ${constraints.pattern}`);
-    if (Array.isArray(constraints.enum))
-      rule("enum", `must be one of: ${(constraints.enum as string[]).join(", ")}`);
-    numericRule("minItems", (value) => `at least ${value} items`);
-    numericRule("maxItems", (value) => `at most ${value} items`);
+    if (Array.isArray(constraints.enum) && constraints.enum.length > 0)
+      rule(
+        "enum",
+        `must be one of: ${constraints.enum.map((value) => JSON.stringify(value)).join(", ")}`,
+      );
+    if (finiteNumber(constraints.minItems))
+      rule("minItems", `at least ${constraints.minItems} items`);
+    if (finiteNumber(constraints.maxItems))
+      rule("maxItems", `at most ${constraints.maxItems} items`);
     if (constraints.uniqueItems === true) rule("uniqueItems", `items must be unique`);
-    numericRule("minProperties", (value) => `at least ${value} properties`);
-    numericRule("maxProperties", (value) => `at most ${value} properties`);
+    if (finiteNumber(constraints.minProperties))
+      rule("minProperties", `at least ${constraints.minProperties} properties`);
+    if (finiteNumber(constraints.maxProperties))
+      rule("maxProperties", `at most ${constraints.maxProperties} properties`);
+    if (constraints.additionalProperties === false)
+      rule("additionalProperties", "must not contain additional properties");
 
     const unrendered = Object.keys(constraints).filter((key) => !rendered.has(key));
     const parts: string[] = [];

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
@@ -25,6 +25,52 @@ const describeOf = (compat: ReturnType<typeof compatFor>, schema: JSONSchema7): 
   String(compat.transformToolSchema(schema).description ?? "");
 
 describe("cloud MCP tool-compatibility constraint rendering (#22068, #22115, #22118)", () => {
+  describe("provider-wide collection boundary", () => {
+    it("does not duplicate a supported additionalProperties keyword into OpenAI prose", () => {
+      const out = compatFor("gpt-4o").transformToolSchema({
+        type: "object",
+        description: "Search the web",
+        additionalProperties: false,
+      });
+
+      expect(out.additionalProperties).toBe(false);
+      expect(out.description).toBe("Search the web");
+    });
+
+    it("preserves stripped Anthropic additionalProperties values without inversion", () => {
+      const anthropic = compatFor("claude-sonnet-4");
+      const closed = anthropic.transformToolSchema({
+        type: "object",
+        description: "Root",
+        additionalProperties: false,
+      });
+      expect(closed.additionalProperties).toBeUndefined();
+      expect(closed.description).toBe("Root. Only use the specified properties");
+
+      const typed = anthropic.transformToolSchema({
+        type: "object",
+        description: "Root",
+        additionalProperties: { type: "string" },
+      });
+      expect(typed.additionalProperties).toBeUndefined();
+      expect(typed.description).toContain('"additionalProperties":{"type":"string"}');
+      expect(typed.description).not.toContain("Only use the specified properties");
+    });
+
+    it("does not coerce malformed Anthropic patterns into misleading prose", () => {
+      const malformed = {
+        type: "string",
+        description: "Root",
+        pattern: { source: "^[a-z]+$" },
+      } as unknown as JSONSchema7;
+      const out = compatFor("claude-sonnet-4").transformToolSchema(malformed);
+
+      expect(out.pattern).toEqual({ source: "^[a-z]+$" });
+      expect(out.description).toBe("Root");
+      expect(out.description).not.toContain("[object Object]");
+    });
+  });
+
   describe("google formatter", () => {
     const google = () => compatFor("gemini-2.0-flash");
 
@@ -77,6 +123,20 @@ describe("cloud MCP tool-compatibility constraint rendering (#22068, #22115, #22
       expect(text).not.toContain(">= -1 items");
       expect(text).not.toContain("<= 1.5 items");
       expect(text).not.toContain("multiple of 0");
+    });
+
+    it("identifies non-finite numeric values instead of JSON-coercing them to null", () => {
+      const schema = {
+        type: "number",
+        minimum: Number.POSITIVE_INFINITY,
+        maximum: Number.NaN,
+      } as unknown as JSONSchema7;
+      const text = describeOf(google(), schema);
+
+      expect(text).toContain('"minimum":"[non-finite number: Infinity]"');
+      expect(text).toContain('"maximum":"[non-finite number: NaN]"');
+      expect(text).not.toContain('"minimum":null');
+      expect(text).not.toContain('"maximum":null');
     });
 
     it("preserves a stripped closed-object constraint", () => {
@@ -171,6 +231,20 @@ describe("cloud MCP tool-compatibility constraint rendering (#22068, #22115, #22
       expect(text).not.toContain("at least -1 properties");
       expect(text).not.toContain("at most 1.5 properties");
       expect(text).not.toContain("multiple of -2");
+    });
+
+    it("identifies non-finite numeric values instead of JSON-coercing them to null", () => {
+      const schema = {
+        type: "number",
+        exclusiveMinimum: Number.NEGATIVE_INFINITY,
+        multipleOf: Number.NaN,
+      } as unknown as JSONSchema7;
+      const text = describeOf(reasoning(), schema);
+
+      expect(text).toContain('"exclusiveMinimum":"[non-finite number: -Infinity]"');
+      expect(text).toContain('"multipleOf":"[non-finite number: NaN]"');
+      expect(text).not.toContain('"exclusiveMinimum":null');
+      expect(text).not.toContain('"multipleOf":null');
     });
 
     it("keeps empty enums in the unrendered tail and renders non-empty enums exactly", () => {

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
@@ -62,6 +62,23 @@ describe("cloud MCP tool-compatibility constraint rendering (#22068, #22115, #22
       expect(text).not.toContain("at least 2 chars");
     });
 
+    it("does not render invalid cardinalities or non-positive multiples as rules", () => {
+      const schema = {
+        type: "array",
+        minItems: -1,
+        maxItems: 1.5,
+        multipleOf: 0,
+      } as unknown as JSONSchema7;
+      const text = describeOf(google(), schema);
+
+      expect(text).toContain('"minItems":-1');
+      expect(text).toContain('"maxItems":1.5');
+      expect(text).toContain('"multipleOf":0');
+      expect(text).not.toContain(">= -1 items");
+      expect(text).not.toContain("<= 1.5 items");
+      expect(text).not.toContain("multiple of 0");
+    });
+
     it("preserves a stripped closed-object constraint", () => {
       const out = google().transformToolSchema({
         type: "object",
@@ -137,6 +154,23 @@ describe("cloud MCP tool-compatibility constraint rendering (#22068, #22115, #22
       expect(text).not.toContain("must match: null");
       expect(text).not.toContain("must be > true");
       expect(text).not.toContain("multiple of 2");
+    });
+
+    it("does not render invalid cardinalities or non-positive multiples as rules", () => {
+      const schema = {
+        type: "object",
+        minProperties: -1,
+        maxProperties: 1.5,
+        multipleOf: -2,
+      } as unknown as JSONSchema7;
+      const text = describeOf(reasoning(), schema);
+
+      expect(text).toContain('"minProperties":-1');
+      expect(text).toContain('"maxProperties":1.5');
+      expect(text).toContain('"multipleOf":-2');
+      expect(text).not.toContain("at least -1 properties");
+      expect(text).not.toContain("at most 1.5 properties");
+      expect(text).not.toContain("multiple of -2");
     });
 
     it("keeps empty enums in the unrendered tail and renders non-empty enums exactly", () => {

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/tool-compatibility.zero-bounds.test.ts
@@ -1,7 +1,9 @@
 /**
  * Pins constraint re-expression in the cloud-vendored MCP tool-compatibility
  * formatters, which strip keywords from the schema and must therefore restate
- * every stripped bound in the description the hosted model reads (#22068).
+ * every stripped bound in the description the hosted model reads. It also
+ * rejects misleading prose for malformed third-party values and preserves the
+ * closed-object constraint (#22068, #22115, #22118).
  * Deterministic: the compat objects come from the real
  * `createMcpToolCompatibilitySync` factory over a literal runtime shape, and
  * assertions run against the real `transformToolSchema` output.
@@ -22,7 +24,7 @@ function compatFor(model: string) {
 const describeOf = (compat: ReturnType<typeof compatFor>, schema: JSONSchema7): string =>
   String(compat.transformToolSchema(schema).description ?? "");
 
-describe("cloud MCP tool-compatibility zero-valued bounds (#22068)", () => {
+describe("cloud MCP tool-compatibility constraint rendering (#22068, #22115, #22118)", () => {
   describe("google formatter", () => {
     const google = () => compatFor("gemini-2.0-flash");
 
@@ -41,6 +43,33 @@ describe("cloud MCP tool-compatibility zero-valued bounds (#22068)", () => {
     it("renders positive bounds unchanged", () => {
       const text = describeOf(google(), { type: "string", minLength: 2, maxLength: 8 });
       expect(text).toBe("Constraints: at least 2 chars; at most 8 chars");
+    });
+
+    it("does not throw or invent prose for malformed optional constraints", () => {
+      const schema = {
+        type: "string",
+        enum: null,
+        pattern: null,
+        minLength: "2",
+      } as unknown as JSONSchema7;
+      const text = describeOf(google(), schema);
+
+      expect(text).toContain('"enum":null');
+      expect(text).toContain('"pattern":null');
+      expect(text).toContain('"minLength":"2"');
+      expect(text).not.toContain("one of:");
+      expect(text).not.toContain("matches null");
+      expect(text).not.toContain("at least 2 chars");
+    });
+
+    it("preserves a stripped closed-object constraint", () => {
+      const out = google().transformToolSchema({
+        type: "object",
+        additionalProperties: false,
+      });
+
+      expect(out.additionalProperties).toBeUndefined();
+      expect(out.description).toContain("no additional properties");
     });
   });
 
@@ -88,6 +117,56 @@ describe("cloud MCP tool-compatibility zero-valued bounds (#22068)", () => {
       expect(out.uniqueItems).toBeUndefined();
       expect(out.description).toContain('"uniqueItems":false');
       expect(out.description).not.toContain("items must be unique");
+    });
+
+    it("does not throw or invent prose for malformed optional constraints", () => {
+      const schema = {
+        type: "number",
+        enum: null,
+        pattern: null,
+        exclusiveMinimum: true,
+        multipleOf: "2",
+      } as unknown as JSONSchema7;
+      const text = describeOf(reasoning(), schema);
+
+      expect(text).toContain('"enum":null');
+      expect(text).toContain('"pattern":null');
+      expect(text).toContain('"exclusiveMinimum":true');
+      expect(text).toContain('"multipleOf":"2"');
+      expect(text).not.toContain("must be one of:");
+      expect(text).not.toContain("must match: null");
+      expect(text).not.toContain("must be > true");
+      expect(text).not.toContain("multiple of 2");
+    });
+
+    it("keeps empty enums in the unrendered tail and renders non-empty enums exactly", () => {
+      const empty = describeOf(reasoning(), { type: "string", enum: [] });
+      expect(empty).toContain('"enum":[]');
+      expect(empty).not.toContain("must be one of:");
+
+      const populated = describeOf(reasoning(), {
+        type: "string",
+        enum: ["alpha", "beta"],
+      });
+      expect(populated).toContain('must be one of: "alpha", "beta"');
+      expect(populated).not.toContain('{"enum"');
+    });
+
+    it("preserves false additionalProperties without inverting true", () => {
+      const closed = reasoning().transformToolSchema({
+        type: "object",
+        additionalProperties: false,
+      });
+      expect(closed.additionalProperties).toBeUndefined();
+      expect(closed.description).toContain("must not contain additional properties");
+
+      const open = reasoning().transformToolSchema({
+        type: "object",
+        additionalProperties: true,
+      });
+      expect(open.additionalProperties).toBeUndefined();
+      expect(open.description).toContain('"additionalProperties":true');
+      expect(open.description).not.toContain("must not contain additional properties");
     });
 
     it("surfaces a collected keyword that has no rule instead of dropping it", () => {


### PR DESCRIPTION
## Summary

This exact-head corrective follow-up validates schema constraints before translating them into provider-facing descriptions.

- validates every numeric constraint before rendering numeric prose;
- keeps malformed or unsupported values in an exact JSON diagnostic tail instead of throwing or inventing a rule;
- handles empty/non-array enums without lossy coercion;
- re-expresses stripped `additionalProperties` values without duplicating the keyword for OpenAI models that retain it;
- applies the value-shape contract to Google, OpenAI reasoning, OpenAI non-reasoning, and Anthropic formatters;
- prevents Anthropic malformed `pattern` values from becoming fabricated `[object Object]` prose.

Closes #22115.
Closes #22118.

## Why the prior repairs were incomplete

The merged #22069 still threw on `enum: null`. The earlier #22126 head accepted non-finite numbers, treated empty enums as useful prose, duplicated retained `additionalProperties` into ordinary OpenAI descriptions, and did not preserve Anthropic non-false `additionalProperties` values after stripping them.

## Sync with develop

- [x] Rebased without conflicts onto `develop@6ac9ca350e7630d871d51f6050d2a39a6533a793`.
- [x] Original #22126 commits and source credit are preserved; the final corrective commit truthfully records the current repair author.

## Exact-head verification

Exact head: `a68cde1cd26da8670c812f7d4e0a355d52443afe`

- `bun test --conditions=eliza-source packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-compatibility/`: 25 passed, 0 failed, 81 assertions.
- `bun run --cwd packages/cloud/shared typecheck`: passed.
- Biome on all five changed files: passed.
- `git diff --check origin/develop...HEAD`: passed.

The real compatibility factory tests assert exact transformed schemas and descriptions for Google, OpenAI reasoning, OpenAI non-reasoning, and Anthropic models. They cover zero-valued bounds, malformed and empty constraints, non-finite-number diagnostic preservation, retained OpenAI `additionalProperties`, Anthropic false/schema `additionalProperties`, and malformed Anthropic patterns. The root `bun run verify` reached 209/211 Turbo tasks before an unrelated current-`develop` Cloud API stub omission (`truncateWellFormed`) failed `@elizaos/cloud-api#typecheck`; the owning package typecheck and all changed-file gates passed independently.

## Evidence gate

<!-- evidence-head:a68cde1cd26da8670c812f7d4e0a355d52443afe -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side deterministic schema transformation with no visual surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side deterministic schema transformation with no visual surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] [22126-pr22126-backend-a68cde1c.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22126-pr22126-backend-a68cde1c.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser boundary.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic preprocessing occurs before model invocation.
<!-- evidence-row:domain-artifacts -->
- [x] [22126-pr22126-domain-a68cde1c.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22126-pr22126-domain-a68cde1c.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@a68cde1cd26da8670c812f7d4e0a355d52443afe:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a68cde1cd26da8670c812f7d4e0a355d52443afe:packages/skills/skills/contribute-to-eliza"} -->

