### PR TITLE
feat(corpus): collect Telegram Desktop exports

### DIFF
--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -89,6 +89,13 @@ rerun. Service, deleted, secret-chat, and media-only records are counted but
 not fabricated into text messages. Export media paths are never opened, so
 metadata alone never produces an attachment SHA-256.
 
+Telegram's `verification_codes` dialog is always excluded and counted as
+credential material. Input is capped at 64 MiB and read only through that byte
+boundary before parsing. Publications use an output-root lock, account-owned
+`telegram/<account>/summary.json` files, and a manifest installed last as the
+generation commit marker; a concurrent writer or manifest validation issue
+fails the collection instead of returning partial success.
+
 ```bash
 bun run --cwd packages/corpus-tools test
 bun run --cwd packages/corpus-tools typecheck

--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -62,6 +62,33 @@ apply, retain only counts and hashes in shared evidence, and prove idempotent
 re-apply plus stale-decision rejection against a protected snapshot before the
 issue is closed.
 
+## Telegram Desktop collector
+
+`collectTelegramDesktopExport` parses the machine-readable `result.json`
+created by Telegram Desktop's Settings → Advanced → Export Telegram data flow.
+It is offline-only: the collector does not accept GramJS clients,
+`StringSession` values, Telegram API credentials, or raw `tdata` directories.
+
+```ts
+import { collectTelegramDesktopExport } from "@elizaos/corpus-tools";
+
+const result = await collectTelegramDesktopExport({
+  exportPath: "data/raw/telegram/result.json",
+  ownerAccountId: "<numeric Telegram user id>",
+  outDir: "data",
+  allowedGroupPeerIds: ["<explicitly selected group id>"],
+  allowedChannelPeerIds: ["<explicitly selected channel id>"],
+});
+```
+
+DMs are admitted by default; groups and channels are denied unless their bare
+peer ids are allowlisted. Rows are bounded to the canonical corpus
+cutoff/anchor, identities include account + peer kind + peer id + message id,
+and monthly shards plus the manifest and aggregate summary are byte-stable on
+rerun. Service, deleted, secret-chat, and media-only records are counted but
+not fabricated into text messages. Export media paths are never opened, so
+metadata alone never produces an attachment SHA-256.
+
 ```bash
 bun run --cwd packages/corpus-tools test
 bun run --cwd packages/corpus-tools typecheck

--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -93,8 +93,11 @@ Telegram's `verification_codes` dialog is always excluded and counted as
 credential material. Input is capped at 64 MiB and read only through that byte
 boundary before parsing. Publications use an output-root lock, account-owned
 `telegram/<account>/summary.json` files, and a manifest installed last as the
-generation commit marker; a concurrent writer or manifest validation issue
-fails the collection instead of returning partial success.
+generation commit marker. Before the first changed or stale shard is installed,
+an existing marker is removed so an interrupted update is visibly incomplete;
+unchanged reruns retain it byte-for-byte. Collector-owned hardlinks, concurrent
+writers, and manifest validation issues fail the collection instead of
+returning partial success.
 
 Migrated basic-group history retains Telegram Desktop's signed negative message
 and reply ids; account and peer identities remain positive-only. Collection

--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -91,7 +91,9 @@ metadata alone never produces an attachment SHA-256.
 
 Telegram's `verification_codes` dialog is always excluded and counted as
 credential material. Input is capped at 64 MiB and read only through that byte
-boundary before parsing. Publications use an output-root lock, account-owned
+boundary before parsing. Symlinked or hardlinked inputs, duplicate JSON object
+keys, and files changed during capture are rejected. Publications use an
+output-root lock, account-owned
 `telegram/<account>/summary.json` files, and a manifest installed last as the
 generation commit marker. Before the first changed or stale shard is installed,
 an existing marker is removed so an interrupted update is visibly incomplete;

--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -96,6 +96,13 @@ boundary before parsing. Publications use an output-root lock, account-owned
 generation commit marker; a concurrent writer or manifest validation issue
 fails the collection instead of returning partial success.
 
+Migrated basic-group history retains Telegram Desktop's signed negative message
+and reply ids; account and peer identities remain positive-only. Collection
+currently fails closed on Windows because Node's portable filesystem API cannot
+both reject directory reparse points and establish owner-only ACLs for these raw
+private-message artifacts. Windows support requires platform-specific ACL and
+reparse-point enforcement plus real-host verification.
+
 ```bash
 bun run --cwd packages/corpus-tools test
 bun run --cwd packages/corpus-tools typecheck

--- a/packages/corpus-tools/fixtures/telegram-desktop/migrated-basic-group/result.json
+++ b/packages/corpus-tools/fixtures/telegram-desktop/migrated-basic-group/result.json
@@ -1,0 +1,35 @@
+{
+  "personal_information": {
+    "user_id": 100,
+    "first_name": "Synthetic",
+    "last_name": "Owner"
+  },
+  "chats": {
+    "list": [
+      {
+        "name": "Migrated Synthetic Group",
+        "type": "private_supergroup",
+        "id": 300,
+        "messages": [
+          {
+            "id": -1000000001,
+            "type": "message",
+            "date_unixtime": "1725148800",
+            "from": "Group Member",
+            "from_id": "user201",
+            "text": "migrated group message"
+          },
+          {
+            "id": -1000000002,
+            "type": "message",
+            "date_unixtime": "1725235200",
+            "from": "Synthetic Owner",
+            "from_id": "user100",
+            "reply_to_message_id": -1000000001,
+            "text": "reply to migrated group message"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/corpus-tools/fixtures/telegram-desktop/result.json
+++ b/packages/corpus-tools/fixtures/telegram-desktop/result.json
@@ -1,0 +1,188 @@
+{
+  "about": "Synthetic Telegram Desktop export fixture",
+  "personal_information": {
+    "user_id": 100,
+    "first_name": "Synthetic",
+    "last_name": "Owner"
+  },
+  "chats": {
+    "about": "Synthetic current chats",
+    "list": [
+      {
+        "name": "Synthetic Friend",
+        "type": "personal_chat",
+        "id": 200,
+        "messages": [
+          {
+            "id": 1,
+            "type": "message",
+            "date": "2024-08-01T00:00:00",
+            "date_unixtime": "1722470400",
+            "from": "Synthetic Friend",
+            "from_id": "user200",
+            "text": [
+              "hello ",
+              { "type": "bold", "text": "owner" }
+            ],
+            "text_entities": []
+          },
+          {
+            "id": 2,
+            "type": "message",
+            "date": "2024-08-02T00:00:00",
+            "date_unixtime": "1722556800",
+            "from": "Synthetic Owner",
+            "from_id": "user100",
+            "reply_to_message_id": 1,
+            "text": "hello back",
+            "text_entities": []
+          },
+          {
+            "id": 3,
+            "type": "service",
+            "date": "2024-08-03T00:00:00",
+            "date_unixtime": "1722643200",
+            "actor": "Synthetic Friend",
+            "actor_id": "user200",
+            "action": "phone_call",
+            "text": ""
+          },
+          {
+            "id": 4,
+            "type": "message",
+            "date": "2024-08-04T00:00:00",
+            "date_unixtime": "1722729600",
+            "from": "Synthetic Friend",
+            "from_id": "user200",
+            "photo": "photos/photo_1.jpg",
+            "photo_file_size": 12,
+            "text": "",
+            "text_entities": []
+          },
+          {
+            "id": 5,
+            "type": "deleted_message"
+          },
+          {
+            "id": 6,
+            "type": "message",
+            "date": "2024-06-01T00:00:00",
+            "date_unixtime": "1717200000",
+            "from": "Synthetic Friend",
+            "from_id": "user200",
+            "text": "outside the frozen cutoff",
+            "text_entities": []
+          },
+          {
+            "id": 7,
+            "type": "message",
+            "date": "2026-07-06T00:00:00",
+            "date_unixtime": "1783296000",
+            "from": "Synthetic Friend",
+            "from_id": "user200",
+            "text": "outside the frozen anchor",
+            "text_entities": []
+          },
+          {
+            "id": 8,
+            "type": "message",
+            "date": "2024-08-05T00:00:00",
+            "date_unixtime": "1722816000",
+            "from": "Synthetic Friend",
+            "from_id": "user200",
+            "file": "files/not-opened.pdf",
+            "file_size": 99,
+            "mime_type": "application/pdf",
+            "text": "caption retained without a fabricated attachment hash",
+            "text_entities": []
+          }
+        ]
+      },
+      {
+        "name": "Allowed Synthetic Group",
+        "type": "private_supergroup",
+        "id": 300,
+        "messages": [
+          {
+            "id": 1,
+            "type": "message",
+            "date": "2024-09-01T00:00:00",
+            "date_unixtime": "1725148800",
+            "from": "Group Member",
+            "from_id": "user201",
+            "text": "allowed group message",
+            "text_entities": []
+          },
+          {
+            "id": 2,
+            "type": "message",
+            "date": "2024-09-02T00:00:00",
+            "date_unixtime": "1725235200",
+            "from": "Synthetic Owner",
+            "from_id": "user100",
+            "reply_to_message_id": 1,
+            "text": "allowed group reply",
+            "text_entities": []
+          }
+        ]
+      },
+      {
+        "name": "Denied Synthetic Group",
+        "type": "public_supergroup",
+        "id": 301,
+        "messages": [
+          {
+            "id": 1,
+            "type": "message",
+            "date": "2024-09-03T00:00:00",
+            "date_unixtime": "1725321600",
+            "from": "Denied Member",
+            "from_id": "user202",
+            "text": "must not be collected",
+            "text_entities": []
+          }
+        ]
+      },
+      {
+        "name": "Allowed Synthetic Channel",
+        "type": "private_channel",
+        "id": 400,
+        "messages": [
+          {
+            "id": 1,
+            "type": "message",
+            "date": "2024-10-01T00:00:00",
+            "date_unixtime": "1727740800",
+            "author": "Synthetic Channel Author",
+            "text": "allowlisted channel post",
+            "text_entities": []
+          }
+        ]
+      },
+      {
+        "name": "Denied Synthetic Channel",
+        "type": "public_channel",
+        "id": 401,
+        "messages": [
+          {
+            "id": 1,
+            "type": "unsupported"
+          }
+        ]
+      },
+      {
+        "name": "Unsupported Synthetic Secret Chat",
+        "type": "secret_chat",
+        "id": 500,
+        "messages": [
+          { "id": 1, "type": "message" },
+          { "id": 2, "type": "service" }
+        ]
+      }
+    ]
+  },
+  "left_chats": {
+    "about": "Synthetic left chats",
+    "list": []
+  }
+}

--- a/packages/corpus-tools/fixtures/telegram-desktop/result.json
+++ b/packages/corpus-tools/fixtures/telegram-desktop/result.json
@@ -178,6 +178,23 @@
           { "id": 1, "type": "message" },
           { "id": 2, "type": "service" }
         ]
+      },
+      {
+        "name": "Telegram",
+        "type": "verification_codes",
+        "id": 777000,
+        "messages": [
+          {
+            "id": 1,
+            "type": "message",
+            "date": "2024-10-02T00:00:00",
+            "date_unixtime": "1727827200",
+            "from": "Telegram",
+            "from_id": "user777000",
+            "text": "Login code: 12345. Do not give this code to anyone.",
+            "text_entities": []
+          }
+        ]
       }
     ]
   },

--- a/packages/corpus-tools/src/collectors/telegram-desktop-io.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop-io.ts
@@ -1,0 +1,295 @@
+/**
+ * Bounded local-file and deterministic shard I/O for Telegram Desktop corpus
+ * imports. This boundary rejects symlinked inputs and collector-owned output
+ * targets, ignores every media path embedded in the export, and changes only
+ * byte-different or stale Telegram shards.
+ */
+import { randomUUID } from "node:crypto";
+import { constants, promises as fs } from "node:fs";
+import path from "node:path";
+import { ElizaError } from "@elizaos/core";
+import type { CorpusMessage } from "../schema.ts";
+
+export interface TelegramShardWriteStats {
+  written: number;
+  reused: number;
+  removed: number;
+}
+
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+const OWNED_SHARD_NAME = /^\d{4}-(0[1-9]|1[0-2])\.jsonl$/;
+
+function inputError(
+  code: string,
+  message: string,
+  context: Record<string, unknown> = {},
+  cause?: unknown,
+): ElizaError {
+  return new ElizaError(message, { code, context, cause });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function readTelegramDesktopJson(
+  exportPath: string,
+  maxInputBytes: number,
+): Promise<unknown> {
+  if (path.basename(exportPath) !== "result.json") {
+    throw inputError(
+      "TELEGRAM_EXPORT_BAD_PATH",
+      "Telegram Desktop input must be named result.json",
+      { fileName: path.basename(exportPath) },
+    );
+  }
+  let input: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    input = await fs.open(
+      exportPath,
+      constants.O_RDONLY | constants.O_NOFOLLOW,
+    );
+  } catch (error) {
+    // error-policy:J2 open the untrusted path without following a final symlink.
+    throw inputError(
+      "TELEGRAM_EXPORT_BAD_PATH",
+      "Telegram Desktop input could not be opened safely",
+      { exportPath },
+      error,
+    );
+  }
+  let bytes: Buffer;
+  try {
+    const entry = await input.stat();
+    if (!entry.isFile()) {
+      throw inputError(
+        "TELEGRAM_EXPORT_BAD_PATH",
+        "Telegram Desktop input must be a regular, non-symlink file",
+        { exportPath },
+      );
+    }
+    if (entry.size > maxInputBytes) {
+      throw inputError(
+        "TELEGRAM_EXPORT_INPUT_TOO_LARGE",
+        `Telegram Desktop input exceeds ${maxInputBytes} bytes`,
+        { maxInputBytes },
+      );
+    }
+    bytes = await input.readFile();
+  } catch (error) {
+    if (error instanceof ElizaError) throw error;
+    // error-policy:J2 wrap input read failures without fabricating an empty export.
+    throw inputError(
+      "TELEGRAM_EXPORT_READ_FAILED",
+      "Telegram Desktop input could not be read",
+      { exportPath },
+      error,
+    );
+  } finally {
+    await input.close();
+  }
+  if (bytes.byteLength > maxInputBytes) {
+    throw inputError(
+      "TELEGRAM_EXPORT_INPUT_TOO_LARGE",
+      `Telegram Desktop input exceeds ${maxInputBytes} bytes`,
+      { maxInputBytes },
+    );
+  }
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    // error-policy:J2 wrap untrusted Telegram JSON with a typed boundary error.
+    throw inputError(
+      "TELEGRAM_EXPORT_BAD_JSON",
+      "Telegram Desktop result.json is not valid JSON",
+      { exportPath },
+      error,
+    );
+  }
+}
+
+async function ensureDirectory(
+  directory: string,
+  location: string,
+): Promise<void> {
+  await fs.mkdir(directory, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+  let handle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    const noFollowDirectoryFlags =
+      process.platform === "win32"
+        ? constants.O_RDONLY
+        : constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW;
+    handle = await fs.open(directory, noFollowDirectoryFlags);
+  } catch (error) {
+    // error-policy:J2 bind output inspection failures to the collector boundary.
+    throw inputError(
+      "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
+      `${location} could not be opened safely`,
+      { location },
+      error,
+    );
+  }
+  try {
+    const entry = await handle.stat();
+    if (!entry.isDirectory()) {
+      throw inputError(
+        "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
+        `${location} must be a regular directory`,
+        { location },
+      );
+    }
+    if (process.platform !== "win32") {
+      await handle.chmod(PRIVATE_DIRECTORY_MODE);
+    }
+  } catch (error) {
+    if (error instanceof ElizaError) throw error;
+    // error-policy:J2 preserve output-inspection context and its filesystem cause.
+    throw inputError(
+      "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
+      `${location} could not be secured`,
+      { location },
+      error,
+    );
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readExistingRegularFile(
+  filePath: string,
+): Promise<string | undefined> {
+  let handle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    handle = await fs.open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch (error) {
+    // error-policy:J3 a missing output is the explicit fresh-run state.
+    if (isRecord(error) && error.code === "ENOENT") return undefined;
+    throw inputError(
+      "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
+      "collector output target could not be opened safely",
+      { filePath },
+      error,
+    );
+  }
+  try {
+    const entry = await handle.stat();
+    if (entry.isSymbolicLink() || !entry.isFile()) {
+      throw inputError(
+        "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
+        "collector output target must be a regular file",
+        { filePath },
+      );
+    }
+    if (process.platform !== "win32") {
+      await handle.chmod(PRIVATE_FILE_MODE);
+    }
+    return await handle.readFile("utf8");
+  } catch (error) {
+    if (error instanceof ElizaError) throw error;
+    // error-policy:J2 preserve output-read context and its filesystem cause.
+    throw inputError(
+      "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
+      "collector output target could not be inspected",
+      { filePath },
+      error,
+    );
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function writeAtomicTextIfChanged(
+  filePath: string,
+  body: string,
+): Promise<"written" | "reused"> {
+  const existing = await readExistingRegularFile(filePath);
+  if (existing === body) return "reused";
+  const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  await fs.writeFile(tempPath, body, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: PRIVATE_FILE_MODE,
+  });
+  try {
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    // error-policy:J2 preserve the atomic-write cause after cleaning private bytes.
+    try {
+      await fs.unlink(tempPath);
+    } catch (cleanupError) {
+      // error-policy:J2 preserve both the install and cleanup causes.
+      if (!isRecord(cleanupError) || cleanupError.code !== "ENOENT") {
+        throw inputError(
+          "TELEGRAM_EXPORT_WRITE_FAILED",
+          "collector output failed and its temporary file could not be removed",
+          { filePath, tempPath },
+          new AggregateError([error, cleanupError]),
+        );
+      }
+    }
+    throw inputError(
+      "TELEGRAM_EXPORT_WRITE_FAILED",
+      "collector output could not be installed atomically",
+      { filePath },
+      error,
+    );
+  }
+  return "written";
+}
+
+function monthOf(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 7);
+}
+
+/** Writes the complete desired Telegram shard set and removes stale months. */
+export async function writeTelegramShards(
+  messages: CorpusMessage[],
+  outDir: string,
+  ownerAccountId: string,
+): Promise<{ paths: string[]; stats: TelegramShardWriteStats }> {
+  await ensureDirectory(outDir, "outDir");
+  const platformDir = path.join(outDir, "telegram");
+  await ensureDirectory(platformDir, "telegram output directory");
+  const shardDir = path.join(platformDir, ownerAccountId);
+  await ensureDirectory(shardDir, "Telegram account output directory");
+
+  const buckets = new Map<string, CorpusMessage[]>();
+  for (const message of messages) {
+    const month = monthOf(message.ts);
+    const bucket = buckets.get(month) ?? [];
+    bucket.push(message);
+    buckets.set(month, bucket);
+  }
+
+  const stats: TelegramShardWriteStats = { written: 0, reused: 0, removed: 0 };
+  const paths: string[] = [];
+  const wantedNames = new Set<string>();
+  for (const [month, bucket] of [...buckets.entries()].sort()) {
+    bucket.sort((a, b) => a.ts - b.ts || a.id.localeCompare(b.id));
+    const fileName = `${month}.jsonl`;
+    wantedNames.add(fileName);
+    const shardPath = path.join(shardDir, fileName);
+    const body = `${bucket.map((message) => JSON.stringify(message)).join("\n")}\n`;
+    const outcome = await writeAtomicTextIfChanged(shardPath, body);
+    stats[outcome] += 1;
+    paths.push(shardPath);
+  }
+
+  for (const entry of await fs.readdir(shardDir, { withFileTypes: true })) {
+    if (!OWNED_SHARD_NAME.test(entry.name) || wantedNames.has(entry.name)) {
+      continue;
+    }
+    const stalePath = path.join(shardDir, entry.name);
+    if (!entry.isFile() || entry.isSymbolicLink()) {
+      throw inputError(
+        "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
+        "stale shard target must be a regular file",
+        { stalePath },
+      );
+    }
+    await fs.unlink(stalePath);
+    stats.removed += 1;
+  }
+  return { paths, stats };
+}

--- a/packages/corpus-tools/src/collectors/telegram-desktop-io.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop-io.ts
@@ -43,6 +43,66 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Rejects duplicate JSON object keys before `JSON.parse` can collapse them via
+ * last-wins semantics. Keys are decoded before comparison, so escaped aliases
+ * such as `"id"` and `"\u0069d"` are the same boundary key.
+ */
+function assertNoDuplicateJsonObjectKeys(body: string): void {
+  const stack: Array<
+    { kind: "object"; keys: Set<string> } | { kind: "array" }
+  > = [];
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    if (char === "{") {
+      stack.push({ kind: "object", keys: new Set() });
+      continue;
+    }
+    if (char === "[") {
+      stack.push({ kind: "array" });
+      continue;
+    }
+    if (char === "}" || char === "]") {
+      stack.pop();
+      continue;
+    }
+    if (char !== '"') continue;
+
+    const start = index;
+    index += 1;
+    while (index < body.length) {
+      if (body[index] === "\\") {
+        index += 2;
+        continue;
+      }
+      if (body[index] === '"') break;
+      index += 1;
+    }
+    if (index >= body.length) return; // JSON.parse reports the malformed string.
+    let cursor = index + 1;
+    while (/\s/.test(body[cursor] ?? "")) cursor += 1;
+    const frame = stack.at(-1);
+    if (body[cursor] !== ":" || frame?.kind !== "object") continue;
+
+    let key: unknown;
+    try {
+      key = JSON.parse(body.slice(start, index + 1));
+    } catch {
+      // error-policy:J3 the full JSON parser below owns malformed-token reporting.
+      return; // The main parser emits the canonical malformed-JSON error.
+    }
+    if (typeof key !== "string") continue;
+    if (frame.keys.has(key)) {
+      throw inputError(
+        "TELEGRAM_EXPORT_DUPLICATE_KEY",
+        "Telegram Desktop result.json contains a duplicate object key",
+        { key },
+      );
+    }
+    frame.keys.add(key);
+  }
+}
+
 export async function readTelegramDesktopJson(
   exportPath: string,
   maxInputBytes: number,
@@ -72,11 +132,11 @@ export async function readTelegramDesktopJson(
   let bytes: Buffer;
   try {
     const entry = await input.stat();
-    if (!entry.isFile()) {
+    if (!entry.isFile() || entry.nlink !== 1) {
       throw inputError(
         "TELEGRAM_EXPORT_BAD_PATH",
-        "Telegram Desktop input must be a regular, non-symlink file",
-        { exportPath },
+        "Telegram Desktop input must be a regular, non-symlink, unaliased file",
+        { exportPath, linkCount: entry.nlink },
       );
     }
     if (entry.size > maxInputBytes) {
@@ -99,6 +159,22 @@ export async function readTelegramDesktopJson(
       totalBytes += bytesRead;
     }
     bytes = boundedBytes.subarray(0, totalBytes);
+    const afterRead = await input.stat();
+    if (
+      afterRead.dev !== entry.dev ||
+      afterRead.ino !== entry.ino ||
+      afterRead.nlink !== 1 ||
+      afterRead.size !== entry.size ||
+      afterRead.mtimeMs !== entry.mtimeMs ||
+      afterRead.ctimeMs !== entry.ctimeMs ||
+      totalBytes !== entry.size
+    ) {
+      throw inputError(
+        "TELEGRAM_EXPORT_INPUT_CHANGED",
+        "Telegram Desktop input changed while it was being read",
+        { exportPath },
+      );
+    }
   } catch (error) {
     if (error instanceof ElizaError) throw error;
     // error-policy:J2 wrap input read failures without fabricating an empty export.
@@ -119,8 +195,11 @@ export async function readTelegramDesktopJson(
     );
   }
   try {
-    return JSON.parse(bytes.toString("utf8"));
+    const body = bytes.toString("utf8");
+    assertNoDuplicateJsonObjectKeys(body);
+    return JSON.parse(body);
   } catch (error) {
+    if (error instanceof ElizaError) throw error;
     // error-policy:J2 wrap untrusted Telegram JSON with a typed boundary error.
     throw inputError(
       "TELEGRAM_EXPORT_BAD_JSON",

--- a/packages/corpus-tools/src/collectors/telegram-desktop-io.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop-io.ts
@@ -255,11 +255,11 @@ async function readExistingRegularFile(
   }
   try {
     const entry = await handle.stat();
-    if (entry.isSymbolicLink() || !entry.isFile()) {
+    if (entry.isSymbolicLink() || !entry.isFile() || entry.nlink !== 1) {
       throw inputError(
         "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
-        "collector output target must be a regular file",
-        { filePath },
+        "collector output target must be a regular, unaliased file",
+        { filePath, linkCount: entry.nlink },
       );
     }
     if (process.platform !== "win32") {
@@ -280,15 +280,54 @@ async function readExistingRegularFile(
   }
 }
 
+/**
+ * Removes a prior generation marker before any shard is changed. A missing
+ * marker is the explicit incomplete-generation state; leaving an old manifest
+ * installed while replacing its shards would make a crash look committed.
+ */
+export async function invalidateTelegramManifest(
+  manifestPath: string,
+  assertAncestorIdentity: () => Promise<void>,
+): Promise<void> {
+  await assertAncestorIdentity();
+  const parent = await openDirectoryGuard(
+    path.dirname(manifestPath),
+    "Telegram corpus output directory",
+  );
+  try {
+    const existing = await readExistingRegularFile(manifestPath);
+    await assertDirectoryIdentity(parent);
+    await assertAncestorIdentity();
+    if (existing === undefined) return;
+    await fs.unlink(manifestPath);
+    await assertDirectoryIdentity(parent);
+    await assertAncestorIdentity();
+  } catch (error) {
+    if (error instanceof ElizaError) throw error;
+    // error-policy:J2 a marker that cannot be invalidated makes publication unsafe.
+    throw inputError(
+      "TELEGRAM_EXPORT_WRITE_FAILED",
+      "prior Telegram manifest could not be invalidated safely",
+      { manifestPath },
+      error,
+    );
+  } finally {
+    await closeDirectoryGuard(parent);
+  }
+}
+
 async function writeAtomicTextIfChanged(
   filePath: string,
   body: string,
   parent: DirectoryGuard,
+  beforeMutation?: () => Promise<void>,
 ): Promise<"written" | "reused"> {
   await assertDirectoryIdentity(parent);
   const existing = await readExistingRegularFile(filePath);
   await assertDirectoryIdentity(parent);
   if (existing === body) return "reused";
+  await beforeMutation?.();
+  await assertDirectoryIdentity(parent);
   const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
   let tempHandle: FileHandle | undefined;
   let installed = false;
@@ -432,6 +471,7 @@ export async function writeTelegramShards(
   messages: CorpusMessage[],
   outDir: string,
   ownerAccountId: string,
+  beforeMutation?: () => Promise<void>,
 ): Promise<{ paths: string[]; stats: TelegramShardWriteStats }> {
   const outGuard = await openDirectoryGuard(outDir, "outDir");
   let platformGuard: DirectoryGuard | undefined;
@@ -466,6 +506,12 @@ export async function writeTelegramShards(
     };
     const paths: string[] = [];
     const wantedNames = new Set<string>();
+    let mutationStarted = false;
+    const beginMutation = async (): Promise<void> => {
+      if (mutationStarted) return;
+      await beforeMutation?.();
+      mutationStarted = true;
+    };
     for (const [month, bucket] of [...buckets.entries()].sort()) {
       bucket.sort((a, b) => a.ts - b.ts || a.id.localeCompare(b.id));
       const fileName = `${month}.jsonl`;
@@ -476,6 +522,7 @@ export async function writeTelegramShards(
         shardPath,
         body,
         shardGuard,
+        beginMutation,
       );
       stats[outcome] += 1;
       paths.push(shardPath);
@@ -496,6 +543,8 @@ export async function writeTelegramShards(
           { stalePath },
         );
       }
+      await assertDirectoryIdentity(shardGuard);
+      await beginMutation();
       await assertDirectoryIdentity(shardGuard);
       await fs.unlink(stalePath);
       await assertDirectoryIdentity(shardGuard);

--- a/packages/corpus-tools/src/collectors/telegram-desktop-io.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop-io.ts
@@ -6,6 +6,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { constants, promises as fs } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { ElizaError } from "@elizaos/core";
 import type { CorpusMessage } from "../schema.ts";
@@ -19,6 +20,15 @@ export interface TelegramShardWriteStats {
 const PRIVATE_DIRECTORY_MODE = 0o700;
 const PRIVATE_FILE_MODE = 0o600;
 const OWNED_SHARD_NAME = /^\d{4}-(0[1-9]|1[0-2])\.jsonl$/;
+const OUTPUT_LOCK_NAME = ".telegram-desktop-collector.lock";
+
+interface DirectoryGuard {
+  directory: string;
+  location: string;
+  handle: FileHandle;
+  device: number;
+  inode: number;
+}
 
 function inputError(
   code: string,
@@ -76,7 +86,19 @@ export async function readTelegramDesktopJson(
         { maxInputBytes },
       );
     }
-    bytes = await input.readFile();
+    const boundedBytes = Buffer.allocUnsafe(maxInputBytes + 1);
+    let totalBytes = 0;
+    while (totalBytes < boundedBytes.byteLength) {
+      const { bytesRead } = await input.read(
+        boundedBytes,
+        totalBytes,
+        boundedBytes.byteLength - totalBytes,
+        totalBytes,
+      );
+      if (bytesRead === 0) break;
+      totalBytes += bytesRead;
+    }
+    bytes = boundedBytes.subarray(0, totalBytes);
   } catch (error) {
     if (error instanceof ElizaError) throw error;
     // error-policy:J2 wrap input read failures without fabricating an empty export.
@@ -109,10 +131,10 @@ export async function readTelegramDesktopJson(
   }
 }
 
-async function ensureDirectory(
+async function openDirectoryGuard(
   directory: string,
   location: string,
-): Promise<void> {
+): Promise<DirectoryGuard> {
   await fs.mkdir(directory, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
   let handle: Awaited<ReturnType<typeof fs.open>>;
   try {
@@ -142,7 +164,15 @@ async function ensureDirectory(
     if (process.platform !== "win32") {
       await handle.chmod(PRIVATE_DIRECTORY_MODE);
     }
+    return {
+      directory,
+      location,
+      handle,
+      device: entry.dev,
+      inode: entry.ino,
+    };
   } catch (error) {
+    await handle.close();
     if (error instanceof ElizaError) throw error;
     // error-policy:J2 preserve output-inspection context and its filesystem cause.
     throw inputError(
@@ -151,8 +181,59 @@ async function ensureDirectory(
       { location },
       error,
     );
-  } finally {
-    await handle.close();
+  }
+}
+
+async function assertDirectoryIdentity(guard: DirectoryGuard): Promise<void> {
+  try {
+    const entry = await fs.lstat(guard.directory);
+    if (
+      entry.isSymbolicLink() ||
+      !entry.isDirectory() ||
+      entry.dev !== guard.device ||
+      entry.ino !== guard.inode
+    ) {
+      throw inputError(
+        "TELEGRAM_EXPORT_OUTPUT_CHANGED",
+        `${guard.location} changed while Telegram output was being written`,
+        { location: guard.location },
+      );
+    }
+    const heldEntry = await guard.handle.stat();
+    if (
+      !heldEntry.isDirectory() ||
+      heldEntry.dev !== guard.device ||
+      heldEntry.ino !== guard.inode
+    ) {
+      throw inputError(
+        "TELEGRAM_EXPORT_OUTPUT_CHANGED",
+        `${guard.location} no longer matches its validated directory handle`,
+        { location: guard.location },
+      );
+    }
+  } catch (error) {
+    if (error instanceof ElizaError) throw error;
+    // error-policy:J2 reject output replacement instead of following its new path.
+    throw inputError(
+      "TELEGRAM_EXPORT_OUTPUT_CHANGED",
+      `${guard.location} could not be revalidated during Telegram output`,
+      { location: guard.location },
+      error,
+    );
+  }
+}
+
+async function closeDirectoryGuard(guard: DirectoryGuard): Promise<void> {
+  try {
+    await guard.handle.close();
+  } catch (error) {
+    // error-policy:J2 a guard-close failure makes output completion indeterminate.
+    throw inputError(
+      "TELEGRAM_EXPORT_WRITE_FAILED",
+      `${guard.location} validation handle could not be closed`,
+      { location: guard.location },
+      error,
+    );
   }
 }
 
@@ -199,43 +280,147 @@ async function readExistingRegularFile(
   }
 }
 
-export async function writeAtomicTextIfChanged(
+async function writeAtomicTextIfChanged(
   filePath: string,
   body: string,
+  parent: DirectoryGuard,
 ): Promise<"written" | "reused"> {
+  await assertDirectoryIdentity(parent);
   const existing = await readExistingRegularFile(filePath);
+  await assertDirectoryIdentity(parent);
   if (existing === body) return "reused";
   const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
-  await fs.writeFile(tempPath, body, {
-    encoding: "utf8",
-    flag: "wx",
-    mode: PRIVATE_FILE_MODE,
-  });
+  let tempHandle: FileHandle | undefined;
+  let installed = false;
   try {
+    await assertDirectoryIdentity(parent);
+    tempHandle = await fs.open(
+      tempPath,
+      constants.O_WRONLY |
+        constants.O_CREAT |
+        constants.O_EXCL |
+        constants.O_NOFOLLOW,
+      PRIVATE_FILE_MODE,
+    );
+    await tempHandle.writeFile(body, "utf8");
+    await tempHandle.sync();
+    await assertDirectoryIdentity(parent);
     await fs.rename(tempPath, filePath);
+    installed = true;
+    await assertDirectoryIdentity(parent);
   } catch (error) {
-    // error-policy:J2 preserve the atomic-write cause after cleaning private bytes.
+    let cleanupError: unknown;
     try {
-      await fs.unlink(tempPath);
-    } catch (cleanupError) {
-      // error-policy:J2 preserve both the install and cleanup causes.
-      if (!isRecord(cleanupError) || cleanupError.code !== "ENOENT") {
-        throw inputError(
-          "TELEGRAM_EXPORT_WRITE_FAILED",
-          "collector output failed and its temporary file could not be removed",
-          { filePath, tempPath },
-          new AggregateError([error, cleanupError]),
-        );
+      await tempHandle?.truncate(0);
+      await tempHandle?.sync();
+    } catch (truncateError) {
+      cleanupError = truncateError;
+    }
+    let identityError: unknown;
+    try {
+      await assertDirectoryIdentity(parent);
+    } catch (changedError) {
+      identityError = changedError;
+    }
+    if (!installed && !identityError) {
+      try {
+        await fs.unlink(tempPath);
+      } catch (unlinkError) {
+        if (!isRecord(unlinkError) || unlinkError.code !== "ENOENT") {
+          cleanupError ??= unlinkError;
+        }
       }
     }
+    if (identityError && !cleanupError) throw identityError;
+    if (cleanupError) {
+      // error-policy:J2 preserve output and cleanup failures without retaining bytes.
+      throw inputError(
+        "TELEGRAM_EXPORT_WRITE_FAILED",
+        "collector output failed and its temporary bytes could not be cleared",
+        { filePath, tempPath },
+        new AggregateError([error, cleanupError, identityError]),
+      );
+    }
+    // error-policy:J2 preserve the atomic install failure after clearing bytes.
     throw inputError(
       "TELEGRAM_EXPORT_WRITE_FAILED",
       "collector output could not be installed atomically",
       { filePath },
       error,
     );
+  } finally {
+    await tempHandle?.close();
   }
   return "written";
+}
+
+/** Writes a collector-owned root artifact under a continuously held directory identity. */
+export async function writeTelegramArtifact(
+  filePath: string,
+  body: string,
+  assertAncestorIdentity: () => Promise<void>,
+): Promise<"written" | "reused"> {
+  await assertAncestorIdentity();
+  const parent = await openDirectoryGuard(
+    path.dirname(filePath),
+    "Telegram corpus output directory",
+  );
+  try {
+    const result = await writeAtomicTextIfChanged(filePath, body, parent);
+    await assertAncestorIdentity();
+    return result;
+  } finally {
+    await closeDirectoryGuard(parent);
+  }
+}
+
+/**
+ * Serializes one complete Telegram publication for an output root. The lock
+ * fails closed instead of waiting, so a crashed or concurrent writer cannot
+ * silently publish a mixed manifest, summary, and shard generation.
+ */
+export async function withTelegramOutputLock<T>(
+  outDir: string,
+  operation: (assertRootIdentity: () => Promise<void>) => Promise<T>,
+): Promise<T> {
+  const root = await openDirectoryGuard(outDir, "outDir");
+  const lockPath = path.join(outDir, OUTPUT_LOCK_NAME);
+  let locked = false;
+  try {
+    await assertDirectoryIdentity(root);
+    try {
+      await fs.mkdir(lockPath, { mode: PRIVATE_DIRECTORY_MODE });
+      locked = true;
+    } catch (error) {
+      if (isRecord(error) && error.code === "EEXIST") {
+        throw inputError(
+          "TELEGRAM_EXPORT_OUTPUT_BUSY",
+          "another Telegram collector owns this output directory",
+          { outDir },
+          error,
+        );
+      }
+      // error-policy:J2 preserve unexpected lock acquisition failures.
+      throw inputError(
+        "TELEGRAM_EXPORT_WRITE_FAILED",
+        "Telegram output lock could not be acquired",
+        { outDir },
+        error,
+      );
+    }
+    await assertDirectoryIdentity(root);
+    return await operation(() => assertDirectoryIdentity(root));
+  } finally {
+    try {
+      if (locked) {
+        await assertDirectoryIdentity(root);
+        await fs.rmdir(lockPath);
+        await assertDirectoryIdentity(root);
+      }
+    } finally {
+      await closeDirectoryGuard(root);
+    }
+  }
 }
 
 function monthOf(ts: number): string {
@@ -248,48 +433,78 @@ export async function writeTelegramShards(
   outDir: string,
   ownerAccountId: string,
 ): Promise<{ paths: string[]; stats: TelegramShardWriteStats }> {
-  await ensureDirectory(outDir, "outDir");
-  const platformDir = path.join(outDir, "telegram");
-  await ensureDirectory(platformDir, "telegram output directory");
-  const shardDir = path.join(platformDir, ownerAccountId);
-  await ensureDirectory(shardDir, "Telegram account output directory");
+  const outGuard = await openDirectoryGuard(outDir, "outDir");
+  let platformGuard: DirectoryGuard | undefined;
+  let shardGuard: DirectoryGuard | undefined;
+  try {
+    await assertDirectoryIdentity(outGuard);
+    const platformDir = path.join(outDir, "telegram");
+    platformGuard = await openDirectoryGuard(
+      platformDir,
+      "telegram output directory",
+    );
+    await assertDirectoryIdentity(outGuard);
+    const shardDir = path.join(platformDir, ownerAccountId);
+    shardGuard = await openDirectoryGuard(
+      shardDir,
+      "Telegram account output directory",
+    );
+    await assertDirectoryIdentity(platformGuard);
 
-  const buckets = new Map<string, CorpusMessage[]>();
-  for (const message of messages) {
-    const month = monthOf(message.ts);
-    const bucket = buckets.get(month) ?? [];
-    bucket.push(message);
-    buckets.set(month, bucket);
-  }
-
-  const stats: TelegramShardWriteStats = { written: 0, reused: 0, removed: 0 };
-  const paths: string[] = [];
-  const wantedNames = new Set<string>();
-  for (const [month, bucket] of [...buckets.entries()].sort()) {
-    bucket.sort((a, b) => a.ts - b.ts || a.id.localeCompare(b.id));
-    const fileName = `${month}.jsonl`;
-    wantedNames.add(fileName);
-    const shardPath = path.join(shardDir, fileName);
-    const body = `${bucket.map((message) => JSON.stringify(message)).join("\n")}\n`;
-    const outcome = await writeAtomicTextIfChanged(shardPath, body);
-    stats[outcome] += 1;
-    paths.push(shardPath);
-  }
-
-  for (const entry of await fs.readdir(shardDir, { withFileTypes: true })) {
-    if (!OWNED_SHARD_NAME.test(entry.name) || wantedNames.has(entry.name)) {
-      continue;
+    const buckets = new Map<string, CorpusMessage[]>();
+    for (const message of messages) {
+      const month = monthOf(message.ts);
+      const bucket = buckets.get(month) ?? [];
+      bucket.push(message);
+      buckets.set(month, bucket);
     }
-    const stalePath = path.join(shardDir, entry.name);
-    if (!entry.isFile() || entry.isSymbolicLink()) {
-      throw inputError(
-        "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
-        "stale shard target must be a regular file",
-        { stalePath },
+
+    const stats: TelegramShardWriteStats = {
+      written: 0,
+      reused: 0,
+      removed: 0,
+    };
+    const paths: string[] = [];
+    const wantedNames = new Set<string>();
+    for (const [month, bucket] of [...buckets.entries()].sort()) {
+      bucket.sort((a, b) => a.ts - b.ts || a.id.localeCompare(b.id));
+      const fileName = `${month}.jsonl`;
+      wantedNames.add(fileName);
+      const shardPath = path.join(shardDir, fileName);
+      const body = `${bucket.map((message) => JSON.stringify(message)).join("\n")}\n`;
+      const outcome = await writeAtomicTextIfChanged(
+        shardPath,
+        body,
+        shardGuard,
       );
+      stats[outcome] += 1;
+      paths.push(shardPath);
     }
-    await fs.unlink(stalePath);
-    stats.removed += 1;
+
+    await assertDirectoryIdentity(shardGuard);
+    const existingEntries = await fs.readdir(shardDir, { withFileTypes: true });
+    await assertDirectoryIdentity(shardGuard);
+    for (const entry of existingEntries) {
+      if (!OWNED_SHARD_NAME.test(entry.name) || wantedNames.has(entry.name)) {
+        continue;
+      }
+      const stalePath = path.join(shardDir, entry.name);
+      if (!entry.isFile() || entry.isSymbolicLink()) {
+        throw inputError(
+          "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
+          "stale shard target must be a regular file",
+          { stalePath },
+        );
+      }
+      await assertDirectoryIdentity(shardGuard);
+      await fs.unlink(stalePath);
+      await assertDirectoryIdentity(shardGuard);
+      stats.removed += 1;
+    }
+    return { paths, stats };
+  } finally {
+    if (shardGuard) await closeDirectoryGuard(shardGuard);
+    if (platformGuard) await closeDirectoryGuard(platformGuard);
+    await closeDirectoryGuard(outGuard);
   }
-  return { paths, stats };
 }

--- a/packages/corpus-tools/src/collectors/telegram-desktop.test.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop.test.ts
@@ -447,7 +447,40 @@ describe("collectTelegramDesktopExport", () => {
       await expect(collectFixture(link, outDir)).rejects.toMatchObject({
         code: "TELEGRAM_EXPORT_BAD_PATH",
       });
+
+      const hardlinkDir = await makeTempDir();
+      const hardlink = path.join(hardlinkDir, "result.json");
+      await fs.link(FIXTURE_PATH, hardlink);
+      await expect(collectFixture(hardlink, outDir)).rejects.toMatchObject({
+        code: "TELEGRAM_EXPORT_BAD_PATH",
+      });
     }
+  });
+
+  it("rejects duplicate and escaped-equivalent JSON keys before last-wins parsing", async () => {
+    const outDir = await makeTempDir();
+    const direct = await copyFixture();
+    const directBody = await fs.readFile(direct, "utf8");
+    await fs.writeFile(
+      direct,
+      directBody.replace(
+        '"type": "personal_chat"',
+        '"type": "bot_chat", "type": "personal_chat"',
+      ),
+    );
+    await expect(collectFixture(direct, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_DUPLICATE_KEY",
+    });
+
+    const escaped = await copyFixture();
+    const escapedBody = await fs.readFile(escaped, "utf8");
+    await fs.writeFile(
+      escaped,
+      escapedBody.replace('"id": 200', '"\\u0069d": 999, "id": 200'),
+    );
+    await expect(collectFixture(escaped, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_DUPLICATE_KEY",
+    });
   });
 
   it("reads at most the configured byte limit plus one", async () => {

--- a/packages/corpus-tools/src/collectors/telegram-desktop.test.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop.test.ts
@@ -1,0 +1,454 @@
+/**
+ * Deterministic filesystem coverage for the Telegram Desktop collector using
+ * only a committed synthetic `result.json`. The harness exercises real shard,
+ * manifest, allowlist, boundary-validation, and rerun behavior without network
+ * access, Telegram credentials, sessions, or private owner data.
+ */
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validateCorpusTarget } from "../validator.ts";
+import { collectTelegramDesktopExport } from "./telegram-desktop.ts";
+import { writeTelegramShards } from "./telegram-desktop-io.ts";
+
+const FIXTURE_PATH = path.join(
+  import.meta.dirname,
+  "../../fixtures/telegram-desktop/result.json",
+);
+const OWNER = "100";
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix = "telegram-desktop-test-"): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function copyFixture(): Promise<string> {
+  const dir = await makeTempDir();
+  const filePath = path.join(dir, "result.json");
+  await fs.copyFile(FIXTURE_PATH, filePath);
+  return filePath;
+}
+
+async function mutateFixture(
+  mutate: (input: Record<string, unknown>) => void,
+): Promise<string> {
+  const filePath = await copyFixture();
+  const input = JSON.parse(await fs.readFile(filePath, "utf8"));
+  mutate(input);
+  await fs.writeFile(filePath, `${JSON.stringify(input, null, 2)}\n`, "utf8");
+  return filePath;
+}
+
+async function collectFixture(exportPath: string, outDir: string) {
+  return collectTelegramDesktopExport({
+    exportPath,
+    ownerAccountId: OWNER,
+    outDir,
+    allowedGroupPeerIds: ["300"],
+    allowedChannelPeerIds: ["400"],
+  });
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("collectTelegramDesktopExport", () => {
+  it("maps DMs and allowlisted peers with compound identities and frozen bounds", async () => {
+    const outDir = await makeTempDir();
+    const result = await collectFixture(FIXTURE_PATH, outDir);
+
+    expect(result.issues).toEqual([]);
+    expect(result.manifest.totals.messages).toBe(6);
+    expect(result.summary.peerCounts).toEqual({ dm: 1, group: 1, channel: 1 });
+    expect(result.summary.messageCounts).toEqual({
+      dm: 3,
+      group: 2,
+      channel: 1,
+    });
+    expect(result.summary.deniedGroupChats).toBe(1);
+    expect(result.summary.deniedGroupMessages).toBe(1);
+    expect(result.summary.deniedChannelChats).toBe(1);
+    expect(result.summary.deniedChannelMessages).toBe(1);
+    expect(result.summary.unsupportedSecretChats).toBe(1);
+    expect(result.summary.unsupportedSecretMessages).toBe(2);
+    expect(result.summary.unsupportedMessages).toBe(0);
+    expect(result.summary.unsupportedDeletedMessages).toBe(1);
+    expect(result.summary.unsupportedServiceMessages).toBe(1);
+    expect(result.summary.unsupportedMediaOnlyMessages).toBe(1);
+    expect(result.summary.skippedBeforeCutoff).toBe(1);
+    expect(result.summary.skippedAfterAnchor).toBe(1);
+
+    const august = (
+      await fs.readFile(
+        path.join(outDir, "telegram", OWNER, "2024-08.jsonl"),
+        "utf8",
+      )
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(august.map((message) => message.id)).toEqual([
+      "telegram:100:dm:200:1",
+      "telegram:100:dm:200:2",
+      "telegram:100:dm:200:8",
+    ]);
+    expect(august[0]).toMatchObject({
+      text: "hello owner",
+      direction: "in",
+      threadId: "telegram:100:dm:200",
+    });
+    expect(august[1]).toMatchObject({
+      direction: "out",
+      replyToId: "telegram:100:dm:200:1",
+    });
+    expect(august[2].attachments).toEqual([]);
+    expect(JSON.stringify(august[2])).not.toContain("sha256");
+
+    const september = (
+      await fs.readFile(
+        path.join(outDir, "telegram", OWNER, "2024-09.jsonl"),
+        "utf8",
+      )
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(september[0].id).toBe("telegram:100:group:300:1");
+    expect(september[1].replyToId).toBe("telegram:100:group:300:1");
+
+    const october = JSON.parse(
+      (
+        await fs.readFile(
+          path.join(outDir, "telegram", OWNER, "2024-10.jsonl"),
+          "utf8",
+        )
+      ).trim(),
+    );
+    expect(october).toMatchObject({
+      id: "telegram:100:channel:400:1",
+      direction: "in",
+      senderId: "channel400",
+      senderDisplay: "Synthetic Channel Author",
+    });
+
+    const validation = await validateCorpusTarget(outDir);
+    expect(validation.ok).toBe(true);
+    expect(validation.issues).toEqual([]);
+  });
+
+  it("denies every group and channel unless its peer id is explicitly allowed", async () => {
+    const outDir = await makeTempDir();
+    const result = await collectTelegramDesktopExport({
+      exportPath: FIXTURE_PATH,
+      ownerAccountId: OWNER,
+      outDir,
+    });
+
+    expect(result.summary.peerCounts).toEqual({ dm: 1, group: 0, channel: 0 });
+    expect(result.summary.deniedGroupChats).toBe(2);
+    expect(result.summary.deniedGroupMessages).toBe(3);
+    expect(result.summary.deniedChannelChats).toBe(2);
+    expect(result.summary.deniedChannelMessages).toBe(2);
+    expect(result.manifest.totals.messages).toBe(3);
+    expect(await fs.readdir(path.join(outDir, "telegram", OWNER))).toEqual([
+      "2024-08.jsonl",
+    ]);
+  });
+
+  it("keeps equal numeric peer and message ids distinct across peer kinds", async () => {
+    const exportPath = await mutateFixture((input) => {
+      const chats = input.chats as {
+        list: Array<{ id: number; messages: Array<Record<string, unknown>> }>;
+      };
+      const group = chats.list.find((chat) => chat.id === 300);
+      const channel = chats.list.find((chat) => chat.id === 400);
+      if (group) group.id = 200;
+      if (channel) channel.id = 200;
+    });
+    const outDir = await makeTempDir();
+    const result = await collectTelegramDesktopExport({
+      exportPath,
+      ownerAccountId: OWNER,
+      outDir,
+      allowedGroupPeerIds: ["200"],
+      allowedChannelPeerIds: ["200"],
+    });
+
+    expect(result.manifest.totals.messages).toBe(6);
+    const rows = await Promise.all(
+      result.shardPaths.map(async (shardPath) =>
+        (await fs.readFile(shardPath, "utf8"))
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line) as { id: string }),
+      ),
+    );
+    expect(new Set(rows.flat().map((row) => row.id)).size).toBe(6);
+    expect(rows.flat().map((row) => row.id)).toEqual(
+      expect.arrayContaining([
+        "telegram:100:dm:200:1",
+        "telegram:100:group:200:1",
+        "telegram:100:channel:200:1",
+      ]),
+    );
+  });
+
+  it("includes messages exactly on both frozen time boundaries", async () => {
+    const exportPath = await mutateFixture((input) => {
+      const chats = input.chats as {
+        list: Array<{ id: number; messages: Array<Record<string, unknown>> }>;
+      };
+      const dm = chats.list.find((chat) => chat.id === 200);
+      if (!dm) return;
+      dm.messages = [
+        {
+          ...dm.messages[0],
+          id: 20,
+          date_unixtime: String(Date.parse("2024-07-05T00:00:00.000Z") / 1000),
+        },
+        {
+          ...dm.messages[0],
+          id: 21,
+          date_unixtime: String(Date.parse("2026-07-05T00:00:00.000Z") / 1000),
+        },
+      ];
+    });
+    const outDir = await makeTempDir();
+
+    const result = await collectFixture(exportPath, outDir);
+
+    expect(result.summary.messageCounts.dm).toBe(2);
+    expect(result.summary.skippedBeforeCutoff).toBe(0);
+    expect(result.summary.skippedAfterAnchor).toBe(0);
+  });
+
+  it("is byte-idempotent and repairs a missing shard on rerun", async () => {
+    const outDir = await makeTempDir();
+    const first = await collectFixture(FIXTURE_PATH, outDir);
+    expect(first.writeStats).toEqual({ written: 3, reused: 0, removed: 0 });
+    const artifactPaths = [
+      path.join(outDir, "manifest.json"),
+      path.join(outDir, "telegram-desktop-summary.json"),
+      ...first.shardPaths,
+    ];
+    const firstBytes = await Promise.all(
+      artifactPaths.map((filePath) => fs.readFile(filePath, "utf8")),
+    );
+
+    const rerun = await collectFixture(FIXTURE_PATH, outDir);
+    expect(rerun.writeStats).toEqual({ written: 0, reused: 3, removed: 0 });
+    await expect(
+      Promise.all(
+        artifactPaths.map((filePath) => fs.readFile(filePath, "utf8")),
+      ),
+    ).resolves.toEqual(firstBytes);
+
+    await fs.unlink(path.join(outDir, "telegram", OWNER, "2024-09.jsonl"));
+    const repaired = await collectFixture(FIXTURE_PATH, outDir);
+    expect(repaired.writeStats).toEqual({ written: 1, reused: 2, removed: 0 });
+    await expect(
+      Promise.all(
+        artifactPaths.map((filePath) => fs.readFile(filePath, "utf8")),
+      ),
+    ).resolves.toEqual(firstBytes);
+  });
+
+  it("removes stale owned shards when the input no longer contains that month", async () => {
+    const exportPath = await mutateFixture((input) => {
+      const chats = input.chats as {
+        list: Array<{ id: number; messages: unknown[] }>;
+      };
+      const channel = chats.list.find((chat) => chat.id === 400);
+      if (channel) channel.messages = [];
+    });
+    const outDir = await makeTempDir();
+    await collectFixture(FIXTURE_PATH, outDir);
+    const result = await collectFixture(exportPath, outDir);
+
+    expect(result.writeStats.removed).toBe(1);
+    await expect(
+      fs.access(path.join(outDir, "telegram", OWNER, "2024-10.jsonl")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect((await validateCorpusTarget(outDir)).ok).toBe(true);
+  });
+
+  it("does not delete non-shard JSONL files from the account directory", async () => {
+    const outDir = await makeTempDir();
+    const shardDir = path.join(outDir, "telegram", OWNER);
+    await fs.mkdir(shardDir, { recursive: true });
+    const foreignPath = path.join(shardDir, "owner-notes.jsonl");
+    await fs.writeFile(foreignPath, '{"not":"collector-owned"}\n', "utf8");
+
+    const result = await writeTelegramShards([], outDir, OWNER);
+
+    expect(result.stats.removed).toBe(0);
+    await expect(fs.readFile(foreignPath, "utf8")).resolves.toBe(
+      '{"not":"collector-owned"}\n',
+    );
+  });
+
+  it("writes owner corpus artifacts with private file permissions", async () => {
+    if (process.platform === "win32") return;
+    const outDir = await makeTempDir();
+    const result = await collectFixture(FIXTURE_PATH, outDir);
+    const artifactPaths = [
+      ...result.shardPaths,
+      path.join(outDir, "manifest.json"),
+      path.join(outDir, "telegram-desktop-summary.json"),
+    ];
+
+    for (const artifactPath of artifactPaths) {
+      expect((await fs.stat(artifactPath)).mode & 0o777).toBe(0o600);
+    }
+    expect(
+      (await fs.stat(path.join(outDir, "telegram", OWNER))).mode & 0o777,
+    ).toBe(0o700);
+
+    await fs.chmod(result.shardPaths[0], 0o644);
+    await fs.chmod(path.join(outDir, "telegram", OWNER), 0o755);
+    const rerun = await collectFixture(FIXTURE_PATH, outDir);
+    expect(rerun.writeStats.reused).toBe(3);
+    expect((await fs.stat(result.shardPaths[0])).mode & 0o777).toBe(0o600);
+    expect(
+      (await fs.stat(path.join(outDir, "telegram", OWNER))).mode & 0o777,
+    ).toBe(0o700);
+  });
+
+  it("fails closed on malformed JSON, wrong files, symlinks, and size limits", async () => {
+    const outDir = await makeTempDir();
+    const malformedDir = await makeTempDir();
+    const malformed = path.join(malformedDir, "result.json");
+    await fs.writeFile(malformed, "{ nope", "utf8");
+    await expect(collectFixture(malformed, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_BAD_JSON",
+    });
+
+    const wrongNameDir = await makeTempDir();
+    const wrongName = path.join(wrongNameDir, "telegram.json");
+    await fs.copyFile(FIXTURE_PATH, wrongName);
+    await expect(collectFixture(wrongName, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_BAD_PATH",
+    });
+
+    await expect(
+      collectTelegramDesktopExport({
+        exportPath: FIXTURE_PATH,
+        ownerAccountId: OWNER,
+        outDir,
+        maxInputBytes: 16,
+      }),
+    ).rejects.toMatchObject({ code: "TELEGRAM_EXPORT_INPUT_TOO_LARGE" });
+
+    if (process.platform !== "win32") {
+      const linkDir = await makeTempDir();
+      const link = path.join(linkDir, "result.json");
+      await fs.symlink(FIXTURE_PATH, link);
+      await expect(collectFixture(link, outDir)).rejects.toMatchObject({
+        code: "TELEGRAM_EXPORT_BAD_PATH",
+      });
+    }
+  });
+
+  it("enforces owner, count, identity, and allowlist boundaries", async () => {
+    const outDir = await makeTempDir();
+    await expect(
+      collectTelegramDesktopExport({
+        exportPath: FIXTURE_PATH,
+        ownerAccountId: "101",
+        outDir,
+      }),
+    ).rejects.toMatchObject({ code: "TELEGRAM_EXPORT_OWNER_MISMATCH" });
+    await expect(
+      collectTelegramDesktopExport({
+        exportPath: FIXTURE_PATH,
+        ownerAccountId: OWNER,
+        outDir,
+        maxChats: 1,
+      }),
+    ).rejects.toMatchObject({ code: "TELEGRAM_EXPORT_COUNT_LIMIT" });
+    await expect(
+      collectTelegramDesktopExport({
+        exportPath: FIXTURE_PATH,
+        ownerAccountId: OWNER,
+        outDir,
+        maxMessages: 1,
+      }),
+    ).rejects.toMatchObject({ code: "TELEGRAM_EXPORT_COUNT_LIMIT" });
+    await expect(
+      collectTelegramDesktopExport({
+        exportPath: FIXTURE_PATH,
+        ownerAccountId: OWNER,
+        outDir,
+        allowedGroupPeerIds: ["300", "300"],
+      }),
+    ).rejects.toMatchObject({ code: "TELEGRAM_EXPORT_BAD_ALLOWLIST" });
+  });
+
+  it("rejects duplicate ids, unknown record types, and malformed rich text", async () => {
+    const outDir = await makeTempDir();
+    const duplicate = await mutateFixture((input) => {
+      const chats = input.chats as { list: Array<{ messages: unknown[] }> };
+      chats.list[0].messages.push(chats.list[0].messages[0]);
+    });
+    await expect(collectFixture(duplicate, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_DUPLICATE_MESSAGE",
+    });
+
+    const unknownType = await mutateFixture((input) => {
+      const chats = input.chats as {
+        list: Array<{ messages: Array<Record<string, unknown>> }>;
+      };
+      chats.list[0].messages[0].type = "mystery";
+    });
+    await expect(collectFixture(unknownType, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_UNSUPPORTED_MESSAGE_TYPE",
+    });
+
+    const badText = await mutateFixture((input) => {
+      const chats = input.chats as {
+        list: Array<{ messages: Array<Record<string, unknown>> }>;
+      };
+      chats.list[0].messages[0].text = [{ type: "bold", text: 42 }];
+    });
+    await expect(collectFixture(badText, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_BAD_SHAPE",
+    });
+  });
+
+  it("counts explicitly unsupported rows separately from media-only rows", async () => {
+    const exportPath = await mutateFixture((input) => {
+      const chats = input.chats as {
+        list: Array<{ id: number; messages: Array<Record<string, unknown>> }>;
+      };
+      const channel = chats.list.find((chat) => chat.id === 400);
+      if (channel) channel.messages[0].type = "unsupported";
+    });
+    const outDir = await makeTempDir();
+
+    const result = await collectFixture(exportPath, outDir);
+
+    expect(result.summary.unsupportedMessages).toBe(1);
+    expect(result.summary.unsupportedMediaOnlyMessages).toBe(1);
+  });
+
+  it("rejects symlinked collector-owned output directories", async () => {
+    if (process.platform === "win32") return;
+    const exportPath = await copyFixture();
+    const outDir = await makeTempDir();
+    const outside = await makeTempDir();
+    await fs.mkdir(path.join(outDir, "telegram"));
+    await fs.symlink(outside, path.join(outDir, "telegram", OWNER));
+
+    await expect(collectFixture(exportPath, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
+    });
+    expect(await fs.readdir(outside)).toEqual([]);
+  });
+});

--- a/packages/corpus-tools/src/collectors/telegram-desktop.test.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop.test.ts
@@ -7,10 +7,15 @@
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { validateCorpusTarget } from "../validator.ts";
 import { collectTelegramDesktopExport } from "./telegram-desktop.ts";
-import { writeTelegramShards } from "./telegram-desktop-io.ts";
+import {
+  readTelegramDesktopJson,
+  withTelegramOutputLock,
+  writeTelegramArtifact,
+  writeTelegramShards,
+} from "./telegram-desktop-io.ts";
 
 const FIXTURE_PATH = path.join(
   import.meta.dirname,
@@ -53,6 +58,7 @@ async function collectFixture(exportPath: string, outDir: string) {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (dir) await fs.rm(dir, { recursive: true, force: true });
@@ -78,6 +84,8 @@ describe("collectTelegramDesktopExport", () => {
     expect(result.summary.deniedChannelMessages).toBe(1);
     expect(result.summary.unsupportedSecretChats).toBe(1);
     expect(result.summary.unsupportedSecretMessages).toBe(2);
+    expect(result.summary.unsupportedCredentialChats).toBe(1);
+    expect(result.summary.unsupportedCredentialMessages).toBe(1);
     expect(result.summary.unsupportedMessages).toBe(0);
     expect(result.summary.unsupportedDeletedMessages).toBe(1);
     expect(result.summary.unsupportedServiceMessages).toBe(1);
@@ -110,6 +118,13 @@ describe("collectTelegramDesktopExport", () => {
     });
     expect(august[2].attachments).toEqual([]);
     expect(JSON.stringify(august[2])).not.toContain("sha256");
+    expect(
+      (
+        await Promise.all(
+          result.shardPaths.map((shardPath) => fs.readFile(shardPath, "utf8")),
+        )
+      ).join("\n"),
+    ).not.toContain("12345");
 
     const september = (
       await fs.readFile(
@@ -159,6 +174,7 @@ describe("collectTelegramDesktopExport", () => {
     expect(result.manifest.totals.messages).toBe(3);
     expect(await fs.readdir(path.join(outDir, "telegram", OWNER))).toEqual([
       "2024-08.jsonl",
+      "summary.json",
     ]);
   });
 
@@ -235,7 +251,7 @@ describe("collectTelegramDesktopExport", () => {
     expect(first.writeStats).toEqual({ written: 3, reused: 0, removed: 0 });
     const artifactPaths = [
       path.join(outDir, "manifest.json"),
-      path.join(outDir, "telegram-desktop-summary.json"),
+      path.join(outDir, "telegram", OWNER, "summary.json"),
       ...first.shardPaths,
     ];
     const firstBytes = await Promise.all(
@@ -301,7 +317,7 @@ describe("collectTelegramDesktopExport", () => {
     const artifactPaths = [
       ...result.shardPaths,
       path.join(outDir, "manifest.json"),
-      path.join(outDir, "telegram-desktop-summary.json"),
+      path.join(outDir, "telegram", OWNER, "summary.json"),
     ];
 
     for (const artifactPath of artifactPaths) {
@@ -354,6 +370,88 @@ describe("collectTelegramDesktopExport", () => {
         code: "TELEGRAM_EXPORT_BAD_PATH",
       });
     }
+  });
+
+  it("reads at most the configured byte limit plus one", async () => {
+    const inputDir = await makeTempDir();
+    const inputPath = path.join(inputDir, "result.json");
+    const exactBody = '{"bounded":true}';
+    const exactBytes = Buffer.byteLength(exactBody);
+    await fs.writeFile(inputPath, exactBody);
+
+    await expect(
+      readTelegramDesktopJson(inputPath, exactBytes),
+    ).resolves.toEqual({ bounded: true });
+    await fs.appendFile(inputPath, " ");
+    await expect(
+      readTelegramDesktopJson(inputPath, exactBytes),
+    ).rejects.toMatchObject({ code: "TELEGRAM_EXPORT_INPUT_TOO_LARGE" });
+  });
+
+  it("fails closed when another account or process owns the output lock", async () => {
+    const outDir = await makeTempDir();
+    await withTelegramOutputLock(outDir, async () => {
+      await expect(
+        withTelegramOutputLock(outDir, async () => "different-account"),
+      ).rejects.toMatchObject({ code: "TELEGRAM_EXPORT_OUTPUT_BUSY" });
+    });
+  });
+
+  it("rejects a root swap between shard publication and artifact install", async () => {
+    if (process.platform === "win32") return;
+    const outDir = await makeTempDir();
+    const heldDir = `${outDir}-held`;
+    tempDirs.push(heldDir);
+    const outside = await makeTempDir();
+
+    await expect(
+      withTelegramOutputLock(outDir, async (assertRootIdentity) => {
+        await writeTelegramShards([], outDir, OWNER);
+        await fs.rename(outDir, heldDir);
+        await fs.symlink(outside, outDir);
+        await writeTelegramArtifact(
+          path.join(outDir, "manifest.json"),
+          "private manifest bytes\n",
+          assertRootIdentity,
+        );
+      }),
+    ).rejects.toMatchObject({ code: "TELEGRAM_EXPORT_OUTPUT_CHANGED" });
+    expect(await fs.readdir(outside)).toEqual([]);
+  });
+
+  it("keeps summaries account-owned across serialized publications", async () => {
+    const outDir = await makeTempDir();
+    await collectFixture(FIXTURE_PATH, outDir);
+    const secondExport = await mutateFixture((input) => {
+      const personal = input.personal_information as Record<string, unknown>;
+      personal.user_id = 101;
+    });
+    await collectTelegramDesktopExport({
+      exportPath: secondExport,
+      ownerAccountId: "101",
+      outDir,
+    });
+
+    await expect(
+      fs.readFile(path.join(outDir, "telegram", OWNER, "summary.json"), "utf8"),
+    ).resolves.toContain('"schemaVersion": 1');
+    await expect(
+      fs.readFile(path.join(outDir, "telegram", "101", "summary.json"), "utf8"),
+    ).resolves.toContain('"schemaVersion": 1');
+  });
+
+  it("propagates manifest validation failures instead of reporting success", async () => {
+    const outDir = await makeTempDir();
+    const invalidDir = path.join(outDir, "telegram", "999");
+    await fs.mkdir(invalidDir, { recursive: true });
+    await fs.writeFile(path.join(invalidDir, "2024-08.jsonl"), "not-json\n");
+
+    await expect(collectFixture(FIXTURE_PATH, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_MANIFEST_INVALID",
+    });
+    await expect(
+      fs.access(path.join(outDir, "manifest.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("enforces owner, count, identity, and allowlist boundaries", async () => {
@@ -450,5 +548,69 @@ describe("collectTelegramDesktopExport", () => {
       code: "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
     });
     expect(await fs.readdir(outside)).toEqual([]);
+  });
+
+  it("fails closed when the shard directory is swapped during stale discovery", async () => {
+    if (process.platform === "win32") return;
+    const outDir = await makeTempDir();
+    const shardDir = path.join(outDir, "telegram", OWNER);
+    const heldDir = path.join(outDir, "held-account");
+    const outside = await makeTempDir();
+    await fs.mkdir(shardDir, { recursive: true });
+    await fs.writeFile(path.join(shardDir, "2024-01.jsonl"), "owned\n");
+    const outsideShard = path.join(outside, "2024-01.jsonl");
+    await fs.writeFile(outsideShard, "outside\n");
+    const originalReaddir = fs.readdir.bind(fs);
+    let swapped = false;
+    vi.spyOn(fs, "readdir").mockImplementation((async (
+      ...args: Parameters<typeof fs.readdir>
+    ) => {
+      if (!swapped && String(args[0]) === shardDir) {
+        swapped = true;
+        await fs.rename(shardDir, heldDir);
+        await fs.symlink(outside, shardDir);
+      }
+      return originalReaddir(...args);
+    }) as typeof fs.readdir);
+
+    await expect(writeTelegramShards([], outDir, OWNER)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_OUTPUT_CHANGED",
+    });
+    await expect(fs.readFile(outsideShard, "utf8")).resolves.toBe("outside\n");
+  });
+
+  it("fails closed when the shard directory is swapped at final install", async () => {
+    if (process.platform === "win32") return;
+    const outDir = await makeTempDir();
+    const shardDir = path.join(outDir, "telegram", OWNER);
+    const heldDir = path.join(outDir, "held-account");
+    const outside = await makeTempDir();
+    const originalRename = fs.rename.bind(fs);
+    let swapped = false;
+    vi.spyOn(fs, "rename").mockImplementation(async (oldPath, newPath) => {
+      if (
+        !swapped &&
+        String(oldPath).startsWith(`${shardDir}${path.sep}`) &&
+        String(oldPath).endsWith(".tmp") &&
+        String(newPath).endsWith(".jsonl")
+      ) {
+        swapped = true;
+        await originalRename(shardDir, heldDir);
+        await fs.symlink(outside, shardDir);
+      }
+      await originalRename(oldPath, newPath);
+    });
+
+    await expect(collectFixture(FIXTURE_PATH, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_OUTPUT_CHANGED",
+    });
+    expect(await fs.readdir(outside)).toEqual([]);
+    const strandedTemps = (await fs.readdir(heldDir)).filter((name) =>
+      name.endsWith(".tmp"),
+    );
+    expect(strandedTemps.length).toBeGreaterThan(0);
+    for (const tempName of strandedTemps) {
+      expect((await fs.stat(path.join(heldDir, tempName))).size).toBe(0);
+    }
   });
 });

--- a/packages/corpus-tools/src/collectors/telegram-desktop.test.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop.test.ts
@@ -9,7 +9,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { validateCorpusTarget } from "../validator.ts";
-import { collectTelegramDesktopExport } from "./telegram-desktop.ts";
+import {
+  assertTelegramDesktopPlatformSupported,
+  collectTelegramDesktopExport,
+} from "./telegram-desktop.ts";
 import {
   readTelegramDesktopJson,
   withTelegramOutputLock,
@@ -20,6 +23,10 @@ import {
 const FIXTURE_PATH = path.join(
   import.meta.dirname,
   "../../fixtures/telegram-desktop/result.json",
+);
+const MIGRATED_GROUP_FIXTURE_PATH = path.join(
+  import.meta.dirname,
+  "../../fixtures/telegram-desktop/migrated-basic-group/result.json",
 );
 const OWNER = "100";
 const tempDirs: string[] = [];
@@ -66,6 +73,30 @@ afterEach(async () => {
 });
 
 describe("collectTelegramDesktopExport", () => {
+  it("fails closed on Windows until ACL and reparse protections are proven", () => {
+    expect(() => assertTelegramDesktopPlatformSupported("win32")).toThrow(
+      expect.objectContaining({
+        code: "TELEGRAM_EXPORT_UNSUPPORTED_PLATFORM",
+      }),
+    );
+  });
+
+  it("preserves signed migrated basic-group message and reply identities", async () => {
+    const outDir = await makeTempDir();
+    const result = await collectFixture(MIGRATED_GROUP_FIXTURE_PATH, outDir);
+
+    expect(result.manifest.totals.messages).toBe(2);
+    const rows = (await fs.readFile(result.shardPaths[0], "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(rows.map((row) => row.id)).toEqual([
+      "telegram:100:group:300:-1000000001",
+      "telegram:100:group:300:-1000000002",
+    ]);
+    expect(rows[1].replyToId).toBe("telegram:100:group:300:-1000000001");
+  });
+
   it("maps DMs and allowlisted peers with compound identities and frozen bounds", async () => {
     const outDir = await makeTempDir();
     const result = await collectFixture(FIXTURE_PATH, outDir);
@@ -172,10 +203,9 @@ describe("collectTelegramDesktopExport", () => {
     expect(result.summary.deniedChannelChats).toBe(2);
     expect(result.summary.deniedChannelMessages).toBe(2);
     expect(result.manifest.totals.messages).toBe(3);
-    expect(await fs.readdir(path.join(outDir, "telegram", OWNER))).toEqual([
-      "2024-08.jsonl",
-      "summary.json",
-    ]);
+    expect(
+      (await fs.readdir(path.join(outDir, "telegram", OWNER))).sort(),
+    ).toEqual(["2024-08.jsonl", "summary.json"]);
   });
 
   it("keeps equal numeric peer and message ids distinct across peer kinds", async () => {

--- a/packages/corpus-tools/src/collectors/telegram-desktop.test.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop.test.ts
@@ -306,6 +306,32 @@ describe("collectTelegramDesktopExport", () => {
     ).resolves.toEqual(firstBytes);
   });
 
+  it("invalidates the prior manifest before changing any shard", async () => {
+    const outDir = await makeTempDir();
+    await collectFixture(FIXTURE_PATH, outDir);
+    const changed = await mutateFixture((input) => {
+      const chats = input.chats as {
+        list: Array<{ id: number; messages: Array<Record<string, unknown>> }>;
+      };
+      const dm = chats.list.find((chat) => chat.id === 200);
+      if (dm) dm.messages[0].text = "changed generation";
+    });
+    const originalRename = fs.rename.bind(fs);
+    vi.spyOn(fs, "rename").mockImplementation(async (oldPath, newPath) => {
+      if (String(newPath).endsWith(".jsonl")) {
+        throw new Error("synthetic shard install failure");
+      }
+      return originalRename(oldPath, newPath);
+    });
+
+    await expect(collectFixture(changed, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_WRITE_FAILED",
+    });
+    await expect(
+      fs.access(path.join(outDir, "manifest.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("removes stale owned shards when the input no longer contains that month", async () => {
     const exportPath = await mutateFixture((input) => {
       const chats = input.chats as {
@@ -365,6 +391,28 @@ describe("collectTelegramDesktopExport", () => {
     expect(
       (await fs.stat(path.join(outDir, "telegram", OWNER))).mode & 0o777,
     ).toBe(0o700);
+  });
+
+  it("rejects hardlinked collector outputs without chmod through the alias", async () => {
+    if (process.platform === "win32") return;
+    const outDir = await makeTempDir();
+    const first = await collectFixture(FIXTURE_PATH, outDir);
+    const shardPath = first.shardPaths[0];
+    const outsideDir = await makeTempDir();
+    const outsidePath = path.join(outsideDir, "outside.jsonl");
+    await fs.copyFile(shardPath, outsidePath);
+    await fs.chmod(outsidePath, 0o644);
+    await fs.unlink(shardPath);
+    await fs.link(outsidePath, shardPath);
+
+    await expect(collectFixture(FIXTURE_PATH, outDir)).rejects.toMatchObject({
+      code: "TELEGRAM_EXPORT_BAD_OUTPUT_PATH",
+    });
+    expect((await fs.stat(outsidePath)).mode & 0o777).toBe(0o644);
+    // No shard was mutated, so the prior committed generation remains valid.
+    await expect(
+      fs.access(path.join(outDir, "manifest.json")),
+    ).resolves.toBeUndefined();
   });
 
   it("fails closed on malformed JSON, wrong files, symlinks, and size limits", async () => {

--- a/packages/corpus-tools/src/collectors/telegram-desktop.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop.ts
@@ -23,14 +23,15 @@ import {
 import {
   readTelegramDesktopJson,
   type TelegramShardWriteStats,
-  writeAtomicTextIfChanged,
+  withTelegramOutputLock,
+  writeTelegramArtifact,
   writeTelegramShards,
 } from "./telegram-desktop-io.ts";
 
 export type { TelegramShardWriteStats } from "./telegram-desktop-io.ts";
 
-const DEFAULT_MAX_INPUT_BYTES = 512 * 1024 * 1024;
-const MAX_MAX_INPUT_BYTES = 1024 * 1024 * 1024;
+const DEFAULT_MAX_INPUT_BYTES = 64 * 1024 * 1024;
+const MAX_MAX_INPUT_BYTES = 64 * 1024 * 1024;
 const DEFAULT_MAX_CHATS = 100_000;
 const MAX_MAX_CHATS = 250_000;
 const DEFAULT_MAX_MESSAGES = 5_000_000;
@@ -40,10 +41,10 @@ const MAX_TEXT_PARTS = 100_000;
 const DM_TYPES = new Set([
   "saved_messages",
   "replies",
-  "verification_codes",
   "personal_chat",
   "bot_chat",
 ]);
+const CREDENTIAL_TYPES = new Set(["verification_codes"]);
 const GROUP_TYPES = new Set([
   "private_group",
   "private_supergroup",
@@ -85,7 +86,7 @@ export interface TelegramDesktopCollectorOptions {
   allowedGroupPeerIds?: readonly string[];
   /** Channel ids admitted into the corpus. Channels are denied when omitted. */
   allowedChannelPeerIds?: readonly string[];
-  /** Input safety bound, configurable only up to one GiB. */
+  /** Input safety bound, configurable only up to the 64 MiB parse ceiling. */
   maxInputBytes?: number;
   /** Chat-count safety bound. */
   maxChats?: number;
@@ -110,6 +111,8 @@ export interface TelegramDesktopSummary {
   deniedChannelMessages: number;
   unsupportedSecretChats: number;
   unsupportedSecretMessages: number;
+  unsupportedCredentialChats: number;
+  unsupportedCredentialMessages: number;
   unsupportedMessages: number;
   unsupportedDeletedMessages: number;
   unsupportedServiceMessages: number;
@@ -256,8 +259,11 @@ function canonicalAllowlist(
   return result;
 }
 
-function classifyChat(type: string): TelegramPeerKind | "secret" {
+function classifyChat(
+  type: string,
+): TelegramPeerKind | "secret" | "credential" {
   if (DM_TYPES.has(type)) return "dm";
+  if (CREDENTIAL_TYPES.has(type)) return "credential";
   if (GROUP_TYPES.has(type)) return "group";
   if (CHANNEL_TYPES.has(type)) return "channel";
   if (SECRET_TYPES.has(type)) return "secret";
@@ -526,6 +532,8 @@ function initialSummary(): TelegramDesktopSummary {
     deniedChannelMessages: 0,
     unsupportedSecretChats: 0,
     unsupportedSecretMessages: 0,
+    unsupportedCredentialChats: 0,
+    unsupportedCredentialMessages: 0,
     unsupportedMessages: 0,
     unsupportedDeletedMessages: 0,
     unsupportedServiceMessages: 0,
@@ -653,6 +661,11 @@ export async function collectTelegramDesktopExport(
       ctx.summary.unsupportedSecretMessages += messages.length;
       continue;
     }
+    if (kind === "credential") {
+      ctx.summary.unsupportedCredentialChats += 1;
+      ctx.summary.unsupportedCredentialMessages += messages.length;
+      continue;
+    }
     if (kind === "group" && !ctx.allowedGroups.has(peerId)) {
       ctx.summary.deniedGroupChats += 1;
       ctx.summary.deniedGroupMessages += messages.length;
@@ -677,23 +690,40 @@ export async function collectTelegramDesktopExport(
     normalized.push(...mapped);
   }
 
-  const { paths: shardPaths, stats: writeStats } = await writeTelegramShards(
-    normalized,
-    options.outDir,
-    ownerAccountId,
-  );
-  ctx.summary.shardCount = shardPaths.length;
-  const { manifest, issues } = await buildCorpusManifest(
-    options.outDir,
-    CORPUS_ANCHOR_ISO,
-  );
-  await writeAtomicTextIfChanged(
-    path.join(options.outDir, "manifest.json"),
-    `${JSON.stringify(manifest, null, 2)}\n`,
-  );
-  await writeAtomicTextIfChanged(
-    path.join(options.outDir, "telegram-desktop-summary.json"),
-    `${JSON.stringify(ctx.summary, null, 2)}\n`,
-  );
-  return { summary: ctx.summary, writeStats, manifest, issues, shardPaths };
+  return withTelegramOutputLock(options.outDir, async (assertRootIdentity) => {
+    await assertRootIdentity();
+    const { paths: shardPaths, stats: writeStats } = await writeTelegramShards(
+      normalized,
+      options.outDir,
+      ownerAccountId,
+    );
+    await assertRootIdentity();
+    ctx.summary.shardCount = shardPaths.length;
+    const { manifest, issues } = await buildCorpusManifest(
+      options.outDir,
+      CORPUS_ANCHOR_ISO,
+    );
+    await assertRootIdentity();
+    if (issues.length > 0) {
+      throw telegramInputError(
+        "TELEGRAM_EXPORT_MANIFEST_INVALID",
+        "Telegram output failed corpus manifest validation",
+        { issueCount: issues.length, issues },
+      );
+    }
+    await writeTelegramArtifact(
+      path.join(options.outDir, "telegram", ownerAccountId, "summary.json"),
+      `${JSON.stringify(ctx.summary, null, 2)}\n`,
+      assertRootIdentity,
+    );
+    await assertRootIdentity();
+    // The manifest is the generation commit marker and is installed last.
+    await writeTelegramArtifact(
+      path.join(options.outDir, "manifest.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      assertRootIdentity,
+    );
+    await assertRootIdentity();
+    return { summary: ctx.summary, writeStats, manifest, issues, shardPaths };
+  });
 }

--- a/packages/corpus-tools/src/collectors/telegram-desktop.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop.ts
@@ -155,6 +155,18 @@ function telegramInputError(
   return new ElizaError(message, { code, context, cause });
 }
 
+/** Fails closed where private ACL and reparse-point enforcement is unavailable. */
+export function assertTelegramDesktopPlatformSupported(
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (platform !== "win32") return;
+  throw telegramInputError(
+    "TELEGRAM_EXPORT_UNSUPPORTED_PLATFORM",
+    "Telegram Desktop corpus collection is disabled on Windows until output reparse-point rejection and owner-only ACL enforcement are implemented and verified",
+    { platform },
+  );
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -212,6 +224,29 @@ function canonicalIntegerId(value: unknown, location: string): string {
     throw telegramInputError(
       "TELEGRAM_EXPORT_BAD_ID",
       `${location} must be a canonical positive integer id`,
+      { location },
+    );
+  }
+  return text;
+}
+
+/**
+ * Telegram Desktop exports migrated basic-group history with negative message
+ * ids (the desktop client shifts them by -1,000,000,000). Message and reply
+ * ids therefore accept canonical signed non-zero integers; account, peer, and
+ * allowlist identities remain positive-only at their existing boundary.
+ */
+function canonicalMessageId(value: unknown, location: string): string {
+  const text =
+    typeof value === "number" && Number.isSafeInteger(value)
+      ? String(value)
+      : typeof value === "string"
+        ? value
+        : undefined;
+  if (!text || !/^-?(?:[1-9]\d{0,18})$/.test(text)) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_BAD_ID",
+      `${location} must be a canonical non-zero signed integer message id`,
       { location },
     );
   }
@@ -374,7 +409,7 @@ function mapChatMessages(
   for (const [index, value] of messages.entries()) {
     const location = `${chatLocation}.messages[${index}]`;
     const record = requireRecord(value, location);
-    const rawMessageId = canonicalIntegerId(record.id, `${location}.id`);
+    const rawMessageId = canonicalMessageId(record.id, `${location}.id`);
     if (rawIds.has(rawMessageId)) {
       throw telegramInputError(
         "TELEGRAM_EXPORT_DUPLICATE_MESSAGE",
@@ -439,7 +474,7 @@ function mapChatMessages(
     const rawReplyToId =
       record.reply_to_message_id === undefined
         ? undefined
-        : canonicalIntegerId(
+        : canonicalMessageId(
             record.reply_to_message_id,
             `${location}.reply_to_message_id`,
           );
@@ -552,6 +587,7 @@ function initialSummary(): TelegramDesktopSummary {
 export async function collectTelegramDesktopExport(
   options: TelegramDesktopCollectorOptions,
 ): Promise<TelegramDesktopCollectResult> {
+  assertTelegramDesktopPlatformSupported();
   const ownerAccountId = canonicalOwnerId(
     options.ownerAccountId,
     "ownerAccountId",

--- a/packages/corpus-tools/src/collectors/telegram-desktop.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop.ts
@@ -1,0 +1,699 @@
+/**
+ * Official Telegram Desktop JSON-export collector. It accepts only a bounded
+ * local `result.json`, never Telegram credentials or sessions, and converts
+ * owner DMs plus explicitly allowlisted groups/channels into deterministic
+ * monthly corpus shards. Export structure, identifiers, counts, and output
+ * paths are validated before use; media paths are never opened and attachment
+ * hashes are never inferred from export metadata.
+ */
+import path from "node:path";
+import { ElizaError } from "@elizaos/core";
+import {
+  CORPUS_ANCHOR_ISO,
+  CORPUS_ANCHOR_MS,
+  CORPUS_CUTOFF_MS,
+  type CorpusManifest,
+  type CorpusMessage,
+  corpusMessageSchema,
+} from "../schema.ts";
+import {
+  buildCorpusManifest,
+  type CorpusValidationIssue,
+} from "../validator.ts";
+import {
+  readTelegramDesktopJson,
+  type TelegramShardWriteStats,
+  writeAtomicTextIfChanged,
+  writeTelegramShards,
+} from "./telegram-desktop-io.ts";
+
+export type { TelegramShardWriteStats } from "./telegram-desktop-io.ts";
+
+const DEFAULT_MAX_INPUT_BYTES = 512 * 1024 * 1024;
+const MAX_MAX_INPUT_BYTES = 1024 * 1024 * 1024;
+const DEFAULT_MAX_CHATS = 100_000;
+const MAX_MAX_CHATS = 250_000;
+const DEFAULT_MAX_MESSAGES = 5_000_000;
+const MAX_MAX_MESSAGES = 10_000_000;
+const MAX_TEXT_PARTS = 100_000;
+
+const DM_TYPES = new Set([
+  "saved_messages",
+  "replies",
+  "verification_codes",
+  "personal_chat",
+  "bot_chat",
+]);
+const GROUP_TYPES = new Set([
+  "private_group",
+  "private_supergroup",
+  "public_supergroup",
+  // Older exports used this spelling before supergroups were distinguished.
+  "public_group",
+]);
+const CHANNEL_TYPES = new Set(["private_channel", "public_channel"]);
+const SECRET_TYPES = new Set(["secret_chat", "encrypted_chat"]);
+const DELETED_MESSAGE_TYPES = new Set(["deleted", "deleted_message"]);
+
+const MEDIA_KEYS = new Set([
+  "photo",
+  "file",
+  "media_type",
+  "contact_information",
+  "contact_vcard",
+  "location_information",
+  "place_name",
+  "game_title",
+  "invoice_information",
+  "poll",
+  "giveaway_information",
+  "story_id",
+]);
+
+type TelegramPeerKind = "dm" | "group" | "channel";
+
+export interface TelegramDesktopCollectorOptions {
+  /** Path to Telegram Desktop's machine-readable `result.json`. */
+  exportPath: string;
+  /** Expected owner user id; collection fails if the export belongs to another account. */
+  ownerAccountId: string;
+  /** Optional owner display override used for outbound rows. */
+  ownerDisplay?: string;
+  /** Root under which `telegram/<owner>/<yyyy-mm>.jsonl` is written. */
+  outDir: string;
+  /** Group ids admitted into the corpus. Groups are denied when omitted. */
+  allowedGroupPeerIds?: readonly string[];
+  /** Channel ids admitted into the corpus. Channels are denied when omitted. */
+  allowedChannelPeerIds?: readonly string[];
+  /** Input safety bound, configurable only up to one GiB. */
+  maxInputBytes?: number;
+  /** Chat-count safety bound. */
+  maxChats?: number;
+  /** Aggregate message-record safety bound. */
+  maxMessages?: number;
+}
+
+export interface TelegramPeerClassCounts {
+  dm: number;
+  group: number;
+  channel: number;
+}
+
+/** Stable, privacy-safe aggregate written beside the local corpus. */
+export interface TelegramDesktopSummary {
+  schemaVersion: 1;
+  peerCounts: TelegramPeerClassCounts;
+  messageCounts: TelegramPeerClassCounts;
+  deniedGroupChats: number;
+  deniedGroupMessages: number;
+  deniedChannelChats: number;
+  deniedChannelMessages: number;
+  unsupportedSecretChats: number;
+  unsupportedSecretMessages: number;
+  unsupportedMessages: number;
+  unsupportedDeletedMessages: number;
+  unsupportedServiceMessages: number;
+  unsupportedMediaOnlyMessages: number;
+  skippedBeforeCutoff: number;
+  skippedAfterAnchor: number;
+  shardCount: number;
+}
+
+export interface TelegramDesktopCollectResult {
+  summary: TelegramDesktopSummary;
+  writeStats: TelegramShardWriteStats;
+  manifest: CorpusManifest;
+  issues: CorpusValidationIssue[];
+  shardPaths: string[];
+}
+
+interface CandidateMessage {
+  message: CorpusMessage;
+  rawMessageId: string;
+  rawReplyToId?: string;
+  replyTargetsSamePeer: boolean;
+}
+
+interface CollectContext {
+  ownerAccountId: string;
+  ownerSenderId: string;
+  ownerDisplay: string;
+  allowedGroups: ReadonlySet<string>;
+  allowedChannels: ReadonlySet<string>;
+  summary: TelegramDesktopSummary;
+}
+
+function telegramInputError(
+  code: string,
+  message: string,
+  context: Record<string, unknown> = {},
+  cause?: unknown,
+): ElizaError {
+  return new ElizaError(message, { code, context, cause });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(
+  value: unknown,
+  location: string,
+): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_BAD_SHAPE",
+      `${location} must be an object`,
+      { location },
+    );
+  }
+  return value;
+}
+
+function requireArray(value: unknown, location: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_BAD_SHAPE",
+      `${location} must be an array`,
+      { location },
+    );
+  }
+  return value;
+}
+
+function requireString(value: unknown, location: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_BAD_SHAPE",
+      `${location} must be a non-empty string`,
+      { location },
+    );
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function canonicalIntegerId(value: unknown, location: string): string {
+  const text =
+    typeof value === "number" && Number.isSafeInteger(value)
+      ? String(value)
+      : typeof value === "string"
+        ? value
+        : undefined;
+  if (!text || !/^[1-9]\d{0,18}$/.test(text)) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_BAD_ID",
+      `${location} must be a canonical positive integer id`,
+      { location },
+    );
+  }
+  return text;
+}
+
+function canonicalOwnerId(value: unknown, location: string): string {
+  const id = canonicalIntegerId(value, location);
+  return id;
+}
+
+function positiveBound(
+  value: number | undefined,
+  fallback: number,
+  ceiling: number,
+  name: string,
+): number {
+  const bound = value ?? fallback;
+  if (!Number.isSafeInteger(bound) || bound <= 0 || bound > ceiling) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_BAD_LIMIT",
+      `${name} must be a positive integer no greater than ${ceiling}`,
+      { name, ceiling },
+    );
+  }
+  return bound;
+}
+
+function canonicalAllowlist(
+  values: readonly string[] | undefined,
+  location: string,
+): ReadonlySet<string> {
+  const result = new Set<string>();
+  for (const [index, value] of (values ?? []).entries()) {
+    const id = canonicalIntegerId(value, `${location}[${index}]`);
+    if (result.has(id)) {
+      throw telegramInputError(
+        "TELEGRAM_EXPORT_BAD_ALLOWLIST",
+        `${location} contains duplicate id ${id}`,
+        { location },
+      );
+    }
+    result.add(id);
+  }
+  return result;
+}
+
+function classifyChat(type: string): TelegramPeerKind | "secret" {
+  if (DM_TYPES.has(type)) return "dm";
+  if (GROUP_TYPES.has(type)) return "group";
+  if (CHANNEL_TYPES.has(type)) return "channel";
+  if (SECRET_TYPES.has(type)) return "secret";
+  throw telegramInputError(
+    "TELEGRAM_EXPORT_UNSUPPORTED_CHAT_TYPE",
+    `unsupported Telegram chat type ${type}`,
+    { type },
+  );
+}
+
+function parseUnixTimestamp(value: unknown, location: string): number {
+  const seconds =
+    typeof value === "string" && /^(0|[1-9]\d{0,11})$/.test(value)
+      ? Number(value)
+      : typeof value === "number" && Number.isSafeInteger(value)
+        ? value
+        : Number.NaN;
+  const milliseconds = seconds * 1000;
+  if (!Number.isSafeInteger(milliseconds)) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_BAD_TIMESTAMP",
+      `${location} must be a Unix timestamp in whole seconds`,
+      { location },
+    );
+  }
+  return milliseconds;
+}
+
+function parseText(value: unknown, location: string): string {
+  if (typeof value === "string") return value;
+  const parts = requireArray(value, location);
+  if (parts.length > MAX_TEXT_PARTS) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_COUNT_LIMIT",
+      `${location} exceeds the rich-text part limit`,
+      { location, limit: MAX_TEXT_PARTS },
+    );
+  }
+  return parts
+    .map((part, index) => {
+      if (typeof part === "string") return part;
+      const record = requireRecord(part, `${location}[${index}]`);
+      if (typeof record.text !== "string") {
+        throw telegramInputError(
+          "TELEGRAM_EXPORT_BAD_SHAPE",
+          `${location}[${index}].text must be a string`,
+          { location: `${location}[${index}].text` },
+        );
+      }
+      return record.text;
+    })
+    .join("");
+}
+
+function hasMedia(record: Record<string, unknown>): boolean {
+  return Object.keys(record).some((key) => MEDIA_KEYS.has(key));
+}
+
+function parseSenderId(value: unknown, location: string): string {
+  const id = requireString(value, location);
+  if (!/^(user|chat|channel)[1-9]\d{0,18}$/.test(id)) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_BAD_ID",
+      `${location} must be an exported Telegram peer id`,
+      { location },
+    );
+  }
+  return id;
+}
+
+function monthOf(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 7);
+}
+
+function compoundId(
+  accountId: string,
+  kind: TelegramPeerKind,
+  peerId: string,
+  messageId?: string,
+): string {
+  const peer = `telegram:${accountId}:${kind}:${peerId}`;
+  return messageId ? `${peer}:${messageId}` : peer;
+}
+
+function sameReplyPeer(
+  value: unknown,
+  kind: TelegramPeerKind,
+  peerId: string,
+): boolean {
+  if (value === undefined) return true;
+  if (typeof value !== "string") return false;
+  const prefix =
+    kind === "channel" ? "channel" : kind === "group" ? "chat" : "user";
+  return value === `${prefix}${peerId}`;
+}
+
+function mapChatMessages(
+  kind: TelegramPeerKind,
+  peerId: string,
+  peerDisplay: string | undefined,
+  messages: unknown[],
+  chatLocation: string,
+  ctx: CollectContext,
+): CorpusMessage[] {
+  const candidates: CandidateMessage[] = [];
+  const rawIds = new Set<string>();
+
+  for (const [index, value] of messages.entries()) {
+    const location = `${chatLocation}.messages[${index}]`;
+    const record = requireRecord(value, location);
+    const rawMessageId = canonicalIntegerId(record.id, `${location}.id`);
+    if (rawIds.has(rawMessageId)) {
+      throw telegramInputError(
+        "TELEGRAM_EXPORT_DUPLICATE_MESSAGE",
+        `${chatLocation} contains duplicate message id ${rawMessageId}`,
+        { chatLocation },
+      );
+    }
+    rawIds.add(rawMessageId);
+
+    const type = requireString(record.type, `${location}.type`);
+    if (type === "service") {
+      ctx.summary.unsupportedServiceMessages += 1;
+      continue;
+    }
+    if (DELETED_MESSAGE_TYPES.has(type) || record.deleted === true) {
+      ctx.summary.unsupportedDeletedMessages += 1;
+      continue;
+    }
+    if (type === "unsupported") {
+      ctx.summary.unsupportedMessages += 1;
+      continue;
+    }
+    if (type !== "message") {
+      throw telegramInputError(
+        "TELEGRAM_EXPORT_UNSUPPORTED_MESSAGE_TYPE",
+        `${location}.type has unsupported value ${type}`,
+        { location, type },
+      );
+    }
+
+    const text = parseText(record.text, `${location}.text`);
+    if (text.trim().length === 0) {
+      if (hasMedia(record)) {
+        ctx.summary.unsupportedMediaOnlyMessages += 1;
+        continue;
+      }
+      throw telegramInputError(
+        "TELEGRAM_EXPORT_EMPTY_MESSAGE",
+        `${location} has neither text nor recognized media`,
+        { location },
+      );
+    }
+
+    const ts = parseUnixTimestamp(
+      record.date_unixtime,
+      `${location}.date_unixtime`,
+    );
+    if (ts < CORPUS_CUTOFF_MS) {
+      ctx.summary.skippedBeforeCutoff += 1;
+      continue;
+    }
+    if (ts > CORPUS_ANCHOR_MS) {
+      ctx.summary.skippedAfterAnchor += 1;
+      continue;
+    }
+
+    const senderId =
+      record.from_id === undefined && kind === "channel"
+        ? `channel${peerId}`
+        : parseSenderId(record.from_id, `${location}.from_id`);
+    const outbound = senderId === ctx.ownerSenderId;
+    const rawReplyToId =
+      record.reply_to_message_id === undefined
+        ? undefined
+        : canonicalIntegerId(
+            record.reply_to_message_id,
+            `${location}.reply_to_message_id`,
+          );
+    const message = corpusMessageSchema.parse({
+      id: compoundId(ctx.ownerAccountId, kind, peerId, rawMessageId),
+      platform: "telegram",
+      accountId: ctx.ownerAccountId,
+      threadId: compoundId(ctx.ownerAccountId, kind, peerId),
+      ts,
+      direction: outbound ? "out" : "in",
+      senderId,
+      senderDisplay: outbound
+        ? ctx.ownerDisplay
+        : (optionalString(record.from) ??
+          optionalString(record.author) ??
+          peerDisplay ??
+          senderId),
+      recipients:
+        kind === "dm"
+          ? [
+              {
+                id: outbound ? `telegram:${kind}:${peerId}` : ctx.ownerSenderId,
+              },
+            ]
+          : [],
+      text,
+      labels: [`telegram:${kind}`],
+      // Telegram result.json contains paths and byte counts, not content hashes.
+      // The collector deliberately does not open those untrusted paths.
+      attachments: [],
+      scrubState: "raw",
+    });
+    candidates.push({
+      message,
+      rawMessageId,
+      rawReplyToId,
+      replyTargetsSamePeer: sameReplyPeer(
+        record.reply_to_peer_id,
+        kind,
+        peerId,
+      ),
+    });
+  }
+
+  const candidatesById = new Map(
+    candidates.map((candidate) => [candidate.rawMessageId, candidate]),
+  );
+  return candidates.map((candidate) => {
+    if (!candidate.rawReplyToId || !candidate.replyTargetsSamePeer) {
+      return candidate.message;
+    }
+    const parent = candidatesById.get(candidate.rawReplyToId);
+    if (
+      !parent ||
+      monthOf(parent.message.ts) !== monthOf(candidate.message.ts)
+    ) {
+      return candidate.message;
+    }
+    return corpusMessageSchema.parse({
+      ...candidate.message,
+      replyToId: parent.message.id,
+    });
+  });
+}
+
+function countMessages(
+  messages: unknown[],
+  current: number,
+  limit: number,
+): number {
+  const next = current + messages.length;
+  if (!Number.isSafeInteger(next) || next > limit) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_COUNT_LIMIT",
+      `Telegram export exceeds the aggregate message limit ${limit}`,
+      { limit },
+    );
+  }
+  return next;
+}
+
+function initialSummary(): TelegramDesktopSummary {
+  return {
+    schemaVersion: 1,
+    peerCounts: { dm: 0, group: 0, channel: 0 },
+    messageCounts: { dm: 0, group: 0, channel: 0 },
+    deniedGroupChats: 0,
+    deniedGroupMessages: 0,
+    deniedChannelChats: 0,
+    deniedChannelMessages: 0,
+    unsupportedSecretChats: 0,
+    unsupportedSecretMessages: 0,
+    unsupportedMessages: 0,
+    unsupportedDeletedMessages: 0,
+    unsupportedServiceMessages: 0,
+    unsupportedMediaOnlyMessages: 0,
+    skippedBeforeCutoff: 0,
+    skippedAfterAnchor: 0,
+    shardCount: 0,
+  };
+}
+
+/**
+ * Collects an official Telegram Desktop `result.json` into canonical local
+ * corpus shards. The function is deliberately offline and accepts no GramJS
+ * client, StringSession, API credentials, or archive-contained output paths.
+ */
+export async function collectTelegramDesktopExport(
+  options: TelegramDesktopCollectorOptions,
+): Promise<TelegramDesktopCollectResult> {
+  const ownerAccountId = canonicalOwnerId(
+    options.ownerAccountId,
+    "ownerAccountId",
+  );
+  const maxInputBytes = positiveBound(
+    options.maxInputBytes,
+    DEFAULT_MAX_INPUT_BYTES,
+    MAX_MAX_INPUT_BYTES,
+    "maxInputBytes",
+  );
+  const maxChats = positiveBound(
+    options.maxChats,
+    DEFAULT_MAX_CHATS,
+    MAX_MAX_CHATS,
+    "maxChats",
+  );
+  const maxMessages = positiveBound(
+    options.maxMessages,
+    DEFAULT_MAX_MESSAGES,
+    MAX_MAX_MESSAGES,
+    "maxMessages",
+  );
+  const input = requireRecord(
+    await readTelegramDesktopJson(options.exportPath, maxInputBytes),
+    "result.json",
+  );
+  const personal = requireRecord(
+    input.personal_information,
+    "result.json.personal_information",
+  );
+  const exportedOwnerId = canonicalOwnerId(
+    personal.user_id,
+    "result.json.personal_information.user_id",
+  );
+  if (exportedOwnerId !== ownerAccountId) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_OWNER_MISMATCH",
+      "Telegram Desktop export belongs to a different account",
+    );
+  }
+
+  const chats = requireArray(
+    requireRecord(input.chats, "result.json.chats").list,
+    "result.json.chats.list",
+  );
+  const leftChats =
+    input.left_chats === undefined
+      ? []
+      : requireArray(
+          requireRecord(input.left_chats, "result.json.left_chats").list,
+          "result.json.left_chats.list",
+        );
+  const chatCount = chats.length + leftChats.length;
+  if (!Number.isSafeInteger(chatCount) || chatCount > maxChats) {
+    throw telegramInputError(
+      "TELEGRAM_EXPORT_COUNT_LIMIT",
+      `Telegram export exceeds the chat limit ${maxChats}`,
+      { maxChats },
+    );
+  }
+  const allChats = [...chats, ...leftChats];
+
+  const firstName = optionalString(personal.first_name);
+  const lastName = optionalString(personal.last_name);
+  const exportedOwnerDisplay = [firstName, lastName].filter(Boolean).join(" ");
+  const ownerDisplay =
+    optionalString(options.ownerDisplay) ||
+    optionalString(exportedOwnerDisplay) ||
+    ownerAccountId;
+  const ctx: CollectContext = {
+    ownerAccountId,
+    ownerSenderId: `user${ownerAccountId}`,
+    ownerDisplay,
+    allowedGroups: canonicalAllowlist(
+      options.allowedGroupPeerIds,
+      "allowedGroupPeerIds",
+    ),
+    allowedChannels: canonicalAllowlist(
+      options.allowedChannelPeerIds,
+      "allowedChannelPeerIds",
+    ),
+    summary: initialSummary(),
+  };
+
+  const peerKeys = new Set<string>();
+  const normalized: CorpusMessage[] = [];
+  let seenMessages = 0;
+  for (const [index, value] of allChats.entries()) {
+    const location = `result.json.${index < chats.length ? "chats" : "left_chats"}.list[${index < chats.length ? index : index - chats.length}]`;
+    const chat = requireRecord(value, location);
+    const type = requireString(chat.type, `${location}.type`);
+    const kind = classifyChat(type);
+    const peerId = canonicalIntegerId(chat.id, `${location}.id`);
+    const messages = requireArray(chat.messages, `${location}.messages`);
+    seenMessages = countMessages(messages, seenMessages, maxMessages);
+    const peerKey = `${kind}:${peerId}`;
+    if (peerKeys.has(peerKey)) {
+      throw telegramInputError(
+        "TELEGRAM_EXPORT_DUPLICATE_CHAT",
+        `Telegram export repeats peer ${peerKey}`,
+      );
+    }
+    peerKeys.add(peerKey);
+
+    if (kind === "secret") {
+      ctx.summary.unsupportedSecretChats += 1;
+      ctx.summary.unsupportedSecretMessages += messages.length;
+      continue;
+    }
+    if (kind === "group" && !ctx.allowedGroups.has(peerId)) {
+      ctx.summary.deniedGroupChats += 1;
+      ctx.summary.deniedGroupMessages += messages.length;
+      continue;
+    }
+    if (kind === "channel" && !ctx.allowedChannels.has(peerId)) {
+      ctx.summary.deniedChannelChats += 1;
+      ctx.summary.deniedChannelMessages += messages.length;
+      continue;
+    }
+
+    ctx.summary.peerCounts[kind] += 1;
+    const mapped = mapChatMessages(
+      kind,
+      peerId,
+      optionalString(chat.name),
+      messages,
+      location,
+      ctx,
+    );
+    ctx.summary.messageCounts[kind] += mapped.length;
+    normalized.push(...mapped);
+  }
+
+  const { paths: shardPaths, stats: writeStats } = await writeTelegramShards(
+    normalized,
+    options.outDir,
+    ownerAccountId,
+  );
+  ctx.summary.shardCount = shardPaths.length;
+  const { manifest, issues } = await buildCorpusManifest(
+    options.outDir,
+    CORPUS_ANCHOR_ISO,
+  );
+  await writeAtomicTextIfChanged(
+    path.join(options.outDir, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  await writeAtomicTextIfChanged(
+    path.join(options.outDir, "telegram-desktop-summary.json"),
+    `${JSON.stringify(ctx.summary, null, 2)}\n`,
+  );
+  return { summary: ctx.summary, writeStats, manifest, issues, shardPaths };
+}

--- a/packages/corpus-tools/src/collectors/telegram-desktop.ts
+++ b/packages/corpus-tools/src/collectors/telegram-desktop.ts
@@ -21,6 +21,7 @@ import {
   type CorpusValidationIssue,
 } from "../validator.ts";
 import {
+  invalidateTelegramManifest,
   readTelegramDesktopJson,
   type TelegramShardWriteStats,
   withTelegramOutputLock,
@@ -732,6 +733,16 @@ export async function collectTelegramDesktopExport(
       normalized,
       options.outDir,
       ownerAccountId,
+      async () => {
+        // Invalidate the prior generation immediately before the first shard
+        // mutation. If the process dies or validation fails below, absence of
+        // manifest.json tells readers that the output is incomplete; unchanged
+        // reruns retain their byte-identical marker without rewriting it.
+        await invalidateTelegramManifest(
+          path.join(options.outDir, "manifest.json"),
+          assertRootIdentity,
+        );
+      },
     );
     await assertRootIdentity();
     ctx.summary.shardCount = shardPaths.length;

--- a/packages/corpus-tools/src/index.ts
+++ b/packages/corpus-tools/src/index.ts
@@ -2,6 +2,7 @@
  * Public entry for corpus schema consumers, validators, and archive
  * collectors.
  */
+export * from "./collectors/telegram-desktop.ts";
 export * from "./collectors/x-archive.ts";
 export * from "./pipeline/delete.ts";
 export * from "./pipeline/delete-command.ts";


### PR DESCRIPTION
# Tracking issue

The owner-export acceptance evidence is tracked separately at https://github.com/elizaOS/eliza/issues/14759 and is outside this PR’s closing scope. This implements the offline Telegram Desktop `result.json` collector; private owner-export validation remains the issue-level evidence gate.

# Summary

- parse untrusted Telegram Desktop exports under a hard 64 MiB read/parse ceiling without loading MTProto sessions or credentials
- derive collision-safe account, peer-kind, peer, and message identities with DM-by-default and group/channel allowlists
- write deterministic private monthly shards, per-account summaries, and a last-installed manifest under a fail-fast output-root publication lock
- classify Telegram's authentic `verification_codes` dialog as credential material and emit none of its text
- keep validated output directory handles open and revalidate device/inode identity around reads, installs, and collector-owned stale cleanup
- fail closed on malformed paths, symlinks, directory replacement, concurrent writers, oversized inputs, manifest issues, and output ownership violations

# Verification

- [x] exact-head corpus-tools suite: 75 passed
- [x] package typecheck
- [x] package source Biome and `git diff --check`
- [x] adversarial directory swaps at stale discovery and final install fail with `TELEGRAM_EXPORT_OUTPUT_CHANGED` while outside files remain unchanged
- [x] a root swap after shard publication is rejected before manifest/summary open; any stranded random temporary inode is truncated to zero bytes through its held handle
- [x] exact-boundary/max+1 input, output-lock contention, per-account summary, manifest-failure, and credential-dialog regressions pass
- [x] synthetic artifact validates, shard digests match, and reruns are byte-identical
- [x] rebased onto current GitHub `develop` at exact head `e2d88fa2784d8b9e3b8b94c323f95ea752869726`/
- [ ] private owner Desktop export, selected-peer review, Windows boundary proof, and sanitized real-artifact receipts remain pending
- [ ] root `bun run verify` passed parity, Biome-version, i18n, Bun/Turbo, dependency, plugin-convention, alias-read, workspace-resolution, and the touched package's Turbo lint/typecheck work; it was interrupted after five minutes while an unrelated Cloud API Wrangler dry-run remained active under host contention. Focused exact-head gates below are green.

# Scope notes

The current issue title is Desktop-export-specific, while older body text preferred GramJS/MTProto. This implementation follows the current offline Desktop-export scope and intentionally never accepts `StringSession`, API credentials, or a live Telegram login. It does not close #14759 until the owner reviews a private real export and posts sanitized validation/count/hash receipts.

Node 24 does not expose portable `openat`/`renameat`/`unlinkat` operations, and macOS does not permit child traversal through `/dev/fd/<directory-fd>`. This repair therefore holds directory handles and checks pathname `lstat` identity against held-handle `fstat` immediately before and after every operation; same-directory random temporary names also make a parent swap at final rename fail with `ENOENT` instead of installing into the replacement. A hostile same-UID process can still race inside a pathname syscall, so OS-native dirfd operations or generation-directory publication would be required for a mathematical race-free guarantee. Windows junction/reparse-point rejection and private ACL behavior remain explicit human/platform evidence gates.

# Evidence Gate

<!-- evidence-head:e2d88fa2784d8b9e3b8b94c323f95ea752869726 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - private backend corpus tooling only.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no rendered or interactive product surface changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head deterministic transcript:

  ```text
  Corpus-tools test suite: 47 tests passed across schema, validator, X archive, and Telegram Desktop collector paths.
  Package typecheck passed; source Biome checked nine files with no fixes; git diff check passed.
  Adversarial cases cover stale-scan and final-install directory swaps, lock contention, bounded max+1 reads, manifest failure, credential dialogs, nofollow reads, private permission repair, identity collisions, exact cutoffs, foreign JSONL preservation, and unsupported/media separation.
  ```
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - deterministic corpus ingestion does not call a model.
<!-- evidence-row:domain-artifacts -->
- [x] Synthetic corpus receipt:

  ```text
  Validator accepted the generated manifest and six messages across three deterministic monthly shards.
  Manifest SHA-256 values matched independent shasum output; rerun and missing-shard repair were byte-stable.
  Privacy inspection found no media paths, attachment hashes, phone numbers, verification codes, credentials, or session material in shards.
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no visual surface changed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@feb0259fa8a01e0d15a280c12496c0a9847c3ff7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@feb0259fa8a01e0d15a280c12496c0a9847c3ff7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-14759]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@feb0259fa8a01e0d15a280c12496c0a9847c3ff7:packages/skills/skills/contribute-to-eliza"} -->

Independent review hardened generation truth and untrusted-input boundaries: the collector invalidates a prior manifest before the first shard mutation, rejects hardlinked or concurrently changed inputs/outputs, and rejects duplicate decoded JSON keys (including escaped equivalents) before parsing. Final package suite: 75/75.