### PR TITLE
fix(plugin-contacts): normalize missing contact fields to typed defaults

### DIFF
--- a/plugins/plugin-contacts/src/providers/contacts.test.ts
+++ b/plugins/plugin-contacts/src/providers/contacts.test.ts
@@ -116,4 +116,82 @@ describe("androidContacts provider", () => {
     });
     expect(result.values).not.toHaveProperty("contactsError");
   });
+
+  it("normalizes missing phoneNumbers and emailAddresses to empty arrays", async () => {
+    const contacts = [
+      {
+        id: "2",
+        lookupKey: "bob",
+        displayName: "Bob",
+        phoneNumbers: undefined as unknown as string[],
+        emailAddresses: undefined as unknown as string[],
+        starred: false,
+      },
+      {
+        id: "3",
+        lookupKey: "carol",
+        displayName: "Carol",
+        phoneNumbers: null as unknown as string[],
+        emailAddresses: null as unknown as string[],
+        starred: false,
+      },
+      {
+        id: "4",
+        lookupKey: "dave",
+        displayName: "Dave",
+        starred: false,
+      } as unknown as Record<string, unknown>,
+    ];
+    contactsMock.listContacts.mockResolvedValue({ contacts });
+
+    const result = await contactsProvider.get(
+      {} as IAgentRuntime,
+      {} as Memory,
+      {} as State,
+    );
+
+    const data = result.data as {
+      contacts: { id: string; phones: string[]; emails: string[] }[];
+    };
+    expect(data.contacts).toHaveLength(3);
+    for (const entry of data.contacts) {
+      expect(Array.isArray(entry.phones)).toBe(true);
+      expect(Array.isArray(entry.emails)).toBe(true);
+      expect(entry.phones).toEqual([]);
+      expect(entry.emails).toEqual([]);
+    }
+    expect(result.text).not.toContain("undefined");
+  });
+
+  it("normalizes missing id and displayName to empty strings", async () => {
+    const contacts = [
+      {
+        lookupKey: "no-id",
+        displayName: undefined as unknown as string,
+        phoneNumbers: ["+15550000000"],
+        emailAddresses: ["x@example.com"],
+        starred: false,
+      } as unknown as Record<string, unknown>,
+      {
+        id: undefined as unknown as string,
+        lookupKey: "no-name",
+        phoneNumbers: [],
+        emailAddresses: [],
+        starred: false,
+      } as unknown as Record<string, unknown>,
+    ];
+    contactsMock.listContacts.mockResolvedValue({ contacts });
+
+    const result = await contactsProvider.get(
+      {} as IAgentRuntime,
+      {} as Memory,
+      {} as State,
+    );
+
+    const data = result.data as {
+      contacts: { id: string; displayName: string }[];
+    };
+    expect(data.contacts[0]?.displayName).toBe("");
+    expect(data.contacts[1]?.id).toBe("");
+  });
 });

--- a/plugins/plugin-contacts/src/providers/contacts.ts
+++ b/plugins/plugin-contacts/src/providers/contacts.ts
@@ -30,10 +30,10 @@ interface AndroidContactEntry {
 
 function toEntry(contact: ContactSummary): AndroidContactEntry {
   return {
-    id: contact.id,
-    displayName: contact.displayName,
-    phones: contact.phoneNumbers,
-    emails: contact.emailAddresses,
+    id: contact.id ?? "",
+    displayName: contact.displayName ?? "",
+    phones: Array.isArray(contact.phoneNumbers) ? contact.phoneNumbers : [],
+    emails: Array.isArray(contact.emailAddresses) ? contact.emailAddresses : [],
     starred: Boolean(contact.starred),
   };
 }


### PR DESCRIPTION
Closes #22048

## Summary
- Fixes `toEntry` in `plugins/plugin-contacts/src/providers/contacts.ts:31` which assigned `contact.phoneNumbers`/`emailAddresses` directly, producing `undefined` when the native bridge returns a contact without phones/emails, violating `AndroidContactEntry`'s `string[]` contract
- Normalizes with `Array.isArray` to `[]` and falls back `id`/`displayName` to `""` via `??`, ensuring typed array contract and no `undefined` in provider JSON/text

## What Changed
- `plugins/plugin-contacts/src/providers/contacts.ts`: `toEntry` now returns `id: contact.id ?? ""`, `displayName: contact.displayName ?? ""`, `phones: Array.isArray(...) ? ... : []`, `emails: Array.isArray(...) ? ... : []`
- `plugins/plugin-contacts/src/providers/contacts.test.ts`: 2 new tests covering missing `phoneNumbers`/`emailAddresses` (undefined, null, absent) normalized to `[]` and missing `id`/`displayName` to `""`

## Exact-head evidence
Head: 5f859f9b9c9e30c6d81dfe77b635159a7599ff76
Base: origin/develop@9f6c33d3546cbc13480e9e0fb516c67440ecdd5e with zero conflicts (`git fetch origin && git rebase origin/develop`)

## Verification / Definition of Done
- [x] Targets `develop`, rebased onto `origin/develop@9f6c33d3546cbc13480e9e0fb516c67440ecdd5e` zero conflicts
- [x] `bun install --frozen-lockfile` passes (3598 installs, no changes)
- [x] Focused gates on exact head: `bunx vitest run plugins/plugin-contacts/src/providers/contacts.test.ts` 6/6 PASS (4 existing + 2 new), `bunx vitest run plugins/plugin-contacts` 37/37 PASS (5 suites pass, 1 pre-existing vite import failure in `contacts-contract.test.ts` reproduced on clean `origin/develop`), `bunx @biomejs/biome check` No fixes, `git diff --check` clean, `bun run check:agents-claude` PASS
- [x] Reviewer can confirm from automated tests / negative control (provider `get` with `phoneNumbers: undefined` → `phones: []` not `undefined`; `result.text` contains no `"undefined"`)
- [x] `N/A - backend provider, no rendered UI` for screenshots/video/frontend logs

## Contribution provenance
<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: openai/gpt-5.6-sol
- Agent tooling: Codex Desktop
- Skill path: elizaOS/eliza@5f859f9b9c9e30c6d81dfe77b635159a7599ff76:packages/skills/skills/contribute-to-eliza

Co-authored-by: byt61 <271805600+byt61@users.noreply.github.com>

---

# Relates to

Fixes `toEntry` producing `undefined` `phones`/`emails` when contact fields are missing on `develop` @ `5f859f9b9c9e30c6d81dfe77b635159a7599ff76` (`9f6c33d3546cbc13480e9e0fb516c67440ecdd5e` base). `AndroidContactEntry` types `phones`/`emails` as `string[]`, but `toEntry` passed through `contact.phoneNumbers`/`emailAddresses` directly. If the native bridge returns `undefined`/`null` or omits the fields, the provider emitted `phones: undefined` violating the contract and surfacing `undefined` in JSON.

## Risks

Low. Adds defensive normalization in `toEntry` only: `Array.isArray` guard for `phones`/`emails` and `?? ""` for `id`/`displayName`. No API or storage change, plugin-scoped, covered by 2 new tests plus 4 existing provider tests. `starred` already used `Boolean()`.

## Background

## What does this PR do?

Normalizes missing contact arrays to `[]` and missing `id`/`displayName` to `""` in the `androidContacts` provider's `toEntry` helper, preserving the typed `string[]` contract and preventing `undefined` from leaking into the provider's `text`/`data` payload.

## What kind of change is this?

Bug fix.

## Documentation changes needed?

My changes do not require a change to the project documentation.

## Testing

## Where should a reviewer start?

- `plugins/plugin-contacts/src/providers/contacts.ts:31`
- `plugins/plugin-contacts/src/providers/contacts.test.ts`

## Detailed testing steps

1. `bunx vitest run plugins/plugin-contacts/src/providers/contacts.test.ts` — provider via mocked `@elizaos/capacitor-contacts`:
   - existing 4 tests still pass (bounded JSON context, error shape, empty book)
   - new: `normalizes missing phoneNumbers and emailAddresses to empty arrays` — 3 contacts with `undefined`/`null`/absent fields → each `phones: []`, `emails: []`, `text` has no `"undefined"`
   - new: `normalizes missing id and displayName to empty strings` — contacts with missing `id`/`displayName` → `""`
2. `bunx vitest run plugins/plugin-contacts` — 37/37 PASS across 5 suites (ContactsView, ContactsAppView, etc.); 1 suite `contacts-contract.test.ts` fails with `Missing "./web" specifier` — reproduced on clean `origin/develop`, not introduced (pre-existing vite import)
3. `bunx @biomejs/biome check plugins/plugin-contacts/src/providers/contacts.ts plugins/plugin-contacts/src/providers/contacts.test.ts` and `git diff --check` clean; `bun run check:agents-claude` PASS

```
contacts.test.ts (6 tests) passed
Checked 2 files in 5ms. No fixes applied.
[assert-agents-claude-identical] PASS: 155 pairs identical
git diff --check: clean
bun install --frozen-lockfile: 3598 installs, no changes
```

# Evidence Gate

<!-- evidence-head:5f859f9b9c9e30c6d81dfe77b635159a7599ff76 -->
<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend provider, no rendered UI`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend provider, no rendered UI`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - deterministic helper, no interactive flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not N/A, logs pasted in Testing`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - no domain artifact beyond helper test`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/model change, pure provider fix.`

## Backend + frontend logs

Backend: `contacts.test.ts` 6/6 passed as above. Frontend: `N/A`.

## Screenshots (before / after) + video walkthrough

`N/A - backend-only provider change.`

## Audio / voice walkthrough

`N/A - no voice change.`

## Known gaps / failures

One pre-existing suite failure (`contacts-contract.test.ts` vite `./web` specifier) reproduced on clean `origin/develop` at `9f6c33d3546cbc13480e9e0fb516c67440ecdd5e`, not introduced. Full `tsc --noEmit` not claimed clean due to known unresolved optional imports (capacitor bridge, cloud-routing) — reproduced on develop.
