### PR TITLE
fix(plugin-signal): honor SSE reconnect exponential backoff

### DIFF
--- a/plugins/plugin-signal/src/rpc.test.ts
+++ b/plugins/plugin-signal/src/rpc.test.ts
@@ -6,7 +6,7 @@
 import fc from "fast-check";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { normalizeBaseUrl, signalCheck, signalRpcRequest } from "./rpc";
+import { createSignalEventStream, normalizeBaseUrl, signalCheck, signalRpcRequest } from "./rpc";
 
 describe("Signal RPC helpers", () => {
   afterEach(() => {
@@ -90,6 +90,121 @@ describe("Signal RPC helpers", () => {
     await expect(signalRpcRequest("bad", {}, { baseUrl: "http://localhost" })).rejects.toThrow(
       "Signal RPC -32602: bad params"
     );
+  });
+
+  it("grows the reconnect delay exponentially up to the cap when the daemon stays down", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("ECONNREFUSED (daemon down)");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Capture reconnect delays and defer each scheduled reconnect so the test
+    // drives the cycles deterministically instead of racing the event loop.
+    const realSetTimeout = globalThis.setTimeout;
+    const delays: number[] = [];
+    let pending: (() => void) | null = null;
+    vi.stubGlobal("setTimeout", ((fn: () => void, ms?: number) => {
+      delays.push(ms ?? 0);
+      pending = fn;
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+    const flush = () => new Promise((resolve) => realSetTimeout(resolve, 0));
+
+    let connects = 0;
+    const stream = createSignalEventStream({
+      baseUrl: "http://localhost:8080",
+      onEvent: () => {},
+      onError: () => {},
+      onConnect: () => {
+        connects += 1;
+      },
+      reconnectDelayMs: 1000,
+      maxReconnectDelayMs: 30000,
+    });
+
+    stream.start();
+    for (let i = 0; i < 7; i++) {
+      await flush();
+      const next = pending;
+      pending = null;
+      next?.();
+    }
+    await flush();
+    stream.stop();
+
+    // Backoff doubles from the base delay and saturates at the configured cap.
+    expect(delays.slice(0, 6)).toEqual([1000, 2000, 4000, 8000, 16000, 30000]);
+    expect(delays.every((d) => d <= 30000)).toBe(true);
+    expect(Math.max(...delays)).toBe(30000);
+    // onConnect never fires because no connection was ever established.
+    expect(connects).toBe(0);
+  });
+
+  it("resets the reconnect delay to base after a connection is actually established", async () => {
+    const okStream = () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } }
+      );
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        throw new Error("down");
+      })
+      .mockImplementationOnce(async () => {
+        throw new Error("down");
+      })
+      .mockImplementationOnce(async () => okStream())
+      .mockImplementation(async () => {
+        throw new Error("down");
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const realSetTimeout = globalThis.setTimeout;
+    const delays: number[] = [];
+    let pending: (() => void) | null = null;
+    vi.stubGlobal("setTimeout", ((fn: () => void, ms?: number) => {
+      delays.push(ms ?? 0);
+      pending = fn;
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+    const flush = async () => {
+      await new Promise((resolve) => realSetTimeout(resolve, 0));
+      await new Promise((resolve) => realSetTimeout(resolve, 0));
+    };
+
+    let connects = 0;
+    const stream = createSignalEventStream({
+      baseUrl: "http://localhost:8080",
+      onEvent: () => {},
+      onError: () => {},
+      onConnect: () => {
+        connects += 1;
+      },
+      reconnectDelayMs: 1000,
+      maxReconnectDelayMs: 30000,
+    });
+
+    stream.start();
+    for (let i = 0; i < 4; i++) {
+      await flush();
+      const next = pending;
+      pending = null;
+      next?.();
+    }
+    await flush();
+    stream.stop();
+
+    // Two failed dials grow the delay (1000 -> 2000); the third dial succeeds
+    // and resets it, so the drop after the established stream restarts at the
+    // base delay rather than continuing the pre-success ramp.
+    expect(delays.slice(0, 4)).toEqual([1000, 2000, 1000, 2000]);
+    // onConnect fires exactly once, only for the genuinely established stream.
+    expect(connects).toBe(1);
   });
 
   it("reports Signal health failures for non-OK and aborted checks", async () => {

--- a/plugins/plugin-signal/src/rpc.ts
+++ b/plugins/plugin-signal/src/rpc.ts
@@ -286,6 +286,7 @@ export async function streamSignalEvents(params: {
   account?: string;
   abortSignal?: AbortSignal;
   onEvent: (event: SignalSseEvent) => void;
+  onConnected?: () => void;
 }): Promise<void> {
   const baseUrl = normalizeBaseUrl(params.baseUrl);
   const url = new URL(`${baseUrl}/api/v1/events`);
@@ -302,6 +303,10 @@ export async function streamSignalEvents(params: {
   if (!res.ok || !res.body) {
     throw new Error(`Signal SSE failed (${res.status} ${res.statusText || "error"})`);
   }
+
+  // Fires only once the daemon has accepted the stream (`res.ok`), so callers
+  // can distinguish a genuinely established connection from a failed dial.
+  params.onConnected?.();
 
   const reader = res.body.getReader();
   const decoder = new TextDecoder();
@@ -411,8 +416,9 @@ export function createSignalEventStream(params: {
 } {
   let abortController: AbortController | null = null;
   let running = false;
-  let reconnectDelay = params.reconnectDelayMs ?? 1000;
+  const baseDelay = params.reconnectDelayMs ?? 1000;
   const maxDelay = params.maxReconnectDelayMs ?? 30000;
+  let reconnectDelay = baseDelay;
 
   const connect = async () => {
     if (!running) {
@@ -422,14 +428,19 @@ export function createSignalEventStream(params: {
     abortController = new AbortController();
 
     try {
-      params.onConnect?.();
-      reconnectDelay = params.reconnectDelayMs ?? 1000;
-
       await streamSignalEvents({
         baseUrl: params.baseUrl,
         account: params.account,
         abortSignal: abortController.signal,
         onEvent: params.onEvent,
+        onConnected: () => {
+          // A connection was actually established; announce it and reset the
+          // backoff so the next drop restarts from the base delay. Resetting
+          // per-attempt (the previous behavior) defeated exponential backoff
+          // and let a persistently-down daemon be hit every base interval.
+          params.onConnect?.();
+          reconnectDelay = baseDelay;
+        },
       });
     } catch (error) {
       if (error instanceof Error && error.name === "AbortError") {


### PR DESCRIPTION
# Relates to

Closes #22123

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and focused package checks were run after sync; the only
      unrelated blocker (a full `bun run verify` needs the whole monorepo built)
      is recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused package checks (`test`, `typecheck`, `lint:check`) pass post-sync;
      see **Known gaps / failures** for the repo-wide `bun run verify` note.

# Risks

Low. The change is confined to one function's reconnect timing in
`plugins/plugin-signal/src/rpc.ts`. It removes an unconditional per-attempt
reset of the backoff delay and threads a connection-established callback into
`streamSignalEvents`. No public type is removed; `onConnected` is a new optional
param on an internal helper. Worst case if wrong: reconnect timing differs — but
the added regression tests pin the exact expected sequence.

# Background

## What does this PR do?

`createSignalEventStream` advertises "Reconnect with exponential backoff" and
accepts `reconnectDelayMs` / `maxReconnectDelayMs`, but the backoff never grew.
Inside `connect()` the delay was reset to the base value at the **top of every
attempt** (`reconnectDelay = params.reconnectDelayMs ?? 1000;`), executed
optimistically right after the misnamed `onConnect()` and before the `fetch` was
even confirmed. So the growth step `reconnectDelay = Math.min(reconnectDelay * 2,
maxDelay)` was immediately discarded on the next iteration. Against a
persistently-down `signal-cli` daemon, `SignalService.startPolling()` creates one
stream per account and each one hammered the SSE endpoint every 1000ms
indefinitely instead of backing off toward the 30s cap — a reconnection storm.
`maxReconnectDelayMs` and the doubling were effectively dead code.

The fix threads an `onConnected` callback into `streamSignalEvents` that fires
**only after `res.ok`** (a genuinely established stream). `createSignalEventStream`
resets the backoff there and nowhere else, and forwards the caller's `onConnect`
through it so `onConnect` now carries correct semantics (fires on real
connection, not optimistically per attempt). The per-attempt reset is removed;
the `*2` growth in the reconnect branch is retained. Result:

- persistent failure ramps `1000 → 2000 → 4000 → 8000 → 16000 → 30000` (capped
  at `maxReconnectDelayMs`), and
- a successful stream cycle resets the ramp back to the base delay.

Scope: ~19 lines in one file plus a regression test.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

None. The behavior now matches the existing doc comment ("Reconnect with
exponential backoff") and the documented `reconnectDelayMs` /
`maxReconnectDelayMs` options.

# Testing

## Where should a reviewer start?

`plugins/plugin-signal/src/rpc.ts` (`createSignalEventStream` and the new
`onConnected` param on `streamSignalEvents`) and the two new cases in
`plugins/plugin-signal/src/rpc.test.ts`.

## Detailed testing steps

```bash
bun install --frozen-lockfile
bun run --cwd packages/core build          # so @elizaos/core resolves for typecheck
bun run --cwd plugins/plugin-signal test   # 6/6 in rpc.test.ts, 50/50 overall
bun run --cwd plugins/plugin-signal typecheck
bun run --cwd plugins/plugin-signal lint:check
```

# Evidence Gate

<!-- evidence-head:d57f26e81b2812888986753949f97d2ae9189e85 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots — `N/A - server/runtime timing fix in a transport module; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots — `N/A - server/runtime timing fix in a transport module; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video — `N/A - no user-facing flow; behavior is reconnect timing observed via probe + tests below.`
<!-- evidence-row:backend-logs -->
- [x] Recorded reconnect-delay sequences from the real `createSignalEventStream` reconnect path (probe imports `plugins/plugin-signal/src/rpc.ts`, `fetch` stubbed to throw, `setTimeout` intercepted to log delays):

<details><summary>Reconnect-delay logs — before vs after</summary>

```
BEFORE (origin/develop rpc.ts):
  reconnect delays observed: [1000,1000,1000,1000,1000,1000,1000,1000,1000]
  max delay: 1000
  -> every attempt hits the endpoint at the base 1000ms interval;
     maxReconnectDelayMs and the *2 doubling are dead code (reconnection storm).

AFTER (this PR):
  reconnect delays observed: [1000,2000,4000,8000,16000,30000,30000,30000,30000]
  max delay: 30000
  -> exponential backoff grows and saturates at maxReconnectDelayMs (30000).
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs — `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Failing-before / passing-after regression test output for the changed contract (`plugins/plugin-signal/src/rpc.test.ts`):

<details><summary>Regression test output — failing before the fix, passing after</summary>

```
FAILING BEFORE (origin/develop rpc.ts + the two new tests):
 × grows the reconnect delay exponentially up to the cap when the daemon stays down
 × resets the reconnect delay to base after a connection is actually established
 AssertionError: expected [ 1000, 1000, 1000, 1000, 1000, 1000 ] to deeply equal [ Array(6) ]
   expect(delays.slice(0, 6)).toEqual([1000, 2000, 4000, 8000, 16000, 30000]);
 AssertionError: expected [ 1000, 1000, 1000, 1000 ] to deeply equal [ 1000, 2000, 1000, 2000 ]
   expect(delays.slice(0, 4)).toEqual([1000, 2000, 1000, 2000]);
 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)

PASSING AFTER (this PR):
 ✓ grows the reconnect delay exponentially up to the cap when the daemon stays down
 ✓ resets the reconnect delay to base after a connection is actually established
 Test Files  1 passed (1)
      Tests  6 passed (6)
 Full plugin suite: Tests 50 passed (50). typecheck clean. lint: no fixes applied.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface.`

# Evidence Details

## Backend logs / domain artifacts

Standalone probe importing `plugins/plugin-signal/src/rpc.ts`, `fetch` stubbed to
always throw (daemon down) and `setTimeout` intercepted to record reconnect
delays across reconnect cycles.

<details><summary>Recorded reconnect-delay sequence — BEFORE (origin/develop rpc.ts)</summary>

```
reconnect delays observed: [1000,1000,1000,1000,1000,1000,1000,1000,1000]
max delay: 1000
```

Every attempt hits the endpoint at the base 1000ms interval; `maxReconnectDelayMs`
and the `*2` doubling are dead code.
</details>

<details><summary>Recorded reconnect-delay sequence — AFTER (this PR)</summary>

```
reconnect delays observed: [1000,2000,4000,8000,16000,30000,30000,30000,30000]
max delay: 30000
```

Exponential backoff now grows and saturates at the configured
`maxReconnectDelayMs` (30000).
</details>

<details><summary>Regression tests: FAILING before the fix (old rpc.ts + new tests)</summary>

```
 × grows the reconnect delay exponentially up to the cap when the daemon stays down
 × resets the reconnect delay to base after a connection is actually established

 FAIL  src/rpc.test.ts > ... > grows the reconnect delay exponentially up to the cap when the daemon stays down
AssertionError: expected [ 1000, 1000, 1000, 1000, 1000, 1000 ] to deeply equal [ Array(6) ]
    expect(delays.slice(0, 6)).toEqual([1000, 2000, 4000, 8000, 16000, 30000]);

 FAIL  src/rpc.test.ts > ... > resets the reconnect delay to base after a connection is actually established
AssertionError: expected [ 1000, 1000, 1000, 1000 ] to deeply equal [ 1000, 2000, 1000, 2000 ]
    expect(delays.slice(0, 4)).toEqual([1000, 2000, 1000, 2000]);

 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)
```
</details>

<details><summary>Regression tests: PASSING after the fix</summary>

```
 ✓ src/rpc.test.ts > Signal RPC helpers > normalizes explicit and shorthand base URLs without trailing slash runs
 ✓ src/rpc.test.ts > Signal RPC helpers > posts a JSON-RPC envelope and returns result payloads
 ✓ src/rpc.test.ts > Signal RPC helpers > handles empty-success, empty-error, and JSON-RPC error responses
 ✓ src/rpc.test.ts > Signal RPC helpers > grows the reconnect delay exponentially up to the cap when the daemon stays down
 ✓ src/rpc.test.ts > Signal RPC helpers > resets the reconnect delay to base after a connection is actually established
 ✓ src/rpc.test.ts > Signal RPC helpers > reports Signal health failures for non-OK and aborted checks

 Test Files  1 passed (1)
      Tests  6 passed (6)
```
</details>

<details><summary>Full plugin suite, typecheck, lint (post-rebase)</summary>

```
$ bun run --cwd plugins/plugin-signal test
 Test Files  6 passed (6)
      Tests  50 passed (50)

$ bun run --cwd plugins/plugin-signal typecheck
$ tsc --noEmit -p tsconfig.json      # clean, no output

$ bun run --cwd plugins/plugin-signal lint:check
$ bunx @biomejs/biome check .
Checked 26 files in 130ms. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - server/runtime reconnect-timing fix; no rendered visual surface. Behavior
is proven by the recorded reconnect-delay sequences and the failing→passing
regression tests above.`

## Known gaps / failures

- Repo-wide `bun run verify` was not run to completion on this machine: a full
  workspace build/verify is heavy for a Raspberry Pi worktree, and
  `@elizaos/core` had to be built explicitly for the plugin typecheck to resolve
  `@elizaos/core`. All **owning-package** gates (test, typecheck, lint) pass on
  the final rebased head. This does not affect the correctness of the scoped
  change.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza"} -->