### PR TITLE
test(vision): cover vertical tiler stride regression

### DIFF
--- a/plugins/plugin-vision/src/screen-tiler.test.ts
+++ b/plugins/plugin-vision/src/screen-tiler.test.ts
@@ -211,6 +211,35 @@ describe("tileScreenshot — full source coverage (regression #22125)", () => {
       expect(overlap).toBeGreaterThanOrEqual(0);
     }
   });
+
+  it("never leaves a gap between vertically adjacent tiles", async () => {
+    // Transpose the formerly failing 5119px axis into the vertical direction.
+    // With floor(strideY), the third tile ends at row 3838 while the anchored
+    // last tile starts at row 3839, leaving source row 3838 uncovered.
+    const height = 5119;
+    const png = await makePng(64, height);
+    const tiles = await tileScreenshot(
+      { displayId: "cov-vertical", width: 64, height, pngBytes: png },
+      { maxEdge: 1280, overlapFraction: 0.12 },
+    );
+    const col0 = tiles.sort((a, b) => a.sourceY - b.sourceY);
+    expect(col0).toHaveLength(4);
+
+    const rowCovered = new Uint8Array(height);
+    for (const tile of col0) {
+      rowCovered.fill(1, tile.sourceY, tile.sourceY + tile.sourceH);
+    }
+    expect([...rowCovered].indexOf(0), "every source row is covered").toBe(-1);
+
+    for (let i = 1; i < col0.length; i += 1) {
+      const prev = expectPresent(col0[i - 1], `tile-${i - 1}-0`);
+      const cur = expectPresent(col0[i], `tile-${i}-0`);
+      const overlap = prev.sourceY + prev.sourceH - cur.sourceY;
+      expect(overlap, `vertical seam before tile ${i}`).toBeGreaterThanOrEqual(
+        0,
+      );
+    }
+  });
 });
 
 describe("tileScreenshot — degenerate axes and extraction bounds", () => {


### PR DESCRIPTION
## Summary

- add a vertical counterpart to the screen-tiler full-coverage regression
- exercise a 5,119-pixel-tall source where the old floored `strideY` skipped row 3,838
- assert both exhaustive row coverage and contiguous-or-overlapping vertical seams
- leave production tiler code unchanged

Closes #22157

## Verification

- `bun run --cwd plugins/plugin-vision typecheck`
- `bun run --cwd plugins/plugin-vision build`
- `bun run --cwd plugins/plugin-vision test` — 43 files, 277 passed, 1 skipped
- `bunx biome check plugins/plugin-vision/src/screen-tiler.test.ts`
- `git diff --check`
- mutation control: temporarily changing only `strideY` from `Math.ceil` to `Math.floor` makes the new test fail with `Received: 3838`; restoring the production math passes

## Evidence

- Backend/domain log: https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22161-vertical-stride-evidence-30148c8e.log
- Frontend/mobile/video: N/A — test-only regression coverage; no UI or runtime behavior changed

<!-- evidence-head:30148c8e8a5ea36c93f9464dd17ff95d222357e7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change; no rendered UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change; no rendered UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change; no interactive path

<!-- evidence-row:backend-logs -->
- [x] [22161-vertical-stride-evidence-30148c8e.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22161-vertical-stride-evidence-30148c8e.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only change; no frontend execution

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic screen-tiler test; no model call

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the backend test log is the complete deterministic artifact for this test-only change

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3e56d090e1988f9b856a293c7cf7394d462cf545:packages/skills/skills/contribute-to-eliza"} -->







