### PR TITLE
fix(plugin-wechat): parse RFC 7231 HTTP-date Retry-After instead of NaN

### DIFF
--- a/plugins/plugin-wechat/src/proxy-client.test.ts
+++ b/plugins/plugin-wechat/src/proxy-client.test.ts
@@ -17,6 +17,13 @@ describe("retryDelayMs", () => {
     expect(delay).toBeLessThanOrEqual(60_000);
   });
 
+  it.each(["Sunday, 06-Nov-37 08:49:37 GMT", "Sun Nov  6 08:49:37 2037"])(
+    "accepts the obsolete HTTP-date form %s",
+    (header) => {
+      expect(retryDelayMs(header, 0)).toBeGreaterThan(0);
+    },
+  );
+
   it("clamps an HTTP-date in the past to 0, not negative", () => {
     const past = new Date(Date.now() - 60_000);
     expect(retryDelayMs(past.toUTCString(), 0)).toBe(0);
@@ -31,5 +38,19 @@ describe("retryDelayMs", () => {
     const delay = retryDelayMs("not-a-valid-header", 1);
     expect(delay).toBe(2000);
     expect(Number.isNaN(delay)).toBe(false);
+  });
+
+  it.each(["1.5", "1e3", "+2", "tomorrow"])(
+    "rejects non-RFC numeric syntax %s",
+    (header) => {
+      expect(retryDelayMs(header, 1)).toBe(2000);
+    },
+  );
+
+  it("bounds valid delays to the JavaScript timer maximum", () => {
+    expect(retryDelayMs("999999999999999999999999", 0)).toBe(2_147_483_647);
+    expect(retryDelayMs("Fri, 31 Dec 9999 23:59:59 GMT", 0)).toBe(
+      2_147_483_647,
+    );
   });
 });

--- a/plugins/plugin-wechat/src/proxy-client.test.ts
+++ b/plugins/plugin-wechat/src/proxy-client.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Coverage for `retryDelayMs`'s RFC 7231 Retry-After parsing (delay-seconds
+ * and HTTP-date forms) and its exponential-backoff fallback.
+ */
+import { describe, expect, it } from "vitest";
+import { retryDelayMs } from "./proxy-client";
+
+describe("retryDelayMs", () => {
+  it("parses delay-seconds form", () => {
+    expect(retryDelayMs("120", 0)).toBe(120_000);
+  });
+
+  it("parses an HTTP-date in the future", () => {
+    const target = new Date(Date.now() + 60_000);
+    const delay = retryDelayMs(target.toUTCString(), 0);
+    expect(delay).toBeGreaterThan(55_000);
+    expect(delay).toBeLessThanOrEqual(60_000);
+  });
+
+  it("clamps an HTTP-date in the past to 0, not negative", () => {
+    const past = new Date(Date.now() - 60_000);
+    expect(retryDelayMs(past.toUTCString(), 0)).toBe(0);
+  });
+
+  it("falls back to exponential backoff when the header is missing", () => {
+    expect(retryDelayMs(null, 0)).toBe(1000);
+    expect(retryDelayMs(null, 3)).toBe(8000);
+  });
+
+  it("falls back to exponential backoff instead of NaN on an unparseable header", () => {
+    const delay = retryDelayMs("not-a-valid-header", 1);
+    expect(delay).toBe(2000);
+    expect(Number.isNaN(delay)).toBe(false);
+  });
+});

--- a/plugins/plugin-wechat/src/proxy-client.ts
+++ b/plugins/plugin-wechat/src/proxy-client.ts
@@ -50,10 +50,7 @@ export class ProxyClient {
         });
 
         if (res.status === 429) {
-          const retryAfter = res.headers.get("Retry-After");
-          const delay = retryAfter
-            ? Number.parseInt(retryAfter, 10) * 1000
-            : Math.min(1000 * 2 ** attempt, 8000);
+          const delay = retryDelayMs(res.headers.get("Retry-After"), attempt);
           // Consume the response body to release the connection
           await res.text().catch(() => {});
           await sleep(delay);
@@ -173,6 +170,31 @@ export class LoginExpiredError extends Error {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const MAX_BACKOFF_MS = 8000;
+
+/**
+ * RFC 7231 §7.1.3 allows Retry-After to be either delay-seconds ("120") or an
+ * HTTP-date ("Wed, 21 Oct 2026 07:28:00 GMT"). `Number.parseInt` on the date
+ * form silently returns NaN, which made `setTimeout` fire almost immediately
+ * instead of honoring the server's backoff. Falls back to the existing
+ * exponential backoff when the header is absent or neither form parses.
+ */
+export function retryDelayMs(
+  retryAfterHeader: string | null,
+  attempt: number,
+): number {
+  const fallback = Math.min(1000 * 2 ** attempt, MAX_BACKOFF_MS);
+  if (!retryAfterHeader) return fallback;
+
+  const seconds = Number(retryAfterHeader);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+
+  const dateMs = Date.parse(retryAfterHeader);
+  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+
+  return fallback;
 }
 
 function normalizeProxyUrl(proxyUrl: string): string {

--- a/plugins/plugin-wechat/src/proxy-client.ts
+++ b/plugins/plugin-wechat/src/proxy-client.ts
@@ -173,6 +173,11 @@ function sleep(ms: number): Promise<void> {
 }
 
 const MAX_BACKOFF_MS = 8000;
+// JavaScript timers overflow above a signed 32-bit delay and may fire almost
+// immediately, which would defeat the rate-limit backoff this parser protects.
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const HTTP_DATE_PATTERN =
+  /^(?:[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT|[A-Z][a-z]+, \d{2}-[A-Z][a-z]{2}-\d{2} \d{2}:\d{2}:\d{2} GMT|[A-Z][a-z]{2} [A-Z][a-z]{2} {1,2}\d{1,2} \d{2}:\d{2}:\d{2} \d{4})$/;
 
 /**
  * RFC 7231 §7.1.3 allows Retry-After to be either delay-seconds ("120") or an
@@ -188,11 +193,19 @@ export function retryDelayMs(
   const fallback = Math.min(1000 * 2 ** attempt, MAX_BACKOFF_MS);
   if (!retryAfterHeader) return fallback;
 
-  const seconds = Number(retryAfterHeader);
-  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const value = retryAfterHeader.trim();
+  if (/^\d+$/.test(value)) {
+    const seconds = Number(value);
+    if (!Number.isFinite(seconds)) return MAX_TIMER_DELAY_MS;
+    return Math.min(seconds * 1000, MAX_TIMER_DELAY_MS);
+  }
 
-  const dateMs = Date.parse(retryAfterHeader);
-  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+  if (HTTP_DATE_PATTERN.test(value)) {
+    const dateMs = Date.parse(value);
+    if (!Number.isNaN(dateMs)) {
+      return Math.min(Math.max(0, dateMs - Date.now()), MAX_TIMER_DELAY_MS);
+    }
+  }
 
   return fallback;
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22162.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Only touched code path is `ProxyClient.request`'s 429 branch in a single
plugin (`plugins/plugin-wechat`); no other file references the old inline
calculation. The new `retryDelayMs` is a pure function with no new
dependencies (`Number`, `Date.parse`, both native). Behavior for the two
previously-working cases (numeric delay-seconds, missing header) is
unchanged; only the previously-broken HTTP-date case and unparseable-garbage
case now resolve to a finite delay instead of `NaN`.

# Background

## What does this PR do?

`ProxyClient.request`'s 429 handling parsed `Retry-After` with
`Number.parseInt(retryAfter, 10) * 1000`. RFC 7231 §7.1.3 allows
`Retry-After` to be either delay-seconds (`"120"`) or an HTTP-date
(`"Wed, 21 Oct 2026 07:28:00 GMT"`); `Number.parseInt` on the date form
returns `NaN`, so `setTimeout(sleep, NaN)` fires almost immediately instead
of honoring the server's requested backoff, hammering the still-rate-limited
proxy endpoint.

Extracts the inline calculation into an exported pure function
`retryDelayMs(retryAfterHeader, attempt)`:
- numeric delay-seconds → `Number(header) * 1000`, clamped to `>= 0`
- HTTP-date → `Date.parse(header) - Date.now()`, clamped to `>= 0` (a
  past/near date resolves to `0`, never negative)
- absent or unparseable → the existing exponential backoff
  (`Math.min(1000 * 2 ** attempt, 8000)`), same as before this fix

No new dependencies; native `Number`/`Date.parse` only.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-wechat/src/proxy-client.test.ts` — new, covers `retryDelayMs` directly (pure function, no network/timer mocking needed)

## Detailed testing steps

None: Automated tests are acceptable. Every test drives the real exported
`retryDelayMs` function used by `ProxyClient.request`.

- `cd plugins/plugin-wechat && bun run test -- src/proxy-client.test.ts` (5 tests)
- Full plugin suite, no regressions: `cd plugins/plugin-wechat && bun run test` (44 tests)
- `cd plugins/plugin-wechat && bun run typecheck`
- `bunx @biomejs/biome check plugins/plugin-wechat/src/proxy-client.ts plugins/plugin-wechat/src/proxy-client.test.ts`

# Evidence Gate

<!-- evidence-head:da5f2952adbb0a0d0ecdf2d151db8d144c779d91 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change (plugins/plugin-wechat), no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change (plugins/plugin-wechat), no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change, no user-facing flow to walk through
<!-- evidence-row:backend-logs -->
- [x] Real Vitest run covering both RFC 7231 Retry-After forms and the
      fallback path.

<details>
<summary>Backend logs — proxy-client.test.ts, full plugin-wechat suite</summary>

```
$ cd plugins/plugin-wechat && bun run test -- src/proxy-client.test.ts

 RUN  v4.1.5 /Users/arefgholami/Desktop/Projects/eliza/plugins/plugin-wechat

 ✓ retryDelayMs > parses delay-seconds form
 ✓ retryDelayMs > parses an HTTP-date in the future
 ✓ retryDelayMs > clamps an HTTP-date in the past to 0, not negative
 ✓ retryDelayMs > falls back to exponential backoff when the header is missing
 ✓ retryDelayMs > falls back to exponential backoff instead of NaN on an unparseable header

 Test Files  1 passed (1)
      Tests  5 passed (5)

$ cd plugins/plugin-wechat && bun run test

 RUN  v4.1.5 /Users/arefgholami/Desktop/Projects/eliza/plugins/plugin-wechat

 Test Files  4 passed (4)
      Tests  44 passed (44)

$ cd plugins/plugin-wechat && bun run typecheck
(no output — clean)

$ bunx @biomejs/biome check plugins/plugin-wechat/src/proxy-client.ts plugins/plugin-wechat/src/proxy-client.test.ts
Checked 2 files in 6ms. No fixes applied.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] Real before/after delay values for the exact failure input, run against
      the actual pre-fix and post-fix code paths.

<details>
<summary>Domain artifact — before/after delay for an HTTP-date Retry-After value</summary>

```
$ bun -e '...'   (input: "Wed, 21 Oct 2026 07:28:00 GMT", the RFC 7231 HTTP-date form)

old behavior (Number.parseInt(retryAfter, 10) * 1000):
  delay ms: NaN
  => setTimeout(sleep, NaN) fires almost immediately in Node/Bun instead of
     honoring the server's requested backoff

fixed behavior (retryDelayMs(retryAfter, attempt)):
  delay ms: 5482387425
  => Date.parse(header) - Date.now(), a finite, correct delay until the
     server-specified retry time
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-manual]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza"} -->
\n\n## Independent exact-final hardening\n\nAt `da5f2952adbb0a0d0ecdf2d151db8d144c779d91`, review tightened delay-seconds to the RFC DIGIT grammar, accepts all three HTTP-date wire forms, and caps valid numeric/date delays at the JavaScript signed-32-bit timer maximum so an overflowing server value cannot collapse to an immediate retry. Exact-final focused tests pass 12/12; the full plugin suite passes 51/51; typecheck, build, package lint, diff integrity, and canonical evidence verification pass.\n