### PR TITLE
fix(wallet): bound Jupiter fetch with timeout

### DIFF
--- a/plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts
+++ b/plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Jupiter fetch deadlines — proves fetchJupiterJson aborts on timeout via
+ * real hanging HTTP server, merging caller signals and keeping signal
+ * through response.json() (body stall).
+ */
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_JUPITER_FETCH_TIMEOUT_MS, fetchJupiterJson } from "./jupiter-api.ts";
+
+describe("fetchJupiterJson timeout (real server)", () => {
+  let origTimeout: typeof AbortSignal.timeout;
+
+  beforeEach(() => {
+    origTimeout = AbortSignal.timeout.bind(AbortSignal);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exposes the documented 10s budget", () => {
+    expect(DEFAULT_JUPITER_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("aborts a stalled Jupiter quote fetch at the deadline (hanging server)", async () => {
+    const server = http.createServer((_req, _res) => {
+      // hang
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/quote?inputMint=So111&outputMint=USDC&amount=1000`;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => origTimeout(10));
+    try {
+      await expect(fetchJupiterJson(globalThis.fetch, url, "quote")).rejects.toMatchObject({
+        // ElizaError wraps TimeoutError as cause
+        cause: expect.objectContaining({ name: "TimeoutError" }),
+      });
+      expect(timeoutSpy).toHaveBeenCalledWith(DEFAULT_JUPITER_FETCH_TIMEOUT_MS);
+    } finally {
+      timeoutSpy.mockRestore();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("aborts a stalled Jupiter swap fetch at the deadline", async () => {
+    const server = http.createServer((_req, _res) => {});
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/swap`;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => origTimeout(10));
+    try {
+      await expect(
+        fetchJupiterJson(globalThis.fetch, url, "swap", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({}),
+        })
+      ).rejects.toMatchObject({
+        cause: expect.objectContaining({ name: "TimeoutError" }),
+      });
+      expect(timeoutSpy).toHaveBeenCalledWith(DEFAULT_JUPITER_FETCH_TIMEOUT_MS);
+    } finally {
+      timeoutSpy.mockRestore();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("aborts a partial JSON body stall (signal kept through response.json)", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write('{"data":');
+      // stall body
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/quote?inputMint=So111&outputMint=USDC&amount=1000`;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => origTimeout(10));
+    try {
+      await expect(fetchJupiterJson(globalThis.fetch, url, "quote")).rejects.toMatchObject({
+        cause: expect.objectContaining({ name: "TimeoutError" }),
+      });
+      expect(timeoutSpy).toHaveBeenCalledWith(DEFAULT_JUPITER_FETCH_TIMEOUT_MS);
+    } finally {
+      timeoutSpy.mockRestore();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("preserves TimeoutError cause and does not swallow abort", async () => {
+    const server = http.createServer((_req, _res) => {});
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/quote`;
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => origTimeout(10));
+    try {
+      try {
+        await fetchJupiterJson(globalThis.fetch, url, "quote");
+        throw new Error("should have timed out");
+      } catch (err) {
+        const e = err as { cause?: unknown };
+        expect((e.cause as Error).name).toBe("TimeoutError");
+        expect(e.cause).toBeInstanceOf(DOMException);
+      }
+    } finally {
+      vi.restoreAllMocks();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("merges a caller signal via AbortSignal.any", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/quote`;
+    const controller = new AbortController();
+    const anySpy = vi.spyOn(AbortSignal, "any");
+    try {
+      const res = await fetchJupiterJson(globalThis.fetch, url, "quote", {
+        signal: controller.signal,
+      });
+      expect(res).toEqual({ ok: true });
+      expect(anySpy).toHaveBeenCalled();
+      const merged = anySpy.mock.calls[0]?.[0] as AbortSignal[] | undefined;
+      expect(merged).toContain(controller.signal);
+    } finally {
+      anySpy.mockRestore();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("sends the abort signal and succeeds on a fast upstream", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ data: "ok" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/quote`;
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      const res = await fetchJupiterJson(globalThis.fetch, url, "quote");
+      expect(res).toEqual({ data: "ok" });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+      const signal = (fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined)?.signal as
+        | AbortSignal
+        | undefined;
+      expect(signal?.aborted).toBe(false);
+    } finally {
+      fetchSpy.mockRestore();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("surfaces a provider error from a completed 503 upstream", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(503, { "content-type": "text/plain" });
+      res.end("Service Unavailable");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/quote`;
+    try {
+      await expect(fetchJupiterJson(globalThis.fetch, url, "quote")).rejects.toMatchObject({
+        code: "JUPITER_QUOTE_HTTP_ERROR",
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("uses fresh timeout signal per attempt (no reused aborted signal)", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/quote`;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    try {
+      await fetchJupiterJson(globalThis.fetch, url, "quote");
+      await fetchJupiterJson(globalThis.fetch, url, "quote");
+      expect(timeoutSpy).toHaveBeenCalledTimes(2);
+      expect(timeoutSpy.mock.calls[0]?.[0]).toBe(DEFAULT_JUPITER_FETCH_TIMEOUT_MS);
+      expect(timeoutSpy.mock.calls[1]?.[0]).toBe(DEFAULT_JUPITER_FETCH_TIMEOUT_MS);
+    } finally {
+      timeoutSpy.mockRestore();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/plugins/plugin-wallet/src/chains/solana/jupiter-api.ts
+++ b/plugins/plugin-wallet/src/chains/solana/jupiter-api.ts
@@ -5,6 +5,7 @@
 import { ElizaError } from "@elizaos/core";
 
 export const DEFAULT_JUPITER_API_BASE_URL = "https://lite-api.jup.ag/swap/v1";
+export const DEFAULT_JUPITER_FETCH_TIMEOUT_MS = 10_000;
 export const JUPITER_API_BASE_URL_SETTING = "JUPITER_API_BASE_URL";
 
 type RuntimeSettings = { getSetting(key: string): unknown };
@@ -58,9 +59,11 @@ export async function fetchJupiterJson(
   stage: JupiterStage,
   init?: RequestInit
 ): Promise<Record<string, unknown>> {
+  const timeoutSignal = AbortSignal.timeout(DEFAULT_JUPITER_FETCH_TIMEOUT_MS);
+  const signal = init?.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal;
   let response: Response;
   try {
-    response = await fetchFn(url, init);
+    response = await fetchFn(url, { ...init, signal });
   } catch (cause) {
     // error-policy:J2 Classify DNS/network failures while retaining the fetch cause.
     throw new ElizaError(`Jupiter ${stage} request failed`, {


### PR DESCRIPTION
Closes #22146

# Relates to

Fixes `fetchJupiterJson` hang on `develop` @ `0db82c3731b55b23faab9cdf74e2ea8259ef57fc` (`0db82c3731b55b23faab9cdf74e2ea8259ef57fc`). `fetchJupiterJson` in `plugins/plugin-wallet/src/chains/solana/jupiter-api.ts:55` had no deadline — any stalled `https://lite-api.jup.ag` hangs Jupiter quote/swap through both Solana paths (`service.ts:852,874` and `registry.ts:954,967`). Mirrors merged `21234`/`21198` and sibling `birdeye/x402` timeouts.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` (`0db82c3731b55b23faab9cdf74e2ea8259ef57fc` parent `0075ea8b5e8c0a646a370d60f609b83f79c36671`) with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0db82c3731b55b23faab9cdf74e2ea8259ef57fc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `0075ea8b5e8c0a646a370d60f609b83f79c36671` (`0075ea8b5e8c0a646a370d60f609b83f79c36671`); zero conflicts.
- [x] `bun install` completed; focused checks on exact final head `0db82c3731b55b23faab9cdf74e2ea8259ef57fc`: `check:agents-claude` PASS (via `bun run verify` lanes), `biome` PASS on changed files, `vitest` 16/16 PASS (see Testing). Full `tsc --noEmit` in frozen install reports pre-existing unresolved artifacts (capacitor bridge, wallet, cloud-routing, generated i18n, optional-plugin imports) — not related to this change and reproduced on `origin/develop` clean; not claimed clean. `git diff --check` clean.

# Risks

Low. Adds `DEFAULT_JUPITER_FETCH_TIMEOUT_MS = 10_000` and `signal: AbortSignal.timeout(DEFAULT_JUPITER_FETCH_TIMEOUT_MS)` merged via `AbortSignal.any([init.signal, timeout])` when caller supplies `init.signal`. No API or storage change. Bounded 10s abort prevents indefinite hang; fresh signal per attempt, not reused. Preserves `TimeoutError` through `response.json()` (merged 21868 pattern) — body stall also aborts.

# Background

## What does this PR do?

Adds deadline to Jupiter fetches: `fetchJupiterJson(fetchFn, url, stage, init)` now creates `timeoutSignal = AbortSignal.timeout(DEFAULT_JUPITER_FETCH_TIMEOUT_MS)` and `signal = init?.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal`, then `fetchFn(url, { ...init, signal })`. Signal is kept through `response.json()` so partial-body stall also times out. Centralizes via `DEFAULT_JUPITER_FETCH_TIMEOUT_MS` for test pinning.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-wallet/src/chains/solana/jupiter-api.ts:7,62`
- `plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts`
- `plugins/plugin-wallet/src/chains/solana/jupiter-api.test.ts` (existing)

## Detailed testing steps

1. `bunx vitest run plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts plugins/plugin-wallet/src/chains/solana/jupiter-api.test.ts` — real `fetchJupiterJson` against hanging `http.createServer` and mocked `fetch`:
   - constant `10_000`
   - hanging Jupiter quote with mocked `AbortSignal.timeout(10)` → `TimeoutError` wrapped as `ElizaError` cause and spy called with `DEFAULT_JUPITER_FETCH_TIMEOUT_MS`
   - hanging Jupiter swap with POST and mocked `AbortSignal.timeout(10)` → `TimeoutError` cause
   - partial JSON body stall (`http.createServer` writes `{"data":` then stalls) → `TimeoutError` cause (signal kept through `response.json()`)
   - preserves `TimeoutError` cause (`DOMException.TIMEOUT_ERR`) not swallowed
   - merges caller signal via `AbortSignal.any` (`controller.signal` in `init` → `anySpy` contains it)
   - fast success via real server 200 → `{ data: "ok" }` and `signal: expect.any(AbortSignal)` not aborted
   - provider 503 via real server → `JUPITER_QUOTE_HTTP_ERROR`
   - fresh timeout per attempt (2 sequential calls → `AbortSignal.timeout` called twice)
2. `bunx vitest run plugins/plugin-wallet/src/chains/solana/jupiter-api.test.ts` included — 7 existing tests still pass. Combined **16/16** (9 timeout + 7 existing).
3. `bunx @biomejs/biome check plugins/plugin-wallet/src/chains/solana/jupiter-api.ts plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts` and `git diff --check` clean on changed files; `tsc --noEmit` pre-existing blockers noted above, not newly introduced.

```
jupiter-api.timeout.test.ts (9 tests) passed
jupiter-api.test.ts (7 tests) passed
Checked 2 files in 6ms. No fixes applied.
git diff --check: clean
tsc --noEmit: pre-existing unresolved modules (capacitor bridge, @elizaos/cloud-routing, etc.) — reproduced on origin/develop, not introduced by this change
```

# Evidence Gate

<!-- evidence-head:0db82c3731b55b23faab9cdf74e2ea8259ef57fc -->
<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only wallet service, no rendered UI`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend-only wallet service, no rendered UI`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - deterministic service timeout, no interactive flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not N/A, logs pasted in Testing`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - no domain artifact beyond test fetch mock`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/model change, pure fetch timeout.`

## Backend + frontend logs

Backend: `jupiter-api.timeout.test.ts` 9 + `jupiter-api.test.ts` 7 = 16 passed as above. Frontend: `N/A`.

## Screenshots (before / after) + video walkthrough

`N/A - backend-only change.`

## Audio / voice walkthrough

`N/A - no voice change.`

## Known gaps / failures

None — pre-existing `tsc` unresolved artifacts (capacitor bridge, cloud-routing) reproduced on `origin/develop` (`0075ea8b5e8c0a646a370d60f609b83f79c36671`) clean checkout, not introduced by this change.

AI provider/model: openai / gpt-5.6
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@0db82c3731b55b23faab9cdf74e2ea8259ef57fc:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
