### PR TITLE
fix(plugin-vision): ceil screen-tiler stride so no source column/row is left uncovered

### DIFF
--- a/plugins/plugin-vision/src/screen-tiler.test.ts
+++ b/plugins/plugin-vision/src/screen-tiler.test.ts
@@ -213,6 +213,58 @@ describe("tileScreenshot — full source coverage (regression #22125)", () => {
   });
 });
 
+describe("tileScreenshot — degenerate axes and extraction bounds", () => {
+  const cases = [
+    { width: 1, height: 65, maxEdge: 64, overlapFraction: 0 },
+    { width: 1, height: 65, maxEdge: 64, overlapFraction: 0.99 },
+    { width: 65, height: 1, maxEdge: 64, overlapFraction: 0 },
+    { width: 65, height: 1, maxEdge: 64, overlapFraction: 0.99 },
+    { width: 65, height: 65, maxEdge: 64, overlapFraction: 0 },
+    { width: 127, height: 193, maxEdge: 64, overlapFraction: 0.37 },
+    { width: 130, height: 257, maxEdge: 64, overlapFraction: 0.12 },
+  ];
+
+  it.each(cases)(
+    "covers and extracts $width x $height at overlap $overlapFraction",
+    async ({ width, height, maxEdge, overlapFraction }) => {
+      const png = await makePng(width, height);
+      const tiles = await tileScreenshot(
+        { displayId: "bounds", width, height, pngBytes: png },
+        { maxEdge, overlapFraction },
+      );
+      const expectedCols = Math.ceil(width / maxEdge);
+      const expectedRows = Math.ceil(height / maxEdge);
+      expect(tiles).toHaveLength(expectedCols * expectedRows);
+
+      const colCovered = new Uint8Array(width);
+      const rowCovered = new Uint8Array(height);
+      for (const tile of tiles) {
+        expect(Number.isInteger(tile.sourceX)).toBe(true);
+        expect(Number.isInteger(tile.sourceY)).toBe(true);
+        expect(Number.isInteger(tile.sourceW)).toBe(true);
+        expect(Number.isInteger(tile.sourceH)).toBe(true);
+        expect(tile.sourceX).toBeGreaterThanOrEqual(0);
+        expect(tile.sourceY).toBeGreaterThanOrEqual(0);
+        expect(tile.sourceW).toBeGreaterThan(0);
+        expect(tile.sourceH).toBeGreaterThan(0);
+        expect(tile.sourceX + tile.sourceW).toBeLessThanOrEqual(width);
+        expect(tile.sourceY + tile.sourceH).toBeLessThanOrEqual(height);
+        expect(tile.sourceW).toBeLessThanOrEqual(maxEdge);
+        expect(tile.sourceH).toBeLessThanOrEqual(maxEdge);
+        await expect(dimsOf(tile.pngBytes)).resolves.toEqual({
+          width: tile.sourceW,
+          height: tile.sourceH,
+        });
+        colCovered.fill(1, tile.sourceX, tile.sourceX + tile.sourceW);
+        rowCovered.fill(1, tile.sourceY, tile.sourceY + tile.sourceH);
+      }
+
+      expect([...colCovered]).not.toContain(0);
+      expect([...rowCovered]).not.toContain(0);
+    },
+  );
+});
+
 describe("tileScreenshot — overlap math", () => {
   it("adjacent tiles in the same row overlap by ~overlapFraction*tileW", async () => {
     const png = await makePng(2400, 1000);

--- a/plugins/plugin-vision/src/screen-tiler.test.ts
+++ b/plugins/plugin-vision/src/screen-tiler.test.ts
@@ -139,6 +139,80 @@ describe("tileScreenshot — ultra-wide 5K case", () => {
   });
 });
 
+describe("tileScreenshot — full source coverage (regression #22125)", () => {
+  // A floored inter-tile stride advanced intermediate tiles too slowly while
+  // the anchored last tile jumped to `width - tileWidth`, leaving a strip of
+  // source columns/rows present in no tile. These sizes each opened such a gap
+  // (e.g. width 5119 dropped source column 3838 entirely). Every source
+  // column and row must land inside at least one tile's cropped rect.
+  const cases: Array<{ width: number; height: number }> = [
+    { width: 5119, height: 1440 },
+    { width: 6399, height: 1440 },
+    { width: 7679, height: 2160 },
+    { width: 5120, height: 2160 },
+  ];
+  for (const { width, height } of cases) {
+    it(`covers every source column and row for ${width}x${height}`, async () => {
+      const png = await makePng(width, height);
+      const tiles = await tileScreenshot(
+        { displayId: "cov", width, height, pngBytes: png },
+        { maxEdge: 1280, overlapFraction: 0.12 },
+      );
+
+      const colCovered = new Uint8Array(width);
+      const rowCovered = new Uint8Array(height);
+      for (const t of tiles) {
+        // No tile may extend past the source bounds.
+        expect(t.sourceX).toBeGreaterThanOrEqual(0);
+        expect(t.sourceY).toBeGreaterThanOrEqual(0);
+        expect(t.sourceX + t.sourceW).toBeLessThanOrEqual(width);
+        expect(t.sourceY + t.sourceH).toBeLessThanOrEqual(height);
+        for (let x = t.sourceX; x < t.sourceX + t.sourceW; x += 1) {
+          colCovered[x] = 1;
+        }
+        for (let y = t.sourceY; y < t.sourceY + t.sourceH; y += 1) {
+          rowCovered[y] = 1;
+        }
+      }
+
+      const firstGapCol = [...colCovered].indexOf(0);
+      const firstGapRow = [...rowCovered].indexOf(0);
+      expect(
+        firstGapCol,
+        `source column ${firstGapCol} covered by no tile for ${width}x${height}`,
+      ).toBe(-1);
+      expect(
+        firstGapRow,
+        `source row ${firstGapRow} covered by no tile for ${width}x${height}`,
+      ).toBe(-1);
+    });
+  }
+
+  it("never leaves a gap between horizontally adjacent tiles", async () => {
+    // At width 5119 four 1280px-max tiles span 5120px of capacity, so only 1px
+    // of total slack is spread across three seams: positive overlap at every
+    // seam is impossible without exceeding maxEdge. The guarantee the ceil
+    // stride restores is that neighbours are contiguous-or-overlapping
+    // (overlap >= 0), which is exactly "no source column falls between tiles".
+    const width = 5119;
+    const png = await makePng(width, 1440);
+    const tiles = await tileScreenshot(
+      { displayId: "cov", width, height: 1440, pngBytes: png },
+      { maxEdge: 1280, overlapFraction: 0.12 },
+    );
+    const row0 = tiles
+      .filter((t) => t.id.startsWith("tile-0-"))
+      .sort((a, b) => a.sourceX - b.sourceX);
+    expect(row0.length).toBeGreaterThanOrEqual(2);
+    for (let i = 1; i < row0.length; i += 1) {
+      const prev = expectPresent(row0[i - 1], `tile-0-${i - 1}`);
+      const cur = expectPresent(row0[i], `tile-0-${i}`);
+      const overlap = prev.sourceX + prev.sourceW - cur.sourceX;
+      expect(overlap).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
 describe("tileScreenshot — overlap math", () => {
   it("adjacent tiles in the same row overlap by ~overlapFraction*tileW", async () => {
     const png = await makePng(2400, 1000);

--- a/plugins/plugin-vision/src/screen-tiler.ts
+++ b/plugins/plugin-vision/src/screen-tiler.ts
@@ -125,10 +125,20 @@ export async function tileScreenshot(
   );
   // Stride between top-left corners of adjacent tiles. With a single tile per
   // axis, stride is the full width/height — no overlap math needed.
+  //
+  // Round the stride *up*: intermediate tiles advance by `stride` while the
+  // final tile is anchored to `width - tileWidth`. A floored stride can leave
+  // the penultimate tile ending before the anchored last tile begins, which
+  // opens a strip of source pixels present in no tile (dropping any glyph in
+  // that column/row from the whole OCR/VLM pipeline). Ceiling guarantees the
+  // penultimate tile's far edge reaches the last tile's near edge because
+  // `tileWidth * cols >= width`, so the grid still fully covers the capture;
+  // `extract()` clamps `sourceW/sourceH` to the source bounds, so a ceil-ed
+  // stride never crops past the screen.
   const strideX =
-    cols > 1 ? Math.floor((width - tileWidth) / (cols - 1)) : tileWidth;
+    cols > 1 ? Math.ceil((width - tileWidth) / (cols - 1)) : tileWidth;
   const strideY =
-    rows > 1 ? Math.floor((height - tileHeight) / (rows - 1)) : tileHeight;
+    rows > 1 ? Math.ceil((height - tileHeight) / (rows - 1)) : tileHeight;
 
   const sharp = await getSharp();
   const image = sharp(pngBytes);


### PR DESCRIPTION
# Relates to

Closes #22125

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. `bun run verify` was not run whole-repo (unrelated blockers documented in **Known gaps / failures**); the owning package's focused test, typecheck, and lint all pass.
- [x] A reviewer can confirm the change works from the evidence below without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures** (repo-wide verify not run on this constrained machine; focused package gates pass).

# Risks

Low. The change is a two-line arithmetic adjustment (`Math.floor` → `Math.ceil`) inside `tileScreenshot`'s stride computation, local to `plugins/plugin-vision/src/screen-tiler.ts`. `extract()` already clamps `sourceW/sourceH` to the source bounds, so tiles still never crop past the screen. The only observable behavior change is that intermediate tiles advance slightly faster, closing previously-uncovered gap columns/rows; adjacent-tile overlap is preserved wherever the grid has slack.

# Background

## What does this PR do?

`tileScreenshot` in `screen-tiler.ts` computed the inter-tile stride with
`Math.floor((width - tileWidth) / (cols - 1))` (and the analogous `strideY`).
Intermediate tiles advanced by the floored stride while the final tile is
anchored to `width - tileWidth`, so the penultimate tile could end **before**
the last tile begins, leaving a strip of source pixels present in **no** tile.
Any glyph/UI element in that gap column (or row) was silently dropped from the
whole OCR/VLM pipeline — the agent literally could not see part of the screen.

The fix switches `strideX`/`strideY` to `Math.ceil`. Since `tileWidth * cols >= width`,
the ceil-ed stride lands the penultimate tile at/after the anchored last tile's
near edge, eliminating the hole while keeping every tile within source bounds.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The module's
existing header contract ("the grid covers the capture") is now actually
upheld; an in-code comment documents why the stride rounds up.

# Testing

## Where should a reviewer start?

`plugins/plugin-vision/src/screen-tiler.test.ts` — the new
`tileScreenshot — full source coverage (regression #22125)` block. Run:

```bash
bun run --cwd plugins/plugin-vision test
# or focused:
cd plugins/plugin-vision && ./node_modules/.bin/vitest run src/screen-tiler.test.ts
```

## Detailed testing steps

The regression test renders real `sharp`-generated PNGs, runs the real
`tileScreenshot`, and asserts the union of every tile's `[sourceX, sourceX+sourceW)`
covers `[0, width)` (and the analogous rows) for previously-broken sizes
(5119x1440, 6399x1440, 7679x2160) plus the already-passing 5120x2160, and that
adjacent tiles never leave a gap.

# Evidence Gate

<!-- evidence-head:406f233e7bf1916b6fa9f27bff0f4d734fffc43c -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - non-UI change`. This is a pure pixel-geometry fix in a Node-only image tiler with no rendered surface; the visual proof is the source-column coverage census below.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - non-UI change` (see before-screenshots row).
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - non-UI change`; there is no user-facing flow. The before/after reproduction is a deterministic test + census, attached below.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — the failing-before / passing-after vitest run below is the real code path (`tileScreenshot`) firing end to end against real `sharp` decode/extract.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs — `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change`; this is deterministic image geometry.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the brute-force gap census (floor: 1709 gap widths / worst 13px vs ceil: 0) and the before/after tile rectangles for width 5119 are attached below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface`; the change fixes which source pixels reach OCR, proven by column-coverage census rather than rendered text.

# Evidence Details

## Backend logs (real `tileScreenshot` path — failing before / passing after)

<details><summary>BEFORE (floor stride) — new regression test fails, real gap columns reported</summary>

```
     × covers every source column and row for 5119x1440
     × covers every source column and row for 6399x1440
     × covers every source column and row for 7679x2160
     × never leaves a gap between horizontally adjacent tiles
 FAIL  ... > covers every source column and row for 5119x1440
AssertionError: source column 3838 covered by no tile for 5119x1440: expected 3838 to be -1
 FAIL  ... > covers every source column and row for 6399x1440
AssertionError: source column 5117 covered by no tile for 6399x1440: expected 5117 to be -1
 FAIL  ... > covers every source column and row for 7679x2160
AssertionError: source column 6396 covered by no tile for 7679x2160: expected 6396 to be -1
      Tests  4 failed | 1 passed | 10 skipped (15)
```
</details>

<details><summary>AFTER (ceil stride) — full package test file passes</summary>

```
 RUN  v4.1.5 plugins/plugin-vision
 Test Files  1 passed (1)
      Tests  22 passed (22)
```
</details>

## Domain artifacts

<details><summary>Brute-force gap census: maxEdge ∈ {64,256,640,1280}, widths up to maxEdge*16</summary>

```
floor: {"gaps":1709,"worst":13}
ceil : {"gaps":0,"worst":0}
```

The floored stride produces 1709 distinct gap widths (worst case 13px) across the
range; the ceil stride produces 0 gaps while preserving the "never extend past the
screen" anchoring (`tileWidth*cols >= width` guarantees ceil-stride still lands the
penultimate tile at/after the last tile's start).
</details>

<details><summary>Before/after tile rectangles for a real capture width (5119 @ maxEdge 1280)</summary>

```
width=5119 maxEdge=1280 cols=4 tileWidth=1280
BEFORE (floor) tiles: [0,1280] [1279,2559] [2558,3838] [3839,5119]
BEFORE gap columns: [[3838,3838]]      <- source column 3838 in NO tile
AFTER  (ceil)  tiles: [0,1280] [1280,2560] [2560,3840] [3839,5119]
AFTER  gap columns: []                 <- gap closed; every column covered
```
</details>

## Screenshots (before / after) + video walkthrough

N/A - non-UI change. `plugin-vision` screen-tiler is a Node-only image-geometry
utility with no rendered surface; the coverage census above is the visual proof.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT surface.

## Known gaps / failures

- Evidence-gate row markers for **backend-logs** and **domain-artifacts** cannot be flipped to a link by a fork contributor: uploading to the \`pr-evidence\` release needs maintainer push access (the gate's own code notes this), and the only other accepted host — GitHub \`user-attachments\` — is minted solely by the browser drag-and-drop flow, which is unavailable to a headless CLI agent. The full, real logs for both rows are therefore embedded inline in the **Evidence Details** section above (failing-before/passing-after vitest run and the gap census + before/after tile rectangles). A maintainer can drag those two \`/tmp\` artifacts onto the PR to satisfy the automated marker if required.

- `bun run verify` (whole-repo) was not run on this constrained machine (16 GB
  Raspberry Pi); the workspace install requires `--minimum-release-age=0` due to a
  machine-global bun security policy, and full-repo typecheck fails only on
  **pre-existing** unrelated missing builds (`@elizaos/core`,
  `@elizaos/plugin-computeruse`) — confirmed present on a clean `git stash` of my
  change. After building those two deps, `plugin-vision` typecheck is clean.
- Owning-package focused gates all pass: `vitest` (15/15), `tsc --noEmit` (clean),
  and biome `lint` (clean).

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza"} -->

