### PR TITLE
fix(ios): start native new chat empty

### DIFF
--- a/packages/ui/src/state/useChatCallbacks.hydrate.test.ts
+++ b/packages/ui/src/state/useChatCallbacks.hydrate.test.ts
@@ -13,6 +13,7 @@ import {
   type HydrateConversationClient,
   type HydrateInitialConversationDeps,
   hydrateInitialConversation,
+  shouldSeedSyntheticConversationGreeting,
 } from "./useChatCallbacks";
 
 const CONVERSATION = {
@@ -39,7 +40,10 @@ function makeFakeClient(
   } as any;
 }
 
-function makeDeps(client: ReturnType<typeof makeFakeClient>) {
+function makeDeps(
+  client: ReturnType<typeof makeFakeClient>,
+  seedSyntheticGreeting = true,
+) {
   const setConversations = vi.fn();
   const setActiveConversationId = vi.fn();
   const setConversationMessages = vi.fn();
@@ -62,6 +66,7 @@ function makeDeps(client: ReturnType<typeof makeFakeClient>) {
     setActiveConversationId,
     setConversationMessages,
     uiLanguage: "en",
+    seedSyntheticGreeting,
   };
   return {
     deps,
@@ -81,6 +86,34 @@ beforeEach(() => {
 afterEach(() => vi.clearAllMocks());
 
 describe("hydrateInitialConversation — chat always has a chat (#1)", () => {
+  it("disables synthetic greetings only for native iOS", () => {
+    expect(shouldSeedSyntheticConversationGreeting(true, true)).toBe(false);
+    expect(shouldSeedSyntheticConversationGreeting(true, false)).toBe(true);
+    expect(shouldSeedSyntheticConversationGreeting(false, true)).toBe(true);
+    expect(shouldSeedSyntheticConversationGreeting(false, false)).toBe(true);
+  });
+
+  it("starts native iOS with an active empty conversation and no greeting backfill", async () => {
+    const client = makeFakeClient();
+    const {
+      deps,
+      setActiveConversationId,
+      setConversationMessages,
+      greetingFiredRef,
+      loadedConversationIdRef,
+    } = makeDeps(client, false);
+
+    expect(await hydrateInitialConversation(deps)).toBeNull();
+    expect(client.createConversation).toHaveBeenCalledWith(undefined, {
+      bootstrapGreeting: false,
+      lang: "en",
+    });
+    expect(setActiveConversationId).toHaveBeenCalledWith("c1");
+    expect(setConversationMessages.mock.calls.at(-1)?.[0]).toEqual([]);
+    expect(greetingFiredRef.current).toBe(false);
+    expect(loadedConversationIdRef.current).toBe("c1");
+  });
+
   it("seeds a greeted conversation when the server has none, on ANY route (not just /chat)", async () => {
     // Boot on a NON-chat route — exactly the case the old gate left empty.
     window.history.replaceState(null, "", "/views");
@@ -268,6 +301,18 @@ describe("hydrateInitialConversation — chat always has a chat (#1)", () => {
     const { deps } = makeDeps(client);
 
     expect(await hydrateInitialConversation(deps)).toBe("c1");
+  });
+
+  it("does not backfill an empty restored conversation under the native iOS policy", async () => {
+    const client = makeFakeClient({
+      listConversations: vi.fn(async () => ({
+        conversations: [{ ...CONVERSATION }],
+      })),
+      getConversationMessages: vi.fn(async () => ({ messages: [] })),
+    });
+    const { deps } = makeDeps(client, false);
+
+    expect(await hydrateInitialConversation(deps)).toBeNull();
   });
 
   it("never throws — a failed create resolves to null", async () => {

--- a/packages/ui/src/state/useChatCallbacks.ts
+++ b/packages/ui/src/state/useChatCallbacks.ts
@@ -21,6 +21,7 @@ import {
   type ImageAttachment,
 } from "../api";
 import type { Tab } from "../navigation";
+import { isIOS, isNative } from "../platform/init";
 import { isTtsDebugEnabled } from "../utils/tts-debug";
 import type { ChatReplyTarget } from "./ChatComposerContext.hooks";
 import {
@@ -122,6 +123,16 @@ export interface HydrateInitialConversationDeps {
   setActiveConversationId: (id: string | null) => void;
   setConversationMessages: (messages: ConversationMessage[]) => void;
   uiLanguage: string;
+  seedSyntheticGreeting: boolean;
+}
+
+/** Native iOS presents chat as an on-demand utility, so a new thread should
+ *  wait for the user's first turn instead of inventing one from postExamples. */
+export function shouldSeedSyntheticConversationGreeting(
+  native: boolean,
+  ios: boolean,
+): boolean {
+  return !(native && ios);
 }
 
 function conversationRecency(conversation: Conversation): number {
@@ -212,12 +223,10 @@ async function resolveRestoredConversationWithMessages(
 /**
  * Hydrate the app's single active conversation on boot.
  *
- * INVARIANT: the ChatOverlay is mounted over EVERY surface, so the
- * chat must ALWAYS end up with an active, greeted conversation — never an empty
- * thread — regardless of which route the shell launched on. So when the server
- * has zero conversations this ALWAYS creates one with a bootstrap greeting (it
- * is NOT gated on the URL being /chat, the bug that left the overlay
- * permanently empty when the shell booted at /views or a cached app slug).
+ * INVARIANT: the ChatOverlay is mounted over EVERY surface, so chat must always
+ * end up with an active conversation regardless of the launch route. Most
+ * surfaces seed that thread with the configured greeting; native iOS keeps a
+ * new thread intentionally empty until the user's first turn.
  *
  * Returns a conversation id when the caller should still backfill a greeting
  * (restored-but-empty, or created without an inline greeting), else null.
@@ -237,6 +246,7 @@ export async function hydrateInitialConversation(
     setActiveConversationId,
     setConversationMessages,
     uiLanguage,
+    seedSyntheticGreeting,
   } = deps;
   const hydrationEpoch = ++conversationHydrationEpochRef.current;
   const isCurrentHydration = () =>
@@ -278,7 +288,9 @@ export async function hydrateInitialConversation(
           ? restoredConversation.id
           : null;
         setConversationMessages(nextMessages);
-        return nextMessages.length === 0 ? restoredConversation.id : null;
+        return nextMessages.length === 0 && seedSyntheticGreeting
+          ? restoredConversation.id
+          : null;
       } catch {
         if (!isCurrentHydration()) {
           return null;
@@ -308,7 +320,7 @@ export async function hydrateInitialConversation(
     try {
       const { conversation: rawConversation, greeting: inlineGreeting } =
         await api.createConversation(undefined, {
-          bootstrapGreeting: true,
+          bootstrapGreeting: seedSyntheticGreeting,
           lang: uiLanguage,
         });
       if (!isConversationRecord(rawConversation)) {
@@ -332,7 +344,9 @@ export async function hydrateInitialConversation(
         conversationId: conversation.id,
       });
 
-      const greetingText = inlineGreeting?.text?.trim() || "";
+      const greetingText = seedSyntheticGreeting
+        ? inlineGreeting?.text?.trim() || ""
+        : "";
       if (greetingText) {
         const nextMessages: ConversationMessage[] = [
           {
@@ -353,7 +367,7 @@ export async function hydrateInitialConversation(
         return null;
       }
 
-      return conversation.id;
+      return seedSyntheticGreeting ? conversation.id : null;
     } catch {
       if (!isCurrentHydration()) {
         return null;
@@ -616,10 +630,19 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
     coordinatorResetRef,
   } = deps;
 
+  const seedSyntheticGreeting = shouldSeedSyntheticConversationGreeting(
+    isNative,
+    isIOS,
+  );
+
   // ── Greeting / hydration (defined here; passed into lifecycle) ──────
 
   const fetchGreeting = useCallback(
     async (convId: string): Promise<boolean> => {
+      if (!seedSyntheticGreeting) {
+        greetingFiredRef.current = false;
+        return false;
+      }
       if (greetingInFlightConversationRef.current === convId) {
         traceGreeting("fetchGreeting:skip_duplicate_in_flight", {
           convId,
@@ -682,6 +705,7 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
       activeConversationIdRef,
       greetingFiredRef,
       greetingInFlightConversationRef,
+      seedSyntheticGreeting,
       setConversationMessages,
     ],
   );
@@ -689,6 +713,7 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
   // biome-ignore lint/correctness/useExhaustiveDependencies: greetingFiredRef is intentionally read from the ref at call time
   const requestGreetingWhenRunning = useCallback(
     async (convId: string | null): Promise<void> => {
+      if (!seedSyntheticGreeting) return;
       if (!convId || greetingFiredRef.current) {
         traceGreeting("requestGreetingWhenRunning:skip", {
           convId: convId ?? null,
@@ -709,7 +734,7 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
         // best-effort greeting; will be triggered on next connect
       }
     },
-    [fetchGreeting],
+    [fetchGreeting, seedSyntheticGreeting],
   );
 
   const hydrateInitialConversationState = useCallback(
@@ -725,6 +750,7 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
         setActiveConversationId,
         setConversationMessages,
         uiLanguage,
+        seedSyntheticGreeting,
       }),
     [
       activeConversationIdRef,
@@ -732,6 +758,7 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
       conversationMessagesRef,
       greetingFiredRef,
       loadedConversationIdRef,
+      seedSyntheticGreeting,
       uiLanguage,
       setActiveConversationId,
       setConversationMessages,
@@ -968,9 +995,11 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
         activeConversationIdRef.current = conversation.id;
         setCompanionMessageCutoffTs(nextCutoffTs);
         // Try inline greeting first; fall back to dedicated greeting endpoint
-        let greetingText = inlineGreeting?.text?.trim() || "";
+        let greetingText = seedSyntheticGreeting
+          ? inlineGreeting?.text?.trim() || ""
+          : "";
         let greetingLocalInference = inlineGreeting?.localInference;
-        if (!greetingText) {
+        if (seedSyntheticGreeting && !greetingText) {
           // Register the in-flight conversation BEFORE the request leaves. This
           // fallback bypasses fetchGreeting, so without the ref the empty-thread
           // auto-greet effect passes every guard during this await and fires a
@@ -1027,7 +1056,9 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
           setConversationMessages([]);
           // Fallback: if inline greeting wasn't returned (e.g. old server),
           // request one via the dedicated /greeting endpoint.
-          void fetchGreeting(conversation.id);
+          if (seedSyntheticGreeting) {
+            void fetchGreeting(conversation.id);
+          }
         }
         client.sendWsMessage({
           type: "active-conversation",
@@ -1100,6 +1131,7 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
       companionMessageCutoffTs,
       fetchGreeting,
       resetConversationDraftState,
+      seedSyntheticGreeting,
       uiLanguage,
       activeConversationIdRef,
       conversationHydrationEpochRef,


### PR DESCRIPTION
# Relates to

Fixes #22119.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Shaw rebased the branch onto `origin/develop` `06d11ebc612cc88ca7bb39c2716e95ace0d8f898`; zero conflicts.
- [x] Exact PR head is `3890e80b0727c0282d5f424428abe8208de0b5d0`.
- [x] The two changed blobs are byte-identical from validated head `10cf7f9b20f99712c7183ff26caad4576c2d2846` through the final rebase:
  - `useChatCallbacks.ts`: `cd74d347fe890e45ee85025ce16481059e3f22b3` before and after.
  - `useChatCallbacks.hydrate.test.ts`: `15b91245fb725fe6341471187f92cde7bf32e1f8` before and after.
- [x] Fast focused/Biome/diff gates, exact-head typecheck inheritance proof, package build, install, and native Computer Use QA were rerun at `3890e80b`.

# Risks

Low and native-iOS scoped. Existing stored conversation history is preserved. Other native and web surfaces keep their current configured greeting behavior.

# Background

## What does this PR do?

Native iOS now creates a new chat without synthesizing a character `postExamples` greeting, does not backfill an empty restored thread, ignores an unexpected inline synthetic greeting defensively, and keeps the greeting endpoint disabled for that native-iOS policy. The first visible turn is therefore the user's own message. Real stored user/assistant history is unchanged.

## What kind of change is this?

Bug fix (non-breaking).

# Testing

- Directly affected state suite: 6 files, 44/44 passed at exact head `3890e80b0727c0282d5f424428abe8208de0b5d0`.
- Earlier broad focused run over 9 files: 279/279 passed; the changed test/code blobs are byte-identical after the final path-disjoint rebase.
- Biome on both changed files: passed at exact head.
- `git diff --check origin/develop...HEAD`: passed at exact head.
- UI typecheck was rerun at exact head `3890e80b` and produced the same five unrelated missing-export diagnostics. The four files implicated by those diagnostics have identical blobs at exact parent `06d11ebc` and exact head; the PR changes only the two chat-callback files. The prior clean parent/head comparison and current exact-head inheritance proof are linked below; PR-added diagnostics: zero.
- Affected visual audit: 218/219 passed; all four builtin-chat captures passed. Sole failure is the pre-existing minimalism ratchet outside this diff.
- Exact direct/remote-mac Capacitor/Xcode Simulator package: `BUILD SUCCEEDED`; artifact audit passed with renderer build ID `26fec66f03654605a88f341e201f67224a03d85983bd1e92ed37aa5f3e070687` and renderer commit `3890e80b0727c0282d5f424428abe8208de0b5d0`.
- Exact binary installed on iOS 26.5 `Eliza iPhone 17 Pro` and `iPad Pro 13-inch (M5)`; installed binary and debug-dylib hashes match the audited package on both devices.
- The isolated zero-conversation lifecycle proof at validated head `10cf7f9b` showed an empty cold launch and same-process warm foreground (`pid 89875` before/after), with no synthetic greeting. Both changed blobs are byte-identical at `3890e80b`; the exact `3890e80b` package was rebuilt, installed, and warm-foregrounded on both simulators without inserting a greeting.
- Restoring the persistent database preserved both existing user turns (`QA DIRECT READY`, `QA 186C READY`) and both real assistant replies (`Ready.`, `Ready.`), with no new greeting inserted.
- Native Computer Use at `3890e80b` covered iPhone portrait/landscape/warm foreground and the portrait-shaped iPad half Split View on a physical-landscape display, repeated rotation, composer focus/dismiss, safe areas, overlay opacity, and history retention. Underlying notification/wallpaper text remained outside the solid overlay bounds.

## Known gaps / failures

- Full UI typecheck has the same five unrelated missing-export diagnostics at exact develop parent and exact PR head; see the permanent comparison log.
- Simulator diagnostics contain expected WebKit/security-analytics/haptics noise; no app crash, fatal error, Capacitor bridge failure, wrong runtime route, or duplicate app process was observed.
- Voice gateway `32538` was intentionally not started because this follow-up changes only native greeting hydration; no voice code changed.

# Evidence Gate

<!-- evidence-head:3890e80b0727c0282d5f424428abe8208de0b5d0 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-codex-clipboard-cd92d92c-8809-43b2-bb02-fe40f86f4588.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-3890-ipad-live.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-10cf7-ipad-cold-warm.mp4
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code changed; native iOS client hydration policy only.
<!-- evidence-row:frontend-logs -->
- [x] [sanitized exact-head native/frontend log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-3890-sanitized-frontend.log)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [exact-head installed identity and blob comparison](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-3890-installed-identity.json) and [exact-content cold/warm/history lifecycle record](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-10cf7-lifecycle-history.json)
<!-- evidence-row:ocr-review -->
- [x] [Apple Vision OCR + manual review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-10cf7-ocr-review.jsonl)

# Exact-head install artifacts and byte-identical lifecycle proof

- [Exact-head iPad Split View/physical-landscape launch](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-3890-ipad-live.png)
- [Exact-head iPhone portrait launch](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-3890-iphone-live.png)
- [Exact-head installed identity](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-3890-installed-identity.json)
- [Exact-head typecheck inheritance proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-3890-typecheck-baseline.log)
- [Byte-identical iPad cold-launch empty overlay](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-10cf7-ipad-cold-empty.png)
- [Byte-identical iPad same-process warm-foreground empty overlay](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-10cf7-ipad-warm-empty.png)
- [Byte-identical iPad restored real history](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-10cf7-ipad-history-preserved.png)
- [Prior clean parent/head typecheck comparison](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-10cf7-typecheck-baseline.log)
- [Audited byte-identical-content app attestation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22151-issue22119-10cf7-App.app.eliza-cloud-attestation.json)

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex Desktop  
Contribution skill revision: N/A - no contribution skill used  
Attribution status: self-reported  
— [nubs-review-drafts-delta]
