### PR TITLE
fix(plugin-scheduling): validate minute projections

### DIFF
--- a/plugins/plugin-scheduling/src/scheduled-task/minute-projection-validation.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/minute-projection-validation.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Real-runner regressions for pre-mutation snooze and gate-defer projections.
+ * The in-memory store proves hostile offsets reject without persisting partial
+ * lifecycle state, including the terminal recurrence-refire path.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createCompletionCheckRegistry,
+  registerBuiltInCompletionChecks,
+} from "./completion-check-registry.js";
+import {
+  createAnchorRegistry,
+  createConsolidationRegistry,
+} from "./consolidation-policy.js";
+import {
+  createEscalationLadderRegistry,
+  registerDefaultEscalationLadders,
+} from "./escalation.js";
+import {
+  createTaskGateRegistry,
+  registerBuiltInGates,
+} from "./gate-registry.js";
+import {
+  createInMemoryScheduledTaskStore,
+  createScheduledTaskRunner,
+  type ScheduledTaskRunnerHandle,
+  type ScheduledTaskStore,
+  TestNoopScheduledTaskDispatcher,
+} from "./runner.js";
+import { createInMemoryScheduledTaskLogStore } from "./state-log.js";
+import { MAX_DATE_MS } from "./time-range.js";
+import type { GateDecision, ScheduledTask } from "./types.js";
+
+const TEST_GATE_KIND = "test_minute_projection";
+const OVERFLOW_MINUTES = 1_000_000_000_000;
+
+interface Harness {
+  runner: ScheduledTaskRunnerHandle;
+  store: ScheduledTaskStore;
+  setGateDecision(decision: GateDecision): void;
+  setNow(iso: string): void;
+}
+
+function makeHarness(initialIso = "2026-05-11T12:00:00.000Z"): Harness {
+  let nowIso = initialIso;
+  let gateDecision: GateDecision = { kind: "allow" };
+  const store = createInMemoryScheduledTaskStore();
+  const gates = createTaskGateRegistry();
+  gates.register({
+    kind: TEST_GATE_KIND,
+    evaluate: () => gateDecision,
+  });
+  registerBuiltInGates(gates);
+  const completionChecks = createCompletionCheckRegistry();
+  registerBuiltInCompletionChecks(completionChecks);
+  const ladders = createEscalationLadderRegistry();
+  registerDefaultEscalationLadders(ladders);
+
+  const runner = createScheduledTaskRunner({
+    agentId: "agent-minute-projection",
+    store,
+    logStore: createInMemoryScheduledTaskLogStore(),
+    gates,
+    completionChecks,
+    ladders,
+    anchors: createAnchorRegistry(),
+    consolidation: createConsolidationRegistry(),
+    ownerFacts: () => ({ timezone: "UTC" }),
+    globalPause: { current: async () => ({ active: false }) },
+    activity: { hasSignalSince: () => false },
+    subjectStore: { wasUpdatedSince: () => false },
+    dispatcher: TestNoopScheduledTaskDispatcher,
+    now: () => new Date(nowIso),
+  });
+
+  return {
+    runner,
+    store,
+    setGateDecision(decision) {
+      gateDecision = decision;
+    },
+    setNow(iso) {
+      nowIso = iso;
+    },
+  };
+}
+
+function input(
+  overrides: Partial<Omit<ScheduledTask, "taskId" | "state">> = {},
+): Omit<ScheduledTask, "taskId" | "state"> {
+  return {
+    kind: "reminder",
+    promptInstructions: "validate bounded minute projection",
+    trigger: { kind: "manual" },
+    priority: "low",
+    respectsGlobalPause: false,
+    ownerVisible: true,
+    source: "user_chat",
+    createdBy: "agent-minute-projection",
+    ...overrides,
+  };
+}
+
+async function expectPersistedUnchanged(
+  store: ScheduledTaskStore,
+  before: ScheduledTask,
+): Promise<void> {
+  expect(await store.get(before.taskId)).toEqual(before);
+}
+
+describe("pre-mutation minute projection validation (#22170)", () => {
+  it("rejects hostile snooze minutes without mutating or persisting the task", async () => {
+    for (const minutes of [
+      0,
+      -1,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      OVERFLOW_MINUTES,
+    ]) {
+      const h = makeHarness();
+      const task = await h.runner.schedule(input());
+      const before = structuredClone(task);
+
+      await expect(
+        h.runner.apply(task.taskId, "snooze", { minutes }),
+      ).rejects.toThrow(/snooze:/);
+      await expectPersistedUnchanged(h.store, before);
+    }
+  });
+
+  it("allows snooze to land exactly on the positive Date bound", async () => {
+    const baseMs = MAX_DATE_MS - 60_000;
+    const h = makeHarness(new Date(baseMs).toISOString());
+    const task = await h.runner.schedule(input());
+
+    const snoozed = await h.runner.apply(task.taskId, "snooze", { minutes: 1 });
+    expect(snoozed.state.firedAt).toBe(new Date(MAX_DATE_MS).toISOString());
+  });
+
+  it("does not consume an idempotency receipt when snooze projection rejects", async () => {
+    const h = makeHarness();
+    const task = await h.runner.schedule(input());
+    const before = structuredClone(task);
+    const options = { idempotencyKey: "retry-after-invalid-projection" };
+
+    await expect(
+      h.runner.applyWithResult(
+        task.taskId,
+        "snooze",
+        { minutes: OVERFLOW_MINUTES },
+        options,
+      ),
+    ).rejects.toThrow(/snooze:/);
+    await expectPersistedUnchanged(h.store, before);
+
+    const recovered = await h.runner.applyWithResult(
+      task.taskId,
+      "snooze",
+      { minutes: 5 },
+      options,
+    );
+    expect(recovered.replayed).toBe(false);
+    expect(recovered.task.state.firedAt).toBe("2026-05-11T12:05:00.000Z");
+  });
+
+  it("rejects hostile gate offsets without mutating or persisting a scheduled task", async () => {
+    for (const offsetMinutes of [
+      -1,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      OVERFLOW_MINUTES,
+    ]) {
+      const h = makeHarness();
+      h.setGateDecision({
+        kind: "defer",
+        until: { offsetMinutes },
+        reason: "hostile test contribution",
+      });
+      const task = await h.runner.schedule(
+        input({ shouldFire: { gates: [{ kind: TEST_GATE_KIND }] } }),
+      );
+      const before = structuredClone(task);
+
+      await expect(h.runner.fireWithResult(task.taskId)).rejects.toThrow(
+        /gate defer: offset/,
+      );
+      await expectPersistedUnchanged(h.store, before);
+    }
+  });
+
+  it("rejects a malformed absolute gate defer instant before persistence", async () => {
+    const h = makeHarness();
+    h.setGateDecision({
+      kind: "defer",
+      until: { atIso: "not-an-instant" },
+      reason: "malformed test contribution",
+    });
+    const task = await h.runner.schedule(
+      input({ shouldFire: { gates: [{ kind: TEST_GATE_KIND }] } }),
+    );
+    const before = structuredClone(task);
+
+    await expect(h.runner.fireWithResult(task.taskId)).rejects.toThrow(
+      /gate defer: offset/,
+    );
+    await expectPersistedUnchanged(h.store, before);
+  });
+
+  it("preserves zero gate delay and both exact Date boundaries", async () => {
+    for (const baseMs of [-MAX_DATE_MS, MAX_DATE_MS - 60_000]) {
+      const offsetMinutes = baseMs < 0 ? 0 : 1;
+      const h = makeHarness(new Date(baseMs).toISOString());
+      h.setGateDecision({
+        kind: "defer",
+        until: { offsetMinutes },
+        reason: "exact boundary",
+      });
+      const task = await h.runner.schedule(
+        input({ shouldFire: { gates: [{ kind: TEST_GATE_KIND }] } }),
+      );
+
+      const result = await h.runner.fireWithResult(task.taskId);
+      expect(result.kind).toBe("skipped");
+      const expectedMs = baseMs + offsetMinutes * 60_000;
+      expect((await h.store.get(task.taskId))?.state.firedAt).toBe(
+        new Date(expectedMs).toISOString(),
+      );
+    }
+  });
+
+  it("keeps a terminal recurrence row unchanged when gate projection rejects", async () => {
+    const h = makeHarness("2026-05-09T09:00:00.000Z");
+    const task = await h.runner.schedule(
+      input({
+        trigger: { kind: "cron", expression: "0 9 * * *", tz: "UTC" },
+        shouldFire: { gates: [{ kind: TEST_GATE_KIND }] },
+      }),
+    );
+    await h.runner.fireWithResult(task.taskId);
+    await h.runner.apply(task.taskId, "complete");
+    h.setNow("2026-05-10T09:00:30.000Z");
+    h.setGateDecision({
+      kind: "defer",
+      until: { offsetMinutes: OVERFLOW_MINUTES },
+      reason: "hostile refire contribution",
+    });
+    const before = await h.store.get(task.taskId);
+    if (!before) throw new Error("expected persisted task");
+
+    await expect(
+      h.runner.fireWithResult(task.taskId, { allowTerminalRefire: true }),
+    ).rejects.toThrow(/gate defer: offset/);
+    await expectPersistedUnchanged(h.store, before);
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -18,7 +18,7 @@
  *    skip: pause suppresses proactive behavior, and chaining is proactive.
  */
 
-import { stableStringify } from "@elizaos/core/edge";
+import { ElizaError, stableStringify } from "@elizaos/core/edge";
 import { decideDispatchPolicy } from "../dispatch-policy.js";
 import type { DispatchResult } from "../dispatch-types.js";
 import type { CompletionCheckRegistry } from "./completion-check-registry.js";
@@ -1226,8 +1226,21 @@ export function createScheduledTaskRunner(
     let newFireAtIso: string;
     if (typeof untilIso === "string") {
       newFireAtIso = new Date(untilIso).toISOString();
-    } else if (typeof minutes === "number" && minutes > 0) {
-      newFireAtIso = new Date(now().getTime() + minutes * 60_000).toISOString();
+    } else if (typeof minutes === "number") {
+      if (minutes <= 0) {
+        throw new Error("snooze: provide minutes or untilIso");
+      }
+      const newFireMs = projectMinuteOffsetMs(now().getTime(), minutes);
+      if (newFireMs === null) {
+        throw new ElizaError(
+          "snooze: minutes must be finite and project to a representable Date",
+          {
+            code: "SCHEDULED_TASK_SNOOZE_PROJECTION_INVALID",
+            context: { minutes },
+          },
+        );
+      }
+      newFireAtIso = new Date(newFireMs).toISOString();
     } else {
       throw new Error("snooze: provide minutes or untilIso");
     }
@@ -1949,19 +1962,31 @@ export function createScheduledTaskRunner(
       };
     }
     if (gateOutcome.decision.kind === "defer") {
+      const nowMs = now().getTime();
       const offset =
         "offsetMinutes" in gateOutcome.decision.until
           ? gateOutcome.decision.until.offsetMinutes
           : Math.max(
               1,
               Math.round(
-                (new Date(gateOutcome.decision.until.atIso).getTime() -
-                  now().getTime()) /
+                (new Date(gateOutcome.decision.until.atIso).getTime() - nowMs) /
                   60_000,
               ),
             );
+      const newFireMs = projectMinuteOffsetMs(nowMs, offset);
+      if (newFireMs === null) {
+        throw new ElizaError(
+          "gate defer: offset must be non-negative and project to a representable Date",
+          {
+            code: "SCHEDULED_TASK_GATE_DEFER_PROJECTION_INVALID",
+            context: {
+              gateKind: gateOutcome.gateKind ?? "gate",
+              offsetMinutes: offset,
+            },
+          },
+        );
+      }
       task.state.lastDecisionLog = `${gateOutcome.gateKind ?? "gate"}: deferred ${offset}m (${gateOutcome.decision.reason})`;
-      const newFireMs = now().getTime() + offset * 60_000;
       if (refireClaim) {
         // Park the deferred occurrence as a plain scheduled-override so it
         // fires AT the defer time (`scheduledOverrideDue`), not at the


### PR DESCRIPTION
## Summary

- route manual snooze and gate-defer minute arithmetic through the shared bounded Date projection helper before lifecycle mutation or persistence
- preserve the existing snooze-zero rejection and gate-zero behavior while rejecting negative, non-finite, malformed, and out-of-range projections deterministically with typed `ElizaError` failures
- prove rejected receipt-based snoozes consume no idempotency receipt and can recover with the same key

Closes #22170.

## Behavior reviewed

Both validation points run before changing task status, timestamps, decision logs, escalation cursor, pending dispatch, or receipt metadata. Invalid gate decisions leave scheduled rows unchanged and also preserve the prior terminal row during recurrence-refire. Exact lower/upper JavaScript Date bounds remain representable.

## Evidence

Final head: `67f4aa4e4e2d9d219b5b6b3e7750428ebedd19a3`  
Base: `06d11ebc612cc88ca7bb39c2716e95ace0d8f898`

- `bun run test`: 33 files, 530/530 tests passed on exact final head
- focused final-head tests: new real-runner suite plus owning SQL invalid-input contract, 8 passed / 15 skipped
- `bun run typecheck`: passed
- `bun run build`: JS, views, and declarations passed on exact final head
- `bun run lint:check`: 81 files passed
- `git diff --check`: passed

## Contribution provenance

- AI assistance: yes
- AI provider/model: openai / gpt-5.6-sol
- Client: Codex Desktop
- Lane: `[codex-cortex-security]`

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@06d11ebc612cc88ca7bb39c2716e95ace0d8f898:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:67f4aa4e4e2d9d219b5b6b3e7750428ebedd19a3 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend scheduling state-machine change; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend scheduling state-machine change; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic real-runner state transitions are the relevant proof.

<!-- evidence-row:backend-logs -->
- [x] [22175-exact-postmerge-backend-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22175-exact-postmerge-backend-v2.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser surface changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent-response behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [22175-minute-projection-domain-artifact.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22175-minute-projection-domain-artifact.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence applies.


