### PR TITLE
fix(plugin-notes): make clear-notes expectedRevision guard atomic with the commit

### DIFF
--- a/plugins/plugin-notes/AGENTS.md
+++ b/plugins/plugin-notes/AGENTS.md
@@ -47,3 +47,6 @@ views or event state to this package.
 - Failures throw typed `ElizaError`s; nothing fabricates a healthy empty state.
 - All chat action and provider exposure is OWNER-gated because storage is
   per-agent rather than per-sender.
+- `clear-notes` validates `expectedRevision` inside the store write barrier, so
+  a note committed between confirmation and commit aborts the clear instead of
+  being wiped. The dispatch-time snapshot check is only a fast path.

--- a/plugins/plugin-notes/CLAUDE.md
+++ b/plugins/plugin-notes/CLAUDE.md
@@ -47,3 +47,6 @@ views or event state to this package.
 - Failures throw typed `ElizaError`s; nothing fabricates a healthy empty state.
 - All chat action and provider exposure is OWNER-gated because storage is
   per-agent rather than per-sender.
+- `clear-notes` validates `expectedRevision` inside the store write barrier, so
+  a note committed between confirmation and commit aborts the clear instead of
+  being wiped. The dispatch-time snapshot check is only a fast path.

--- a/plugins/plugin-notes/src/__tests__/backend.test.ts
+++ b/plugins/plugin-notes/src/__tests__/backend.test.ts
@@ -681,6 +681,72 @@ describe("Notes capabilities", () => {
     expect(service.listNotes()).toEqual([]);
   });
 
+  it("rejects a clear confirmed against a revision a concurrent create advances (issue #22122)", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact("create-note", { content: "A", color: "yellow" }, service);
+    // The user confirmed against this snapshot; a note created before the clear
+    // actually commits must not be wiped without a fresh confirmation.
+    const confirmedRevision = service.snapshot().revision;
+
+    // Dispatch both in the same tick. create-note acquires the store write
+    // barrier first and commits at confirmedRevision + 1 before the clear's
+    // transaction body runs, so the dispatch-time check alone would be defeated.
+    const createB = service.createNote({ title: "B", body: "racing insert" });
+    const clear = interact(
+      "clear-notes",
+      { confirm: true, expectedRevision: confirmedRevision },
+      service,
+    );
+    const [, clearResult] = await Promise.all([createB, clear]);
+
+    expect(clearResult).toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+    const remaining = service.listNotes();
+    const titles = remaining.map((note) => note.title);
+    expect(titles).toContain("A");
+    expect(titles).toContain("B");
+    expect(remaining).toHaveLength(2);
+
+    // A clear confirmed against the now-current revision still succeeds.
+    const cleared = await interact(
+      "clear-notes",
+      { confirm: true, expectedRevision: service.snapshot().revision },
+      service,
+    );
+    expect(cleared).toMatchObject({ success: true, data: { cleared: 2 } });
+    expect(service.listNotes()).toEqual([]);
+  });
+
+  it("rejects a clear confirmed against a revision a concurrent update advances (issue #22122)", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    const seed = await service.createNote({ title: "Keep", body: "original" });
+    const confirmedRevision = service.snapshot().revision;
+
+    const updateSeed = service.updateNote(seed.id, {
+      title: "Keep",
+      body: "edited in the race window",
+    });
+    const clear = interact(
+      "clear-notes",
+      { confirm: true, expectedRevision: confirmedRevision },
+      service,
+    );
+    const [, clearResult] = await Promise.all([updateSeed, clear]);
+
+    expect(clearResult).toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+    const remaining = service.listNotes();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]).toMatchObject({
+      title: "Keep",
+      body: "edited in the race window",
+    });
+  });
+
   it("persists intentional clear-notes across service restart", async () => {
     const filePath = await temporaryStateFile();
     const first = await serviceFor(filePath);

--- a/plugins/plugin-notes/src/interact.ts
+++ b/plugins/plugin-notes/src/interact.ts
@@ -111,7 +111,7 @@ type NoteSelector =
 function parseClearNotesConfirmation(
   params: Record<string, unknown>,
   currentRevision: number,
-): void {
+): number {
   assertOnlyParams(params, ["confirm", "expectedRevision"]);
   if (!Object.hasOwn(params, "confirm")) {
     throw new ElizaError("clear-notes requires confirm: true.", {
@@ -166,6 +166,7 @@ function parseClearNotesConfirmation(
       },
     );
   }
+  return expectedRevision;
 }
 
 function parseLookupTarget(
@@ -382,8 +383,16 @@ async function dispatchCapability(
     );
   }
   if (capability === "clear-notes") {
-    parseClearNotesConfirmation(params, service.snapshot().revision);
-    const { value: cleared, snapshot } = await service.clearNotesWithCommit();
+    // The synchronous check is a fast path against the current snapshot; the
+    // authoritative guard runs atomically inside clearNotesWithCommit's write
+    // barrier so a note committed in the dispatch/commit race window is not
+    // silently wiped (issue #22122).
+    const expectedRevision = parseClearNotesConfirmation(
+      params,
+      service.snapshot().revision,
+    );
+    const { value: cleared, snapshot } =
+      await service.clearNotesWithCommit(expectedRevision);
     return mutationSuccess(
       snapshot,
       capability,

--- a/plugins/plugin-notes/src/service.ts
+++ b/plugins/plugin-notes/src/service.ts
@@ -512,11 +512,35 @@ export class NotesService extends Service {
     };
   }
 
-  async clearNotesWithCommit(): Promise<{
+  /**
+   * Clear every note, optionally guarded by `expectedRevision`. The guard is
+   * validated inside the serialized write barrier where `draft.revision` still
+   * equals the committed revision, so a note that commits between a caller's
+   * snapshot and this transaction aborts the clear instead of being wiped. A
+   * dispatch-time check upstream is only a fast path; this is the atomic one.
+   */
+  async clearNotesWithCommit(expectedRevision?: number): Promise<{
     value: number;
     snapshot: NotesSnapshot;
   }> {
     const transaction = await this.store.transact((draft) => {
+      if (
+        expectedRevision !== undefined &&
+        draft.revision !== expectedRevision
+      ) {
+        throw new ElizaError(
+          "clear-notes expectedRevision is stale; refresh the notes snapshot and try again.",
+          {
+            code: "NOTES_VALIDATION_FAILED",
+            context: {
+              field: "expectedRevision",
+              expectedRevision,
+              currentRevision: draft.revision,
+            },
+            severity: "ephemeral",
+          },
+        );
+      }
       const count = draft.notes.length;
       draft.notes = [];
       return count;
@@ -525,8 +549,8 @@ export class NotesService extends Service {
     return transaction;
   }
 
-  async clearNotes(): Promise<number> {
-    return (await this.clearNotesWithCommit()).value;
+  async clearNotes(expectedRevision?: number): Promise<number> {
+    return (await this.clearNotesWithCommit(expectedRevision)).value;
   }
 
   private async emitStateUpdated(


### PR DESCRIPTION
# Relates to

Closes #22122

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and the owning package's `test`/`typecheck`/`lint` were run
      after sync; repo-wide `bun run verify` is blocked by an unrelated
      environment limit recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures**
      (repo-wide install is blocked by this host's `minimumReleaseAge` supply-chain
      policy for unrelated packages; the owning package gates were run instead).

# Risks

Low. The change is confined to `plugins/plugin-notes`. It adds an atomic
optimistic-concurrency guard to a bulk destructive path (`clear-notes`) and does
not alter create/update/delete/read behavior. The dispatch-time snapshot check
is retained as a fast path, so already-passing callers see no behavior change
except that a clear racing a concurrent commit now fails closed with the
existing `NOTES_VALIDATION_FAILED` error instead of wiping unconfirmed notes.

# Background

## What does this PR do?

`clear-notes` requires `expectedRevision` to match the current notes revision
"at execution time" (per `capabilities.ts` and issue #18383's stale/concurrency
acceptance). But `interact.ts` validated `expectedRevision` against
`service.snapshot().revision` **synchronously at dispatch**, before calling
`clearNotesWithCommit()`, whose `store.transact` re-reads the latest document
inside the serialized write barrier. If another mutation commits between the
dispatch-time check and the clear's transaction commit, the guard was defeated:
the clear proceeded against newer state and deleted notes the user never saw or
confirmed — a TOCTOU / lost-update on a bulk destructive operation whose whole
safety contract is optimistic concurrency.

The fix threads `expectedRevision` from the `interact.ts` clear path into
`NotesService.clearNotesWithCommit(expectedRevision)` and validates it **inside
the `store.transact` mutate callback**, where `draft.revision` still equals the
committed revision (the `draft.revision = current.revision + 1` increment
happens after `mutate` returns). A note committed in the race window now aborts
the clear with the existing `NOTES_VALIDATION_FAILED` "stale" `ElizaError`
instead of being destroyed. No store API change was required.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

Updated the plugin's `CLAUDE.md`/`AGENTS.md` invariants to document that
`clear-notes` validates `expectedRevision` inside the store write barrier and
that the dispatch-time check is only a fast path. `bun run check:agents-claude`
passes (155 pairs byte-identical).

# Testing

## Where should a reviewer start?

`plugins/plugin-notes/src/service.ts` (`clearNotesWithCommit`) and
`plugins/plugin-notes/src/interact.ts` (clear-notes dispatch). The regression
tests are in `plugins/plugin-notes/src/__tests__/backend.test.ts`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-notes test        # 93 passed (2 new)
bun run --cwd plugins/plugin-notes typecheck    # clean
bun run --cwd plugins/plugin-notes lint:check   # clean
```

To see the failing-then-passing reproduction: stash `service.ts` + `interact.ts`
and run the two `issue #22122` tests — the clear returns `success:true` and
`listNotes()` no longer contains the racing note (fails). Unstash and they pass.

# Evidence Gate

<!-- evidence-head:317a34b8ad7c055204abb0d2cd8f38536f1dd3a2 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - server/runtime change in plugin-notes backend; no rendered UI surface touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - server/runtime change in plugin-notes backend; no rendered UI surface touched.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI flow; the behavior is a backend concurrency guard proven by deterministic tests and durable state artifacts below.`
<!-- evidence-row:backend-logs -->
- [x] Backend real-path logs (focused package test, after fix) — 93 passed incl. 2 new `issue #22122` regression tests:

<details>
<summary>bun run --cwd plugins/plugin-notes test (after fix)</summary>

```
 RUN  v4.1.5 plugins/plugin-notes

 Test Files  10 passed (10)
      Tests  93 passed (93)

 src/__tests__/backend.test.ts > rejects a clear confirmed against a revision a concurrent create advances (issue #22122)  PASS
 src/__tests__/backend.test.ts > rejects a clear confirmed against a revision a concurrent update advances (issue #22122)  PASS
```
</details>

<details>
<summary>Before fix (service.ts + interact.ts stashed) — the clear WIPES the racing note</summary>

```
 FAIL  src/__tests__/backend.test.ts > rejects a clear confirmed against a revision a concurrent create advances (issue #22122)
 AssertionError: expected { success: true, …(5) } to match object { success: false, …(1) }
 -   "error": { "code": "NOTES_VALIDATION_FAILED" },
 -   "success": false,
 +   "success": true,

 Test Files  1 failed (1)
      Tests  2 failed | 27 skipped (29)
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changed; this is a store-level concurrency guard.`
<!-- evidence-row:domain-artifacts -->
- [x] Durable `state.json` captured from a real `NotesService` driving the exact race (seed "A" @ rev 1, then non-awaited `createNote("B")` + `clear-notes{expectedRevision:1}`):

<details>
<summary>state.json before/after the racing clear — B survives, clear rejected as stale</summary>

```json
// BEFORE racing clear (revision 1, note A only)
{ "schemaVersion": 1, "revision": 1,
  "notes": [ { "title": "A", "body": "seed", "color": "yellow" } ] }

// clear result:
{ "success": false,
  "error": { "code": "NOTES_VALIDATION_FAILED",
    "message": "clear-notes expectedRevision is stale; refresh the notes snapshot and try again." } }
// listNotes() titles: [ "B", "A" ]

// AFTER racing clear (revision 2) — B committed at rev 2 and SURVIVES; clear did
// not advance to rev 3 and wipe everything
{ "schemaVersion": 1, "revision": 2,
  "notes": [
    { "title": "B", "body": "racing insert", "color": "yellow" },
    { "title": "A", "body": "seed", "color": "yellow" } ] }
```
</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changed.`

## Backend + frontend logs

Focused package test (after fix) — 93 passed, including the two new
`issue #22122` regression tests:

<details>
<summary>bun run --cwd plugins/plugin-notes test</summary>

```
 Test Files  10 passed (10)
      Tests  93 passed (93)
```
</details>

Failing-then-passing proof — with `service.ts` + `interact.ts` reverted
(`git stash`), the two new tests FAIL because the clear wipes the racing note:

<details>
<summary>Before fix (stashed) — clear wipes the racing note</summary>

```
 FAIL  src/__tests__/backend.test.ts > Notes capabilities > rejects a clear confirmed against a revision a concurrent create advances (issue #22122)
AssertionError: expected { success: true, …(5) } to match object { success: false, …(1) }
  {
-   "error": { "code": "NOTES_VALIDATION_FAILED" },
-   "success": false,
+   "success": true,
  }

 FAIL  src/__tests__/backend.test.ts > Notes capabilities > rejects a clear confirmed against a revision a concurrent update advances (issue #22122)
AssertionError: expected { success: true, …(5) } to match object { success: false, …(1) }

 Test Files  1 failed (1)
      Tests  2 failed | 27 skipped (29)
```
</details>

typecheck + lint (after fix):

```
$ tsc --noEmit -p tsconfig.json      # clean, no errors
$ bunx @biomejs/biome check .        # Checked 34 files. No fixes applied.
```

`N/A (frontend) - no frontend path changed.`

## Screenshots (before / after) + video walkthrough

`N/A - server/runtime change; no rendered UI surface.`

## Domain artifacts

Durable `state.json` captured from a real `NotesService` (temp state dir) driving
the exact race: seed note "A" → confirmed revision 1; then in the same tick a
non-awaited `createNote({title:"B"})` and an `interact("clear-notes",{confirm:true,expectedRevision:1})`.

Before the racing clear (revision 1, note A):

```json
{
  "schemaVersion": 1,
  "revision": 1,
  "notes": [ { "title": "A", "body": "seed", "color": "yellow", ... } ]
}
```

Clear result: `{"success":false,"error":{"code":"NOTES_VALIDATION_FAILED","message":"clear-notes expectedRevision is stale; refresh the notes snapshot and try again."}}`

`listNotes()` titles: `[ "B", "A" ]`

After the racing clear — B committed at revision 2 and **survives**; the clear
was rejected as stale rather than advancing to revision 3 and wiping everything:

```json
{
  "schemaVersion": 1,
  "revision": 2,
  "notes": [
    { "title": "B", "body": "racing insert", ... },
    { "title": "A", "body": "seed", ... }
  ]
}
```

## Audio / voice walkthrough

`N/A - no voice/audio path.`

## Known gaps / failures

- Repo-wide `bun run verify` was not run to completion: this host enforces a
  global `minimumReleaseAge` (604800s) supply-chain policy that blocks resolving
  several unrelated recently-published dependencies (`viem`, `pepr`,
  `kubernetes-fluent-client`, `smthrs`) in other workspaces. `bun install`
  succeeded with `--frozen-lockfile` (trusted committed lockfile with integrity
  hashes). The owning package's `test`, `typecheck`, and `lint:check` gates and
  `check:agents-claude` all pass on the final synced head. No plugin-notes
  source produced any typecheck or lint error.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza"} -->
