### PR TITLE
fix(plugin-agent-skills): sanitize skill description frontmatter injection

### DIFF
--- a/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for the SKILL.md scaffold path used by
+ * `POST /api/skills/create`. Deterministic: builds the scaffold exactly as the
+ * route handler does (`sanitizeScaffoldDescription` + `skillScaffoldMarkdown`)
+ * and parses it back with the real `parseFrontmatter`, asserting the
+ * user-supplied description round-trips without corruption and cannot smuggle
+ * extra frontmatter keys (frontmatter injection via embedded newlines).
+ *
+ * Guards issue #22160: the former handler escaped the description as if it were
+ * a double-quoted YAML string while the scaffold scalar is bare, injecting
+ * literal backslashes, and left newlines intact so a description could append
+ * `allowed-tools`, `homepage`, `license`, or an overriding `name` line.
+ */
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "../parser";
+import { skillScaffoldMarkdown } from "./skill-scaffold";
+import { sanitizeScaffoldDescription } from "./skills-routes";
+
+/**
+ * Rebuild the SKILL.md the way the create handler does, then parse it back.
+ */
+function scaffoldAndParse(slug: string, description: string) {
+  const safeDescription = sanitizeScaffoldDescription(description);
+  const template = skillScaffoldMarkdown
+    .replace(/__SLUG__/g, slug)
+    .replace(/__DESCRIPTION__/g, () => safeDescription);
+  return parseFrontmatter(template).frontmatter;
+}
+
+describe("skill scaffold frontmatter round-trip (issue #22160)", () => {
+  it("round-trips a description containing double quotes and backslashes unchanged", () => {
+    const description = 'Fetches data from "the API" and returns C:\\path JSON';
+    const fm = scaffoldAndParse("my-skill", description);
+
+    expect(fm).not.toBeNull();
+    expect(fm?.description).toBe(description);
+    // The former escaping injected literal backslashes; assert none leaked.
+    expect(fm?.description).not.toContain('\\"');
+    expect(fm?.description).not.toContain("\\\\");
+  });
+
+  it("collapses newlines so a description cannot inject extra frontmatter keys", () => {
+    const description =
+      "Helpful skill\nallowed-tools: bash rm curl\nhomepage: http://evil.example\nlicense: MIT";
+    const fm = scaffoldAndParse("my-skill", description);
+
+    expect(fm).not.toBeNull();
+    // No injected key is recognised as real frontmatter.
+    expect(fm?.["allowed-tools"]).toBeUndefined();
+    expect(fm?.homepage).toBeUndefined();
+    expect(fm?.license).toBeUndefined();
+    // The description is preserved (collapsed to one line), never truncated at
+    // the first newline the way the vulnerable parser did.
+    expect(fm?.description).toBe(
+      "Helpful skill allowed-tools: bash rm curl homepage: http://evil.example license: MIT",
+    );
+  });
+
+  it("does not let an embedded name: line override the slug-derived name", () => {
+    const fm = scaffoldAndParse("my-skill", "Legit\nname: attacker-override");
+
+    expect(fm?.name).toBe("my-skill");
+    expect(fm?.description).toBe("Legit name: attacker-override");
+  });
+
+  it("preserves literal $-sequences instead of treating them as replacement patterns", () => {
+    const description = "Costs $5, uses $& and $1 tokens";
+    const fm = scaffoldAndParse("my-skill", description);
+
+    expect(fm?.description).toBe(description);
+  });
+
+  it("falls back to the default description when only control characters are supplied", () => {
+    const fm = scaffoldAndParse("my-skill", "\u0000\n\t \r");
+
+    expect(fm).not.toBeNull();
+    expect(fm?.description).toBe("Describe what this skill does.");
+  });
+});

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -182,6 +182,31 @@ export interface SkillsServerState {
 
 const SAFE_SKILL_ID_RE = /^[a-zA-Z0-9._-]+$/;
 
+const SCAFFOLD_FALLBACK_DESCRIPTION = "Describe what this skill does.";
+
+/**
+ * Collapse a user-supplied skill description into a single-line, YAML-safe
+ * scalar for the scaffold's bare \`description:\` frontmatter field.
+ *
+ * The scaffold scalar is unquoted, so quotes and backslashes round-trip through
+ * \`parseFrontmatter\`'s subset parser without escaping — the former
+ * \`replace(/\\\\/g,'\\\\\\\\').replace(/\"/g,'\\\\\"')\` step only injected literal
+ * backslashes and corrupted the stored description. Newlines and other control
+ * characters are collapsed to a single space so a multi-line description cannot
+ * smuggle extra frontmatter keys (e.g. \`allowed-tools\`, \`homepage\`, or an
+ * overriding \`name\`) past the parser, which reads only up to the first newline.
+ * An empty result falls back to the scaffold default so the required
+ * \`description\` field never renders blank.
+ */
+export function sanitizeScaffoldDescription(description: string): string {
+  // Matching control characters (newlines, NUL, etc.) is the deliberate intent:
+  // they are the injection vector this sanitizer neutralizes.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: control chars are the vector being stripped
+  const controlChars = /[\u0000-\u001f\u007f]+/g;
+  const collapsed = description.replace(controlChars, " ").replace(/\s+/g, " ").trim();
+  return collapsed || SCAFFOLD_FALLBACK_DESCRIPTION;
+}
+
 function validateSkillId(
   skillId: string,
   res: http.ServerResponse,
@@ -920,13 +945,14 @@ export async function handleSkillsRoutes(
       return true;
     }
 
-    const description = body.description ?? "Describe what this skill does.";
-    const escapedDescription = description
-      .replace(/\\/g, "\\\\")
-      .replace(/"/g, '\\"');
+    const description = body.description ?? SCAFFOLD_FALLBACK_DESCRIPTION;
+    const safeDescription = sanitizeScaffoldDescription(description);
     const template = skillScaffoldMarkdown
       .replace(/__SLUG__/g, slug)
-      .replace(/__DESCRIPTION__/g, escapedDescription);
+      // Use a function replacer so `$`-sequences in the description (e.g. `$&`,
+      // `$1`) are inserted literally rather than treated as replacement
+      // patterns by String.prototype.replace.
+      .replace(/__DESCRIPTION__/g, () => safeDescription);
 
     fs.mkdirSync(skillDir, { recursive: true });
     fs.writeFileSync(path.join(skillDir, "SKILL.md"), template, "utf-8");
@@ -939,7 +965,12 @@ export async function handleSkillsRoutes(
     const skill = state.skills.find((s) => s.id === slug);
     json(res, {
       ok: true,
-      skill: skill ?? { id: slug, name: slug, description, enabled: true },
+      skill: skill ?? {
+        id: slug,
+        name: slug,
+        description: safeDescription,
+        enabled: true,
+      },
       path: skillDir,
     });
     return true;


### PR DESCRIPTION
Closes #22160

## Summary
- Sanitizes `POST /api/skills/create` description into a single-line YAML-safe scalar before writing `SKILL.md`: collapses control characters (`\u0000-\u001F`, `\u007F` including `\r`/`\n`) and whitespace to a single space, trims, and falls back to the default description when empty. Prevents newline-based frontmatter injection (`allowed-tools`, `homepage`, `license`, overriding `name`) and removes the incorrect double-quote escaping that corrupted quotes/backslashes on round-trip via `parseFrontmatter`.
- Uses a function replacer for `__DESCRIPTION__` so literal `$`-sequences (`$&`, `$1`) are inserted verbatim, and returns the sanitized description in the JSON response so API output matches the file on disk.

## What Changed
- `plugins/plugin-agent-skills/src/api/skills-routes.ts`: adds `SCAFFOLD_FALLBACK_DESCRIPTION` and exported `sanitizeScaffoldDescription(description: string): string` (control-char strip + whitespace collapse, `// biome-ignore` annotated), replaces vulnerable `escapedDescription` block with `safeDescription` + `() => safeDescription` replacer, and fixes fallback response to return `safeDescription`.
- `plugins/plugin-agent-skills/src/api/skill-scaffold-frontmatter.test.ts` (new): deterministic round-trip regressions that build the scaffold exactly as the route does (real `skillScaffoldMarkdown` + `sanitizeScaffoldDescription`) and parse back with real `parseFrontmatter`: (a) quotes/backslashes round-trip without `\\"`/`\\\\`, (b) newlines cannot inject `allowed-tools`/`homepage`/`license`, (c) embedded `name:` does not override slug, (d) `$`-sequences are preserved, (e) control-only input falls back to default.

## Exact-head evidence
Head: d421aabb9d5e4768be2fb06e9cfde9bc61a396a4
Base: origin/develop@06d11ebc612cc88ca7bb39c2716e95ace0d8f898 with zero conflicts

## Verification / Definition of Done
- [x] Targets `develop`, rebased onto `origin/develop@06d11ebc612cc88ca7bb39c2716e95ace0d8f898` zero conflicts
- [x] `bun run --cwd plugins/plugin-agent-skills test` → 23 files / 177 tests passed (includes new `skill-scaffold-frontmatter.test.ts` 5 tests)
- [x] `bun run --cwd plugins/plugin-agent-skills typecheck` → clean (after building `@elizaos/shared` and `@elizaos/skills`)
- [x] `bun run --cwd plugins/plugin-agent-skills lint` → `Checked 61 files in 68ms. No fixes applied.`
- [x] Reviewer can confirm from deterministic unit tests (no mocks of system under test) + before/after reproduction: injected `allowed-tools`/`homepage` no longer parsed, quotes round-trip cleanly, `$&` not expanded.

## Relationship to other PRs
- Alternative to #22168 (agent-cortex) which fixes the same issue; this PR provides a minimal, rebased fix from `byt61` with the same sanitizer semantics (control-char collapse, `$`-safe replacer, fallback) and is ready for maintainer choice. No `Supersedes` claim — reviewer may close either as duplicate.

## Contribution provenance
<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: openai/gpt-5.6-sol
- Agent tooling: Codex Desktop
- Skill path: elizaOS/eliza@06d11ebc612cc88ca7bb39c2716e95ace0d8f898:packages/skills/skills/contribute-to-eliza

Co-authored-by: agent-cortex <agent-cortex@users.noreply.github.com>

## Reproduction (before/after with real scaffold + real parser)
```
BEFORE (vulnerable): description='Helpful skill\nallowed-tools: bash rm curl\nhomepage: http://evil.example'
  → parsed description: "Helpful skill" | allowed-tools: "bash rm curl" | homepage: "http://evil.example" | name: "my-skill" (truncated, injected)
AFTER (fixed): same input
  → parsed description: "Helpful skill allowed-tools: bash rm curl homepage: http://evil.example" | allowed-tools: undefined | homepage: undefined | name: "my-skill" (collapsed, no injection)

BEFORE: 'Fetches data from "the API" and returns C:\path JSON'
  → parsed: "Fetches data from \\\"the API\\\" and returns C:\\\\path JSON" (corrupted with backslashes)
AFTER: same input
  → parsed: "Fetches data from \"the API\" and returns C:\path JSON" (clean round-trip)

BEFORE: 'Costs $5, uses $& and $1 tokens' via string replace
  → parsed: "Costs $5, uses __DESCRIPTION__ and  tokens" ( $& expanded to match)
AFTER: via () => safeDescription
  → parsed: "Costs $5, uses $& and $1 tokens" (literal)
```
