### PR TITLE
fix(agent): bound and refresh memory search cache

### DIFF
--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -18,6 +18,7 @@ import {
   ChannelType,
   composePrompt,
   createMessageMemory,
+  ElizaError,
   MESSAGE_SOURCE_CLIENT_CHAT,
   type Memory,
   ModelType,
@@ -42,6 +43,17 @@ export const HASH_MEMORY_SOURCE = "hash_memory";
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MEMORY_SEARCH_SCAN_LIMIT = 2_000;
+/**
+ * Warm-corpus reuse window for the hash-memory search cache. Module-local
+ * writes (remember/delete/patch) invalidate explicitly and a row-count check
+ * runs before every reuse. Count-preserving out-of-band edits trigger refresh
+ * after 10 seconds and may be served stale only until the 20-second hard bound.
+ */
+const MEMORY_SEARCH_CACHE_TTL_MS = 10_000;
+const MEMORY_SEARCH_CACHE_MAX_STALE_MS = 20_000;
+const MEMORY_SEARCH_CACHE_MAX_ENTRIES = 4;
+const MEMORY_SEARCH_CACHE_MAX_TEXT_BYTES = 8 * 1024 * 1024;
+const MEMORY_SEARCH_MAX_UNSTABLE_BUILD_ATTEMPTS = 3;
 const MEMORY_SEARCH_DEFAULT_LIMIT = 10;
 const MEMORY_SEARCH_MAX_LIMIT = 50;
 const QUICK_CONTEXT_DEFAULT_LIMIT = 8;
@@ -145,6 +157,20 @@ export function rankByKeyword<T>(
     items.map((item) => ({ content: getText(item) })),
     { stemming: true },
   );
+  return rankWithIndex(query, items, bm25);
+}
+
+/**
+ * Same ranking contract as {@link rankByKeyword} but against a prebuilt BM25
+ * index whose docs correspond 1:1 (by array index) with `items`. This is the
+ * shared scoring tail, so cached and cold paths cannot drift.
+ */
+function rankWithIndex<T>(
+  query: string,
+  items: T[],
+  bm25: BM25,
+): Array<{ item: T; score: number }> {
+  if (items.length === 0) return [];
   const results = bm25.search(query, items.length);
   if (results.length === 0) return items.map((item) => ({ item, score: 0 }));
   const firstScore = results[0]?.score;
@@ -178,21 +204,148 @@ export function matchesKeyword(text: string, query: string): boolean {
     .some((term) => normalizedText.includes(term));
 }
 
-async function searchMemoryNotes(
+type MemorySearchCandidate = { id: UUID; text: string; createdAt: number };
+
+type MemorySearchCorpus = {
+  candidates: MemorySearchCandidate[];
+  /** BM25 index whose doc order matches `candidates` by array index. */
+  bm25: BM25;
+  /** Room message-row count observed when this corpus was built. */
+  rowCount: number;
+  builtAt: number;
+};
+
+type MemorySearchCacheSlot = {
+  generation: number;
+  corpus?: MemorySearchCorpus;
+  inFlight?: Promise<MemorySearchCorpusBuild>;
+};
+
+type MemorySearchCorpusBuild = {
+  corpus: MemorySearchCorpus;
+  disposition: "cacheable" | "uncached" | "obsolete";
+  countBefore: number | null;
+  countAfter: number | null;
+};
+
+/**
+ * Per-runtime, per-room corpus + BM25 index cache for the hash-memory search
+ * endpoints. Building this per request was the whole latency story: a full
+ * `getMemories` scan (up to {@link MEMORY_SEARCH_SCAN_LIMIT} rows, some
+ * multi-KB) plus a fresh BM25 tokenize/index pass cost ~2s+ at ~2k rows while
+ * the actual query scoring is sub-millisecond.
+ *
+ * Freshness model (memories can be written outside this module, e.g. normal
+ * chat writes to the "messages" table):
+ *  - explicit invalidation on every mutation routed through this module
+ *    (remember / DELETE / PATCH);
+ *  - a cheap COUNT check before every reuse catches out-of-band creates and
+ *    deletes immediately;
+ *  - a short TTL triggers refresh for count-preserving out-of-band edits, and
+ *    {@link MEMORY_SEARCH_CACHE_MAX_STALE_MS} is their absolute stale bound.
+ */
+let memorySearchCorpusCaches = new WeakMap<
+  AgentRuntime,
+  Map<string, MemorySearchCacheSlot>
+>();
+
+function invalidateMemorySearchCacheSlot(slot: MemorySearchCacheSlot): void {
+  slot.generation++;
+  slot.corpus = undefined;
+  // Detach an older build so a request arriving after invalidation cannot join
+  // a stale snapshot. Its generation check prevents that build from publishing.
+  slot.inFlight = undefined;
+}
+
+export function invalidateMemorySearchCache(
+  runtime?: AgentRuntime,
+  roomId?: UUID,
+): void {
+  if (!runtime) {
+    // Test/process reset only. Runtime-owned maps otherwise disappear when the
+    // runtime is collected, without keeping tenant state alive module-wide.
+    memorySearchCorpusCaches = new WeakMap();
+    return;
+  }
+  const cache = memorySearchCorpusCaches.get(runtime);
+  if (!cache) return;
+  if (roomId) {
+    const slot = cache.get(roomId);
+    if (slot) invalidateMemorySearchCacheSlot(slot);
+    return;
+  }
+  for (const slot of cache.values()) invalidateMemorySearchCacheSlot(slot);
+}
+
+async function countRoomMessages(
   runtime: AgentRuntime,
   roomId: UUID,
-  query: string,
-  limit: number,
-): Promise<MemorySearchHit[]> {
+): Promise<number | null> {
+  if (typeof runtime.countMemories !== "function") return null;
+  try {
+    return await runtime.countMemories({
+      roomId,
+      tableName: "messages",
+    });
+  } catch (error) {
+    // error-policy:J7 A freshness-probe failure is reported but cannot turn a
+    // safe uncached search into a user-visible route failure.
+    runtime.reportError("MemorySearchCache.countRoomMessages", error, {
+      roomId,
+    });
+    return null;
+  }
+}
+
+function runtimeMemorySearchCache(
+  runtime: AgentRuntime,
+): Map<string, MemorySearchCacheSlot> {
+  let cache = memorySearchCorpusCaches.get(runtime);
+  if (!cache) {
+    cache = new Map();
+    memorySearchCorpusCaches.set(runtime, cache);
+  }
+  return cache;
+}
+
+function retainMemorySearchCacheSlot(
+  cache: Map<string, MemorySearchCacheSlot>,
+  roomId: string,
+  slot: MemorySearchCacheSlot,
+): void {
+  // Map insertion order is the LRU order. Bound slots themselves, not only
+  // populated corpora: uncached, failed, invalidated, and in-flight rooms must
+  // not let an attacker grow the per-runtime map without limit.
+  cache.delete(roomId);
+  cache.set(roomId, slot);
+  while (cache.size > MEMORY_SEARCH_CACHE_MAX_ENTRIES) {
+    const oldestRoomId = cache.keys().next().value;
+    if (typeof oldestRoomId !== "string") break;
+    cache.delete(oldestRoomId);
+  }
+}
+
+async function buildMemorySearchCorpus(
+  runtime: AgentRuntime,
+  roomId: UUID,
+): Promise<MemorySearchCorpusBuild> {
+  // The two counts form a lightweight seqlock around the scan. A create/delete
+  // interleaving with getMemories makes the counts disagree, so that mixed
+  // snapshot is marked obsolete and retried instead of being returned or
+  // published for later reuse.
+  const countBefore = await countRoomMessages(runtime, roomId);
   const memories = await runtime.getMemories({
     roomId,
     tableName: "messages",
     limit: MEMORY_SEARCH_SCAN_LIMIT,
     includeEmbedding: false, // only reads content.text
   });
+  const countAfter =
+    countBefore === null ? null : await countRoomMessages(runtime, roomId);
 
-  // Gather hash-memory candidates first, then BM25-rank them as a corpus.
-  const candidates: Array<{ id: UUID; text: string; createdAt: number }> = [];
+  const candidates: MemorySearchCandidate[] = [];
+  const textEncoder = new TextEncoder();
+  let retainedTextBytes = 0;
   for (const memory of memories) {
     const text = (
       memory.content as { text?: string } | undefined
@@ -201,6 +354,7 @@ async function searchMemoryNotes(
     const source = (memory.content as { source?: string } | undefined)?.source;
     if (source !== HASH_MEMORY_SOURCE) continue;
     if (!memory.id || typeof memory.createdAt !== "number") continue;
+    retainedTextBytes += textEncoder.encode(text).byteLength;
     candidates.push({
       id: memory.id,
       text,
@@ -208,10 +362,169 @@ async function searchMemoryNotes(
     });
   }
 
-  const hits: MemorySearchHit[] = rankByKeyword(
+  const countsMatch =
+    countBefore !== null && countAfter !== null && countBefore === countAfter;
+  return {
+    corpus: {
+      candidates,
+      bm25: new BM25(
+        candidates.map((candidate) => ({ content: candidate.text })),
+        { stemming: true },
+      ),
+      rowCount: countAfter ?? memories.length,
+      builtAt: Date.now(),
+    },
+    disposition:
+      countBefore !== null && countAfter !== null && !countsMatch
+        ? "obsolete"
+        : countsMatch && retainedTextBytes <= MEMORY_SEARCH_CACHE_MAX_TEXT_BYTES
+          ? "cacheable"
+          : "uncached",
+    countBefore,
+    countAfter,
+  };
+}
+
+function startMemorySearchCorpusBuild(
+  runtime: AgentRuntime,
+  roomId: UUID,
+  slot: MemorySearchCacheSlot,
+): Promise<MemorySearchCorpusBuild> {
+  if (slot.inFlight) return slot.inFlight;
+  const generation = slot.generation;
+  const build = buildMemorySearchCorpus(runtime, roomId).then((result) => {
+    if (slot.generation === generation) {
+      slot.corpus =
+        result.disposition === "cacheable" ? result.corpus : undefined;
+    }
+    return result;
+  });
+  slot.inFlight = build;
+  // error-policy:J7 A background refresh is observed and reported here; a
+  // synchronous caller awaiting the same promise still receives the failure.
+  void build.then(
+    () => {
+      if (slot.inFlight === build) slot.inFlight = undefined;
+    },
+    (error: unknown) => {
+      if (slot.inFlight === build) slot.inFlight = undefined;
+      runtime.reportError("MemorySearchCache.refresh", error, { roomId });
+    },
+  );
+  return build;
+}
+
+async function awaitCurrentMemorySearchCorpusBuild(
+  runtime: AgentRuntime,
+  roomId: UUID,
+  cache: Map<string, MemorySearchCacheSlot>,
+  slot: MemorySearchCacheSlot,
+): Promise<MemorySearchCorpus> {
+  let unstableBuildAttempts = 0;
+  while (true) {
+    const generation = slot.generation;
+    const result = await startMemorySearchCorpusBuild(runtime, roomId, slot);
+    // The slot may have been evicted while its scan was pending. Re-enter via
+    // the bounded canonical map so a mutation cannot be missed by an orphaned
+    // in-flight request.
+    if (cache.get(roomId) !== slot) {
+      return await getMemorySearchCorpus(runtime, roomId);
+    }
+    // Invalidation already prevents this build from publishing. It must also
+    // prevent a request awaiting the old generation from returning that stale
+    // snapshot after the mutation has completed.
+    if (slot.generation !== generation) continue;
+    if (result.disposition !== "obsolete") return result.corpus;
+
+    unstableBuildAttempts++;
+    invalidateMemorySearchCacheSlot(slot);
+    if (unstableBuildAttempts >= MEMORY_SEARCH_MAX_UNSTABLE_BUILD_ATTEMPTS) {
+      throw new ElizaError(
+        "Memory search corpus could not obtain a stable room snapshot",
+        {
+          code: "MEMORY_SEARCH_UNSTABLE_SNAPSHOT",
+          context: {
+            roomId,
+            attempts: unstableBuildAttempts,
+            countBefore: result.countBefore,
+            countAfter: result.countAfter,
+          },
+        },
+      );
+    }
+  }
+}
+
+async function getMemorySearchCorpus(
+  runtime: AgentRuntime,
+  roomId: UUID,
+): Promise<MemorySearchCorpus> {
+  const cache = runtimeMemorySearchCache(runtime);
+  let slot = cache.get(roomId);
+  if (!slot) {
+    slot = { generation: 0 };
+  }
+  retainMemorySearchCacheSlot(cache, roomId, slot);
+  const cached = slot.corpus;
+  if (cached) {
+    const rowCount = await countRoomMessages(runtime, roomId);
+
+    // Eviction may have orphaned this slot while COUNT was pending. Re-enter
+    // through the canonical map so the replacement build can be single-flighted
+    // and published for later requests.
+    if (cache.get(roomId) !== slot) {
+      return await getMemorySearchCorpus(runtime, roomId);
+    }
+
+    // A module-local mutation may have invalidated this slot while COUNT was
+    // pending. Never return the snapshot captured before that mutation.
+    if (slot.corpus !== cached) {
+      return await awaitCurrentMemorySearchCorpusBuild(
+        runtime,
+        roomId,
+        cache,
+        slot,
+      );
+    }
+
+    if (rowCount !== null && rowCount === cached.rowCount) {
+      const age = Date.now() - cached.builtAt;
+      if (age <= MEMORY_SEARCH_CACHE_TTL_MS) return cached;
+      if (age <= MEMORY_SEARCH_CACHE_MAX_STALE_MS) {
+        // Keep the first post-TTL request warm while one shared refresh runs.
+        // The absolute max-stale boundary below prevents persistent failures
+        // from extending this stale-while-revalidate window indefinitely.
+        startMemorySearchCorpusBuild(runtime, roomId, slot);
+        return cached;
+      }
+    } else {
+      // A changed/unknown count makes both the cached corpus and any older
+      // background refresh ineligible. Detach that refresh before rebuilding;
+      // otherwise this request could join a snapshot that predates the count
+      // mismatch it just observed.
+      invalidateMemorySearchCacheSlot(slot);
+    }
+  }
+  return await awaitCurrentMemorySearchCorpusBuild(
+    runtime,
+    roomId,
+    cache,
+    slot,
+  );
+}
+
+async function searchMemoryNotes(
+  runtime: AgentRuntime,
+  roomId: UUID,
+  query: string,
+  limit: number,
+): Promise<MemorySearchHit[]> {
+  const corpus = await getMemorySearchCorpus(runtime, roomId);
+
+  const hits: MemorySearchHit[] = rankWithIndex(
     query,
-    candidates,
-    (c) => c.text,
+    corpus.candidates,
+    corpus.bm25,
   )
     .filter(({ score }) => score > 0)
     .map(({ item, score }) => ({
@@ -496,6 +809,7 @@ export async function handleMemoryRoutes(
       },
     });
     await runtime.createMemory(message, "messages");
+    invalidateMemorySearchCache(runtime, roomId);
     json(res, {
       ok: true,
       id: message.id,
@@ -753,6 +1067,7 @@ export async function handleMemoryRoutes(
 
     if (method === "DELETE") {
       await runtime.deleteMemory(memoryId);
+      invalidateMemorySearchCache(runtime, existing.roomId);
       json(res, { deleted: true, id: memoryId });
       return true;
     }
@@ -795,6 +1110,7 @@ export async function handleMemoryRoutes(
       content: nextContent,
       embedding,
     });
+    invalidateMemorySearchCache(runtime, existing.roomId);
 
     const updated = await runtime.getMemoryById(memoryId);
     json(res, { updated: true, id: memoryId, memory: updated });

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -219,6 +219,8 @@ type MemorySearchCacheSlot = {
   generation: number;
   corpus?: MemorySearchCorpus;
   inFlight?: Promise<MemorySearchCorpusBuild>;
+  builds: Set<Promise<MemorySearchCorpusBuild>>;
+  leases: number;
 };
 
 type MemorySearchCorpusBuild = {
@@ -226,6 +228,10 @@ type MemorySearchCorpusBuild = {
   disposition: "cacheable" | "uncached" | "obsolete";
   countBefore: number | null;
   countAfter: number | null;
+};
+
+type MemorySearchBuildRetryBudget = {
+  unstableAttempts: number;
 };
 
 /**
@@ -249,6 +255,17 @@ let memorySearchCorpusCaches = new WeakMap<
   Map<string, MemorySearchCacheSlot>
 >();
 
+type MemorySearchBuildAdmission = {
+  active: number;
+  waiters: Array<() => void>;
+};
+
+let memorySearchBuildAdmissions = new WeakMap<
+  AgentRuntime,
+  MemorySearchBuildAdmission
+>();
+let memorySearchSlotWaiters = new WeakMap<AgentRuntime, Set<() => void>>();
+
 function invalidateMemorySearchCacheSlot(slot: MemorySearchCacheSlot): void {
   slot.generation++;
   slot.corpus = undefined;
@@ -265,6 +282,8 @@ export function invalidateMemorySearchCache(
     // Test/process reset only. Runtime-owned maps otherwise disappear when the
     // runtime is collected, without keeping tenant state alive module-wide.
     memorySearchCorpusCaches = new WeakMap();
+    memorySearchBuildAdmissions = new WeakMap();
+    memorySearchSlotWaiters = new WeakMap();
     return;
   }
   const cache = memorySearchCorpusCaches.get(runtime);
@@ -313,15 +332,103 @@ function retainMemorySearchCacheSlot(
   roomId: string,
   slot: MemorySearchCacheSlot,
 ): void {
-  // Map insertion order is the LRU order. Bound slots themselves, not only
-  // populated corpora: uncached, failed, invalidated, and in-flight rooms must
-  // not let an attacker grow the per-runtime map without limit.
+  // Map insertion order is the LRU order.
   cache.delete(roomId);
   cache.set(roomId, slot);
-  while (cache.size > MEMORY_SEARCH_CACHE_MAX_ENTRIES) {
-    const oldestRoomId = cache.keys().next().value;
-    if (typeof oldestRoomId !== "string") break;
-    cache.delete(oldestRoomId);
+}
+
+async function acquireMemorySearchCacheSlot(
+  runtime: AgentRuntime,
+  roomId: string,
+): Promise<{
+  cache: Map<string, MemorySearchCacheSlot>;
+  slot: MemorySearchCacheSlot;
+}> {
+  const cache = runtimeMemorySearchCache(runtime);
+  while (true) {
+    const existing = cache.get(roomId);
+    if (existing) {
+      retainMemorySearchCacheSlot(cache, roomId, existing);
+      existing.leases++;
+      return { cache, slot: existing };
+    }
+
+    if (cache.size < MEMORY_SEARCH_CACHE_MAX_ENTRIES) {
+      const slot: MemorySearchCacheSlot = {
+        generation: 0,
+        builds: new Set(),
+        leases: 1,
+      };
+      retainMemorySearchCacheSlot(cache, roomId, slot);
+      return { cache, slot };
+    }
+
+    // Never evict a slot while one of its current or invalidated builds still
+    // owns work. Otherwise the caller retains an orphaned slot, a later request
+    // starts a replacement scan, and the Map bound says nothing about live work.
+    const evictable = [...cache].find(
+      ([, candidate]) => candidate.builds.size === 0 && candidate.leases === 0,
+    );
+    if (evictable) {
+      cache.delete(evictable[0]);
+      continue;
+    }
+
+    // All bounded slots are busy. Wait for one to become evictable before
+    // allocating another slot; concurrent callers remain ordinary request
+    // promises rather than cache-owned room state.
+    await new Promise<void>((resolve) => {
+      let waiters = memorySearchSlotWaiters.get(runtime);
+      if (!waiters) {
+        waiters = new Set();
+        memorySearchSlotWaiters.set(runtime, waiters);
+      }
+      waiters.add(resolve);
+    });
+  }
+}
+
+function signalMemorySearchSlotAvailability(runtime: AgentRuntime): void {
+  const waiters = memorySearchSlotWaiters.get(runtime);
+  if (!waiters) return;
+  memorySearchSlotWaiters.delete(runtime);
+  for (const resolve of waiters) resolve();
+}
+
+async function withMemorySearchBuildPermit<T>(
+  runtime: AgentRuntime,
+  task: () => Promise<T>,
+): Promise<T> {
+  let admission = memorySearchBuildAdmissions.get(runtime);
+  if (!admission) {
+    admission = { active: 0, waiters: [] };
+    memorySearchBuildAdmissions.set(runtime, admission);
+  }
+
+  if (admission.active < MEMORY_SEARCH_CACHE_MAX_ENTRIES) {
+    admission.active++;
+  } else {
+    await new Promise<void>((resolve) => {
+      admission.waiters.push(() => {
+        admission.active++;
+        resolve();
+      });
+    });
+  }
+
+  try {
+    return await task();
+  } finally {
+    admission.active--;
+    const next = admission.waiters.shift();
+    if (next) {
+      next();
+    } else if (
+      admission.active === 0 &&
+      memorySearchBuildAdmissions.get(runtime) === admission
+    ) {
+      memorySearchBuildAdmissions.delete(runtime);
+    }
   }
 }
 
@@ -392,7 +499,9 @@ function startMemorySearchCorpusBuild(
 ): Promise<MemorySearchCorpusBuild> {
   if (slot.inFlight) return slot.inFlight;
   const generation = slot.generation;
-  const build = buildMemorySearchCorpus(runtime, roomId).then((result) => {
+  const build = withMemorySearchBuildPermit(runtime, async () =>
+    buildMemorySearchCorpus(runtime, roomId),
+  ).then((result) => {
     if (slot.generation === generation) {
       slot.corpus =
         result.disposition === "cacheable" ? result.corpus : undefined;
@@ -400,14 +509,19 @@ function startMemorySearchCorpusBuild(
     return result;
   });
   slot.inFlight = build;
+  slot.builds.add(build);
   // error-policy:J7 A background refresh is observed and reported here; a
   // synchronous caller awaiting the same promise still receives the failure.
   void build.then(
     () => {
+      slot.builds.delete(build);
       if (slot.inFlight === build) slot.inFlight = undefined;
+      signalMemorySearchSlotAvailability(runtime);
     },
     (error: unknown) => {
+      slot.builds.delete(build);
       if (slot.inFlight === build) slot.inFlight = undefined;
+      signalMemorySearchSlotAvailability(runtime);
       runtime.reportError("MemorySearchCache.refresh", error, { roomId });
     },
   );
@@ -419,98 +533,133 @@ async function awaitCurrentMemorySearchCorpusBuild(
   roomId: UUID,
   cache: Map<string, MemorySearchCacheSlot>,
   slot: MemorySearchCacheSlot,
+  retryBudget: MemorySearchBuildRetryBudget,
 ): Promise<MemorySearchCorpus> {
-  let unstableBuildAttempts = 0;
   while (true) {
     const generation = slot.generation;
     const result = await startMemorySearchCorpusBuild(runtime, roomId, slot);
-    // The slot may have been evicted while its scan was pending. Re-enter via
+    // The slot may have been replaced while its scan was pending. Re-enter via
     // the bounded canonical map so a mutation cannot be missed by an orphaned
     // in-flight request.
-    if (cache.get(roomId) !== slot) {
-      return await getMemorySearchCorpus(runtime, roomId);
+    if (
+      memorySearchCorpusCaches.get(runtime) !== cache ||
+      cache.get(roomId) !== slot
+    ) {
+      consumeMemorySearchRetryBudget(retryBudget, roomId, "map_identity", {
+        countBefore: result.countBefore,
+        countAfter: result.countAfter,
+      });
+      return await getMemorySearchCorpus(runtime, roomId, retryBudget);
     }
     // Invalidation already prevents this build from publishing. It must also
     // prevent a request awaiting the old generation from returning that stale
     // snapshot after the mutation has completed.
-    if (slot.generation !== generation) continue;
+    if (slot.generation !== generation) {
+      consumeMemorySearchRetryBudget(retryBudget, roomId, "generation", {
+        countBefore: result.countBefore,
+        countAfter: result.countAfter,
+      });
+      continue;
+    }
     if (result.disposition !== "obsolete") return result.corpus;
 
-    unstableBuildAttempts++;
     invalidateMemorySearchCacheSlot(slot);
-    if (unstableBuildAttempts >= MEMORY_SEARCH_MAX_UNSTABLE_BUILD_ATTEMPTS) {
-      throw new ElizaError(
-        "Memory search corpus could not obtain a stable room snapshot",
-        {
-          code: "MEMORY_SEARCH_UNSTABLE_SNAPSHOT",
-          context: {
-            roomId,
-            attempts: unstableBuildAttempts,
-            countBefore: result.countBefore,
-            countAfter: result.countAfter,
-          },
-        },
-      );
-    }
+    consumeMemorySearchRetryBudget(retryBudget, roomId, "count_mismatch", {
+      countBefore: result.countBefore,
+      countAfter: result.countAfter,
+    });
   }
+}
+
+function consumeMemorySearchRetryBudget(
+  retryBudget: MemorySearchBuildRetryBudget,
+  roomId: UUID,
+  reason: "count_mismatch" | "generation" | "map_identity",
+  context: { countBefore?: number | null; countAfter?: number | null } = {},
+): void {
+  retryBudget.unstableAttempts++;
+  if (
+    retryBudget.unstableAttempts < MEMORY_SEARCH_MAX_UNSTABLE_BUILD_ATTEMPTS
+  ) {
+    return;
+  }
+  throw new ElizaError(
+    "Memory search corpus could not obtain a stable room snapshot",
+    {
+      code: "MEMORY_SEARCH_UNSTABLE_SNAPSHOT",
+      context: {
+        roomId,
+        attempts: retryBudget.unstableAttempts,
+        reason,
+        ...context,
+      },
+    },
+  );
 }
 
 async function getMemorySearchCorpus(
   runtime: AgentRuntime,
   roomId: UUID,
+  retryBudget: MemorySearchBuildRetryBudget = { unstableAttempts: 0 },
 ): Promise<MemorySearchCorpus> {
-  const cache = runtimeMemorySearchCache(runtime);
-  let slot = cache.get(roomId);
-  if (!slot) {
-    slot = { generation: 0 };
-  }
-  retainMemorySearchCacheSlot(cache, roomId, slot);
-  const cached = slot.corpus;
-  if (cached) {
-    const rowCount = await countRoomMessages(runtime, roomId);
+  const { cache, slot } = await acquireMemorySearchCacheSlot(runtime, roomId);
+  try {
+    const cached = slot.corpus;
+    if (cached) {
+      const rowCount = await countRoomMessages(runtime, roomId);
 
-    // Eviction may have orphaned this slot while COUNT was pending. Re-enter
-    // through the canonical map so the replacement build can be single-flighted
-    // and published for later requests.
-    if (cache.get(roomId) !== slot) {
-      return await getMemorySearchCorpus(runtime, roomId);
-    }
-
-    // A module-local mutation may have invalidated this slot while COUNT was
-    // pending. Never return the snapshot captured before that mutation.
-    if (slot.corpus !== cached) {
-      return await awaitCurrentMemorySearchCorpusBuild(
-        runtime,
-        roomId,
-        cache,
-        slot,
-      );
-    }
-
-    if (rowCount !== null && rowCount === cached.rowCount) {
-      const age = Date.now() - cached.builtAt;
-      if (age <= MEMORY_SEARCH_CACHE_TTL_MS) return cached;
-      if (age <= MEMORY_SEARCH_CACHE_MAX_STALE_MS) {
-        // Keep the first post-TTL request warm while one shared refresh runs.
-        // The absolute max-stale boundary below prevents persistent failures
-        // from extending this stale-while-revalidate window indefinitely.
-        startMemorySearchCorpusBuild(runtime, roomId, slot);
-        return cached;
+      // A process/test cache reset may replace this runtime's canonical map while
+      // COUNT is pending. Re-enter through that map with the shared retry budget.
+      if (
+        memorySearchCorpusCaches.get(runtime) !== cache ||
+        cache.get(roomId) !== slot
+      ) {
+        consumeMemorySearchRetryBudget(retryBudget, roomId, "map_identity");
+        return await getMemorySearchCorpus(runtime, roomId, retryBudget);
       }
-    } else {
-      // A changed/unknown count makes both the cached corpus and any older
-      // background refresh ineligible. Detach that refresh before rebuilding;
-      // otherwise this request could join a snapshot that predates the count
-      // mismatch it just observed.
-      invalidateMemorySearchCacheSlot(slot);
+
+      // A module-local mutation may have invalidated this slot while COUNT was
+      // pending. Never return the snapshot captured before that mutation.
+      if (slot.corpus !== cached) {
+        consumeMemorySearchRetryBudget(retryBudget, roomId, "generation");
+        return await awaitCurrentMemorySearchCorpusBuild(
+          runtime,
+          roomId,
+          cache,
+          slot,
+          retryBudget,
+        );
+      }
+
+      if (rowCount !== null && rowCount === cached.rowCount) {
+        const age = Date.now() - cached.builtAt;
+        if (age <= MEMORY_SEARCH_CACHE_TTL_MS) return cached;
+        if (age <= MEMORY_SEARCH_CACHE_MAX_STALE_MS) {
+          // Keep the first post-TTL request warm while one shared refresh runs.
+          // The absolute max-stale boundary below prevents persistent failures
+          // from extending this stale-while-revalidate window indefinitely.
+          startMemorySearchCorpusBuild(runtime, roomId, slot);
+          return cached;
+        }
+      } else {
+        // A changed/unknown count makes both the cached corpus and any older
+        // background refresh ineligible. Detach that refresh before rebuilding;
+        // otherwise this request could join a snapshot that predates the count
+        // mismatch it just observed.
+        invalidateMemorySearchCacheSlot(slot);
+      }
     }
+    return await awaitCurrentMemorySearchCorpusBuild(
+      runtime,
+      roomId,
+      cache,
+      slot,
+      retryBudget,
+    );
+  } finally {
+    slot.leases--;
+    signalMemorySearchSlotAvailability(runtime);
   }
-  return await awaitCurrentMemorySearchCorpusBuild(
-    runtime,
-    roomId,
-    cache,
-    slot,
-  );
 }
 
 async function searchMemoryNotes(

--- a/packages/agent/src/api/memory-search-cache.test.ts
+++ b/packages/agent/src/api/memory-search-cache.test.ts
@@ -8,6 +8,7 @@
 
 import {
   type AgentRuntime,
+  ElizaError,
   InMemoryDatabaseAdapter,
   type Memory,
   stringToUuid,
@@ -43,7 +44,9 @@ function note(
 
 function makeRuntime(store: Store) {
   const getMemories = vi.fn(async () => [...store.rows]);
-  const countMemories = vi.fn(async () => store.rows.length);
+  const countMemories = vi.fn(
+    async (_params: { roomId?: UUID }) => store.rows.length,
+  );
   const runtime = {
     agentId: AGENT_ID,
     character: { name: "Eliza" },
@@ -151,6 +154,14 @@ async function search(
       results: Array<{ id: string; text: string; score: number }>;
     }
   ).results;
+}
+
+async function waitForTestCondition(condition: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (condition()) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("Timed out waiting for test condition");
 }
 
 beforeEach(() => {
@@ -527,7 +538,7 @@ describe("GET /api/memory/search corpus cache", () => {
     expect(getMemories).toHaveBeenCalledTimes(9);
   });
 
-  test("bounds uncached and in-flight room slots", async () => {
+  test("retains an in-flight room slot instead of starting orphaned replacement work", async () => {
     const roomId = (name: string) =>
       stringToUuid(`${name}-hash-memory-room`) as UUID;
     let releaseFirstA = () => {};
@@ -561,21 +572,111 @@ describe("GET /api/memory/search corpus cache", () => {
     } as unknown as AgentRuntime;
 
     const firstA = search(runtime, "puffin");
-    await vi.waitFor(() => expect(aScans).toBe(1));
+    await waitForTestCondition(() => aScans === 1);
     for (const room of ["B", "C", "D", "E"]) {
       runtime.character.name = room;
       await search(runtime, "puffin");
     }
 
-    // The fifth distinct room must evict A even though A has no corpus and its
-    // scan is pending. A second request therefore starts a fresh scan instead
-    // of joining the unbounded orphaned slot.
+    // Completed uncached slots remain evictable, but A stays canonical while
+    // its scan is pending. A second request joins that work instead of starting
+    // an orphaned replacement scan outside the Map bound.
     runtime.character.name = "A";
-    await expect(search(runtime, "puffin")).resolves.toHaveLength(1);
-    expect(aScans).toBe(2);
+    const secondA = search(runtime, "puffin");
+    await waitForTestCondition(() => aScans === 1);
 
     releaseFirstA();
     await expect(firstA).resolves.toHaveLength(1);
+    await expect(secondA).resolves.toHaveLength(1);
+    expect(getMemories).toHaveBeenCalledTimes(5);
+  });
+
+  test("caps peak active corpus builds across concurrent room churn", async () => {
+    let activeBuilds = 0;
+    let peakActiveBuilds = 0;
+    const getMemories = vi.fn(
+      async ({ roomId }: { roomId: UUID }): Promise<Memory[]> => {
+        activeBuilds++;
+        peakActiveBuilds = Math.max(peakActiveBuilds, activeBuilds);
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        activeBuilds--;
+        return [
+          note(crypto.randomUUID(), `${roomId} bounded puffin`, 1, roomId),
+        ];
+      },
+    );
+    const runtime = {
+      agentId: AGENT_ID,
+      character: { name: "room-0" },
+      ensureConnection: vi.fn(async () => undefined),
+      getMemories,
+      // No countMemories keeps every completed result intentionally uncached.
+      reportError: vi.fn(() => undefined),
+    } as unknown as AgentRuntime;
+
+    const searches = Array.from({ length: 12 }, (_, index) => {
+      runtime.character.name = `room-${index}`;
+      return search(runtime, "puffin");
+    });
+
+    const settled = await Promise.allSettled(searches);
+    expect(
+      settled.flatMap((result) =>
+        result.status === "rejected"
+          ? [
+              result.reason instanceof ElizaError
+                ? { code: result.reason.code, context: result.reason.context }
+                : result.reason,
+            ]
+          : [],
+      ),
+    ).toEqual([]);
+    expect(settled).toHaveLength(12);
+    expect(getMemories).toHaveBeenCalledTimes(12);
+    expect(activeBuilds).toBe(0);
+    expect(peakActiveBuilds).toBe(4);
+  });
+
+  test("caps detached same-room builds during invalidation churn", async () => {
+    let activeBuilds = 0;
+    let peakActiveBuilds = 0;
+    let releaseBuilds = () => {};
+    const buildGate = new Promise<void>((resolve) => {
+      releaseBuilds = resolve;
+    });
+    const store: Store = {
+      rows: [note("aaaaaaaa-0000-4000-8000-000000000001", "storm petrel", 1)],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    getMemories.mockImplementation(async () => {
+      activeBuilds++;
+      peakActiveBuilds = Math.max(peakActiveBuilds, activeBuilds);
+      await buildGate;
+      activeBuilds--;
+      return [...store.rows];
+    });
+    const roomId = stringToUuid("Eliza-hash-memory-room") as UUID;
+
+    const searches: Array<Promise<unknown>> = [];
+    for (let index = 0; index < 4; index++) {
+      searches.push(search(runtime, "petrel"));
+      await waitForTestCondition(
+        () => getMemories.mock.calls.length === index + 1,
+      );
+      invalidateMemorySearchCache(runtime, roomId);
+    }
+    for (let index = 4; index < 12; index++) {
+      searches.push(search(runtime, "petrel"));
+      invalidateMemorySearchCache(runtime, roomId);
+    }
+
+    expect(activeBuilds).toBe(4);
+    expect(peakActiveBuilds).toBe(4);
+    releaseBuilds();
+
+    await expect(Promise.all(searches)).resolves.toHaveLength(12);
+    expect(activeBuilds).toBe(0);
+    expect(peakActiveBuilds).toBeLessThanOrEqual(4);
   });
 
   test("retries a cold build invalidated by a completed mutation", async () => {
@@ -838,6 +939,98 @@ describe("GET /api/memory/search corpus cache", () => {
       },
     });
     expect(getMemories).toHaveBeenCalledTimes(3);
+  });
+
+  test("shares the retry budget across perpetual generation invalidation", async () => {
+    const store: Store = {
+      rows: [
+        note("aaaaaaaa-0000-4000-8000-000000000001", "restless petrel", 1),
+      ],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    const releases: Array<() => void> = [];
+    getMemories.mockImplementation(async () => {
+      const snapshot = [...store.rows];
+      await new Promise<void>((resolve) => releases.push(resolve));
+      return snapshot;
+    });
+    const roomId = stringToUuid("Eliza-hash-memory-room") as UUID;
+
+    const pending = search(runtime, "petrel");
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      await waitForTestCondition(
+        () => getMemories.mock.calls.length === attempt,
+      );
+      invalidateMemorySearchCache(runtime, roomId);
+      const release = releases.shift();
+      if (!release) throw new Error("Expected a gated memory scan");
+      release();
+    }
+
+    await expect(pending).rejects.toMatchObject({
+      code: "MEMORY_SEARCH_UNSTABLE_SNAPSHOT",
+      context: { attempts: 3, reason: "generation" },
+    });
+    expect(getMemories).toHaveBeenCalledTimes(3);
+  });
+
+  test("shares the retry budget across repeated canonical slot replacement", async () => {
+    const roomA = stringToUuid("A-hash-memory-room") as UUID;
+    const store: Store = {
+      rows: [
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000001",
+          "canonical sparrow",
+          1,
+          roomA,
+        ),
+      ],
+    };
+    const { runtime, countMemories } = makeRuntime(store);
+    runtime.character.name = "A";
+    let roomACountCalls = 0;
+    const countGates = new Map<number, Promise<void>>();
+    const releaseCountGates = new Map<number, () => void>();
+    for (const call of [3, 6, 9]) {
+      countGates.set(
+        call,
+        new Promise<void>((resolve) => releaseCountGates.set(call, resolve)),
+      );
+    }
+    countMemories.mockImplementation(
+      async ({ roomId }: { roomId?: UUID }): Promise<number> => {
+        if (!roomId) return store.rows.length;
+        if (roomId === roomA) {
+          roomACountCalls++;
+          const gate = countGates.get(roomACountCalls);
+          if (gate) await gate;
+        }
+        return store.rows.filter((row) => row.roomId === roomId).length;
+      },
+    );
+
+    await expect(search(runtime, "sparrow")).resolves.toHaveLength(1);
+    const pending = search(runtime, "sparrow");
+
+    const replaceMapAndRebuildRoomA = async () => {
+      invalidateMemorySearchCache();
+      runtime.character.name = "A";
+      await search(runtime, "sparrow");
+    };
+
+    for (const gatedCall of [3, 6, 9]) {
+      await waitForTestCondition(() => roomACountCalls >= gatedCall);
+      await replaceMapAndRebuildRoomA();
+      const release = releaseCountGates.get(gatedCall);
+      if (!release) throw new Error("Expected a gated COUNT probe");
+      release();
+    }
+
+    await expect(pending).rejects.toMatchObject({
+      code: "MEMORY_SEARCH_UNSTABLE_SNAPSHOT",
+      context: { attempts: 3, reason: "map_identity" },
+    });
+    expect(roomACountCalls).toBe(11);
   });
 
   test("single-flights concurrent cold rebuilds for one runtime and room", async () => {

--- a/packages/agent/src/api/memory-search-cache.test.ts
+++ b/packages/agent/src/api/memory-search-cache.test.ts
@@ -1,0 +1,910 @@
+/**
+ * Regression coverage for the /api/memory/search corpus + BM25 cache:
+ * identical ranking cached vs cold, explicit invalidation on module-local
+ * mutations (remember / DELETE / PATCH), count-based staleness detection,
+ * same-request retry and bounded typed failure for unstable snapshots, bounded
+ * refresh failure, runtime isolation, rebuild races, and memory limits.
+ */
+
+import {
+  type AgentRuntime,
+  InMemoryDatabaseAdapter,
+  type Memory,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { MemoryRouteContext } from "./memory-routes.ts";
+import {
+  HASH_MEMORY_SOURCE,
+  handleMemoryRoutes,
+  invalidateMemorySearchCache,
+} from "./memory-routes.ts";
+
+const AGENT_ID = "11111111-1111-4111-8111-111111111111" as UUID;
+
+type Store = { rows: Memory[] };
+
+function note(
+  id: string,
+  text: string,
+  createdAt: number,
+  roomId = stringToUuid("Eliza-hash-memory-room") as UUID,
+): Memory {
+  return {
+    id: id as UUID,
+    entityId: AGENT_ID,
+    agentId: AGENT_ID,
+    roomId,
+    createdAt,
+    content: { text, source: HASH_MEMORY_SOURCE },
+  } as Memory;
+}
+
+function makeRuntime(store: Store) {
+  const getMemories = vi.fn(async () => [...store.rows]);
+  const countMemories = vi.fn(async () => store.rows.length);
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    ensureConnection: vi.fn(async () => undefined),
+    getMemories,
+    countMemories,
+    getMemoryById: vi.fn(
+      async (id: UUID) => store.rows.find((row) => row.id === id) ?? null,
+    ),
+    createMemory: vi.fn(async (memory: Memory) => {
+      store.rows.push(memory);
+      return memory.id;
+    }),
+    deleteMemory: vi.fn(async (id: UUID) => {
+      store.rows = store.rows.filter((row) => row.id !== id);
+    }),
+    updateMemory: vi.fn(
+      async (patch: { id: UUID; content: Record<string, unknown> }) => {
+        const row = store.rows.find((r) => r.id === patch.id);
+        if (row) row.content = patch.content as Memory["content"];
+      },
+    ),
+    useModel: vi.fn(async () => [0.1, 0.2, 0.3]),
+    reportError: vi.fn(() => undefined),
+  } as unknown as AgentRuntime;
+  return { runtime, getMemories, countMemories };
+}
+
+async function makeAdapterRuntime() {
+  const adapter = new InMemoryDatabaseAdapter();
+  await adapter.initialize();
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    ensureConnection: vi.fn(async () => undefined),
+    getMemories: vi.fn(
+      async (params: Parameters<InMemoryDatabaseAdapter["getMemories"]>[0]) =>
+        adapter.getMemories(params),
+    ),
+    countMemories: vi.fn(
+      async (params: { roomId?: UUID; tableName?: string }) =>
+        adapter.countMemories({
+          roomIds: params.roomId ? [params.roomId] : undefined,
+          tableName: params.tableName,
+        }),
+    ),
+    getMemoryById: vi.fn(
+      async (id: UUID) => (await adapter.getMemoriesByIds([id]))[0] ?? null,
+    ),
+    createMemory: vi.fn(
+      async (memory: Memory, tableName: string) =>
+        (await adapter.createMemories([{ memory, tableName }]))[0],
+    ),
+    deleteMemory: vi.fn(async (id: UUID) => adapter.deleteMemories([id])),
+    updateMemory: vi.fn(async (patch: Partial<Memory> & { id: UUID }) =>
+      adapter.updateMemories([patch]),
+    ),
+    useModel: vi.fn(async () => [0.1, 0.2, 0.3]),
+    reportError: vi.fn(() => undefined),
+  } as unknown as AgentRuntime;
+  return { runtime, adapter };
+}
+
+function contextFor(args: {
+  runtime: AgentRuntime;
+  method: string;
+  path: string;
+  body?: Record<string, unknown>;
+  response: { value?: unknown };
+}): MemoryRouteContext {
+  return {
+    req: {} as never,
+    res: {} as never,
+    method: args.method,
+    pathname: args.path.split("?")[0] ?? args.path,
+    url: new URL(`https://agent.test${args.path}`),
+    runtime: args.runtime,
+    agentName: "Eliza",
+    json: (_res, value) => {
+      args.response.value = value;
+    },
+    error: (_res, message, status) => {
+      throw new Error(`unexpected ${status}: ${message}`);
+    },
+    readJsonBody: async <T extends object>() => (args.body ?? {}) as T,
+  };
+}
+
+async function search(
+  runtime: AgentRuntime,
+  query: string,
+): Promise<Array<{ id: string; text: string; score: number }>> {
+  const response: { value?: unknown } = {};
+  const handled = await handleMemoryRoutes(
+    contextFor({
+      runtime,
+      method: "GET",
+      path: `/api/memory/search?q=${encodeURIComponent(query)}&limit=50`,
+      response,
+    }),
+  );
+  expect(handled).toBe(true);
+  return (
+    response.value as {
+      results: Array<{ id: string; text: string; score: number }>;
+    }
+  ).results;
+}
+
+beforeEach(() => {
+  invalidateMemorySearchCache();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("GET /api/memory/search corpus cache", () => {
+  test("finds remember-created rows through the real adapter", async () => {
+    const { runtime } = await makeAdapterRuntime();
+    for (const text of [
+      "quartz deadline moved to Friday",
+      "voice pipeline ships tonight",
+      "morning workout at the gym",
+    ]) {
+      const response: { value?: unknown } = {};
+      await handleMemoryRoutes(
+        contextFor({
+          runtime,
+          method: "POST",
+          path: "/api/memory/remember",
+          body: { text },
+          response,
+        }),
+      );
+    }
+
+    const results = await search(runtime, "quartz");
+
+    expect(results).toEqual([
+      expect.objectContaining({ text: "quartz deadline moved to Friday" }),
+    ]);
+    expect(runtime.getMemories).toHaveBeenCalledWith(
+      expect.not.objectContaining({ agentId: expect.anything() }),
+    );
+    expect(runtime.countMemories).toHaveBeenCalledWith(
+      expect.not.objectContaining({ agentId: expect.anything() }),
+    );
+  });
+
+  test("warm search reuses the corpus (no rescan) and returns identical ordering", async () => {
+    const store: Store = {
+      rows: [
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000001",
+          "alexis gym signup together planned",
+          3,
+        ),
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000002",
+          "shipping the voice pipeline tonight",
+          2,
+        ),
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000003",
+          "alexis prefers morning workouts at the gym",
+          1,
+        ),
+      ],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+
+    const cold = await search(runtime, "alexis gym");
+    expect(getMemories).toHaveBeenCalledTimes(1);
+
+    const warm = await search(runtime, "alexis gym");
+    expect(getMemories).toHaveBeenCalledTimes(1); // corpus reused
+    expect(warm).toEqual(cold);
+
+    // Cold path after explicit invalidation must produce the exact same
+    // ranking (cache is a pure perf optimization, not a semantic change).
+    invalidateMemorySearchCache();
+    const rebuilt = await search(runtime, "alexis gym");
+    expect(getMemories).toHaveBeenCalledTimes(2);
+    expect(rebuilt).toEqual(cold);
+  });
+
+  test("remember invalidates: new note is searchable immediately", async () => {
+    const store: Store = {
+      rows: [
+        note("aaaaaaaa-0000-4000-8000-000000000001", "old note about tea", 1),
+      ],
+    };
+    const { runtime } = makeRuntime(store);
+
+    await search(runtime, "quartz"); // prime the cache
+
+    const response: { value?: unknown } = {};
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "POST",
+        path: "/api/memory/remember",
+        body: { text: "the quartz deadline moved to friday" },
+        response,
+      }),
+    );
+    expect(response.value).toEqual(expect.objectContaining({ ok: true }));
+
+    const results = await search(runtime, "quartz");
+    expect(results.some((r) => r.text.includes("quartz deadline"))).toBe(true);
+  });
+
+  test("DELETE invalidates: removed note stops appearing immediately", async () => {
+    const target = "aaaaaaaa-0000-4000-8000-000000000009";
+    const store: Store = {
+      rows: [
+        note(target, "obsolete plan about zeppelin logistics", 2),
+        note("aaaaaaaa-0000-4000-8000-000000000002", "unrelated note", 1),
+      ],
+    };
+    const { runtime } = makeRuntime(store);
+
+    const before = await search(runtime, "zeppelin");
+    expect(before.some((r) => r.id === target)).toBe(true);
+
+    const response: { value?: unknown } = {};
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "DELETE",
+        path: `/api/memories/${target}`,
+        response,
+      }),
+    );
+    expect(response.value).toEqual(expect.objectContaining({ deleted: true }));
+
+    const after = await search(runtime, "zeppelin");
+    expect(after.some((r) => r.id === target)).toBe(false);
+  });
+
+  test("PATCH invalidates: edited text is searchable immediately", async () => {
+    const target = "aaaaaaaa-0000-4000-8000-000000000005";
+    const store: Store = {
+      rows: [note(target, "original wording", 1)],
+    };
+    const { runtime } = makeRuntime(store);
+
+    await search(runtime, "gyroscope"); // prime the cache with the old text
+
+    const response: { value?: unknown } = {};
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "PATCH",
+        path: `/api/memories/${target}`,
+        body: { text: "corrected wording about the gyroscope" },
+        response,
+      }),
+    );
+    expect(response.value).toEqual(expect.objectContaining({ updated: true }));
+
+    const results = await search(runtime, "gyroscope");
+    expect(results.some((r) => r.id === target)).toBe(true);
+  });
+
+  test("PATCH invalidates the mutated memory room, not the current hash room", async () => {
+    const target = "aaaaaaaa-0000-4000-8000-000000000005";
+    const roomId = (name: string) =>
+      stringToUuid(`${name}-hash-memory-room`) as UUID;
+    const store: Store = {
+      rows: [note(target, "original wording", 1, roomId("A"))],
+    };
+    const { runtime } = makeRuntime(store);
+
+    runtime.character.name = "A";
+    await search(runtime, "gyroscope");
+
+    // A by-id mutation can be issued while a different character-derived room
+    // is current. The memory's own room is the cache ownership authority.
+    runtime.character.name = "B";
+    const response: { value?: unknown } = {};
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "PATCH",
+        path: `/api/memories/${target}`,
+        body: { text: "corrected wording about the gyroscope" },
+        response,
+      }),
+    );
+
+    runtime.character.name = "A";
+    await expect(search(runtime, "gyroscope")).resolves.toEqual([
+      expect.objectContaining({
+        id: target,
+        text: "corrected wording about the gyroscope",
+      }),
+    ]);
+  });
+
+  test("does not return a cached snapshot invalidated while COUNT is pending", async () => {
+    const target = "aaaaaaaa-0000-4000-8000-000000000005";
+    const store: Store = { rows: [note(target, "original wording", 1)] };
+    const { runtime, getMemories, countMemories } = makeRuntime(store);
+    await search(runtime, "gyroscope");
+
+    let releaseCount = () => {};
+    const countGate = new Promise<void>((resolve) => {
+      releaseCount = resolve;
+    });
+    countMemories.mockImplementationOnce(async () => {
+      await countGate;
+      return store.rows.length;
+    });
+    const pendingSearch = search(runtime, "gyroscope");
+    await vi.waitFor(() => expect(countMemories).toHaveBeenCalledTimes(3));
+
+    const response: { value?: unknown } = {};
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "PATCH",
+        path: `/api/memories/${target}`,
+        body: { text: "corrected wording about the gyroscope" },
+        response,
+      }),
+    );
+    releaseCount();
+
+    await expect(pendingSearch).resolves.toEqual([
+      expect.objectContaining({
+        text: "corrected wording about the gyroscope",
+      }),
+    ]);
+    expect(getMemories).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not return a cached snapshot whose COUNT-waiting slot was evicted", async () => {
+    const target = "aaaaaaaa-0000-4000-8000-000000000005";
+    const roomId = (name: string) =>
+      stringToUuid(`${name}-hash-memory-room`) as UUID;
+    const stores = new Map<UUID, Store>([
+      [
+        roomId("A"),
+        { rows: [note(target, "original wording", 1, roomId("A"))] },
+      ],
+      [
+        roomId("B"),
+        {
+          rows: [note("bbbbbbbb-0000-4000-8000-000000000001", "room B", 1)],
+        },
+      ],
+      [
+        roomId("C"),
+        {
+          rows: [note("cccccccc-0000-4000-8000-000000000001", "room C", 1)],
+        },
+      ],
+      [
+        roomId("D"),
+        {
+          rows: [note("dddddddd-0000-4000-8000-000000000001", "room D", 1)],
+        },
+      ],
+      [
+        roomId("E"),
+        {
+          rows: [note("eeeeeeee-0000-4000-8000-000000000001", "room E", 1)],
+        },
+      ],
+      [
+        roomId("F"),
+        {
+          rows: [note("ffffffff-0000-4000-8000-000000000001", "room F", 1)],
+        },
+      ],
+      [
+        roomId("G"),
+        {
+          rows: [note("99999999-0000-4000-8000-000000000001", "room G", 1)],
+        },
+      ],
+      [
+        roomId("H"),
+        {
+          rows: [note("88888888-0000-4000-8000-000000000001", "room H", 1)],
+        },
+      ],
+    ]);
+    const getMemories = vi.fn(
+      async ({ roomId: currentRoomId }: { roomId: UUID }) => [
+        ...(stores.get(currentRoomId)?.rows ?? []),
+      ],
+    );
+    const countMemories = vi.fn(
+      async ({ roomId: currentRoomId }: { roomId: UUID }) =>
+        stores.get(currentRoomId)?.rows.length ?? 0,
+    );
+    const runtime = {
+      agentId: AGENT_ID,
+      character: { name: "A" },
+      ensureConnection: vi.fn(async () => undefined),
+      getMemories,
+      countMemories,
+      getMemoryById: vi.fn(async (id: UUID) => {
+        for (const store of stores.values()) {
+          const row = store.rows.find((candidate) => candidate.id === id);
+          if (row) return row;
+        }
+        return null;
+      }),
+      updateMemory: vi.fn(
+        async (patch: { id: UUID; content: Record<string, unknown> }) => {
+          for (const store of stores.values()) {
+            const row = store.rows.find(
+              (candidate) => candidate.id === patch.id,
+            );
+            if (row) row.content = patch.content as Memory["content"];
+          }
+        },
+      ),
+      useModel: vi.fn(async () => [0.1, 0.2, 0.3]),
+      reportError: vi.fn(() => undefined),
+    } as unknown as AgentRuntime;
+
+    for (const room of ["A", "B", "C", "D"]) {
+      runtime.character.name = room;
+      await search(runtime, "gyroscope");
+    }
+
+    let releaseCount = () => {};
+    const countGate = new Promise<void>((resolve) => {
+      releaseCount = resolve;
+    });
+    let markCountEntered = () => {};
+    const countEntered = new Promise<void>((resolve) => {
+      markCountEntered = resolve;
+    });
+    let gateNextACount = true;
+    countMemories.mockImplementation(async ({ roomId: currentRoomId }) => {
+      if (gateNextACount && currentRoomId === roomId("A")) {
+        gateNextACount = false;
+        markCountEntered();
+        await countGate;
+      }
+      return stores.get(currentRoomId)?.rows.length ?? 0;
+    });
+    runtime.character.name = "A";
+    const pendingSearch = search(runtime, "gyroscope");
+    await countEntered;
+
+    for (const room of ["E", "F", "G", "H"]) {
+      runtime.character.name = room;
+      await search(runtime, "gyroscope");
+    }
+
+    const response: { value?: unknown } = {};
+    runtime.character.name = "A";
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "PATCH",
+        path: `/api/memories/${target}`,
+        body: { text: "corrected wording about the gyroscope" },
+        response,
+      }),
+    );
+    releaseCount();
+
+    await expect(pendingSearch).resolves.toEqual([
+      expect.objectContaining({
+        text: "corrected wording about the gyroscope",
+      }),
+    ]);
+    await expect(search(runtime, "gyroscope")).resolves.toEqual([
+      expect.objectContaining({
+        text: "corrected wording about the gyroscope",
+      }),
+    ]);
+    expect(getMemories).toHaveBeenCalledTimes(9);
+  });
+
+  test("bounds uncached and in-flight room slots", async () => {
+    const roomId = (name: string) =>
+      stringToUuid(`${name}-hash-memory-room`) as UUID;
+    let releaseFirstA = () => {};
+    const firstAGate = new Promise<void>((resolve) => {
+      releaseFirstA = resolve;
+    });
+    let aScans = 0;
+    const getMemories = vi.fn(
+      async ({ roomId: currentRoomId }: { roomId: UUID }) => {
+        if (currentRoomId === roomId("A")) {
+          aScans++;
+          if (aScans === 1) await firstAGate;
+        }
+        return [
+          note(
+            "aaaaaaaa-0000-4000-8000-000000000001",
+            `${currentRoomId} puffin`,
+            1,
+            currentRoomId,
+          ),
+        ];
+      },
+    );
+    const runtime = {
+      agentId: AGENT_ID,
+      character: { name: "A" },
+      ensureConnection: vi.fn(async () => undefined),
+      getMemories,
+      // No countMemories means every result is intentionally uncached.
+      reportError: vi.fn(() => undefined),
+    } as unknown as AgentRuntime;
+
+    const firstA = search(runtime, "puffin");
+    await vi.waitFor(() => expect(aScans).toBe(1));
+    for (const room of ["B", "C", "D", "E"]) {
+      runtime.character.name = room;
+      await search(runtime, "puffin");
+    }
+
+    // The fifth distinct room must evict A even though A has no corpus and its
+    // scan is pending. A second request therefore starts a fresh scan instead
+    // of joining the unbounded orphaned slot.
+    runtime.character.name = "A";
+    await expect(search(runtime, "puffin")).resolves.toHaveLength(1);
+    expect(aScans).toBe(2);
+
+    releaseFirstA();
+    await expect(firstA).resolves.toHaveLength(1);
+  });
+
+  test("retries a cold build invalidated by a completed mutation", async () => {
+    const target = "aaaaaaaa-0000-4000-8000-000000000005";
+    const store: Store = { rows: [note(target, "original wording", 1)] };
+    const { runtime, getMemories } = makeRuntime(store);
+    let releaseScan = () => {};
+    const scanGate = new Promise<void>((resolve) => {
+      releaseScan = resolve;
+    });
+    getMemories.mockImplementationOnce(async () => {
+      const staleSnapshot = [...store.rows];
+      await scanGate;
+      return staleSnapshot;
+    });
+
+    const pendingSearch = search(runtime, "gyroscope");
+    await vi.waitFor(() => expect(getMemories).toHaveBeenCalledOnce());
+
+    const response: { value?: unknown } = {};
+    await handleMemoryRoutes(
+      contextFor({
+        runtime,
+        method: "PATCH",
+        path: `/api/memories/${target}`,
+        body: { text: "corrected wording about the gyroscope" },
+        response,
+      }),
+    );
+    releaseScan();
+
+    await expect(pendingSearch).resolves.toEqual([
+      expect.objectContaining({
+        text: "corrected wording about the gyroscope",
+      }),
+    ]);
+    expect(getMemories).toHaveBeenCalledTimes(2);
+  });
+
+  test("out-of-band create (row count change) is picked up on the next search", async () => {
+    const store: Store = {
+      rows: [note("aaaaaaaa-0000-4000-8000-000000000001", "baseline note", 1)],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+
+    await search(runtime, "meteor");
+    expect(getMemories).toHaveBeenCalledTimes(1);
+
+    // Simulate a write that did NOT go through this module (normal chat
+    // writing to the "messages" table).
+    store.rows.push(
+      note("aaaaaaaa-0000-4000-8000-000000000002", "meteor shower friday", 2),
+    );
+
+    const results = await search(runtime, "meteor");
+    expect(getMemories).toHaveBeenCalledTimes(2); // count mismatch forced rebuild
+    expect(results.some((r) => r.text.includes("meteor shower"))).toBe(true);
+  });
+
+  test("count mismatch supersedes an older in-flight background refresh", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T00:00:00Z"));
+    const store: Store = {
+      rows: [note("aaaaaaaa-0000-4000-8000-000000000001", "baseline note", 1)],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    await search(runtime, "meteor");
+
+    let releaseStaleScan = () => {};
+    const staleScanGate = new Promise<void>((resolve) => {
+      releaseStaleScan = resolve;
+    });
+    getMemories.mockImplementationOnce(async () => {
+      const staleSnapshot = [...store.rows];
+      await staleScanGate;
+      return staleSnapshot;
+    });
+
+    // Start a stale-while-revalidate build and leave its old snapshot in flight.
+    vi.advanceTimersByTime(11_000);
+    await search(runtime, "meteor");
+    await vi.waitFor(() => expect(getMemories).toHaveBeenCalledTimes(2));
+
+    // The next request observes the changed count. It must start a new scan,
+    // not join the older refresh that captured the one-row corpus.
+    store.rows.push(
+      note("aaaaaaaa-0000-4000-8000-000000000002", "meteor shower friday", 2),
+    );
+    const freshSearch = search(runtime, "meteor");
+    await vi.waitFor(() => expect(getMemories).toHaveBeenCalledTimes(3));
+    await expect(freshSearch).resolves.toEqual([
+      expect.objectContaining({ text: "meteor shower friday" }),
+    ]);
+
+    releaseStaleScan();
+  });
+
+  test("count-preserving edit refreshes after one bounded stale response", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T00:00:00Z"));
+    const target = "aaaaaaaa-0000-4000-8000-000000000001";
+    const store: Store = { rows: [note(target, "stale text", 1)] };
+    const { runtime } = makeRuntime(store);
+
+    await search(runtime, "kestrel");
+
+    // In-place edit that keeps the row count identical.
+    const row = store.rows.find((r) => r.id === target);
+    if (row)
+      row.content = { text: "kestrel sighting", source: HASH_MEMORY_SOURCE };
+
+    // The first request after the TTL remains warm and launches one refresh.
+    vi.advanceTimersByTime(16_000);
+    const staleWhileRefreshing = await search(runtime, "kestrel");
+    expect(staleWhileRefreshing).toEqual([]);
+    for (let index = 0; index < 10; index++) await Promise.resolve();
+
+    const results = await search(runtime, "kestrel");
+    expect(results.some((r) => r.text === "kestrel sighting")).toBe(true);
+  });
+
+  test("persistent refresh failure cannot extend staleness past the hard bound", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T00:00:00Z"));
+    const store: Store = {
+      rows: [note("aaaaaaaa-0000-4000-8000-000000000001", "old osprey", 1)],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    await search(runtime, "osprey");
+    const row = store.rows[0];
+    if (row)
+      row.content = {
+        text: "replacement condor",
+        source: HASH_MEMORY_SOURCE,
+      };
+    getMemories.mockRejectedValue(new Error("refresh backend unavailable"));
+
+    vi.advanceTimersByTime(11_000);
+    const boundedStale = await search(runtime, "osprey");
+    expect(boundedStale).toHaveLength(1);
+    for (let index = 0; index < 10; index++) await Promise.resolve();
+
+    vi.advanceTimersByTime(10_000);
+    await expect(search(runtime, "osprey")).rejects.toThrow(
+      "refresh backend unavailable",
+    );
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "MemorySearchCache.refresh",
+      expect.objectContaining({ message: "refresh backend unavailable" }),
+      expect.objectContaining({ roomId: expect.any(String) }),
+    );
+  });
+
+  test("runtime without countMemories degrades to the uncached scan", async () => {
+    const store: Store = {
+      rows: [
+        note("aaaaaaaa-0000-4000-8000-000000000001", "fallback path note", 1),
+      ],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    (runtime as unknown as Record<string, unknown>).countMemories = undefined;
+
+    const first = await search(runtime, "fallback");
+    const second = await search(runtime, "fallback");
+    expect(getMemories).toHaveBeenCalledTimes(2); // no cache without a freshness signal
+    expect(second).toEqual(first);
+  });
+
+  test("isolates equal-count corpora owned by distinct runtime instances", async () => {
+    const firstStore: Store = {
+      rows: [
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000001",
+          "first runtime albatross",
+          1,
+        ),
+      ],
+    };
+    const secondStore: Store = {
+      rows: [
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000002",
+          "second runtime kestrel",
+          1,
+        ),
+      ],
+    };
+    const first = makeRuntime(firstStore);
+    const second = makeRuntime(secondStore);
+
+    expect(await search(first.runtime, "albatross")).toHaveLength(1);
+    const secondResults = await search(second.runtime, "kestrel");
+
+    expect(secondResults.map((result) => result.text)).toEqual([
+      "second runtime kestrel",
+    ]);
+    expect(second.getMemories).toHaveBeenCalledOnce();
+  });
+
+  test("retries a corpus whose scan raced a row-count change before returning", async () => {
+    const store: Store = {
+      rows: [
+        note("aaaaaaaa-0000-4000-8000-000000000001", "baseline sparrow", 1),
+      ],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    getMemories.mockImplementationOnce(async () => {
+      const staleSnapshot = [...store.rows];
+      store.rows.push(
+        note("aaaaaaaa-0000-4000-8000-000000000002", "racing pelican", 2),
+      );
+      return staleSnapshot;
+    });
+
+    const fresh = await search(runtime, "pelican");
+
+    expect(getMemories).toHaveBeenCalledTimes(2);
+    expect(fresh.map((result) => result.text)).toEqual(["racing pelican"]);
+  });
+
+  test("single-flights the retry shared by count-mismatch joiners", async () => {
+    const store: Store = {
+      rows: [
+        note("aaaaaaaa-0000-4000-8000-000000000001", "baseline sparrow", 1),
+      ],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    getMemories.mockImplementationOnce(async () => {
+      const staleSnapshot = [...store.rows];
+      store.rows.push(
+        note("aaaaaaaa-0000-4000-8000-000000000002", "racing pelican", 2),
+      );
+      return staleSnapshot;
+    });
+
+    const [first, second] = await Promise.all([
+      search(runtime, "pelican"),
+      search(runtime, "pelican"),
+    ]);
+
+    expect(first.map((result) => result.text)).toEqual(["racing pelican"]);
+    expect(second).toEqual(first);
+    expect(getMemories).toHaveBeenCalledTimes(2);
+  });
+
+  test("fails with a typed bounded error when room counts never stabilize", async () => {
+    const store: Store = {
+      rows: [note("aaaaaaaa-0000-4000-8000-000000000001", "restless tern", 1)],
+    };
+    const { runtime, getMemories, countMemories } = makeRuntime(store);
+    let count = 0;
+    countMemories.mockImplementation(async () => ++count);
+
+    await expect(search(runtime, "tern")).rejects.toMatchObject({
+      code: "MEMORY_SEARCH_UNSTABLE_SNAPSHOT",
+      context: {
+        attempts: 3,
+        countBefore: 5,
+        countAfter: 6,
+      },
+    });
+    expect(getMemories).toHaveBeenCalledTimes(3);
+  });
+
+  test("single-flights concurrent cold rebuilds for one runtime and room", async () => {
+    const store: Store = {
+      rows: [
+        note(
+          "aaaaaaaa-0000-4000-8000-000000000001",
+          "shared rebuild puffin",
+          1,
+        ),
+      ],
+    };
+    const { runtime, getMemories } = makeRuntime(store);
+    let releaseScan = () => {};
+    const scanGate = new Promise<void>((resolve) => {
+      releaseScan = resolve;
+    });
+    getMemories.mockImplementationOnce(async () => {
+      await scanGate;
+      return [...store.rows];
+    });
+
+    const first = search(runtime, "puffin");
+    const second = search(runtime, "puffin");
+    await vi.waitFor(() => expect(getMemories).toHaveBeenCalledOnce());
+    releaseScan();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.any(Array),
+      expect.any(Array),
+    ]);
+    expect(getMemories).toHaveBeenCalledOnce();
+  });
+
+  test("reports count failures and keeps the fallback corpus uncached", async () => {
+    const store: Store = {
+      rows: [
+        note("aaaaaaaa-0000-4000-8000-000000000001", "fallback count heron", 1),
+      ],
+    };
+    const { runtime, getMemories, countMemories } = makeRuntime(store);
+    countMemories.mockRejectedValue(new Error("count backend unavailable"));
+
+    await search(runtime, "heron");
+    await search(runtime, "heron");
+
+    expect(getMemories).toHaveBeenCalledTimes(2);
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "MemorySearchCache.countRoomMessages",
+      expect.objectContaining({ message: "count backend unavailable" }),
+      expect.objectContaining({ roomId: expect.any(String) }),
+    );
+  });
+
+  test("does not retain a corpus whose source text exceeds the byte budget", async () => {
+    const rows = Array.from({ length: 2_000 }, (_, index) =>
+      note(
+        `aaaaaaaa-0000-4000-8000-${index.toString().padStart(12, "0")}`,
+        `oversized-${index}-${"x".repeat(4_200)}`,
+        index,
+      ),
+    );
+    const { runtime, getMemories } = makeRuntime({ rows });
+
+    await search(runtime, "term-not-present");
+    await search(runtime, "term-not-present");
+
+    expect(getMemories).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Closes #21633.
Closes #22072.

Supersedes #21128. That closed PR's commits were never merged into `develop`; this replacement reapplies and independently reviews the complete seven-commit delta on current `develop`, preserves its source credit, and includes the additional repairs found during review.

## What changed

- Caches each runtime/room memory-search corpus and BM25 index, with count-based freshness checks, bounded stale-while-revalidate, single-flight rebuilds, source-text byte limits, runtime isolation, and explicit route-mutation invalidation.
- Preserves room-scoped COUNT and scan behavior and identical cached/cold ranking.
- Fences invalidation, count-mismatch, generation, map-identity, and eviction races so an orphaned or obsolete build cannot publish or return stale data.
- Retries unstable snapshots under one per-request budget; after three count, generation, or map-identity invalidations it fails with typed `MEMORY_SEARCH_UNSTABLE_SNAPSHOT` instead of returning ineligible data.
- Bounds all per-room slots, including uncacheable, failed, invalidated, and in-flight slots. Canonical slots are leased across the full request, invalidated builds remain owned until settlement, and per-runtime admission caps active scans/BM25 builds at four even during same-room invalidation churn.
- Invalidates the actual mutated memory's `roomId` for by-ID PATCH/DELETE. The original delta invalidated the currently derived hash room, which could leave another room's cached corpus stale after a count-preserving edit.

## Independent full-delta disposition

The complete seven-commit source delta was reviewed, not only the final #22072 fence. Its caching architecture and performance scope are retained; the slot-retention, active-build admission, cross-room invalidation, and same-request count-race gaps were repaired before replacement. The replacement therefore addresses both the original performance issue and the eviction-race issue.

Source commits preserved from #21128:

- `f7b1c717`, `0124809d` by 0xSolace
- `15c112b6`, `768863ef` by moon
- `f8ad139d`, `81e6242c`, `3b42290f` by Shaw

The squashed replacement commit carries `Co-authored-by` credit for 0xSolace and moon; Shaw is the replacement commit author.

## Verification

Exact head `46c2538d34c6bcf774a126274c96cf705e91e279`, rebased on `4dca17f6de54b5abf20c26898f1125929cfe6364`:

- `node packages/shared/scripts/generate-keywords.mjs` — pass, 241 entries for 6 locales.
- Four route/cache suites — pass, 4 files and 47 tests at the exact pushed head.
- Exact-head adversarial subset — pass, 7 tests: canonical-slot retention, 12-room admission peak, same-room invalidation storm, same-request count retry, and exact three-attempt count/generation/map-identity exhaustion.
- `bunx @biomejs/biome check packages/agent/src/api/memory-routes.ts packages/agent/src/api/memory-search-cache.test.ts` — pass, no fixes.
- `git diff origin/develop...HEAD --check` — pass.
- Real `handleMemoryRoutes` + `InMemoryDatabaseAdapter` coverage verifies persisted-row retrieval, cached/cold equality, and PATCH/DELETE invalidation of the persisted memory room.
- Exact-head active-build route execution — 12 distinct rooms on one runtime completed 12 scans and responses with `peakActiveBuilds=4`, the configured bound, and zero active work after settlement.
- `bun run --cwd packages/agent typecheck` was attempted in the borrowed exact-lock tree but is not claimed as a package pass: optional workspace dependencies such as plugin-capacitor-bridge, plugin-wallet, drizzle-orm, and Solana/viem packages are absent. The only new changed-file diagnostic exposed by that run was corrected; the repeat emitted no diagnostics for either changed file.
- Root `bun run verify` and the full 458-batch agent aggregate are not claimed as final-head passes. Earlier bounded attempts were stopped by unrelated unchanged UI failures and host-wide test contention; the exact issue-owning lanes above completed cleanly.

## Evidence Gate

<!-- evidence-head:46c2538d34c6bcf774a126274c96cf705e91e279 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only runtime cache; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only runtime cache; no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic HTTP route execution exercises the changed behavior; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head backend evidence log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22127-memory-search-backend-v6.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, console, network, or state behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, planner, action, provider, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head concurrency and route domain artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22127-memory-search-domain-v8.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual content.

## Risk

Medium. The change is a performance cache on a read path, so stale-data and resource-bound regressions matter. Freshness probes, explicit invalidation, hard stale bounds, per-runtime ownership, byte/entry caps, request leases, active-work admission, generation and map-identity fences, same-request retries, and adversarial concurrency tests constrain those risks.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->