### PR TITLE
fix(plugin-todos): reconcile writeList against the entity-scoped todo set (#22124)

### DIFF
--- a/plugins/plugin-todos/AGENTS.md
+++ b/plugins/plugin-todos/AGENTS.md
@@ -129,9 +129,10 @@ the Cloud Shared host currently supplies a Hyperdrive-backed Drizzle client.
   behavior in a host package. Node and edge both use `TodoStore` and
   `createTodosSqlStore`.
 - **Every operation is tenant-scoped.** `agentId` and `entityId` are required in
-  all storage predicates. `roomId` narrows presentation and room-scoped bulk
-  operations; `worldId` is stored and remapped as projection metadata. Neither
-  is an ownership boundary.
+  all storage predicates. `write` replaces the entity-scoped list exposed to
+  the planner across rooms, while `clear` may narrow deletion to the current
+  room. `roomId` and `worldId` otherwise remain projection metadata, not
+  ownership boundaries.
 - **Planner mutations use the ledger.** Calling direct `create` / `update` /
   `delete` from an action bypasses exactly-once replay and is a correctness bug.
 - **`write` is a full replacement.** It reconciles the desired scoped list,

--- a/plugins/plugin-todos/CLAUDE.md
+++ b/plugins/plugin-todos/CLAUDE.md
@@ -129,9 +129,10 @@ the Cloud Shared host currently supplies a Hyperdrive-backed Drizzle client.
   behavior in a host package. Node and edge both use `TodoStore` and
   `createTodosSqlStore`.
 - **Every operation is tenant-scoped.** `agentId` and `entityId` are required in
-  all storage predicates. `roomId` narrows presentation and room-scoped bulk
-  operations; `worldId` is stored and remapped as projection metadata. Neither
-  is an ownership boundary.
+  all storage predicates. `write` replaces the entity-scoped list exposed to
+  the planner across rooms, while `clear` may narrow deletion to the current
+  room. `roomId` and `worldId` otherwise remain projection metadata, not
+  ownership boundaries.
 - **Planner mutations use the ledger.** Calling direct `create` / `update` /
   `delete` from an action bypasses exactly-once replay and is a correctness bug.
 - **`write` is a full replacement.** It reconciles the desired scoped list,

--- a/plugins/plugin-todos/src/actions/todo.test.ts
+++ b/plugins/plugin-todos/src/actions/todo.test.ts
@@ -184,7 +184,6 @@ class FakeTodosService {
       await this.list({
         entityId: args.entityId,
         agentId: args.agentId,
-        roomId: args.roomId,
       })
     ).map((todo) => ({ ...todo }));
     const beforeById = new Map(before.map((t) => [t.id, t]));
@@ -218,7 +217,6 @@ class FakeTodosService {
     this.rows = this.rows.filter((r) => {
       if (r.entityId !== args.entityId) return true;
       if (r.agentId !== args.agentId) return true;
-      if (r.roomId !== args.roomId) return true;
       return keep.has(r.id);
     });
     return { before, after };
@@ -622,6 +620,37 @@ describe("TODO action", () => {
       expect(service.rows.length).toBe(2);
       const stored = service.rows.find((r) => r.id === originalId);
       expect(stored?.status).toBe("completed");
+    });
+
+    it("reconciles the entity-scoped list across rooms", async () => {
+      const otherRoom = "11111111-2222-4333-8444-555555555555";
+      const existing = await service.create({
+        entityId: ENTITY,
+        agentId: AGENT,
+        roomId: otherRoom,
+        worldId: null,
+        content: "cross-room task",
+        status: "pending",
+      });
+
+      const result = await invoke(runtime, {
+        action: "write",
+        todos: [
+          {
+            id: existing.id,
+            content: existing.content,
+            status: "completed",
+          },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+      expect(service.rows).toHaveLength(1);
+      expect(service.rows[0]).toMatchObject({
+        id: existing.id,
+        roomId: otherRoom,
+        status: "completed",
+      });
     });
 
     it("rejects invalid status", async () => {

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -778,7 +778,7 @@ export function createTodoAction(options: TodoActionOptions = {}): Action {
       {
         name: "todos",
         description:
-          "Array of {id?, content, status, activeForm?, parentTodoId?} for action=write. Replaces the user's list for this conversation.",
+          "Array of {id?, content, status, activeForm?, parentTodoId?} for action=write. Replaces the user's full shared list across conversations.",
         required: false,
         schema: {
           type: "array" as const,

--- a/plugins/plugin-todos/src/sql-store.ts
+++ b/plugins/plugin-todos/src/sql-store.ts
@@ -1176,10 +1176,18 @@ class SqlTodoStore<TSchema extends Record<string, unknown>>
   }
 
   /**
-   * Bulk-replace the user's todo list for a given (entityId, roomId) scope.
-   * Mirrors Claude Code's TodoWrite contract: the caller passes the full
-   * desired list, and the store reconciles. Existing rows are matched by id;
-   * absent rows are deleted; new rows are inserted.
+   * Bulk-replace the user's entire todo list for a given (agentId, entityId)
+   * scope. Mirrors Claude Code's TodoWrite contract: the caller passes the
+   * full desired list, and the store reconciles. Existing rows are matched by
+   * id; absent rows are deleted; new rows are inserted.
+   *
+   * The reconciled `before` set is keyed only on (agentId, entityId) — the same
+   * cross-room scope every read path uses (the CURRENT_TODOS provider,
+   * actionList, and list()), because todos persist across rooms for one user.
+   * Narrowing `before` by roomId here would reconcile the planner's write
+   * against a different set than it observed, re-creating todos it marked
+   * complete in another room (duplicate) and resurrecting ones it omitted
+   * (lost update). roomId/worldId are used only to seed newly created rows.
    */
   private async writeListInTransaction(
     tx: TodoTransaction<TSchema>,
@@ -1195,17 +1203,15 @@ class SqlTodoStore<TSchema extends Record<string, unknown>>
         },
       );
     }
-    const conditions = [
-      eq(todosTable.agentId, args.agentId as UUID),
-      eq(todosTable.entityId, args.entityId as UUID),
-    ];
-    if (args.roomId !== null) {
-      conditions.push(eq(todosTable.roomId, args.roomId as UUID));
-    }
     const beforeRows = await tx
       .select()
       .from(todosTable)
-      .where(and(...conditions))
+      .where(
+        and(
+          eq(todosTable.agentId, args.agentId as UUID),
+          eq(todosTable.entityId, args.entityId as UUID),
+        ),
+      )
       .orderBy(desc(todosTable.updatedAt));
     const before = beforeRows.map(rowToTodo);
     const beforeById = new Map(before.map((todo) => [todo.id, todo]));

--- a/plugins/plugin-todos/src/store.ts
+++ b/plugins/plugin-todos/src/store.ts
@@ -144,6 +144,7 @@ export interface TodoStore {
     patch: UpdateTodoInput,
   ): Promise<Todo | null>;
   delete(scope: TodoScope, id: string): Promise<boolean>;
+  /** Replace the complete `(agentId, entityId)` list; room identifies new rows. */
   writeList(
     input: WriteTodoListInput,
   ): Promise<{ before: Todo[]; after: Todo[] }>;

--- a/plugins/plugin-todos/test/todos.real-db.test.ts
+++ b/plugins/plugin-todos/test/todos.real-db.test.ts
@@ -221,6 +221,88 @@ describe("TodosService + currentTodosProvider — real PGLite", () => {
     );
   });
 
+  it("reconciles a cross-room mark-complete by id instead of duplicating (regression #22124)", async () => {
+    // Reads (CURRENT_TODOS provider, list()) are entity-scoped across rooms,
+    // so writeList must reconcile against that same cross-room set. A todo
+    // created in ROOM_A and marked complete by id from ROOM_B must be UPDATED
+    // in place, not re-created as a new ROOM_B row while the ROOM_A original
+    // survives untouched (the pre-fix duplicate + lost-update corruption).
+    const entityId = "9a9a9a9a-9a9a-4a9a-8a9a-9a9a9a9a9a9a" as UUID;
+    const roomA = "a1a1a1a1-a1a1-4a1a-8a1a-a1a1a1a1a1a1" as UUID;
+    const roomB = "b2b2b2b2-b2b2-4b2b-8b2b-b2b2b2b2b2b2" as UUID;
+    const seeded = await service.create({
+      entityId,
+      agentId: runtime.agentId,
+      roomId: roomA,
+      content: "Cross-room todo",
+      status: "pending",
+    });
+
+    const { before, after } = await service.writeList({
+      entityId,
+      agentId: runtime.agentId,
+      roomId: roomB,
+      worldId: null,
+      parentTrajectoryStepId: null,
+      todos: [
+        { id: seeded.id, content: "Cross-room todo", status: "completed" },
+      ],
+    });
+    // The reconciler saw the ROOM_A row (matched by id) and updated it in place.
+    expect(before.map((t) => t.id)).toEqual([seeded.id]);
+    expect(after).toHaveLength(1);
+    expect(after[0]?.id).toBe(seeded.id);
+    expect(after[0]?.status).toBe("completed");
+
+    const rows = await service.list({ entityId, agentId: runtime.agentId });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(seeded.id);
+    expect(rows[0]?.status).toBe("completed");
+    // The original room is preserved; no duplicate ROOM_B row was minted.
+    expect(rows[0]?.roomId).toBe(roomA);
+  });
+
+  it("deletes a cross-room todo omitted from a writeList without duplicating the kept one (regression #22124)", async () => {
+    const entityId = "7c7c7c7c-7c7c-4c7c-8c7c-7c7c7c7c7c7c" as UUID;
+    const roomA = "c3c3c3c3-c3c3-4c3c-8c3c-c3c3c3c3c3c3" as UUID;
+    const roomB = "d4d4d4d4-d4d4-4d4d-8d4d-d4d4d4d4d4d4" as UUID;
+    const keep = await service.create({
+      entityId,
+      agentId: runtime.agentId,
+      roomId: roomA,
+      content: "Keep across rooms",
+      status: "pending",
+    });
+    const drop = await service.create({
+      entityId,
+      agentId: runtime.agentId,
+      roomId: roomA,
+      content: "Drop across rooms",
+      status: "pending",
+    });
+
+    // From ROOM_B the planner submits only the kept todo by id; the omitted one
+    // must be deleted from the shared cross-room set, not silently survive.
+    const { after } = await service.writeList({
+      entityId,
+      agentId: runtime.agentId,
+      roomId: roomB,
+      worldId: null,
+      parentTrajectoryStepId: null,
+      todos: [{ id: keep.id, content: "Keep across rooms", status: "pending" }],
+    });
+    expect(after.map((t) => t.id)).toEqual([keep.id]);
+
+    const rows = await service.list({ entityId, agentId: runtime.agentId });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(keep.id);
+    expect(rows.some((t) => t.id === drop.id)).toBe(false);
+    // Exactly one row, matched by id — no duplicate of the kept todo appeared.
+    expect(rows.filter((t) => t.content === "Keep across rooms")).toHaveLength(
+      1,
+    );
+  });
+
   it("rejects duplicate write ids without deleting rows or issuing a receipt", async () => {
     const entityId = "12345678-1234-4234-8234-123456789abc" as UUID;
     const roomId = "abcdefab-cdef-4def-8def-abcdefabcdef" as UUID;
@@ -577,7 +659,10 @@ describe("TodosService + currentTodosProvider — real PGLite", () => {
     ).toBeNull();
   });
 
-  it("detaches cross-room children when room-scoped writeList removes their parent", async () => {
+  it("detaches a cross-room child when writeList omits (deletes) its parent", async () => {
+    // writeList reconciles against the user's whole cross-room set, so a child
+    // kept by id while its parent is omitted must be detached, not orphaned or
+    // deleted, even though the two rows live in different rooms.
     const entityId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd" as UUID;
     const parent = await service.create({
       entityId,
@@ -593,17 +678,20 @@ describe("TodosService + currentTodosProvider — real PGLite", () => {
       parentTodoId: parent.id,
     });
 
+    // Called from a THIRD room; the desired list keeps only the child by id.
     await service.writeList({
       entityId,
       agentId: runtime.agentId,
-      roomId: "11111111-2222-4333-8444-555555555555",
+      roomId: "77777777-8888-4999-8aaa-bbbbbbbbbbbb",
       worldId: null,
       parentTrajectoryStepId: null,
-      todos: [],
+      todos: [{ id: child.id, content: "Room B child", status: "pending" }],
     });
-    expect(
-      (await service.get(scope(entityId), child.id))?.parentTodoId,
-    ).toBeNull();
+    // Parent (omitted) is deleted; child (kept) survives with a null parent.
+    expect(await service.get(scope(entityId), parent.id)).toBeNull();
+    const survivingChild = await service.get(scope(entityId), child.id);
+    expect(survivingChild).not.toBeNull();
+    expect(survivingChild?.parentTodoId).toBeNull();
   });
 
   it("serializes a parent clear against concurrent child creation", async () => {


### PR DESCRIPTION
# Relates to

Closes #22124

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates (test/typecheck/lint) pass. Full `bun run verify` was not run end-to-end on this machine — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below (`bun run --cwd plugins/plugin-todos test`).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — not run whole-repo here; owning-package gates pass. See **Known gaps / failures**.

# Risks

Low. The change is a few lines in one method (`SqlTodoStore.writeListInTransaction`) and only widens the reconciliation read from a room-scoped subset to the same `(agentId, entityId)` scope every other read path already uses. No schema change, no API change, no new export. The insert path (`roomId`/`worldId` seeding of new rows) is unchanged. Cross-room `clear` remains room-scoped and is unaffected.

# Background

## What does this PR do?

`TodosService.writeList()` is the "replace the whole list" reconciler behind the TODO action's `write` op: the caller passes the full desired list and the store reconciles — rows matched by id are updated, absent rows are deleted, new rows are inserted.

The bug: `writeList` computed its `before` (reconciliation) set with an extra `roomId` filter:

```ts
if (args.roomId !== null) filter.roomId = args.roomId;
```

But every **read** path is entity-scoped across rooms — the `CURRENT_TODOS` provider, `actionList`, and `service.list()` all key only on `(entityId, agentId)`, and the code/docs state "todos persist across rooms for the same user." The action always passes `roomId = message.roomId` (non-null in real chats). So the planner sees the user's whole todo set (entity-scoped provider) while its write reconciles against only the current room's subset. Result for any user who talks to the agent from more than one room (e.g. Telegram DM vs group):

1. An existing todo the model marks complete by id — created in another room — is **not matched**, so it is re-created as a **new duplicate row** while the original is left untouched (lost update).
2. Todos the model omits intending deletion **survive** because they aren't in the room-scoped `before`.

The fix drops the `roomId` narrowing on `before` so id-matching, update, and deletion all operate on the same set the model observed. `roomId`/`worldId` remain used only to seed newly created rows.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require project documentation changes. The method JSDoc in `sql-store.ts` was updated to state the `(agentId, entityId)` cross-room reconciliation scope and why room-narrowing is wrong.

# Testing

## Where should a reviewer start?

`plugins/plugin-todos/test/todos.real-db.test.ts` — real PGLite `AgentRuntime` via `packages/app-core/test/helpers/real-runtime.ts`, every assertion a write-then-read-back round-trip against a live DB (no network, no LLM, no credentials).

## Detailed testing steps

```bash
bun install
bun run --cwd plugins/plugin-todos test
```

Added real-DB regression cases:
- `reconciles a cross-room mark-complete by id instead of duplicating (regression #22124)` — create todo in ROOM_A pending; `writeList` from ROOM_B marking it complete by id; assert exactly 1 row, status `completed`, still in ROOM_A (no duplicate, no lost update).
- `deletes a cross-room todo omitted from a writeList without duplicating the kept one (regression #22124)` — seed two todos in ROOM_A; `writeList` from ROOM_B keeping only one by id; assert the omitted one is deleted and the kept one is not duplicated.
- Updated the cross-room child-detach case to the corrected entity-scoped semantics (parent omitted → deleted; kept child detached, not orphaned).

# Evidence Gate

<!-- evidence-head:b2ae2c6d64c663c144300fd8c3ebc3fc5630e2aa -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - back-end drizzle/DB reconciler change; no UI surface touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - back-end drizzle/DB reconciler change; no UI surface touched.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI/user flow; pure service-layer DB round-trip verified by real-PGLite tests.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - real-PGLite failing-before/passing-after logs are inline in Evidence Details; fork contributors cannot push to the pr-evidence release and this headless agent cannot mint /user-attachments URLs. Reviewer reproduces with: bun run --cwd plugins/plugin-todos test
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/LLM/prompt/model change; the reconciler is pure drizzle. The action that calls it is unchanged.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - stored todos row-states (before: [{ROOM_B,completed},{ROOM_A,pending}] count=2; after: [{ROOM_A,completed}] count=1) are inline in Evidence Details; same upload limitation as backend-logs
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Frontend: `N/A - no frontend`.

Backend — concrete stored `todos` row states after the exact reproduction (create todo in ROOM_A pending, then `writeList` from ROOM_B marking it complete by id, then `list({entityId, agentId})`), captured from a throwaway probe against the real PGLite DB:

<details>
<summary>Failing-before (buggy room-scoped <code>before</code>) — duplicate + lost update</summary>

```
PROBE_ROWS=[{"room":"ROOM_B","status":"completed"},{"room":"ROOM_A","status":"pending"}] count=2
```

A duplicate `completed` row was minted in ROOM_B while the original ROOM_A row was left `pending` (never matched/updated).
</details>

<details>
<summary>Passing-after (entity-scoped <code>before</code>) — single reconciled row</summary>

```
PROBE_ROWS=[{"room":"ROOM_A","status":"completed"}] count=1
```

The ROOM_A row was matched by id and updated in place; no duplicate.
</details>

Vitest, new regression cases against the **unpatched** code (failing-before):

<details>
<summary>failing-before — 2 failed</summary>

```
 ❯ test/todos.real-db.test.ts (25 tests | 2 failed | 23 skipped)
   × reconciles a cross-room mark-complete by id instead of duplicating (regression #22124)
   × deletes a cross-room todo omitted from a writeList without duplicating the kept one (regression #22124)

 FAIL > reconciles a cross-room mark-complete by id instead of duplicating (regression #22124)
 AssertionError: expected [] to deeply equal [ Array(1) ]
 - Expected  [ "05e526a9-...id-of-seeded-todo" ]
 + Received  []
   250|     expect(before.map((t) => t.id)).toEqual([seeded.id]);

 FAIL > deletes a cross-room todo omitted from a writeList without duplicating the kept one (regression #22124)
 AssertionError: expected [ "6b45636c-..." (a NEW duplicate id) ] to deeply equal [ "6174f690-..." (kept id) ]
   294|     expect(after.map((t) => t.id)).toEqual([keep.id]);
```
</details>

Vitest, full package suite against the **patched** code (passing-after):

<details>
<summary>passing-after — todos.real-db.test.ts, 25 passed</summary>

```
 Test Files  1 passed (1)
      Tests  25 passed (25)
   Duration  34.90s
```
</details>

<details>
<summary>passing-after — full plugin-todos suite, 113 passed</summary>

```
 Test Files  7 passed (7)
      Tests  113 passed (113)
```
</details>

Typecheck + lint (patched):

```
$ bun run --cwd plugins/plugin-todos typecheck
$ tsc --noEmit -p tsconfig.json        # clean, no errors

$ bun run --cwd plugins/plugin-todos lint:check
$ bunx @biomejs/biome check .
Checked 29 files in 161ms. No fixes applied.
```

## Screenshots (before / after) + video walkthrough

`N/A - back-end DB reconciler change with no rendered surface.`

## Audio / voice walkthrough

`N/A - no voice/audio path.`

## Known gaps / failures

- Whole-repo `bun run verify` was not run to completion on this machine: the environment's global bun `minimumReleaseAge` gate blocks a fresh `bun install` of the pinned lockfile, so install required `--minimum-release-age=0` (installs only the versions already pinned by `origin/develop`). Two generated/build prerequisites also had to be produced locally (`packages/core` i18n keyword codegen and the `@elizaos/core`/`@elizaos/cloud-routing`/`@elizaos/logger` builds) before the package could typecheck/test. After those, the owning package's `test` (113 passed), `typecheck` (clean), and `lint:check` (clean) all pass, and the failing-before → passing-after regression is demonstrated above. None of these are related to the change.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@e565c3f0bc65a8d3429c78b47bc04e63943d2216:packages/skills/skills/contribute-to-eliza"} -->



