### PR TITLE
fix(plugin-signal): cancel stale SSE reconnect timers

### DIFF
--- a/plugins/plugin-signal/src/rpc.test.ts
+++ b/plugins/plugin-signal/src/rpc.test.ts
@@ -207,6 +207,173 @@ describe("Signal RPC helpers", () => {
     expect(connects).toBe(1);
   });
 
+  it("cancels stale reconnect timers across stop and restart", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => {
+      throw new Error("down");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stream = createSignalEventStream({
+      baseUrl: "http://localhost:8080",
+      onEvent: () => {},
+      onError: () => {},
+      reconnectDelayMs: 1000,
+      maxReconnectDelayMs: 30000,
+    });
+
+    stream.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
+
+    stream.stop();
+    expect(vi.getTimerCount()).toBe(0);
+    stream.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(1);
+    stream.stop();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("stops an in-flight dial without reporting or scheduling an abort as a failure", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn((_url: string | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onError = vi.fn();
+
+    const stream = createSignalEventStream({
+      baseUrl: "http://localhost:8080",
+      onEvent: () => {},
+      onError,
+    });
+    stream.start();
+    await vi.advanceTimersByTimeAsync(0);
+    stream.stop();
+    await vi.advanceTimersByTimeAsync(60000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("reconnects after an unowned AbortError on the current generation", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => {
+      throw new DOMException("upstream aborted independently", "AbortError");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onError = vi.fn();
+
+    const stream = createSignalEventStream({
+      baseUrl: "http://localhost:8080",
+      onEvent: () => {},
+      onError,
+      reconnectDelayMs: 1000,
+      maxReconnectDelayMs: 2000,
+    });
+    stream.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(1);
+    stream.stop();
+  });
+
+  it("suppresses stale events and errors from an abort-resistant prior generation", async () => {
+    const controllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controllers.push(controller);
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const events: string[] = [];
+    const onError = vi.fn();
+    const onConnect = vi.fn();
+    const onDisconnect = vi.fn();
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    const stream = createSignalEventStream({
+      baseUrl: "http://localhost:8080",
+      onEvent: (event) => events.push(event.data ?? ""),
+      onError,
+      onConnect,
+      onDisconnect,
+    });
+
+    stream.start();
+    await flush();
+    expect(onConnect).toHaveBeenCalledTimes(1);
+    stream.stop();
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+
+    stream.start();
+    await flush();
+    expect(onConnect).toHaveBeenCalledTimes(2);
+    expect(controllers).toHaveLength(2);
+
+    controllers[0]?.enqueue(new TextEncoder().encode("data: stale-old-generation\n\n"));
+    controllers[0]?.error(new Error("late old-generation failure"));
+    await flush();
+
+    expect(events).toEqual([]);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+    expect(stream.isRunning()).toBe(true);
+
+    stream.stop();
+    expect(onDisconnect).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats non-OK responses as failed dials without announcing a connection", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => new Response("unavailable", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const onConnect = vi.fn();
+    const onDisconnect = vi.fn();
+    const onError = vi.fn();
+
+    const stream = createSignalEventStream({
+      baseUrl: "http://localhost:8080",
+      onEvent: () => {},
+      onConnect,
+      onDisconnect,
+      onError,
+      reconnectDelayMs: 1000,
+      maxReconnectDelayMs: 2000,
+    });
+    stream.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onConnect).not.toHaveBeenCalled();
+    expect(onDisconnect).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(String(onError.mock.calls[0]?.[0])).toContain("Signal SSE failed (503");
+    expect(vi.getTimerCount()).toBe(1);
+    stream.stop();
+  });
+
   it("reports Signal health failures for non-OK and aborted checks", async () => {
     const fetchMock = vi.fn(async () => new Response("nope", { status: 503 }));
     vi.stubGlobal("fetch", fetchMock);

--- a/plugins/plugin-signal/src/rpc.ts
+++ b/plugins/plugin-signal/src/rpc.ts
@@ -415,25 +415,37 @@ export function createSignalEventStream(params: {
   isRunning: () => boolean;
 } {
   let abortController: AbortController | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let establishedController: AbortController | null = null;
   let running = false;
+  let generation = 0;
   const baseDelay = params.reconnectDelayMs ?? 1000;
   const maxDelay = params.maxReconnectDelayMs ?? 30000;
   let reconnectDelay = baseDelay;
 
-  const connect = async () => {
-    if (!running) {
+  const connect = async (expectedGeneration: number) => {
+    if (!running || generation !== expectedGeneration) {
       return;
     }
 
-    abortController = new AbortController();
+    const controller = new AbortController();
+    abortController = controller;
 
     try {
       await streamSignalEvents({
         baseUrl: params.baseUrl,
         account: params.account,
-        abortSignal: abortController.signal,
-        onEvent: params.onEvent,
+        abortSignal: controller.signal,
+        onEvent: (event) => {
+          if (running && generation === expectedGeneration && !controller.signal.aborted) {
+            params.onEvent(event);
+          }
+        },
         onConnected: () => {
+          if (!running || generation !== expectedGeneration || controller.signal.aborted) {
+            return;
+          }
+          establishedController = controller;
           // A connection was actually established; announce it and reset the
           // backoff so the next drop restarts from the base delay. Resetting
           // per-attempt (the previous behavior) defeated exponential backoff
@@ -443,17 +455,26 @@ export function createSignalEventStream(params: {
         },
       });
     } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") {
+      if (controller.signal.aborted || generation !== expectedGeneration || !running) {
         return;
       }
       params.onError?.(error instanceof Error ? error : new Error(String(error)));
     } finally {
-      params.onDisconnect?.();
+      if (abortController === controller) {
+        abortController = null;
+      }
+      if (establishedController === controller) {
+        establishedController = null;
+        params.onDisconnect?.();
+      }
     }
 
     // Reconnect with exponential backoff
-    if (running) {
-      setTimeout(connect, reconnectDelay);
+    if (running && generation === expectedGeneration) {
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        void connect(expectedGeneration);
+      }, reconnectDelay);
       reconnectDelay = Math.min(reconnectDelay * 2, maxDelay);
     }
   };
@@ -464,12 +485,25 @@ export function createSignalEventStream(params: {
         return;
       }
       running = true;
-      connect();
+      generation += 1;
+      reconnectDelay = baseDelay;
+      void connect(generation);
     },
     stop: () => {
       running = false;
-      abortController?.abort();
+      generation += 1;
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      const controller = abortController;
+      const notifyDisconnect = establishedController !== null;
+      establishedController = null;
+      controller?.abort();
       abortController = null;
+      if (notifyDisconnect) {
+        params.onDisconnect?.();
+      }
     },
     isRunning: () => running,
   };


### PR DESCRIPTION
# Relates to

Closes #22123. Follow-up to #22132 after independent lifecycle review.

# Summary

#22132 correctly restores exponential backoff and moves `onConnect` to an established HTTP stream. A stop/restart race remained: `stop()` did not own or cancel the pending reconnect timer, so restarting before that timer fired allowed the stale callback to observe `running === true` and open a second concurrent SSE stream.

This repair:

- explicitly owns and clears the reconnect timer on stop;
- gives each start cycle a generation so stale async completions and callbacks cannot mutate or reconnect a newer cycle;
- generation-guards event and error delivery so an abort-resistant prior stream cannot reach the current consumer;
- retains a local abort controller per attempt and only clears the active controller;
- globally owns the established controller so stop and late completion pair exactly one disconnect per established generation;
- distinguishes owned cancellation from an unrelated current-generation `AbortError`, which remains an observable failure and reconnects;
- resets a deliberate restart to the base delay;
- pairs `onDisconnect` only with an established stream, avoiding disconnect notifications for failed dials;
- preserves the accepted exponential sequence and cap behavior.

Regression coverage verifies stop/restart has exactly one live timer and one reconnect, stop-abort produces no error or later reconnect, an unowned current-generation `AbortError` reports and reconnects, an abort-resistant prior stream cannot deliver stale events/errors or double-disconnect, and HTTP non-OK responses neither announce a connection nor a disconnect.

# Testing

At exact head `9635ceb5eb028ce336f155399aa7a363d0a6efee`, based current `develop` `189f964eb197be920a59740ab15d011f9a461c82`:

- `bun run --cwd plugins/plugin-signal test` — 55 pass, 0 fail across 6 files.
- `bun run --cwd plugins/plugin-signal lint:check` — 26 files clean.
- `bun run --cwd plugins/plugin-signal typecheck` — pass.
- `bun run --cwd plugins/plugin-signal build` — Node bundle and declarations pass.
- `git diff --check` — pass.

# Evidence

Backend-only transport lifecycle repair. UI screenshots, video, frontend logs, visual artifacts, and LLM trajectory are N/A.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@189f964eb197be920a59740ab15d011f9a461c82:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-cortex-security]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@189f964eb197be920a59740ab15d011f9a461c82:packages/skills/skills/contribute-to-eliza"} -->
