### PR TITLE
fix(wallet): bound news RSS fetch with timeout

### DIFF
--- a/plugins/plugin-wallet/src/analytics/news/services/newsDataService.timeout.test.ts
+++ b/plugins/plugin-wallet/src/analytics/news/services/newsDataService.timeout.test.ts
@@ -1,0 +1,168 @@
+/**
+ * NewsDataService RSS deadline and caller-cancellation contract tests.
+ * The deterministic harness covers header and body stalls, signal composition,
+ * wrapper forwarding, the public timeout budget, and successful RSS parsing.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_NEWS_RSS_FETCH_TIMEOUT_MS,
+  NewsDataService,
+} from "./newsDataService";
+
+function stallUntilAborted(signal?: AbortSignal): Promise<Response> {
+  return new Promise<Response>((_resolve, reject) => {
+    if (!signal) return;
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    signal.addEventListener("abort", () => reject(signal.reason), {
+      once: true,
+    });
+  });
+}
+
+function makeResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/xml" },
+  });
+}
+
+function stalledTextResponse(signal?: AbortSignal): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: () => stallUntilAborted(signal).then(() => ""),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+function makeService(): NewsDataService {
+  return new NewsDataService({} as IAgentRuntime);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("NewsDataService RSS timeout", () => {
+  it("exposes DEFAULT_NEWS_RSS_FETCH_TIMEOUT_MS === 10_000", () => {
+    expect(DEFAULT_NEWS_RSS_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("passes AbortSignal.timeout budget to fetch (hanging fetch → TimeoutError)", async () => {
+    const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation((_ms: number) => origTimeout(10));
+
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) =>
+      stallUntilAborted(init?.signal),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const svc = makeService();
+
+    await expect(svc.getLatestNews()).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(DEFAULT_NEWS_RSS_FETCH_TIMEOUT_MS);
+    // Verify our mock was called with a signal (the timeout signal)
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeDefined();
+    expect(init.signal?.aborted).toBe(true);
+  });
+
+  it("aborts stalled response.text() body via same timeout signal", async () => {
+    const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) =>
+      origTimeout(10),
+    );
+
+    // Fetch returns headers quickly but body stalls — same signal must abort text()
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) =>
+      stalledTextResponse(init?.signal),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const svc = makeService();
+
+    await expect(svc.getLatestNews()).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+  });
+
+  it("merges caller signal via AbortSignal.any when provided", async () => {
+    const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation((_ms: number) => origTimeout(10));
+    const anySpy = vi.spyOn(AbortSignal, "any");
+
+    const callerCtrl = new AbortController();
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) =>
+      stallUntilAborted(init?.signal),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const svc = makeService();
+    const pending = svc.getLatestNews({ signal: callerCtrl.signal });
+
+    // Abort via caller before timeout — should also reject with caller reason
+    callerCtrl.abort(new DOMException("caller abort", "AbortError"));
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(timeoutSpy).toHaveBeenCalledWith(DEFAULT_NEWS_RSS_FETCH_TIMEOUT_MS);
+    expect(anySpy).toHaveBeenCalled();
+    const anyArgs = anySpy.mock.calls[0][0] as AbortSignal[];
+    expect(anyArgs).toHaveLength(2);
+    expect(anyArgs[0]).toBe(callerCtrl.signal);
+  });
+
+  it("forwards caller cancellation through every query wrapper", async () => {
+    const svc = makeService();
+    const signal = new AbortController().signal;
+    const latestSpy = vi.spyOn(svc, "getLatestNews").mockResolvedValue([]);
+
+    await svc.getTokenNews("BTC", { language: "en", limit: 2, signal });
+    expect(latestSpy).toHaveBeenLastCalledWith({
+      query: "btc",
+      language: "en",
+      limit: 2,
+      signal,
+    });
+
+    await svc.getDefiNews({ language: "en", limit: 3, signal });
+    expect(latestSpy).toHaveBeenLastCalledWith({
+      query: "defi",
+      language: "en",
+      limit: 3,
+      signal,
+    });
+
+    await svc.getCryptoMarketNews({ language: "en", limit: 4, signal });
+    expect(latestSpy).toHaveBeenLastCalledWith({
+      language: "en",
+      limit: 4,
+      signal,
+    });
+  });
+
+  it("succeeds when fetch returns valid RSS within budget", async () => {
+    const rss = `<?xml version="1.0"?><rss><channel><item><title>BTC up</title><link>https://example.test/a</link><description>hello</description><pubDate>Mon, 19 Aug 2026 00:00:00 GMT</pubDate><guid>guid-1</guid></item></channel></rss>`;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(rss)));
+
+    const svc = makeService();
+    const articles = await svc.getLatestNews({ limit: 5 });
+
+    expect(articles).toHaveLength(1);
+    expect(articles[0].title).toBe("BTC up");
+    expect(articles[0].link).toBe("https://example.test/a");
+  });
+});

--- a/plugins/plugin-wallet/src/analytics/news/services/newsDataService.ts
+++ b/plugins/plugin-wallet/src/analytics/news/services/newsDataService.ts
@@ -20,6 +20,8 @@ interface RSSItem {
   creator?: string;
 }
 
+export const DEFAULT_NEWS_RSS_FETCH_TIMEOUT_MS = 10_000;
+
 export class NewsDataService extends Service {
   static serviceType = "NEWS_DATA_SERVICE";
   private rssUrl: string = "https://bravenewcoin.com/rss/insights";
@@ -155,17 +157,24 @@ export class NewsDataService extends Service {
     language?: string;
     category?: string;
     limit?: number;
+    signal?: AbortSignal;
   }): Promise<RealWorldNewsArticle[]> {
     try {
       const limit = options?.limit || 10;
       const query = options?.query?.toLowerCase();
+      const timeoutSignal = AbortSignal.timeout(
+        DEFAULT_NEWS_RSS_FETCH_TIMEOUT_MS,
+      );
+      const signal = options?.signal
+        ? AbortSignal.any([options.signal, timeoutSignal])
+        : timeoutSignal;
 
       const response = await fetch(this.rssUrl, {
         method: "GET",
         headers: {
           "User-Agent": "Mozilla/5.0 (compatible; SpartanBot/1.0)",
         },
-        signal: AbortSignal.timeout(10_000),
+        signal,
       });
 
       if (!response.ok) {
@@ -240,6 +249,7 @@ export class NewsDataService extends Service {
     options?: {
       language?: string;
       limit?: number;
+      signal?: AbortSignal;
     },
   ): Promise<RealWorldNewsArticle[]> {
     const query = tokenSymbol.toLowerCase();
@@ -247,29 +257,34 @@ export class NewsDataService extends Service {
       query,
       language: options?.language,
       limit: options?.limit,
+      signal: options?.signal,
     });
   }
 
   async getDefiNews(options?: {
     language?: string;
     limit?: number;
+    signal?: AbortSignal;
   }): Promise<RealWorldNewsArticle[]> {
     const query = "defi";
     return this.getLatestNews({
       query,
       language: options?.language,
       limit: options?.limit,
+      signal: options?.signal,
     });
   }
 
   async getCryptoMarketNews(options?: {
     language?: string;
     limit?: number;
+    signal?: AbortSignal;
   }): Promise<RealWorldNewsArticle[]> {
     // Return all crypto news from the feed
     return this.getLatestNews({
       language: options?.language,
       limit: options?.limit,
+      signal: options?.signal,
     });
   }
 }


### PR DESCRIPTION
Relates to #21251

Fixes #22187

## Summary
- Exports `DEFAULT_NEWS_RSS_FETCH_TIMEOUT_MS = 10_000` and bounds `NewsDataService.getLatestNews` with `AbortSignal.timeout`; composes caller `signal` via `AbortSignal.any([caller, timeout])` so both deadline and caller cancellation abort the fetch and the stalled `response.text()` body (`plugins/plugin-wallet/src/analytics/news/services/newsDataService.ts:25,167-185`).
- Forwards `signal` through `getTokenNews`/`getDefiNews`/`getCryptoMarketNews` wrappers to preserve caller cancellation end-to-end.
- Adds `newsDataService.timeout.test.ts` covering hanging fetch → `TimeoutError`, stalled body abort, `AbortSignal.any` merge, budget exposure and successful RSS parsing.

## What Changed
- `plugins/plugin-wallet/src/analytics/news/services/newsDataService.ts`: export timeout constant, add optional `signal?: AbortSignal` to `getLatestNews` and wrappers, create timeout signal and compose with caller signal, pass composed signal to `fetch` (same signal remains active for `response.text()`).
- `plugins/plugin-wallet/src/analytics/news/services/newsDataService.timeout.test.ts`: new, 5 tests.

## Exact-head evidence
Head: 115ef73d315d01f1d8c8db0b1bbd84f83d7ba7f6
Base: origin/develop@af9d315090853d2b4df531095a534e31c1016123 with zero conflicts

## Verification / Definition of Done
- [x] Targets `develop`, rebased onto `origin/develop@af9d315090853d2b4df531095a534e31c1016123` zero conflicts
- [x] `bun install --frozen-lockfile` completed (bun.lock unchanged)
- [x] `bunx vitest run plugins/plugin-wallet/src/analytics/news/services/newsDataService.timeout.test.ts` — 6/6 passed, including hanging-fetch `TimeoutError` (10ms), stalled `response.text()` abort, `AbortSignal.any` merge, budget exposure `DEFAULT_NEWS_RSS_FETCH_TIMEOUT_MS === 10_000`, and successful RSS parse
- [x] `bunx vitest run plugins/plugin-wallet/src/analytics/news` — 10/10 passed (news utils + timeout)
- [x] `bunx tsc --noEmit -p plugins/plugin-wallet/tsconfig.json` — passed
- [x] Reviewer can confirm from automated tests / negative control

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@af9d315090853d2b4df531095a534e31c1016123:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@af9d315090853d2b4df531095a534e31c1016123:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@af9d315090853d2b4df531095a534e31c1016123:packages/skills/skills/contribute-to-eliza"} -->

Co-authored-by: byt61 <byt61@users.noreply.github.com>

# Sync with develop

- [x] Rebased onto current `origin/develop` before the exact-head validation; zero conflicts.
- [x] Frozen `bun install` completed.
- [x] Exact focused tests, Node typecheck, and diff check pass.

# Risks

Low and bounded to the news RSS HTTP boundary (`GET https://bravenewcoin.com/rss/insights`). Each request creates a fresh 10-second deadline. A caller-provided signal is composed with the deadline using `AbortSignal.any`, so caller cancellation is preserved. Both header stalls and response-body stalls remain bounded. Existing parse/filter/limit contracts are unchanged; only the fetch signal is added.

# Background

## What does this PR do?

Adds `DEFAULT_NEWS_RSS_FETCH_TIMEOUT_MS = 10_000` and always supplies a fresh deadline signal to `fetch` in `NewsDataService.getLatestNews`. If a caller already supplied a signal (via wrappers), the request uses a composed signal that aborts on either caller cancellation or deadline expiry. Because the same signal remains attached to the native fetch response, stalled `response.text()` bodies are also interrupted; the existing catch path retains the original `TimeoutError` or `AbortError`.

This follows the merged wallet timeout pattern (#21882 Kamino, #21137 attestation) and extends the simple `AbortSignal.timeout(10_000)` added in #21251 to the full bar: exported budget, `AbortSignal.any` composition, body-stall coverage, and tests.

## What kind of change is this?

Bug fix.

# Testing

## Where should a reviewer start?

- `plugins/plugin-wallet/src/analytics/news/services/newsDataService.ts`
- `plugins/plugin-wallet/src/analytics/news/services/newsDataService.timeout.test.ts`

## Detailed testing steps

On exact head `115ef73d315d01f1d8c8db0b1bbd84f83d7ba7f6`:

- `bunx vitest run plugins/plugin-wallet/src/analytics/news/services/newsDataService.timeout.test.ts` from repo root: 6/6 passed.
  - real timeout signal via `vi.spyOn(AbortSignal, "timeout")` → 10ms hanging fetch → `TimeoutError`;
  - stalled `response.text()` body via same signal → `TimeoutError`;
  - `AbortSignal.any` merge with caller `AbortController` → caller `AbortError` preserved;
  - budget exposure `DEFAULT_NEWS_RSS_FETCH_TIMEOUT_MS === 10_000`;
  - successful RSS parse within budget.
- `bunx vitest run plugins/plugin-wallet/src/analytics/news` — 10/10 passed.
- `bun run --cwd plugins/plugin-wallet typecheck` — passed (Node and UI trees).\n- `bun run --cwd plugins/plugin-wallet build` — passed (Node, browser UI, declarations, and views).
- changed-file Biome: passed (both changed files).
- `git diff --check origin/develop...HEAD` — no whitespace errors.

# Evidence Gate

<!-- evidence-head:115ef73d315d01f1d8c8db0b1bbd84f83d7ba7f6 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only wallet transport boundary; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only wallet transport boundary; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic request deadline with no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] [22178-news-cancellation-review-backend-v1.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22178-news-cancellation-review-backend-v1.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action routing, or agent planning change.
<!-- evidence-row:domain-artifacts -->
- [x] [22178-news-cancellation-review-native-v1.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22178-news-cancellation-review-native-v1.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text surface changed.

# Known gaps / failures

The full wallet test run completed with 47 files / 285 tests passing. Eleven zero-test suites were blocked by sparse linked-worktree resolution of unchanged `@elizaos/core/client-public` and `@elizaos/ui/*` exports; the remaining unchanged EVM sign-route assertion expected a different validation message. None imports or reaches the news RSS path. Focused news tests, full Node/UI typecheck, package build, package-wide Biome, and diff-check pass on the exact head.





