### PR TITLE
chore: bind Slop policy revision 2026-08-18.1

### DIFF
--- a/.github/slop-project.json
+++ b/.github/slop-project.json
@@ -1,17 +1,1 @@
-{
-  "kind": "slop-project-authority",
-  "policyRevision": "2026-08-16.3",
-  "projectId": "eliza",
-  "proposal": "https://github.com/elizaOS/slopdotcash/issues/115",
-  "repository": {
-    "fullName": "elizaOS/eliza",
-    "id": "826170402",
-    "integrationBranch": "develop"
-  },
-  "schemaVersion": "1",
-  "steward": {
-    "actorId": "186240462",
-    "login": "elizaOS",
-    "nodeId": "O_kgDOCxnNzg"
-  }
-}
+{"kind":"slop-project-authority","policyRevision":"2026-08-18.1","projectId":"eliza","proposal":"https://github.com/elizaOS/slopdotcash/issues/115","repository":{"fullName":"elizaOS/eliza","id":"826170402","integrationBranch":"develop"},"schemaVersion":"1","steward":{"actorId":"186240462","login":"elizaOS","nodeId":"O_kgDOCxnNzg"}}


### PR DESCRIPTION
Updates the repository-owned Slop authority marker to a new immutable policy revision for the August scoring and receipt-policy activation. No repository contribution or license terms are changed.