### PR TITLE
fix(cloud): bind remote pairing verifiers

### DIFF
--- a/packages/cloud/api/v1/remote/pair/route.test.ts
+++ b/packages/cloud/api/v1/remote/pair/route.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Exercises the real remote-pair route boundary with deterministic repository
+ * collaborators and WebCrypto-backed pairing-code verifiers.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import {
+  deriveRemotePairingCodeVerifier,
+  isRemotePairingSessionCurrent,
+  isRemotePairingVerifierCurrent,
+  verifyRemotePairingCodeVerifier,
+} from "@/db/crypto/remote-pairing-code";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "11111111-1111-4111-8111-111111111111",
+  organization_id: "22222222-2222-4222-8222-222222222222",
+}));
+const findByIdAndOrg = mock();
+const create = mock();
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: { findByIdAndOrg },
+}));
+
+mock.module("@/db/repositories/remote-sessions", () => ({
+  remoteSessionsRepository: { create },
+}));
+
+const { default: pairingRoute } = await import("./route");
+
+const app = new Hono<AppEnv>();
+app.route("/api/v1/remote/pair", pairingRoute);
+
+const secret = "a-dedicated-remote-pairing-secret-with-32-bytes";
+const agentId = "33333333-3333-4333-8333-333333333333";
+
+async function postPair(
+  body: string,
+  bindings: Partial<AppEnv["Bindings"]> = {
+    REMOTE_PAIRING_HMAC_SECRET: secret,
+  },
+) {
+  return app.fetch(
+    new Request("https://api.example.test/api/v1/remote/pair", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    }),
+    bindings as AppEnv["Bindings"],
+  );
+}
+
+describe("remote pairing route", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    findByIdAndOrg.mockReset();
+    create.mockReset();
+    findByIdAndOrg.mockResolvedValue({ id: agentId });
+    create.mockImplementation(async (data) => ({
+      ...data,
+      created_at: new Date(),
+      updated_at: new Date(),
+      ended_at: null,
+      ingress_url: null,
+      ingress_reason: null,
+    }));
+  });
+
+  test("binds a short-lived keyed verifier to the authenticated owner and session", async () => {
+    const startedAt = Date.now();
+    const response = await postPair(
+      JSON.stringify({ agentId, requesterIdentity: "attacker-controlled" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    const body = (await response.json()) as {
+      data: {
+        sessionId: string;
+        code: string;
+        expiresAt: string;
+        ttlSeconds: number;
+      };
+    };
+    expect(body.data.code).toMatch(/^\d{6}$/);
+    expect(body.data.ttlSeconds).toBe(300);
+    expect(Date.parse(body.data.expiresAt)).toBeGreaterThanOrEqual(
+      startedAt + 299_000,
+    );
+
+    expect(create).toHaveBeenCalledTimes(1);
+    const persisted = create.mock.calls[0]?.[0] as {
+      id: string;
+      requester_identity: string;
+      pairing_token_hash: string;
+    };
+    expect(persisted.id).toBe(body.data.sessionId);
+    expect(persisted.requester_identity).toBe(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    expect(persisted.pairing_token_hash).toBe(
+      await deriveRemotePairingCodeVerifier(
+        secret,
+        body.data.sessionId,
+        body.data.code,
+        new Date(body.data.expiresAt),
+      ),
+    );
+    expect(persisted.pairing_token_hash).not.toContain(body.data.code);
+  });
+
+  test("binds the verifier to both the session id and dedicated secret", async () => {
+    const expiry = new Date("2026-08-18T20:00:00.000Z");
+    const first = await deriveRemotePairingCodeVerifier(
+      secret,
+      "44444444-4444-4444-8444-444444444444",
+      "123456",
+      expiry,
+    );
+    const otherSession = await deriveRemotePairingCodeVerifier(
+      secret,
+      "55555555-5555-4555-8555-555555555555",
+      "123456",
+      expiry,
+    );
+    const otherSecret = await deriveRemotePairingCodeVerifier(
+      "another-dedicated-remote-pairing-secret-value",
+      "44444444-4444-4444-8444-444444444444",
+      "123456",
+      expiry,
+    );
+
+    expect(first).toMatch(/^hmac-sha256-v1:\d{13}:[0-9a-f]{64}$/);
+    expect(otherSession).not.toBe(first);
+    expect(otherSecret).not.toBe(first);
+    expect(isRemotePairingVerifierCurrent(first, expiry.getTime() - 1)).toBe(
+      true,
+    );
+    expect(isRemotePairingVerifierCurrent(first, expiry.getTime())).toBe(false);
+    expect(
+      isRemotePairingSessionCurrent("pending", first, expiry.getTime() - 1),
+    ).toBe(true);
+    expect(
+      isRemotePairingSessionCurrent("pending", first, expiry.getTime()),
+    ).toBe(false);
+    expect(
+      isRemotePairingSessionCurrent(
+        "pending",
+        "0f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f",
+        expiry.getTime() - 1,
+      ),
+    ).toBe(false);
+    expect(
+      isRemotePairingSessionCurrent("active", null, expiry.getTime()),
+    ).toBe(true);
+    expect(
+      await verifyRemotePairingCodeVerifier(
+        secret,
+        "44444444-4444-4444-8444-444444444444",
+        "123456",
+        first,
+        new Date(expiry.getTime() - 1),
+      ),
+    ).toBe(true);
+    expect(
+      await verifyRemotePairingCodeVerifier(
+        secret,
+        "44444444-4444-4444-8444-444444444444",
+        "123457",
+        first,
+        new Date(expiry.getTime() - 1),
+      ),
+    ).toBe(false);
+    expect(
+      await verifyRemotePairingCodeVerifier(
+        secret,
+        "44444444-4444-4444-8444-444444444444",
+        "123456",
+        first,
+        expiry,
+      ),
+    ).toBe(false);
+  });
+
+  test("fails closed before creating state when the dedicated secret is absent", async () => {
+    const response = await postPair(JSON.stringify({ agentId }), {});
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      code: "REMOTE_PAIRING_NOT_CONFIGURED",
+    });
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test("rejects malformed JSON without fabricating an empty request", async () => {
+    const response = await postPair("{");
+
+    expect(response.status).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test("does not create a pairing session for another organization agent", async () => {
+    findByIdAndOrg.mockResolvedValue(undefined);
+
+    const response = await postPair(JSON.stringify({ agentId }));
+
+    expect(response.status).toBe(404);
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/remote/pair/route.test.ts
+++ b/packages/cloud/api/v1/remote/pair/route.test.ts
@@ -61,7 +61,10 @@ describe("remote pairing route", () => {
     requireUserOrApiKeyWithOrg.mockClear();
     findByIdAndOrg.mockReset();
     create.mockReset();
-    findByIdAndOrg.mockResolvedValue({ id: agentId });
+    findByIdAndOrg.mockResolvedValue({
+      id: agentId,
+      user_id: "11111111-1111-4111-8111-111111111111",
+    });
     create.mockImplementation(async (data) => ({
       ...data,
       created_at: new Date(),
@@ -112,7 +115,10 @@ describe("remote pairing route", () => {
         new Date(body.data.expiresAt),
       ),
     );
-    expect(persisted.pairing_token_hash).not.toContain(body.data.code);
+    expect(persisted.pairing_token_hash).toMatch(
+      /^hmac-sha256-v1:\d{13}:[0-9a-f]{64}$/,
+    );
+    expect(persisted.pairing_token_hash).not.toBe(body.data.code);
   });
 
   test("binds the verifier to both the session id and dedicated secret", async () => {
@@ -186,6 +192,24 @@ describe("remote pairing route", () => {
         expiry,
       ),
     ).toBe(false);
+    expect(
+      await verifyRemotePairingCodeVerifier(
+        secret,
+        "44444444-4444-4444-8444-444444444444",
+        "123456",
+        first,
+        new Date(Number.NaN),
+      ),
+    ).toBe(false);
+    await expect(
+      verifyRemotePairingCodeVerifier(
+        "too-short",
+        "44444444-4444-4444-8444-444444444444",
+        "123456",
+        first,
+        new Date(expiry.getTime() - 1),
+      ),
+    ).rejects.toThrow("REMOTE_PAIRING_HMAC_SECRET");
   });
 
   test("fails closed before creating state when the dedicated secret is absent", async () => {
@@ -209,6 +233,18 @@ describe("remote pairing route", () => {
 
   test("does not create a pairing session for another organization agent", async () => {
     findByIdAndOrg.mockResolvedValue(undefined);
+
+    const response = await postPair(JSON.stringify({ agentId }));
+
+    expect(response.status).toBe(404);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test("does not create a pairing session for another user in the organization", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      id: agentId,
+      user_id: "66666666-6666-4666-8666-666666666666",
+    });
 
     const response = await postPair(JSON.stringify({ agentId }));
 

--- a/packages/cloud/api/v1/remote/pair/route.ts
+++ b/packages/cloud/api/v1/remote/pair/route.ts
@@ -3,9 +3,10 @@
  *
  * T9a — Remote-control control plane.
  *
- * Authenticated user requests a pairing token for one of their agents. The
- * returned token is a 6-digit pairing code intended for out-of-band entry
- * into the agent (e.g. the companion app enters it to authorize a session).
+ * An authenticated owner requests a pairing token for one of their agents.
+ * The returned token is a short-lived 6-digit pairing code intended for
+ * out-of-band entry into the local agent. Cloud persists only a session-bound
+ * keyed verifier and the authoritative expiry.
  *
  * Body: { agentId: string }
  * Returns: { code, expiresAt, sessionId, status }
@@ -16,6 +17,7 @@
  */
 
 import { Hono } from "hono";
+import { deriveRemotePairingCodeVerifier } from "@/db/crypto/remote-pairing-code";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { remoteSessionsRepository } from "@/db/repositories/remote-sessions";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
@@ -25,26 +27,21 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const PAIRING_CODE_TTL_SECONDS = 5 * 60;
 
 function generatePairingCode(): string {
-  // WebCrypto: getRandomValues fills a Uint32; modulo 1e6 gives a uniform
-  // 6-digit code. The bias from 2^32 mod 1e6 is negligible for a 6-digit
-  // pairing token (skew per digit < 0.024%).
+  // Rejection sampling avoids modulo bias in the human-entered code space.
+  const codeSpace = 1_000_000;
+  const acceptedRange = Math.floor(2 ** 32 / codeSpace) * codeSpace;
   const buf = new Uint32Array(1);
-  crypto.getRandomValues(buf);
-  const n = (buf[0] ?? 0) % 1_000_000;
+  let sample: number;
+  do {
+    crypto.getRandomValues(buf);
+    sample = buf[0] ?? acceptedRange;
+  } while (sample >= acceptedRange);
+  const n = sample % codeSpace;
   return n.toString().padStart(6, "0");
-}
-
-async function hashCode(code: string): Promise<string> {
-  const data = new TextEncoder().encode(code);
-  const buf = await crypto.subtle.digest("SHA-256", data);
-  return Array.from(new Uint8Array(buf))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
 }
 
 interface PairRequestBody {
   agentId?: unknown;
-  requesterIdentity?: unknown;
 }
 
 const app = new Hono<AppEnv>();
@@ -53,17 +50,35 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
-    const body = (await c.req.json().catch(() => ({}))) as PairRequestBody;
+    const pairingSecret = c.env.REMOTE_PAIRING_HMAC_SECRET?.trim();
+    if (
+      !pairingSecret ||
+      new TextEncoder().encode(pairingSecret).byteLength < 32
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: "Remote pairing is unavailable",
+          code: "REMOTE_PAIRING_NOT_CONFIGURED",
+        },
+        503,
+      );
+    }
+
+    let body: PairRequestBody;
+    try {
+      body = (await c.req.json()) as PairRequestBody;
+    } catch {
+      // error-policy:J3 malformed request JSON is an explicit client error.
+      return c.json(
+        { success: false, error: "Request body must be valid JSON" },
+        400,
+      );
+    }
     const agentId = typeof body.agentId === "string" ? body.agentId.trim() : "";
     if (!agentId) {
       return c.json({ success: false, error: "agentId is required" }, 400);
     }
-
-    const requesterIdentity =
-      typeof body.requesterIdentity === "string" &&
-      body.requesterIdentity.trim().length > 0
-        ? body.requesterIdentity.trim()
-        : user.id;
 
     const sandbox = await agentSandboxesRepository.findByIdAndOrg(
       agentId,
@@ -74,15 +89,22 @@ app.post("/", async (c) => {
     }
 
     const code = generatePairingCode();
-    const tokenHash = await hashCode(code);
+    const sessionId = crypto.randomUUID();
     const expiresAt = new Date(Date.now() + PAIRING_CODE_TTL_SECONDS * 1000);
+    const tokenHash = await deriveRemotePairingCodeVerifier(
+      pairingSecret,
+      sessionId,
+      code,
+      expiresAt,
+    );
 
     const session = await remoteSessionsRepository.create({
+      id: sessionId,
       organization_id: user.organization_id,
       user_id: user.id,
       agent_id: agentId,
       status: "pending",
-      requester_identity: requesterIdentity,
+      requester_identity: user.id,
       pairing_token_hash: tokenHash,
     });
 
@@ -103,6 +125,7 @@ app.post("/", async (c) => {
       },
     });
   } catch (error) {
+    // error-policy:J1 the HTTP boundary translates typed/internal failures.
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/api/v1/remote/pair/route.ts
+++ b/packages/cloud/api/v1/remote/pair/route.ts
@@ -84,7 +84,7 @@ app.post("/", async (c) => {
       agentId,
       user.organization_id,
     );
-    if (!sandbox) {
+    if (!sandbox || sandbox.user_id !== user.id) {
       return c.json({ success: false, error: "Agent not found" }, 404);
     }
 

--- a/packages/cloud/api/v1/remote/sessions/[id]/revoke/route.ts
+++ b/packages/cloud/api/v1/remote/sessions/[id]/revoke/route.ts
@@ -25,9 +25,10 @@ async function __hono_POST(
     const { user } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
-    const existing = await remoteSessionsRepository.findByIdAndOrg(
+    const existing = await remoteSessionsRepository.findByIdAndOwner(
       id,
       user.organization_id,
+      user.id,
     );
     if (!existing) {
       return applyCorsHeaders(
@@ -56,6 +57,7 @@ async function __hono_POST(
     const revoked = await remoteSessionsRepository.revoke(
       id,
       user.organization_id,
+      user.id,
     );
     if (!revoked) {
       return applyCorsHeaders(

--- a/packages/cloud/api/v1/remote/sessions/owner-boundary.test.ts
+++ b/packages/cloud/api/v1/remote/sessions/owner-boundary.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Exercises the remote-session list and revoke route boundaries with mocked
+ * persistence so same-organization users cannot inspect or mutate each
+ * other's remote-control sessions.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const ownerId = "11111111-1111-4111-8111-111111111111";
+const organizationId = "22222222-2222-4222-8222-222222222222";
+const agentId = "33333333-3333-4333-8333-333333333333";
+const sessionId = "44444444-4444-4444-8444-444444444444";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: ownerId,
+  organization_id: organizationId,
+}));
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+  user: { id: ownerId, organization_id: organizationId },
+}));
+const findByIdAndOrg = mock();
+const findByIdAndOwner = mock();
+const listActiveByAgent = mock();
+const revoke = mock();
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: { findByIdAndOrg },
+}));
+mock.module("@/db/repositories/remote-sessions", () => ({
+  remoteSessionsRepository: {
+    findByIdAndOwner,
+    listActiveByAgent,
+    revoke,
+  },
+}));
+
+const { default: listRoute } = await import("./route");
+const { default: revokeRoute } = await import("./[id]/revoke/route");
+
+const app = new Hono<AppEnv>();
+app.route("/api/v1/remote/sessions", listRoute);
+app.route("/api/v1/remote/sessions/:id/revoke", revokeRoute);
+
+describe("remote session owner boundaries", () => {
+  beforeEach(() => {
+    findByIdAndOrg.mockReset();
+    findByIdAndOwner.mockReset();
+    listActiveByAgent.mockReset();
+    revoke.mockReset();
+    findByIdAndOrg.mockResolvedValue({ id: agentId, user_id: ownerId });
+    listActiveByAgent.mockResolvedValue([]);
+  });
+
+  test("lists sessions through organization and authenticated-owner scope", async () => {
+    const response = await app.request(
+      `/api/v1/remote/sessions?agentId=${agentId}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(listActiveByAgent).toHaveBeenCalledWith(
+      agentId,
+      organizationId,
+      ownerId,
+    );
+  });
+
+  test("hides another same-organization user's agent sessions", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      id: agentId,
+      user_id: "55555555-5555-4555-8555-555555555555",
+    });
+
+    const response = await app.request(
+      `/api/v1/remote/sessions?agentId=${agentId}`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(listActiveByAgent).not.toHaveBeenCalled();
+  });
+
+  test("looks up and revokes a session through authenticated-owner scope", async () => {
+    const active = {
+      id: sessionId,
+      status: "active",
+      ended_at: null,
+    };
+    findByIdAndOwner.mockResolvedValue(active);
+    revoke.mockResolvedValue({
+      ...active,
+      status: "revoked",
+      ended_at: new Date("2026-08-18T20:00:00.000Z"),
+    });
+
+    const response = await app.request(
+      `/api/v1/remote/sessions/${sessionId}/revoke`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(findByIdAndOwner).toHaveBeenCalledWith(
+      sessionId,
+      organizationId,
+      ownerId,
+    );
+    expect(revoke).toHaveBeenCalledWith(sessionId, organizationId, ownerId);
+  });
+
+  test("does not reveal or revoke another owner's session", async () => {
+    findByIdAndOwner.mockResolvedValue(undefined);
+
+    const response = await app.request(
+      `/api/v1/remote/sessions/${sessionId}/revoke`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(404);
+    expect(revoke).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/remote/sessions/route.ts
+++ b/packages/cloud/api/v1/remote/sessions/route.ts
@@ -30,13 +30,14 @@ app.get("/", async (c) => {
       agentId,
       user.organization_id,
     );
-    if (!sandbox) {
+    if (!sandbox || sandbox.user_id !== user.id) {
       return c.json({ success: false, error: "Agent not found" }, 404);
     }
 
     const sessions = await remoteSessionsRepository.listActiveByAgent(
       agentId,
       user.organization_id,
+      user.id,
     );
 
     return c.json({

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -328,6 +328,7 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 #       defaults to NEXT_PUBLIC_STEWARD_API_URL or NEXT_PUBLIC_API_URL + /steward
 #   STEWARD_JWT_SECRET                 Canonical HS256 secret for Steward JWT verify (jose); MUST match Steward host
 #   STEWARD_SESSION_SECRET             Deprecated compatibility alias for STEWARD_JWT_SECRET
+#   REMOTE_PAIRING_HMAC_SECRET          Dedicated 32+ byte HMAC key for short-lived remote pairing verifiers
 #   STEWARD_MASTER_PASSWORD            Steward vault encryption master password; required for wallet/key ops
 #   STEWARD_TENANT_ID                  Default tenant scope; verifier rejects other tenants
 #   STEWARD_DEFAULT_TENANT_ID          Embedded Steward default tenant id (optional; defaults to elizacloud)

--- a/packages/cloud/shared/src/db/crypto/remote-pairing-code.ts
+++ b/packages/cloud/shared/src/db/crypto/remote-pairing-code.ts
@@ -1,0 +1,136 @@
+/**
+ * Defines the versioned keyed verifier stored for human-entered remote
+ * pairing codes. The signed payload binds the code to one session and expiry;
+ * callers must still atomically consume the corresponding pending row.
+ */
+
+const VERIFIER_PREFIX = "hmac-sha256-v1";
+const VERIFIER_PATTERN = /^hmac-sha256-v1:(\d{13}):([0-9a-f]{64})$/;
+const SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const CODE_PATTERN = /^\d{6}$/;
+
+function textBuffer(value: string): ArrayBuffer {
+  const encoded = new TextEncoder().encode(value);
+  const copy = new Uint8Array(encoded.byteLength);
+  copy.set(encoded);
+  return copy.buffer;
+}
+
+function assertSecret(secret: string): ArrayBuffer {
+  const secretBytes = textBuffer(secret);
+  if (secretBytes.byteLength < 32) {
+    throw new TypeError("REMOTE_PAIRING_HMAC_SECRET must contain at least 32 bytes");
+  }
+  return secretBytes;
+}
+
+function assertInputs(sessionId: string, code: string, expiresAtMs: number): void {
+  if (!SESSION_ID_PATTERN.test(sessionId)) {
+    throw new TypeError("remote pairing session id must be a canonical UUID");
+  }
+  if (!CODE_PATTERN.test(code)) {
+    throw new TypeError("remote pairing code must contain exactly six digits");
+  }
+  if (!Number.isSafeInteger(expiresAtMs) || expiresAtMs < 1_000_000_000_000) {
+    throw new TypeError("remote pairing expiry must be a millisecond timestamp");
+  }
+}
+
+function signingPayload(sessionId: string, code: string, expiresAtMs: number): ArrayBuffer {
+  return textBuffer(`eliza.remote-pairing.v1\0${sessionId}\0${expiresAtMs}\0${code}`);
+}
+
+function bytesToHex(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function hexToBuffer(hex: string): ArrayBuffer {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes.buffer;
+}
+
+async function importHmacKey(secret: string, usage: "sign" | "verify"): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    assertSecret(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    [usage],
+  );
+}
+
+/** Returns the signed expiry for a structurally valid verifier. */
+export function remotePairingVerifierExpiryMs(verifier: string | null): number | null {
+  const match = VERIFIER_PATTERN.exec(verifier ?? "");
+  if (!match?.[1]) return null;
+  const expiresAtMs = Number(match[1]);
+  return Number.isSafeInteger(expiresAtMs) ? expiresAtMs : null;
+}
+
+/** Reports whether a verifier has a structurally valid, unexpired signed-expiry slot. */
+export function isRemotePairingVerifierCurrent(verifier: string | null, nowMs: number): boolean {
+  const expiresAtMs = remotePairingVerifierExpiryMs(verifier);
+  return expiresAtMs !== null && expiresAtMs > nowMs;
+}
+
+/** Keeps active sessions and only pending sessions with a current v1 verifier. */
+export function isRemotePairingSessionCurrent(
+  status: "pending" | "active" | "denied" | "revoked",
+  verifier: string | null,
+  nowMs: number,
+): boolean {
+  return (
+    status === "active" || (status === "pending" && isRemotePairingVerifierCurrent(verifier, nowMs))
+  );
+}
+
+/** Derives the versioned verifier persisted instead of the six-digit code. */
+export async function deriveRemotePairingCodeVerifier(
+  secret: string,
+  sessionId: string,
+  code: string,
+  expiresAt: Date,
+): Promise<string> {
+  const expiresAtMs = expiresAt.getTime();
+  assertInputs(sessionId, code, expiresAtMs);
+  const key = await importHmacKey(secret, "sign");
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    signingPayload(sessionId, code, expiresAtMs),
+  );
+  return `${VERIFIER_PREFIX}:${expiresAtMs}:${bytesToHex(signature)}`;
+}
+
+/** Verifies the code, session binding, signature, and expiry without exposing the code. */
+export async function verifyRemotePairingCodeVerifier(
+  secret: string,
+  sessionId: string,
+  code: string,
+  verifier: string,
+  now: Date,
+): Promise<boolean> {
+  const match = VERIFIER_PATTERN.exec(verifier);
+  if (!match?.[1] || !match[2]) return false;
+  const expiresAtMs = Number(match[1]);
+  if (!Number.isSafeInteger(expiresAtMs) || expiresAtMs <= now.getTime()) return false;
+  try {
+    assertInputs(sessionId, code, expiresAtMs);
+    const key = await importHmacKey(secret, "verify");
+    return crypto.subtle.verify(
+      "HMAC",
+      key,
+      hexToBuffer(match[2]),
+      signingPayload(sessionId, code, expiresAtMs),
+    );
+  } catch {
+    // error-policy:J3 untrusted pairing material is an explicit invalid result.
+    return false;
+  }
+}

--- a/packages/cloud/shared/src/db/crypto/remote-pairing-code.ts
+++ b/packages/cloud/shared/src/db/crypto/remote-pairing-code.ts
@@ -119,18 +119,21 @@ export async function verifyRemotePairingCodeVerifier(
   const match = VERIFIER_PATTERN.exec(verifier);
   if (!match?.[1] || !match[2]) return false;
   const expiresAtMs = Number(match[1]);
-  if (!Number.isSafeInteger(expiresAtMs) || expiresAtMs <= now.getTime()) return false;
+  const nowMs = now.getTime();
+  if (!Number.isSafeInteger(nowMs) || !Number.isSafeInteger(expiresAtMs) || expiresAtMs <= nowMs) {
+    return false;
+  }
   try {
     assertInputs(sessionId, code, expiresAtMs);
-    const key = await importHmacKey(secret, "verify");
-    return crypto.subtle.verify(
-      "HMAC",
-      key,
-      hexToBuffer(match[2]),
-      signingPayload(sessionId, code, expiresAtMs),
-    );
   } catch {
     // error-policy:J3 untrusted pairing material is an explicit invalid result.
     return false;
   }
+  const key = await importHmacKey(secret, "verify");
+  return crypto.subtle.verify(
+    "HMAC",
+    key,
+    hexToBuffer(match[2]),
+    signingPayload(sessionId, code, expiresAtMs),
+  );
 }

--- a/packages/cloud/shared/src/db/repositories/remote-sessions.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-sessions.ts
@@ -22,16 +22,30 @@ export class RemoteSessionsRepository {
     return row;
   }
 
-  async findByIdAndOrg(id: string, orgId: string): Promise<RemoteSession | undefined> {
+  async findByIdAndOwner(
+    id: string,
+    orgId: string,
+    userId: string,
+  ): Promise<RemoteSession | undefined> {
     const [row] = await dbRead
       .select()
       .from(remoteSessions)
-      .where(and(eq(remoteSessions.id, id), eq(remoteSessions.organization_id, orgId)))
+      .where(
+        and(
+          eq(remoteSessions.id, id),
+          eq(remoteSessions.organization_id, orgId),
+          eq(remoteSessions.user_id, userId),
+        ),
+      )
       .limit(1);
     return row;
   }
 
-  async listActiveByAgent(agentId: string, orgId: string): Promise<RemoteSession[]> {
+  async listActiveByAgent(
+    agentId: string,
+    orgId: string,
+    userId: string,
+  ): Promise<RemoteSession[]> {
     const rows = await dbRead
       .select()
       .from(remoteSessions)
@@ -39,6 +53,7 @@ export class RemoteSessionsRepository {
         and(
           eq(remoteSessions.agent_id, agentId),
           eq(remoteSessions.organization_id, orgId),
+          eq(remoteSessions.user_id, userId),
           inArray(remoteSessions.status, ACTIVE_STATUSES),
         ),
       )
@@ -49,7 +64,7 @@ export class RemoteSessionsRepository {
     );
   }
 
-  async revoke(id: string, orgId: string): Promise<RemoteSession | undefined> {
+  async revoke(id: string, orgId: string, userId: string): Promise<RemoteSession | undefined> {
     const now = new Date();
     const [row] = await dbWrite
       .update(remoteSessions)
@@ -58,6 +73,7 @@ export class RemoteSessionsRepository {
         and(
           eq(remoteSessions.id, id),
           eq(remoteSessions.organization_id, orgId),
+          eq(remoteSessions.user_id, userId),
           inArray(remoteSessions.status, ACTIVE_STATUSES),
         ),
       )

--- a/packages/cloud/shared/src/db/repositories/remote-sessions.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-sessions.ts
@@ -1,5 +1,6 @@
 // Persists remote sessions records for cloud services through the shared DB boundary.
 import { and, desc, eq, inArray } from "drizzle-orm";
+import { isRemotePairingSessionCurrent } from "../crypto/remote-pairing-code";
 import { dbRead, dbWrite } from "../helpers";
 import {
   type NewRemoteSession,
@@ -31,7 +32,7 @@ export class RemoteSessionsRepository {
   }
 
   async listActiveByAgent(agentId: string, orgId: string): Promise<RemoteSession[]> {
-    return dbRead
+    const rows = await dbRead
       .select()
       .from(remoteSessions)
       .where(
@@ -42,6 +43,10 @@ export class RemoteSessionsRepository {
         ),
       )
       .orderBy(desc(remoteSessions.created_at));
+    const nowMs = Date.now();
+    return rows.filter((row) =>
+      isRemotePairingSessionCurrent(row.status, row.pairing_token_hash, nowMs),
+    );
   }
 
   async revoke(id: string, orgId: string): Promise<RemoteSession | undefined> {

--- a/packages/cloud/shared/src/db/schemas/remote-sessions.ts
+++ b/packages/cloud/shared/src/db/schemas/remote-sessions.ts
@@ -2,7 +2,9 @@
  * Remote-control sessions (T9a control plane).
  *
  * Tracks pending/active/revoked/denied sessions issued by an agent via the
- * cloud `pair` endpoint. The actual data plane (VNC / tunnel) is separate.
+ * cloud `pair` endpoint. The versioned pairing verifier carries its signed
+ * expiry so a restart or delayed consumer cannot turn an expired grant back
+ * into authority. The actual data plane (VNC / tunnel) is separate.
  */
 
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -304,6 +304,8 @@ export interface Bindings {
   STEWARD_SESSION_SECRET?: string;
   /** Optional dedicated secret for OAuth success-page HMAC proofs; falls back to STEWARD_SESSION_SECRET. */
   OAUTH_SUCCESS_PROOF_SECRET?: string;
+  /** Dedicated HMAC key for short-lived remote pairing-code verifiers. */
+  REMOTE_PAIRING_HMAC_SECRET?: string;
   /** Required managed Google OAuth application credentials. */
   GOOGLE_CLIENT_ID?: string;
   GOOGLE_CLIENT_SECRET?: string;


### PR DESCRIPTION
# Relates to

Refs #21784 — bounded Cloud pairing hardening only. This PR does not claim or close the production phone-remote milestone.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop multi-agent review`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@23847b41687cc69da953583ef6b80bd388a02e2f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `23847b41687cc69da953583ef6b80bd388a02e2f`; zero conflicts.
- [x] Exact-head focused security tests, owning typechecks, Worker bundle dry-run, Biome, diff integrity, and evidence gate pass.

# What changed

- The authenticated user, never client input, becomes the requester identity.
- Pair, list, and revoke now require both organization scope and the authenticated owner ID. Same-organization cross-user access returns 404.
- Six-digit codes use rejection sampling and are persisted only as a versioned HMAC-SHA-256 verifier bound to session ID, code, and signed five-minute expiry.
- Missing or short dedicated secret configuration fails with 503 before state creation.
- Legacy, malformed, and expired pending rows are not returned as current; active sessions remain visible.
- Invalid clocks fail verifier checks closed. Invalid pairing material returns false, while secret or WebCrypto configuration failures propagate instead of being hidden as user input failures.
- No consume endpoint is added. A future consume path must atomically transition one pending row exactly once.

# Risk

Medium, security-sensitive, fail-closed control-plane hardening. Existing incomplete pairing becomes unavailable until `REMOTE_PAIRING_HMAC_SECRET` contains at least 32 bytes. There is no schema migration; existing active rows remain compatible and legacy pending hashes become invisible.

# Exact-head verification

Exact PR head `10fc4345bd8c343e8505bf38824c5157803a85e7`:

```text
bun test packages/cloud/api/v1/remote
10 pass, 0 fail, 44 assertions

bun run --cwd packages/cloud/shared typecheck
PASS

bun run --cwd packages/cloud/api typecheck
PASS; includes production Worker dry-run
Total Upload: 23959.44 KiB / gzip: 5666.95 KiB

bunx biome check <nine changed TypeScript files>
Checked 9 files. No fixes applied.

git diff --check origin/develop...HEAD
PASS
```

# Evidence Gate

<!-- evidence-head:10fc4345bd8c343e8505bf38824c5157803a85e7 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - server-only route, repository, and cryptographic helper change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - server-only route, repository, and cryptographic helper change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - the bounded change has no rendered end-user flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no live pairing secret or consume path exists; deploying a partial grant flow would misrepresent this bounded hardening.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend is changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model, prompt, provider, action, or agent behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - creating a live pairing row would require unavailable production secret configuration and still could not be consumed. Deterministic route tests inspect the exact persisted owner, session ID, verifier, expiry, and fail-closed outcomes.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface is changed.

# Known remaining scope

Full #21784 remains open. This PR does not provide local owner-presence approval, atomic single-use consume, per-device keys and revocation, signed and encrypted replay-safe command envelopes, deterministic ordering and cancellation, an OS broker, local pause or kill controls, catastrophic-action confirmation boundaries, or real iOS or Android plus Linux evidence.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop multi-agent review
Contribution skill revision: elizaOS/eliza@23847b41687cc69da953583ef6b80bd388a02e2f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [security-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop multi-agent review","skill_revision":"elizaOS/eliza@23847b41687cc69da953583ef6b80bd388a02e2f:packages/skills/skills/contribute-to-eliza"} -->