### PR TITLE
fix(telegram): keep surrogate pairs (emoji) intact when chunking outbound messages

### DIFF
--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -107,6 +107,32 @@ describe("MessageManager long message splitting", () => {
     expect(sentMessages.map((message) => message.text).join("")).toBe(text);
   });
 
+  it("keeps a surrogate pair (emoji) intact instead of splitting it across chunks", async () => {
+    const { manager, sendMessage } = createManager();
+    // "x" * 4095 then a 2-code-unit emoji then more text: a naive slice(0, 4096)
+    // would cut between the emoji's high and low surrogate.
+    const text = `${"x".repeat(4095)}\u{1F600}${"y".repeat(10)}`;
+
+    const sentMessages = await manager.sendMessageInChunks(
+      {
+        chat: { id: 123 },
+        telegram: {
+          sendChatAction: vi.fn(async () => undefined),
+          sendMessage,
+        },
+      } as never,
+      { text },
+    );
+
+    const sentTexts = sendMessage.mock.calls.map((call) => call[1] as string);
+    for (const chunk of sentTexts) {
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+    expect(sentTexts.join("")).toBe(text);
+    expect(sentMessages.map((message) => message.text).join("")).toBe(text);
+  });
+
   it("prefers newline boundaries when they fit within Telegram's limit", async () => {
     const { manager, sendMessage } = createManager();
     const firstLine = "x".repeat(4094);

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -33,6 +33,7 @@ import {
   type ResolvedAttachmentBytes,
   resolveAttachmentBytes,
   ServiceType,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
 import type {
@@ -1404,8 +1405,15 @@ export class MessageManager {
         }
 
         if (availableLength > 0) {
-          currentChunk += remaining.slice(0, availableLength);
-          remaining = remaining.slice(availableLength);
+          // A raw slice() can land between the two UTF-16 code units of a
+          // surrogate pair (most emoji), leaving a lone surrogate at the
+          // chunk boundary that corrupts the character on the wire.
+          // truncateWellFormed backs the cut off by one unit instead.
+          const head = truncateWellFormed(remaining, availableLength);
+          if (head.length > 0) {
+            currentChunk += head;
+            remaining = remaining.slice(head.length);
+          }
         }
 
         if (currentChunk) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22203.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low, and narrowing. `MessageManager.splitMessage` is a private method with a
single caller (`sendMessageInChunks` in the same class); the change only
alters where a chunk boundary falls when it would otherwise land inside a
surrogate pair — every other split decision (newline preference, exact
4096-char cap) is unchanged and covered by the pre-existing test suite (all
27 prior tests still pass unmodified). Worst case on a bad rollout: a chunk
is one code unit shorter than the 4096 cap in the rare case a boundary would
have split a pair — never longer, never dropped content (`sentTexts.join("")
=== text` is asserted).

# Background

## What does this PR do?

`MessageManager.splitMessage` (`plugins/plugin-telegram/src/messageManager.ts`)
cut oversized outbound replies into ≤4096-char chunks with a raw
`remaining.slice(0, availableLength)`. `String.prototype.slice` indexes by
UTF-16 code unit, not character — when a chunk boundary landed between the
two code units of a surrogate pair (most emoji), the pair was torn in half:
one chunk ended with a lone high surrogate, the next started with a lone low
surrogate, and both are malformed UTF-16 (`String.prototype.isWellFormed()
=== false`).

The repo already has a purpose-built, well-tested fix for exactly this bug
shape: `truncateWellFormed` in `packages/core/src/utils/well-formed.ts`
(`text.slice(0, maxLength)` that backs the cut off by one code unit instead
of splitting a pair), already used at ~20 call sites across `packages/core`,
`packages/agent`, `packages/skills`, and `plugin-openai`. This PR swaps the
raw slice for `truncateWellFormed` at the one call site in `plugin-telegram`
that wasn't using it — no new logic, no new dependency, reusing an existing,
already-reviewed helper.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-telegram/src/messageManager.test.ts` — new test `keeps a
  surrogate pair (emoji) intact instead of splitting it across chunks`,
  placed directly after the existing raw-hard-split test it extends.

## Detailed testing steps

None: Automated tests are acceptable. The new test drives the real exported
`MessageManager.sendMessageInChunks` → `splitMessage` path (Telegraf mocked
at the `sendMessage` boundary only) with a 4106-char string engineered so a
2-code-unit emoji straddles the 4096-char boundary, and asserts every sent
chunk is `isWellFormed()` and the chunks reassemble to the exact original
text.

- `bun run --cwd plugins/plugin-telegram test -- src/messageManager.test.ts` (28 tests)
- Full plugin-telegram suite (206 tests, no regressions): `bun run --cwd plugins/plugin-telegram test`
- `bun run --cwd plugins/plugin-telegram typecheck`
- `bunx biome check plugins/plugin-telegram/src/messageManager.ts plugins/plugin-telegram/src/messageManager.test.ts`

I also verified the new test is not a tautology: reverting only the
production fix (keeping the raw `slice`) makes it fail with
`expected false to be true` on `chunk.isWellFormed()` — see the backend-logs
evidence below for both runs.

# Evidence Gate

<!-- evidence-head:9201bfd132db14b182aa13db3c6cd32fb68fb595 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change (packages/core-consumed plugin logic), no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change, no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change, no user-facing flow to walk through
<!-- evidence-row:backend-logs -->
- [x] Real Vitest run, plus a control run proving the new test fails without the fix.

<details>
<summary>Backend logs — new test (fix applied), full suite, control run against unpatched code</summary>

```
$ bun run --cwd plugins/plugin-telegram test -- src/messageManager.test.ts

 ✓ MessageManager long message splitting > sends interaction-only replies with fallback text and inline keyboard
 ✓ MessageManager long message splitting > hard-splits a single over-limit line into Telegram-sized messages
 ✓ MessageManager long message splitting > keeps a surrogate pair (emoji) intact instead of splitting it across chunks
 ✓ MessageManager long message splitting > prefers newline boundaries when they fit within Telegram's limit
   ... (24 more, all passing)

 Test Files  1 passed (1)
      Tests  28 passed (28)

$ bun run --cwd plugins/plugin-telegram test   # full plugin suite

 Test Files  22 passed (22)
      Tests  206 passed (206)

$ bun run --cwd plugins/plugin-telegram typecheck
(no output — clean)

$ bunx biome check plugins/plugin-telegram/src/messageManager.ts plugins/plugin-telegram/src/messageManager.test.ts
Checked 2 files in 24ms. No fixes applied.

--- Control: temporarily reverted ONLY the production fix (kept raw slice),
--- re-ran just the new test, to prove it's not a tautology:

$ bun run --cwd plugins/plugin-telegram test -- src/messageManager.test.ts -t "surrogate pair"

 ❯ MessageManager long message splitting > keeps a surrogate pair (emoji) intact instead of splitting it across chunks
   AssertionError: expected false to be true
     ❯ src/messageManager.test.ts:130:36
        128|     for (const chunk of sentTexts) {
        129|       expect(chunk.length).toBeLessThanOrEqual(4096);
        130|       expect(chunk.isWellFormed()).toBe(true);

 Tests  1 failed | 27 skipped (28)

--- Fix restored, full suite re-verified green (shown above).
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] Real standalone reproduction of the pre-fix corruption against the
      exact unpatched algorithm (not a paraphrase), showing the lone
      surrogates by char code.

<details>
<summary>Domain artifact — standalone repro of the pre-fix corruption</summary>

```
$ node -e '<the unpatched splitMessage() function, pasted verbatim, plus:>
const text = "x".repeat(4095) + "\u{1F600}";
const chunks = splitMessage(text);
...'

text.length (UTF-16 units): 4097
chunk count: 2
chunk[0] length=4096 lastCharCode=0xd83d   <- lone high surrogate
chunk[1] length=1    firstCharCode=0xde00  <- lone low surrogate
is chunk0 well-formed: false
is chunk1 well-formed: false
```

Same emoji, same boundary, run again against the PR's fixed algorithm
(reflected in the new Vitest test above): chunk 0 comes out 4095 chars
(backed off by one unit to keep the pair together), both chunks
`isWellFormed() === true`, and rejoining them reproduces the original emoji
exactly.

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-manual]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza"} -->

