### PR TITLE
fix(ci): pin the staging renderer Cloud origin instead of defaulting to production

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -392,13 +392,15 @@ jobs:
         run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
 
       - name: Build app renderer bundle
-        # The renderer resolves its Cloud origin at BUILD time from
-        # VITE_ELIZA_CLOUD_BASE and otherwise falls back to production
-        # (ui/src/platform/ios-runtime.ts resolveCloudApiBase). Onboarding
-        # provisions straight from the browser, so without this the bundle
-        # carries a production origin while the lane hands it a staging key,
-        # and every provision 401s. The job-level ELIZAOS_CLOUD_BASE_URL only
-        # pins the spawned runtime's proxy -- Vite never sees it (#18076).
+        # The renderer resolves its Cloud base at BUILD time from
+        # VITE_ELIZA_CLOUD_BASE and otherwise defaults to production
+        # (ui/src/platform/ios-runtime.ts resolveCloudApiBase). The job-level
+        # ELIZAOS_CLOUD_BASE_URL pins the spawned runtime's proxy, which
+        # carries create/provision; it does NOT reach Vite. The chat leg is
+        # what breaks: selectOrProvisionCloudAgent derives the shared-agent
+        # base from the boot value, so a production-defaulted bundle sends a
+        # staging agent id and this lane's staging bearer to api.eliza.app
+        # (#18076).
         env:
           VITE_ELIZA_CLOUD_BASE: ${{ env.ELIZAOS_CLOUD_BASE_URL }}
         run: bun run --cwd packages/app build:web

--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -392,6 +392,15 @@ jobs:
         run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
 
       - name: Build app renderer bundle
+        # The renderer resolves its Cloud origin at BUILD time from
+        # VITE_ELIZA_CLOUD_BASE and otherwise falls back to production
+        # (ui/src/platform/ios-runtime.ts resolveCloudApiBase). Onboarding
+        # provisions straight from the browser, so without this the bundle
+        # carries a production origin while the lane hands it a staging key,
+        # and every provision 401s. The job-level ELIZAOS_CLOUD_BASE_URL only
+        # pins the spawned runtime's proxy -- Vite never sees it (#18076).
+        env:
+          VITE_ELIZA_CLOUD_BASE: ${{ env.ELIZAOS_CLOUD_BASE_URL }}
         run: bun run --cwd packages/app build:web
 
       - name: Run real STAGING cloud login + provision + chat

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -5,6 +5,7 @@
  * credits and must never run in a keyless PR lane.
  */
 
+import { resolveDirectCloudAuthApiBase } from "@elizaos/ui/api/direct-cloud-endpoints";
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import { seedCloudLiveBrowserAuth } from "../cloud-live-browser-auth";
 import { resolveCloudLiveOriginContract } from "../cloud-live-origin";
@@ -134,12 +135,15 @@ test.describe("real cloud login + provisioning + chat", () => {
     });
 
     // The process-level contract above only pins the spawned runtime's proxy.
-    // The renderer resolves its own Cloud origin at BUILD time from
-    // VITE_ELIZA_CLOUD_BASE and silently falls back to production, and
-    // onboarding provisions straight from the browser -- so a bundle built
-    // without that var drives production while holding a staging key and every
-    // provision 401s. Assert what the loaded bundle actually targets (#18076).
-    const rendererCloudOrigin = await page.evaluate(() => {
+    // The renderer carries its own Cloud base, resolved at BUILD time from
+    // VITE_ELIZA_CLOUD_BASE and otherwise defaulted, and the shared-agent base
+    // for the chat leg is derived from it
+    // (client-cloud.ts buildCloudSharedAgentApiBase). A bundle built for the
+    // wrong deployment therefore talks to the wrong Cloud with this lane's
+    // bearer. Compare through resolveDirectCloudAuthApiBase because the boot
+    // value is a SITE base ("https://eliza.app") while the contract exposes an
+    // API origin ("https://api.eliza.app") -- equivalent, differently spelled.
+    const rendererCloudBase = await page.evaluate(() => {
       const config = (
         window as unknown as {
           __ELIZAOS_APP_BOOT_CONFIG__?: { cloudApiBase?: string };
@@ -147,13 +151,23 @@ test.describe("real cloud login + provisioning + chat", () => {
       ).__ELIZAOS_APP_BOOT_CONFIG__;
       return config?.cloudApiBase ?? "";
     });
+    const rendererApiOrigin = (() => {
+      if (!rendererCloudBase) return "";
+      try {
+        return new URL(resolveDirectCloudAuthApiBase(rendererCloudBase)).origin;
+      } catch {
+        // error-policy:J3 a malformed boot value is reported as an explicit
+        // mismatch carrying the offending string, never as a raw TypeError.
+        return `<unparseable: ${rendererCloudBase}>`;
+      }
+    })();
     test.info().annotations.push({
       type: "renderer-cloud-origin",
-      description: rendererCloudOrigin,
+      description: rendererApiOrigin,
     });
     expect(
-      rendererCloudOrigin ? new URL(rendererCloudOrigin).origin : "",
-      `renderer bundle targets ${rendererCloudOrigin || "<unset>"}; the lane pinned ${originContract.origin}`,
+      rendererApiOrigin,
+      `renderer bundle resolves ${rendererCloudBase || "<unset>"} -> ${rendererApiOrigin || "<empty>"}; the lane pinned ${originContract.origin}`,
     ).toBe(originContract.origin);
 
     await chooseCloudRuntime(page);

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -133,6 +133,29 @@ test.describe("real cloud login + provisioning + chat", () => {
       timeout: 60_000,
     });
 
+    // The process-level contract above only pins the spawned runtime's proxy.
+    // The renderer resolves its own Cloud origin at BUILD time from
+    // VITE_ELIZA_CLOUD_BASE and silently falls back to production, and
+    // onboarding provisions straight from the browser -- so a bundle built
+    // without that var drives production while holding a staging key and every
+    // provision 401s. Assert what the loaded bundle actually targets (#18076).
+    const rendererCloudOrigin = await page.evaluate(() => {
+      const config = (
+        window as unknown as {
+          __ELIZAOS_APP_BOOT_CONFIG__?: { cloudApiBase?: string };
+        }
+      ).__ELIZAOS_APP_BOOT_CONFIG__;
+      return config?.cloudApiBase ?? "";
+    });
+    test.info().annotations.push({
+      type: "renderer-cloud-origin",
+      description: rendererCloudOrigin,
+    });
+    expect(
+      rendererCloudOrigin ? new URL(rendererCloudOrigin).origin : "",
+      `renderer bundle targets ${rendererCloudOrigin || "<unset>"}; the lane pinned ${originContract.origin}`,
+    ).toBe(originContract.origin);
+
     await chooseCloudRuntime(page);
 
     // Real provisioning (create -> provision -> poll jobs -> launch) persists a

--- a/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
@@ -149,6 +149,25 @@ describe("App Live E2E staging Cloud job (#18076)", () => {
     expect(stagingJob?.env?.ELIZAOS_CLOUD_API_KEY).not.toContain("||");
   });
 
+  test("builds the renderer against the staging Cloud origin, and never retargets production", () => {
+    // The renderer resolves its Cloud base at BUILD time from
+    // VITE_ELIZA_CLOUD_BASE (ui/src/platform/ios-runtime.ts) and otherwise
+    // defaults to production. The job-level ELIZAOS_CLOUD_BASE_URL never
+    // reaches Vite, so without this wiring the staging bundle drives
+    // production while holding a staging bearer (#18076).
+    expect(
+      stagingStep("Build app renderer bundle").env?.VITE_ELIZA_CLOUD_BASE,
+    ).toBe("$" + "{{ env.ELIZAOS_CLOUD_BASE_URL }}");
+
+    // The production lane must stay on its default origin: retargeting it
+    // would point a production key at staging.
+    const productionBuild = workflow.jobs?.["cloud-live"]?.steps?.find(
+      (candidate) => candidate.name === "Build app renderer bundle",
+    );
+    expect(productionBuild).toBeDefined();
+    expect(productionBuild?.env?.VITE_ELIZA_CLOUD_BASE).toBeUndefined();
+  });
+
   test("stays opt-in on schedule until the staging key is provisioned", () => {
     expect(stagingJob?.if).toContain("ELIZA_CLOUD_STAGING_LIVE_READY");
     expect(stagingJob?.if).toContain("inputs.run_cloud_staging");


### PR DESCRIPTION
Relates to #18076. This does **not** close it — the issue's acceptance is a deployed `app-staging` browser lane proving auth return, agent selection, a real reply, reload/history and cleanup semantics. This PR fixes one blocker on the way there: the lane could not reach staging at all.

## The defect

The staging lane pins `ELIZAOS_CLOUD_BASE_URL` and asserts it before any traffic (`cloud-live-origin.ts`). That assertion passed. It governs **the spawned runtime's proxy** — its own docstring says so.

The renderer resolves its Cloud base independently, at **build time**:

```ts
// packages/ui/src/platform/ios-runtime.ts
export function resolveCloudApiBase(env: RuntimeEnv): string {
  return (readString(env, ["VITE_ELIZA_CLOUD_BASE", "VITE_CLOUD_BASE"]) ?? DEFAULT_ELIZA_CLOUD_BASE)
```

`Build app renderer bundle` never set it, and Vite does not read `ELIZAOS_CLOUD_BASE_URL`. So the bundle carried a production base while the lane handed it a staging bearer, and the job died on:

```
Cloud request failed (401): Invalid or expired API key
```

**Where it breaks, precisely.** Create/provision is *not* the failing leg: the page origin is `127.0.0.1`, so `directCloudRequest` returns null (`client-cloud.ts:934`) and the call falls through to the local agent's Cloud proxy, whose upstream the job-level env already pins. The **chat** leg is what breaks — `selectOrProvisionCloudAgent` derives the shared-agent base from the boot value (`client-cloud.ts:4242,4330`, `cloud-agent-base.ts:191`), so a production-defaulted bundle sends a staging agent id and this lane's staging bearer to `api.eliza.app`.

## The change

1. Pin `VITE_ELIZA_CLOUD_BASE` for the staging renderer build.
2. Assert, after boot, that the loaded bundle's resolved origin equals the one the lane pinned — recorded as a `renderer-cloud-origin` annotation.
3. A deterministic workflow contract test covering both directions of that wiring.

Both sides of the assertion go through `resolveDirectCloudAuthApiBase`, because the boot value is a *site* base (`https://eliza.app`) while the contract exposes an *API* origin (`https://api.eliza.app`) — equivalent, differently spelled. Comparing them raw would have reddened the unguarded production lane, which this change never touches.

## Verification

Simulated against the real resolvers, not reasoned about:

```
cloud-live (production)         eliza.app             -> api.eliza.app          == contract  PASS
cloud-live-staging              api-staging.eliza.app -> api-staging.eliza.app  == contract  PASS
staging WITHOUT the build env   eliza.app             -> api.eliza.app          != contract  FAIL
```

The third line is the point: it still catches the defect this PR exists to fix.

Workflow contract test, mutation-proofed both ways:

```
remove VITE_ELIZA_CLOUD_BASE from the staging build  -> 11 pass / 1 fail
add it to the production build (retarget prod)       -> 11 pass / 1 fail
baseline                                             -> 12 pass / 0 fail
```

Exact-head verification after rebasing onto current `develop`:

```
app-live-e2e workflow guard                   12 pass / 47 assertions
app boot + origin + browser-auth contracts    13 pass
packages/app lint                             304 files clean
packages/app typecheck                        pass
actionlint                                    pass
staging-configured production renderer build pass (9,148 modules)
root bun run verify                           358 / 358 tasks + final audits pass
```

The exact built `dist` was served keylessly and opened through Playwright at `/join`. The real public entry redirected to `/login` and exposed `window.__ELIZAOS_APP_BOOT_CONFIG__.cloudApiBase === "https://api-staging.eliza.app"`; there were no unexpected browser errors. The complete command/output receipt is attached in the Evidence Gate.

## What this does not do

It does not prove the staging lane green, and that is not a choice — the lane is
structurally undispatchable from a PR branch. I tried: run
[32189237598](https://github.com/elizaOS/eliza/actions/runs/32189237598) at this exact
head `063f4896e101160d644b6350f72ec2b6800c32c1`. The staging job died in two seconds,
before any step, with:

```
Branch "fix/18076-staging-cloud-origin" is not allowed to deploy to staging
due to environment protection rules.
```

`repos/elizaOS/eliza/environments/staging` carries `custom_branch_policies: true` with
exactly one allowed branch, `develop`. So the `staging` Environment secret this lane
needs — `ELIZAOS_CLOUD_API_KEY` — is unreachable from any branch but `develop`, and the
decisive run can only happen after merge. Worth knowing rather than guessing at.

The same dispatch does prove the negative case that matters here. Retargeting production
was the plausible way for this change to do damage, and in that run the production lane
`cloud-live` **passed** from this branch — it builds without `VITE_ELIZA_CLOUD_BASE` and
still resolves `https://api.eliza.app`, exactly as before.

After merge, the confirming step is a `workflow_dispatch` on `develop` with
`run_cloud_staging=true`, checking the `renderer-cloud-origin` annotation. The previous
staging attempt is [32176030322](https://github.com/elizaOS/eliza/actions/runs/32176030322),
where the job failed on the 401 above while production passed.

Two adjacent findings left out of scope, worth their own issues: `VITE_ELIZA_CLOUD_BASE`
is set to the *web* origin elsewhere (`cloud-cf-deploy.yml:592`, `cloud-cf-release.yml:1723`)
while this lane sets the API origin — both normalize to the same place, but the convention
is inconsistent. And `startup-phase-poll.ts:232` hardcodes `https://api.eliza.app` for
agent-gone recovery probes instead of deriving it from boot, so on a staging lane a
per-agent 404 is verified against production; same pattern at `resolve-cloud-connection.ts:17`
and `ios-local-agent-kernel.ts:76`.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:23cc3395e2267ff99db014916728d017756421a1 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI workflow wiring plus a contract test; no rendered UI surface changes (changed files: app-live-e2e.yml, cloud-live.spec.ts, app-live-e2e-workflow.test.ts)
<!-- evidence-row:after-screenshots -->
- [ ] N/A - same; no rendered UI surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the only user-visible flow is the CI lane itself, and its staging job cannot be dispatched from a PR branch (staging Environment allows only develop)
<!-- evidence-row:backend-logs -->
- [x] [22171-gate-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22171-gate-logs.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - the renderer origin assertion runs inside the staging lane's browser leg, which is undispatchable from this branch; run 32189237598 shows the job refused at the environment-protection gate before any step
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt or model surface is touched
<!-- evidence-row:domain-artifacts -->
- [x] [22171-exact-head-gates.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22171-exact-head-gates.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface





