### PR TITLE
fix(personal-assistant): keep late mornings wake-relative

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/defaults.adaptive-window.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/defaults.adaptive-window.test.ts
@@ -61,11 +61,21 @@ describe("computeAdaptiveWindowPolicy", () => {
   });
 
   it.each([
-    { wakeTime: "14:30", typicalWakeHour: 14.5 },
-    { wakeTime: "15:00", typicalWakeHour: 15 },
+    {
+      wakeTime: "14:30",
+      typicalWakeHour: 14.5,
+      startMinute: 840,
+      endMinute: 900,
+    },
+    {
+      wakeTime: "15:00",
+      typicalWakeHour: 15,
+      startMinute: 870,
+      endMinute: 930,
+    },
   ])(
-    "keeps the morning window non-empty for a $wakeTime wake rhythm",
-    ({ typicalWakeHour }) => {
+    "keeps the morning window wake-relative for a $wakeTime wake rhythm",
+    ({ typicalWakeHour, startMinute, endMinute }) => {
       const policy = computeAdaptiveWindowPolicy(
         {
           typicalWakeHour,
@@ -78,12 +88,33 @@ describe("computeAdaptiveWindowPolicy", () => {
 
       expect(policy.windows[0]).toMatchObject({
         name: "morning",
-        startMinute: 780,
-        endMinute: 840,
+        startMinute,
+        endMinute,
       });
-      expect(policy.windows[1]?.startMinute).toBe(840);
+      const wakeMinute = typicalWakeHour * 60;
+      expect(startMinute).toBeLessThanOrEqual(wakeMinute);
+      expect(endMinute).toBeGreaterThan(wakeMinute);
+      expect(policy.windows[1]?.startMinute).toBe(endMinute);
     },
   );
+
+  it("keeps downstream dayparts positive when a very late wake crosses both caps", () => {
+    const policy = computeAdaptiveWindowPolicy(
+      {
+        typicalWakeHour: 21,
+        typicalFirstActiveHour: null,
+        typicalLastActiveHour: null,
+        typicalSleepHour: null,
+      },
+      "UTC",
+    );
+
+    expect(policy.windows.slice(0, 3)).toMatchObject([
+      { name: "morning", startMinute: 1230, endMinute: 1290 },
+      { name: "afternoon", startMinute: 1290, endMinute: 1350 },
+      { name: "evening", startMinute: 1350, endMinute: 1410 },
+    ]);
+  });
 
   it("keeps every adaptive daypart contiguous and non-empty across wake rhythms", () => {
     for (
@@ -136,7 +167,7 @@ describe("computeAdaptiveWindowPolicy", () => {
     ).toBe(true);
     expect(
       occurrences.every(
-        ({ scheduledAt }) => scheduledAt?.slice(11, 16) === "13:00",
+        ({ scheduledAt }) => scheduledAt?.slice(11, 16) === "14:30",
       ),
     ).toBe(true);
   });

--- a/plugins/plugin-personal-assistant/src/lifeops/defaults.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/defaults.ts
@@ -93,12 +93,9 @@ export function windowPolicyMatchesDefaults(
 
 /** Floor value for the morning window start (4:00 AM in minutes). */
 const ADAPTIVE_MORNING_FLOOR_MINUTES = 4 * 60;
-/** Ceiling value for the morning window end (2:00 PM in minutes). */
+/** Nominal cap for the morning window end (2:00 PM in minutes). */
 const ADAPTIVE_MORNING_END_CAP_MINUTES = 14 * 60;
-/** Latest morning start that preserves a one-hour window before the end cap. */
-const ADAPTIVE_MORNING_START_CAP_MINUTES =
-  ADAPTIVE_MORNING_END_CAP_MINUTES - 60;
-/** Ceiling value for the afternoon window end (8:00 PM in minutes). */
+/** Nominal cap for the afternoon window end (8:00 PM in minutes). */
 const ADAPTIVE_AFTERNOON_END_CAP_MINUTES = 20 * 60;
 /** Ceiling value for the evening window end (4:00 AM next day in minutes). */
 const ADAPTIVE_EVENING_END_CAP_MINUTES = 28 * 60;
@@ -106,6 +103,8 @@ const ADAPTIVE_EVENING_END_CAP_MINUTES = 28 * 60;
 const ADAPTIVE_LEAD_HOURS = 0.5;
 /** Standard span of the morning and afternoon windows. */
 const ADAPTIVE_WINDOW_SPAN_HOURS = 5;
+/** Minimum span retained when a late rhythm crosses a nominal daypart cap. */
+const ADAPTIVE_MIN_WINDOW_SPAN_MINUTES = 60;
 /** How long after typical last active to end the evening window. */
 const ADAPTIVE_LAST_ACTIVE_LAG_HOURS = 1;
 
@@ -138,23 +137,30 @@ export function computeAdaptiveWindowPolicy(
     };
   }
 
-  const morningStartMinute = Math.min(
-    Math.max(
-      Math.round((wakeSource - ADAPTIVE_LEAD_HOURS) * 60),
-      ADAPTIVE_MORNING_FLOOR_MINUTES,
-    ),
-    ADAPTIVE_MORNING_START_CAP_MINUTES,
+  const morningStartMinute = Math.max(
+    Math.round((wakeSource - ADAPTIVE_LEAD_HOURS) * 60),
+    ADAPTIVE_MORNING_FLOOR_MINUTES,
   );
 
-  const morningEndMinute = Math.min(
-    morningStartMinute + ADAPTIVE_WINDOW_SPAN_HOURS * 60,
-    ADAPTIVE_MORNING_END_CAP_MINUTES,
+  // The wall-clock cap is soft for late rhythms: preserve a wake-relative
+  // interval around the reported wake instead of moving the whole window to
+  // before that wake. The one-hour floor leaves the configured half-hour lead
+  // and at least half an hour after wake.
+  const morningEndMinute = Math.max(
+    Math.min(
+      morningStartMinute + ADAPTIVE_WINDOW_SPAN_HOURS * 60,
+      ADAPTIVE_MORNING_END_CAP_MINUTES,
+    ),
+    morningStartMinute + ADAPTIVE_MIN_WINDOW_SPAN_MINUTES,
   );
 
   const afternoonStartMinute = morningEndMinute;
-  const afternoonEndMinute = Math.min(
-    afternoonStartMinute + ADAPTIVE_WINDOW_SPAN_HOURS * 60,
-    ADAPTIVE_AFTERNOON_END_CAP_MINUTES,
+  const afternoonEndMinute = Math.max(
+    Math.min(
+      afternoonStartMinute + ADAPTIVE_WINDOW_SPAN_HOURS * 60,
+      ADAPTIVE_AFTERNOON_END_CAP_MINUTES,
+    ),
+    afternoonStartMinute + ADAPTIVE_MIN_WINDOW_SPAN_MINUTES,
   );
 
   const eveningStartMinute = afternoonEndMinute;


### PR DESCRIPTION
# Relates to

Fixes #21938. Corrects the semantic defect left by merged PR #22083.

## What changed

The 14:00 morning and 20:00 afternoon boundaries are now nominal caps. When a late wake crosses one, the policy retains the configured 30-minute pre-wake lead and a one-hour minimum window, leaving at least 30 minutes after wake instead of relocating the whole morning to 13:00-14:00. The afternoon receives the same minimum-span guard so very late rhythms remain positive and contiguous; the existing evening guard completes the chain.

Ordinary rhythms are unchanged: a 07:00 wake still produces 06:30-11:30.

## Exact-head evidence

Head: `8ecab6038a5ca9c9a2ab08289733ee29e5536031`
Base: `bdf7d875bdc53d246871f5c921ff41edc73fb729`

- focused adaptive-window Vitest: 1 file, 6 tests passed
- `build:types`: passed
- Biome on both changed files: passed
- `git diff --check`: passed

Boundary artifacts:

```text
wake 07:00 -> morning 06:30-11:30 (unchanged)
wake 14:30 -> morning 14:00-15:00 (contains wake; 30m after)
wake 15:00 -> morning 14:30-15:30 (contains wake; 30m after)
wake 21:00 -> morning 20:30-21:30, afternoon 21:30-22:30, evening 22:30-23:30
```

The half-hour sweep across 00:00-23:30 asserts every daypart remains strictly positive and contiguous. The real occurrence materializer continues producing ten daily morning occurrences and now schedules the 15:00-wake policy at 14:30 instead of the detached 13:00 cap.

No UI, model, connector, or external integration changes; screenshots/video/LLM trajectory are N/A.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@bdf7d875bdc53d246871f5c921ff41edc73fb729:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@bdf7d875bdc53d246871f5c921ff41edc73fb729:packages/skills/skills/contribute-to-eliza"} -->
