### PR TITLE
fix(lifeops): resolve bare month/day travel return to correct year and local day

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
@@ -223,16 +223,49 @@ const TRAVEL_UNTIL_PATTERN =
 function parseTravelReturnIso(phrase: string, now: Date): string | null {
   const trimmed = phrase.trim().replace(/[.,]+$/u, "");
   if (trimmed.length === 0) return null;
-  let parsed = Date.parse(trimmed);
-  if (Number.isNaN(parsed)) {
+  // Bare "Month Day" (e.g. "July 20") without a year: Date.parse("July 20") in V8
+  // returns a fixed placeholder year (2001) instead of NaN, so the NaN check never
+  // fires and the date is wrongly pushed to next year. Detect missing year explicitly.
+  const hasYear = /\b\d{4}\b/.test(trimmed);
+  let parsed: number;
+  if (!hasYear) {
+    // No year present — append current year before parsing.
     parsed = Date.parse(`${trimmed} ${now.getFullYear()}`);
-  }
-  if (Number.isNaN(parsed)) return null;
-  // A month/day that resolves to the past almost always means next year.
-  if (parsed < now.getTime()) {
-    const nextYear = Date.parse(`${trimmed} ${now.getFullYear() + 1}`);
-    if (Number.isNaN(nextYear) || nextYear < now.getTime()) return null;
-    parsed = nextYear;
+    if (Number.isNaN(parsed)) return null;
+    // If the current-year date is already in the past, try next year.
+    if (parsed < now.getTime()) {
+      const nextYear = Date.parse(`${trimmed} ${now.getFullYear() + 1}`);
+      if (!Number.isNaN(nextYear) && nextYear >= now.getTime()) {
+        parsed = nextYear;
+      } else if (parsed - now.getTime() > MAX_TRAVEL_HORIZON_MS) {
+        return null;
+      }
+    }
+  } else {
+    // Year present — parse directly, but normalize YYYY-MM-DD to local midnight
+    // for cross-timezone determinism (ECMA-262: YYYY-MM-DD is UTC midnight,
+    // while "July 20, 2026" is local midnight). The docstring lists both forms.
+    const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (isoMatch) {
+      const y = Number(isoMatch[1]);
+      const m = Number(isoMatch[2]);
+      const d = Number(isoMatch[3]);
+      // Construct as local midnight, then validate rollover like plugin-finances.
+      const local = new Date(y, m - 1, d);
+      if (
+        local.getFullYear() !== y ||
+        local.getMonth() + 1 !== m ||
+        local.getDate() !== d
+      ) {
+        return null;
+      }
+      parsed = local.getTime();
+    } else {
+      parsed = Date.parse(trimmed);
+      if (Number.isNaN(parsed)) return null;
+      // If year-bearing date is in the past, it is not a future travel return — reject.
+      if (parsed < now.getTime()) return null;
+    }
   }
   if (parsed - now.getTime() > MAX_TRAVEL_HORIZON_MS) return null;
   return new Date(parsed).toISOString();


### PR DESCRIPTION
Closes #22173

## Summary
- Fixes `parseTravelReturnIso` in `plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts:223` which used `Date.parse(trimmed)` then `if (NaN) append year`; `Date.parse("July 20")` never returns `NaN` in V8 (placeholder 2001), so the append never ran and every bare `Month Day` was pushed to next year, exceeding `MAX_TRAVEL_HORIZON_MS` and silently discarding near-term returns (e.g. July 5 → July 20 was resolved to 2027 and returned `null`).
- Detects missing year via `/\b\d{4}\b/` before parsing: no year → `Date.parse("${trimmed} ${now.getFullYear()}")`; only rolls to next year when current-year date is past. Year-bearing `YYYY-MM-DD` is now constructed as local midnight (`new Date(y,m-1,d)`) with rollover validation, matching the docstring-listed `Month Day, Year` local-midnight semantics and eliminating the UTC-vs-local 1-day offset.

## What Changed
- `profile-extraction-evaluator.ts`: `parseTravelReturnIso` now branches on `hasYear`; bare month/day appends current year, ISO is local-midnight with validation.

## Exact-head evidence
Head: 622be48a30
Base: origin/develop@4dca17f6de with zero conflicts

## Verification / Definition of Done
- [x] Targets `develop`, rebased onto `origin/develop@4dca17f6de` zero conflicts
- [x] `bun --cwd plugins/plugin-personal-assistant vitest run` — existing lifeops tests pass (profile-extraction-evaluator)
- [x] Manual repro: `TZ=UTC parseTravelReturnIso("July 20", new Date("2026-07-05"))` → `2026-07-20T00:00:00.000Z` (was `null`); `TZ=America/Los_Angeles` both `2026-07-20` and `July 20, 2026` resolve to `2026-07-20T07:00:00.000Z`

## Contribution provenance
<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: openai/gpt-5.6-sol
- Agent tooling: Codex Desktop
- Skill path: elizaOS/eliza@4dca17f6de:packages/skills/skills/contribute-to-eliza

Closes #22173
