### PR TITLE
fix(lifeops): resolve travel return-date year correctly, read ISO dates as local

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
@@ -233,9 +233,26 @@ const ISO_DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
 function parseLocalDate(value: string): number | null {
   const isoMatch = ISO_DATE_ONLY.exec(value);
   if (isoMatch) {
-    const [, year, month, day] = isoMatch;
-    const local = new Date(Number(year), Number(month) - 1, Number(day));
-    return Number.isNaN(local.getTime()) ? null : local.getTime();
+    const [, yearStr, monthStr, dayStr] = isoMatch;
+    const year = Number(yearStr);
+    const month = Number(monthStr);
+    const day = Number(dayStr);
+    // `new Date(y, m, d)` silently rolls an impossible calendar date into a
+    // real one (Feb 29 on a non-leap year, month 13, day 0) instead of
+    // rejecting it -- round-trip the constructed date's local fields against
+    // the parsed input and reject on any mismatch. This also rejects a
+    // 4-digit-but-under-100 year like "0099", which the Date constructor's
+    // legacy two-digit-year rule (0-99 -> 1900-1999) would otherwise remap.
+    const local = new Date(year, month - 1, day);
+    if (
+      Number.isNaN(local.getTime()) ||
+      local.getFullYear() !== year ||
+      local.getMonth() !== month - 1 ||
+      local.getDate() !== day
+    ) {
+      return null;
+    }
+    return local.getTime();
   }
   const parsed = Date.parse(value);
   return Number.isNaN(parsed) ? null : parsed;

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
@@ -220,18 +220,47 @@ const TRAVEL_UNTIL_PATTERN =
  * ("July 20", "2026-07-20", "Aug 3"); the current year is assumed when the
  * parsed date lands in the past (a bare month/day for a future trip).
  */
+const HAS_EXPLICIT_YEAR = /\b\d{4}\b/;
+const ISO_DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * `Date.parse` reads a bare `YYYY-MM-DD` string as UTC midnight but a
+ * `Month Day[, Year]` string as LOCAL midnight (ECMA-262 Date Time String
+ * Format) -- read the ISO date-only form as a local calendar date too, so
+ * "back on 2026-07-20" and "back on July 20, 2026" always land on the same
+ * day regardless of the caller's UTC offset. Never NaN; unparseable => null.
+ */
+function parseLocalDate(value: string): number | null {
+  const isoMatch = ISO_DATE_ONLY.exec(value);
+  if (isoMatch) {
+    const [, year, month, day] = isoMatch;
+    const local = new Date(Number(year), Number(month) - 1, Number(day));
+    return Number.isNaN(local.getTime()) ? null : local.getTime();
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
 function parseTravelReturnIso(phrase: string, now: Date): string | null {
   const trimmed = phrase.trim().replace(/[.,]+$/u, "");
   if (trimmed.length === 0) return null;
-  let parsed = Date.parse(trimmed);
-  if (Number.isNaN(parsed)) {
-    parsed = Date.parse(`${trimmed} ${now.getFullYear()}`);
-  }
-  if (Number.isNaN(parsed)) return null;
+
+  // A bare "Month Day" string never fails to parse: absent a year,
+  // `Date.parse` silently substitutes a fixed placeholder year instead of
+  // returning NaN, so detecting "no year given" from the parse result never
+  // fires. Detect it from the text instead and only then append the current
+  // year, so a date still upcoming this year isn't skipped straight to next
+  // year -- which usually lands outside MAX_TRAVEL_HORIZON_MS and silently
+  // discards the user's stated return date entirely.
+  const candidate = HAS_EXPLICIT_YEAR.test(trimmed)
+    ? trimmed
+    : `${trimmed} ${now.getFullYear()}`;
+  let parsed = parseLocalDate(candidate);
+  if (parsed === null) return null;
   // A month/day that resolves to the past almost always means next year.
   if (parsed < now.getTime()) {
-    const nextYear = Date.parse(`${trimmed} ${now.getFullYear() + 1}`);
-    if (Number.isNaN(nextYear) || nextYear < now.getTime()) return null;
+    const nextYear = parseLocalDate(`${trimmed} ${now.getFullYear() + 1}`);
+    if (nextYear === null || nextYear < now.getTime()) return null;
     parsed = nextYear;
   }
   if (parsed - now.getTime() > MAX_TRAVEL_HORIZON_MS) return null;
@@ -250,7 +279,10 @@ function detectTravelSignal(text: string, now: Date): TravelSignal | null {
   return null;
 }
 
-function extractProfileDetails(text: string, now: Date): ProfileExtraction {
+export function extractProfileDetails(
+  text: string,
+  now: Date,
+): ProfileExtraction {
   const facts: OwnerFactsPatch = {};
   collectFactHints(text, facts);
   collectTravelPreferenceHints(text, facts);

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/travel-return-date-parsing.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/travel-return-date-parsing.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression coverage for `parseTravelReturnIso` (internal to
+ * `extractProfileDetails`), which turns a free-text return-date phrase like
+ * "until July 20" into a bounded ISO end for the owner's travel window.
+ *
+ * Two bugs fixed here:
+ *   1. `Date.parse("July 20")` never returns NaN -- absent a year it
+ *      silently substitutes a fixed placeholder year (2001 in V8) instead of
+ *      failing, so the "no year given, use the current year" fallback was
+ *      dead code. Every bare "Month Day" phrase fell straight into the
+ *      "resolve to next year" branch, even when the date was still upcoming
+ *      this year, almost always exceeding the 30-day travel horizon and
+ *      silently discarding the user's stated return date.
+ *   2. A bare `YYYY-MM-DD` string parses as UTC midnight while a
+ *      `Month Day, Year` string parses as LOCAL midnight -- the same
+ *      intended calendar day could land a day earlier depending on which
+ *      literal form the user (or an upstream LLM) happened to use, in any
+ *      timezone west of UTC.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { extractProfileDetails } from "./profile-extraction-evaluator.ts";
+
+const ORIGINAL_TZ = process.env.TZ;
+
+afterEach(() => {
+  process.env.TZ = ORIGINAL_TZ;
+});
+
+function travelEndIso(text: string, now: Date): string | undefined {
+  const travel = extractProfileDetails(text, now).travel;
+  return travel?.kind === "set" ? travel.endIso : undefined;
+}
+
+describe("parseTravelReturnIso — year resolution", () => {
+  it("a bare month/day still upcoming this year (and within the horizon) resolves to THIS year, not next", () => {
+    process.env.TZ = "UTC";
+    const now = new Date("2026-07-05T12:00:00.000Z");
+    const endIso = travelEndIso("I'm traveling until July 20", now);
+    expect(endIso).toBe("2026-07-20T00:00:00.000Z");
+  });
+
+  it("a bare month/day already past this year rolls over to next year when still within the horizon", () => {
+    process.env.TZ = "UTC";
+    const now = new Date("2026-12-28T12:00:00.000Z");
+    const endIso = travelEndIso("I'm traveling until Jan 5", now);
+    expect(endIso).toBe("2027-01-05T00:00:00.000Z");
+  });
+
+  it("a bare month/day already past this year AND beyond the horizon next year is discarded, not misdated", () => {
+    process.env.TZ = "UTC";
+    const now = new Date("2026-08-15T12:00:00.000Z");
+    // "July 20" already passed this year; next year's July 20 is ~11 months
+    // away, past the 30-day horizon -- must fall back to undefined, never a
+    // date silently a year later than the user meant.
+    const endIso = travelEndIso("I'm traveling until July 20", now);
+    expect(endIso).toBeUndefined();
+  });
+});
+
+describe("parseTravelReturnIso — ISO date-only reads as a local calendar date", () => {
+  it("matches the local day a month-name phrase would produce, in a UTC- timezone", () => {
+    process.env.TZ = "America/Los_Angeles";
+    const now = new Date("2026-07-01T12:00:00.000Z");
+    const isoForm = travelEndIso("I'm traveling until 2026-07-20", now);
+    const nameForm = travelEndIso("I'm traveling until July 20, 2026", now);
+    expect(isoForm).toBe(nameForm);
+    // Local PDT midnight on 2026-07-20 is 07:00 UTC, not 00:00 UTC.
+    expect(isoForm).toBe("2026-07-20T07:00:00.000Z");
+  });
+
+  it("matches the local day a month-name phrase would produce, in a UTC+ timezone", () => {
+    process.env.TZ = "Asia/Tokyo";
+    const now = new Date("2026-07-01T12:00:00.000Z");
+    const isoForm = travelEndIso("I'm traveling until 2026-07-20", now);
+    const nameForm = travelEndIso("I'm traveling until July 20, 2026", now);
+    expect(isoForm).toBe(nameForm);
+    // Local JST midnight on 2026-07-20 is the previous UTC day.
+    expect(isoForm).toBe("2026-07-19T15:00:00.000Z");
+  });
+});
+
+describe("parseTravelReturnIso — unaffected cases stay unaffected", () => {
+  it("an explicit past year is discarded, not bumped forward", () => {
+    process.env.TZ = "UTC";
+    const now = new Date("2026-06-01T12:00:00.000Z");
+    const endIso = travelEndIso("I'm traveling until July 20 2020", now);
+    expect(endIso).toBeUndefined();
+  });
+
+  it("no return-date phrase at all still opens an open-ended travel signal", () => {
+    process.env.TZ = "UTC";
+    const now = new Date("2026-06-01T12:00:00.000Z");
+    const travel = extractProfileDetails("I'm traveling", now).travel;
+    expect(travel).toEqual({ kind: "set" });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/travel-return-date-parsing.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/travel-return-date-parsing.test.ts
@@ -16,6 +16,11 @@
  *      intended calendar day could land a day earlier depending on which
  *      literal form the user (or an upstream LLM) happened to use, in any
  *      timezone west of UTC.
+ *   3. `new Date(year, month - 1, day)` normalizes an impossible calendar
+ *      date (Feb 29 on a non-leap year, month 13, day 0) into a real one
+ *      instead of rejecting it, and remaps a 4-digit year under 100 to
+ *      1900-1999 (legacy two-digit-year behavior) -- both silently persist
+ *      a fabricated travel end date instead of failing.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { extractProfileDetails } from "./profile-extraction-evaluator.ts";
@@ -92,5 +97,70 @@ describe("parseTravelReturnIso — unaffected cases stay unaffected", () => {
     const now = new Date("2026-06-01T12:00:00.000Z");
     const travel = extractProfileDetails("I'm traveling", now).travel;
     expect(travel).toEqual({ kind: "set" });
+  });
+});
+
+describe("parseTravelReturnIso — impossible calendar dates are rejected, not normalized", () => {
+  it("Feb 29 on a non-leap year is rejected", () => {
+    process.env.TZ = "UTC";
+    const now = new Date("2025-02-10T12:00:00.000Z");
+    expect(travelEndIso("I'm traveling until 2025-02-29", now)).toBeUndefined();
+  });
+
+  it("control: a real nearby date through the same phrase shape still resolves (proves the pipeline itself works)", () => {
+    process.env.TZ = "UTC";
+    const now = new Date("2025-02-10T12:00:00.000Z");
+    expect(travelEndIso("I'm traveling until 2025-03-01", now)).toBe(
+      "2025-03-01T00:00:00.000Z",
+    );
+  });
+
+  it("Feb 29 on an actual leap year is accepted", () => {
+    process.env.TZ = "UTC";
+    const now = new Date("2024-02-10T12:00:00.000Z");
+    expect(travelEndIso("I'm traveling until 2024-02-29", now)).toBe(
+      "2024-02-29T00:00:00.000Z",
+    );
+  });
+
+  it("April 31 (April has 30 days) is rejected", () => {
+    process.env.TZ = "UTC";
+    const now = new Date("2026-04-10T12:00:00.000Z");
+    expect(travelEndIso("I'm traveling until 2026-04-31", now)).toBeUndefined();
+  });
+
+  it("month 13 is rejected, not rolled into January of the next year", () => {
+    process.env.TZ = "UTC";
+    // `new Date(2026, 12, 1)` would silently roll to 2027-01-01 -- pick `now`
+    // close enough to that wrong date that the 30-day horizon cap can't
+    // coincidentally produce the same `undefined` result for the wrong
+    // reason (masking a missing calendar-validity check).
+    const now = new Date("2026-12-15T12:00:00.000Z");
+    expect(travelEndIso("I'm traveling until 2026-13-01", now)).toBeUndefined();
+  });
+
+  it("month 00 is rejected, not rolled into December of the prior year", () => {
+    process.env.TZ = "UTC";
+    // `new Date(2026, -1, 15)` would silently roll to 2025-12-15.
+    const now = new Date("2025-12-01T12:00:00.000Z");
+    expect(travelEndIso("I'm traveling until 2026-00-15", now)).toBeUndefined();
+  });
+
+  it("day 00 is rejected", () => {
+    process.env.TZ = "UTC";
+    // `new Date(2026, 5, 0)` would silently roll to 2026-05-31 (day 0 of
+    // June = last day of May).
+    const now = new Date("2026-05-15T12:00:00.000Z");
+    expect(travelEndIso("I'm traveling until 2026-06-00", now)).toBeUndefined();
+  });
+
+  it("a 4-digit year under 100 is rejected instead of being remapped to 19xx by the Date constructor's legacy two-digit-year rule", () => {
+    process.env.TZ = "UTC";
+    // `new Date(99, 5, 15)` remaps to local 1999-06-15 under the legacy
+    // 0-99 -> 1900-1999 rule -- pick `now` near that wrong year so the
+    // "past date, try next year" branch can't independently absorb this
+    // instead of the round-trip check.
+    const now = new Date("1999-06-01T12:00:00.000Z");
+    expect(travelEndIso("I'm traveling until 0099-06-15", now)).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22173.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. `parseTravelReturnIso` is a pure function with a single call site
(`detectTravelSignal`, itself only called from `extractProfileDetails`). The
change only affects which year/instant a parsed return-date phrase resolves
to — it does not touch the regex triggers, the travel `set`/`clear` state
machine, or any DB/store schema. `extractProfileDetails` is now exported
(previously module-private) purely so this parsing logic is directly
unit-testable without a full runtime/message mock; its only other consumer
(`ownerProfileExtractionEvaluator` in the same file) is unchanged.

# Background

## What does this PR do?

Fixes three bugs in `parseTravelReturnIso` (`plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts`), the free-text
travel-return-date parser used by the owner-profile-extraction evaluator:

1. **Wrong year for bare `Month Day` phrases.** The old code detected "no
   year was given" by checking `Number.isNaN(Date.parse(trimmed))`. But
   `Date.parse("July 20")` never returns `NaN` — absent a year, it silently
   substitutes a fixed placeholder year (2001 in V8) — so the "append the
   current year" fallback was dead code. Every bare `Month Day` phrase fell
   straight into the "already past, must mean next year" branch, even when
   the date was still comfortably upcoming this year. Since the module caps
   travel windows at a 30-day horizon (`MAX_TRAVEL_HORIZON_MS`, by design),
   a date wrongly pushed a year out almost always exceeded that cap, so the
   function returned `null` and the user's stated return date was silently
   discarded in favor of an untargeted 30-day placeholder.

   Fix: detect "no explicit year" from the text itself (`/\b\d{4}\b/`)
   instead of from `Date.parse`'s return value, and only then append the
   current year before parsing.

2. **ISO date-only vs. month-name form disagree on calendar day.** A bare
   `YYYY-MM-DD` string parses as **UTC midnight** while a `Month Day, Year`
   string parses as **LOCAL midnight** (ECMA-262 Date Time String Format).
   The function's own docstring lists both `"2026-07-20"` and `"July 20"` as
   supported forms, but for a caller in any UTC-negative timezone they could
   resolve to different calendar days.

   Fix: a new `parseLocalDate` helper reads the ISO date-only form as local
   `Date(year, month-1, day)` components instead of delegating straight to
   `Date.parse`, so both forms agree.

3. **Impossible calendar dates were silently normalized, not rejected**
   (found in review by `lalalune`). The `parseLocalDate` helper from fix #2
   passed year/month/day straight into `new Date(year, month - 1, day)`
   without validating the result. That constructor rolls an impossible date
   into a real one instead of erroring: `2026-02-29` (non-leap year) becomes
   local March 1, `2026-04-31` becomes May 1, month 13 becomes January of the
   next year, month 0 becomes December of the prior year — and a 4-digit
   year under 100 (e.g. `0099`) is remapped to `1900`-`1999` by the Date
   constructor's legacy two-digit-year rule. The helper's contract is
   "resolve a real date or return `null`"; silently mutating the user's
   stated calendar date violates that and could persist a fabricated travel
   end.

   Fix: round-trip the constructed local date's `getFullYear()`/`getMonth()`/
   `getDate()` against the parsed input components and return `null` on any
   mismatch — same pattern as `utcMidnightIsoOrNull` in the sibling CSV-import
   fix (#22179) in this same session, applied to the local-date path here.

`extractProfileDetails` is exported (previously module-private) so this is
directly testable without mocking a runtime/message — mirrors the existing
pure-module pattern in `packages/agent/src/runtime/memory-retention.ts`.

**Addressed from the first review round (`lalalune`, CHANGES_REQUESTED):**
implemented fix #3 above (calendar round-trip validation) exactly as
specified — including the called-out 4-digit-year-under-100 edge case; added
8 new tests for impossible-date rejection (non-leap Feb 29, leap Feb 29
accepted, Apr 31, month 13, month 00, day 00, year < 100, plus a "control"
test proving a real nearby date through the identical phrase shape still
resolves, so the reject-tests aren't silently passing because nothing in
that shape ever resolves). Verified via reverse-mutation: reverted the
round-trip check locally and confirmed all 6 impossible-date reject-tests
fail without it (one already failed pre-fix from a coincidental horizon-cap
interaction; the other cases needed `now` picked close enough to the wrong
rolled-over date that the horizon cap couldn't independently produce the
same `undefined` result for the wrong reason) — see the domain-artifacts
block below for the exact values.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-personal-assistant/src/lifeops/owner/travel-return-date-parsing.test.ts` — 15 tests (7 original + 8 new for the calendar-validity round-trip), driving the real exported
`extractProfileDetails` (no implementation-detail mocking).

## Detailed testing steps

None: Automated tests are acceptable. Every test drives the real exported
`extractProfileDetails` through natural trigger phrases (e.g. `"I'm
traveling until July 20"`), asserting the exact `travel.endIso` produced.

- `bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/owner/travel-return-date-parsing.test.ts` (15 tests)
- Full owner-directory suite, no regressions: `bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/owner` (59 tests)
- `bun run --cwd plugins/plugin-personal-assistant typecheck`
- `bunx biome check plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts plugins/plugin-personal-assistant/src/lifeops/owner/travel-return-date-parsing.test.ts`

# Evidence Gate

<!-- evidence-head:c65401a8357155bc2f9a89335bd06f995c7786e1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change (a plugin's date-parsing logic), no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change, no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change, no user-facing flow to walk through
<!-- evidence-row:backend-logs -->
- [x] Real Vitest run against the actual exported `extractProfileDetails`,
      with `process.env.TZ` pinned per test (UTC / America/Los_Angeles /
      Asia/Tokyo) to make all three bugs deterministic and reproducible.

<details>
<summary>Backend logs — new suite (verbose, 15 tests), full owner-directory suite, typecheck, Biome</summary>

```
$ bun run --cwd plugins/plugin-personal-assistant vitest run --config vitest.config.ts src/lifeops/owner/travel-return-date-parsing.test.ts --reporter=verbose

 ✓ parseTravelReturnIso — year resolution > a bare month/day still upcoming this year (and within the horizon) resolves to THIS year, not next
 ✓ parseTravelReturnIso — year resolution > a bare month/day already past this year rolls over to next year when still within the horizon
 ✓ parseTravelReturnIso — year resolution > a bare month/day already past this year AND beyond the horizon next year is discarded, not misdated
 ✓ parseTravelReturnIso — ISO date-only reads as a local calendar date > matches the local day a month-name phrase would produce, in a UTC- timezone
 ✓ parseTravelReturnIso — ISO date-only reads as a local calendar date > matches the local day a month-name phrase would produce, in a UTC+ timezone
 ✓ parseTravelReturnIso — unaffected cases stay unaffected > an explicit past year is discarded, not bumped forward
 ✓ parseTravelReturnIso — unaffected cases stay unaffected > no return-date phrase at all still opens an open-ended travel signal
 ✓ parseTravelReturnIso — impossible calendar dates are rejected, not normalized > Feb 29 on a non-leap year is rejected
 ✓ parseTravelReturnIso — impossible calendar dates are rejected, not normalized > control: a real nearby date through the same phrase shape still resolves (proves the pipeline itself works)
 ✓ parseTravelReturnIso — impossible calendar dates are rejected, not normalized > Feb 29 on an actual leap year is accepted
 ✓ parseTravelReturnIso — impossible calendar dates are rejected, not normalized > April 31 (April has 30 days) is rejected
 ✓ parseTravelReturnIso — impossible calendar dates are rejected, not normalized > month 13 is rejected, not rolled into January of the next year
 ✓ parseTravelReturnIso — impossible calendar dates are rejected, not normalized > month 00 is rejected, not rolled into December of the prior year
 ✓ parseTravelReturnIso — impossible calendar dates are rejected, not normalized > day 00 is rejected
 ✓ parseTravelReturnIso — impossible calendar dates are rejected, not normalized > a 4-digit year under 100 is rejected instead of being remapped to 19xx by the Date constructor's legacy two-digit-year rule

 Test Files  1 passed (1)
      Tests  15 passed (15)

$ bun run --cwd plugins/plugin-personal-assistant vitest run --config vitest.config.ts src/lifeops/owner

 Test Files  6 passed (6)
      Tests  59 passed (59)

$ bun run --cwd plugins/plugin-personal-assistant typecheck
$ tsc --noEmit -p tsconfig.build.json
(no output — clean)

$ bunx biome check plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts plugins/plugin-personal-assistant/src/lifeops/owner/travel-return-date-parsing.test.ts
Checked 2 files in 9ms. No fixes applied.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved
<!-- evidence-row:llm-trajectory -->
- [x] N/A - pure date-string-parsing function; no agent/action/prompt/model behavior involved
<!-- evidence-row:domain-artifacts -->
- [x] Actual before/after `travel.endIso` values produced by the real
      (unmocked) parser, proving all three bugs and all three fixes,
      including the reverse-mutation control for the round-trip check.

<details>
<summary>Domain artifact — actual endIso values, before vs. after this fix; reverse-mutation control</summary>

```
Bug 1 (wrong year, silently discarded near-term date):
  TZ=UTC, now = 2026-07-05T12:00:00.000Z ("today"), phrase = "I'm traveling until July 20"
  BEFORE this fix: endIso = undefined
    (internally resolved to July 20, 2027 -- ~380 days away, past the
    30-day MAX_TRAVEL_HORIZON_MS, so the real date was discarded)
  AFTER this fix:  endIso = "2026-07-20T00:00:00.000Z"
    (correctly resolved to THIS year, 15 days away, within the horizon)

Bug 2 (ISO date-only vs. month-name form disagree on calendar day):
  TZ=Asia/Tokyo, now = 2026-07-01T12:00:00.000Z, phrase = "I'm traveling until 2026-07-20"
  BEFORE this fix: endIso = "2026-07-20T00:00:00.000Z"  (UTC midnight -- WRONG local day)
  AFTER this fix:  endIso = "2026-07-19T15:00:00.000Z"  (= local JST midnight on 2026-07-20,
                                                           matches "July 20, 2026" phrasing)

Bug 3 (impossible calendar date silently normalized -- review round):
  TZ=UTC, now = 2025-02-10T12:00:00.000Z, phrase = "I'm traveling until 2025-02-29" (2025 is NOT a leap year)
  BEFORE fix #3: endIso = "2025-03-01T00:00:00.000Z"  (silently rolled Feb 29 -> Mar 1)
  AFTER fix #3:  endIso = undefined                    (rejected, calendar date does not exist)

  TZ=UTC, now = 2026-04-10T12:00:00.000Z, phrase = "I'm traveling until 2026-04-31" (April has 30 days)
  BEFORE fix #3: endIso = "2026-05-01T00:00:00.000Z"  (silently rolled Apr 31 -> May 1)
  AFTER fix #3:  endIso = undefined

  Reverse-mutation control (proves the new tests exercise the round-trip
  check, not an unrelated code path): reverting fix #3 locally and rerunning
  the 6 new reject-tests fails all 6 -- e.g. month 13 (`now` pinned to
  2026-12-15, so the wrongly-rolled 2027-01-01 falls inside the 30-day
  horizon and can't be masked by the horizon cap): endIso =
  "2027-01-01T00:00:00.000Z" before, undefined after. Full 6/6 failure
  output kept in the PR discussion thread, not reproduced here for length.

All values above are the real return of `extractProfileDetails(text, now).travel.endIso`
against the unmodified vs. fixed source, not hand-computed.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-manual]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza"} -->


