### PR TITLE
test(plugin-google-genai): pin NON_FINITE metering and AbortError non-metering (#22110 follow-up)

### DIFF
--- a/plugins/plugin-google-genai/__tests__/embedding.usage-ordering.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.usage-ordering.test.ts
@@ -136,6 +136,24 @@ describe("Google GenAI embedding usage accounting on billed-but-failing calls (#
     expect(mocks.emitModelUsageEvent).toHaveBeenCalledTimes(1);
   });
 
+  it("still reports usage when a component is non-finite", async () => {
+    const values = Array(768).fill(0.5);
+    values[41] = Number.NaN;
+    mocks.embedContent.mockResolvedValue({ embeddings: [{ values }] });
+    const runtime = createRuntime();
+
+    await expect(handleTextEmbedding(runtime, "hello")).rejects.toMatchObject({
+      code: "EMBEDDING_NON_FINITE",
+    });
+    expect(mocks.emitModelUsageEvent).toHaveBeenCalledTimes(1);
+    expect(mocks.emitModelUsageEvent).toHaveBeenCalledWith(
+      runtime,
+      "TEXT_EMBEDDING",
+      "hello",
+      EXPECTED_USAGE,
+    );
+  });
+
   it("reports usage exactly once on a failing call", async () => {
     mocks.embedContent.mockResolvedValue({ embeddings: [{ values: [] }] });
 
@@ -150,6 +168,18 @@ describe("Google GenAI embedding usage accounting on billed-but-failing calls (#
 
     await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
       /network exploded/,
+    );
+    expect(mocks.emitModelUsageEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not meter an aborted provider call (AbortError)", async () => {
+    const abortError = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+    });
+    mocks.embedContent.mockRejectedValue(abortError);
+
+    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
+      /aborted/,
     );
     expect(mocks.emitModelUsageEvent).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
# Relates to

- Follow-up to #22110 (merged 2026-08-18, squash 23847b4168) — post-merge verification comment: https://github.com/elizaOS/eliza/pull/22110#issuecomment-5333522460
- Review finding 1 in #22110's CHANGES_REQUESTED asked for the two usage-metering test controls this PR adds.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2`, `zai/glm-5.3` (RepoPrompt CE review agent: GPT-5.6-sol)
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts. (Branched directly from develop tip `aa6bb930db`.)
- [x] Plugin gates pass post-sync: full unit suite 88 passed | 2 skipped, `tsc --noEmit` clean, `biome check` clean (32 files).

# Risks

Low. Test-only change (+30 lines, one file, no production code). The two tests pin already-correct landed behavior; the only risk they remove is silent regression of usage metering on the two paths the #22110 review explicitly called out.

# Background

## What does this PR do?

Adds the two usage-accounting test controls that #22110's review (finding 1) asked for and the merged suite dropped, to `plugins/plugin-google-genai/__tests__/embedding.usage-ordering.test.ts`:

1. **`still reports usage when a component is non-finite`** — a 768-wide vector with one `NaN` component (index 41) must reject with `code: "EMBEDDING_NON_FINITE"` **and** still be metered exactly once with the expected payload. This is the billed-but-failing path: `l2Normalize` throws after the provider call returned, so usage accounting must already have run.
2. **`does not meter an aborted provider call (AbortError)`** — an `AbortError`-shaped rejection from `embedContent` must NOT be metered (the call was never billed) and the original error rethrows without 404-rebucketing.

The landed code already behaves correctly on both paths (verified by execution in the post-merge review of #22110, linked above); this PR pins that behavior so it cannot silently regress.

## What kind of change is this?

Tests (regression controls for existing behavior; no production change).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-genai/__tests__/embedding.usage-ordering.test.ts` — the two new `it(...)` blocks ("still reports usage when a component is non-finite" and "does not meter an aborted provider call (AbortError)").

## Detailed testing steps

- `bun run --cwd plugins/plugin-google-genai test` — 88 passed | 2 skipped (90) at branch head `44b6b19ca4` (11→13 tests in the target suite).
- Mutation red-control A (metering moved back to the happy-path tail — the original #22102 bug shape): 7 tests fail, including the new NON_FINITE test. Restored → 13/13 green.
- Mutation red-control B (metering hoisted above the `embedContent` call): both negative controls fail, including the new AbortError test. Restored → 13/13 green.
- `tsc --noEmit -p tsconfig.json` clean; `biome check` clean; `biome format` clean on the changed file.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:44b6b19ca45294d618692459cffa6113fe2adc6e -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change to a deterministic vitest suite; no UI surface exists to capture.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change to a deterministic vitest suite; no UI surface exists to capture.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; the inline vitest transcripts (green run + mutation red-controls) are the complete behavioral evidence.
<!-- evidence-row:backend-logs -->
- [x] Real vitest transcripts at branch head 44b6b19ca4 (see "Backend + frontend logs" for the same blocks with full context):
```
$ bunx vitest run __tests__/embedding.usage-ordering.test.ts
RUN  v4.1.5 /private/tmp/wt-22110-followup/plugins/plugin-google-genai
Test Files  1 passed (1)
Tests  13 passed (13)
Duration  4.35s

$ bunx vitest run --config vitest.config.ts
Test Files  10 passed | 1 skipped (11)
Tests  88 passed | 2 skipped (90)
Duration  4.41s

$ bun run typecheck   # tsc --noEmit -p tsconfig.json -> clean (no output)
$ bunx @biomejs/biome check build.ts index.ts index.browser.ts index.node.ts init.ts __tests__ generated models types utils
Checked 32 files in 93ms. No fixes applied.

# Mutation red-control A (metering moved to happy-path tail, the #22102 bug shape):
x still reports usage when a component is non-finite   <- NEW CONTROL FIRES
Tests  7 failed | 6 passed (13)
# Mutation red-control B (metering hoisted above the billed embedContent call):
x does not meter an aborted provider call (AbortError) <- NEW CONTROL FIRES
Tests  2 failed | 11 passed (13)
# Both mutations restored -> 13/13 green.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface touched (single __tests__ file in plugins/plugin-google-genai).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic vitest suite with fully mocked provider layers; no model, prompt, or provider code changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - tests only; no runtime state, DB rows, or generated artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.
