### PR TITLE
feat(documents): inject pinned knowledge without relevance gating

### DIFF
--- a/packages/core/src/features/documents/provider-pinned.test.ts
+++ b/packages/core/src/features/documents/provider-pinned.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import { logger } from "../../logger";
+import { type Memory, MemoryType, type UUID } from "../../types";
+import {
+	documentsProvider,
+	PINNED_DOCUMENT_TRUNCATION_MARKER,
+	renderPinnedDocuments,
+} from "./provider";
+import { DocumentService } from "./service";
+
+const id = (value: string) => value.padEnd(36, "0") as UUID;
+
+function document(title: string, text: string, pinned = false): Memory {
+	return {
+		id: id(title),
+		agentId: id("agent"),
+		entityId: id("entity"),
+		roomId: id("room"),
+		content: { text },
+		metadata: {
+			type: MemoryType.DOCUMENT,
+			source: "test",
+			title,
+			pinned,
+		},
+	};
+}
+
+describe("pinned DOCUMENTS provider knowledge", () => {
+	it("keeps an irrelevant unpinned document absent, then injects it whole when pinned", async () => {
+		const irrelevant = document("Operating rules", "ALWAYS TELL THE TRUTH");
+		const service = {
+			composeProviderDocuments: vi.fn(async () => ({
+				relevantFragments: [],
+				documents: [irrelevant],
+			})),
+		};
+		const runtime = {
+			getService: vi.fn((type: string) =>
+				type === DocumentService.serviceType ? service : null,
+			),
+		};
+		const message = document("query", "What is the weather?");
+
+		const before = await documentsProvider.get(runtime as never, message);
+		expect(before.text).not.toContain("ALWAYS TELL THE TRUTH");
+		expect(before.data?.pinnedDocumentIds).toEqual([]);
+
+		irrelevant.metadata = { ...irrelevant.metadata, pinned: true };
+		const after = await documentsProvider.get(runtime as never, message);
+		expect(after.text).toContain("ALWAYS TELL THE TRUTH");
+		expect(after.data?.pinnedDocumentIds).toEqual([irrelevant.id]);
+		expect(service.composeProviderDocuments).toHaveBeenLastCalledWith(message, {
+			limit: 25,
+		});
+	});
+
+	it("preserves ordinary retrieval snippets for unpinned documents", async () => {
+		const unpinned = document("Reference", "whole text stays unpinned");
+		const runtime = {
+			getService: vi.fn(() => ({
+				composeProviderDocuments: vi.fn(async () => ({
+					relevantFragments: [
+						{
+							id: id("fragment"),
+							content: { text: "retrieved fragment" },
+							metadata: { title: "Reference", documentId: unpinned.id },
+							similarity: 0.91,
+						},
+					],
+					documents: [unpinned],
+				})),
+			})),
+		};
+		const result = await documentsProvider.get(
+			runtime as never,
+			document("query", "reference query"),
+		);
+		expect(result.text).toContain("retrieved fragment");
+		expect(result.text).not.toContain("whole text stays unpinned");
+	});
+
+	it("orders pinned documents deterministically", () => {
+		const first = document("B rules", "BBBB", true);
+		const second = document("A rules", "AAAA", true);
+		const rendered = renderPinnedDocuments([first, second]);
+		expect(rendered.text.indexOf("A rules")).toBeLessThan(
+			rendered.text.indexOf("B rules"),
+		);
+		expect(rendered.truncated).toBe(false);
+	});
+
+	it("marks overflow explicitly and emits a warning from the provider", async () => {
+		const oversized = document("Ground truth", "X".repeat(40_000), true);
+		const runtime = {
+			getService: vi.fn(() => ({
+				composeProviderDocuments: vi.fn(async () => ({
+					relevantFragments: [],
+					documents: [oversized],
+				})),
+			})),
+		};
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+		const result = await documentsProvider.get(
+			runtime as never,
+			document("query", "unrelated query"),
+		);
+		expect(result.text).toContain(PINNED_DOCUMENT_TRUNCATION_MARKER);
+		expect(result.data?.pinnedDocumentsTruncated).toBe(true);
+		expect(warn).toHaveBeenCalledWith(
+			expect.objectContaining({ tokenBudget: 8_000 }),
+			expect.stringContaining("explicitly truncated"),
+		);
+		warn.mockRestore();
+	});
+});

--- a/packages/core/src/features/documents/provider-pinned.test.ts
+++ b/packages/core/src/features/documents/provider-pinned.test.ts
@@ -33,6 +33,8 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 			composeProviderDocuments: vi.fn(async () => ({
 				relevantFragments: [],
 				documents: [irrelevant],
+				pinnedDocuments:
+					irrelevant.metadata?.pinned === true ? [irrelevant] : [],
 			})),
 		};
 		const runtime = {
@@ -69,6 +71,7 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 						},
 					],
 					documents: [unpinned],
+					pinnedDocuments: [],
 				})),
 			})),
 		};
@@ -90,6 +93,29 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 		expect(rendered.truncated).toBe(false);
 	});
 
+	it("injects an authorized pin even when it is outside the recent-document page", async () => {
+		const recent = Array.from({ length: 25 }, (_, index) =>
+			document(`Recent ${index}`, `recent ${index}`),
+		);
+		const olderPinned = document("Standing rule", "NEVER FABRICATE", true);
+		const runtime = {
+			getService: vi.fn(() => ({
+				composeProviderDocuments: vi.fn(async () => ({
+					relevantFragments: [],
+					documents: recent,
+					pinnedDocuments: [olderPinned],
+				})),
+			})),
+		};
+		const result = await documentsProvider.get(
+			runtime as never,
+			document("query", "unrelated query"),
+		);
+		expect(result.text).toContain("NEVER FABRICATE");
+		expect(result.data?.documents).toHaveLength(25);
+		expect(result.data?.pinnedDocumentIds).toEqual([olderPinned.id]);
+	});
+
 	it("marks overflow explicitly and emits a warning from the provider", async () => {
 		const oversized = document("Ground truth", "X".repeat(40_000), true);
 		const runtime = {
@@ -97,6 +123,7 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 				composeProviderDocuments: vi.fn(async () => ({
 					relevantFragments: [],
 					documents: [oversized],
+					pinnedDocuments: [oversized],
 				})),
 			})),
 		};
@@ -106,7 +133,9 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 			document("query", "unrelated query"),
 		);
 		expect(result.text).toContain(PINNED_DOCUMENT_TRUNCATION_MARKER);
+		expect(result.text).not.toContain("X".repeat(100));
 		expect(result.data?.pinnedDocumentsTruncated).toBe(true);
+		expect(result.data?.pinnedDocumentIds).toEqual([]);
 		expect(warn).toHaveBeenCalledWith(
 			expect.objectContaining({ tokenBudget: 8_000 }),
 			expect.stringContaining("explicitly truncated"),

--- a/packages/core/src/features/documents/provider.ts
+++ b/packages/core/src/features/documents/provider.ts
@@ -8,6 +8,7 @@
  * exact `documents` and `knowledge` contexts and a minimum `USER` role, with
  * per-turn cache scope.
  */
+import { logger } from "../../logger";
 import {
 	type IAgentRuntime,
 	type Memory,
@@ -22,6 +23,10 @@ import { normalizeDocumentSourceValue } from "./utils.ts";
 const MAX_RELEVANT_SNIPPETS = 5;
 const MAX_RECENT_DOCUMENTS = 10;
 const MAX_AVAILABLE_DOCUMENTS = 25;
+export const PINNED_DOCUMENT_TOKEN_BUDGET = 8_000;
+const CHARS_PER_TOKEN_ESTIMATE = 4;
+export const PINNED_DOCUMENT_TRUNCATION_MARKER =
+	"[PINNED KNOWLEDGE TRUNCATED: token budget exceeded]";
 
 function getDocumentTitle(memory: Memory, index: number): string {
 	const metadata = memory.metadata as DocumentMetadataExtended | undefined;
@@ -30,6 +35,48 @@ function getDocumentTitle(memory: Memory, index: number): string {
 	return typeof title === "string" && title.trim().length > 0
 		? title.trim()
 		: `Document ${index + 1}`;
+}
+
+export function renderPinnedDocuments(
+	documents: Memory[],
+	tokenBudget = PINNED_DOCUMENT_TOKEN_BUDGET,
+): { text: string; truncated: boolean; includedIds: Array<Memory["id"]> } {
+	const pinned = documents
+		.filter((document) => {
+			const metadata = document.metadata as
+				| DocumentMetadataExtended
+				| undefined;
+			return metadata?.type === MemoryType.DOCUMENT && metadata.pinned === true;
+		})
+		.sort((a, b) => {
+			const titleOrder = getDocumentTitle(a, 0).localeCompare(
+				getDocumentTitle(b, 0),
+			);
+			return titleOrder || String(a.id ?? "").localeCompare(String(b.id ?? ""));
+		});
+	const maxChars =
+		Math.max(0, Math.floor(tokenBudget)) * CHARS_PER_TOKEN_ESTIMATE;
+	let usedChars = 0;
+	let truncated = false;
+	const includedIds: Array<Memory["id"]> = [];
+	const blocks: string[] = [];
+	for (const [index, document] of pinned.entries()) {
+		const block = `## ${getDocumentTitle(document, index)} (${document.id})\n${document.content.text ?? ""}`;
+		if (usedChars + block.length > maxChars) {
+			truncated = true;
+			const remaining = Math.max(0, maxChars - usedChars);
+			if (remaining > 0) {
+				blocks.push(block.slice(0, remaining));
+				includedIds.push(document.id);
+			}
+			break;
+		}
+		blocks.push(block);
+		includedIds.push(document.id);
+		usedChars += block.length;
+	}
+	if (truncated) blocks.push(PINNED_DOCUMENT_TRUNCATION_MARKER);
+	return { text: blocks.join("\n\n"), truncated, includedIds };
 }
 
 function summarizeDocument(memory: Memory, index: number) {
@@ -81,6 +128,16 @@ export const documentsProvider: Provider = {
 			await service.composeProviderDocuments(message, {
 				limit: MAX_AVAILABLE_DOCUMENTS,
 			});
+		const pinned = renderPinnedDocuments(documents);
+		if (pinned.truncated) {
+			logger.warn(
+				{
+					tokenBudget: PINNED_DOCUMENT_TOKEN_BUDGET,
+					includedIds: pinned.includedIds,
+				},
+				"Pinned knowledge exceeded its provider token budget; prompt content was explicitly truncated",
+			);
+		}
 		const relevantSnippets = relevantFragments
 			.slice(0, MAX_RELEVANT_SNIPPETS)
 			.map((fragment, index) => {
@@ -116,7 +173,13 @@ export const documentsProvider: Provider = {
 			.join("\n");
 		const text = addHeader(
 			"# Documents",
-			[snippetsText, recentText ? `Recent documents:\n${recentText}` : ""]
+			[
+				pinned.text
+					? `Pinned knowledge (always applicable):\n${pinned.text}`
+					: "",
+				snippetsText,
+				recentText ? `Recent documents:\n${recentText}` : "",
+			]
 				.filter(Boolean)
 				.join("\n\n"),
 		);
@@ -127,6 +190,8 @@ export const documentsProvider: Provider = {
 			documentsRelevant: relevantSnippets,
 			recentDocuments,
 			documentsCount: summaries.length,
+			pinnedDocumentIds: pinned.includedIds,
+			pinnedDocumentsTruncated: pinned.truncated,
 		};
 
 		return {

--- a/packages/core/src/features/documents/provider.ts
+++ b/packages/core/src/features/documents/provider.ts
@@ -62,18 +62,14 @@ export function renderPinnedDocuments(
 	const blocks: string[] = [];
 	for (const [index, document] of pinned.entries()) {
 		const block = `## ${getDocumentTitle(document, index)} (${document.id})\n${document.content.text ?? ""}`;
-		if (usedChars + block.length > maxChars) {
+		const separatorLength = blocks.length > 0 ? 2 : 0;
+		if (usedChars + separatorLength + block.length > maxChars) {
 			truncated = true;
-			const remaining = Math.max(0, maxChars - usedChars);
-			if (remaining > 0) {
-				blocks.push(block.slice(0, remaining));
-				includedIds.push(document.id);
-			}
 			break;
 		}
 		blocks.push(block);
 		includedIds.push(document.id);
-		usedChars += block.length;
+		usedChars += separatorLength + block.length;
 	}
 	if (truncated) blocks.push(PINNED_DOCUMENT_TRUNCATION_MARKER);
 	return { text: blocks.join("\n\n"), truncated, includedIds };
@@ -124,11 +120,11 @@ export const documentsProvider: Provider = {
 			};
 		}
 
-		const { relevantFragments, documents } =
+		const { relevantFragments, documents, pinnedDocuments } =
 			await service.composeProviderDocuments(message, {
 				limit: MAX_AVAILABLE_DOCUMENTS,
 			});
-		const pinned = renderPinnedDocuments(documents);
+		const pinned = renderPinnedDocuments(pinnedDocuments);
 		if (pinned.truncated) {
 			logger.warn(
 				{

--- a/packages/core/src/features/documents/service-list.test.ts
+++ b/packages/core/src/features/documents/service-list.test.ts
@@ -312,6 +312,29 @@ describe("DocumentService list semantics", () => {
 		expect(getWorld).toHaveBeenCalledTimes(1);
 	});
 
+	it("composes visible pinned documents beyond the recent page without leaking private pins", async () => {
+		const { runtime, service } = await makeHarness();
+		const documents = Array.from({ length: 126 }, (_, index) =>
+			documentMemory(index, { metadata: { pinned: index === 0 } }),
+		);
+		const privatePinned = documentMemory(999, {
+			roomId: ROOM_A,
+			metadata: { pinned: true, scope: "owner-private" },
+		});
+		await seedDocuments(runtime, [...documents, privatePinned]);
+
+		const composed = await service.composeProviderDocuments(userMessage(), {
+			limit: 25,
+		});
+
+		expect(composed.documents).toHaveLength(25);
+		expect(composed.documents).not.toContainEqual(documents[0]);
+		expect(composed.pinnedDocuments.map((document) => document.id)).toEqual([
+			documents[0]?.id,
+		]);
+		expect(composed.pinnedDocuments).not.toContainEqual(privatePinned);
+	});
+
 	it("fails fast for adapters without the exact native capability", async () => {
 		const { adapter, runtime, service } = await makeHarness();
 		await seedDocuments(

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -1022,6 +1022,7 @@ export class DocumentService extends Service {
 		addedByRole,
 		addedFrom,
 		metadata,
+		pinned = false,
 		fragments,
 	}: AddDocumentOptions): Promise<{
 		clientDocumentId: string;
@@ -1173,6 +1174,7 @@ export class DocumentService extends Service {
 				addedAt: Date.now(),
 				ingestionAttemptId,
 				ingestionState: "pending" as const,
+				pinned,
 			};
 
 			const documentMemory = createDocumentMemory({

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -670,12 +670,16 @@ export class DocumentService extends Service {
 	async composeProviderDocuments(
 		message: Memory,
 		listOptions: DocumentListOptions,
-	): Promise<{ relevantFragments: StoredDocument[]; documents: Memory[] }> {
+	): Promise<{
+		relevantFragments: StoredDocument[];
+		documents: Memory[];
+		pinnedDocuments: Memory[];
+	}> {
 		const resolveRequester = createDocumentProviderRequesterResolver(
 			this.runtime,
 			message,
 		);
-		const [relevantFragments, listResult] = await Promise.all([
+		const [relevantFragments, listResult, pinnedDocuments] = await Promise.all([
 			this.searchDocumentsWithRequester(
 				message,
 				undefined,
@@ -685,8 +689,53 @@ export class DocumentService extends Service {
 				resolveRequester,
 			),
 			this.listDocumentsDetailedWithRequester(listOptions, resolveRequester),
+			this.listPinnedDocumentsWithRequester(resolveRequester),
 		]);
-		return { relevantFragments, documents: listResult.documents };
+		return {
+			relevantFragments,
+			documents: listResult.documents,
+			pinnedDocuments,
+		};
+	}
+
+	/** Lists every pinned document visible to the provider's requester. */
+	private async listPinnedDocumentsWithRequester(
+		resolveRequester: DocumentRequesterResolver,
+	): Promise<Memory[]> {
+		const pinnedDocuments: Memory[] = [];
+		let cursor: DocumentListCursor | undefined;
+		do {
+			const page = await this.listDocumentsDetailedWithRequester(
+				{
+					limit: DOCUMENT_LIST_MAX_LIMIT,
+					...(cursor ? { cursor } : {}),
+				},
+				resolveRequester,
+			);
+			pinnedDocuments.push(
+				...page.documents.filter((document) => {
+					const metadata = document.metadata as
+						| DocumentMemoryMetadata
+						| undefined;
+					return (
+						metadata?.type === MemoryType.DOCUMENT && metadata.pinned === true
+					);
+				}),
+			);
+			if (!page.hasMore) break;
+			if (!page.nextCursor) {
+				throw new ElizaError(
+					"Document list reported another page without a continuation cursor",
+					{
+						code: "DOCUMENT_LIST_CURSOR_MISSING",
+						context: { returnedDocuments: page.documents.length },
+						severity: "fatal",
+					},
+				);
+			}
+			cursor = page.nextCursor;
+		} while (cursor);
+		return pinnedDocuments;
 	}
 
 	async deleteDocument(documentId: UUID, message?: Memory): Promise<void> {

--- a/packages/core/src/features/documents/types.ts
+++ b/packages/core/src/features/documents/types.ts
@@ -168,6 +168,8 @@ export interface AddDocumentOptions {
 	addedByRole?: DocumentAddedByRole;
 	addedFrom?: DocumentAddedFrom;
 	metadata?: Record<string, unknown>;
+	/** Always inject this document whole through the DOCUMENTS provider. */
+	pinned?: boolean;
 	/** Store these verbatim fragments instead of token-splitting `content`. */
 	fragments?: PreChunkedFragmentInput[];
 }
@@ -239,6 +241,8 @@ export interface DocumentMemoryMetadata
 	textBacked?: boolean;
 	timestamp?: number;
 	editedAt?: number;
+	/** Always inject the complete document through the DOCUMENTS provider. */
+	pinned?: boolean;
 	/** Served original-bytes file (content-addressed) linked to this document. */
 	mediaUrl?: string;
 	/** Served original-bytes file (content-addressed) linked to this document. */

--- a/packages/core/src/features/provider-io-concurrency.test.ts
+++ b/packages/core/src/features/provider-io-concurrency.test.ts
@@ -347,6 +347,7 @@ describe("provider database I/O concurrency", () => {
 		const composition = deferred<{
 			relevantFragments: Memory[];
 			documents: Memory[];
+			pinnedDocuments: Memory[];
 		}>();
 		const service = {
 			composeProviderDocuments: vi.fn(() => composition.promise),
@@ -365,6 +366,7 @@ describe("provider database I/O concurrency", () => {
 
 		composition.resolve({
 			relevantFragments: [],
+			pinnedDocuments: [],
 			documents: [
 				{
 					id: "10000000-0000-0000-0000-000000000008" as UUID,


### PR DESCRIPTION
# Relates to

Fixes #22182

- [x] This PR targets `develop` and was based on the latest `upstream/develop` at implementation start with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync. Exact workspace/dependency blockers are recorded below.
- [x] A reviewer can confirm the semantics from focused bidirectional tests in `provider-pinned.test.ts`.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Sol`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@995e0ff4ca0957657d2387e3895d3cab58a3f7f7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto fresh `origin/develop` commit `995e0ff4ca0957657d2387e3895d3cab58a3f7f7`; zero conflicts.
- [ ] `bun run verify` passes post-sync. See exact environment blockers below.

# Risks

Low to medium. The change adds provider prompt content for documents explicitly marked pinned. It has an 8,000 estimated-token budget, deterministic ordering, an explicit truncation marker, and a structured warning. Existing unpinned retrieval behavior is unchanged.

# Background

## What does this PR do?

Adds native `pinned` document metadata, defaulting false at ingestion. The DOCUMENTS provider injects visible pinned documents whole before retrieval snippets, without scoring or fragment selection. Overflow is explicit in prompt text and warning logs.

A document-management checkbox is intentionally left as a follow-up UI surface.

## What kind of change is this?

Feature, non-breaking.

# Documentation changes needed?

No public documentation change is required for the runtime-only initial surface. UI documentation belongs with the follow-up checkbox.

# Testing

## Where should a reviewer start?

`packages/core/src/features/documents/provider-pinned.test.ts`, then `provider.ts`.

## Detailed testing steps

Run `bun test packages/core/src/features/documents/provider-pinned.test.ts packages/core/src/features/documents/service-list.test.ts packages/core/src/features/provider-io-concurrency.test.ts`. The 30 focused tests cover authorization-filtered pagination beyond the recent page, unchanged ordinary retrieval, deterministic ordering, whole-document overflow, and provider I/O concurrency.

# Evidence Gate

<!-- evidence-head:2d005a322d59b7a70af1a24f7b1ba13f817eb849 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - runtime-only provider and document metadata change; no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - runtime-only provider and document metadata change; no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow changed; checkbox UI is explicitly follow-up work.
<!-- evidence-row:backend-logs -->
- [x] [22184-pr22184-provider-evidence.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22184-pr22184-provider-evidence.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this change deterministically composes provider state and does not alter model invocation or model output parsing; the exact provider payload is covered directly.
<!-- evidence-row:domain-artifacts -->
- [x] [22184-pr22184-domain-evidence.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22184-pr22184-domain-evidence.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - provider composition is deterministic and model-independent; no live model behavior is claimed.

## Backend + frontend logs

Exact-head backend/provider artifact and the structured overflow warning are recorded at https://github.com/elizaOS/eliza/pull/22184#issuecomment-5334456157.

## Screenshots (before / after) + video walkthrough

N/A - no UI diff.

## Audio / voice walkthrough

N/A - no audio, transcript, TTS, STT, or omnivoice changes.

## Known gaps / failures

- The isolated sparse checkout cannot establish the repository-wide `bun install` / `bun run verify` gate.
- Exact-head focused behavior, real storage/authorization, provider payload, overflow warning, Biome, and whitespace gates passed; details are linked above.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Sol
Contribution skill revision: elizaOS/eliza@995e0ff4ca0957657d2387e3895d3cab58a3f7f7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sol-knowledge-pinned-flag-r4]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Sol","skill_revision":"elizaOS/eliza@995e0ff4ca0957657d2387e3895d3cab58a3f7f7:packages/skills/skills/contribute-to-eliza"} -->
