### PR TITLE
fix(wallet): bound Jupiter requests with timeout

### DIFF
--- a/plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts
+++ b/plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts
@@ -139,6 +139,7 @@ describe("Jupiter API request deadline", () => {
   });
 
   it("creates a fresh deadline signal for every successful request", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
     const signals: AbortSignal[] = [];
     const fetchFn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       if (!init?.signal) throw new Error("missing deadline signal");
@@ -149,6 +150,8 @@ describe("Jupiter API request deadline", () => {
     await fetchJupiterJson(fetchFn, "https://jupiter.test/quote", "quote");
     await fetchJupiterJson(fetchFn, "https://jupiter.test/swap", "swap");
 
+    expect(timeoutSpy).toHaveBeenCalledTimes(2);
+    expect(timeoutSpy).toHaveBeenCalledWith(DEFAULT_JUPITER_FETCH_TIMEOUT_MS);
     expect(signals).toHaveLength(2);
     expect(signals[0]).not.toBe(signals[1]);
     expect(signals.every((signal) => !signal.aborted)).toBe(true);

--- a/plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts
+++ b/plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Exercises Jupiter request deadlines through native fetch and real stalled
+ * HTTP responses, including caller cancellation and response-body stalls.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_JUPITER_FETCH_TIMEOUT_MS, fetchJupiterJson } from "./jupiter-api";
+
+interface TestServer {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function startServer(handler: Parameters<typeof http.createServer>[0]): Promise<TestServer> {
+  const server = http.createServer(handler);
+  const sockets = new Set<import("node:net").Socket>();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: async () => {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+describe("Jupiter API request deadline", () => {
+  let nativeTimeout: typeof AbortSignal.timeout;
+
+  beforeEach(() => {
+    nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("publishes the ten-second production budget", () => {
+    expect(DEFAULT_JUPITER_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("wraps a stalled response-header timeout with its original cause", async () => {
+    const server = await startServer(() => undefined);
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => nativeTimeout(10));
+    try {
+      await expect(fetchJupiterJson(fetch, server.url, "quote")).rejects.toEqual(
+        expect.objectContaining({
+          code: "JUPITER_QUOTE_TRANSPORT_FAILED",
+          cause: expect.objectContaining({ name: "TimeoutError" }),
+        })
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("bounds a real partial response-body stall", async () => {
+    const server = await startServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.write('{"route":"');
+    });
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => nativeTimeout(10));
+    try {
+      const failure = await fetchJupiterJson(fetch, server.url, "swap").catch(
+        (cause: unknown) => cause
+      );
+      expect(failure).toEqual(
+        expect.objectContaining({
+          cause: expect.objectContaining({ name: "TimeoutError" }),
+        })
+      );
+      expect(["JUPITER_SWAP_TRANSPORT_FAILED", "JUPITER_SWAP_INVALID_RESPONSE"]).toContain(
+        (failure as { code?: unknown }).code
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("keeps the composed signal active through response.json", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => nativeTimeout(10));
+    const fetchFn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("missing deadline signal");
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"route":"'));
+          signal.addEventListener("abort", () => controller.error(signal.reason), {
+            once: true,
+          });
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(fetchJupiterJson(fetchFn, "https://jupiter.test/swap", "swap")).rejects.toEqual(
+      expect.objectContaining({
+        code: "JUPITER_SWAP_INVALID_RESPONSE",
+        cause: expect.objectContaining({ name: "TimeoutError" }),
+      })
+    );
+  });
+
+  it("preserves caller cancellation when composing the deadline", async () => {
+    const caller = new AbortController();
+    const callerReason = new DOMException("cancelled by caller", "AbortError");
+    const fetchFn = vi.fn(
+      (_url: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) throw new Error("missing composed signal");
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        })
+    ) as unknown as typeof fetch;
+
+    const pending = fetchJupiterJson(fetchFn, "https://jupiter.test/quote", "quote", {
+      signal: caller.signal,
+    });
+    caller.abort(callerReason);
+
+    await expect(pending).rejects.toEqual(
+      expect.objectContaining({
+        code: "JUPITER_QUOTE_TRANSPORT_FAILED",
+        cause: callerReason,
+      })
+    );
+  });
+
+  it("creates a fresh deadline signal for every successful request", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchFn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (!init?.signal) throw new Error("missing deadline signal");
+      signals.push(init.signal);
+      return Response.json({ ok: true });
+    }) as unknown as typeof fetch;
+
+    await fetchJupiterJson(fetchFn, "https://jupiter.test/quote", "quote");
+    await fetchJupiterJson(fetchFn, "https://jupiter.test/swap", "swap");
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).not.toBe(signals[1]);
+    expect(signals.every((signal) => !signal.aborted)).toBe(true);
+  });
+});

--- a/plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts
+++ b/plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts
@@ -73,11 +73,10 @@ describe("Jupiter API request deadline", () => {
       );
       expect(failure).toEqual(
         expect.objectContaining({
+          code: "JUPITER_SWAP_TRANSPORT_FAILED",
           cause: expect.objectContaining({ name: "TimeoutError" }),
+          severity: "ephemeral",
         })
-      );
-      expect(["JUPITER_SWAP_TRANSPORT_FAILED", "JUPITER_SWAP_INVALID_RESPONSE"]).toContain(
-        (failure as { code?: unknown }).code
       );
     } finally {
       await server.close();
@@ -105,8 +104,9 @@ describe("Jupiter API request deadline", () => {
 
     await expect(fetchJupiterJson(fetchFn, "https://jupiter.test/swap", "swap")).rejects.toEqual(
       expect.objectContaining({
-        code: "JUPITER_SWAP_INVALID_RESPONSE",
+        code: "JUPITER_SWAP_TRANSPORT_FAILED",
         cause: expect.objectContaining({ name: "TimeoutError" }),
+        severity: "ephemeral",
       })
     );
   });

--- a/plugins/plugin-wallet/src/chains/solana/jupiter-api.ts
+++ b/plugins/plugin-wallet/src/chains/solana/jupiter-api.ts
@@ -6,6 +6,7 @@ import { ElizaError } from "@elizaos/core";
 
 export const DEFAULT_JUPITER_API_BASE_URL = "https://lite-api.jup.ag/swap/v1";
 export const JUPITER_API_BASE_URL_SETTING = "JUPITER_API_BASE_URL";
+export const DEFAULT_JUPITER_FETCH_TIMEOUT_MS = 10_000;
 
 type RuntimeSettings = { getSetting(key: string): unknown };
 type JupiterStage = "quote" | "swap";
@@ -58,9 +59,11 @@ export async function fetchJupiterJson(
   stage: JupiterStage,
   init?: RequestInit
 ): Promise<Record<string, unknown>> {
+  const timeoutSignal = AbortSignal.timeout(DEFAULT_JUPITER_FETCH_TIMEOUT_MS);
+  const signal = init?.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal;
   let response: Response;
   try {
-    response = await fetchFn(url, init);
+    response = await fetchFn(url, { ...init, signal });
   } catch (cause) {
     // error-policy:J2 Classify DNS/network failures while retaining the fetch cause.
     throw new ElizaError(`Jupiter ${stage} request failed`, {

--- a/plugins/plugin-wallet/src/chains/solana/jupiter-api.ts
+++ b/plugins/plugin-wallet/src/chains/solana/jupiter-api.ts
@@ -15,6 +15,10 @@ function stageCode(stage: JupiterStage, suffix: string): string {
   return `JUPITER_${stage.toUpperCase()}_${suffix}`;
 }
 
+function isAbortLikeError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+}
+
 export function resolveJupiterApiBaseUrl(runtime: RuntimeSettings): string {
   const configured = runtime.getSetting(JUPITER_API_BASE_URL_SETTING);
   const configuredUrl = typeof configured === "string" ? configured.trim() : undefined;
@@ -86,6 +90,17 @@ export async function fetchJupiterJson(
   try {
     payload = await response.json();
   } catch (cause) {
+    if (signal.aborted || isAbortLikeError(cause)) {
+      // error-policy:J2 A deadline or caller cancellation can occur after the
+      // response headers arrive. It remains an ephemeral transport failure,
+      // not a fatal malformed-provider-response verdict.
+      throw new ElizaError(`Jupiter ${stage} response body was interrupted`, {
+        code: stageCode(stage, "TRANSPORT_FAILED"),
+        cause,
+        context: { url, status: response.status },
+        severity: "ephemeral",
+      });
+    }
     // error-policy:J2 The response boundary adds endpoint context to malformed JSON.
     throw new ElizaError(`Jupiter ${stage} response was not valid JSON`, {
       code: stageCode(stage, "INVALID_RESPONSE"),


### PR DESCRIPTION
# Relates to

Closes #22146

Definition of Done: full standard in `CONTRIBUTING.md`.

# Contribution provenance

<!-- contribution-attribution:v1 -->
- AI assistance: `yes`
- Model(s) used: `openai/gpt-5.6-sol`
- Agent tooling: `Codex Desktop`
- Skill path: `elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza`
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop` before the exact-head validation; zero conflicts.
- [x] Frozen `bun install` completed.
- [x] Exact focused tests, Node typecheck, package Node/browser/declaration build, changed-file Biome, and diff check pass.

# Risks

Low and bounded to the shared Jupiter HTTP boundary used by both Solana quote/swap builders. Each request creates a fresh 10-second deadline. A caller-provided signal is composed with the deadline using `AbortSignal.any`, so caller cancellation is preserved. Both header stalls and response-body stalls remain bounded. Existing typed `ElizaError` codes, contexts, severity, and causes remain intact.

# Background

## What does this PR do?

Adds `DEFAULT_JUPITER_FETCH_TIMEOUT_MS = 10_000` and always supplies a fresh deadline signal to `fetchJupiterJson`. If a caller already supplied a signal, the request uses a composed signal that aborts on either caller cancellation or deadline expiry. Because the same signal remains attached to the native fetch response, stalled JSON bodies are also interrupted; the existing J2 boundaries retain the original `TimeoutError` or `AbortError` as `cause`.

This is the single shared function used for quote and swap requests from both `SolanaService` and the canonical wallet-chain registry, so no signing or confirmation behavior changes.

## What kind of change is this?

Bug fix.

# Testing

## Where should a reviewer start?

- `plugins/plugin-wallet/src/chains/solana/jupiter-api.ts`
- `plugins/plugin-wallet/src/chains/solana/jupiter-api.timeout.test.ts`

## Detailed testing steps

On exact head `8cfe32b946ec`:

- `bunx vitest run src/chains/solana/jupiter-api.test.ts src/chains/solana/jupiter-api.timeout.test.ts` from `plugins/plugin-wallet`: 2 files, 13/13 passed.
  - real native fetch against a server that never sends headers;
  - real native fetch against a server that sends partial JSON and never ends;
  - a controlled stalled `ReadableStream` proving the composed signal remains active inside `response.json()`;
  - caller `AbortError` wins and remains the typed cause;
  - two successful requests receive distinct, un-aborted deadline signals;
  - existing DNS, HTTP status, and endpoint validation contracts remain green.
- `bunx tsc --noEmit -p tsconfig.json`: passed (Node tree).
- `bun run build.ts`: Node, browser UI, and declarations passed.
- changed-file Biome: passed.
- `git diff --check origin/develop...HEAD`: passed.
- Full wallet lane: 56 files and 351 tests passed, with two unrelated current-workspace failures: missing built `@elizaos/ui/spatial` for `InventoryView.test.tsx`, and the unchanged EVM sign-route expected-message mismatch (`unsupported EVM chainId: -1` vs current `chainId must be a number or hex string`). Neither imports or reaches the Jupiter boundary.

# Evidence Gate

<!-- evidence-head:7b5c8023c461fbadcc7d9bed0e7986bdb0b6e2cc -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only wallet transport boundary; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only wallet transport boundary; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic request deadline with no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] [22156-exact-7b5c802.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22156-exact-7b5c802.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action routing, or agent planning change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - transport failure is the domain result; no transaction is signed, simulated, or submitted.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text surface changed.

# Known gaps / failures

The full wallet lane's two unrelated failures are recorded in Testing. Focused transport tests, owning Node typecheck, package build, formatting, and diff gates pass on the exact head.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza"} -->



