### PR TITLE
fix(agent): bound model catalog fetches

### DIFF
--- a/packages/agent/src/api/model-provider-helpers.test.ts
+++ b/packages/agent/src/api/model-provider-helpers.test.ts
@@ -60,7 +60,10 @@ describe("fetchNearAIModels", () => {
     ]);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://cloud-api.near.ai/v1/models",
-      { headers: { Authorization: "Bearer near-key" } },
+      expect.objectContaining({
+        headers: { Authorization: "Bearer near-key" },
+        signal: expect.any(AbortSignal),
+      }),
     );
   });
 
@@ -94,7 +97,10 @@ describe("fetchNearAIModels", () => {
     ]);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://cloud-api.near.ai/v1/models",
-      { headers: {} },
+      expect.objectContaining({
+        headers: {},
+        signal: expect.any(AbortSignal),
+      }),
     );
   });
 });

--- a/packages/agent/src/api/model-provider-helpers.timeout.test.ts
+++ b/packages/agent/src/api/model-provider-helpers.timeout.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Model-catalog transport deadline tests cover every remote provider fetch,
+ * fresh signals per request, and real response-body cancellation.
+ */
+
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MODEL_CATALOG_FETCH_TIMEOUT_MS,
+  fetchAnthropicModels,
+  fetchGoogleModels,
+  fetchModelsREST,
+  fetchNearAIModels,
+  fetchOpenRouterModels,
+} from "./model-provider-helpers.ts";
+
+describe("model catalog fetch deadlines", () => {
+  let originalTimeout: typeof AbortSignal.timeout;
+
+  beforeEach(() => {
+    originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("exposes the documented ten-second budget", () => {
+    expect(DEFAULT_MODEL_CATALOG_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("installs a fresh deadline on every provider request", async () => {
+    const signals: AbortSignal[] = [];
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation((milliseconds) => {
+        expect(milliseconds).toBe(DEFAULT_MODEL_CATALOG_FETCH_TIMEOUT_MS);
+        const signal = originalTimeout(60_000);
+        signals.push(signal);
+        return signal;
+      });
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        Promise.resolve(new Response(JSON.stringify({ data: [], models: [] }))),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchModelsREST("openai", "key", "https://api.openai.test/v1");
+    await fetchAnthropicModels("key");
+    await fetchGoogleModels("key");
+    await fetchOpenRouterModels("key");
+    await fetchNearAIModels("key", "https://cloud-api.near.test/v1");
+
+    expect(timeoutSpy).toHaveBeenCalledTimes(6);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(new Set(signals).size).toBe(6);
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(init).toEqual(
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    }
+  });
+
+  it("aborts a provider whose response headers never arrive", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() =>
+      originalTimeout(10),
+    );
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) throw new Error("model catalog signal missing");
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchModelsREST("openai", "key", "https://api.openai.test/v1"),
+    ).resolves.toEqual([]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.openai.test/v1/models",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("keeps the deadline armed while the response body stalls", async () => {
+    const server = http.createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.write('{"data": [');
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address() as import("node:net").AddressInfo;
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() =>
+      originalTimeout(10),
+    );
+
+    try {
+      await expect(
+        fetchModelsREST("openai", "key", `http://127.0.0.1:${address.port}/v1`),
+      ).resolves.toEqual([]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/packages/agent/src/api/model-provider-helpers.timeout.test.ts
+++ b/packages/agent/src/api/model-provider-helpers.timeout.test.ts
@@ -30,7 +30,7 @@ describe("model catalog fetch deadlines", () => {
     expect(DEFAULT_MODEL_CATALOG_FETCH_TIMEOUT_MS).toBe(10_000);
   });
 
-  it("installs a fresh deadline on every provider request", async () => {
+  it("installs a fresh deadline on every provider request and retry", async () => {
     const signals: AbortSignal[] = [];
     const timeoutSpy = vi
       .spyOn(AbortSignal, "timeout")
@@ -51,10 +51,12 @@ describe("model catalog fetch deadlines", () => {
     await fetchGoogleModels("key");
     await fetchOpenRouterModels("key");
     await fetchNearAIModels("key", "https://cloud-api.near.test/v1");
+    await fetchModelsREST("openai", "key", "https://api.openai.test/v1");
 
-    expect(timeoutSpy).toHaveBeenCalledTimes(6);
-    expect(fetchMock).toHaveBeenCalledTimes(6);
-    expect(new Set(signals).size).toBe(6);
+    expect(timeoutSpy).toHaveBeenCalledTimes(7);
+    expect(fetchMock).toHaveBeenCalledTimes(7);
+    expect(new Set(signals).size).toBe(7);
+    expect(signals.every((signal) => !signal.aborted)).toBe(true);
     for (const [, init] of fetchMock.mock.calls) {
       expect(init).toEqual(
         expect.objectContaining({ signal: expect.any(AbortSignal) }),

--- a/packages/agent/src/api/model-provider-helpers.ts
+++ b/packages/agent/src/api/model-provider-helpers.ts
@@ -15,6 +15,8 @@ import {
 import { isMobilePlatform } from "@elizaos/shared/runtime-env";
 import { resolveModelsCacheDir } from "../config/paths.ts";
 
+export const DEFAULT_MODEL_CATALOG_FETCH_TIMEOUT_MS = 10_000;
+
 type ModelOption = {
   id: string;
   name: string;
@@ -357,7 +359,10 @@ export async function fetchModelsREST(
     const url = `${baseUrl.replace(/\/+$/, "")}/models`;
     const headers: Record<string, string> = {};
     if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-    const res = await fetch(url, { headers });
+    const res = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(DEFAULT_MODEL_CATALOG_FETCH_TIMEOUT_MS),
+    });
     if (!res.ok) return [];
     const data = (await res.json()) as {
       data?: Array<{ id: string; name?: string; type?: string }>;
@@ -398,6 +403,7 @@ export async function fetchAnthropicModels(
     if (apiKey) headers["x-api-key"] = apiKey;
     const res = await fetch("https://api.anthropic.com/v1/models?limit=100", {
       headers,
+      signal: AbortSignal.timeout(DEFAULT_MODEL_CATALOG_FETCH_TIMEOUT_MS),
     });
     if (!res.ok) return [];
     const data = (await res.json()) as {
@@ -425,7 +431,9 @@ export async function fetchGoogleModels(
     const url = apiKey
       ? `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(apiKey)}`
       : "https://generativelanguage.googleapis.com/v1beta/models";
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(DEFAULT_MODEL_CATALOG_FETCH_TIMEOUT_MS),
+    });
     if (!res.ok) return [];
     const data = (await res.json()) as {
       models?: Array<{ name: string; displayName?: string }>;
@@ -498,6 +506,7 @@ export async function fetchOpenRouterModels(
   const [chatRes, embedRes] = await Promise.all([
     fetch("https://openrouter.ai/api/v1/models?output_modalities=all", {
       headers,
+      signal: AbortSignal.timeout(DEFAULT_MODEL_CATALOG_FETCH_TIMEOUT_MS),
     }).catch((error) => {
       // error-policy:J4 the combined catalog can remain partially available.
       logger.warn(
@@ -505,15 +514,16 @@ export async function fetchOpenRouterModels(
       );
       return null;
     }),
-    fetch("https://openrouter.ai/api/v1/embeddings/models", { headers }).catch(
-      (error) => {
-        // error-policy:J4 the combined catalog can remain partially available.
-        logger.warn(
-          `[model-catalog] OpenRouter embedding catalog unavailable: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        return null;
-      },
-    ),
+    fetch("https://openrouter.ai/api/v1/embeddings/models", {
+      headers,
+      signal: AbortSignal.timeout(DEFAULT_MODEL_CATALOG_FETCH_TIMEOUT_MS),
+    }).catch((error) => {
+      // error-policy:J4 the combined catalog can remain partially available.
+      logger.warn(
+        `[model-catalog] OpenRouter embedding catalog unavailable: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    }),
   ]);
 
   const models: CachedModel[] = [];
@@ -593,7 +603,10 @@ export async function fetchNearAIModels(
     const url = `${baseUrl.replace(/\/+$/, "")}/models`;
     const headers: Record<string, string> = {};
     if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-    const res = await fetch(url, { headers });
+    const res = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(DEFAULT_MODEL_CATALOG_FETCH_TIMEOUT_MS),
+    });
     if (!res.ok) return [];
     const data = (await res.json()) as {
       data?: NearAIModelEntry[];

--- a/packages/agent/src/api/model-provider-helpers.ts
+++ b/packages/agent/src/api/model-provider-helpers.ts
@@ -375,6 +375,7 @@ export async function fetchModelsREST(
       }))
       .sort((a, b) => a.id.localeCompare(b.id));
   } catch (e: unknown) {
+    // error-policy:J4 an unavailable catalog is an explicit empty provider list.
     logger.warn(
       `[model-catalog] Failed to fetch models for ${providerId}: ${e instanceof Error ? e.message : e}`,
     );
@@ -417,6 +418,7 @@ export async function fetchAnthropicModels(
       }))
       .sort((a, b) => a.id.localeCompare(b.id));
   } catch (e: unknown) {
+    // error-policy:J4 an unavailable catalog is an explicit empty provider list.
     logger.warn(
       `[model-catalog] Failed to fetch Anthropic models: ${e instanceof Error ? e.message : e}`,
     );
@@ -447,6 +449,7 @@ export async function fetchGoogleModels(
       };
     });
   } catch (e: unknown) {
+    // error-policy:J4 an unavailable catalog is an explicit empty provider list.
     logger.warn(
       `[model-catalog] Failed to fetch Google models: ${e instanceof Error ? e.message : e}`,
     );
@@ -639,6 +642,7 @@ export async function fetchNearAIModels(
       .filter((model): model is CachedModel => model !== null)
       .sort((a, b) => a.id.localeCompare(b.id));
   } catch (e: unknown) {
+    // error-policy:J4 an unavailable catalog is an explicit empty provider list.
     logger.warn(
       `[model-catalog] Failed to fetch NEAR AI models: ${e instanceof Error ? e.message : e}`,
     );


### PR DESCRIPTION
# Relates to

Closes #22149.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated verify blocker is recorded below.
- [x] A reviewer can confirm the change from the transport evidence and focused tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@1a1ffb12ba0c4fddbaa476d0a52dfe1a3c62eadf`; zero conflicts.
- [x] Root verify reached 352/356 tasks and stopped only on unrelated current-develop `packages/ui` timeout tests importing non-exported BuildBadge/load-pack symbols.

# Risks

Low. This only bounds model-catalog discovery requests. Existing success, non-OK, parse-error, logging, partial OpenRouter, and empty-catalog fallback behavior is preserved. Slow providers now become unavailable for that refresh after ten seconds rather than blocking warm-up indefinitely.

# Background

## What does this PR do?

Adds one exported 10-second model-catalog transport budget to every remote provider lookup: generic REST (OpenAI/Groq/xAI/DeepSeek/ZAI/Moonshot), Anthropic, Google, both OpenRouter catalogs, and NEAR AI. Each request receives a fresh `AbortSignal.timeout`; because the same signal remains attached to the fetch response, a partial JSON body is also bounded.

The regression suite covers all six request sites, signal uniqueness, header stall, and a real local HTTP server that stalls mid-body.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This is an internal reliability boundary with an exported constant for tests/callers; user-facing configuration and APIs do not change.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/model-provider-helpers.timeout.test.ts`, then the six production request sites in `model-provider-helpers.ts`.

## Detailed testing steps

```bash
bunx vitest run packages/agent/src/api/model-provider-helpers.test.ts packages/agent/src/api/model-provider-helpers.timeout.test.ts --reporter=verbose
bunx biome check packages/agent/src/api/model-provider-helpers.ts packages/agent/src/api/model-provider-helpers.test.ts packages/agent/src/api/model-provider-helpers.timeout.test.ts
bun run --cwd packages/agent typecheck
bun run --cwd packages/agent build
git diff --check HEAD^ HEAD
```

Exact head: `304aab7d6d8887869572f77d53c62c8bf3dedcc8`. Results: 8/8 focused tests, changed-file Biome, Agent typecheck, Agent build, and diff check all pass.

# Evidence Gate

<!-- evidence-head:feeb5b7eab3030f6748813a70814f874a4f74665 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - transport-only backend change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - transport-only backend change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no interactive or visual flow changes.
<!-- evidence-row:backend-logs -->
- [x] [22158-exact-review-feeb5b7.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22158-exact-review-feeb5b7.log)
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or browser request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - catalog discovery transport only; no inference, prompt, action, or evaluator behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persistence or domain-state mutation; the observable artifact is request cancellation and empty-catalog fallback in the backend log.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no UI change.

# Evidence Details

The attached backend artifact records the exact head/base, command, 8/8 result, all six fresh signals, and the real partial-body cancellation result.

## Known gaps / failures

`bun run verify` completed 352/356 tasks and failed only in untouched current-develop `packages/ui` tests (`BuildBadge-timeout.test.ts` and `load-pack-timeout.test.ts`) whose tested symbols are not exported. The changed Agent package typechecks and builds cleanly after the same workspace build phase, and no changed-file diagnostic occurred.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->


