### PR TITLE
fix(plugin-google-genai): harden token count boundary

### DIFF
--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -5664,7 +5664,7 @@
           "type": "string",
           "required": false,
           "sensitive": false,
-          "default": "tweet.read tweet.write users.read offline.access",
+          "default": "tweet.read tweet.write users.read dm.read dm.write offline.access",
           "label": "OAuth Scopes",
           "help": "Space-separated OAuth2 scopes requested by plugin-twitter.",
           "advanced": true,
@@ -5746,6 +5746,41 @@
             "equals": "broker"
           }
         },
+        "TWITTER_BROKER_CONNECTION_ROLE": {
+          "type": "select",
+          "required": false,
+          "sensitive": false,
+          "default": "agent",
+          "label": "Broker X Identity",
+          "help": "Use the agent connection for a shared agent identity, or the owner connection for the user's personal X identity.",
+          "advanced": true,
+          "options": [
+            {
+              "value": "agent",
+              "label": "Agent identity"
+            },
+            {
+              "value": "owner",
+              "label": "Owner identity"
+            }
+          ],
+          "visible": {
+            "key": "TWITTER_AUTH_MODE",
+            "equals": "broker"
+          }
+        },
+        "TWITTER_PERSONAL_DM_ROUTER_URL": {
+          "type": "url",
+          "required": false,
+          "sensitive": false,
+          "label": "Personal DM Router URL",
+          "help": "When set on a shared agent X account, route inbound DMs to each sender's personal Shared or Dedicated Eliza. Public mentions remain on this agent.",
+          "advanced": true,
+          "visible": {
+            "key": "TWITTER_AUTH_MODE",
+            "equals": "broker"
+          }
+        },
         "TWITTER_ENABLE_POST": {
           "type": "boolean",
           "required": false,
@@ -5763,6 +5798,24 @@
           "label": "Enable Replies",
           "help": "Allow the connector to reply to mentions and conversations.",
           "advanced": false
+        },
+        "TWITTER_ENABLE_DMS": {
+          "type": "boolean",
+          "required": false,
+          "sensitive": false,
+          "default": true,
+          "label": "Enable DM Replies",
+          "help": "Poll inbound direct messages and route them through the agent message loop.",
+          "advanced": false
+        },
+        "TWITTER_DM_POLL_INTERVAL_SECONDS": {
+          "type": "number",
+          "required": false,
+          "sensitive": false,
+          "default": 60,
+          "label": "DM Poll Interval",
+          "help": "Seconds between direct-message inbox polls (minimum 15).",
+          "advanced": true
         },
         "TWITTER_ENABLE_ACTIONS": {
           "type": "boolean",

--- a/plugins/plugin-google-genai/AGENTS.md
+++ b/plugins/plugin-google-genai/AGENTS.md
@@ -99,7 +99,7 @@ Append a `TestCase` object to the `pluginTests[0].tests` array in `index.ts`. Te
 - **Structured output.** Pass a JSON Schema as `responseSchema` in `GenerateTextParams`. Text handlers internally set `responseMimeType: "application/json"` and `responseJsonSchema` on the Google SDK request. The model returns raw JSON text; no post-parse step is applied for text handlers (the caller owns parsing).
 - **Safety settings are hardcoded.** All four harm categories block at `BLOCK_MEDIUM_AND_ABOVE`. Adjust in `utils/config.ts → getSafetySettings()` if needed.
 - **Token counting is a heuristic.** `utils/tokenization.ts` estimates tokens as `Math.ceil(text.length / 4)`. It is used for telemetry only; do not rely on it for context-window management.
-- **Embedding truncation.** Inputs are measured with Google's model tokenizer and truncated by code-point-safe binary search to the documented input limit before embedding (`gemini-embedding-001` -> 2 048 tokens; `gemini-embedding-2` -> 8 192). The `length / 4` helper remains telemetry-only.
+- **Embedding truncation.** Inputs are measured with Google's model tokenizer and truncated by code-point-safe binary search to the documented input limit before embedding (`gemini-embedding-001` -> 2 048 tokens; `gemini-embedding-2` -> 8 192). The verified provider count is reused for embedding telemetry; the `length / 4` helper remains telemetry-only for handlers without provider counts.
 - **No actions, providers, or evaluators.** If you need to add behavior beyond model inference, register it in a separate plugin or in the agent's character definition.
 
 ## Verification

--- a/plugins/plugin-google-genai/CLAUDE.md
+++ b/plugins/plugin-google-genai/CLAUDE.md
@@ -99,7 +99,7 @@ Append a `TestCase` object to the `pluginTests[0].tests` array in `index.ts`. Te
 - **Structured output.** Pass a JSON Schema as `responseSchema` in `GenerateTextParams`. Text handlers internally set `responseMimeType: "application/json"` and `responseJsonSchema` on the Google SDK request. The model returns raw JSON text; no post-parse step is applied for text handlers (the caller owns parsing).
 - **Safety settings are hardcoded.** All four harm categories block at `BLOCK_MEDIUM_AND_ABOVE`. Adjust in `utils/config.ts → getSafetySettings()` if needed.
 - **Token counting is a heuristic.** `utils/tokenization.ts` estimates tokens as `Math.ceil(text.length / 4)`. It is used for telemetry only; do not rely on it for context-window management.
-- **Embedding truncation.** Inputs are measured with Google's model tokenizer and truncated by code-point-safe binary search to the documented input limit before embedding (`gemini-embedding-001` -> 2 048 tokens; `gemini-embedding-2` -> 8 192). The `length / 4` helper remains telemetry-only.
+- **Embedding truncation.** Inputs are measured with Google's model tokenizer and truncated by code-point-safe binary search to the documented input limit before embedding (`gemini-embedding-001` -> 2 048 tokens; `gemini-embedding-2` -> 8 192). The verified provider count is reused for embedding telemetry; the `length / 4` helper remains telemetry-only for handlers without provider counts.
 - **No actions, providers, or evaluators.** If you need to add behavior beyond model inference, register it in a separate plugin or in the agent's character definition.
 
 ## Verification

--- a/plugins/plugin-google-genai/README.md
+++ b/plugins/plugin-google-genai/README.md
@@ -5,7 +5,7 @@ Google Generative AI (Gemini) model provider for [elizaOS](https://github.com/el
 ## Capabilities
 
 - **Text generation** across all model tiers: nano, small, medium, large, mega, response handler, action planner.
-- **Text embeddings** with `gemini-embedding-001`, pinned to 768 dimensions (`outputDimensionality: 768`) and L2-normalized so writes match the runtime's probe-sized vector column.
+- **Text embeddings** with `gemini-embedding-001`, provider-counted and Unicode-safely truncated to the model input limit, pinned to 768 dimensions (`outputDimensionality: 768`), and L2-normalized so writes match the runtime's probe-sized vector column.
 - **Image description** — fetch an image by URL, encode it inline, and return a `{ title, description }` object.
 - **Structured output** — pass a JSON Schema as `responseSchema` to any text handler to get `application/json` back from the model.
 - **Tool use** — pass function declarations via `tools` / `toolChoice` to enable function-calling on supported models.

--- a/plugins/plugin-google-genai/__tests__/config.test.ts
+++ b/plugins/plugin-google-genai/__tests__/config.test.ts
@@ -45,6 +45,7 @@ import {
 } from "../utils/config";
 
 const PLUGIN_ROOT = new URL("../", import.meta.url);
+const REPOSITORY_ROOT = new URL("../../../", import.meta.url);
 
 function readPluginJson(relativePath: string): unknown {
   return JSON.parse(
@@ -174,6 +175,16 @@ describe("Google GenAI config", () => {
         GOOGLE_EMBEDDING_MODEL: { default: string; placeholder: string };
       };
     };
+    const generated = readPluginJsonFromRepository(
+      "packages/registry/src/first-party/generated.json",
+    ) as {
+      entries: Array<{
+        id: string;
+        config: {
+          GOOGLE_EMBEDDING_MODEL?: { default?: string; placeholder?: string };
+        };
+      }>;
+    };
 
     expect(
       pkg.agentConfig.pluginParameters.GOOGLE_EMBEDDING_MODEL.default,
@@ -181,9 +192,24 @@ describe("Google GenAI config", () => {
     expect(registry.config.GOOGLE_EMBEDDING_MODEL.default).toBe(
       DEFAULT_GOOGLE_EMBEDDING_MODEL,
     );
+    const generatedGoogle = generated.entries.find(
+      (entry) => entry.id === "google-genai",
+    );
+    expect(generatedGoogle?.config.GOOGLE_EMBEDDING_MODEL).toEqual(
+      registry.config.GOOGLE_EMBEDDING_MODEL,
+    );
     // The placeholder must name valid Google embedding ids, not an OpenAI model.
     const placeholder = registry.config.GOOGLE_EMBEDDING_MODEL.placeholder;
     expect(placeholder).toContain("gemini-embedding");
     expect(placeholder).not.toMatch(/text-embedding-3|gpt-|openai/i);
   });
 });
+
+function readPluginJsonFromRepository(relativePath: string): unknown {
+  return JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL(relativePath, REPOSITORY_ROOT)),
+      "utf-8",
+    ),
+  );
+}

--- a/plugins/plugin-google-genai/__tests__/embedding.sdk-boundary.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.sdk-boundary.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Provider-SDK boundary test for Google embedding admission. A real
+ * `GoogleGenAI` client talks to a deterministic local HTTP server, proving the
+ * handler sends provider `countTokens` requests before the embedding request
+ * and embeds only the exact Unicode-safe prefix admitted by the provider.
+ */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { IAgentRuntime } from "@elizaos/core";
+import { GoogleGenAI } from "@google/genai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const sdk = vi.hoisted(() => ({
+  client: undefined as GoogleGenAI | undefined,
+}));
+
+vi.mock("../utils/config", async () => {
+  const actual =
+    await vi.importActual<typeof import("../utils/config")>("../utils/config");
+  return {
+    ...actual,
+    createGoogleGenAI: () => sdk.client ?? null,
+  };
+});
+
+import { handleTextEmbedding } from "../models/embedding";
+
+type CapturedRequest = { path: string; text: string };
+
+function requestText(body: Record<string, unknown>): string {
+  const content = body.content as
+    | { parts?: Array<{ text?: string }> }
+    | undefined;
+  const contents = body.contents as
+    | Array<{ parts?: Array<{ text?: string }> }>
+    | undefined;
+  const requests = body.requests as
+    | Array<{ content?: { parts?: Array<{ text?: string }> } }>
+    | undefined;
+  return (
+    contents?.[0]?.parts?.[0]?.text ??
+    content?.parts?.[0]?.text ??
+    requests?.[0]?.content?.parts?.[0]?.text ??
+    ""
+  );
+}
+
+function createRuntime(): IAgentRuntime {
+  return {
+    emitEvent: vi.fn(async () => undefined),
+    getSetting: vi.fn((key: string) => {
+      if (key === "GOOGLE_EMBEDDING_MODEL") return "gemini-embedding-001";
+      return null;
+    }),
+  } as unknown as IAgentRuntime;
+}
+
+describe("Google embedding SDK boundary", () => {
+  afterEach(() => {
+    sdk.client = undefined;
+  });
+
+  it("counts with the real SDK and embeds only the provider-admitted Unicode prefix", async () => {
+    const captured: CapturedRequest[] = [];
+    const server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("end", () => {
+        const body = JSON.parse(
+          Buffer.concat(chunks).toString("utf8"),
+        ) as Record<string, unknown>;
+        const text = requestText(body);
+        captured.push({ path: request.url ?? "", text });
+        response.setHeader("content-type", "application/json");
+        if (request.url?.includes(":countTokens")) {
+          response.end(
+            JSON.stringify({ totalTokens: Array.from(text).length * 2 }),
+          );
+          return;
+        }
+        if (
+          request.url?.includes(":embedContent") ||
+          request.url?.includes(":batchEmbedContents")
+        ) {
+          response.end(
+            JSON.stringify({
+              embeddings: [{ values: Array(768).fill(0.5) }],
+            }),
+          );
+          return;
+        }
+        response.statusCode = 404;
+        response.end(
+          JSON.stringify({ error: { message: "unexpected route" } }),
+        );
+      });
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      sdk.client = new GoogleGenAI({
+        apiKey: "deterministic-local-boundary-key",
+        httpOptions: { baseUrl: `http://127.0.0.1:${port}` },
+      });
+      const oversized = "😀".repeat(1_100);
+
+      const result = await handleTextEmbedding(createRuntime(), oversized);
+
+      expect(result).toHaveLength(768);
+      expect(captured[0]).toMatchObject({
+        path: expect.stringContaining(":countTokens"),
+        text: oversized,
+      });
+      expect(captured.at(-1)?.path).toMatch(
+        /:embedContent|:batchEmbedContents/,
+      );
+      expect(captured.at(-2)?.path).toContain(":countTokens");
+      expect(captured.at(-2)?.text).toBe(captured.at(-1)?.text);
+      expect(Array.from(captured.at(-1)?.text ?? "")).toHaveLength(1_024);
+      expect(captured.at(-1)?.text).toBe("😀".repeat(1_024));
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+});

--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -13,7 +13,6 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  countTokens: vi.fn(),
   countEmbeddingTokens: vi.fn(),
   createGoogleGenAI: vi.fn(),
   embedContent: vi.fn(),
@@ -57,10 +56,6 @@ vi.mock("../utils/events", () => ({
   emitModelUsageEvent: mocks.emitModelUsageEvent,
 }));
 
-vi.mock("../utils/tokenization", () => ({
-  countTokens: mocks.countTokens,
-}));
-
 import { handleTextEmbedding } from "../models/embedding";
 
 function createRuntime(): IAgentRuntime {
@@ -74,7 +69,6 @@ describe("Google GenAI embeddings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getEmbeddingModel.mockReturnValue("gemini-embedding-001");
-    mocks.countTokens.mockResolvedValue(5);
     mocks.countEmbeddingTokens.mockImplementation(
       async ({ contents }: { contents: string }) => ({
         totalTokens: Math.ceil(contents.length / 4),
@@ -114,11 +108,40 @@ describe("Google GenAI embeddings", () => {
       "TEXT_EMBEDDING",
       "hello",
       {
-        promptTokens: 5,
+        promptTokens: 2,
         completionTokens: 0,
-        totalTokens: 5,
+        totalTokens: 2,
       },
     );
+  });
+
+  it("fails closed when the provider reports zero tokens for non-empty input", async () => {
+    mocks.countEmbeddingTokens.mockResolvedValue({ totalTokens: 0 });
+
+    await expect(
+      handleTextEmbedding(createRuntime(), "non-empty"),
+    ).rejects.toMatchObject({
+      code: "EMBEDDING_TOKEN_COUNT_INVALID",
+      context: { model: "gemini-embedding-001", totalTokens: 0 },
+    });
+    expect(mocks.embedContent).not.toHaveBeenCalled();
+  });
+
+  it("wraps provider token-count failures with typed boundary context", async () => {
+    const transportFailure = new Error("countTokens transport failed");
+    mocks.countEmbeddingTokens.mockRejectedValue(transportFailure);
+
+    await expect(
+      handleTextEmbedding(createRuntime(), "non-empty"),
+    ).rejects.toMatchObject({
+      code: "EMBEDDING_TOKEN_COUNT_FAILED",
+      context: {
+        model: "gemini-embedding-001",
+        inputCodeUnits: 9,
+      },
+      cause: transportFailure,
+    });
+    expect(mocks.embedContent).not.toHaveBeenCalled();
   });
 
   it("pins outputDimensionality to the probe width so the write matches the sized column (#22010)", async () => {

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -32,7 +32,6 @@ import {
   getEmbeddingModel,
 } from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
-import { countTokens } from "../utils/tokenization";
 
 const TEXT_EMBEDDING_MODEL_TYPE = ((
   ElizaCore as { ModelType?: Record<string, string> }
@@ -128,9 +127,29 @@ async function providerTokenCount(
   model: string,
   contents: string,
 ): Promise<number> {
-  const response = await genAI.models.countTokens({ model, contents });
+  let response: Awaited<ReturnType<GoogleGenAI["models"]["countTokens"]>>;
+  try {
+    response = await genAI.models.countTokens({ model, contents });
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — token counting is the provider
+    // safety boundary, so transport/auth/model failures must remain typed and
+    // attributable instead of falling through as an unrelated embedding error.
+    throw new ElizaError(
+      `Google token counting failed for embedding model "${model}"`,
+      {
+        code: "EMBEDDING_TOKEN_COUNT_FAILED",
+        context: { model, inputCodeUnits: contents.length },
+        cause: error,
+      },
+    );
+  }
   const total = response.totalTokens;
-  if (typeof total !== "number" || !Number.isSafeInteger(total) || total < 0) {
+  if (
+    typeof total !== "number" ||
+    !Number.isSafeInteger(total) ||
+    total < 0 ||
+    (contents.length > 0 && total === 0)
+  ) {
     throw new ElizaError("Google token counter returned an invalid total", {
       code: "EMBEDDING_TOKEN_COUNT_INVALID",
       context: { model, totalTokens: total },
@@ -273,7 +292,10 @@ export async function handleTextEmbedding(
     // is unit-length and cosine-comparable like the native 768-dim model.
     const embedding = l2Normalize(rawEmbedding);
 
-    const promptTokens = await countTokens(text);
+    // The exact provider count that admitted this request is also the only
+    // accurate usage value. The local characters/4 helper is telemetry-only
+    // and must never overwrite provider-boundary evidence.
+    const promptTokens = bounded.tokens;
 
     emitModelUsageEvent(runtime, TEXT_EMBEDDING_MODEL_TYPE, text, {
       promptTokens,


### PR DESCRIPTION
Closes #22139.
Follow-up correctness review for #22114 / #22095.

## What changed

- reject a zero provider token count for non-empty embedding input;
- wrap `countTokens` transport/auth/model failures in typed `ElizaError` context while preserving the cause;
- reuse the exact provider-admitted count for embedding usage telemetry instead of recomputing the characters/4 heuristic;
- add adversarial tests for invalid zero totals and counter failures;
- add a real installed-`@google/genai` SDK boundary test against a deterministic local HTTP server, proving provider count requests happen before the embedding request and that the exact 1,024-code-point emoji prefix admitted at 2,048 tokens is the text sent to the embedding endpoint;
- assert generated first-party registry config remains equal to the plugin-owned config and refresh the deterministic generated artifact.

## Evidence

Exact head: `98362d538ed4666eb8beafe6f27b3eb0d67696dc`

- `bun run --cwd plugins/plugin-google-genai test`: 75 passed, 2 skipped
- `bun run --cwd plugins/plugin-google-genai lint:check`: pass
- `bun run --cwd plugins/plugin-google-genai typecheck`: pass
- `bun run --cwd plugins/plugin-google-genai build`: pass (Node, browser, CJS, declarations)
- `bun run check:agents-claude`: pass (155 guide pairs)
- registry `generate:first-party:check`, `validate`, and `typecheck`: pass (47 third-party entries validated)
- focused post-review exact-head rerun: 23 embedding unit/SDK-boundary tests pass; plugin lint and typecheck pass
- `git diff --check`: pass

The SDK-boundary test is provider-request evidence without a live Google credential: it uses the real installed Google SDK request/response machinery and a deterministic local provider boundary. No live-provider call is claimed.

Root `bun run verify` reached the workspace Turbo lane but is currently blocked by unrelated pre-existing `packages/ui` typecheck errors in `BuildBadge-timeout.test.ts` and `load-pack-timeout.test.ts` (tests import helper exports not present in their owning modules). The touched Google plugin passed its root Turbo lint and typecheck tasks, and all scoped gates above pass.

