### PR TITLE
fix(core): admit DOCUMENT action in the knowledge context, read-only (provider/action gate mismatch from #19701)

### DIFF
--- a/packages/core/src/features/documents/action-context-gate.test.ts
+++ b/packages/core/src/features/documents/action-context-gate.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Pins the DOCUMENT action's context-gate membership against the runtime's
+ * real action gate, mirroring provider-context-gate.test.ts so the provider
+ * and action cannot drift apart again (the post-#19701 hole: the DOCUMENTS
+ * provider composed on knowledge-routed turns and advertised document IDs for
+ * follow-up reads while the DOCUMENT action was context-gate rejected).
+ *
+ * The `knowledge` context is retrieval-only, so the action's admission there
+ * is paired with a handler-level operation gate: read-only subactions (list,
+ * search, read) run on knowledge-routed turns; mutating subactions (write,
+ * edit, delete, import_file, import_url) require `documents` routing. Both
+ * directions of that gate are pinned here with a deterministic stubbed
+ * runtime — no live model or DB.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { actionGateRejection } from "../../runtime/action-gate.ts";
+import type {
+	AgentContext,
+	HandlerOptions,
+	IAgentRuntime,
+	Memory,
+	SearchCategoryRegistration,
+	UUID,
+} from "../../types";
+import { setContextRoutingMetadata } from "../../utils/context-routing.ts";
+import { documentAction } from "./actions.ts";
+import { documentsProvider } from "./provider.ts";
+import { type DocumentListResult, DocumentService } from "./service.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-00000000a9e7" as UUID;
+const USER_ID = "00000000-0000-0000-0000-00000000c0de" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-00000000d00d" as UUID;
+const WORLD_ID = "00000000-0000-4000-8000-00000000face" as UUID;
+const DOC_ID = "11111111-2222-3333-4444-555555555555" as UUID;
+
+function gateRejectionFor(activeContexts: AgentContext[]) {
+	return actionGateRejection(documentAction, {
+		message: { content: {} } as Memory,
+		activeContexts,
+		userRoles: ["USER"],
+	});
+}
+
+function makeMessage(text: string, routedContext?: AgentContext): Memory {
+	const message = {
+		id: "00000000-0000-0000-0000-0000000000aa" as UUID,
+		entityId: USER_ID,
+		agentId: AGENT_ID,
+		roomId: ROOM_ID,
+		content: { text },
+		createdAt: Date.now(),
+	} as Memory;
+	if (routedContext) {
+		setContextRoutingMetadata(message, { primaryContext: routedContext });
+	}
+	return message;
+}
+
+function listResult(
+	overrides: Partial<DocumentListResult> = {},
+): DocumentListResult {
+	return {
+		status: "empty_store",
+		documents: [],
+		availableDocuments: [],
+		limit: 25,
+		offset: 0,
+		totalVisible: 0,
+		totalAvailable: 0,
+		totalMatched: 0,
+		hasMore: false,
+		availableOffset: 0,
+		availableHasMore: false,
+		...overrides,
+	};
+}
+
+function makeService() {
+	return {
+		listDocumentsDetailed: vi.fn(async () => listResult()),
+		searchDocuments: vi.fn(async () => []),
+		getDocumentById: vi.fn(async () => null),
+		addDocument: vi.fn(async () => ({
+			clientDocumentId: DOC_ID,
+			fragmentCount: 1,
+		})),
+		updateDocument: vi.fn(async () => ({
+			documentId: DOC_ID,
+			fragmentCount: 1,
+		})),
+		deleteDocument: vi.fn(async () => undefined),
+	};
+}
+
+function makeRuntime(service: ReturnType<typeof makeService>): IAgentRuntime {
+	const categories = new Map<string, SearchCategoryRegistration>();
+	return {
+		agentId: AGENT_ID,
+		getService: vi.fn(<T>(type: string): T | null =>
+			type === DocumentService.serviceType ? (service as unknown as T) : null,
+		),
+		registerSearchCategory: vi.fn((reg: SearchCategoryRegistration) => {
+			categories.set(reg.category, reg);
+		}),
+		getSearchCategory: vi.fn((category: string) => {
+			const found = categories.get(category);
+			if (!found) {
+				throw new Error(`unknown category ${category}`);
+			}
+			return found;
+		}),
+		getSetting: vi.fn(() => undefined),
+		getRoom: vi.fn(async () => ({ id: ROOM_ID, worldId: WORLD_ID })),
+		getWorld: vi.fn(async () => ({
+			id: WORLD_ID,
+			agentId: AGENT_ID,
+			metadata: { roles: { [USER_ID]: "USER" } },
+		})),
+		getRoomsForParticipants: vi.fn(async () => {
+			throw new Error("room lookup is unavailable");
+		}),
+		reportError: vi.fn(),
+		useModel: vi.fn(async () => {
+			throw new Error("useModel must not be called on the planner-trust path");
+		}),
+	} as unknown as IAgentRuntime;
+}
+
+function options(parameters: Record<string, unknown>): HandlerOptions {
+	return { parameters } as HandlerOptions;
+}
+
+describe("DOCUMENT action context gating", () => {
+	it("is admitted in both exact stored-document contexts", () => {
+		expect(gateRejectionFor(["documents"])).toBeUndefined();
+		// The mismatch this file pins closed: the DOCUMENTS provider composes
+		// on knowledge-routed turns and hands the model document IDs "for
+		// follow-up reads" — the action gate must admit DOCUMENT there too.
+		expect(gateRejectionFor(["knowledge"])).toBeUndefined();
+		expect(gateRejectionFor(["knowledge", "general"])).toBeUndefined();
+	});
+
+	it("does not expand into unrelated contexts", () => {
+		expect(gateRejectionFor(["web"])?.kind).toBe("context");
+		expect(gateRejectionFor(["wallet"])?.kind).toBe("context");
+		expect(gateRejectionFor(["simple"])?.kind).toBe("context");
+	});
+
+	it("keeps provider and action context membership identical", () => {
+		// The drift guard: whatever contexts compose the DOCUMENTS provider must
+		// also admit the DOCUMENT action, or the model is handed IDs it cannot
+		// dereference. `research` (the remaining taxonomy hole) is deliberately
+		// excluded from both until it gets its own decision.
+		expect([...(documentAction.contexts ?? [])].sort()).toEqual(
+			[...(documentsProvider.contexts ?? [])].sort(),
+		);
+		expect([...(documentAction.contextGate?.anyOf ?? [])].sort()).toEqual(
+			[...(documentsProvider.contextGate?.anyOf ?? [])].sort(),
+		);
+	});
+});
+
+describe("DOCUMENT handler operation gate on knowledge-routed turns", () => {
+	it.each([
+		["list", {}, "listDocumentsDetailed"],
+		["search", { query: "launch notes" }, "searchDocuments"],
+		["read", { id: DOC_ID }, "getDocumentById"],
+	] as const)(
+		"allows the read-only %s subaction when routed to knowledge",
+		async (action, extraParams, method) => {
+			const service = makeService();
+			const runtime = makeRuntime(service);
+			await documentAction.handler?.(
+				runtime,
+				makeMessage("what do we know about the launch?", "knowledge"),
+				undefined,
+				options({ action, ...extraParams }),
+			);
+			expect(service[method]).toHaveBeenCalledTimes(1);
+		},
+	);
+
+	it.each([
+		["write", { text: "Launch is Friday." }],
+		["edit", { id: DOC_ID, text: "Launch moved." }],
+		["delete", { id: DOC_ID }],
+		["import_file", { filePath: "/tmp/launch.md" }],
+		// Unroutable loopback port: the gate must reject before any fetch, so a
+		// regression fails fast on a connection error instead of a live request.
+		["import_url", { url: "https://127.0.0.1:9/launch" }],
+	] as const)(
+		"rejects the mutating %s subaction when routed to knowledge",
+		async (action, extraParams) => {
+			const service = makeService();
+			const runtime = makeRuntime(service);
+			const res = await documentAction.handler?.(
+				runtime,
+				makeMessage("do the thing", "knowledge"),
+				undefined,
+				options({ action, ...extraParams }),
+			);
+			expect(res?.success).toBe(false);
+			expect(res?.values).toMatchObject({
+				error: "knowledge_context_read_only",
+			});
+			expect(service.addDocument).not.toHaveBeenCalled();
+			expect(service.updateDocument).not.toHaveBeenCalled();
+			expect(service.deleteDocument).not.toHaveBeenCalled();
+		},
+	);
+
+	it("still allows mutating subactions when routed to documents", async () => {
+		const service = makeService();
+		const runtime = makeRuntime(service);
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("save this as a document: launch is Friday", "documents"),
+			undefined,
+			options({ action: "write", text: "Launch is Friday." }),
+		);
+		expect(res?.success).toBe(true);
+		expect(service.addDocument).toHaveBeenCalledTimes(1);
+	});
+
+	it("stays permissive when no routing metadata is present", async () => {
+		// Direct invocations (tests, deterministic evaluator calls, legacy
+		// paths) carry no routing decision; the operation gate only narrows
+		// knowledge-routed turns, it does not invent a restriction elsewhere.
+		const service = makeService();
+		const runtime = makeRuntime(service);
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("save this: launch is Friday"),
+			undefined,
+			options({ action: "write", text: "Launch is Friday." }),
+		);
+		expect(res?.success).toBe(true);
+		expect(service.addDocument).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -32,6 +32,7 @@ import type {
 	State,
 	UUID,
 } from "../../types";
+import { getActiveRoutingContextsForTurn } from "../../utils/context-routing.ts";
 import {
 	describeUserReference,
 	userReferenceLogView as queryLogView,
@@ -174,6 +175,51 @@ const DOCUMENT_SUBACTIONS: SubactionsMap<DocumentSubAction> = {
 const DOCUMENT_SUB_ACTION_KEYS = Object.keys(
 	DOCUMENT_SUBACTIONS,
 ) as DocumentSubAction[];
+
+/**
+ * Subactions that only read the document store. On `knowledge`-routed turns
+ * (retrieval-only by taxonomy) the DOCUMENT action is admitted so the model
+ * can dereference the document IDs the DOCUMENTS provider advertises, but the
+ * handler restricts execution to this read-only surface — mutations require
+ * `documents` routing. See the operation gate in the handler.
+ */
+const READ_ONLY_DOCUMENT_SUBACTIONS: ReadonlySet<DocumentSubAction> = new Set([
+	"list",
+	"search",
+	"read",
+]);
+
+/**
+ * Rejects mutating subactions on turns stage-1 routed to `knowledge` without
+ * also routing to `documents`. The context gate admits DOCUMENT on knowledge
+ * turns for reads only; blanket-widening `contexts` alone would expose
+ * write/edit/delete/import on a retrieval-only routing surface. Unrouted
+ * invocations (no routing metadata on state or message) are unaffected — the
+ * gate narrows knowledge-routed turns, it does not invent a restriction for
+ * direct callers.
+ */
+function knowledgeReadOnlyRejection(
+	subaction: DocumentSubAction,
+	message: Memory,
+	state: State | undefined,
+): string | null {
+	if (READ_ONLY_DOCUMENT_SUBACTIONS.has(subaction)) {
+		return null;
+	}
+	const activeContexts = getActiveRoutingContextsForTurn(state, message).map(
+		(context) => `${context}`.toLowerCase(),
+	);
+	if (
+		!activeContexts.includes("knowledge") ||
+		activeContexts.includes("documents")
+	) {
+		return null;
+	}
+	return (
+		`The documents ${subaction.replace("_", " ")} operation is not available on a knowledge-routed turn; ` +
+		"knowledge is retrieval-only (list, search, read). Ask again as an explicit document request to modify stored documents."
+	);
+}
 
 const DOCUMENT_SCOPES = new Set<DocumentVisibilityScope>([
 	"global",
@@ -1169,8 +1215,15 @@ async function handleImportUrl(
 
 export const documentAction: Action = {
 	name: "DOCUMENT",
-	contexts: ["documents"],
-	contextGate: { anyOf: ["documents"] },
+	// Exact-membership context gates do not expand parent/child relationships
+	// (#19701), and the DOCUMENTS provider composes for both `documents` and
+	// `knowledge` — advertising document IDs "for follow-up reads". The action
+	// must be admitted in both contexts or knowledge-routed turns hand the
+	// model IDs it cannot dereference. `knowledge` stays retrieval-only via the
+	// handler's operation gate (see knowledgeReadOnlyRejection): mutating
+	// subactions require `documents` routing.
+	contexts: ["documents", "knowledge"],
+	contextGate: { anyOf: ["documents", "knowledge"] },
 	roleGate: { minRole: "USER" },
 	description:
 		"List, search, read, write, edit, delete, and import stored documents. Select one action and provide the fields needed for that operation.",
@@ -1394,6 +1447,17 @@ export const documentAction: Action = {
 		}
 
 		const { subaction, params } = resolved;
+
+		const readOnlyRejection = knowledgeReadOnlyRejection(
+			subaction,
+			message,
+			state,
+		);
+		if (readOnlyRejection) {
+			return result(false, readOnlyRejection, subaction, {
+				values: { error: "knowledge_context_read_only" },
+			});
+		}
 
 		try {
 			switch (subaction) {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -846,7 +846,6 @@ const CORE_RESPONSE_STATE_PROVIDERS = [
 	"ATTACHMENTS",
 	"PLATFORM_CHAT_CONTEXT",
 	"PLATFORM_USER_CONTEXT",
-	"RUNTIME_MODEL_CONTEXT",
 	// FACTS is dynamic and would otherwise never run during response
 	// composition. Stage 1 keeps it rendered when present (see
 	// STAGE1_EXTRA_PROVIDER_EXCLUSIONS) precisely so durable user facts


### PR DESCRIPTION
## The mismatch

PR #19701 fixed the DOCUMENTS **provider** for `knowledge`-routed turns: context gates are exact set membership with no parent/child expansion, so `contexts: ["documents"]` alone meant stage-1 routing to `knowledge` skipped stored-document retrieval entirely. The provider now declares `anyOf: ["documents", "knowledge"]` with a pin test (`provider-context-gate.test.ts`).

The DOCUMENT **action** never got the same treatment. It still declared `contexts: ["documents"]` / `contextGate: { anyOf: ["documents"] }`. On a turn stage-1 routes to `knowledge` only:

- the DOCUMENTS provider composes and its text explicitly advertises document IDs "for follow-up reads",
- but the planner's action gate (`actionGateRejection`) rejects DOCUMENT on context, and the selected-context representation guarantee cannot rescue it because no action declares `knowledge`.

The model is handed IDs it cannot dereference.

## Why not just widen `contexts`

`knowledge` is retrieval-only by taxonomy ("Answer from stored knowledge/RAG"). Blanket-widening the action's contexts would expose the ENTIRE umbrella action — write, edit, delete, import_file, import_url — on retrieval-only routed turns. Mutation surface deliberately requires `documents` routing.

## The fix

1. Admit DOCUMENT in `knowledge` (`contexts` and `contextGate.anyOf` now match the provider exactly), so knowledge-routed reads work.
2. Pair it with a handler-level operation gate (`knowledgeReadOnlyRejection`): when the turn's routing metadata says `knowledge` without `documents`, mutating subactions are rejected with a clear planner-facing error (`knowledge_context_read_only`); read-only subactions (list, search, read) run normally. Unrouted/direct invocations are unaffected — the gate narrows knowledge-routed turns only.

A per-operation context gate in the action/gate framework itself would be the cleanest shape, but no such facility exists today (`ContextGate` is action-scoped), and splitting a read-only `DOCUMENT_READ` action would bloat the planner's action catalog for one routing case.

## Tests (bidirectional)

New `action-context-gate.test.ts` mirrors `provider-context-gate.test.ts` for the action gate, so provider/action membership can't silently drift apart again:

- gate membership: DOCUMENT admitted in `documents`, `knowledge`, `knowledge+general`; rejected in `web` / `wallet` / `simple`
- drift guard: action `contexts`/`contextGate.anyOf` must equal the provider's
- operation gate, allow direction: list / search / read succeed on knowledge-routed turns
- operation gate, deny direction: write / edit / delete / import_file / import_url rejected on knowledge-routed turns with `knowledge_context_read_only`, service mutation spies never called
- mutations still succeed when routed to `documents`, and when no routing metadata is present

On unfixed develop the suite fails 7/13 exactly on the mismatch (knowledge admission + all five mutation rejections); with the fix all 13 pass. Existing suites green: `actions-routing`, `actions-echo`, `provider-context-gate`, `action-gate`, `context-gates`, `context-catalog`, `action-retrieval`, `message-runtime-stage1` (145). `tsc --noEmit` and biome clean.

## Also

- Dedupes the doubled `RUNTIME_MODEL_CONTEXT` entry in `CORE_RESPONSE_STATE_PROVIDERS` (merge artifact; both consumers dedupe via Set, so cosmetic).

## Not in scope

The `research` context has the same structural hole (routable subcontext of documents, zero provider/action representatives) but needs its own membership decision; deliberately not touched here.


Fixes #22172

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

- AI assistance: yes
- AI provider/model: Anthropic / claude-fable-5 (via anthropic-proxy alias)
- Client / agent tooling: OCPlatform subagent (Sol)
- Contribution skill revision: elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

## Evidence

<!-- evidence-head:560ecf5f8dab31b3ffdf1ecdfa4aa4f127b4064e -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - core runtime planner-gate and action-handler change only; no rendered UI surface exists, nothing visible to photograph. The textual "before" state (new pin suite failing 7/13 on unfixed develop) is attached under backend logs.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - no rendered UI surface (packages/core runtime + tests only); the passing exact-head suite output is attached under backend logs.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - runtime-only planner gating with no visible behavior to record; the mutation-sensitivity transcript below is the walkthrough equivalent for this change class.

<!-- evidence-row:backend-logs -->
- [x] [22159-exact-review-560ecf5.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22159-exact-review-560ecf5.log)

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs/checks: N/A - no frontend code, view, or network path changed; the diff touches packages/core runtime and tests only (see the diff-stat artifact under domain artifacts).

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - the change alters deterministic pre-model gating (action context gate + handler operation gate), not prompt content or model behavior; the gate fires before any model call, and the pin tests assert `useModel` is never invoked on this path. A live trajectory would exercise the planner LLM, not the gate under test.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR file diff](https://github.com/elizaOS/eliza/pull/22159/files), [22159-diff-check.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22159-diff-check.log) (diff-stat + clean worktree at head), [22159-core-typecheck.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22159-core-typecheck.log) (tsc exit 0), [22159-core-build.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22159-core-build.log) (core build + edge declarations verified, exit 0), [22159-biome-changed-files.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22159-biome-changed-files.log) (3 changed files clean), [22159-root-verify-proportional.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22159-root-verify-proportional.log) (focused-test audit, plugin test conventions, test-lane membership, biome version contract — all pass).

— [Sol]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Sol","skill_revision":"elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza"} -->