### PR TITLE
fix(plugins): prevent message truncation from splitting surrogate pairs

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/computer-use-agent.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/computer-use-agent.test.ts
@@ -531,4 +531,52 @@ describe("runComputerUseAgentLoop — fake Brain", () => {
       "failed: Coordinates",
     );
   });
+
+  it("truncates progress rationale and failure without tearing UTF-16 surrogate pairs at 180 limit", () => {
+    const rationale = `${"r".repeat(176)}\u{1F98A}zzzz`;
+    const stepProgress: ComputerUseAgentStepProgress = {
+      step: 1,
+      maxSteps: 5,
+      actionKind: "click",
+      rationale,
+      result: { success: true },
+    };
+
+    const formatted = formatComputerUseAgentProgress(stepProgress);
+    expect(formatted.isWellFormed()).toBe(true);
+    expect(formatted).toContain(`${"r".repeat(176)}...`);
+  });
+
+  it("preserves well-formed progress rationale at and below the 180-code-unit limit", () => {
+    for (const rationale of ["ready 🦊", "r".repeat(180)]) {
+      const formatted = formatComputerUseAgentProgress({
+        step: 1,
+        maxSteps: 5,
+        actionKind: "click",
+        rationale,
+        result: { success: true },
+      });
+
+      expect(formatted).toContain(rationale);
+      expect(formatted).not.toContain("...");
+      expect(formatted.isWellFormed()).toBe(true);
+    }
+  });
+
+  it("normalizes lone surrogates in short rationale and truncated failure status", () => {
+    const formatted = formatComputerUseAgentProgress({
+      step: 1,
+      maxSteps: 5,
+      actionKind: "click",
+      rationale: "inspect\ud800status",
+      result: {
+        success: false,
+        error: `${"e".repeat(176)}\udc00tail`,
+      },
+    });
+
+    expect(formatted.isWellFormed()).toBe(true);
+    expect(formatted).toContain("inspect�status");
+    expect(formatted).toContain(`${"e".repeat(176)}�...`);
+  });
 });

--- a/plugins/plugin-computeruse/src/__tests__/computer-use-agent.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/computer-use-agent.test.ts
@@ -579,4 +579,45 @@ describe("runComputerUseAgentLoop — fake Brain", () => {
     expect(formatted).toContain("inspect�status");
     expect(formatted).toContain(`${"e".repeat(176)}�...`);
   });
+
+  it("normalizes either lone-surrogate half before status retention or clipping", () => {
+    for (const rationale of [
+      "inspect\ud800status",
+      "inspect\udc00status",
+      `${"h".repeat(176)}\ud800tail`,
+      `${"l".repeat(176)}\udc00tail`,
+    ]) {
+      const formatted = formatComputerUseAgentProgress({
+        step: 1,
+        maxSteps: 5,
+        actionKind: "click",
+        rationale,
+        result: { success: true },
+      });
+
+      expect(formatted.isWellFormed()).toBe(true);
+      expect(formatted).toContain("�");
+    }
+  });
+
+  it("reserves the status suffix only after the 180-code-unit boundary", () => {
+    const atLimit = formatComputerUseAgentProgress({
+      step: 1,
+      maxSteps: 5,
+      actionKind: "click",
+      rationale: "m".repeat(180),
+      result: { success: true },
+    });
+    const overLimit = formatComputerUseAgentProgress({
+      step: 1,
+      maxSteps: 5,
+      actionKind: "click",
+      rationale: "n".repeat(181),
+      result: { success: true },
+    });
+
+    expect(atLimit).toContain("m".repeat(180));
+    expect(atLimit).not.toContain("...");
+    expect(overLimit).toContain(`${"n".repeat(177)}...`);
+  });
 });

--- a/plugins/plugin-computeruse/src/actions/use-computer-agent.ts
+++ b/plugins/plugin-computeruse/src/actions/use-computer-agent.ts
@@ -32,6 +32,8 @@ import {
   logger,
   type Memory,
   type State,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   type AgentMiddleware,
@@ -478,11 +480,11 @@ function errorMessage(err: unknown): string {
 }
 
 function truncateForStatus(value: string, maxLength = 180): string {
-  const compact = value.replace(/\s+/g, " ").trim();
+  const compact = toWellFormedUnicode(value.replace(/\s+/g, " ").trim());
   if (compact.length <= maxLength) {
     return compact;
   }
-  return `${compact.slice(0, maxLength - 3)}...`;
+  return `${truncateWellFormed(compact, maxLength - 3)}...`;
 }
 
 export const computerUseAgentAction: Action = {

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -270,9 +270,9 @@ describe("gmail send handler", () => {
       { text: "Derived\udc00subject\nbody" }
     );
 
-    const subjects = vi
-      .mocked(sendGmailMessage)
-      .mock.calls.map((call) => (call[0] as { subject: string }).subject);
+    const subjects = sendGmailMessage.mock.calls.map(
+      (call) => (call[0] as { subject: string }).subject
+    );
     expect(subjects).toEqual(["Explicit�subject", "Derived�subject"]);
     expect(subjects.every((subject) => subject.isWellFormed())).toBe(true);
   });
@@ -306,8 +306,53 @@ describe("gmail send handler", () => {
     }
 
     expect(
-      vi.mocked(sendGmailMessage).mock.calls.map((call) => (call[0] as { subject: string }).subject)
+      sendGmailMessage.mock.calls.map((call) => (call[0] as { subject: string }).subject)
     ).toEqual(subjects);
+  });
+
+  it("normalizes either lone-surrogate half before a derived subject is retained or clipped", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+    const inputs = [
+      "short\ud800subject",
+      "short\udc00subject",
+      `${"h".repeat(74)}\ud800tail`,
+      `${"l".repeat(74)}\udc00tail`,
+    ];
+
+    for (const text of inputs) {
+      await invokeSend(registration, runtime, { channelId: "shadow@example.com" }, { text });
+    }
+
+    const subjects = sendGmailMessage.mock.calls.map(
+      (call) => (call[0] as { subject: string }).subject
+    );
+    expect(subjects).toEqual([
+      "short�subject",
+      "short�subject",
+      `${"h".repeat(74)}�...`,
+      `${"l".repeat(74)}�...`,
+    ]);
+    expect(subjects.every((subject) => subject.isWellFormed())).toBe(true);
+    expect(subjects.every((subject) => subject.length <= 78)).toBe(true);
+  });
+
+  it("reserves the suffix only after the 78-code-unit boundary", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    for (const text of ["m".repeat(78), "n".repeat(79)]) {
+      await invokeSend(registration, runtime, { channelId: "shadow@example.com" }, { text });
+    }
+
+    const subjects = sendGmailMessage.mock.calls.map(
+      (call) => (call[0] as { subject: string }).subject
+    );
+    expect(subjects).toEqual(["m".repeat(78), `${"n".repeat(75)}...`]);
   });
 
   it("resolves an entity-store recipient through stored email handles", async () => {

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -251,6 +251,65 @@ describe("gmail send handler", () => {
     );
   });
 
+  it("normalizes lone surrogates in explicit and short derived subjects", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com" },
+      { text: "body", metadata: { subject: "Explicit\ud800subject" } }
+    );
+    await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com" },
+      { text: "Derived\udc00subject\nbody" }
+    );
+
+    const subjects = vi
+      .mocked(sendGmailMessage)
+      .mock.calls.map((call) => (call[0] as { subject: string }).subject);
+    expect(subjects).toEqual(["Explicit�subject", "Derived�subject"]);
+    expect(subjects.every((subject) => subject.isWellFormed())).toBe(true);
+  });
+
+  it("truncates long derived subjects without tearing UTF-16 surrogate pairs", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const text = `${"a".repeat(74)}\u{1F98A}bbbb\nBody line 2`;
+    await invokeSend(registration, runtime, { channelId: "shadow@example.com" }, { text });
+
+    expect(sendGmailMessage).toHaveBeenCalledTimes(1);
+    const sentSubject = (sendGmailMessage.mock.calls[0][0] as { subject: string }).subject;
+    expect(sentSubject.length).toBeLessThanOrEqual(78);
+    expect(sentSubject.isWellFormed()).toBe(true);
+    expect(sentSubject.endsWith("...")).toBe(true);
+    expect(sentSubject).toBe(`${"a".repeat(74)}...`);
+  });
+
+  it("preserves derived subjects at and below the 78-code-unit limit", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+    const subjects = ["Status 🦊", "s".repeat(78)];
+
+    for (const text of subjects) {
+      await invokeSend(registration, runtime, { channelId: "shadow@example.com" }, { text });
+    }
+
+    expect(
+      vi.mocked(sendGmailMessage).mock.calls.map((call) => (call[0] as { subject: string }).subject)
+    ).toEqual(subjects);
+  });
+
   it("resolves an entity-store recipient through stored email handles", async () => {
     const { runtime, sendGmailMessage } = runtimeStub({
       accounts: [CONNECTED_ACCOUNT],

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -30,6 +30,7 @@ import {
   type TargetInfo,
   type UUID,
 } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core/utils/well-formed";
 import { GOOGLE_SERVICE_NAME } from "./types.js";
 
 export const GMAIL_MESSAGE_SOURCE = "gmail";
@@ -210,14 +211,16 @@ function subjectFromContent(content: Content): string {
       ? (metadata as Record<string, unknown>).subject
       : undefined;
   if (typeof explicit === "string" && explicit.trim().length > 0) {
-    return explicit.trim();
+    return toWellFormedUnicode(explicit.trim());
   }
-  const firstLine = String(content.text ?? "")
-    .split("\n", 1)[0]
-    .trim();
+  const firstLine = toWellFormedUnicode(
+    String(content.text ?? "")
+      .split("\n", 1)[0]
+      .trim()
+  );
   return firstLine.length <= SUBJECT_MAX_LENGTH
     ? firstLine
-    : `${firstLine.slice(0, SUBJECT_MAX_LENGTH - 3)}...`;
+    : `${truncateWellFormed(firstLine, SUBJECT_MAX_LENGTH - 3)}...`;
 }
 
 async function sendGmailFromTarget(

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -28,9 +28,10 @@ import {
   type MessageConnectorTarget,
   type SendHandlerOutcome,
   type TargetInfo,
+  toWellFormedUnicode,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core/utils/well-formed";
 import { GOOGLE_SERVICE_NAME } from "./types.js";
 
 export const GMAIL_MESSAGE_SOURCE = "gmail";

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.test.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.test.ts
@@ -200,6 +200,70 @@ describe("GoogleGmailAdapter", () => {
     expect(sent.externalId).toBe("sent_new_1");
   });
 
+  it("clips draft body preview without tearing UTF-16 surrogate pairs at 240 limit", async () => {
+    const runtime = runtimeWithGoogleService({});
+    const adapter = new GoogleGmailAdapter();
+
+    const body = `${"x".repeat(236)}\u{1F98A}yyyy`;
+    const draft = await adapter.createDraft(runtime, {
+      source: "gmail",
+      to: [{ identifier: "test@example.com" }],
+      subject: "Test Subject",
+      body,
+      worldId: "acct_google_1",
+    });
+
+    expect(draft.preview.length).toBeLessThanOrEqual(240);
+    expect(draft.preview.isWellFormed()).toBe(true);
+    expect(draft.preview.endsWith("...")).toBe(true);
+    expect(draft.preview).toBe(`${"x".repeat(236)}...`);
+  });
+
+  it("preserves well-formed draft previews at and below the 240-code-unit limit", async () => {
+    const runtime = runtimeWithGoogleService({});
+    const adapter = new GoogleGmailAdapter();
+    const bodies = ["ready 🦊", "x".repeat(240)];
+
+    for (const body of bodies) {
+      const draft = await adapter.createDraft(runtime, {
+        source: "gmail",
+        to: [{ identifier: "test@example.com" }],
+        subject: "Test Subject",
+        body,
+        worldId: "acct_google_1",
+      });
+
+      expect(draft.preview).toBe(body);
+      expect(draft.preview.isWellFormed()).toBe(true);
+    }
+  });
+
+  it("normalizes lone surrogates in short and clipped draft previews", async () => {
+    const runtime = runtimeWithGoogleService({});
+    const adapter = new GoogleGmailAdapter();
+    const baseRequest = {
+      source: "gmail" as const,
+      to: [{ identifier: "test@example.com" }],
+      subject: "Test Subject",
+      worldId: "acct_google_1",
+    };
+
+    const shortDraft = await adapter.createDraft(runtime, {
+      ...baseRequest,
+      body: "short\ud800preview",
+    });
+    const longDraft = await adapter.createDraft(runtime, {
+      ...baseRequest,
+      body: `${"x".repeat(237)}\udc00tail`,
+    });
+
+    expect(shortDraft.preview).toBe("short�preview");
+    expect(longDraft.preview).toBe(`${"x".repeat(237)}...`);
+    expect(shortDraft.preview.isWellFormed()).toBe(true);
+    expect(longDraft.preview.isWellFormed()).toBe(true);
+    expect(longDraft.preview.length).toBeLessThanOrEqual(240);
+  });
+
   it("refuses a new draft without an email-address recipient", async () => {
     const runtime = runtimeWithGoogleService({});
     await expect(

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.test.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.test.ts
@@ -264,6 +264,55 @@ describe("GoogleGmailAdapter", () => {
     expect(longDraft.preview.length).toBeLessThanOrEqual(240);
   });
 
+  it("normalizes either lone-surrogate half on both sides of the preview limit", async () => {
+    const runtime = runtimeWithGoogleService({});
+    const adapter = new GoogleGmailAdapter();
+    const baseRequest = {
+      source: "gmail" as const,
+      to: [{ identifier: "test@example.com" }],
+      subject: "Test Subject",
+      worldId: "acct_google_1",
+    };
+    const bodies = [
+      "short\ud800preview",
+      "short\udc00preview",
+      `${"h".repeat(236)}\ud800tail`,
+      `${"l".repeat(236)}\udc00tail`,
+    ];
+
+    const previews: string[] = [];
+    for (const body of bodies) {
+      const draft = await adapter.createDraft(runtime, { ...baseRequest, body });
+      previews.push(draft.preview);
+    }
+
+    expect(previews).toEqual([
+      "short�preview",
+      "short�preview",
+      `${"h".repeat(236)}�...`,
+      `${"l".repeat(236)}�...`,
+    ]);
+    expect(previews.every((preview) => preview.isWellFormed())).toBe(true);
+    expect(previews.every((preview) => preview.length <= 240)).toBe(true);
+  });
+
+  it("reserves the suffix only after the 240-code-unit boundary", async () => {
+    const runtime = runtimeWithGoogleService({});
+    const adapter = new GoogleGmailAdapter();
+    const baseRequest = {
+      source: "gmail" as const,
+      to: [{ identifier: "test@example.com" }],
+      subject: "Test Subject",
+      worldId: "acct_google_1",
+    };
+
+    const exact = await adapter.createDraft(runtime, { ...baseRequest, body: "m".repeat(240) });
+    const over = await adapter.createDraft(runtime, { ...baseRequest, body: "n".repeat(241) });
+
+    expect(exact.preview).toBe("m".repeat(240));
+    expect(over.preview).toBe(`${"n".repeat(237)}...`);
+  });
+
   it("refuses a new draft without an email-address recipient", async () => {
     const runtime = runtimeWithGoogleService({});
     await expect(

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
@@ -22,6 +22,7 @@ import {
   type MessageSource,
   type SearchMessagesFilters,
 } from "@elizaos/core/node";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core/utils/well-formed";
 import { isEmailAddress } from "./gmail-message-connector.js";
 import type {
   GoogleGmailBulkOperation,
@@ -47,7 +48,10 @@ interface GmailDraftContext {
 }
 
 function clip(value: string, maxLength: number): string {
-  return value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
+  const wellFormedValue = toWellFormedUnicode(value);
+  return wellFormedValue.length > maxLength
+    ? `${truncateWellFormed(wellFormedValue, maxLength - 3)}...`
+    : wellFormedValue;
 }
 
 function refId(messageId: string): string {

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
@@ -9,6 +9,8 @@
  * no-ops as unavailable when the plugin is not loaded; `accountId` is carried
  * on each `MessageRef` via `worldId` so triage stays multi-account.
  */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   BaseMessageAdapter,
   type DraftRequest,
@@ -22,7 +24,6 @@ import {
   type MessageSource,
   type SearchMessagesFilters,
 } from "@elizaos/core/node";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core/utils/well-formed";
 import { isEmailAddress } from "./gmail-message-connector.js";
 import type {
   GoogleGmailBulkOperation,


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:7b6f76c79e0ac4a11947a1588af55ec0837dff9b -->

### Problem

UTF-16 `slice` truncation could split a surrogate pair in computer-use status text and Google Workspace message summaries, producing malformed strings.

### Solution

- Use the supported `truncateWellFormed` export from `@elizaos/core` at the 180-, 78-, and 240-code-unit boundaries.
- Add exact-boundary regression coverage for each consumer.
- Preserve the existing numeric limits and UTF-16 code-unit policy; grapheme-aware display truncation remains separate.

Refs #23245.

### Exact-head verification

Verified at `7b6f76c79e0ac4a11947a1588af55ec0837dff9b`, replayed on live develop `9f6e368bd14b6e73c31cf55fd650034a6198551f`:

- plugin-computeruse typecheck and Biome: pass
- plugin-computeruse focused tests: 21/21 pass
- plugin-google-workspace Biome: pass
- Google Workspace focused tests: 38/38 pass
- plugin-google-workspace typecheck: blocked by a current-develop regression in untouched `src/gmail.ts`, which imports `stripHtmlRawTextElements` after that symbol ceased to be exported from core

### Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI path change.

<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic boundary assertions and emitted runtime imports are the relevant evidence.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface change.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - truncation is deterministic and does not involve a model.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - deterministic exact-boundary assertions cover all three changed consumers; no external domain artifact is produced.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:ai-provider -->
- AI provider: OpenAI
<!-- attribution-row:ai-model -->
- AI model: gpt-5.6-sol
<!-- attribution-row:agent-tooling -->
- Agent tooling: Codex Desktop
<!-- attribution-row:contribution-skill -->
- Contribution skill: packages/skills/skills/contribute-to-eliza
<!-- attribution-row:attribution-status -->
- Attribution status: self-reported

