### PR TITLE
feat(trajectories): add semantic stage contract

### DIFF
--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -21,6 +21,7 @@ import {
   type JsonValue,
   ModelType,
   observationExtractionTemplate,
+  parseTrajectorySemanticStages,
   redactBasicEmails,
   resolveStateDir,
   resolveTrajectoryGate,
@@ -3454,6 +3455,7 @@ export function parsePersistedStepObject(
   const skillInvocations = parsePersistedSkillInvocations(
     record.skillInvocations,
   );
+  const semanticStages = parseTrajectorySemanticStages(record.semanticStages);
   const action = parsePersistedActionAttempt(record.action);
   return {
     stepId,
@@ -3474,6 +3476,7 @@ export function parsePersistedStepObject(
     ...(scriptHash !== undefined ? { scriptHash } : {}),
     ...(evaluatorName !== undefined ? { evaluatorName } : {}),
     ...(skillInvocations !== undefined ? { skillInvocations } : {}),
+    ...(semanticStages !== undefined ? { semanticStages } : {}),
   };
 }
 
@@ -3558,6 +3561,7 @@ function normalizeStepForPersistence(
     childSteps,
     usedSkills,
     skillInvocations,
+    semanticStages,
     script,
     ...scalarFields
   } = step;
@@ -3624,6 +3628,9 @@ function normalizeStepForPersistence(
           skillInvocations:
             parsePersistedSkillInvocations(skillInvocations) ?? [],
         }
+      : {}),
+    ...(semanticStages !== undefined
+      ? { semanticStages: parseTrajectorySemanticStages(semanticStages) }
       : {}),
     ...(script !== undefined ? { script } : {}),
   };

--- a/packages/agent/src/runtime/trajectory-steps.test.ts
+++ b/packages/agent/src/runtime/trajectory-steps.test.ts
@@ -527,6 +527,72 @@ describe("trajectory_steps dedicated table", () => {
     });
   });
 
+  it("round-trips versioned semantic stages through dedicated step rows", async () => {
+    const trajectory = createBaseTrajectory(
+      trajectoryId,
+      1_700_000_000_000,
+      runtime.agentId,
+      "test",
+    );
+    const step = trajectory.steps[0];
+    if (!step) throw new Error("fixture step is missing");
+    step.semanticStages = [
+      {
+        schemaVersion: 1,
+        stageId: "tool-search-1",
+        kind: "toolSearch",
+        iteration: 1,
+        startedAt: 1_700_000_000_001,
+        endedAt: 1_700_000_000_009,
+        latencyMs: 8,
+        payload: {
+          toolSearch: {
+            query: {
+              text: "schedule a workout",
+              candidateActions: ["OWNER_ROUTINES", "VIEWS"],
+            },
+            results: [
+              { name: "OWNER_ROUTINES", score: 0.91, rank: 1 },
+              { name: "VIEWS", score: 0.22, rank: 2 },
+            ],
+            selectedActions: ["OWNER_ROUTINES"],
+          },
+        },
+      },
+    ];
+
+    await expect(saveTrajectory(runtime, trajectory)).resolves.toBe(true);
+    const loaded = await loadTrajectoryById(runtime, trajectoryId);
+
+    expect(loaded?.steps[0]?.semanticStages).toEqual(step.semanticStages);
+  });
+
+  it("rejects malformed semantic stages before persisting a step", async () => {
+    const trajectory = createBaseTrajectory(
+      trajectoryId,
+      1_700_000_000_000,
+      runtime.agentId,
+      "test",
+    );
+    const step = trajectory.steps[0];
+    if (!step) throw new Error("fixture step is missing");
+    step.semanticStages = [
+      {
+        schemaVersion: 1,
+        stageId: "invalid-stage",
+        kind: "toolSearch",
+        startedAt: 2,
+        endedAt: 1,
+        latencyMs: 1,
+        payload: {},
+      },
+    ];
+
+    await expect(saveTrajectory(runtime, trajectory)).rejects.toMatchObject({
+      code: "TRAJECTORY_SEMANTIC_STAGE_INVALID",
+    });
+  });
+
   it("rejects malformed SQL result containers instead of reporting empty reads or deletes", async () => {
     type MalformedDb = {
       execute: () => Promise<Record<string, never>>;

--- a/packages/core/src/features/trajectories/read-routes.test.ts
+++ b/packages/core/src/features/trajectories/read-routes.test.ts
@@ -186,6 +186,22 @@ describe("tryHandleTrajectoryReadRoutes", () => {
 				steps: [
 					{
 						stepId: "s0",
+						semanticStages: [
+							{
+								schemaVersion: 1,
+								stageId: "search-1",
+								kind: "toolSearch",
+								startedAt: 501,
+								endedAt: 503,
+								latencyMs: 2,
+								payload: {
+									toolSearch: {
+										query: { candidateActions: ["REPLY"] },
+										results: [{ name: "REPLY", rank: 1, score: 1 }],
+									},
+								},
+							},
+						],
 						llmCalls: [
 							{
 								callId: "c0",
@@ -237,6 +253,10 @@ describe("tryHandleTrajectoryReadRoutes", () => {
 			llmCalls: Array<{ stepType: string }>;
 			providerAccesses: unknown[];
 			toolEvents: Array<{ actionName: string; success: boolean }>;
+			semanticStages: Array<{
+				stageId: string;
+				payload: Record<string, unknown>;
+			}>;
 		};
 		expect(b.trajectory).toMatchObject({
 			id: "abc",
@@ -257,6 +277,17 @@ describe("tryHandleTrajectoryReadRoutes", () => {
 			success: true,
 			type: "tool_result",
 		});
+		expect(b.semanticStages).toMatchObject([
+			{
+				stageId: "search-1",
+				payload: {
+					toolSearch: {
+						query: { candidateActions: ["REPLY"] },
+						results: [{ name: "REPLY", rank: 1 }],
+					},
+				},
+			},
+		]);
 	});
 
 	it("returns LLM-only detail without fabricating a tool event", async () => {

--- a/packages/core/src/features/trajectories/read-routes.ts
+++ b/packages/core/src/features/trajectories/read-routes.ts
@@ -13,6 +13,7 @@
 
 import type { ServerResponse } from "node:http";
 import { ElizaError } from "../../errors";
+import type { TrajectorySemanticStageRecord } from "../../services/trajectory-semantic-stage";
 import type { IAgentRuntime, UUID } from "../../types";
 
 interface ServiceTrajectoryListItem {
@@ -61,6 +62,7 @@ interface ServiceTrajectoryStep {
 	providerAccesses: ServiceProviderAccess[];
 	/** Absent on action-optional Agent-bridge steps (LLM-only capture). */
 	action?: ServiceActionAttempt;
+	semanticStages?: TrajectorySemanticStageRecord[];
 }
 
 interface ServiceTrajectory {
@@ -203,9 +205,11 @@ function detailToUi(
 	const llmCalls: Array<Record<string, unknown>> = [];
 	const providerAccesses: Array<Record<string, unknown>> = [];
 	const toolEvents: Array<Record<string, unknown>> = [];
+	const semanticStages: TrajectorySemanticStageRecord[] = [];
 
 	const steps = traj.steps;
 	for (const step of steps) {
+		if (step.semanticStages) semanticStages.push(...step.semanticStages);
 		const calls = step.llmCalls;
 		for (const c of calls) {
 			llmCalls.push({
@@ -280,6 +284,7 @@ function detailToUi(
 		providerAccesses,
 		toolEvents,
 		evaluationEvents: [],
+		semanticStages,
 	};
 }
 

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -50,20 +50,16 @@ import {
 	canonicalPromptForModelCall,
 	omitUnvalidatedProviderSpans,
 } from "./trajectory-provider-attribution";
+import type { RecordedStageKind } from "./trajectory-stage-kind";
+
+export {
+	RECORDED_STAGE_KINDS,
+	type RecordedStageKind,
+} from "./trajectory-stage-kind";
 
 // ---------------------------------------------------------------------------
 // Schema (mirrors PLAN.md §18.1)
 // ---------------------------------------------------------------------------
-
-export type RecordedStageKind =
-	| "messageHandler"
-	| "planner"
-	| "tool"
-	| "toolSearch"
-	| "evaluation"
-	| "subPlanner"
-	| "compaction"
-	| "factsAndRelationships";
 
 export interface RecordedUsage {
 	promptTokens?: number;

--- a/packages/core/src/runtime/trajectory-stage-kind.ts
+++ b/packages/core/src/runtime/trajectory-stage-kind.ts
@@ -1,0 +1,14 @@
+/** Defines the canonical semantic stage-kind vocabulary shared by trajectory producers and transports. */
+
+export const RECORDED_STAGE_KINDS = [
+	"messageHandler",
+	"planner",
+	"tool",
+	"toolSearch",
+	"evaluation",
+	"subPlanner",
+	"compaction",
+	"factsAndRelationships",
+] as const;
+
+export type RecordedStageKind = (typeof RECORDED_STAGE_KINDS)[number];

--- a/packages/core/src/services/trajectories.ts
+++ b/packages/core/src/services/trajectories.ts
@@ -9,6 +9,7 @@ export { tryHandleTrajectoryReadRoutes } from "../features/trajectories/read-rou
 export { TrajectoriesService } from "../features/trajectories/TrajectoriesService";
 export * from "./trajectory-export";
 export * from "./trajectory-json";
+export * from "./trajectory-semantic-stage";
 export * from "./trajectory-types";
 
 import type {

--- a/packages/core/src/services/trajectory-export.test.ts
+++ b/packages/core/src/services/trajectory-export.test.ts
@@ -32,6 +32,22 @@ const sampleTrajectory: TrajectoryDetailRecord = {
 			stepId: "step-1",
 			timestamp: 1_700_000_000_010,
 			kind: "llm",
+			semanticStages: [
+				{
+					schemaVersion: 1,
+					stageId: "stage-tool-search-1",
+					kind: "toolSearch",
+					startedAt: 1_700_000_000_001,
+					endedAt: 1_700_000_000_009,
+					latencyMs: 8,
+					payload: {
+						toolSearch: {
+							query: { candidateActions: ["OWNER_ROUTINES", "VIEWS"] },
+							results: [{ name: "OWNER_ROUTINES", rank: 1, score: 0.91 }],
+						},
+					},
+				},
+			],
 			llmCalls: [
 				{
 					callId: "call-1",
@@ -97,6 +113,30 @@ describe("trajectory-export", () => {
 				stepsJson: JSON.stringify({ stepId: "not-an-array" }),
 			}),
 		).toThrow("Trajectory steps must be an array");
+		expect(() =>
+			summarizeTrajectoryUsage({
+				...sampleTrajectory,
+				stepsJson: JSON.stringify([
+					{
+						stepId: "corrupt-semantic-stage",
+						timestamp: 1,
+						llmCalls: [],
+						semanticStages: [
+							{
+								schemaVersion: 1,
+								stageId: "self-parent",
+								parentStageId: "self-parent",
+								kind: "planner",
+								startedAt: 1,
+								endedAt: 2,
+								latencyMs: 1,
+								payload: {},
+							},
+						],
+					},
+				]),
+			}),
+		).toThrow("Trajectory semantic stage is invalid");
 	});
 
 	it("summarizes cache usage without double-counting prompt tokens", () => {
@@ -151,6 +191,23 @@ describe("trajectory-export", () => {
 			},
 			response: {
 				text: "Hello there",
+			},
+			metadata: {
+				trajectory_step: {
+					semanticStages: [
+						{
+							stageId: "stage-tool-search-1",
+							payload: {
+								toolSearch: {
+									query: {
+										candidateActions: ["OWNER_ROUTINES", "VIEWS"],
+									},
+									results: [{ name: "OWNER_ROUTINES", rank: 1 }],
+								},
+							},
+						},
+					],
+				},
 			},
 		});
 

--- a/packages/core/src/services/trajectory-export.ts
+++ b/packages/core/src/services/trajectory-export.ts
@@ -14,6 +14,7 @@ export {
 	trajectoryToPlaintext,
 } from "../activity-plaintext";
 
+import { parseTrajectorySemanticStages } from "./trajectory-semantic-stage";
 import type {
 	ElizaNativeModelBoundary,
 	ElizaNativeModelRequestRecord,
@@ -143,7 +144,7 @@ function listTrajectorySteps(
 	trajectory: TrajectoryDetailRecord,
 ): TrajectoryStepRecord[] {
 	if (Array.isArray(trajectory.steps)) {
-		return trajectory.steps;
+		return trajectory.steps.map(validateStepSemanticStages);
 	}
 	if (
 		typeof trajectory.stepsJson !== "string" ||
@@ -169,7 +170,19 @@ function listTrajectorySteps(
 			context: { trajectoryId: trajectory.trajectoryId },
 		});
 	}
-	return parsed as TrajectoryStepRecord[];
+	return parsed.map((step) =>
+		validateStepSemanticStages(step as TrajectoryStepRecord),
+	);
+}
+
+function validateStepSemanticStages(
+	step: TrajectoryStepRecord,
+): TrajectoryStepRecord {
+	if (step.semanticStages === undefined) return step;
+	return {
+		...step,
+		semanticStages: parseTrajectorySemanticStages(step.semanticStages),
+	};
 }
 
 function listStepLlmCalls(
@@ -340,6 +353,9 @@ export function iterateTrajectoryLlmCalls(
 						? { skillInvocations: step.skillInvocations }
 						: {}),
 					...(step.evaluatorName ? { evaluatorName: step.evaluatorName } : {}),
+					...(step.semanticStages
+						? { semanticStages: step.semanticStages }
+						: {}),
 				},
 			});
 		}

--- a/packages/core/src/services/trajectory-semantic-stage.test.ts
+++ b/packages/core/src/services/trajectory-semantic-stage.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Exercises the semantic-stage adapter and strict persisted-envelope parser
+ * with deterministic runtime-stage fixtures, including retrieval diagnostics.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { RecordedStage } from "../runtime/trajectory-recorder";
+import {
+	parseTrajectorySemanticStage,
+	parseTrajectorySemanticStages,
+	recordedStageToSemanticStage,
+} from "./trajectory-semantic-stage";
+
+const toolSearchStage: RecordedStage = {
+	stageId: "stage-tool-search-1",
+	kind: "toolSearch",
+	iteration: 1,
+	startedAt: 1_000,
+	endedAt: 1_012,
+	latencyMs: 12,
+	toolSearch: {
+		query: {
+			text: "schedule a workout",
+			candidateActions: ["OWNER_ROUTINES", "VIEWS"],
+			parentActionHints: ["OWNER_ROUTINES"],
+		},
+		results: [
+			{ name: "OWNER_ROUTINES", score: 0.91, rank: 1, rrfScore: 0.031 },
+			{ name: "VIEWS", score: 0.22, rank: 2, rrfScore: 0.016 },
+		],
+		tier: {
+			tierA: ["OWNER_ROUTINES"],
+			tierB: ["VIEWS"],
+			omitted: 0,
+		},
+		durationMs: 12,
+		fusedTopK: [{ actionName: "OWNER_ROUTINES", rrfScore: 0.031, rank: 1 }],
+		selectedActions: ["OWNER_ROUTINES"],
+	},
+};
+
+describe("trajectory semantic stages", () => {
+	it("adapts the established runtime stage without losing candidates or ranks", () => {
+		const semantic = recordedStageToSemanticStage(toolSearchStage);
+
+		expect(semantic).toMatchObject({
+			schemaVersion: 1,
+			stageId: "stage-tool-search-1",
+			kind: "toolSearch",
+			iteration: 1,
+			latencyMs: 12,
+			payload: {
+				toolSearch: {
+					query: {
+						candidateActions: ["OWNER_ROUTINES", "VIEWS"],
+					},
+					results: [
+						{ name: "OWNER_ROUTINES", rank: 1 },
+						{ name: "VIEWS", rank: 2 },
+					],
+					selectedActions: ["OWNER_ROUTINES"],
+				},
+			},
+		});
+	});
+
+	it("round-trips a valid versioned envelope", () => {
+		const semantic = recordedStageToSemanticStage(toolSearchStage);
+		expect(
+			parseTrajectorySemanticStage(JSON.parse(JSON.stringify(semantic))),
+		).toEqual(semantic);
+		expect(parseTrajectorySemanticStages([semantic])).toEqual([semantic]);
+		expect(parseTrajectorySemanticStages(undefined)).toBeUndefined();
+	});
+
+	it.each([
+		["unknown schema", { schemaVersion: 2 }],
+		["unknown stage kind", { kind: "retrieval" }],
+		["negative timing", { latencyMs: -1 }],
+		["reversed timing", { endedAt: 999 }],
+		["unknown envelope field", { unexpected: true }],
+		["contradictory latency", { latencyMs: 11 }],
+		["whitespace stage id", { stageId: " stage-tool-search-1" }],
+		["self parent", { parentStageId: "stage-tool-search-1" }],
+	])("rejects %s", (_label, patch) => {
+		const semantic = recordedStageToSemanticStage(toolSearchStage);
+		expect(() =>
+			parseTrajectorySemanticStage({ ...semantic, ...patch }),
+		).toThrow(/semantic stage is invalid/i);
+	});
+
+	it("rejects unknown, non-JSON, cyclic, and over-bounded payloads", () => {
+		const semantic = recordedStageToSemanticStage(toolSearchStage);
+		expect(() =>
+			parseTrajectorySemanticStage({
+				...semantic,
+				payload: { retrieval: {} },
+			}),
+		).toThrow(/semantic stage is invalid/i);
+		expect(() =>
+			parseTrajectorySemanticStage({
+				...semantic,
+				payload: { toolSearch: { invalid: undefined } },
+			}),
+		).toThrow(/semantic stage is invalid/i);
+
+		const cyclic: Record<string, unknown> = {};
+		cyclic.self = cyclic;
+		expect(() =>
+			parseTrajectorySemanticStage({
+				...semantic,
+				payload: { toolSearch: cyclic },
+			}),
+		).toThrow(/semantic stage is invalid/i);
+		expect(() =>
+			parseTrajectorySemanticStages(
+				Array.from({ length: 251 }, () => semantic),
+			),
+		).toThrow(/semantic stage is invalid/i);
+	});
+});

--- a/packages/core/src/services/trajectory-semantic-stage.test.ts
+++ b/packages/core/src/services/trajectory-semantic-stage.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, it } from "vitest";
 import type { RecordedStage } from "../runtime/trajectory-recorder";
+import { RECORDED_STAGE_KINDS } from "../runtime/trajectory-stage-kind";
 import {
 	parseTrajectorySemanticStage,
 	parseTrajectorySemanticStages,
@@ -73,6 +74,15 @@ describe("trajectory semantic stages", () => {
 		expect(parseTrajectorySemanticStages(undefined)).toBeUndefined();
 	});
 
+	it("accepts every stage kind from the runtime's canonical vocabulary", () => {
+		const semantic = recordedStageToSemanticStage(toolSearchStage);
+		for (const kind of RECORDED_STAGE_KINDS) {
+			expect(parseTrajectorySemanticStage({ ...semantic, kind }).kind).toBe(
+				kind,
+			);
+		}
+	});
+
 	it.each([
 		["unknown schema", { schemaVersion: 2 }],
 		["unknown stage kind", { kind: "retrieval" }],
@@ -116,6 +126,31 @@ describe("trajectory semantic stages", () => {
 			parseTrajectorySemanticStages(
 				Array.from({ length: 251 }, () => semantic),
 			),
+		).toThrow(/semantic stage is invalid/i);
+	});
+
+	it("applies node and byte budgets across the complete stage array", () => {
+		const semantic = recordedStageToSemanticStage(toolSearchStage);
+		expect(() =>
+			parseTrajectorySemanticStages([
+				{ ...semantic, stageId: "duplicate" },
+				{ ...semantic, stageId: "duplicate" },
+			]),
+		).toThrow(/semantic stage is invalid/i);
+
+		const largePayload = {
+			model: Object.fromEntries(
+				Array.from({ length: 10 }, (_, index) => [
+					`field-${index}`,
+					"x".repeat(60_000),
+				]),
+			),
+		};
+		expect(() =>
+			parseTrajectorySemanticStages([
+				{ ...semantic, stageId: "large-1", payload: largePayload },
+				{ ...semantic, stageId: "large-2", payload: largePayload },
+			]),
 		).toThrow(/semantic stage is invalid/i);
 	});
 });

--- a/packages/core/src/services/trajectory-semantic-stage.ts
+++ b/packages/core/src/services/trajectory-semantic-stage.ts
@@ -5,10 +5,11 @@
  */
 
 import { ElizaError } from "../errors";
-import type {
-	RecordedStage,
-	RecordedStageKind,
-} from "../runtime/trajectory-recorder";
+import type { RecordedStage } from "../runtime/trajectory-recorder";
+import {
+	RECORDED_STAGE_KINDS,
+	type RecordedStageKind,
+} from "../runtime/trajectory-stage-kind";
 import type { JsonValue } from "../types/primitives";
 import { asRecord } from "../utils/type-guards";
 import { sanitizeTrajectoryJsonObject } from "./trajectory-json";
@@ -20,6 +21,8 @@ const TRAJECTORY_SEMANTIC_STAGE_MAX_DEPTH = 20;
 const TRAJECTORY_SEMANTIC_STAGE_MAX_NODES = 5_000;
 const TRAJECTORY_SEMANTIC_STAGE_MAX_STRING_CHARS = 64 * 1024;
 const TRAJECTORY_SEMANTIC_STAGE_MAX_ID_CHARS = 256;
+const TRAJECTORY_SEMANTIC_STAGES_MAX_JSON_BYTES = 1024 * 1024;
+const utf8Encoder = new TextEncoder();
 
 const SEMANTIC_STAGE_KEYS = new Set([
 	"schemaVersion",
@@ -43,16 +46,7 @@ const SEMANTIC_STAGE_PAYLOAD_KEYS = new Set([
 	"factsAndRelationships",
 ]);
 
-const RECORDED_STAGE_KINDS = new Set<RecordedStageKind>([
-	"messageHandler",
-	"planner",
-	"tool",
-	"toolSearch",
-	"evaluation",
-	"subPlanner",
-	"compaction",
-	"factsAndRelationships",
-]);
+const RECORDED_STAGE_KIND_SET = new Set<string>(RECORDED_STAGE_KINDS);
 
 /** A bounded, transport-safe semantic stage attached to a trajectory step. */
 export interface TrajectorySemanticStageRecord {
@@ -124,7 +118,11 @@ function optionalNonNegativeInteger(
 
 function isJsonValue(
 	value: unknown,
-	state: { seen: WeakSet<object>; nodes: number },
+	state: {
+		seen: WeakSet<object>;
+		nodes: number;
+		remainingBytes: number;
+	},
 	depth = 0,
 ): value is JsonValue {
 	state.nodes += 1;
@@ -134,13 +132,22 @@ function isJsonValue(
 	) {
 		return false;
 	}
+	const serializedScalarBytes = (scalar: string | number | boolean | null) =>
+		utf8Encoder.encode(JSON.stringify(scalar)).byteLength;
 	if (value === null || typeof value === "boolean") {
-		return true;
+		state.remainingBytes -= serializedScalarBytes(value);
+		return state.remainingBytes >= 0;
 	}
 	if (typeof value === "string") {
-		return value.length <= TRAJECTORY_SEMANTIC_STAGE_MAX_STRING_CHARS;
+		if (value.length > TRAJECTORY_SEMANTIC_STAGE_MAX_STRING_CHARS) return false;
+		state.remainingBytes -= serializedScalarBytes(value);
+		return state.remainingBytes >= 0;
 	}
-	if (typeof value === "number") return Number.isFinite(value);
+	if (typeof value === "number") {
+		if (!Number.isFinite(value)) return false;
+		state.remainingBytes -= serializedScalarBytes(value);
+		return state.remainingBytes >= 0;
+	}
 	if (typeof value !== "object") return false;
 	if (state.seen.has(value)) return false;
 	state.seen.add(value);
@@ -154,11 +161,24 @@ function isJsonValue(
 	if (prototype !== Object.prototype && prototype !== null) return false;
 	const record = asRecord(value);
 	if (!record || Object.keys(record).length > 200) return false;
-	const valid = Object.values(record).every((entry) =>
-		isJsonValue(entry, state, depth + 1),
-	);
+	const valid = Object.entries(record).every(([key, entry]) => {
+		state.remainingBytes -= serializedScalarBytes(key) + 1;
+		return state.remainingBytes >= 0 && isJsonValue(entry, state, depth + 1);
+	});
 	state.seen.delete(value);
 	return valid;
+}
+
+function createSemanticStageValidationState(): {
+	seen: WeakSet<object>;
+	nodes: number;
+	remainingBytes: number;
+} {
+	return {
+		seen: new WeakSet(),
+		nodes: 0,
+		remainingBytes: TRAJECTORY_SEMANTIC_STAGES_MAX_JSON_BYTES,
+	};
 }
 
 /** Convert the established runtime recorder stage into the shared envelope. */
@@ -194,12 +214,25 @@ export function recordedStageToSemanticStage(
 export function recordedStagesToSemanticStages(
 	stages: readonly RecordedStage[],
 ): TrajectorySemanticStageRecord[] {
-	return stages.map(recordedStageToSemanticStage);
+	return (
+		parseTrajectorySemanticStages(stages.map(recordedStageToSemanticStage)) ??
+		[]
+	);
 }
 
 /** Validate one untrusted persisted semantic-stage envelope. */
 export function parseTrajectorySemanticStage(
 	value: unknown,
+): TrajectorySemanticStageRecord {
+	return parseTrajectorySemanticStageWithState(
+		value,
+		createSemanticStageValidationState(),
+	);
+}
+
+function parseTrajectorySemanticStageWithState(
+	value: unknown,
+	validationState: ReturnType<typeof createSemanticStageValidationState>,
 ): TrajectorySemanticStageRecord {
 	const record = asRecord(value);
 	if (!record) throw invalidSemanticStage("stage");
@@ -212,7 +245,7 @@ export function parseTrajectorySemanticStage(
 	const stageId = requiredStageId(record.stageId, "stageId");
 	if (
 		typeof record.kind !== "string" ||
-		!RECORDED_STAGE_KINDS.has(record.kind as RecordedStageKind)
+		!RECORDED_STAGE_KIND_SET.has(record.kind)
 	) {
 		throw invalidSemanticStage("kind", record.kind);
 	}
@@ -240,7 +273,7 @@ export function parseTrajectorySemanticStage(
 	if (
 		!payload ||
 		!hasOnlyKeys(payload, SEMANTIC_STAGE_PAYLOAD_KEYS) ||
-		!isJsonValue(payload, { seen: new WeakSet(), nodes: 0 })
+		!isJsonValue(payload, validationState)
 	) {
 		throw invalidSemanticStage("payload");
 	}
@@ -267,5 +300,17 @@ export function parseTrajectorySemanticStages(
 	if (value.length > TRAJECTORY_SEMANTIC_STAGES_MAX_ITEMS) {
 		throw invalidSemanticStage("semanticStages.length", value.length);
 	}
-	return value.map(parseTrajectorySemanticStage);
+	const validationState = createSemanticStageValidationState();
+	const stageIds = new Set<string>();
+	return value.map((stage) => {
+		const parsed = parseTrajectorySemanticStageWithState(
+			stage,
+			validationState,
+		);
+		if (stageIds.has(parsed.stageId)) {
+			throw invalidSemanticStage("stageId.duplicate", parsed.stageId);
+		}
+		stageIds.add(parsed.stageId);
+		return parsed;
+	});
 }

--- a/packages/core/src/services/trajectory-semantic-stage.ts
+++ b/packages/core/src/services/trajectory-semantic-stage.ts
@@ -1,0 +1,271 @@
+/**
+ * Defines the versioned semantic-stage envelope shared by trajectory storage,
+ * exports, and viewer read contracts, adapting the richer runtime recorder
+ * stages without creating a second stage vocabulary.
+ */
+
+import { ElizaError } from "../errors";
+import type {
+	RecordedStage,
+	RecordedStageKind,
+} from "../runtime/trajectory-recorder";
+import type { JsonValue } from "../types/primitives";
+import { asRecord } from "../utils/type-guards";
+import { sanitizeTrajectoryJsonObject } from "./trajectory-json";
+
+export const TRAJECTORY_SEMANTIC_STAGE_SCHEMA_VERSION = 1 as const;
+
+const TRAJECTORY_SEMANTIC_STAGES_MAX_ITEMS = 250;
+const TRAJECTORY_SEMANTIC_STAGE_MAX_DEPTH = 20;
+const TRAJECTORY_SEMANTIC_STAGE_MAX_NODES = 5_000;
+const TRAJECTORY_SEMANTIC_STAGE_MAX_STRING_CHARS = 64 * 1024;
+const TRAJECTORY_SEMANTIC_STAGE_MAX_ID_CHARS = 256;
+
+const SEMANTIC_STAGE_KEYS = new Set([
+	"schemaVersion",
+	"stageId",
+	"kind",
+	"iteration",
+	"retryIdx",
+	"parentStageId",
+	"startedAt",
+	"endedAt",
+	"latencyMs",
+	"payload",
+]);
+
+const SEMANTIC_STAGE_PAYLOAD_KEYS = new Set([
+	"model",
+	"tool",
+	"toolSearch",
+	"evaluation",
+	"cache",
+	"factsAndRelationships",
+]);
+
+const RECORDED_STAGE_KINDS = new Set<RecordedStageKind>([
+	"messageHandler",
+	"planner",
+	"tool",
+	"toolSearch",
+	"evaluation",
+	"subPlanner",
+	"compaction",
+	"factsAndRelationships",
+]);
+
+/** A bounded, transport-safe semantic stage attached to a trajectory step. */
+export interface TrajectorySemanticStageRecord {
+	schemaVersion: typeof TRAJECTORY_SEMANTIC_STAGE_SCHEMA_VERSION;
+	stageId: string;
+	kind: RecordedStageKind;
+	iteration?: number;
+	retryIdx?: number;
+	parentStageId?: string;
+	startedAt: number;
+	endedAt: number;
+	latencyMs: number;
+	payload: Record<string, JsonValue>;
+}
+
+function invalidSemanticStage(field: string, value?: unknown): ElizaError {
+	return new ElizaError("Trajectory semantic stage is invalid", {
+		code: "TRAJECTORY_SEMANTIC_STAGE_INVALID",
+		context: {
+			field,
+			...(typeof value === "string" || typeof value === "number"
+				? { value }
+				: {}),
+		},
+	});
+}
+
+function hasOnlyKeys(
+	record: Record<string, unknown>,
+	allowed: ReadonlySet<string>,
+): boolean {
+	return Object.keys(record).every((key) => allowed.has(key));
+}
+
+function requiredStageId(value: unknown, field: string): string {
+	if (
+		typeof value !== "string" ||
+		!value.trim() ||
+		value !== value.trim() ||
+		value.length > TRAJECTORY_SEMANTIC_STAGE_MAX_ID_CHARS
+	) {
+		throw invalidSemanticStage(field);
+	}
+	return value;
+}
+
+function requiredFiniteNumber(
+	record: Record<string, unknown>,
+	field: "startedAt" | "endedAt" | "latencyMs",
+): number {
+	const value = record[field];
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+		throw invalidSemanticStage(field, value);
+	}
+	return value;
+}
+
+function optionalNonNegativeInteger(
+	record: Record<string, unknown>,
+	field: "iteration" | "retryIdx",
+): number | undefined {
+	const value = record[field];
+	if (value === undefined) return undefined;
+	if (!Number.isInteger(value) || (value as number) < 0) {
+		throw invalidSemanticStage(field, value);
+	}
+	return value as number;
+}
+
+function isJsonValue(
+	value: unknown,
+	state: { seen: WeakSet<object>; nodes: number },
+	depth = 0,
+): value is JsonValue {
+	state.nodes += 1;
+	if (
+		state.nodes > TRAJECTORY_SEMANTIC_STAGE_MAX_NODES ||
+		depth > TRAJECTORY_SEMANTIC_STAGE_MAX_DEPTH
+	) {
+		return false;
+	}
+	if (value === null || typeof value === "boolean") {
+		return true;
+	}
+	if (typeof value === "string") {
+		return value.length <= TRAJECTORY_SEMANTIC_STAGE_MAX_STRING_CHARS;
+	}
+	if (typeof value === "number") return Number.isFinite(value);
+	if (typeof value !== "object") return false;
+	if (state.seen.has(value)) return false;
+	state.seen.add(value);
+	if (Array.isArray(value)) {
+		if (value.length > TRAJECTORY_SEMANTIC_STAGES_MAX_ITEMS) return false;
+		const valid = value.every((entry) => isJsonValue(entry, state, depth + 1));
+		state.seen.delete(value);
+		return valid;
+	}
+	const prototype = Object.getPrototypeOf(value);
+	if (prototype !== Object.prototype && prototype !== null) return false;
+	const record = asRecord(value);
+	if (!record || Object.keys(record).length > 200) return false;
+	const valid = Object.values(record).every((entry) =>
+		isJsonValue(entry, state, depth + 1),
+	);
+	state.seen.delete(value);
+	return valid;
+}
+
+/** Convert the established runtime recorder stage into the shared envelope. */
+export function recordedStageToSemanticStage(
+	stage: RecordedStage,
+): TrajectorySemanticStageRecord {
+	const payload = sanitizeTrajectoryJsonObject({
+		...(stage.model ? { model: stage.model } : {}),
+		...(stage.tool ? { tool: stage.tool } : {}),
+		...(stage.toolSearch ? { toolSearch: stage.toolSearch } : {}),
+		...(stage.evaluation ? { evaluation: stage.evaluation } : {}),
+		...(stage.cache ? { cache: stage.cache } : {}),
+		...(stage.factsAndRelationships
+			? { factsAndRelationships: stage.factsAndRelationships }
+			: {}),
+	});
+	if (!payload) throw invalidSemanticStage("payload");
+	return parseTrajectorySemanticStage({
+		schemaVersion: TRAJECTORY_SEMANTIC_STAGE_SCHEMA_VERSION,
+		stageId: stage.stageId,
+		kind: stage.kind,
+		...(stage.iteration !== undefined ? { iteration: stage.iteration } : {}),
+		...(stage.retryIdx !== undefined ? { retryIdx: stage.retryIdx } : {}),
+		...(stage.parentStageId ? { parentStageId: stage.parentStageId } : {}),
+		startedAt: stage.startedAt,
+		endedAt: stage.endedAt,
+		latencyMs: stage.latencyMs,
+		payload,
+	});
+}
+
+/** Convert runtime recorder stages while preserving their recorded order. */
+export function recordedStagesToSemanticStages(
+	stages: readonly RecordedStage[],
+): TrajectorySemanticStageRecord[] {
+	return stages.map(recordedStageToSemanticStage);
+}
+
+/** Validate one untrusted persisted semantic-stage envelope. */
+export function parseTrajectorySemanticStage(
+	value: unknown,
+): TrajectorySemanticStageRecord {
+	const record = asRecord(value);
+	if (!record) throw invalidSemanticStage("stage");
+	if (!hasOnlyKeys(record, SEMANTIC_STAGE_KEYS)) {
+		throw invalidSemanticStage("stage.keys");
+	}
+	if (record.schemaVersion !== TRAJECTORY_SEMANTIC_STAGE_SCHEMA_VERSION) {
+		throw invalidSemanticStage("schemaVersion", record.schemaVersion);
+	}
+	const stageId = requiredStageId(record.stageId, "stageId");
+	if (
+		typeof record.kind !== "string" ||
+		!RECORDED_STAGE_KINDS.has(record.kind as RecordedStageKind)
+	) {
+		throw invalidSemanticStage("kind", record.kind);
+	}
+	const startedAt = requiredFiniteNumber(record, "startedAt");
+	const endedAt = requiredFiniteNumber(record, "endedAt");
+	const latencyMs = requiredFiniteNumber(record, "latencyMs");
+	if (endedAt < startedAt) throw invalidSemanticStage("endedAt", endedAt);
+	if (latencyMs !== endedAt - startedAt) {
+		throw invalidSemanticStage("latencyMs", latencyMs);
+	}
+	const iteration = optionalNonNegativeInteger(record, "iteration");
+	const retryIdx = optionalNonNegativeInteger(record, "retryIdx");
+	const parentStageId = record.parentStageId;
+	if (
+		parentStageId !== undefined &&
+		(typeof parentStageId !== "string" ||
+			!parentStageId.trim() ||
+			parentStageId !== parentStageId.trim() ||
+			parentStageId === stageId ||
+			parentStageId.length > TRAJECTORY_SEMANTIC_STAGE_MAX_ID_CHARS)
+	) {
+		throw invalidSemanticStage("parentStageId");
+	}
+	const payload = asRecord(record.payload);
+	if (
+		!payload ||
+		!hasOnlyKeys(payload, SEMANTIC_STAGE_PAYLOAD_KEYS) ||
+		!isJsonValue(payload, { seen: new WeakSet(), nodes: 0 })
+	) {
+		throw invalidSemanticStage("payload");
+	}
+	return {
+		schemaVersion: TRAJECTORY_SEMANTIC_STAGE_SCHEMA_VERSION,
+		stageId,
+		kind: record.kind as RecordedStageKind,
+		...(iteration !== undefined ? { iteration } : {}),
+		...(retryIdx !== undefined ? { retryIdx } : {}),
+		...(typeof parentStageId === "string" ? { parentStageId } : {}),
+		startedAt,
+		endedAt,
+		latencyMs,
+		payload: payload as Record<string, JsonValue>,
+	};
+}
+
+/** Validate an optional untrusted array from a persisted trajectory step. */
+export function parseTrajectorySemanticStages(
+	value: unknown,
+): TrajectorySemanticStageRecord[] | undefined {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value)) throw invalidSemanticStage("semanticStages");
+	if (value.length > TRAJECTORY_SEMANTIC_STAGES_MAX_ITEMS) {
+		throw invalidSemanticStage("semanticStages.length", value.length);
+	}
+	return value.map(parseTrajectorySemanticStage);
+}

--- a/packages/core/src/services/trajectory-types.ts
+++ b/packages/core/src/services/trajectory-types.ts
@@ -7,6 +7,7 @@
 
 import type { TrajectoryProviderAttribution } from "../runtime/trajectory-provider-attribution";
 import type { JsonValue } from "../types/primitives.ts";
+import type { TrajectorySemanticStageRecord } from "./trajectory-semantic-stage";
 
 // Re-export the canonical retrieval-funnel shapes from `trajectory-recorder`
 // so external consumers depend on the services-layer surface instead of
@@ -259,6 +260,8 @@ export interface TrajectoryStepRecord {
 	 * can isolate the evaluator seam.
 	 */
 	evaluatorName?: string;
+	/** Ordered semantic stages captured during this step's runtime work. */
+	semanticStages?: TrajectorySemanticStageRecord[];
 }
 
 export const TRAJECTORY_STEP_SCRIPT_MAX_CHARS = 4096;

--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -11,6 +11,7 @@ import type {
   TrajectoryLlmCallRecord as CoreTrajectoryLlmCallRecord,
   TrajectoryProviderAccessRecord as CoreTrajectoryProviderAccessRecord,
   TrajectorySummaryRecord as CoreTrajectorySummaryRecord,
+  TrajectorySemanticStageRecord,
 } from "@elizaos/core";
 import type {
   AppLaunchDiagnostic,
@@ -806,6 +807,7 @@ export interface TrajectoryDetailResult {
   trajectory: TrajectoryRecord;
   llmCalls: TrajectoryLlmCall[];
   providerAccesses: TrajectoryProviderAccess[];
+  semanticStages?: TrajectorySemanticStageRecord[];
   events?: TrajectoryEvent[];
   contextEvents?: ContextEvent[];
   toolEvents?: NativeToolCallEvent[];


### PR DESCRIPTION
# Relates to

Relates to #17030. This is a narrow enabling slice: it establishes and carries a versioned semantic-stage contract through trajectory persistence, export, and the viewer detail API. It does not claim to close the issue or prove that fresh app-chat turns already record every Stage-1/planner decision.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto GitHub's live `develop` (`570e590940de258a260c8e030e0aa8ca09e71f8d`) with zero conflicts.
- [x] `bun install` completed after sync. `bun run verify` was run and its host-contention interruption is recorded honestly below.
- [x] A reviewer can verify the DTO, persistence, export, and detail-response behavior from the focused exact-head tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e27f86827a234ecabe1e452843c4a0e5c3490ae9:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto GitHub `develop` at `570e590940de258a260c8e030e0aa8ca09e71f8d`; zero conflicts.
- [x] The 28 core contract/export/API tests, targeted Biome, and `git diff --check` pass on exact draft head `af63524e8a9dbf3fdcfe3f5a43bcd3c5fbb768b0`. Earlier complete persistence/typecheck/build proof and the remaining exact-head rerun status are documented below.

# Risks

**Low to medium.** The new field is additive and optional, but malformed persisted semantic-stage data now fails explicitly at parsing, persistence normalization, and native export boundaries. This is intentional fail-closed behavior. Payload size/depth limits and a strict key allowlist prevent unbounded or ambiguous trajectory metadata.

# Background

## What does this PR do?

- Adds schema-v1 `TrajectorySemanticStageRecord`, reusing the existing `RecordedStageKind` vocabulary instead of creating a parallel stage taxonomy.
- Adapts existing recorded stages into JSON-safe semantic-stage records while retaining tool-search candidate actions, retrieval scores/ranks, fusion output, and selected actions.
- Adds a strict parser for persisted/untrusted records: canonical identifiers, no self-parenting, consistent timing, known stage/payload fields, bounded JSON, and typed invalid-data errors.
- Carries `semanticStages` through `TrajectoryStepRecord`, dedicated step-row persistence, native JSONL export metadata, and the viewer detail API.
- Adds adversarial parser tests and round-trip tests for database persistence, export metadata, and viewer detail responses.

This PR deliberately does not wire new live model calls or claim UI completeness. Remaining #17030 work includes fresh app-chat recorder wiring, full Stage-1/planner/evaluator and action/result/effect receipt coverage, diagnostic failure reporting, viewer UI rendering, native/scenario parity, and live-model/evidence validation.

## What kind of change is this?

Feature foundation / non-breaking trajectory contract improvement.

# Documentation changes needed?

No user documentation change is needed for this internal additive contract slice. Public behavior documentation belongs with the later recorder/UI integration that completes #17030.

# Testing

## Where should a reviewer start?

1. `packages/core/src/services/trajectory-semantic-stage.ts`
2. `packages/agent/src/runtime/trajectory-internals.ts`
3. `packages/core/src/services/trajectory-export.ts`
4. `packages/core/src/features/trajectories/read-routes.ts`

## Detailed testing steps

```text
PATH=/Users/shawwalters/.bun/bin:$PATH bunx vitest run \
  packages/core/src/services/trajectory-semantic-stage.test.ts \
  packages/core/src/services/trajectory-export.test.ts \
  packages/core/src/features/trajectories/read-routes.test.ts \
  --config packages/core/vitest.config.ts --configLoader runner
=> 3 files passed, 28 tests passed

PATH=/Users/shawwalters/.bun/bin:$PATH bunx vitest run \
  src/runtime/trajectory-steps.test.ts \
  --config vitest.config.ts --configLoader runner
=> 1 file passed, 19 tests passed

bun run --cwd packages/core typecheck
=> passed

NPM_CONFIG_CACHE=/tmp/eliza-17030-npm-cache bun run --cwd packages/core build
=> Node, browser, edge, testing, declarations, and packed-edge smoke all passed

bunx biome check <all 10 changed files>
=> passed, no fixes

git diff HEAD^..HEAD --check
=> clean
```

# Evidence Gate

<!-- evidence-head:e27f86827a234ecabe1e452843c4a0e5c3490ae9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - internal trajectory contract and API serialization only; no rendered UI surface changed.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - internal trajectory contract and API serialization only; no rendered UI surface changed.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - this enabling slice adds no user-facing interactive flow.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no live app-chat wiring is claimed; deterministic persistence and export tests exercise this slice.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend code or network behavior changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no prompt, provider, model call, or agent decision behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - automated round-trip tests verify the new database and native-export data shapes; no live run is claimed.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface changed.`

# Evidence Details

## Real LLM-call trajectory

`N/A - this change transports already-recorded semantic stages and does not alter or invoke live model behavior.`

## Backend + frontend logs

`N/A - no end-to-end app-chat wiring or frontend behavior is part of this slice. Exact-head contract and round-trip test results are listed above.`

## Screenshots (before / after) + video walkthrough

`N/A - no UI files or rendered product surface changed.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT behavior changed.`

## Known gaps / failures

- Root `bun run verify` passed guide parity, Biome-version, i18n, Bun/Turbo, dependency, plugin-convention, alias-read, and tsconfig-resolution audits, then spent approximately 16 minutes in the workspace-wide Turbo `typecheck`/`lint:check` phase while this shared host was concurrently running several other repository TypeScript builds. It was interrupted to avoid an unbounded broad-gate hang; no changed-file failure was reported.
- On rebased head `38fa68eb21bb6501761eb6ebaa4f5a16e92ac2f6`, all 47 focused tests, core typecheck, and the complete Node/browser/edge/testing/declarations/packed-edge build passed. GitHub `develop` then advanced with unrelated scheduling commits, producing `ae86e2e1f6a58193947821ce2466dd8872a1c196`; on that head, the 28 core contract/export/API tests and core typecheck passed, while the agent persistence rerun and the tail of the full core build were interrupted under host contention after Node/browser/edge bundles passed. A final unrelated iOS merge produced draft head `af63524e8a9dbf3fdcfe3f5a43bcd3c5fbb768b0`; its 28 core tests pass exactly, while its agent persistence rerun was interrupted under host contention. This draft does not represent interrupted final-head lanes as green.
- No live app-chat, native-device, UI, or real-LLM artifact is claimed. Those are acceptance work remaining on #17030, so this PR must not close that issue.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@e27f86827a234ecabe1e452843c4a0e5c3490ae9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-17030]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@e27f86827a234ecabe1e452843c4a0e5c3490ae9:packages/skills/skills/contribute-to-eliza"} -->



