### PR TITLE
fix(shared): bound Stripe checkout fetch with timeout

### DIFF
--- a/packages/shared/src/checkout/index.test.ts
+++ b/packages/shared/src/checkout/index.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Checkout fetch deadline — proves the shared Stripe checkout client aborts
+ * hanging and body-stalled requests at the documented 10s budget and merges
+ * a caller signal via AbortSignal.any.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createStripeCheckoutSession,
+  DEFAULT_STRIPE_CHECKOUT_FETCH_TIMEOUT_MS,
+} from "./index.ts";
+
+const request = {
+  hardwareSku: "sku-1",
+  hardwareColor: "black",
+  returnUrl: "https://example.com/return",
+};
+
+describe("createStripeCheckoutSession fetch timeout", () => {
+  let origTimeout: typeof AbortSignal.timeout;
+
+  beforeEach(() => {
+    origTimeout = AbortSignal.timeout.bind(AbortSignal);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exposes the documented 10s budget", () => {
+    expect(DEFAULT_STRIPE_CHECKOUT_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("aborts a stalled checkout POST at the deadline", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => origTimeout(10));
+    const spy = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const sig = init?.signal as AbortSignal | undefined;
+        if (!sig) throw new Error("signal missing");
+        sig.addEventListener("abort", () => reject(sig.reason), { once: true });
+      });
+    });
+    const prev = globalThis.fetch;
+    globalThis.fetch = spy as unknown as typeof fetch;
+    try {
+      await expect(
+        createStripeCheckoutSession(request, {
+          apiBaseUrl: "https://api.example.com",
+        }),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/stripe/create-checkout-session"),
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+          method: "POST",
+        }),
+      );
+    } finally {
+      globalThis.fetch = prev;
+    }
+  });
+
+  it("keeps the deadline active while the response body stalls", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => origTimeout(10));
+    const spy = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      const sig = init?.signal as AbortSignal | undefined;
+      if (!sig) throw new Error("signal missing body stall");
+      return {
+        ok: true,
+        status: 200,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            sig.addEventListener("abort", () => reject(sig.reason), {
+              once: true,
+            });
+          }),
+      } as unknown as Response;
+    });
+    const prev = globalThis.fetch;
+    globalThis.fetch = spy as unknown as typeof fetch;
+    try {
+      await expect(
+        createStripeCheckoutSession(request, {
+          apiBaseUrl: "https://api.example.com",
+        }),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+    } finally {
+      globalThis.fetch = prev;
+    }
+  });
+
+  it("merges a caller signal via AbortSignal.any", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() =>
+      origTimeout(10_000),
+    );
+    const anySpy = vi.spyOn(AbortSignal, "any");
+    const controller = new AbortController();
+    const spy = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      // trigger caller abort immediately
+      queueMicrotask(() =>
+        controller.abort(new DOMException("caller abort", "AbortError")),
+      );
+      return new Promise<Response>((_resolve, reject) => {
+        const sig = init?.signal as AbortSignal | undefined;
+        if (!sig) throw new Error("signal missing any");
+        sig.addEventListener("abort", () => reject(sig.reason), { once: true });
+      });
+    });
+    const prev = globalThis.fetch;
+    globalThis.fetch = spy as unknown as typeof fetch;
+    try {
+      await expect(
+        createStripeCheckoutSession(request, {
+          apiBaseUrl: "https://api.example.com",
+          signal: controller.signal,
+        }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(anySpy).toHaveBeenCalled();
+      const sig = (spy.mock.calls[0]?.[1] as RequestInit | undefined)?.signal as
+        | AbortSignal
+        | undefined;
+      expect(sig).toBeDefined();
+    } finally {
+      globalThis.fetch = prev;
+    }
+  });
+
+  it("passes through a successful checkout response", async () => {
+    const spy = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ url: "https://checkout.stripe.com/c/pay_123" }),
+      } as unknown as Response;
+    });
+    const prev = globalThis.fetch;
+    globalThis.fetch = spy as unknown as typeof fetch;
+    try {
+      const url = await createStripeCheckoutSession(request, {
+        apiBaseUrl: "https://api.example.com",
+        timeoutMs: 5000,
+      });
+      expect(url).toBe("https://checkout.stripe.com/c/pay_123");
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = prev;
+    }
+  });
+});

--- a/packages/shared/src/checkout/index.ts
+++ b/packages/shared/src/checkout/index.ts
@@ -20,16 +20,22 @@ export interface StripeCheckoutRequest {
   returnUrl: string;
 }
 
+export const DEFAULT_STRIPE_CHECKOUT_FETCH_TIMEOUT_MS = 10_000;
+
 export interface StripeCheckoutOptions {
   /**
    * Absolute base URL of the Cloud API, or empty string for same-origin.
    * The endpoint path `/api/stripe/create-checkout-session` is appended.
    */
   apiBaseUrl: string;
-  /** Optional bearer token (Steward session) for guest-flow auth. */
+  /** Optional Bearer token (Steward session) for guest-flow auth. */
   bearerToken?: string | null;
   /** Whether to send credentials (cookies). Defaults to "include". */
   credentials?: RequestCredentials;
+  /** Optional caller abort signal to merge with the request deadline. */
+  signal?: AbortSignal;
+  /** Optional override for the request deadline in milliseconds. */
+  timeoutMs?: number;
 }
 
 interface StripeCheckoutResponse {
@@ -63,18 +69,34 @@ export async function createStripeCheckoutSession(
     headers.Authorization = `Bearer ${options.bearerToken}`;
   }
 
+  const timeoutMs =
+    options.timeoutMs ?? DEFAULT_STRIPE_CHECKOUT_FETCH_TIMEOUT_MS;
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, timeoutSignal])
+    : timeoutSignal;
+
   const response = await fetch(endpoint, {
     method: "POST",
     credentials: options.credentials ?? "include",
     headers,
     body: JSON.stringify(request),
+    signal,
   });
 
   // error-policy:J3 a non-JSON checkout body → null; the failure is surfaced by
   // the throw below when `response.ok` is false or `body.url` is absent.
-  const body = (await response
-    .json()
-    .catch(() => null)) as StripeCheckoutResponse | null;
+  let body: StripeCheckoutResponse | null;
+  try {
+    body = (await response.json()) as StripeCheckoutResponse | null;
+  } catch (err) {
+    if (
+      err instanceof DOMException &&
+      (err.name === "TimeoutError" || err.name === "AbortError")
+    )
+      throw err;
+    body = null;
+  }
 
   if (!response.ok || !body?.url) {
     throw new StripeCheckoutError(


### PR DESCRIPTION
## Summary
- Bound `POST /api/stripe/create-checkout-session` in `packages/shared/src/checkout/index.ts:72-84` with `DEFAULT_STRIPE_CHECKOUT_FETCH_TIMEOUT_MS=10_000` via `AbortSignal.timeout`, merging caller signal via `AbortSignal.any`, and preserving the same signal through `response.json()` (rethrow `TimeoutError`/`AbortError` before J3 fallback). Prevents indefinite hang of both `os-homepage` and `cloud-frontend` checkout redirects.
- Preserved J3 fallback for non-JSON / non-abort bodies and existing `StripeCheckoutError` contract; no callers changed.

## What Changed
- `packages/shared/src/checkout/index.ts`: export `DEFAULT_STRIPE_CHECKOUT_FETCH_TIMEOUT_MS`, extend `StripeCheckoutOptions` with optional `signal` + `timeoutMs`, add deadline signal to `fetch`, rethrow abort errors from `json()`.
- `packages/shared/src/checkout/index.test.ts`: 5 tests — exposed budget, stalled POST abort (10ms mock), body-stall abort via `json()`, `AbortSignal.any` merge, and success passthrough.

## Exact-head evidence
Head: 535d9a1ff054ed19a0889c746f2c81e945350c1b
Base: origin/develop@c0459a8069b927bc30255f75345b94425512c6b0 with zero conflicts

## Verification / Definition of Done
- [x] Targets `develop`, rebased onto `origin/develop@c0459a8069b927bc30255f75345b94425512c6b0` with zero conflicts (`git merge-base --is-ancestor` true)
- [x] `bun install --frozen-lockfile` intact (no lockfile change)
- [x] `bun run --cwd packages/shared typecheck` — pass
- [x] `bun run --cwd packages/shared test src/checkout/index.test.ts` — 5 passed (budget / hanging fetch TimeoutError / body-stall TimeoutError / AbortSignal.any merge / success)
- [x] Full `bun run --cwd packages/shared test` — 2009+5 passed, 3 pre-existing failures in `steward-session-client` (verified on base via `git stash` — identical)
- [x] `bunx @biomejs/biome check --write` — fixed, no remaining errors
- [x] Reviewer can confirm from automated tests and current-catalog negative control (`Number(beforeParam)` not used here; fetch deadline is the contract)

## Contribution provenance
<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: Muse Spark
- Agent tooling: Muse Code

Original contribution direction credited to byt61 in commit trailer.
Co-authored-by: byt61 <byt61@users.noreply.github.com>
