### PR TITLE
fix(plugin-scheduling): centralize bounded minute projection

### DIFF
--- a/plugins/plugin-scheduling/src/scheduled-task/dispatch-policy-overflow.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/dispatch-policy-overflow.test.ts
@@ -260,4 +260,58 @@ describe("dispatch-policy overflow guard (#22136)", () => {
     );
     expect(ok?.fireAtIso).toBe("2026-05-11T12:30:00.000Z");
   });
+
+  it("rejects invalid registered-ladder delays instead of parking in the past", () => {
+    const cursor = {
+      stepIndex: -1,
+      lastDispatchedAt: "2026-05-11T12:00:00.000Z",
+    };
+    for (const delayMinutes of [
+      -1,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+    ]) {
+      expect(
+        nextEscalationStep(
+          {
+            ladderKey: "invalid-contributor-ladder",
+            steps: [{ delayMinutes, channelKey: "in_app" }],
+          },
+          cursor,
+        ),
+      ).toBeNull();
+    }
+  });
+
+  it("settles an overflowing concurrent claim once and spawns onFail once", async () => {
+    const h = makeHarness();
+    const onFailChild: ScheduledTask = {
+      taskId: "st_overflow_concurrent_onfail",
+      state: { status: "scheduled", followupCount: 0 },
+      ...reminderInput({ trigger: { kind: "manual" } }),
+    };
+    const task = await h.runner.schedule(
+      reminderInput({ pipeline: { onFail: [onFailChild] } }),
+    );
+    h.queueDispatchResults({
+      ok: false,
+      reason: "rate_limited",
+      retryAfterMinutes: OVERFLOW_MINUTES,
+      userActionable: false,
+    });
+
+    const results = await Promise.all([
+      h.runner.fireWithResult(task.taskId),
+      h.runner.fireWithResult(task.taskId),
+    ]);
+    expect(results.map((result) => result.kind).sort()).toEqual([
+      "dispatch_failed",
+      "raced",
+    ]);
+    const children = (await h.store.list()).filter(
+      (candidate) => candidate.state.pipelineParentId === task.taskId,
+    );
+    expect(children).toHaveLength(1);
+  });
 });

--- a/plugins/plugin-scheduling/src/scheduled-task/due.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.ts
@@ -13,6 +13,7 @@ import { computeNextCronRunAtMs, stringToUuid } from "@elizaos/core/edge";
 
 import type { AnchorRegistry } from "../anchors/anchor-registry.js";
 import { InvalidLocalTimeError, resolveLocalHHMMToIso } from "./local-time.js";
+import { isRepresentableMs } from "./time-range.js";
 import { resolveTriggerTz } from "./trigger-tz.js";
 import type {
   OwnerFactsView,
@@ -42,13 +43,6 @@ function parseIsoMs(value: unknown): number | null {
   if (typeof value !== "string" || value.length === 0) return null;
   const parsed = Date.parse(value);
   return Number.isFinite(parsed) ? parsed : null;
-}
-
-/** Maximum |ms| a JS Date can represent (±100,000,000 days from epoch). */
-const MAX_DATE_MS = 8_640_000_000_000_000;
-
-function isRepresentableMs(ms: number): boolean {
-  return Number.isFinite(ms) && Math.abs(ms) <= MAX_DATE_MS;
 }
 
 function isTerminalStatus(status: ScheduledTaskStatus): boolean {

--- a/plugins/plugin-scheduling/src/scheduled-task/escalation.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/escalation.ts
@@ -11,7 +11,7 @@
  * `priority_<level>_default` keys.
  */
 
-import { isRepresentableMs } from "./time-range.js";
+import { projectMinuteOffsetMs } from "./time-range.js";
 import type {
   EscalationStep,
   ScheduledTask,
@@ -152,12 +152,12 @@ export function nextEscalationStep(
   const step = ladder.steps[nextIdx];
   if (!step) return null;
   const lastMs = new Date(cursor.lastDispatchedAt).getTime();
-  const fireAtMs = lastMs + step.delayMinutes * 60_000;
+  const fireAtMs = projectMinuteOffsetMs(lastMs, step.delayMinutes);
   // A schema-valid but unbounded `delayMinutes` (no upper bound in schema.ts)
   // can push the product past the JS Date range, where `toISOString()` would
   // throw. Treat that as "no next step" so the ladder settles instead of
   // stranding a claimed row.
-  if (!isRepresentableMs(fireAtMs)) return null;
+  if (fireAtMs === null) return null;
   return {
     step,
     nextStepIndex: nextIdx,

--- a/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.ts
@@ -20,6 +20,7 @@ import { computeNextCronRunAtMs } from "@elizaos/core/edge";
 import type { AnchorRegistry } from "../anchors/anchor-registry.js";
 import { windowOccurrenceKey } from "./due.js";
 import { resolveLocalHHMMToIso } from "./local-time.js";
+import { isRepresentableMs, MAX_DATE_MS } from "./time-range.js";
 import { resolveTriggerTz } from "./trigger-tz.js";
 import type {
   OwnerFactsView,
@@ -46,15 +47,8 @@ function parseIsoMs(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-/** Maximum |ms| a JS Date can represent (±100,000,000 days from epoch). */
-const MAX_DATE_MS = 8_640_000_000_000_000;
-
 /** Headroom for core's cron scan window (366 days) before the Date limit. */
 const CRON_SCAN_HEADROOM_MS = 366 * 24 * 60 * MINUTE_MS;
-
-function isRepresentableMs(ms: number): boolean {
-  return Number.isFinite(ms) && Math.abs(ms) <= MAX_DATE_MS;
-}
 
 function nextWindowStartIso(
   windowKey: string,

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -39,7 +39,7 @@ import {
 import type { TaskGateRegistry } from "./gate-registry.js";
 import { computeNextFireAt } from "./next-fire-at.js";
 import { createStateLogger, type ScheduledTaskLogStore } from "./state-log.js";
-import { isRepresentableMs } from "./time-range.js";
+import { projectMinuteOffsetMs } from "./time-range.js";
 import {
   type ActivitySignalBusView,
   APPROVAL_DEFAULT_FOLLOWUP_AFTER_MINUTES,
@@ -2231,9 +2231,11 @@ export function createScheduledTaskRunner(
         // huge value would push the park-back instant past the JS Date range
         // and make `toISOString()` throw AFTER the row was atomically claimed
         // to `"fired"`, stranding it. Settle terminally instead of stranding.
-        const nextAttemptMs =
-          Date.parse(fireAtIso) + decision.retryAfterMinutes * 60_000;
-        if (!isRepresentableMs(nextAttemptMs)) {
+        const nextAttemptMs = projectMinuteOffsetMs(
+          Date.parse(fireAtIso),
+          decision.retryAfterMinutes,
+        );
+        if (nextAttemptMs === null) {
           return failTerminal(task, decision.reason, failure.message);
         }
         const nextAttemptAtIso = new Date(nextAttemptMs).toISOString();
@@ -2276,9 +2278,11 @@ export function createScheduledTaskRunner(
         // upper limit); guard the park-back instant against the Date range so
         // a claimed row settles terminally instead of throwing while stranded
         // in `"fired"`.
-        const nextAttemptMs =
-          Date.parse(fireAtIso) + nextStep.delayMinutes * 60_000;
-        if (!isRepresentableMs(nextAttemptMs)) {
+        const nextAttemptMs = projectMinuteOffsetMs(
+          Date.parse(fireAtIso),
+          nextStep.delayMinutes,
+        );
+        if (nextAttemptMs === null) {
           if (decision.kind === "surface_degraded") {
             recordConnectorDegradation(task, decision, fireAtIso);
           }

--- a/plugins/plugin-scheduling/src/scheduled-task/time-range.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/time-range.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Boundary tests for the shared scheduling Date-range projection helpers.
+ * The cases are deterministic and exercise exact JS Date limits plus hostile
+ * connector/contributor minute offsets without invoking the runner.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isRepresentableMs,
+  MAX_DATE_MS,
+  projectMinuteOffsetMs,
+} from "./time-range.js";
+
+describe("scheduling Date-range projection", () => {
+  it("accepts both exact Date bounds and rejects every non-representable value", () => {
+    expect(isRepresentableMs(MAX_DATE_MS)).toBe(true);
+    expect(isRepresentableMs(-MAX_DATE_MS)).toBe(true);
+    expect(isRepresentableMs(MAX_DATE_MS + 1)).toBe(false);
+    expect(isRepresentableMs(-MAX_DATE_MS - 1)).toBe(false);
+    expect(isRepresentableMs(Number.NaN)).toBe(false);
+    expect(isRepresentableMs(Number.POSITIVE_INFINITY)).toBe(false);
+    expect(isRepresentableMs(Number.NEGATIVE_INFINITY)).toBe(false);
+  });
+
+  it("projects exact-bound offsets while rejecting negative and non-finite minutes", () => {
+    expect(projectMinuteOffsetMs(MAX_DATE_MS - 60_000, 1)).toBe(MAX_DATE_MS);
+    expect(projectMinuteOffsetMs(MAX_DATE_MS, 0)).toBe(MAX_DATE_MS);
+    expect(projectMinuteOffsetMs(MAX_DATE_MS, 1)).toBeNull();
+    expect(projectMinuteOffsetMs(0, -1)).toBeNull();
+    expect(projectMinuteOffsetMs(0, Number.NaN)).toBeNull();
+    expect(projectMinuteOffsetMs(0, Number.POSITIVE_INFINITY)).toBeNull();
+    expect(projectMinuteOffsetMs(Number.NaN, 1)).toBeNull();
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/time-range.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/time-range.ts
@@ -22,3 +22,23 @@ export const MAX_DATE_MS = 8_640_000_000_000_000;
 export function isRepresentableMs(ms: number): boolean {
   return Number.isFinite(ms) && Math.abs(ms) <= MAX_DATE_MS;
 }
+
+/**
+ * Add a non-negative minute offset to a representable epoch instant.
+ * Returns `null` for untrusted negative/non-finite offsets or when the result
+ * would fall outside the JS Date range.
+ */
+export function projectMinuteOffsetMs(
+  baseMs: number,
+  offsetMinutes: number,
+): number | null {
+  if (
+    !isRepresentableMs(baseMs) ||
+    !Number.isFinite(offsetMinutes) ||
+    offsetMinutes < 0
+  ) {
+    return null;
+  }
+  const projectedMs = baseMs + offsetMinutes * 60_000;
+  return isRepresentableMs(projectedMs) ? projectedMs : null;
+}


### PR DESCRIPTION
# Relates to

Completes #22136 after merged PR #22150. The original overflow fix correctly prevents `Date` overflow from stranding a claimed row, but adversarial post-merge review found two remaining gaps in the same boundary.

Closes #22136.

# What changed

- Replaces the three private copies of `MAX_DATE_MS` / `isRepresentableMs` in `due.ts`, `next-fire-at.ts`, and the new dispatch guard with the single scheduling-owned helper.
- Adds `projectMinuteOffsetMs(baseMs, offsetMinutes)`, which rejects invalid base dates, non-finite offsets, negative offsets, and projected values outside the exact JS Date range.
- Routes dispatch retry, ladder advance, and `nextEscalationStep` through that shared projection.
- Prevents programmatically registered contributor ladders with negative/non-finite steps from parking a task in the past. This matters because `EscalationLadderRegistry.register()` validates the ladder key but does not validate contributed step values.
- Pins exact `±8_640_000_000_000_000` equality, ±1 overflow, `NaN`, infinities, negative offsets, and concurrent overflow settlement with exactly one `pipeline.onFail` child.

# Exact evidence

Head at publication: `eb5d823da668` on develop `189f964eb197`.

- Full scheduling suite: 32 files, 523 passed, 0 failed.
- Focused overflow/time-range lane after final rebase: 8 passed, 0 failed.
- Package typecheck: passed.
- Package build: JS, views, declarations passed.
- Touched-file Biome: passed.
- Guide parity and base diff check: passed.

Backend-only scheduling state-machine hardening; UI screenshots/video/frontend logs and LLM trajectory are N/A.

AI provider/model: `openai / gpt-5.6-sol`
Client: `Codex Desktop`
Skill revision: `189f964eb197:packages/skills/skills/contribute-to-eliza`
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@189f964eb197:packages/skills/skills/contribute-to-eliza"} -->
