### PR TITLE
perf(core,agent): stop double-serializing recall results into planner and evaluator prompts

### DIFF
--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -602,9 +602,6 @@ describe("MEMORY routing aliases", () => {
   });
 
   it("resolves the bare stage-1 RECALL_MEMORY candidate to MEMORY", () => {
-    // Live sol-dev 2026-08-17/18: stage-1 emitted candidate=RECALL_MEMORY,
-    // it resolved to no runtime action (only RECALL_MEMORY_FILTERED was a
-    // simile), and every recall turn paid a full extra planner round.
     const lookup = new Map<string, string>();
     const normalized = normalizeActionIdentifier(memoryAction.name);
     if (normalized) lookup.set(normalized, memoryAction.name);
@@ -625,11 +622,6 @@ describe("MEMORY routing aliases", () => {
 
 describe("MEMORY op:search rendered line width", () => {
   it("renders up to 300 chars of each windowed hit so text carries the claim", async () => {
-    // The rendered `text` is the model's primary view of a hit: the
-    // full-text data payload is capped downstream by toolMessageContent
-    // (MAX_RENDERED_DATA_CHARS_WITH_TEXT). At the old 120-char slice a
-    // stored correction's operative clause fell outside the rendered line
-    // and was legible only via the (now capped) data blob.
     const { runtime, rows } = makeRuntime();
     const head = "CORRECTION (2026-08-18): the user's earlier claim was ";
     const operative =
@@ -646,7 +638,13 @@ describe("MEMORY op:search rendered line width", () => {
     });
     expect(result.success).toBe(true);
     const text = String(result.text ?? "");
-    // 120-char rendering cut the line before the operative clause; 300 keeps it.
     expect(text).toContain(operative);
+    expect(result.promptData).toMatchObject({
+      actionName: "MEMORY",
+      op: "search",
+      matchedInWindow: 1,
+      rendered: 1,
+    });
+    expect(result.promptData).not.toHaveProperty("memories");
   });
 });

--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -600,4 +600,53 @@ describe("MEMORY routing aliases", () => {
       "MEMORY",
     );
   });
+
+  it("resolves the bare stage-1 RECALL_MEMORY candidate to MEMORY", () => {
+    // Live sol-dev 2026-08-17/18: stage-1 emitted candidate=RECALL_MEMORY,
+    // it resolved to no runtime action (only RECALL_MEMORY_FILTERED was a
+    // simile), and every recall turn paid a full extra planner round.
+    const lookup = new Map<string, string>();
+    const normalized = normalizeActionIdentifier(memoryAction.name);
+    if (normalized) lookup.set(normalized, memoryAction.name);
+    for (const simile of memoryAction.similes ?? []) {
+      const key = normalizeActionIdentifier(simile);
+      if (key && !lookup.has(key)) lookup.set(key, memoryAction.name);
+    }
+    for (const candidate of [
+      "RECALL_MEMORY",
+      "RECALL_MEMORIES",
+      "MEMORY_RECALL",
+      "MEMORY_SEARCH",
+    ]) {
+      expect(lookup.get(normalizeActionIdentifier(candidate))).toBe("MEMORY");
+    }
+  });
+});
+
+describe("MEMORY op:search rendered line width", () => {
+  it("renders up to 300 chars of each windowed hit so text carries the claim", async () => {
+    // The rendered `text` is the model's primary view of a hit: the
+    // full-text data payload is capped downstream by toolMessageContent
+    // (MAX_RENDERED_DATA_CHARS_WITH_TEXT). At the old 120-char slice a
+    // stored correction's operative clause fell outside the rendered line
+    // and was legible only via the (now capped) data blob.
+    const { runtime, rows } = makeRuntime();
+    const head = "CORRECTION (2026-08-18): the user's earlier claim was ";
+    const operative =
+      "retracted because it quoted song lyrics, not a real decision";
+    const filler = "x".repeat(160);
+    seedFact(rows, {
+      text: `${head}${filler} ${operative}`,
+      entityId: USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "correction claim retracted",
+    });
+    expect(result.success).toBe(true);
+    const text = String(result.text ?? "");
+    // 120-char rendering cut the line before the operative clause; 300 keeps it.
+    expect(text).toContain(operative);
+  });
 });

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -365,9 +365,16 @@ async function doSearch(
   const items = scan.matches
     .slice(0, limit)
     .map((c) => toListItem(c.memory, c.type));
+  // 300 chars per line: the rendered `text` is now the model's PRIMARY view
+  // of each hit — the full-text `data.memories` payload is capped by the
+  // planner/evaluator renderers (toolMessageContent
+  // MAX_RENDERED_DATA_CHARS_WITH_TEXT) after one search result's duplicated
+  // ~46KB data blob doubled recall-turn prompts (live measurement,
+  // 2026-08-18). At 120 chars a stored correction was legible only via that
+  // doomed blob; at 300 the line itself carries the claim.
   const lines = items
     .slice(0, 25)
-    .map((m) => `- [${m.type}] ${m.id}: ${m.text.slice(0, 120)}`);
+    .map((m) => `- [${m.type}] ${m.id}: ${m.text.slice(0, 300)}`);
 
   // Report what was actually rendered, not what was collected: the previous
   // header claimed up to 50 items while printing 25 lines, and printed the
@@ -610,6 +617,15 @@ export const memoryAction: Action = {
     "UPDATE_MEMORY",
     "DELETE_MEMORY",
     "RECALL_MEMORY_FILTERED",
+    // Stage-1 recall candidates: the classifier emits RECALL_MEMORY (bare)
+    // for "who is X" recalls, and without this simile the explicit candidate
+    // resolved to no runtime action (gate=resolved-to-no-runtime-action) —
+    // the turn then paid a full extra planner round to rediscover MEMORY
+    // op:search (live sol-dev 2026-08-17/18).
+    "RECALL_MEMORY",
+    "RECALL_MEMORIES",
+    "MEMORY_RECALL",
+    "MEMORY_SEARCH",
     "FORGET_MEMORY",
     "EDIT_MEMORY",
     // Common aliases

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -365,13 +365,8 @@ async function doSearch(
   const items = scan.matches
     .slice(0, limit)
     .map((c) => toListItem(c.memory, c.type));
-  // 300 chars per line: the rendered `text` is now the model's PRIMARY view
-  // of each hit — the full-text `data.memories` payload is capped by the
-  // planner/evaluator renderers (toolMessageContent
-  // MAX_RENDERED_DATA_CHARS_WITH_TEXT) after one search result's duplicated
-  // ~46KB data blob doubled recall-turn prompts (live measurement,
-  // 2026-08-18). At 120 chars a stored correction was legible only via that
-  // doomed blob; at 300 the line itself carries the claim.
+  // The text projection carries enough of each hit for model reasoning; the
+  // complete records remain machine data for state and trajectory consumers.
   const lines = items
     .slice(0, 25)
     .map((m) => `- [${m.type}] ${m.id}: ${m.text.slice(0, 300)}`);
@@ -406,6 +401,15 @@ async function doSearch(
       op: "search" as const,
       memories: items,
       matchedInWindow,
+      scanWindowPerTable: scan.perTable,
+      scanWindowSaturatedTables: scan.saturatedTables,
+      limit,
+    },
+    promptData: {
+      actionName: "MEMORY",
+      op: "search" as const,
+      matchedInWindow,
+      rendered: lines.length,
       scanWindowPerTable: scan.perTable,
       scanWindowSaturatedTables: scan.saturatedTables,
       limit,
@@ -617,11 +621,7 @@ export const memoryAction: Action = {
     "UPDATE_MEMORY",
     "DELETE_MEMORY",
     "RECALL_MEMORY_FILTERED",
-    // Stage-1 recall candidates: the classifier emits RECALL_MEMORY (bare)
-    // for "who is X" recalls, and without this simile the explicit candidate
-    // resolved to no runtime action (gate=resolved-to-no-runtime-action) —
-    // the turn then paid a full extra planner round to rediscover MEMORY
-    // op:search (live sol-dev 2026-08-17/18).
+    // Stage-1 recall names bind directly to the MEMORY umbrella action.
     "RECALL_MEMORY",
     "RECALL_MEMORIES",
     "MEMORY_RECALL",

--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -859,6 +859,27 @@ describe("action catalogue and retrieval", () => {
 		]);
 	});
 
+	// Stage-1 recall candidates must resolve to the MEMORY umbrella: the
+	// classifier emits RECALL_MEMORY for "who is X" recalls, and when the name
+	// resolved to nothing the turn paid a full extra planner round to
+	// rediscover MEMORY op:search (live sol-dev 2026-08-17/18,
+	// gate=resolved-to-no-runtime-action).
+	it("hints memory-recall candidates at the MEMORY umbrella", () => {
+		for (const candidate of [
+			"RECALL_MEMORY",
+			"RECALL_MEMORIES",
+			"MEMORY_RECALL",
+			"MEMORY_SEARCH",
+			"SEARCH_MEMORIES",
+			"CHECK_MEMORY",
+		]) {
+			expect(parentAliasesForCandidateAction(candidate)).toEqual(["MEMORY"]);
+		}
+		expect(parentAliasesForCandidateAction("recall memory")).toEqual([
+			"MEMORY",
+		]);
+	});
+
 	it("hints reminder candidates at OWNER_REMINDERS and TRIGGER", () => {
 		for (const candidate of [
 			"ADD_REMINDER",

--- a/packages/core/src/runtime/__tests__/planner-rendering.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-rendering.test.ts
@@ -7,7 +7,6 @@
 import { describe, expect, it } from "vitest";
 import type { ChatMessage } from "../../types/model";
 import {
-	MAX_RENDERED_DATA_CHARS_WITH_TEXT,
 	toolMessageContent,
 	trajectoryStepsToMessages,
 	truncateToolResultText,
@@ -273,14 +272,8 @@ describe("trajectoryStepsToMessages — maxToolResultChars option", () => {
 	});
 });
 
-describe("toolMessageContent — data cap when a text projection exists", () => {
-	// Live incident (sol-dev 2026-08-18, trajectories ipd1zs/rv6oxq/5m6ir4):
-	// one MEMORY_SEARCH result rendered a ~5KB `text` PLUS a ~46KB
-	// pretty-printed `data` blob duplicating every hit's full text — the
-	// post-search planner call ballooned 18K -> 36-37K prompt tokens and the
-	// evaluator to ~50K, paid on every recall turn.
-
-	it("caps an oversized data payload when result.text is present", () => {
+describe("toolMessageContent — action-owned data projection", () => {
+	it("renders promptData instead of a duplicated machine payload", () => {
 		const memories = Array.from({ length: 17 }, (_, i) => ({
 			id: `id-${i}`,
 			type: "facts",
@@ -289,30 +282,32 @@ describe("toolMessageContent — data cap when a text projection exists", () => 
 		const rendered = toolMessageContent({
 			success: true,
 			text: "Showing all 17 match(es) found in the scanned window.",
-			data: { actionName: "MEMORY_SEARCH", memories },
+			data: { actionName: "MEMORY", op: "search", memories },
+			promptData: {
+				actionName: "MEMORY",
+				op: "search",
+				matchedInWindow: 17,
+			},
 		});
 		expect(rendered.startsWith("text: Showing all 17")).toBe(true);
-		const dataSection = rendered.slice(rendered.indexOf("data: "));
-		// The cap plus the "data: " label and truncation marker overhead.
-		expect(dataSection.length).toBeLessThanOrEqual(
-			MAX_RENDERED_DATA_CHARS_WITH_TEXT + 64,
-		);
-		expect(dataSection).toMatch(/chars truncated/);
+		expect(rendered).toContain('"matchedInWindow": 17');
+		expect(rendered).not.toContain("stored fact 0");
 	});
 
-	it("renders small structured data fully alongside text (chaining payloads survive)", () => {
+	it("keeps arbitrary large chaining data complete when no projection is supplied", () => {
+		const chainingMarker = `CHAINING_FIELD_${"x".repeat(5000)}`;
 		const rendered = toolMessageContent({
 			success: true,
 			text: "Created workspace.",
-			data: { agentId: "a1", workspaceId: "w1" },
+			data: { agentId: "a1", chainingMarker, workspaceId: "w1" },
 		});
 		expect(rendered).toContain("text: Created workspace.");
 		expect(rendered).toContain('"agentId": "a1"');
 		expect(rendered).toContain('"workspaceId": "w1"');
-		expect(rendered).not.toMatch(/chars truncated/);
+		expect(rendered).toContain(chainingMarker);
 	});
 
-	it("renders data in full when there is NO text projection (documented fallback role)", () => {
+	it("renders data in full when there is no text projection", () => {
 		const bigPayload = {
 			rows: Array.from(
 				{ length: 200 },
@@ -323,20 +318,21 @@ describe("toolMessageContent — data cap when a text projection exists", () => 
 			success: true,
 			data: bigPayload,
 		});
-		expect(rendered.length).toBeGreaterThan(MAX_RENDERED_DATA_CHARS_WITH_TEXT);
+		expect(rendered.length).toBeGreaterThan(4_000);
 		expect(rendered).not.toMatch(/chars truncated/);
 		expect(rendered).toContain("row 199");
 	});
 
-	it("keeps error rendering intact when data is capped", () => {
+	it("keeps error rendering alongside projected data", () => {
 		const rendered = toolMessageContent({
 			success: false,
 			text: "search failed",
 			data: { dump: "z".repeat(50_000) },
+			promptData: { actionName: "MEMORY", op: "search" },
 			error: "backend exploded",
 		});
 		expect(rendered).toContain("text: search failed");
-		expect(rendered).toMatch(/chars truncated/);
+		expect(rendered).not.toContain("z".repeat(100));
 		expect(rendered).toContain("error: backend exploded");
 	});
 });

--- a/packages/core/src/runtime/__tests__/planner-rendering.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-rendering.test.ts
@@ -313,7 +313,12 @@ describe("toolMessageContent — data cap when a text projection exists", () => 
 	});
 
 	it("renders data in full when there is NO text projection (documented fallback role)", () => {
-		const bigPayload = { rows: Array.from({ length: 200 }, (_, i) => `row ${i} ${"y".repeat(100)}`) };
+		const bigPayload = {
+			rows: Array.from(
+				{ length: 200 },
+				(_, i) => `row ${i} ${"y".repeat(100)}`,
+			),
+		};
 		const rendered = toolMessageContent({
 			success: true,
 			data: bigPayload,

--- a/packages/core/src/runtime/__tests__/planner-rendering.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-rendering.test.ts
@@ -7,6 +7,8 @@
 import { describe, expect, it } from "vitest";
 import type { ChatMessage } from "../../types/model";
 import {
+	MAX_RENDERED_DATA_CHARS_WITH_TEXT,
+	toolMessageContent,
 	trajectoryStepsToMessages,
 	truncateToolResultText,
 } from "../planner-rendering";
@@ -268,5 +270,68 @@ describe("trajectoryStepsToMessages — maxToolResultChars option", () => {
 		trajectoryStepsToMessages(steps, { maxToolResultChars: 200 });
 		// Trajectory must remain pristine — only the rendered message is truncated.
 		expect(steps[0]?.result?.text).toBe(original);
+	});
+});
+
+describe("toolMessageContent — data cap when a text projection exists", () => {
+	// Live incident (sol-dev 2026-08-18, trajectories ipd1zs/rv6oxq/5m6ir4):
+	// one MEMORY_SEARCH result rendered a ~5KB `text` PLUS a ~46KB
+	// pretty-printed `data` blob duplicating every hit's full text — the
+	// post-search planner call ballooned 18K -> 36-37K prompt tokens and the
+	// evaluator to ~50K, paid on every recall turn.
+
+	it("caps an oversized data payload when result.text is present", () => {
+		const memories = Array.from({ length: 17 }, (_, i) => ({
+			id: `id-${i}`,
+			type: "facts",
+			text: `stored fact ${i}: ${"detail ".repeat(400)}`,
+		}));
+		const rendered = toolMessageContent({
+			success: true,
+			text: "Showing all 17 match(es) found in the scanned window.",
+			data: { actionName: "MEMORY_SEARCH", memories },
+		});
+		expect(rendered.startsWith("text: Showing all 17")).toBe(true);
+		const dataSection = rendered.slice(rendered.indexOf("data: "));
+		// The cap plus the "data: " label and truncation marker overhead.
+		expect(dataSection.length).toBeLessThanOrEqual(
+			MAX_RENDERED_DATA_CHARS_WITH_TEXT + 64,
+		);
+		expect(dataSection).toMatch(/chars truncated/);
+	});
+
+	it("renders small structured data fully alongside text (chaining payloads survive)", () => {
+		const rendered = toolMessageContent({
+			success: true,
+			text: "Created workspace.",
+			data: { agentId: "a1", workspaceId: "w1" },
+		});
+		expect(rendered).toContain("text: Created workspace.");
+		expect(rendered).toContain('"agentId": "a1"');
+		expect(rendered).toContain('"workspaceId": "w1"');
+		expect(rendered).not.toMatch(/chars truncated/);
+	});
+
+	it("renders data in full when there is NO text projection (documented fallback role)", () => {
+		const bigPayload = { rows: Array.from({ length: 200 }, (_, i) => `row ${i} ${"y".repeat(100)}`) };
+		const rendered = toolMessageContent({
+			success: true,
+			data: bigPayload,
+		});
+		expect(rendered.length).toBeGreaterThan(MAX_RENDERED_DATA_CHARS_WITH_TEXT);
+		expect(rendered).not.toMatch(/chars truncated/);
+		expect(rendered).toContain("row 199");
+	});
+
+	it("keeps error rendering intact when data is capped", () => {
+		const rendered = toolMessageContent({
+			success: false,
+			text: "search failed",
+			data: { dump: "z".repeat(50_000) },
+			error: "backend exploded",
+		});
+		expect(rendered).toContain("text: search failed");
+		expect(rendered).toMatch(/chars truncated/);
+		expect(rendered).toContain("error: backend exploded");
 	});
 });

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -190,6 +190,19 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	READ_EMAIL: ["MESSAGE", "INBOX"],
 	CHECK_EMAIL: ["MESSAGE", "INBOX"],
 	CHECK_INBOX: ["MESSAGE", "INBOX"],
+	// Memory-recall candidates bind to the MEMORY umbrella. Stage-1 emits
+	// RECALL_MEMORY for "who is X" / "what did we say about X" turns, but the
+	// MEMORY action's similes only cover RECALL_MEMORY_FILTERED — so the
+	// candidate died with gate=resolved-to-no-runtime-action and the turn paid
+	// a full planner round to reach the same MEMORY op:search (live sol-dev
+	// 2026-08-17/18: every recall turn logged the resolved-to-nothing warn and
+	// ran 4 model calls instead of 2).
+	RECALL_MEMORY: ["MEMORY"],
+	RECALL_MEMORIES: ["MEMORY"],
+	MEMORY_RECALL: ["MEMORY"],
+	MEMORY_SEARCH: ["MEMORY"],
+	SEARCH_MEMORIES: ["MEMORY"],
+	CHECK_MEMORY: ["MEMORY"],
 	// Terminal-shaped candidates bind to the shell surface (same F21 batch:
 	// TERMINAL_COMMAND resolved to nothing).
 	TERMINAL_COMMAND: ["SHELL", "TERMINAL_SHELL"],

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -190,13 +190,7 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	READ_EMAIL: ["MESSAGE", "INBOX"],
 	CHECK_EMAIL: ["MESSAGE", "INBOX"],
 	CHECK_INBOX: ["MESSAGE", "INBOX"],
-	// Memory-recall candidates bind to the MEMORY umbrella. Stage-1 emits
-	// RECALL_MEMORY for "who is X" / "what did we say about X" turns, but the
-	// MEMORY action's similes only cover RECALL_MEMORY_FILTERED — so the
-	// candidate died with gate=resolved-to-no-runtime-action and the turn paid
-	// a full planner round to reach the same MEMORY op:search (live sol-dev
-	// 2026-08-17/18: every recall turn logged the resolved-to-nothing warn and
-	// ran 4 model calls instead of 2).
+	// Memory-recall candidates bind to the canonical MEMORY umbrella action.
 	RECALL_MEMORY: ["MEMORY"],
 	RECALL_MEMORIES: ["MEMORY"],
 	MEMORY_RECALL: ["MEMORY"],

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -5827,6 +5827,7 @@ export function actionResultToPlannerToolResult(
 		effectReceipts: result.effectReceipts,
 		userFacingEffectReceiptIds: result.userFacingEffectReceiptIds,
 		data: Object.keys(data).length > 0 ? data : undefined,
+		promptData: result.promptData,
 		error: result.error,
 		failureProvenance: result.failureProvenance,
 		turnComplete: result.turnComplete,

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -251,7 +251,10 @@ export function toolMessageContent(result: PlannerToolResult): string {
 		parts.push(
 			`data: ${
 				hasText
-					? truncateToolResultText(serialized, MAX_RENDERED_DATA_CHARS_WITH_TEXT)
+					? truncateToolResultText(
+							serialized,
+							MAX_RENDERED_DATA_CHARS_WITH_TEXT,
+						)
 					: serialized
 			}`,
 		);

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -206,19 +206,55 @@ function shortArgsDigest(params: Record<string, unknown> | undefined): string {
 }
 
 /**
+ * When a tool result carries BOTH a text projection and a `data` payload,
+ * the rendered `data:` section is capped to this many characters (head +
+ * `[N chars truncated]` marker + tail via {@link truncateToolResultText}).
+ *
+ * Why: `text` is the projection the action authored FOR the model; `data`
+ * is the machine payload, and for recall-shaped actions it duplicates the
+ * text at full fidelity. Live sol-dev 2026-08-18 (trajectories ipd1zs /
+ * rv6oxq / 5m6ir4): one MEMORY_SEARCH result rendered a ~5 KB `text` plus a
+ * ~46 KB pretty-printed `data` blob (`data.memories` + `data.durableMemories`
+ * carrying every hit's full text), ballooning the post-search planner call
+ * from ~18K to ~36-37K prompt tokens and the evaluator render to ~50K. Every
+ * recall turn paid that twice — 10-25s of pure duplicated-serialization
+ * latency at fable per-call speeds.
+ *
+ * The cap keeps small structured payloads (ids, URLs, workspace handles the
+ * planner chains on) fully intact and truncates only pathological dumps.
+ * Results with NO text projection still render `data` in full — that is the
+ * documented fallback role, unchanged. The trajectory itself always archives
+ * the complete `data`; only the model-bound wire shape is capped.
+ */
+export const MAX_RENDERED_DATA_CHARS_WITH_TEXT = 4_000;
+
+/**
  * Project a PlannerToolResult to plain-text `tool` message content per OpenAI
  * conventions: prefer `result.text`, fall back to a JSON serialization of
  * `data`/`error` only when no text projection exists. Strict-grammar
  * providers (Cerebras) and Anthropic both prefer text over a JSON blob in
  * the tool turn, and this preserves byte-stability when text is consistent.
+ *
+ * When both `text` and `data` are present, the `data:` section is capped at
+ * {@link MAX_RENDERED_DATA_CHARS_WITH_TEXT} — see that constant for the
+ * live-incident rationale.
  */
 export function toolMessageContent(result: PlannerToolResult): string {
 	const parts: string[] = [];
-	if (typeof result.text === "string" && result.text.trim().length > 0) {
+	const hasText =
+		typeof result.text === "string" && result.text.trim().length > 0;
+	if (hasText && typeof result.text === "string") {
 		parts.push(`text: ${result.text.trim()}`);
 	}
 	if (result.data && Object.keys(result.data).length > 0) {
-		parts.push(`data: ${stringifyForModel(result.data)}`);
+		const serialized = stringifyForModel(result.data);
+		parts.push(
+			`data: ${
+				hasText
+					? truncateToolResultText(serialized, MAX_RENDERED_DATA_CHARS_WITH_TEXT)
+					: serialized
+			}`,
+		);
 	}
 	if (result.error) {
 		const errMsg =

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -206,38 +206,15 @@ function shortArgsDigest(params: Record<string, unknown> | undefined): string {
 }
 
 /**
- * When a tool result carries BOTH a text projection and a `data` payload,
- * the rendered `data:` section is capped to this many characters (head +
- * `[N chars truncated]` marker + tail via {@link truncateToolResultText}).
- *
- * Why: `text` is the projection the action authored FOR the model; `data`
- * is the machine payload, and for recall-shaped actions it duplicates the
- * text at full fidelity. Live sol-dev 2026-08-18 (trajectories ipd1zs /
- * rv6oxq / 5m6ir4): one MEMORY_SEARCH result rendered a ~5 KB `text` plus a
- * ~46 KB pretty-printed `data` blob (`data.memories` + `data.durableMemories`
- * carrying every hit's full text), ballooning the post-search planner call
- * from ~18K to ~36-37K prompt tokens and the evaluator render to ~50K. Every
- * recall turn paid that twice — 10-25s of pure duplicated-serialization
- * latency at fable per-call speeds.
- *
- * The cap keeps small structured payloads (ids, URLs, workspace handles the
- * planner chains on) fully intact and truncates only pathological dumps.
- * Results with NO text projection still render `data` in full — that is the
- * documented fallback role, unchanged. The trajectory itself always archives
- * the complete `data`; only the model-bound wire shape is capped.
- */
-export const MAX_RENDERED_DATA_CHARS_WITH_TEXT = 4_000;
-
-/**
  * Project a PlannerToolResult to plain-text `tool` message content per OpenAI
  * conventions: prefer `result.text`, fall back to a JSON serialization of
  * `data`/`error` only when no text projection exists. Strict-grammar
  * providers (Cerebras) and Anthropic both prefer text over a JSON blob in
  * the tool turn, and this preserves byte-stability when text is consistent.
  *
- * When both `text` and `data` are present, the `data:` section is capped at
- * {@link MAX_RENDERED_DATA_CHARS_WITH_TEXT} — see that constant for the
- * live-incident rationale.
+ * An action may provide `promptData` when its complete machine payload is not
+ * an appropriate model projection. This keeps projection ownership with the
+ * action and leaves arbitrary chaining data intact by default.
  */
 export function toolMessageContent(result: PlannerToolResult): string {
 	const parts: string[] = [];
@@ -246,18 +223,9 @@ export function toolMessageContent(result: PlannerToolResult): string {
 	if (hasText && typeof result.text === "string") {
 		parts.push(`text: ${result.text.trim()}`);
 	}
-	if (result.data && Object.keys(result.data).length > 0) {
-		const serialized = stringifyForModel(result.data);
-		parts.push(
-			`data: ${
-				hasText
-					? truncateToolResultText(
-							serialized,
-							MAX_RENDERED_DATA_CHARS_WITH_TEXT,
-						)
-					: serialized
-			}`,
-		);
+	const modelData = result.promptData ?? result.data;
+	if (modelData && Object.keys(modelData).length > 0) {
+		parts.push(`data: ${stringifyForModel(modelData)}`);
 	}
 	if (result.error) {
 		const errMsg =

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -183,6 +183,8 @@ export interface PlannerToolResult {
 	 */
 	summary?: string;
 	data?: Record<string, unknown>;
+	/** Model-bound projection of `data`; complete data remains on the result. */
+	promptData?: Record<string, unknown>;
 	error?: unknown;
 	/** Typed boundary provenance retained through planner retry exhaustion. */
 	failureProvenance?: ActionFailureProvenance;

--- a/packages/core/src/services/evaluator.test.ts
+++ b/packages/core/src/services/evaluator.test.ts
@@ -523,12 +523,6 @@ describe("EvaluatorService", () => {
 	});
 
 	it("renders action results bounded (text projection, not the raw data payload)", async () => {
-		// Live sol-dev 2026-08-18: state.data.actionResults carried a full
-		// MEMORY_SEARCH ActionResult whose data.memories/durableMemories
-		// duplicated every hit's complete text; the old raw stringify pushed the
-		// merged post-turn evaluator call to ~50-52K prompt tokens on every
-		// recall turn. The prompt must render the bounded text projection and
-		// must NOT serialize the data payload.
 		const runtime = makeRuntime();
 		runtime.registerEvaluator({
 			name: "gamma",
@@ -547,19 +541,26 @@ describe("EvaluatorService", () => {
 			success: true,
 			text: "Showing all 7 match(es) found in the scanned window.",
 			data: {
-				actionName: "MEMORY_SEARCH",
+				actionName: "MEMORY",
+				op: "search",
 				memories: Array.from({ length: 17 }, (_, i) => ({
 					id: `id-${i}`,
 					text: `${hugeDataMarker} ${"detail ".repeat(300)}`,
 				})),
+			},
+			promptData: {
+				actionName: "MEMORY",
+				op: "search",
+				matchedInWindow: 7,
 			},
 		};
 
 		const useModel = vi.fn(async (_modelType, params) => {
 			const prompt = String(params.messages?.[0]?.content ?? "");
 			// The bounded text projection is present…
-			expect(prompt).toContain("MEMORY_SEARCH - succeeded");
+			expect(prompt).toContain("MEMORY - succeeded");
 			expect(prompt).toContain("Showing all 7 match(es)");
+			expect(prompt).toContain('"matchedInWindow":7');
 			// …and the raw data payload is NOT serialized into the prompt.
 			expect(prompt).not.toContain(hugeDataMarker);
 			return { gamma: { ok: true } };
@@ -575,6 +576,94 @@ describe("EvaluatorService", () => {
 		expect(useModel).toHaveBeenCalledTimes(1);
 		expect(result.skipped).toBe(false);
 		expect(result.errors).toEqual([]);
+	});
+
+	it("keeps supported data-only action fields visible to the evaluator model", async () => {
+		const runtime = makeRuntime();
+		runtime.registerEvaluator({
+			name: "data-only",
+			description: "data-only section",
+			schema: schema(),
+			shouldRun: async () => true,
+			prompt: () => "Inspect the action result.",
+			parse: (output) => output as never,
+			processors: [
+				{ name: "storeDataOnly", process: async () => ({ success: true }) },
+			],
+		});
+		const useModel = vi.fn(async (_modelType, params) => {
+			const prompt = String(params.messages?.[0]?.content ?? "");
+			expect(prompt).toContain("UNINSTALL_SKILL - succeeded");
+			expect(prompt).toContain('"awaitingUserInput":true');
+			expect(prompt).toContain('"slug":"demo-skill"');
+			return { "data-only": { ok: true } };
+		});
+		runtime.useModel = useModel as AgentRuntime["useModel"];
+
+		const actionResult = {
+			success: true,
+			data: {
+				actionName: "UNINSTALL_SKILL",
+				awaitingUserInput: true,
+				slug: "demo-skill",
+			},
+		};
+		const state = {
+			values: {},
+			data: { actionResults: [actionResult] },
+			text: "",
+		};
+		await new EvaluatorService(runtime).run(makeMessage(), state);
+
+		expect(useModel).toHaveBeenCalledTimes(1);
+		expect(state.data.actionResults[0]?.data).toEqual(actionResult.data);
+	});
+
+	it("bounds oversized data-only action JSON without hiding control fields", async () => {
+		const runtime = makeRuntime();
+		runtime.registerEvaluator({
+			name: "bounded-data",
+			description: "bounded-data section",
+			schema: schema(),
+			shouldRun: async () => true,
+			prompt: () => "Inspect the action result.",
+			parse: (output) => output as never,
+			processors: [
+				{ name: "storeBoundedData", process: async () => ({ success: true }) },
+			],
+		});
+		const oversizedMarker = "OVERSIZED_PRIVATE_DETAIL".repeat(2_000);
+		const useModel = vi.fn(async (_modelType, params) => {
+			const prompt = String(params.messages?.[0]?.content ?? "");
+			expect(prompt).toContain('"actionName":"UNINSTALL_SKILL"');
+			expect(prompt).toContain('"awaitingUserInput":true');
+			expect(prompt).toContain('"slug":"demo-skill"');
+			expect(prompt).toContain('"__truncated":true');
+			expect(prompt).not.toContain(oversizedMarker);
+			expect(prompt.length).toBeLessThan(EVALUATOR_PROMPT_MAX_CHARS);
+			return { "bounded-data": { ok: true } };
+		});
+		runtime.useModel = useModel as AgentRuntime["useModel"];
+
+		await new EvaluatorService(runtime).run(makeMessage(), {
+			values: {},
+			data: {
+				actionResults: [
+					{
+						success: true,
+						data: {
+							actionName: "UNINSTALL_SKILL",
+							awaitingUserInput: true,
+							slug: "demo-skill",
+							details: oversizedMarker,
+						},
+					},
+				],
+			},
+			text: "",
+		});
+
+		expect(useModel).toHaveBeenCalledTimes(1);
 	});
 
 	it("trims oversized shared provider context and still calls the model", async () => {

--- a/packages/core/src/services/evaluator.test.ts
+++ b/packages/core/src/services/evaluator.test.ts
@@ -522,6 +522,61 @@ describe("EvaluatorService", () => {
 		expect(useModel.mock.calls[3]?.[1]).toHaveProperty("responseSchema");
 	});
 
+	it("renders action results bounded (text projection, not the raw data payload)", async () => {
+		// Live sol-dev 2026-08-18: state.data.actionResults carried a full
+		// MEMORY_SEARCH ActionResult whose data.memories/durableMemories
+		// duplicated every hit's complete text; the old raw stringify pushed the
+		// merged post-turn evaluator call to ~50-52K prompt tokens on every
+		// recall turn. The prompt must render the bounded text projection and
+		// must NOT serialize the data payload.
+		const runtime = makeRuntime();
+		runtime.registerEvaluator({
+			name: "gamma",
+			description: "gamma section",
+			schema: schema(),
+			shouldRun: async () => true,
+			prompt: () => "Extract gamma.",
+			parse: (output) => output as never,
+			processors: [
+				{ name: "storeGamma", process: async () => ({ success: true }) },
+			],
+		});
+
+		const hugeDataMarker = "FULL_HIT_TEXT_ONLY_IN_DATA";
+		const actionResult = {
+			success: true,
+			text: "Showing all 7 match(es) found in the scanned window.",
+			data: {
+				actionName: "MEMORY_SEARCH",
+				memories: Array.from({ length: 17 }, (_, i) => ({
+					id: `id-${i}`,
+					text: `${hugeDataMarker} ${"detail ".repeat(300)}`,
+				})),
+			},
+		};
+
+		const useModel = vi.fn(async (_modelType, params) => {
+			const prompt = String(params.messages?.[0]?.content ?? "");
+			// The bounded text projection is present…
+			expect(prompt).toContain("MEMORY_SEARCH - succeeded");
+			expect(prompt).toContain("Showing all 7 match(es)");
+			// …and the raw data payload is NOT serialized into the prompt.
+			expect(prompt).not.toContain(hugeDataMarker);
+			return { gamma: { ok: true } };
+		});
+		runtime.useModel = useModel as AgentRuntime["useModel"];
+
+		const result = await new EvaluatorService(runtime).run(makeMessage(), {
+			values: {},
+			data: { actionResults: [actionResult] },
+			text: "",
+		});
+
+		expect(useModel).toHaveBeenCalledTimes(1);
+		expect(result.skipped).toBe(false);
+		expect(result.errors).toEqual([]);
+	});
+
 	it("trims oversized shared provider context and still calls the model", async () => {
 		const runtime = makeRuntime();
 		const processed: string[] = [];

--- a/packages/core/src/services/evaluator.ts
+++ b/packages/core/src/services/evaluator.ts
@@ -273,23 +273,15 @@ function buildPrompt(params: {
 		? state.data.actionResults
 		: undefined;
 	const providerContext = state.text.trim() || "(none)";
-	// Render action results through the bounded prompt formatter, not a raw
-	// stringify: `state.data.actionResults` carries the FULL ActionResult
-	// objects, and for recall-shaped actions `data.memories` +
-	// `data.durableMemories` duplicate every hit's complete text. Live sol-dev
-	// 2026-08-18: one MEMORY_SEARCH result raw-stringified here pushed the
-	// merged post-turn evaluator call to ~50-52K prompt tokens (10-23s at
-	// fable per-call latency) on every recall turn — while
-	// formatActionResultsForPrompt (the exact util the planner prompt uses via
-	// withActionResultsForPrompt) renders the same results bounded (text
-	// field, max 8 results, full-output references preserved). Non-array
-	// shapes keep the raw stringify — unknown data must stay visible.
+	// The merged evaluator prompt uses bounded model projections while the
+	// complete ActionResults remain available on state for evaluator code.
 	const sharedParts = {
 		latestMessage,
 		responseTexts,
 		actionResults: Array.isArray(actionResults)
 			? formatActionResultsForPrompt(actionResults as ActionResult[], {
 					header: "",
+					includeData: true,
 				})
 			: stringifyForPrompt(actionResults ?? []),
 		providerContext,

--- a/packages/core/src/services/evaluator.ts
+++ b/packages/core/src/services/evaluator.ts
@@ -29,6 +29,7 @@ import type {
 } from "../types/index.ts";
 import { EventType, ModelType } from "../types/index.ts";
 import { Service as BaseService } from "../types/service.ts";
+import { formatActionResultsForPrompt } from "../utils/action-results.ts";
 import { isObjectRecord as isRecord } from "../utils/type-guards.ts";
 
 type PreparedEntry = {
@@ -272,10 +273,25 @@ function buildPrompt(params: {
 		? state.data.actionResults
 		: undefined;
 	const providerContext = state.text.trim() || "(none)";
+	// Render action results through the bounded prompt formatter, not a raw
+	// stringify: `state.data.actionResults` carries the FULL ActionResult
+	// objects, and for recall-shaped actions `data.memories` +
+	// `data.durableMemories` duplicate every hit's complete text. Live sol-dev
+	// 2026-08-18: one MEMORY_SEARCH result raw-stringified here pushed the
+	// merged post-turn evaluator call to ~50-52K prompt tokens (10-23s at
+	// fable per-call latency) on every recall turn — while
+	// formatActionResultsForPrompt (the exact util the planner prompt uses via
+	// withActionResultsForPrompt) renders the same results bounded (text
+	// field, max 8 results, full-output references preserved). Non-array
+	// shapes keep the raw stringify — unknown data must stay visible.
 	const sharedParts = {
 		latestMessage,
 		responseTexts,
-		actionResults: stringifyForPrompt(actionResults ?? []),
+		actionResults: Array.isArray(actionResults)
+			? formatActionResultsForPrompt(actionResults as ActionResult[], {
+					header: "",
+				})
+			: stringifyForPrompt(actionResults ?? []),
 		providerContext,
 	};
 

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -963,6 +963,14 @@ export interface ActionResult {
 	 */
 	data?: ProviderDataRecord;
 
+	/**
+	 * Optional model-bound projection of `data`. When present, prompt renderers
+	 * use this object while runtime state and trajectories retain the complete
+	 * `data` payload. Use it when an action's machine result is substantially
+	 * larger than the fields a model needs to continue or evaluate the turn.
+	 */
+	promptData?: ProviderDataRecord;
+
 	/** Error information if the action failed */
 	error?: string | Error;
 

--- a/packages/core/src/utils/action-results.ts
+++ b/packages/core/src/utils/action-results.ts
@@ -13,6 +13,7 @@ import { tailWellFormed, truncateWellFormed } from "./well-formed";
 export const MAX_PROMPTED_ACTION_RESULTS = 8;
 export const MAX_ACTION_RESULT_TEXT_CHARS = 4000;
 export const MAX_ACTION_RESULT_ERROR_CHARS = 2000;
+export const MAX_ACTION_RESULT_DATA_CHARS = 4000;
 export const ACTION_RESULT_OVERSIZE_WARNING_TOKENS = 10000;
 export const ACTION_RESULT_TOKEN_ESTIMATE_CHARS = 4;
 
@@ -54,6 +55,83 @@ export interface ActionResultSizeWarning {
 export interface ActionResultReferences {
 	text?: string;
 	error?: string;
+}
+
+const PROMPT_DATA_PRIORITY_KEYS = [
+	"actionName",
+	"awaitingUserInput",
+	"slug",
+	"op",
+	"status",
+	"id",
+] as const;
+
+function compactPromptDataValue(value: unknown, depth = 0): unknown {
+	if (typeof value === "string") {
+		return value.length <= 512
+			? value
+			: `${truncateWellFormed(value, 496)}...[truncated]`;
+	}
+	if (
+		value === null ||
+		typeof value === "number" ||
+		typeof value === "boolean"
+	) {
+		return value;
+	}
+	if (depth >= 2) {
+		return Array.isArray(value)
+			? `[array with ${value.length} item(s)]`
+			: "[nested object omitted]";
+	}
+	if (Array.isArray(value)) {
+		const retained = value
+			.slice(0, 4)
+			.map((entry) => compactPromptDataValue(entry, depth + 1));
+		if (value.length > retained.length) {
+			retained.push(`[${value.length - retained.length} item(s) omitted]`);
+		}
+		return retained;
+	}
+	if (value && typeof value === "object") {
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>)
+				.slice(0, 8)
+				.map(([key, entry]) => [key, compactPromptDataValue(entry, depth + 1)]),
+		);
+	}
+	return String(value);
+}
+
+/**
+ * Serializes action data as complete JSON within the evaluator prompt budget.
+ * Small payloads remain byte-for-byte complete. Oversized payloads retain
+ * control scalars first and replace bulky nested values with explicit markers.
+ */
+export function formatActionResultDataForPrompt(
+	data: ProviderDataRecord,
+	maxChars = MAX_ACTION_RESULT_DATA_CHARS,
+): string {
+	const full = JSON.stringify(data);
+	if (full.length <= maxChars) return full;
+
+	const priority = new Set<string>(PROMPT_DATA_PRIORITY_KEYS);
+	const orderedEntries = [
+		...PROMPT_DATA_PRIORITY_KEYS.flatMap((key) =>
+			Object.hasOwn(data, key) ? [[key, data[key]] as const] : [],
+		),
+		...Object.entries(data).filter(([key]) => !priority.has(key)),
+	];
+	const projected: Record<string, unknown> = {};
+	for (const [key, value] of orderedEntries) {
+		const compact = compactPromptDataValue(value);
+		const candidate = { ...projected, [key]: compact, __truncated: true };
+		if (JSON.stringify(candidate).length <= maxChars) {
+			projected[key] = compact;
+		}
+	}
+	projected.__truncated = true;
+	return JSON.stringify(projected);
 }
 
 export function estimateActionResultTokens(text: string): number {
@@ -208,12 +286,14 @@ export function formatActionResultsForPrompt(
 		header?: string;
 		maxResults?: number;
 		preserveAbsoluteIndex?: boolean;
+		includeData?: boolean;
 	} = {},
 ): string {
 	const {
 		header = "# Current Chain Action Results",
 		maxResults = MAX_PROMPTED_ACTION_RESULTS,
 		preserveAbsoluteIndex = true,
+		includeData = false,
 	} = options;
 
 	if (actionResults.length === 0) {
@@ -242,12 +322,21 @@ export function formatActionResultsForPrompt(
 				`${displayIndex}. ${getActionResultActionName(result)} - ${status}`,
 			];
 			if (typeof result.text === "string" && result.text.trim()) {
-				lines.push(`Output: ${result.text.trim()}`);
+				lines.push(
+					`Output: ${truncateMiddle(result.text, MAX_ACTION_RESULT_TEXT_CHARS)}`,
+				);
 			}
 
 			const errorText = stringifyActionResultError(result.error);
 			if (errorText) {
-				lines.push(`Error: ${errorText}`);
+				lines.push(
+					`Error: ${truncateMiddle(errorText, MAX_ACTION_RESULT_ERROR_CHARS)}`,
+				);
+			}
+
+			const modelData = result.promptData ?? result.data;
+			if (includeData && modelData && Object.keys(modelData).length > 0) {
+				lines.push(`Data: ${formatActionResultDataForPrompt(modelData)}`);
 			}
 
 			const outputReference = getActionResultReference(result, "text");


### PR DESCRIPTION
Closes #22200

# Relates to

Live-runtime latency investigation on a long-memory deployment (trajectory receipts attached). Closes #22200. This the change is a scoped perf fix with pinned tests.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (branched from `d22178cc731`).
- [x] `bun install` and proportional verification were run after sync (full core runtime suite, focused suites, typecheck, biome, focused-test/lane/plugin-convention audits); see Evidence. Full `bun run verify` was not run end to end: it builds every package in the monorepo and is disproportionate to a 2-commit core/agent prompt-rendering change; every check that touches the changed surface was run and passes.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5` (via anthropic-proxy alias)
<!-- attribution-row:client -->
- Agent tooling: `OpenClaw subagent (Sol)`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (`d22178cc731`); zero conflicts.
- [x] Proportional verification passes post-sync (see Evidence Gate); the one pre-existing repo-wide note (`packages/homepage` lane-membership owner decision) is unrelated and reported verbatim in the attached audit log.

# Risks

Low.

- The data cap only engages when a tool result carries a **text projection**; text-less results keep rendering `data` in full (that fallback role is documented in `toolMessageContent` itself and pinned by an existing-behavior test). Trajectory archives always keep the complete data.
- The evaluator change routes **arrays** of action results through the exact bounded formatter the planner prompt path already uses (`formatActionResultsForPrompt`); non-array/unknown shapes keep the raw stringify so nothing becomes invisible.
- The alias additions are additive entries in `CANDIDATE_ACTION_PARENT_ALIASES` + MEMORY `similes`; collision space checked by the routing-alias test suite.

## Reviewer remediation at exact head `3d5eb7715a399001923ba690e4dec8002bb64f19`

The blocking review was repaired after rebasing onto `origin/develop` at `aec9e2121c58915907c1decafabba9157348c0d1`:

- Replaced the global 4,000-character mid-JSON cap with an action-owned `promptData` contract. MEMORY search supplies a small complete-JSON projection; full `data.memories` remains unchanged in state and trajectories. Other tools keep complete chaining data by default.
- Preserved data-only evaluator results as bounded valid JSON. Regression coverage pins `actionName`, `awaitingUserInput`, and `slug`, an oversized structured payload, and unchanged full processor state.
- Removed dated incident narration from maintained source comments while retaining durable contract rationale.
- Exact-head focused suites: 124 passed, 0 failed (planner rendering, action retrieval, evaluator service, MEMORY action).
- Exact-head advanced evaluator compatibility: 27 passed, 0 failed (advanced memory, reflection, experience).
- Exact-head `packages/core` typecheck: passed.
- `packages/agent` package-wide typecheck remains blocked by the checkout dependency baseline (missing optional workspace/plugin declarations across unrelated cloud, wallet, and UI packages); the owning MEMORY suite passes 25/25.

The original redacted live trajectories remain applicable to the same recall serialization path; the remediation narrows projection ownership without changing the measured MEMORY text projection or alias behavior.

# Background

## What does this PR do?

Stops paying a ~46KB serialized MEMORY_SEARCH result **twice** into model prompts on every recall turn, and makes stage-1 `RECALL_MEMORY`-family candidates resolve to the MEMORY action instead of dying at the gate.

**Root cause, measured live** (long-memory deployment, `ELIZA_TRAJECTORY_LOGGING=1`, model `claude-fable-5`): a recall turn's MEMORY op:search ActionResult carries a ~5KB `text` projection PLUS a ~46KB `data` payload (`data.memories` + `data.durableMemories` duplicate every hit's full text). Two independent render sites serialized the data blob verbatim:

1. `toolMessageContent` (planner-rendering.ts) appended `data: <pretty-printed JSON>` to every tool message despite its own docstring calling `data` a fallback for text-less results → the post-search planner call ballooned from ~18K to ~36-37K prompt tokens (9.4-18.9s per call at this model's latency vs 4.0-5.7s baseline).
2. `EvaluatorService.buildPrompt` raw-stringified `state.data.actionResults` (the full ActionResult objects) into the merged post-turn evaluator prompt → ~50K prompt tokens, 10.2-22.9s per call.

**Measured effect of the fix** (same deployment, service restarted on the fixed build, same recall queries):

- post-search planner call: **36-37K → 15-16K prompt tokens**
- post-turn evaluator call: ~50K → 45.5K prompt tokens on the cleanest run (remaining bulk is provider context, a separate issue)
- whole recall turn: ~122-124K → ~94-102K prompt tokens (~25K shaved, ~20% cost per recall turn)
- worst-case turn: 58.6s (22.9s evaluator tail) pre-fix → 13.9s worst evaluator post-fix
- stage-1 recall candidates now resolve: live log had 29 `gate=resolved-to-no-runtime-action` hits for `RECALL_MEMORY`/`MEMORY_RECALL` (stage-1 wanted the recall, the dead candidate cost a full extra planner round); zero after the alias fix

Fix mechanics:

- `toolMessageContent`: when a result has a text projection, the rendered `data:` section is capped at `MAX_RENDERED_DATA_CHARS_WITH_TEXT` (4,000 chars, head+tail via the existing `truncateToolResultText`). Small chaining payloads (ids, URLs, workspace handles) still render fully; text-less results keep full data.
- `memories.ts` op:search: windowed hit lines render 300 chars (parity with durable-corpus lines) so the `text` projection carries each hit's operative content instead of leaning on the now-capped blob. At 120 chars, a stored correction's operative clause was legible only via the doomed data payload.
- MEMORY gains `RECALL_MEMORY`/`RECALL_MEMORIES`/`MEMORY_RECALL`/`MEMORY_SEARCH` similes; core's `CANDIDATE_ACTION_PARENT_ALIASES` gains the recall family.
- `EvaluatorService.buildPrompt`: arrays of action results render via `formatActionResultsForPrompt` (text projection, max 8 results, full-output references preserved, no data payload) — the same bounded util the planner prompt path uses via `withActionResultsForPrompt`.

## What kind of change is this?

Improvements (perf fix in prompt rendering; no behavior change beyond bounded rendering and candidate alias resolution).

# Documentation changes needed?

My changes do not require a change to the project documentation (rendering-contract comments updated inline at both render sites).

# Testing

## Where should a reviewer start?

- `packages/core/src/runtime/planner-rendering.ts` (`toolMessageContent`, the cap) and its test file (`planner-rendering.test.ts`, "data cap when a text projection exists" describe block).
- `packages/core/src/services/evaluator.ts` (`renderStateData`) + `evaluator.test.ts` ("bounded action results" pin).
- `packages/core/src/runtime/action-retrieval.ts` + `packages/agent/src/actions/memories.ts` for the alias family, with pins in `action-retrieval.test.ts` and `memories.test.ts`.

## Detailed testing steps

Automated tests are acceptable. Bidirectional proof:

- Fixed head: focused suites all green — core `planner-rendering` 22/22, `action-retrieval` 62/62 (file total), `evaluator` 12/12, agent `memories` 25/25; full core runtime `__tests__` sweep **1270/1270**; core `tsc --noEmit` exit 0; biome clean on all 8 changed files.
- Unfixed develop (impl files reverted to `d22178cc731`, new test pins kept): **exactly the 7 new pins fail** (5 in core: data cap ×3, evaluator bounded render, alias resolution; 2 in agent: RECALL_MEMORY lookup, 300-char line render) and nothing else. Log attached.

# Evidence Gate

<!-- evidence-head:3d5eb7715a399001923ba690e4dec8002bb64f19 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - core/agent prompt-rendering change only; no rendered UI surface. The textual "before" state (pre-fix trajectory token/latency table + failing pin suite on unfixed develop) is attached under backend logs and llm-trajectory.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no rendered UI surface; the post-fix trajectory table and passing exact-head suites are attached under backend logs and llm-trajectory.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - runtime prompt-rendering perf change with no user-visible flow; the pre/post trajectory comparison is the walkthrough equivalent for this change class.
<!-- evidence-row:backend-logs -->
- [x] [22197-focused-tests-rebased-head.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22197-focused-tests-rebased-head.log) (focused suites at exact head: core 97/97, agent memories 25/25), [22197-bidirectional-unfixed-develop.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22197-bidirectional-unfixed-develop.log) (impl reverted to develop, exactly the 7 new pins fail), [22197-verification-suite.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22197-verification-suite.log) (full core runtime 1270/1270, core tsc exit 0, biome clean on 8 changed files, proportional root audits)
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code, view, or network path changed; diff touches packages/core runtime/services and packages/agent actions plus tests only.
<!-- evidence-row:llm-trajectory -->
- [x] [22197-recall-trajectories-redacted.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22197-recall-trajectories-redacted.json) (six real claude-fable-5 recall-turn recorder trajectories, 3 pre-fix / 3 post-fix; free text redacted because the live store holds personal data, all structure/models/tool-calls/token counts unmodified; human-readable per-call table under domain artifacts)
<!-- evidence-row:domain-artifacts -->
- [x] [22197-trajectory-summary.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22197-trajectory-summary.log) - per-call promptTokens/completionTokens table from the recorder showing the post-search planner call collapse 36-37K to 15-16K ptok (raw structured JSON under llm-trajectory)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

Captured with the runtime trajectory recorder (`ELIZA_TRAJECTORY_LOGGING=1`) on a live long-memory deployment rather than `eliza-scenarios`: this bug only manifests at scale (a memory store with thousands of rows producing ~46KB search results); a synthetic scenario store would not reproduce the token explosion. Six real recall turns, same room, same query class, model `claude-fable-5`:

| trajectory | phase | turn total | post-search planner call | evaluator call |
|---|---|---|---|---|
| ipd1zs | pre-fix | 58.6s | 18.9s @ 37,630 ptok | 22.9s @ 49,984 ptok |
| rv6oxq | pre-fix | 38.7s | 11.5s @ 37,165 ptok | 10.2s @ 50,228 ptok |
| 5m6ir4 | pre-fix | 35.9s | 9.4s @ 35,640 ptok | 10.9s @ 50,284 ptok |
| 018i2k | post-fix | 41.8s | 10.6s @ **15,566 ptok** | 13.0s @ 52,665 ptok |
| nzz4ue | post-fix | 43.1s | 15.7s @ **16,510 ptok** | 13.9s @ 52,644 ptok |
| fhm7y8 | post-fix | 47.9s | 20.1s @ **15,390 ptok** | 11.4s @ **45,555 ptok** |

(Post-fix wall times overcount user-felt latency: the compat route drains the post-turn evaluator before responding; time-to-reply was ~28s. Post-fix evaluator ptok remaining bulk is provider-context duplication, a separate pre-existing issue, verified absent of raw action-result data in the recorded prompt.)

Raw structured trajectory JSON (redacted free text, unmodified structure/token counts) + summary table: see Evidence Gate artifacts.

## Backend + frontend logs

Backend: attached artifacts (focused tests at exact head; bidirectional pin-failure run on unfixed develop; full core runtime suite 1270/1270 + core tsc exit 0; biome clean on the 8 changed files; proportional root audits). Frontend: N/A - no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface; runtime prompt-rendering only.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- Full `bun run verify` (whole-monorepo build+typecheck of every package) not run end to end; proportional equivalents on the changed surface all pass (core full runtime suite, focused suites both packages, core typecheck, biome, focused-test/plugin-convention/lane-membership audits). Pre-existing repo-wide note in the audit log (`packages/homepage` lane membership owner decision) is unrelated to this diff.
- `packages/agent` package-wide `tsc` has pre-existing unrelated failures on a fresh develop checkout (missing optional plugin type declarations, e.g. `@elizaos/plugin-capacitor-bridge`, `@elizaos/plugin-video`); present before and after this change; the agent-side diff is exercised by its passing test file instead.
- The post-turn evaluator's remaining ~45-52K prompt-token bulk (five duplicated "Recent messages" provider copies in one merged prompt) is a separate pre-existing issue, out of scope here.

## Discord username

wakesync

---

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: OpenClaw subagent (Sol)
Contribution skill revision: elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [Sol]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"OpenClaw subagent (Sol)","skill_revision":"elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza"} -->