### PR TITLE
fix(ci): gate merge candidates with pinned Biome

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,12 +6,18 @@ runners, environments, and a concise job graph.
 
 ## Required validation
 
-`ci.yml` is the canonical required pull-request workflow for both `develop` and
-`main`. It classifies changed paths, runs repository quality checks, affected
-tests, deterministic smoke tests, a path-scoped Android release AAB audit, and a
-diff-scoped secret scan. The stable `CI / Required` job is the only status
-intended for branch protection. Individual jobs remain visible for diagnosis
-but are not separately wired into protection rules.
+`merge-candidate-biome.yml` is the pre-merge admission gate. GitHub's merge
+queue synthesizes its checkout SHA from the current `develop` tip and the
+queued pull requests, then the workflow runs the repository-pinned full lint
+and format contracts on that exact tree. Branch rules must require the stable
+`Merge Candidate Biome / Candidate tree` check for the queue to block a bad
+candidate; post-merge workflows remain health checks rather than admission.
+
+`ci.yml` is the canonical post-merge branch-health workflow for `develop`. It
+classifies changed paths, runs repository quality checks, affected tests,
+deterministic smoke tests, a path-scoped Android release AAB audit, and a
+diff-scoped secret scan. Its stable `CI / Required` job diagnoses the integrated
+branch; it does not replace the merge-candidate admission check above.
 
 `nightly.yml` calls the same CI workflow once per day and adds macOS and Windows
 core smoke tests. It never publishes packages or creates releases.

--- a/.github/workflows/merge-candidate-biome.yml
+++ b/.github/workflows/merge-candidate-biome.yml
@@ -1,0 +1,47 @@
+name: Merge Candidate Biome
+
+# Merge queue events point github.sha at GitHub's synthesized candidate commit,
+# which includes the current develop tip and every queued pull request in the
+# candidate group. This gate intentionally runs on that tree instead of a PR
+# head so formatting conflicts introduced by integration cannot land.
+on:
+  merge_group:
+    types: [checks_requested]
+
+concurrency:
+  group: merge-candidate-biome-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  candidate-tree:
+    name: Candidate tree
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          submodules: false
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14"
+          install-command: bun install --frozen-lockfile
+          install-native-deps: "false"
+          install-protoc: "false"
+          setup-python: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Verify the repository-pinned Biome version
+        run: bun run check:biome-version
+
+      - name: Check candidate lint
+        run: bun run lint:check
+
+      - name: Check candidate formatting
+        run: bun run format:check

--- a/packages/scripts/__tests__/merge-candidate-biome-workflow.test.ts
+++ b/packages/scripts/__tests__/merge-candidate-biome-workflow.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Proves the merge-queue Biome workflow checks GitHub's synthesized candidate
+ * SHA and that the repository-pinned formatter rejects a planted bad file.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const WORKFLOW_PATH = path.join(
+  REPO_ROOT,
+  ".github/workflows/merge-candidate-biome.yml",
+);
+
+describe("merge candidate Biome workflow", () => {
+  test("checks the exact merge-group candidate with pinned repository commands", () => {
+    const workflow = parse(readFileSync(WORKFLOW_PATH, "utf8"));
+
+    expect(workflow.on).toEqual({
+      merge_group: { types: ["checks_requested"] },
+    });
+    const job = workflow.jobs["candidate-tree"];
+    const checkout = job.steps.find(
+      (step: Record<string, unknown>) =>
+        typeof step.uses === "string" &&
+        step.uses.startsWith("actions/checkout@"),
+    );
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: this is the literal GitHub Actions expression the checkout must use.
+    expect(checkout.with.ref).toBe("${{ github.sha }}");
+    expect(
+      job.steps
+        .map((step: Record<string, unknown>) => step.run)
+        .filter(Boolean),
+    ).toEqual([
+      "bun run check:biome-version",
+      "bun run lint:check",
+      "bun run format:check",
+    ]);
+  });
+
+  test("the pinned Biome rejects a planted deliberately misformatted candidate", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "merge-candidate-biome-"));
+    const sourceDir = path.join(root, "packages", "fixture", "src");
+    mkdirSync(sourceDir, { recursive: true });
+    const planted = path.join(sourceDir, "planted.ts");
+    writeFileSync(planted, "export const candidate={nested:{value:1}}\n");
+
+    try {
+      const result = Bun.spawnSync([
+        process.execPath,
+        "x",
+        "@biomejs/biome",
+        "format",
+        "--config-path",
+        path.join(REPO_ROOT, "biome.json"),
+        planted,
+      ]);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr.toString()).toContain(
+        "Formatter would have printed",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/scripts/__tests__/workflow-trigger-policy.test.ts
+++ b/packages/scripts/__tests__/workflow-trigger-policy.test.ts
@@ -1,4 +1,4 @@
-/** Exercises the repository policy that excludes pull-request workflow runs and restricts branch pushes to develop. */
+/** Exercises the repository policy that excludes pull-request workflow runs, reserves merge-queue admission, and restricts branch pushes to develop. */
 
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -19,7 +19,9 @@ function buildRepo(workflows: Record<string, string>): string {
   return root;
 }
 
-function validateFixture(workflow: string): ReturnType<typeof validateWorkflowTriggerPolicy> {
+function validateFixture(
+  workflow: string,
+): ReturnType<typeof validateWorkflowTriggerPolicy> {
   const root = buildRepo({ "test.yml": workflow });
   try {
     return validateWorkflowTriggerPolicy(root);
@@ -61,14 +63,36 @@ jobs: {}
   test.each([
     "pull_request",
     "pull_request_target",
-    "merge_group",
     "issue_comment",
     "pull_request_review",
     "pull_request_review_comment",
   ])("rejects the PR-adjacent %s trigger", (eventName) => {
     expect(() =>
-      validateFixture(`on:\n  push:\n    branches: [develop]\n  ${eventName}:\njobs: {}\n`),
+      validateFixture(
+        `on:\n  push:\n    branches: [develop]\n  ${eventName}:\njobs: {}\n`,
+      ),
     ).toThrow(/forbidden pull-request event trigger/);
+  });
+
+  test("reserves merge_group for the candidate Biome workflow", () => {
+    expect(() =>
+      validateFixture(
+        `on:\n  push:\n    branches: [develop]\n  merge_group:\njobs: {}\n`,
+      ),
+    ).toThrow(/merge_group is reserved for merge-candidate-biome\.yml/);
+
+    const root = buildRepo({
+      "develop.yml": `on:\n  push:\n    branches: [develop]\njobs: {}\n`,
+      "merge-candidate-biome.yml": `on:\n  merge_group:\n    types: [checks_requested]\njobs: {}\n`,
+    });
+    try {
+      expect(validateWorkflowTriggerPolicy(root)).toEqual({
+        developPushWorkflows: 1,
+        files: 2,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("rejects an unrestricted push", () => {

--- a/packages/scripts/workflow-trigger-policy.mjs
+++ b/packages/scripts/workflow-trigger-policy.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * Enforces develop-only automated branch workflows and rejects pull-request
- * event triggers so contributor branches cannot consume repository CI runners.
+ * event triggers. The credential-free merge-candidate Biome gate is the sole
+ * exception because it checks GitHub's synthesized queue tree before landing.
  */
 
 import { readdirSync, readFileSync } from "node:fs";
@@ -11,12 +12,13 @@ import { parseDocument } from "yaml";
 
 const FORBIDDEN_EVENTS = new Set([
   "issue_comment",
-  "merge_group",
   "pull_request",
   "pull_request_review",
   "pull_request_review_comment",
   "pull_request_target",
 ]);
+
+const MERGE_GROUP_WORKFLOW = "merge-candidate-biome.yml";
 
 function triggerEntries(value) {
   if (typeof value === "string") return [[value, null]];
@@ -52,8 +54,15 @@ export function validateWorkflowTriggerPolicy(repoRoot) {
     const workflow = document.toJS();
     const entries = triggerEntries(workflow?.on);
     for (const [eventName, config] of entries) {
+      if (eventName === "merge_group" && name !== MERGE_GROUP_WORKFLOW) {
+        failures.push(
+          `${name}: merge_group is reserved for ${MERGE_GROUP_WORKFLOW}`,
+        );
+      }
       if (FORBIDDEN_EVENTS.has(eventName)) {
-        failures.push(`${name}: forbidden pull-request event trigger: ${eventName}`);
+        failures.push(
+          `${name}: forbidden pull-request event trigger: ${eventName}`,
+        );
       }
       if (eventName !== "push") continue;
 
@@ -67,7 +76,8 @@ export function validateWorkflowTriggerPolicy(repoRoot) {
       const branches = stringList(config.branches);
       const tags = stringList(config.tags);
       const hasBranchIgnore = stringList(config["branches-ignore"]).length > 0;
-      if (branches.length === 0 && tags.length > 0 && !hasBranchIgnore) continue;
+      if (branches.length === 0 && tags.length > 0 && !hasBranchIgnore)
+        continue;
       if (
         branches.length !== 1 ||
         branches[0] !== "develop" ||
@@ -89,7 +99,7 @@ export function validateWorkflowTriggerPolicy(repoRoot) {
   if (failures.length > 0) {
     throw new Error(
       [
-        "GitHub workflow triggers must not run for pull requests, and automated branch pushes must target develop only:",
+        "GitHub workflow triggers must not run for pull requests, merge_group is reserved for the candidate Biome gate, and automated branch pushes must target develop only:",
         ...failures,
       ].join("\n"),
     );


### PR DESCRIPTION
# Relates to

Relates to #20523. This PR installs the repository side of the candidate-tree gate. A maintainer must enable the `develop` merge queue and require `Merge Candidate Biome / Candidate tree` in the ruleset before it becomes merge-blocking, so this does not claim to close the external policy/configuration step.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto current upstream `develop` (`d22178cc731a19b1da5e9c47c079f7ab4e78d087`) with zero conflicts.
- [x] `bun install` completed after sync; focused and full workspace gates were rerun on the exact rebased head.
- [x] A reviewer can confirm the candidate-tree and planted-format-failure contracts from the focused test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@46e5b107dafeb73244e5a063d463c43162d088d4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto upstream `develop` at `d22178cc731a19b1da5e9c47c079f7ab4e78d087`; zero conflicts.
- [x] Focused contracts and the full workspace lint and format gates were rerun after the final rebase; the exact-head contention caveat is recorded below.

# Risks

**Medium.** Once maintainers require the new stable check on `develop`, a formatting or lint failure in the synthesized queue tree blocks that candidate. That is the intended fail-closed behavior, but enabling the requirement should be coordinated with a green `develop` baseline and available hosted-runner capacity. The workflow is credential-free, read-only, listens only to `merge_group: checks_requested` (the event supports activity filtering, not target-branch filtering), and runs on `ubuntu-24.04` so a drained self-hosted fleet cannot silently bypass admission. The `develop` scope is enforced by the merge-queue ruleset that requires the check.

# Background

## What does this PR do?

- Adds one narrow `merge_group` workflow that explicitly checks out `${{ github.sha }}`, GitHub's synthesized candidate commit containing the current `develop` tip plus the queued PR group.
- Runs `check:biome-version`, full `lint:check`, and full `format:check` using the repository-pinned Bun/workspace setup.
- Changes the workflow-trigger policy from a blanket `merge_group` ban to an exact one-file exception; every other workflow remains prohibited from adding PR-adjacent triggers.
- Adds a workflow-shape test and a real planted regression: the test writes deliberately misformatted TypeScript and proves the pinned Biome CLI exits nonzero with formatter diagnostics.
- Documents that the merge-queue check, not post-merge health workflows, is the admission boundary.

This is deliberately not another one-file formatting repair. Closed PR #20552 repaired the original six files and merged PR #20589 repaired a later recurrence, but neither changed admission. The open issue comments explicitly leave the broader enforcement policy unresolved.

## What kind of change is this?

Bug fix / CI admission improvement.

# Documentation changes needed?

Documentation was required and `.github/workflows/README.md` now describes the candidate-tree gate, its stable required-check name, and the separate post-merge role of `ci.yml`.

# Testing

## Where should a reviewer start?

1. `.github/workflows/merge-candidate-biome.yml`
2. `packages/scripts/__tests__/merge-candidate-biome-workflow.test.ts`
3. `packages/scripts/workflow-trigger-policy.mjs`

## Detailed testing steps

```text
bun test --config packages/scripts/bunfig.script-tests.toml \
  packages/scripts/__tests__/workflow-trigger-policy.test.ts \
  packages/scripts/__tests__/merge-candidate-biome-workflow.test.ts
=> 12 assertions passed, including the real planted misformatted-file rejection; the checked-in 54-workflow census exceeded its five-second harness deadline under concurrent full-workspace gate load (see Known gaps)

node packages/scripts/workflow-trigger-policy.mjs
=> verified 54 workflows; 18 develop push surfaces

bun run check:biome-version
=> Biome version consistency passed

bun run lint:check
=> 135 successful / 135 total

bun run format:check
=> 135 successful / 135 total

git diff --check
=> clean
```

# Evidence Gate

<!-- evidence-head:c9db5fb2c01ed4beeb88bc0f467dd5638db5f4d1 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - CI workflow and script-contract change; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - CI workflow and script-contract change; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing interactive flow.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no server/runtime path; exact focused test and workspace-gate output is included above.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no data/domain state; the produced artifact is the workflow contract itself.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic CI metadata and formatter execution only.`

## Backend + frontend logs

`N/A - no backend or frontend runtime path. The exact-head deterministic command results are listed under Testing.`

## Screenshots (before / after) + video walkthrough

`N/A - no UI files or rendered product surface changed.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT change.`

## Known gaps / failures

- `bun run verify` progressed through repository preflight audits and the clean-build/typecheck graph without a reported failure, but was interrupted after roughly twelve minutes because host contention left declaration builds taking more than ten minutes each. The directly affected contracts and both full workspace Biome gates completed successfully; hosted CI remains authoritative for the unfinished aggregate gate.
- After the final upstream rebase, the focused suite completed 12 assertions before the checked-in 54-workflow census exceeded its five-second test-harness deadline while the two full workspace gates were running concurrently. The same census passed on the immediately preceding head, and the exact-head full lint and format gates both completed 135/135; hosted CI should rerun the focused suite without host contention.
- No live `merge_group` run can exist before the branch is published and maintainers enable the queue/ruleset. After publication, require `Merge Candidate Biome / Candidate tree`, enqueue a deliberately bad test branch, and retain the failed candidate-run URL as final external evidence before closing #20523.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@46e5b107dafeb73244e5a063d463c43162d088d4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-20523]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@46e5b107dafeb73244e5a063d463c43162d088d4:packages/skills/skills/contribute-to-eliza"} -->
