### PR TITLE
fix(plugin-agent-skills): sanitize skill-create description to prevent corruption and frontmatter injection

### DIFF
--- a/packages/shared/src/contracts/skills-routes.test.ts
+++ b/packages/shared/src/contracts/skills-routes.test.ts
@@ -132,6 +132,25 @@ describe("PostSkillCreateRequestSchema", () => {
     ).toEqual({ name: "skillz" });
   });
 
+  it("accepts the 1024-character SKILL.md limit after trimming", () => {
+    const description = "x".repeat(1024);
+    expect(
+      PostSkillCreateRequestSchema.parse({
+        name: "skillz",
+        description: `  ${description}  `,
+      }),
+    ).toEqual({ name: "skillz", description });
+  });
+
+  it("rejects descriptions beyond the SKILL.md limit", () => {
+    expect(() =>
+      PostSkillCreateRequestSchema.parse({
+        name: "skillz",
+        description: "x".repeat(1025),
+      }),
+    ).toThrow(/description must be 1024 characters or less/);
+  });
+
   it("rejects whitespace-only name", () => {
     expect(() => PostSkillCreateRequestSchema.parse({ name: " " })).toThrow(
       /name is required/,

--- a/packages/shared/src/contracts/skills-routes.ts
+++ b/packages/shared/src/contracts/skills-routes.ts
@@ -56,14 +56,16 @@ export const PostSkillAcknowledgeRequestSchema = z
 export const PostSkillCreateRequestSchema = z
   .object({
     name: z.string().regex(/\S/, "name is required"),
-    description: z.string().optional(),
+    description: z
+      .string()
+      .trim()
+      .max(1024, "description must be 1024 characters or less")
+      .optional(),
   })
   .strict()
   .transform((value) => ({
     name: value.name.trim(),
-    ...(value.description?.trim()
-      ? { description: value.description.trim() }
-      : {}),
+    ...(value.description ? { description: value.description } : {}),
   }));
 
 export const PutSkillSourceRequestSchema = z

--- a/plugins/plugin-agent-skills/src/api/skill-discovery-helpers.ts
+++ b/plugins/plugin-agent-skills/src/api/skill-discovery-helpers.ts
@@ -9,6 +9,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { type AgentRuntime, logger, resolveStateDir } from "@elizaos/core";
 import { getSkillsDir } from "@elizaos/skills";
+import { decodeFrontmatterScalarString } from "../parser";
 import type { ElizaConfig, SkillEntry } from "./skills-routes";
 
 /** Cache key for persisting skill enable/disable state in the agent database. */
@@ -437,10 +438,13 @@ export function scanSkillsDir(
           const fmBlock = fmMatch[1];
           const nameMatch = /^name:\s*(.+)$/m.exec(fmBlock);
           const descMatch = /^description:\s*(.+)$/m.exec(fmBlock);
+          // Decode via the shared frontmatter scalar decoder so a quoted,
+          // JSON-escaped description written by the create scaffold round-trips
+          // to its exact value instead of leaking literal backslashes.
           if (nameMatch)
-            skillName = nameMatch[1].trim().replace(/^["']|["']$/g, "");
+            skillName = decodeFrontmatterScalarString(nameMatch[1]);
           if (descMatch)
-            description = descMatch[1].trim().replace(/^["']|["']$/g, "");
+            description = decodeFrontmatterScalarString(descMatch[1]);
         }
 
         // Fallback to heading / first paragraph

--- a/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
@@ -1,47 +1,107 @@
 /**
  * Regression tests for the SKILL.md scaffold path used by
- * `POST /api/skills/create`. Deterministic: builds the scaffold exactly as the
- * route handler does (`sanitizeScaffoldDescription` + `skillScaffoldMarkdown`)
- * and parses it back with the real `parseFrontmatter`, asserting the
- * user-supplied description round-trips without corruption and cannot smuggle
- * extra frontmatter keys (frontmatter injection via embedded newlines).
+ * `POST /api/skills/create`. Two layers of real coverage:
+ *
+ *  1. Helper-level: builds the scaffold exactly as the route does
+ *     (`serializeScaffoldDescription` + `skillScaffoldMarkdown`) and parses it
+ *     back with the real `parseFrontmatter`, asserting the description is stored
+ *     as an unambiguously quoted scalar that round-trips to the exact string —
+ *     never coerced to a boolean/number/null/object/array and never able to
+ *     smuggle extra frontmatter keys via embedded newlines.
+ *  2. Route-level: drives the real `handleSkillsRoutes` create handler against a
+ *     temp workspace with the real `discoverSkills`, then reads the written
+ *     SKILL.md back through both the canonical `parseFrontmatter` loader and the
+ *     filesystem discovery scan, proving the actual HTTP write→discover path.
  *
  * Guards issue #22160: the former handler escaped the description as if it were
- * a double-quoted YAML string while the scaffold scalar is bare, injecting
- * literal backslashes, and left newlines intact so a description could append
- * `allowed-tools`, `homepage`, `license`, or an overriding `name` line.
+ * a double-quoted string while emitting a bare scalar (injecting backslashes),
+ * left newlines intact so a description could append `allowed-tools`/`homepage`/
+ * `license`/`name`, and — because the bare scalar was type-coerced by the subset
+ * parser — could yield a non-string description that `toSkillFrontmatter`
+ * rejects, silently producing an undiscoverable skill.
  */
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import type http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { parseFrontmatter } from "../parser";
+import { discoverSkills } from "./skill-discovery-helpers";
 import { skillScaffoldMarkdown } from "./skill-scaffold";
-import { sanitizeScaffoldDescription } from "./skills-routes";
+import {
+  handleSkillsRoutes,
+  type SkillsRouteContext,
+  serializeScaffoldDescription,
+} from "./skills-routes";
+
+const DEFAULT_DESCRIPTION = "Describe what this skill does.";
 
 /**
- * Rebuild the SKILL.md the way the create handler does, then parse it back.
+ * Rebuild the SKILL.md the way the create handler does, then parse it back with
+ * the canonical frontmatter loader.
  */
 function scaffoldAndParse(slug: string, description: string) {
-  const safeDescription = sanitizeScaffoldDescription(description);
   const template = skillScaffoldMarkdown
     .replace(/__SLUG__/g, slug)
-    .replace(/__DESCRIPTION__/g, () => safeDescription);
+    .replace(/__DESCRIPTION__/g, () => serializeScaffoldDescription(description));
   return parseFrontmatter(template).frontmatter;
 }
 
+// Every value the subset parser would otherwise type-coerce out of a bare
+// scalar (booleans, null aliases, ints, floats, inline JSON object/array) plus
+// the quote-delimited forms `parseYamlValue` would silently unwrap.
+const COERCION_FAMILY_INPUTS = [
+  "true",
+  "false",
+  "null",
+  "~",
+  "123",
+  "1.5",
+  "-42",
+  "{}",
+  "[]",
+  '{"a":1}',
+  "[1,2,3]",
+  '"quoted"',
+  "'quoted'",
+];
+
 describe("skill scaffold frontmatter round-trip (issue #22160)", () => {
-  it("round-trips a description containing double quotes and backslashes unchanged", () => {
-    const description = 'Fetches data from "the API" and returns C:\\path JSON';
+  it.each(COERCION_FAMILY_INPUTS)(
+    "stores %j as an exact string, never a coerced non-string",
+    (input) => {
+      const fm = scaffoldAndParse("my-skill", input);
+
+      expect(fm).not.toBeNull();
+      expect(typeof fm?.description).toBe("string");
+      expect(fm?.description).toBe(input);
+      expect(fm?.name).toBe("my-skill");
+    },
+  );
+
+  it("round-trips quotes, backslashes, unicode, and $-sequences exactly", () => {
+    const description =
+      'Fetches "the API" at C:\\path — costs $5, uses $& and $1 — café ☕ ✓';
+    const fm = scaffoldAndParse("my-skill", description);
+
+    expect(fm?.description).toBe(description);
+    // The former double-quote escaping injected literal backslashes; assert none leaked.
+    expect(fm?.description).not.toContain('\\"');
+    expect(fm?.description).not.toContain("\\\\");
+  });
+
+  it("round-trips control characters exactly without breaking the frontmatter block", () => {
+    const description = "line1\nline2\ttab\u0000nul\rcr";
     const fm = scaffoldAndParse("my-skill", description);
 
     expect(fm).not.toBeNull();
     expect(fm?.description).toBe(description);
-    // The former escaping injected literal backslashes; assert none leaked.
-    expect(fm?.description).not.toContain("\\\"");
-    expect(fm?.description).not.toContain("\\\\");
+    expect(fm?.name).toBe("my-skill");
   });
 
-  it("collapses newlines so a description cannot inject extra frontmatter keys", () => {
+  it("cannot inject extra frontmatter keys via embedded newlines", () => {
     const description =
-      "Helpful skill\nallowed-tools: bash rm curl\nhomepage: http://evil.example\nlicense: MIT";
+      "Helpful skill\nallowed-tools: bash rm curl\nhomepage: http://evil.example\nlicense: MIT\nname: attacker-override";
     const fm = scaffoldAndParse("my-skill", description);
 
     expect(fm).not.toBeNull();
@@ -49,31 +109,119 @@ describe("skill scaffold frontmatter round-trip (issue #22160)", () => {
     expect(fm?.["allowed-tools"]).toBeUndefined();
     expect(fm?.homepage).toBeUndefined();
     expect(fm?.license).toBeUndefined();
-    // The description is preserved (collapsed to one line), never truncated at
-    // the first newline the way the vulnerable parser did.
-    expect(fm?.description).toBe(
-      "Helpful skill allowed-tools: bash rm curl homepage: http://evil.example license: MIT",
-    );
-  });
-
-  it("does not let an embedded name: line override the slug-derived name", () => {
-    const fm = scaffoldAndParse("my-skill", "Legit\nname: attacker-override");
-
+    // The slug-derived name cannot be overridden.
     expect(fm?.name).toBe("my-skill");
-    expect(fm?.description).toBe("Legit name: attacker-override");
-  });
-
-  it("preserves literal $-sequences instead of treating them as replacement patterns", () => {
-    const description = "Costs $5, uses $& and $1 tokens";
-    const fm = scaffoldAndParse("my-skill", description);
-
+    // The description is preserved verbatim (the quoted scalar keeps the
+    // newlines inside the value rather than truncating at the first one).
     expect(fm?.description).toBe(description);
   });
 
-  it("falls back to the default description when only control characters are supplied", () => {
-    const fm = scaffoldAndParse("my-skill", "\u0000\n\t \r");
+  it("falls back to the default when the description is only whitespace", () => {
+    const fm = scaffoldAndParse("my-skill", "   \t  \n ");
 
     expect(fm).not.toBeNull();
-    expect(fm?.description).toBe("Describe what this skill does.");
+    expect(fm?.description).toBe(DEFAULT_DESCRIPTION);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real route write → discover/read round trip
+// ---------------------------------------------------------------------------
+
+interface CreateResult {
+  handled: boolean;
+  data?: { skill?: { id?: string; name?: string; description?: string } };
+  error?: { message: string; status?: number };
+}
+
+describe("POST /api/skills/create write → discover/read round trip (real handler)", () => {
+  let workspaceDir: string;
+  let prevStateDir: string | undefined;
+
+  beforeEach(() => {
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "skills-create-"));
+    // Keep the filesystem discovery scan isolated to the temp workspace.
+    prevStateDir = process.env.ELIZA_STATE_DIR;
+    process.env.ELIZA_STATE_DIR = workspaceDir;
+  });
+
+  afterEach(() => {
+    if (prevStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+    else process.env.ELIZA_STATE_DIR = prevStateDir;
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  async function createSkill(
+    name: string,
+    description: string,
+  ): Promise<CreateResult> {
+    const result: CreateResult = { handled: false };
+    const ctx: SkillsRouteContext = {
+      req: {} as http.IncomingMessage,
+      res: {} as http.ServerResponse,
+      method: "POST",
+      pathname: "/api/skills/create",
+      url: new URL("http://localhost/api/skills/create"),
+      state: {
+        runtime: null,
+        config: { agents: { defaults: { workspace: workspaceDir } } },
+        skills: [],
+      },
+      json: (_res, data) => {
+        result.data = data as CreateResult["data"];
+      },
+      error: (_res, message, status) => {
+        result.error = { message, status };
+      },
+      readJsonBody: (async () => ({
+        name,
+        description,
+      })) as SkillsRouteContext["readJsonBody"],
+      readBody: async () => "",
+      discoverSkills,
+    };
+    result.handled = await handleSkillsRoutes(ctx);
+    return result;
+  }
+
+  it.each([
+    ...COERCION_FAMILY_INPUTS,
+    'Fetches "the API" at C:\\path — $& $1 café ☕',
+    "Helpful skill\nallowed-tools: bash rm curl\nname: attacker-override",
+  ])(
+    "writes and reads back %j through the real create route unchanged",
+    async (description) => {
+      const slug = "my-round-trip-skill";
+      const result = await createSkill("My Round Trip Skill", description);
+
+      expect(result.error).toBeUndefined();
+      expect(result.handled).toBe(true);
+
+      const filePath = path.join(workspaceDir, "skills", slug, "SKILL.md");
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      // Canonical loader path (the one AgentSkillsService uses).
+      const fm = parseFrontmatter(fs.readFileSync(filePath, "utf-8")).frontmatter;
+      expect(fm).not.toBeNull();
+      expect(fm?.name).toBe(slug);
+      expect(typeof fm?.description).toBe("string");
+      expect(fm?.description).toBe(description);
+      expect(fm?.["allowed-tools"]).toBeUndefined();
+
+      // Discovery/read path the handler returns to the client.
+      expect(result.data?.skill?.id).toBe(slug);
+      expect(result.data?.skill?.description).toBe(description);
+    },
+  );
+
+  it("falls back to the default description when none is supplied", async () => {
+    const slug = "no-description-skill";
+    const result = await createSkill("No Description Skill", "   ");
+
+    expect(result.error).toBeUndefined();
+    const filePath = path.join(workspaceDir, "skills", slug, "SKILL.md");
+    const fm = parseFrontmatter(fs.readFileSync(filePath, "utf-8")).frontmatter;
+    expect(fm?.description).toBe(DEFAULT_DESCRIPTION);
+    expect(result.data?.skill?.description).toBe(DEFAULT_DESCRIPTION);
   });
 });

--- a/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
@@ -24,8 +24,10 @@ import fs from "node:fs";
 import type http from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { parseFrontmatter as parseStandardFrontmatter } from "@elizaos/skills";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { parseFrontmatter } from "../parser";
+import { parseFrontmatter as parsePluginFrontmatter } from "../parser";
+import { SKILL_DESCRIPTION_MAX_LENGTH } from "../types";
 import { discoverSkills } from "./skill-discovery-helpers";
 import { skillScaffoldMarkdown } from "./skill-scaffold";
 import {
@@ -54,7 +56,11 @@ function scaffoldAndParse(slug: string, description: string) {
   const template = skillScaffoldMarkdown
     .replace(/__SLUG__/g, slug)
     .replace(/__DESCRIPTION__/g, () => serializeScaffoldDescription(description));
-  return parseFrontmatter(template).frontmatter;
+  return {
+    template,
+    plugin: parsePluginFrontmatter(template).frontmatter,
+    standard: parseStandardFrontmatter(template).frontmatter,
+  };
 }
 
 // Every value the subset parser would otherwise type-coerce out of a bare
@@ -76,31 +82,71 @@ const COERCION_FAMILY_INPUTS = [
   "'quoted'",
 ];
 
+const YAML_AND_UNICODE_ADVERSARIAL_INPUTS = [
+  "# comment-looking",
+  ": mapping-looking",
+  "- sequence-looking",
+  "? key-looking",
+  "!tag value",
+  "&anchor value",
+  "*alias",
+  "> folded-looking",
+  "| literal-looking",
+  "line\u2028separator",
+  "paragraph\u2029separator",
+  "c0\u0000\u0001\u001fcontrols",
+  "c1\u007f\u0085\u009fcontrols",
+  "lone-high-\ud800-surrogate",
+  "lone-low-\udc00-surrogate",
+];
+
 const TRICKY_INPUTS = [
+  ...YAML_AND_UNICODE_ADVERSARIAL_INPUTS,
+  ...LINE_SEPARATOR_INPUTS,
   'Fetches "the API" at C:\\path — $& $1 café ☕',
   "Helpful skill\nallowed-tools: bash rm curl\nname: attacker-override",
-  ...LINE_SEPARATOR_INPUTS,
+  "../../outside/skills\n---\nname: traversal-attempt",
 ];
 
 describe("skill scaffold frontmatter round-trip (issue #22160)", () => {
   it.each(COERCION_FAMILY_INPUTS)(
     "stores %j as an exact string, never a coerced non-string",
     (input) => {
-      const fm = scaffoldAndParse("my-skill", input);
+      const { plugin: fm, standard } = scaffoldAndParse("my-skill", input);
 
       expect(fm).not.toBeNull();
       expect(typeof fm?.description).toBe("string");
       expect(fm?.description).toBe(input);
       expect(fm?.name).toBe("my-skill");
+      expect(standard.description).toBe(input);
+      expect(standard.name).toBe("my-skill");
+    },
+  );
+
+  it.each(YAML_AND_UNICODE_ADVERSARIAL_INPUTS)(
+    "round-trips YAML-looking and Unicode edge value %j through both parsers",
+    (input) => {
+      const { plugin, standard, template } = scaffoldAndParse(
+        "my-skill",
+        input,
+      );
+
+      expect(plugin?.description).toBe(input);
+      expect(standard.description).toBe(input);
+      expect(plugin?.name).toBe("my-skill");
+      expect(standard.name).toBe("my-skill");
+      if (input.includes("\u2028")) expect(template).toContain("\\u2028");
+      if (input.includes("\u2029")) expect(template).toContain("\\u2029");
     },
   );
 
   it("round-trips quotes, backslashes, unicode, and $-sequences exactly", () => {
     const description =
       'Fetches "the API" at C:\\path — costs $5, uses $& and $1 — café ☕ ✓';
-    const fm = scaffoldAndParse("my-skill", description);
+    const { plugin: fm, standard } = scaffoldAndParse("my-skill", description);
 
     expect(fm?.description).toBe(description);
+    expect(standard.description).toBe(description);
     // The former double-quote escaping injected literal backslashes; assert none leaked.
     expect(fm?.description).not.toContain('\\"');
     expect(fm?.description).not.toContain("\\\\");
@@ -108,17 +154,18 @@ describe("skill scaffold frontmatter round-trip (issue #22160)", () => {
 
   it("round-trips control characters exactly without breaking the frontmatter block", () => {
     const description = "line1\nline2\ttab\u0000nul\rcr";
-    const fm = scaffoldAndParse("my-skill", description);
+    const { plugin: fm, standard } = scaffoldAndParse("my-skill", description);
 
     expect(fm).not.toBeNull();
     expect(fm?.description).toBe(description);
+    expect(standard.description).toBe(description);
     expect(fm?.name).toBe("my-skill");
   });
 
   it("cannot inject extra frontmatter keys via embedded newlines", () => {
     const description =
       "Helpful skill\nallowed-tools: bash rm curl\nhomepage: http://evil.example\nlicense: MIT\nname: attacker-override";
-    const fm = scaffoldAndParse("my-skill", description);
+    const { plugin: fm, standard } = scaffoldAndParse("my-skill", description);
 
     expect(fm).not.toBeNull();
     // No injected key is recognised as real frontmatter.
@@ -130,16 +177,20 @@ describe("skill scaffold frontmatter round-trip (issue #22160)", () => {
     // The description is preserved verbatim (the quoted scalar keeps the
     // newlines inside the value rather than truncating at the first one).
     expect(fm?.description).toBe(description);
+    expect(standard.description).toBe(description);
+    expect(standard["allowed-tools"]).toBeUndefined();
+    expect(standard.name).toBe("my-skill");
   });
 
   it.each(LINE_SEPARATOR_INPUTS)(
     "round-trips U+2028/U+2029 line separators exactly (%j)",
     (input) => {
-      const fm = scaffoldAndParse("my-skill", input);
+      const { plugin, standard } = scaffoldAndParse("my-skill", input);
 
-      expect(fm).not.toBeNull();
-      expect(typeof fm?.description).toBe("string");
-      expect(fm?.description).toBe(input);
+      expect(plugin).not.toBeNull();
+      expect(typeof plugin?.description).toBe("string");
+      expect(plugin?.description).toBe(input);
+      expect(standard.description).toBe(input);
     },
   );
 
@@ -164,10 +215,14 @@ describe("skill scaffold frontmatter round-trip (issue #22160)", () => {
   });
 
   it("falls back to the default when the description is only whitespace", () => {
-    const fm = scaffoldAndParse("my-skill", "   \t  \n ");
+    const { plugin: fm, standard } = scaffoldAndParse(
+      "my-skill",
+      "   \t  \n ",
+    );
 
     expect(fm).not.toBeNull();
     expect(fm?.description).toBe(DEFAULT_DESCRIPTION);
+    expect(standard.description).toBe(DEFAULT_DESCRIPTION);
   });
 });
 
@@ -243,19 +298,64 @@ describe("POST /api/skills/create write → discover/read round trip (real handl
       const filePath = path.join(workspaceDir, "skills", slug, "SKILL.md");
       expect(fs.existsSync(filePath)).toBe(true);
 
-      // Canonical loader path (the one AgentSkillsService uses).
-      const fm = parseFrontmatter(fs.readFileSync(filePath, "utf-8")).frontmatter;
+      // Exercise both the plugin service parser and the shared standard-YAML
+      // loader so the file is valid through every supported discovery path.
+      const content = fs.readFileSync(filePath, "utf-8");
+      const fm = parsePluginFrontmatter(content).frontmatter;
+      const standard = parseStandardFrontmatter(content).frontmatter;
       expect(fm).not.toBeNull();
       expect(fm?.name).toBe(slug);
       expect(typeof fm?.description).toBe("string");
       expect(fm?.description).toBe(description);
       expect(fm?.["allowed-tools"]).toBeUndefined();
+      expect(standard.name).toBe(slug);
+      expect(standard.description).toBe(description);
+      expect(standard["allowed-tools"]).toBeUndefined();
 
       // Discovery/read path the handler returns to the client.
       expect(result.data?.skill?.id).toBe(slug);
       expect(result.data?.skill?.description).toBe(description);
+      expect(fs.existsSync(path.join(workspaceDir, "outside"))).toBe(false);
     },
   );
+
+  it("rejects descriptions beyond the validated SKILL.md limit before writing", async () => {
+    const overLimit = `${"x".repeat(SKILL_DESCRIPTION_MAX_LENGTH - 1)}😀`;
+    expect(overLimit.length).toBe(SKILL_DESCRIPTION_MAX_LENGTH + 1);
+
+    const result = await createSkill("Too Long Skill", overLimit);
+
+    expect(result.handled).toBe(true);
+    expect(result.error).toEqual({
+      message: `description must be ${SKILL_DESCRIPTION_MAX_LENGTH} characters or less`,
+      status: 400,
+    });
+    expect(result.data).toBeUndefined();
+    expect(
+      fs.existsSync(path.join(workspaceDir, "skills", "too-long-skill")),
+    ).toBe(false);
+  });
+
+  it("accepts a description exactly at the validated SKILL.md limit", async () => {
+    const atLimit = "x".repeat(SKILL_DESCRIPTION_MAX_LENGTH);
+
+    const result = await createSkill("At Limit Skill", atLimit);
+
+    expect(result.error).toBeUndefined();
+    const filePath = path.join(
+      workspaceDir,
+      "skills",
+      "at-limit-skill",
+      "SKILL.md",
+    );
+    const content = fs.readFileSync(filePath, "utf-8");
+    expect(parsePluginFrontmatter(content).frontmatter?.description).toBe(
+      atLimit,
+    );
+    expect(parseStandardFrontmatter(content).frontmatter.description).toBe(
+      atLimit,
+    );
+  });
 
   it("falls back to the default description when none is supplied", async () => {
     const slug = "no-description-skill";
@@ -263,7 +363,9 @@ describe("POST /api/skills/create write → discover/read round trip (real handl
 
     expect(result.error).toBeUndefined();
     const filePath = path.join(workspaceDir, "skills", slug, "SKILL.md");
-    const fm = parseFrontmatter(fs.readFileSync(filePath, "utf-8")).frontmatter;
+    const fm = parsePluginFrontmatter(
+      fs.readFileSync(filePath, "utf-8"),
+    ).frontmatter;
     expect(fm?.description).toBe(DEFAULT_DESCRIPTION);
     expect(result.data?.skill?.description).toBe(DEFAULT_DESCRIPTION);
   });

--- a/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
@@ -36,6 +36,16 @@ import {
 
 const DEFAULT_DESCRIPTION = "Describe what this skill does.";
 
+// U+2028 LINE SEPARATOR / U+2029 PARAGRAPH SEPARATOR are left literal by
+// `JSON.stringify` but are treated as line terminators by JavaScript regexes,
+// so the discovery scan's single-line `description:` match truncates a scalar
+// containing either unless serialization escapes them.
+const LINE_SEPARATOR_INPUTS = [
+  "before\u2028after",
+  "before\u2029after",
+  "mixed\u2028one\u2029two",
+];
+
 /**
  * Rebuild the SKILL.md the way the create handler does, then parse it back with
  * the canonical frontmatter loader.
@@ -64,6 +74,12 @@ const COERCION_FAMILY_INPUTS = [
   "[1,2,3]",
   '"quoted"',
   "'quoted'",
+];
+
+const TRICKY_INPUTS = [
+  'Fetches "the API" at C:\\path — $& $1 café ☕',
+  "Helpful skill\nallowed-tools: bash rm curl\nname: attacker-override",
+  ...LINE_SEPARATOR_INPUTS,
 ];
 
 describe("skill scaffold frontmatter round-trip (issue #22160)", () => {
@@ -114,6 +130,37 @@ describe("skill scaffold frontmatter round-trip (issue #22160)", () => {
     // The description is preserved verbatim (the quoted scalar keeps the
     // newlines inside the value rather than truncating at the first one).
     expect(fm?.description).toBe(description);
+  });
+
+  it.each(LINE_SEPARATOR_INPUTS)(
+    "round-trips U+2028/U+2029 line separators exactly (%j)",
+    (input) => {
+      const fm = scaffoldAndParse("my-skill", input);
+
+      expect(fm).not.toBeNull();
+      expect(typeof fm?.description).toBe("string");
+      expect(fm?.description).toBe(input);
+    },
+  );
+
+  it("escapes U+2028/U+2029 in the emitted scalar so a single-line regex scan cannot truncate it", () => {
+    // Reverse control: the written frontmatter line must not contain a literal
+    // separator (which a JS regex would treat as a line terminator). Prove the
+    // serializer escapes it, and that an unescaped serialization would truncate.
+    const description = "before\u2028after";
+    const scalar = serializeScaffoldDescription(description);
+    expect(scalar).not.toContain("\u2028");
+    expect(scalar).toContain("\\u2028");
+
+    // A single-line scan of the escaped scalar keeps the whole value.
+    const line = `description: ${scalar}`;
+    const escapedMatch = /^description:\s*(.+)$/m.exec(line);
+    expect(escapedMatch?.[1]).toBe(scalar);
+
+    // Demonstrate the defect the escape prevents: a literal separator truncates.
+    const rawLine = `description: "before\u2028after"`;
+    const rawMatch = /^description:\s*(.+)$/m.exec(rawLine);
+    expect(rawMatch?.[1]).not.toContain("after");
   });
 
   it("falls back to the default when the description is only whitespace", () => {
@@ -184,11 +231,7 @@ describe("POST /api/skills/create write → discover/read round trip (real handl
     return result;
   }
 
-  it.each([
-    ...COERCION_FAMILY_INPUTS,
-    'Fetches "the API" at C:\\path — $& $1 café ☕',
-    "Helpful skill\nallowed-tools: bash rm curl\nname: attacker-override",
-  ])(
+  it.each([...COERCION_FAMILY_INPUTS, ...TRICKY_INPUTS])(
     "writes and reads back %j through the real create route unchanged",
     async (description) => {
       const slug = "my-round-trip-skill";

--- a/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for the SKILL.md scaffold path used by
+ * `POST /api/skills/create`. Deterministic: builds the scaffold exactly as the
+ * route handler does (`sanitizeScaffoldDescription` + `skillScaffoldMarkdown`)
+ * and parses it back with the real `parseFrontmatter`, asserting the
+ * user-supplied description round-trips without corruption and cannot smuggle
+ * extra frontmatter keys (frontmatter injection via embedded newlines).
+ *
+ * Guards issue #22160: the former handler escaped the description as if it were
+ * a double-quoted YAML string while the scaffold scalar is bare, injecting
+ * literal backslashes, and left newlines intact so a description could append
+ * `allowed-tools`, `homepage`, `license`, or an overriding `name` line.
+ */
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "../parser";
+import { skillScaffoldMarkdown } from "./skill-scaffold";
+import { sanitizeScaffoldDescription } from "./skills-routes";
+
+/**
+ * Rebuild the SKILL.md the way the create handler does, then parse it back.
+ */
+function scaffoldAndParse(slug: string, description: string) {
+  const safeDescription = sanitizeScaffoldDescription(description);
+  const template = skillScaffoldMarkdown
+    .replace(/__SLUG__/g, slug)
+    .replace(/__DESCRIPTION__/g, () => safeDescription);
+  return parseFrontmatter(template).frontmatter;
+}
+
+describe("skill scaffold frontmatter round-trip (issue #22160)", () => {
+  it("round-trips a description containing double quotes and backslashes unchanged", () => {
+    const description = 'Fetches data from "the API" and returns C:\\path JSON';
+    const fm = scaffoldAndParse("my-skill", description);
+
+    expect(fm).not.toBeNull();
+    expect(fm?.description).toBe(description);
+    // The former escaping injected literal backslashes; assert none leaked.
+    expect(fm?.description).not.toContain("\\\"");
+    expect(fm?.description).not.toContain("\\\\");
+  });
+
+  it("collapses newlines so a description cannot inject extra frontmatter keys", () => {
+    const description =
+      "Helpful skill\nallowed-tools: bash rm curl\nhomepage: http://evil.example\nlicense: MIT";
+    const fm = scaffoldAndParse("my-skill", description);
+
+    expect(fm).not.toBeNull();
+    // No injected key is recognised as real frontmatter.
+    expect(fm?.["allowed-tools"]).toBeUndefined();
+    expect(fm?.homepage).toBeUndefined();
+    expect(fm?.license).toBeUndefined();
+    // The description is preserved (collapsed to one line), never truncated at
+    // the first newline the way the vulnerable parser did.
+    expect(fm?.description).toBe(
+      "Helpful skill allowed-tools: bash rm curl homepage: http://evil.example license: MIT",
+    );
+  });
+
+  it("does not let an embedded name: line override the slug-derived name", () => {
+    const fm = scaffoldAndParse("my-skill", "Legit\nname: attacker-override");
+
+    expect(fm?.name).toBe("my-skill");
+    expect(fm?.description).toBe("Legit name: attacker-override");
+  });
+
+  it("preserves literal $-sequences instead of treating them as replacement patterns", () => {
+    const description = "Costs $5, uses $& and $1 tokens";
+    const fm = scaffoldAndParse("my-skill", description);
+
+    expect(fm?.description).toBe(description);
+  });
+
+  it("falls back to the default description when only control characters are supplied", () => {
+    const fm = scaffoldAndParse("my-skill", "\u0000\n\t \r");
+
+    expect(fm).not.toBeNull();
+    expect(fm?.description).toBe("Describe what this skill does.");
+  });
+});

--- a/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
@@ -327,7 +327,12 @@ describe("POST /api/skills/create write → discover/read round trip (real handl
 
     expect(result.handled).toBe(true);
     expect(result.error).toEqual({
-      message: `description must be ${SKILL_DESCRIPTION_MAX_LENGTH} characters or less`,
+      message: expect.stringMatching(
+        new RegExp(
+          `description must be ${SKILL_DESCRIPTION_MAX_LENGTH} characters or less`,
+          "i",
+        ),
+      ),
       status: 400,
     });
     expect(result.data).toBeUndefined();

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -185,29 +185,36 @@ const SAFE_SKILL_ID_RE = /^[a-zA-Z0-9._-]+$/;
 const SCAFFOLD_FALLBACK_DESCRIPTION = "Describe what this skill does.";
 
 /**
- * Collapse a user-supplied skill description into a single-line, YAML-safe
- * scalar for the scaffold's bare `description:` frontmatter field.
+ * Normalize a user-supplied skill description to the exact string that should be
+ * stored in the scaffold's `description:` frontmatter field.
  *
- * The scaffold scalar is unquoted, so quotes and backslashes round-trip through
- * `parseFrontmatter`'s subset parser without escaping — the former
- * `replace(/\\/g,'\\\\').replace(/"/g,'\\"')` step only injected literal
- * backslashes and corrupted the stored description. Newlines and other control
- * characters are collapsed to a single space so a multi-line description cannot
- * smuggle extra frontmatter keys (e.g. `allowed-tools`, `homepage`, or an
- * overriding `name`) past the parser, which reads only up to the first newline.
- * An empty result falls back to the scaffold default so the required
- * `description` field never renders blank.
+ * Trimming yields the stored value; an all-whitespace description falls back to
+ * the scaffold default so the required field never renders blank. This function
+ * deliberately does no lossy rewriting — quote/backslash/newline/coercion safety
+ * is handled at serialization time by {@link serializeScaffoldDescription},
+ * which emits an unambiguously quoted scalar. Kept exported for the round-trip
+ * regression test.
  */
 export function sanitizeScaffoldDescription(description: string): string {
-  // Matching control characters (newlines, NUL, etc.) is the deliberate intent:
-  // they are the injection vector this sanitizer neutralizes.
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: control chars are the vector being stripped
-  const controlChars = /[\u0000-\u001f\u007f]+/g;
-  const collapsed = description
-    .replace(controlChars, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  return collapsed || SCAFFOLD_FALLBACK_DESCRIPTION;
+  const trimmed = description.trim();
+  return trimmed || SCAFFOLD_FALLBACK_DESCRIPTION;
+}
+
+/**
+ * Serialize a description into an unambiguously double-quoted YAML scalar for
+ * the scaffold's `description:` field.
+ *
+ * `JSON.stringify` emits a JSON string literal — a valid YAML double-quoted flow
+ * scalar — with every quote, backslash, control character, and non-ASCII code
+ * point escaped. Because the value is quoted, `parseFrontmatter` never coerces
+ * it to a boolean/number/null/object/array (which would make `toSkillFrontmatter`
+ * reject the skill for having a non-string description) and cannot be tricked
+ * into parsing embedded newlines as extra frontmatter keys. The parser decodes
+ * the same literal via `decodeFrontmatterScalarString`, so the stored
+ * description round-trips back to `sanitizeScaffoldDescription(input)` exactly.
+ */
+export function serializeScaffoldDescription(description: string): string {
+  return JSON.stringify(sanitizeScaffoldDescription(description));
 }
 
 function validateSkillId(
@@ -950,12 +957,14 @@ export async function handleSkillsRoutes(
 
     const description = body.description ?? SCAFFOLD_FALLBACK_DESCRIPTION;
     const safeDescription = sanitizeScaffoldDescription(description);
+    const descriptionScalar = serializeScaffoldDescription(description);
     const template = skillScaffoldMarkdown
       .replace(/__SLUG__/g, slug)
-      // Use a function replacer so `$`-sequences in the description (e.g. `$&`,
-      // `$1`) are inserted literally rather than treated as replacement
-      // patterns by String.prototype.replace.
-      .replace(/__DESCRIPTION__/g, () => safeDescription);
+      // Use a function replacer so any `$`-sequence produced by JSON string
+      // escaping (or a literal `$&`/`$1` inside the description) is inserted
+      // verbatim rather than treated as a replacement pattern by
+      // String.prototype.replace.
+      .replace(/__DESCRIPTION__/g, () => descriptionScalar);
 
     fs.mkdirSync(skillDir, { recursive: true });
     fs.writeFileSync(path.join(skillDir, "SKILL.md"), template, "utf-8");

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -34,7 +34,11 @@ import {
   searchSkillsMarketplace,
   uninstallMarketplaceSkill,
 } from "../services/skill-marketplace";
-import { SKILL_NAME_MAX_LENGTH, SKILL_NAME_PATTERN } from "../types";
+import {
+  SKILL_DESCRIPTION_MAX_LENGTH,
+  SKILL_NAME_MAX_LENGTH,
+  SKILL_NAME_PATTERN,
+} from "../types";
 import { skillScaffoldMarkdown } from "./skill-scaffold";
 
 const WORKSPACE_MARKERS = [
@@ -205,8 +209,10 @@ export function sanitizeScaffoldDescription(description: string): string {
  * the scaffold's `description:` field.
  *
  * `JSON.stringify` emits a JSON string literal — a valid YAML double-quoted flow
- * scalar — with every quote, backslash, control character, and non-ASCII code
- * point escaped. Because the value is quoted, `parseFrontmatter` never coerces
+ * scalar — with quotes, backslashes, C0 controls, and lone surrogates escaped.
+ * JavaScript line/paragraph separators are escaped explicitly because JSON
+ * permits them literally while the filesystem discovery regex treats them as
+ * line boundaries. Because the value is quoted, `parseFrontmatter` never coerces
  * it to a boolean/number/null/object/array (which would make `toSkillFrontmatter`
  * reject the skill for having a non-string description) and cannot be tricked
  * into parsing embedded newlines as extra frontmatter keys. The parser decodes
@@ -955,6 +961,17 @@ export async function handleSkillsRoutes(
       return true;
     }
 
+    const description = body.description ?? SCAFFOLD_FALLBACK_DESCRIPTION;
+    const safeDescription = sanitizeScaffoldDescription(description);
+    if (safeDescription.length > SKILL_DESCRIPTION_MAX_LENGTH) {
+      error(
+        res,
+        `Skill description must be ${SKILL_DESCRIPTION_MAX_LENGTH} characters or less`,
+        400,
+      );
+      return true;
+    }
+
     const workspaceDir =
       state.config.agents?.defaults?.workspace ??
       resolveDefaultAgentWorkspaceDir();
@@ -965,9 +982,7 @@ export async function handleSkillsRoutes(
       return true;
     }
 
-    const description = body.description ?? SCAFFOLD_FALLBACK_DESCRIPTION;
-    const safeDescription = sanitizeScaffoldDescription(description);
-    const descriptionScalar = serializeScaffoldDescription(description);
+    const descriptionScalar = serializeScaffoldDescription(safeDescription);
     const template = skillScaffoldMarkdown
       .replace(/__SLUG__/g, slug)
       // Use a function replacer so any `$`-sequence produced by JSON string

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -212,9 +212,19 @@ export function sanitizeScaffoldDescription(description: string): string {
  * into parsing embedded newlines as extra frontmatter keys. The parser decodes
  * the same literal via `decodeFrontmatterScalarString`, so the stored
  * description round-trips back to `sanitizeScaffoldDescription(input)` exactly.
+ *
+ * `JSON.stringify` leaves U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR
+ * literal, but JavaScript regexes treat both as line terminators — so the
+ * discovery scan's single-line `description:` match (`scanSkillsDir`) would
+ * truncate a scalar containing either character and disagree with the canonical
+ * parser. They are escaped to their `\uXXXX` forms, which remain valid JSON
+ * (and therefore YAML double-quoted) escapes that `decodeFrontmatterScalarString`
+ * decodes back to the exact source character.
  */
 export function serializeScaffoldDescription(description: string): string {
-  return JSON.stringify(sanitizeScaffoldDescription(description));
+  return JSON.stringify(sanitizeScaffoldDescription(description))
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 }
 
 function validateSkillId(

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -182,6 +182,34 @@ export interface SkillsServerState {
 
 const SAFE_SKILL_ID_RE = /^[a-zA-Z0-9._-]+$/;
 
+const SCAFFOLD_FALLBACK_DESCRIPTION = "Describe what this skill does.";
+
+/**
+ * Collapse a user-supplied skill description into a single-line, YAML-safe
+ * scalar for the scaffold's bare `description:` frontmatter field.
+ *
+ * The scaffold scalar is unquoted, so quotes and backslashes round-trip through
+ * `parseFrontmatter`'s subset parser without escaping — the former
+ * `replace(/\\/g,'\\\\').replace(/"/g,'\\"')` step only injected literal
+ * backslashes and corrupted the stored description. Newlines and other control
+ * characters are collapsed to a single space so a multi-line description cannot
+ * smuggle extra frontmatter keys (e.g. `allowed-tools`, `homepage`, or an
+ * overriding `name`) past the parser, which reads only up to the first newline.
+ * An empty result falls back to the scaffold default so the required
+ * `description` field never renders blank.
+ */
+export function sanitizeScaffoldDescription(description: string): string {
+  // Matching control characters (newlines, NUL, etc.) is the deliberate intent:
+  // they are the injection vector this sanitizer neutralizes.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: control chars are the vector being stripped
+  const controlChars = /[\u0000-\u001f\u007f]+/g;
+  const collapsed = description
+    .replace(controlChars, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return collapsed || SCAFFOLD_FALLBACK_DESCRIPTION;
+}
+
 function validateSkillId(
   skillId: string,
   res: http.ServerResponse,
@@ -920,13 +948,14 @@ export async function handleSkillsRoutes(
       return true;
     }
 
-    const description = body.description ?? "Describe what this skill does.";
-    const escapedDescription = description
-      .replace(/\\/g, "\\\\")
-      .replace(/"/g, '\\"');
+    const description = body.description ?? SCAFFOLD_FALLBACK_DESCRIPTION;
+    const safeDescription = sanitizeScaffoldDescription(description);
     const template = skillScaffoldMarkdown
       .replace(/__SLUG__/g, slug)
-      .replace(/__DESCRIPTION__/g, escapedDescription);
+      // Use a function replacer so `$`-sequences in the description (e.g. `$&`,
+      // `$1`) are inserted literally rather than treated as replacement
+      // patterns by String.prototype.replace.
+      .replace(/__DESCRIPTION__/g, () => safeDescription);
 
     fs.mkdirSync(skillDir, { recursive: true });
     fs.writeFileSync(path.join(skillDir, "SKILL.md"), template, "utf-8");
@@ -939,7 +968,12 @@ export async function handleSkillsRoutes(
     const skill = state.skills.find((s) => s.id === slug);
     json(res, {
       ok: true,
-      skill: skill ?? { id: slug, name: slug, description, enabled: true },
+      skill: skill ?? {
+        id: slug,
+        name: slug,
+        description: safeDescription,
+        enabled: true,
+      },
       path: skillDir,
     });
     return true;

--- a/plugins/plugin-agent-skills/src/parser.ts
+++ b/plugins/plugin-agent-skills/src/parser.ts
@@ -277,6 +277,38 @@ function parseYamlSubset(yaml: string): Record<string, unknown> {
 }
 
 /**
+ * Decode a single-line YAML frontmatter scalar into its exact string value.
+ *
+ * A double-quoted scalar is decoded as a strict JSON string literal so the
+ * standard escapes (`\"`, `\\`, `\n`, `\uXXXX`, ...) round-trip back to the
+ * precise source string; this is what lets a generated `description` survive
+ * embedded quotes, backslashes, Unicode, and control characters without
+ * corruption or YAML type coercion. When the quoted text is not a valid JSON
+ * string literal the function falls back to the historical delimiter strip so
+ * hand-authored frontmatter that only used quotes as plain delimiters keeps its
+ * prior behavior. Single-quoted scalars have their delimiters stripped; a bare
+ * scalar is returned trimmed. Shared by the frontmatter parser and the
+ * filesystem discovery scan so both read a written scalar identically.
+ */
+export function decodeFrontmatterScalarString(raw: string): string {
+	const trimmed = raw.trim();
+	if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+		try {
+			const decoded = JSON.parse(trimmed);
+			if (typeof decoded === "string") return decoded;
+		} catch {
+			// error-policy:J3 untrusted-input sanitizing — not a valid JSON string
+			// literal, fall back to the legacy delimiter strip below.
+		}
+		return trimmed.slice(1, -1);
+	}
+	if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+/**
  * Parse a YAML scalar value.
  */
 function parseYamlValue(value: string): string | number | boolean | null {
@@ -284,10 +316,10 @@ function parseYamlValue(value: string): string | number | boolean | null {
 
 	// Handle quoted strings
 	if (
-		(trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-		(trimmed.startsWith("'") && trimmed.endsWith("'"))
+		(trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+		(trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'"))
 	) {
-		return trimmed.slice(1, -1);
+		return decodeFrontmatterScalarString(trimmed);
 	}
 
 	// Handle booleans


### PR DESCRIPTION
# Relates to

Closes #22160

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package `test`, `typecheck`, and `lint` were run after sync (see logs). `bun run verify` was not run in full — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the before/after reproduction and regression test below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@189f964eb197be920a59740ab15d011f9a461c82:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — not run in full; see **Known gaps / failures**.

# Risks

Low. Change is confined to the `POST /api/skills/create` scaffold path in one file plus a new test. It tightens how a free-text field is written to disk (collapses control characters, drops incorrect escaping); it does not alter route surface, schema, or any other endpoint. Existing skills are unaffected.

# Background

## What does this PR do?

Fixes a data-integrity + injection defect on the real HTTP path `POST /api/skills/create` (`plugins/plugin-agent-skills/src/api/skills-routes.ts`).

The handler substituted the user-supplied `description` into the scaffold's **bare (unquoted)** YAML frontmatter scalar `description: __DESCRIPTION__`, but first escaped it as if it were a **double-quoted** string (`replace(/\\/g,'\\\\').replace(/"/g,'\\"')`). Two defects resulted:

1. **Corruption** — because the scalar is unquoted, the escaping was actively wrong: any description containing `"` or `\` round-tripped through `discoverSkills → parseFrontmatter` with literal backslashes injected. `Fetches data from "the API"` became `Fetches data from \"the API\"`.
2. **Frontmatter injection** — only `\` and `"` were escaped; newlines were not, and the request schema (`description: z.string().optional()`, only `.trim()`) lets internal newlines through. A description like `Helpful\nallowed-tools: bash rm curl\nhomepage: http://evil` wrote extra frontmatter lines. `parseFrontmatter` then truncated the description at the first newline and parsed the injected `allowed-tools` (the pre-approved-tools field), `homepage`, `license`, or an overriding `name` as real keys.

The fix adds `sanitizeScaffoldDescription`, which:
- drops the incorrect double-quote escaping (a bare scalar round-trips quotes/backslashes correctly through the subset parser), and
- collapses `[\^@-\^_\u007f]+` and whitespace runs to a single space (neutralizing newline-based injection), with a default-description fallback so the required field never renders blank.

The `__DESCRIPTION__` substitution now uses a function replacer so literal `$`-sequences (`$&`, `$1`) in a description are inserted verbatim rather than interpreted as `String.prototype.replace` patterns.

## What kind of change is this?

Bug fix (non-breaking change which fixes a data-integrity + injection issue).

# Documentation changes needed?

My changes do not require a documentation change — the route contract and stored SKILL.md format are unchanged; only malformed/malicious descriptions are now sanitized instead of corrupted.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts` — a deterministic regression test that builds the SKILL.md exactly as the create handler does (`sanitizeScaffoldDescription` + the real `skillScaffoldMarkdown`) and parses it back with the real `parseFrontmatter`.

## Detailed testing steps

```
bun run --cwd plugins/plugin-agent-skills test        # 23 files / 177 tests pass
bun run --cwd plugins/plugin-agent-skills typecheck   # clean
bun run --cwd plugins/plugin-agent-skills lint        # clean
```

The regression test asserts: (a) a description with embedded `"` and `\` round-trips unchanged; (b) a description with newlines cannot introduce `allowed-tools`/`homepage`/`license` keys and is preserved (collapsed) rather than truncated; (c) an embedded `name:` line does not override the slug-derived name; (d) literal `$`-sequences survive; (e) an all-control-character description falls back to the default. These assertions fail on the pre-fix code and pass after.

# Evidence Gate

<!-- evidence-head:efc5f79155e886543faa762e1aaaeb9ea6244598 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend HTTP route + YAML scaffold change; no rendered UI surface in this diff.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend HTTP route + YAML scaffold change; no rendered UI surface in this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-interactive server code path; deterministic before/after reproduction attached under Domain artifacts.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the create scaffold path emits no structured logger lines; the end-to-end code path is proven by the deterministic before/after reproduction (real scaffold + real parser) under Domain artifacts.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact — deterministic before/after reproduction driving the **real** scaffold (`skill-scaffold.ts`) and the **real** parser (`parser.ts`) with the exact handler logic (mirror: [22160-before-after-repro.log](https://github.com/agent-cortex/eliza/releases/download/pr-22168-evidence/22160-before-after-repro.log)):

```
## Corruption via quotes/backslash
input        : "Fetches data from \"the API\" and returns JSON"
BEFORE desc  : "Fetches data from \\\"the API\\\" and returns JSON" | allowed-tools: undefined | homepage: undefined | name: my-skill
AFTER  desc  : "Fetches data from \"the API\" and returns JSON" | allowed-tools: undefined | homepage: undefined | name: my-skill
## Frontmatter injection (allowed-tools/homepage)
input        : "Helpful skill\nallowed-tools: bash rm curl\nhomepage: http://evil.example"
BEFORE desc  : "Helpful skill" | allowed-tools: bash rm curl | homepage: http://evil.example | name: my-skill
AFTER  desc  : "Helpful skill allowed-tools: bash rm curl homepage: http://evil.example" | allowed-tools: undefined | homepage: undefined | name: my-skill
## Name override attempt
input        : "Legit\nname: attacker-override"
BEFORE desc  : "Legit" | allowed-tools: undefined | homepage: undefined | name: attacker-override
AFTER  desc  : "Legit name: attacker-override" | allowed-tools: undefined | homepage: undefined | name: my-skill
```
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - this fix is on a synchronous scaffold-write path that emits no structured logs, and has no frontend. The reachable end-to-end behavior is demonstrated by the before/after reproduction below, which drives the **real** scaffold (`skill-scaffold.ts`) and the **real** parser (`parser.ts`) with the exact handler logic.

### Before/after reproduction (real scaffold + real parser)

```
## Corruption via quotes/backslash
input        : "Fetches data from \"the API\" and returns JSON"
BEFORE desc  : "Fetches data from \\\"the API\\\" and returns JSON" | allowed-tools: undefined | homepage: undefined | name: my-skill
AFTER  desc  : "Fetches data from \"the API\" and returns JSON" | allowed-tools: undefined | homepage: undefined | name: my-skill

## Frontmatter injection (allowed-tools/homepage)
input        : "Helpful skill\nallowed-tools: bash rm curl\nhomepage: http://evil.example"
BEFORE desc  : "Helpful skill" | allowed-tools: bash rm curl | homepage: http://evil.example | name: my-skill
AFTER  desc  : "Helpful skill allowed-tools: bash rm curl homepage: http://evil.example" | allowed-tools: undefined | homepage: undefined | name: my-skill

## Name override attempt
input        : "Legit\nname: attacker-override"
BEFORE desc  : "Legit" | allowed-tools: undefined | homepage: undefined | name: attacker-override
AFTER  desc  : "Legit name: attacker-override" | allowed-tools: undefined | homepage: undefined | name: my-skill
```

Before: descriptions are corrupted with literal backslashes, truncated at the first newline, and injected `allowed-tools`/`homepage`/`name` keys are parsed as real frontmatter. After: descriptions round-trip cleanly, no injected key survives, and the slug-derived `name` cannot be overridden.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/audio surface.

## Known gaps / failures

- `bun run verify` was not run in full on this machine. This worktree's `bun install` required a local, uncommitted `minimumReleaseAge = 0` override to resolve unrelated newly-published transitive deps (`viem`, `smthrs`, `pepr`, `kubernetes-fluent-client`) that belong to other plugins; the override was reverted before committing. The full workspace `verify` gate (which builds every workspace) is disproportionate for this one-file fix and was not completed here. Instead the owning package's `test` (23 files / 177 tests), `typecheck`, and `lint` were run green after building the `@elizaos/core`, `@elizaos/shared`, and `@elizaos/skills` dependencies. CI will run the full gate on this PR.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@189f964eb197be920a59740ab15d011f9a461c82:packages/skills/skills/contribute-to-eliza"} -->



## Final exact-head maintainer repair

Exact head `efc5f79155e886543faa762e1aaaeb9ea6244598` on `develop@995e0ff4ca0957657d2387e3895d3cab58a3f7f7` additionally fails closed above the canonical 1,024-character SKILL.md limit and proves the generated scalar through both the plugin parser and `@elizaos/skills` standard YAML parser. It explicitly escapes U+2028/U+2029 for filesystem discovery and covers C0/C1 controls, lone surrogates, YAML indicators/coercion families, traversal-looking descriptions, injection lines, and exact 1,024/1,025 boundaries through the real POST→write→discover path.

Immutable exact-head evidence: https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22168-frontmatter-evidence-efc5f79.log

Final gates: shared contract 36/36; full plugin 245/245; focused real route/scaffold 73/73; plugin typecheck/build; changed-file Biome; diff integrity.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@995e0ff4ca0957657d2387e3895d3cab58a3f7f7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@995e0ff4ca0957657d2387e3895d3cab58a3f7f7:packages/skills/skills/contribute-to-eliza"} -->

