### PR TITLE
fix(discord): keep surrogate pairs intact when chunking outbound messages

### DIFF
--- a/plugins/plugin-discord/__tests__/messaging-chunking.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-chunking.test.ts
@@ -6,14 +6,17 @@
  * rather than bisect a pair, in both the no-whitespace fallback path and the
  * fence-preserving path.
  */
+import { toWellFormedUnicode } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { chunkDiscordText } from "../messaging.ts";
 
+// toWellFormedUnicode only rewrites lone surrogates, so an unmodified
+// round-trip is a real (and portable -- it has its own manual-scan fallback
+// for runtimes without native String.prototype.isWellFormed) well-formedness
+// check, unlike a helper that silently returns `true` when the native method
+// is absent.
 function isWellFormedString(text: string): boolean {
-	return typeof (text as unknown as { isWellFormed?: () => boolean })
-		.isWellFormed === "function"
-		? (text as unknown as { isWellFormed: () => boolean }).isWellFormed()
-		: true;
+	return toWellFormedUnicode(text) === text;
 }
 
 describe("chunkDiscordText surrogate-pair safety", () => {
@@ -49,4 +52,33 @@ describe("chunkDiscordText surrogate-pair safety", () => {
 		expect(chunks.length).toBeGreaterThan(1);
 		expect(chunks.join("")).toBe(text);
 	});
+
+	// maxChars: 1 forces splitLongLine's internal limit to 1 code unit -- too
+	// small to fit a surrogate pair without splitting it. Before the fix,
+	// truncateWellFormed(remaining, 1) on emoji-leading text returned "" and
+	// both branches below made zero progress per iteration; `out` grows
+	// unbounded until V8 throws `RangeError: Invalid array length` a few
+	// seconds in (verified: reverting the source fix makes both tests below
+	// fail with that RangeError, not a hang). These are load-bearing.
+	it("terminates and stays well formed at maxChars: 1 (no-whitespace path)", () => {
+		const text = "\u{1F600}".repeat(5);
+		const chunks = chunkDiscordText(text, { maxChars: 1, maxLines: 999 });
+
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(isWellFormedString(chunk)).toBe(true);
+		}
+		expect(chunks.join("")).toBe(text);
+	}, 5_000);
+
+	it("terminates and stays well formed at maxChars: 1 (fenced/preserve-whitespace path)", () => {
+		const body = "\u{1F600}".repeat(5);
+		const text = `\`\`\`\n${body}\n\`\`\``;
+		const chunks = chunkDiscordText(text, { maxChars: 1, maxLines: 999 });
+
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(isWellFormedString(chunk)).toBe(true);
+		}
+	}, 5_000);
 });

--- a/plugins/plugin-discord/__tests__/messaging-chunking.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-chunking.test.ts
@@ -8,7 +8,7 @@
  */
 import { toWellFormedUnicode } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { chunkDiscordText } from "../messaging.ts";
+import { chunkDiscordText, MIN_CHUNK_CHARS } from "../messaging.ts";
 
 // toWellFormedUnicode only rewrites lone surrogates, so an unmodified
 // round-trip is a real (and portable -- it has its own manual-scan fallback
@@ -60,17 +60,31 @@ describe("chunkDiscordText surrogate-pair safety", () => {
 	// unbounded until V8 throws `RangeError: Invalid array length` a few
 	// seconds in (verified: reverting the source fix makes both tests below
 	// fail with that RangeError, not a hang). These are load-bearing.
-	it("terminates and stays well formed at maxChars: 1 (no-whitespace path)", () => {
+	//
+	// maxChars: 1 is below MIN_CHUNK_CHARS, so chunkDiscordText raises it to
+	// MIN_CHUNK_CHARS (2) -- the load-bearing chunk.length assertion checks
+	// against that *effective* bound, not the literal requested value, since
+	// no cut below it can stay well-formed (see ChunkDiscordTextOpts.maxChars).
+	it("terminates, stays well formed, and honors the effective bound at maxChars: 1 (no-whitespace path)", () => {
 		const text = "\u{1F600}".repeat(5);
 		const chunks = chunkDiscordText(text, { maxChars: 1, maxLines: 999 });
 
 		expect(chunks.length).toBeGreaterThan(1);
 		for (const chunk of chunks) {
 			expect(isWellFormedString(chunk)).toBe(true);
+			expect(chunk.length).toBeLessThanOrEqual(MIN_CHUNK_CHARS);
 		}
 		expect(chunks.join("")).toBe(text);
 	}, 5_000);
 
+	// At maxChars: 1 the fence delimiter itself (```, 3 ASCII chars) no longer
+	// fits the budget, so splitLongLine shreds it across chunks like any other
+	// line -- a real but pre-existing, orthogonal characteristic of degenerate
+	// tiny bounds that has nothing to do with surrogate pairs, and no chunk
+	// length bound is provable here. Only what this PR guarantees is checked:
+	// termination and surrogate-pair well-formedness. The realistic
+	// wrapper-accounting case (fence marker comfortably fits the budget) is
+	// covered separately below.
 	it("terminates and stays well formed at maxChars: 1 (fenced/preserve-whitespace path)", () => {
 		const body = "\u{1F600}".repeat(5);
 		const text = `\`\`\`\n${body}\n\`\`\``;
@@ -81,4 +95,38 @@ describe("chunkDiscordText surrogate-pair safety", () => {
 			expect(isWellFormedString(chunk)).toBe(true);
 		}
 	}, 5_000);
+
+	// The fence-reservation fallback used to silently drop back to the full
+	// (unreserved) maxChars whenever the closing marker's width made the
+	// reserved budget go non-positive, letting a chunk overrun by the fence's
+	// entire width. At a small-but-sane bound (large enough for the marker to
+	// actually fit) every chunk -- including the ones that close and reopen
+	// the fence across a split -- must stay within the requested maxChars.
+	it("keeps every chunk within maxChars when closing/reopening a fence at a small bound", () => {
+		const maxChars = 10;
+		const body = `x${"\u{1F600}".repeat(30)}`;
+		const text = `\`\`\`\n${body}\n\`\`\``;
+		const chunks = chunkDiscordText(text, { maxChars, maxLines: 999 });
+
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(isWellFormedString(chunk)).toBe(true);
+			expect(chunk.length).toBeLessThanOrEqual(maxChars);
+		}
+	});
+
+	// The reasoning-italics path reserves 2 chars off maxChars specifically so
+	// a re-opening/closing "_" can be added back to each chunk without
+	// exceeding the requested bound -- verify that budget actually holds at
+	// the realistic default, not just that chunking terminates.
+	it("keeps every chunk within maxChars when rebalancing reasoning italics", () => {
+		const maxChars = 40;
+		const body = `Reasoning:\n_${"word ".repeat(30).trim()}_`;
+		const chunks = chunkDiscordText(body, { maxChars, maxLines: 999 });
+
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(chunk.length).toBeLessThanOrEqual(maxChars);
+		}
+	});
 });

--- a/plugins/plugin-discord/__tests__/messaging-chunking.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-chunking.test.ts
@@ -1,0 +1,52 @@
+/**
+ * `chunkDiscordText` must never split a surrogate pair (emoji) across two
+ * chunks. A run of multi-byte characters with no whitespace break point (or
+ * inside a fenced code block, where whitespace is preserved verbatim) falls
+ * through to a raw character-index cut; that cut must back off by one unit
+ * rather than bisect a pair, in both the no-whitespace fallback path and the
+ * fence-preserving path.
+ */
+import { describe, expect, it } from "vitest";
+import { chunkDiscordText } from "../messaging.ts";
+
+function isWellFormedString(text: string): boolean {
+	return typeof (text as unknown as { isWellFormed?: () => boolean })
+		.isWellFormed === "function"
+		? (text as unknown as { isWellFormed: () => boolean }).isWellFormed()
+		: true;
+}
+
+describe("chunkDiscordText surrogate-pair safety", () => {
+	it("never tears an emoji across chunks when no whitespace break exists", () => {
+		// Odd-length prefix shifts parity so the 2000-char boundary lands mid-pair
+		// (verified: unpatched code emits a chunk ending in a lone high surrogate
+		// and the next chunk starting with the orphaned low surrogate).
+		const text = `x${"\u{1F600}".repeat(1200)}`;
+		const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 999 });
+
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(isWellFormedString(chunk)).toBe(true);
+		}
+		// No characters lost or duplicated across the split.
+		expect(chunks.join("")).toBe(text);
+	});
+
+	it("never tears an emoji across chunks inside a fenced code block", () => {
+		const body = `x${"\u{1F600}".repeat(1200)}`;
+		const text = `\`\`\`\n${body}\n\`\`\``;
+		const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 999 });
+
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(isWellFormedString(chunk)).toBe(true);
+		}
+	});
+
+	it("still breaks at whitespace when one is available near the limit", () => {
+		const text = `${"a".repeat(1990)} ${"b".repeat(50)}`;
+		const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 999 });
+		expect(chunks.length).toBeGreaterThan(1);
+		expect(chunks.join("")).toBe(text);
+	});
+});

--- a/plugins/plugin-discord/__tests__/messaging-chunking.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-chunking.test.ts
@@ -6,9 +6,9 @@
  * rather than bisect a pair, in both the no-whitespace fallback path and the
  * fence-preserving path.
  */
-import { toWellFormedUnicode } from "@elizaos/core";
+import { ElizaError, toWellFormedUnicode } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { chunkDiscordText, MIN_CHUNK_CHARS } from "../messaging.ts";
+import { chunkDiscordText } from "../messaging.ts";
 
 // toWellFormedUnicode only rewrites lone surrogates, so an unmodified
 // round-trip is a real (and portable -- it has its own manual-scan fallback
@@ -53,55 +53,68 @@ describe("chunkDiscordText surrogate-pair safety", () => {
 		expect(chunks.join("")).toBe(text);
 	});
 
-	// maxChars: 1 forces splitLongLine's internal limit to 1 code unit -- too
-	// small to fit a surrogate pair without splitting it. Before the fix,
-	// truncateWellFormed(remaining, 1) on emoji-leading text returned "" and
-	// both branches below made zero progress per iteration; `out` grows
-	// unbounded until V8 throws `RangeError: Invalid array length` a few
-	// seconds in (verified: reverting the source fix makes both tests below
-	// fail with that RangeError, not a hang). These are load-bearing.
-	//
-	// maxChars: 1 is below MIN_CHUNK_CHARS, so chunkDiscordText raises it to
-	// MIN_CHUNK_CHARS (2) -- the load-bearing chunk.length assertion checks
-	// against that *effective* bound, not the literal requested value, since
-	// no cut below it can stay well-formed (see ChunkDiscordTextOpts.maxChars).
-	it("terminates, stays well formed, and honors the effective bound at maxChars: 1 (no-whitespace path)", () => {
+	// maxChars: 1 is too small to fit a surrogate pair without splitting it
+	// (truncateWellFormed(remaining, 1) on emoji-leading text returns "").
+	// Before the round-1 fix that made zero progress per loop iteration --
+	// `out` grew unbounded until V8 threw `RangeError: Invalid array length`
+	// a few seconds in. A transport limit is a hard cap, not advisory: a
+	// bound too small for even one well-formed unit must fail closed with a
+	// typed error instead of silently widening past it (matching the
+	// fail-closed contract already merged for plugin-slack). These are
+	// load-bearing: reverting the fix makes both tests below fail (the
+	// call either hangs/crashes or returns an over-limit chunk instead of
+	// throwing).
+	it("fails closed at maxChars: 1 with emoji-leading content (no-whitespace path)", () => {
 		const text = "\u{1F600}".repeat(5);
-		const chunks = chunkDiscordText(text, { maxChars: 1, maxLines: 999 });
 
-		expect(chunks.length).toBeGreaterThan(1);
-		for (const chunk of chunks) {
-			expect(isWellFormedString(chunk)).toBe(true);
-			expect(chunk.length).toBeLessThanOrEqual(MIN_CHUNK_CHARS);
+		try {
+			chunkDiscordText(text, { maxChars: 1, maxLines: 999 });
+			expect.unreachable();
+		} catch (err) {
+			expect(err).toBeInstanceOf(ElizaError);
+			expect((err as ElizaError).code).toBe("DISCORD_CHUNK_LIMIT_TOO_SMALL");
 		}
-		expect(chunks.join("")).toBe(text);
 	}, 5_000);
 
-	// At maxChars: 1 the fence delimiter itself (```, 3 ASCII chars) no longer
-	// fits the budget, so splitLongLine shreds it across chunks like any other
-	// line -- a real but pre-existing, orthogonal characteristic of degenerate
-	// tiny bounds that has nothing to do with surrogate pairs, and no chunk
-	// length bound is provable here. Only what this PR guarantees is checked:
-	// termination and surrogate-pair well-formedness. The realistic
-	// wrapper-accounting case (fence marker comfortably fits the budget) is
-	// covered separately below.
-	it("terminates and stays well formed at maxChars: 1 (fenced/preserve-whitespace path)", () => {
+	// At maxChars: 1 the fence delimiter itself (```, 3 ASCII chars) can't fit
+	// the reservation either -- this must fail closed at the fence-close
+	// reservation, before ever attempting to split the emoji body.
+	it("fails closed at maxChars: 1 on a fenced/preserve-whitespace payload", () => {
 		const body = "\u{1F600}".repeat(5);
 		const text = `\`\`\`\n${body}\n\`\`\``;
-		const chunks = chunkDiscordText(text, { maxChars: 1, maxLines: 999 });
 
-		expect(chunks.length).toBeGreaterThan(1);
-		for (const chunk of chunks) {
-			expect(isWellFormedString(chunk)).toBe(true);
+		try {
+			chunkDiscordText(text, { maxChars: 1, maxLines: 999 });
+			expect.unreachable();
+		} catch (err) {
+			expect(err).toBeInstanceOf(ElizaError);
+			expect((err as ElizaError).code).toBe("DISCORD_CHUNK_LIMIT_TOO_SMALL");
 		}
 	}, 5_000);
 
-	// The fence-reservation fallback used to silently drop back to the full
-	// (unreserved) maxChars whenever the closing marker's width made the
-	// reserved budget go non-positive, letting a chunk overrun by the fence's
-	// entire width. At a small-but-sane bound (large enough for the marker to
-	// actually fit) every chunk -- including the ones that close and reopen
-	// the fence across a split -- must stay within the requested maxChars.
+	it("rejects a non-positive-integer maxChars instead of silently coercing it", () => {
+		for (const invalid of [0, -1, 1.5, NaN, Infinity, -Infinity]) {
+			try {
+				chunkDiscordText("hello world", { maxChars: invalid });
+				expect.unreachable();
+			} catch (err) {
+				expect(err).toBeInstanceOf(ElizaError);
+				expect((err as ElizaError).code).toBe("DISCORD_CHUNK_LIMIT_INVALID");
+			}
+		}
+	});
+
+	// Two related overrun bugs, both load-bearing here: (1) the fence
+	// reservation used to silently drop back to the full (unreserved)
+	// maxChars whenever the closing marker's width made the reserved budget
+	// go non-positive; (2) when a segment got flushed mid-fence, `current`
+	// was reset to the fence's re-opening line and then the segment was
+	// appended unconditionally, without accounting for that re-opening
+	// prefix's own width, so a segment sized right up to the (already
+	// reserved) budget still overran once the prefix was added. At a
+	// small-but-sane bound (large enough for the marker to actually fit)
+	// every chunk -- including ones that close and reopen the fence across a
+	// split -- must stay within the requested maxChars.
 	it("keeps every chunk within maxChars when closing/reopening a fence at a small bound", () => {
 		const maxChars = 10;
 		const body = `x${"\u{1F600}".repeat(30)}`;

--- a/plugins/plugin-discord/__tests__/messaging-chunking.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-chunking.test.ts
@@ -128,6 +128,95 @@ describe("chunkDiscordText surrogate-pair safety", () => {
 		}
 	});
 
+	// When a mid-fence flush reopens `current` with the fence's own opening
+	// line (e.g. "```" or "```js"), the very next appended segment is NOT a
+	// continuation of that opening line -- it must start on its own line.
+	// Before the fix, the append loop used a stale delimiter computed before
+	// the flush, gluing content directly onto the opener (e.g. "```😀"
+	// instead of "```\n😀"), which Discord parses as fence info/language
+	// metadata rather than code content. Covers backtick and tilde fences,
+	// plain and language-tagged and indented openers.
+	function assertNoContentGluedOntoFenceOpener(
+		chunks: string[],
+		openLine: string,
+	) {
+		for (const chunk of chunks) {
+			if (!chunk.startsWith(openLine)) {
+				continue;
+			}
+			const rest = chunk.slice(openLine.length);
+			if (rest.length > 0) {
+				expect(rest.startsWith("\n")).toBe(true);
+			}
+		}
+	}
+
+	it("separates a reopened fence opener from its content with a newline (backtick)", () => {
+		const maxChars = 10;
+		const body = `x${"\u{1F600}".repeat(30)}`;
+		const text = `\`\`\`\n${body}\n\`\`\``;
+		const chunks = chunkDiscordText(text, { maxChars, maxLines: 999 });
+
+		expect(chunks.length).toBeGreaterThan(1);
+		assertNoContentGluedOntoFenceOpener(chunks, "```");
+	});
+
+	it("separates a reopened fence opener from its content with a newline (tilde)", () => {
+		const maxChars = 10;
+		const body = `x${"\u{1F600}".repeat(30)}`;
+		const text = `~~~\n${body}\n~~~`;
+		const chunks = chunkDiscordText(text, { maxChars, maxLines: 999 });
+
+		expect(chunks.length).toBeGreaterThan(1);
+		assertNoContentGluedOntoFenceOpener(chunks, "~~~");
+	});
+
+	it("separates a reopened fence opener from its content with a newline (language tag)", () => {
+		const maxChars = 12;
+		const body = `x${"\u{1F600}".repeat(30)}`;
+		const text = `\`\`\`js\n${body}\n\`\`\``;
+		const chunks = chunkDiscordText(text, { maxChars, maxLines: 999 });
+
+		expect(chunks.length).toBeGreaterThan(1);
+		assertNoContentGluedOntoFenceOpener(chunks, "```js");
+	});
+
+	it("separates a reopened fence opener from its content with a newline (indented)", () => {
+		const maxChars = 20;
+		const body = `x${"\u{1F600}".repeat(30)}`;
+		const text = `   \`\`\`\n${body}\n   \`\`\``;
+		const chunks = chunkDiscordText(text, { maxChars, maxLines: 999 });
+
+		expect(chunks.length).toBeGreaterThan(1);
+		assertNoContentGluedOntoFenceOpener(chunks, "   ```");
+	});
+
+	// Balanced, parseable fences and exact content preservation: every open
+	// marker line must be matched by a close marker line, and stripping all
+	// marker lines from every chunk (in order) must reproduce the original
+	// body exactly -- no characters lost, duplicated, or merged into a
+	// marker line during a close/reopen split.
+	it("keeps fences balanced and preserves body content exactly across a close/reopen split", () => {
+		const maxChars = 10;
+		const body = `x${"\u{1F600}".repeat(30)}`;
+		const text = `\`\`\`\n${body}\n\`\`\``;
+		const chunks = chunkDiscordText(text, { maxChars, maxLines: 999 });
+
+		expect(chunks.length).toBeGreaterThan(1);
+		const isMarkerLine = (line: string) => /^ {0,3}`{3,}$/.test(line);
+		let bodyOnly = "";
+		for (const chunk of chunks) {
+			const lines = chunk.split("\n");
+			expect(lines.filter(isMarkerLine).length % 2).toBe(0);
+			for (const line of lines) {
+				if (!isMarkerLine(line)) {
+					bodyOnly += line;
+				}
+			}
+		}
+		expect(bodyOnly).toBe(body);
+	});
+
 	// The reasoning-italics path reserves 2 chars off maxChars specifically so
 	// a re-opening/closing "_" can be added back to each chunk without
 	// exceeding the requested bound -- verify that budget actually holds at

--- a/plugins/plugin-discord/messaging.ts
+++ b/plugins/plugin-discord/messaging.ts
@@ -72,6 +72,18 @@ function closeFenceIfNeeded(text: string, openFence: OpenFence | null): string {
 	return `${text}${closeLine}`;
 }
 
+// truncateWellFormed(remaining, limit) returns "" only when limit === 1 and
+// `remaining` opens with a surrogate pair: the pair needs 2 code units and
+// truncateWellFormed refuses to split it, so it backs the cut off to 0. An
+// empty chunk makes zero progress, turning the caller's while-loop infinite
+// instead of just malformed. Every other limit/input combination already
+// makes progress via truncateWellFormed alone, so widen the ask by exactly
+// one unit only in that single failure mode -- enough to fit the whole pair.
+function takeWellFormedChunk(text: string, limit: number): string {
+	const chunk = truncateWellFormed(text, limit);
+	return chunk.length > 0 ? chunk : truncateWellFormed(text, limit + 1);
+}
+
 function splitLongLine(
 	line: string,
 	maxChars: number,
@@ -91,13 +103,13 @@ function splitLongLine(
 			// emoji), splitting one character across two chunks as a lone high
 			// surrogate + lone low surrogate. truncateWellFormed backs the cut off
 			// by one unit instead.
-			const chunk = truncateWellFormed(remaining, limit);
+			const chunk = takeWellFormedChunk(remaining, limit);
 			out.push(chunk);
 			remaining = remaining.slice(chunk.length);
 			continue;
 		}
 
-		const window = truncateWellFormed(remaining, limit);
+		const window = takeWellFormedChunk(remaining, limit);
 		let breakIdx = -1;
 		for (let i = window.length - 1; i >= 0; i--) {
 			if (/\s/.test(window[i])) {

--- a/plugins/plugin-discord/messaging.ts
+++ b/plugins/plugin-discord/messaging.ts
@@ -10,7 +10,18 @@ import type { Guild, MessageReaction } from "discord.js";
  * Options for chunking Discord text
  */
 export interface ChunkDiscordTextOpts {
-	/** Max characters per Discord message. Default: 2000. */
+	/**
+	 * Max characters per Discord message. Default: 2000.
+	 *
+	 * Values below {@link MIN_CHUNK_CHARS} are raised to it: `truncateWellFormed`
+	 * cannot guarantee a non-empty, well-formed cut below the width of a UTF-16
+	 * surrogate pair (an astral-plane emoji), so a smaller request can't be
+	 * honored exactly. Even at or above the floor, a chunk that closes an open
+	 * fenced code block or reasoning-italics wrapper may exceed this bound by
+	 * the wrapper's own fixed width -- there's no valid split short enough to
+	 * fit an arbitrarily small budget and still close the wrapper (e.g. you
+	 * cannot emit a closing ` ``` ` in fewer than 3 characters).
+	 */
 	maxChars?: number;
 	/**
 	 * Soft max line count per message. Default: 17.
@@ -30,6 +41,11 @@ interface OpenFence {
 
 const DEFAULT_MAX_CHARS = 2000;
 const DEFAULT_MAX_LINES = 17;
+// The widest atomic unit truncateWellFormed can guarantee a cut around: a
+// UTF-16 surrogate pair (2 code units). Below this, no cut can both make
+// progress and stay well-formed when the text starts with an astral-plane
+// character, so every maxChars-derived limit floors here instead of at 1.
+export const MIN_CHUNK_CHARS = 2;
 const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
 
 function countLines(text: string): number {
@@ -76,9 +92,10 @@ function closeFenceIfNeeded(text: string, openFence: OpenFence | null): string {
 // `remaining` opens with a surrogate pair: the pair needs 2 code units and
 // truncateWellFormed refuses to split it, so it backs the cut off to 0. An
 // empty chunk makes zero progress, turning the caller's while-loop infinite
-// instead of just malformed. Every other limit/input combination already
-// makes progress via truncateWellFormed alone, so widen the ask by exactly
-// one unit only in that single failure mode -- enough to fit the whole pair.
+// instead of just malformed. Callers now floor `limit` at MIN_CHUNK_CHARS
+// (2), which already fits any single surrogate pair, so this widening is
+// unreachable through chunkDiscordText/chunkDiscordTextWithMode -- kept as a
+// defensive guarantee for any future direct caller of splitLongLine.
 function takeWellFormedChunk(text: string, limit: number): string {
 	const chunk = truncateWellFormed(text, limit);
 	return chunk.length > 0 ? chunk : truncateWellFormed(text, limit + 1);
@@ -89,7 +106,7 @@ function splitLongLine(
 	maxChars: number,
 	opts: { preserveWhitespace: boolean },
 ): string[] {
-	const limit = Math.max(1, Math.floor(maxChars));
+	const limit = Math.max(MIN_CHUNK_CHARS, Math.floor(maxChars));
 	if (line.length <= limit) {
 		return [line];
 	}
@@ -189,7 +206,7 @@ export function chunkDiscordText(
 	opts: ChunkDiscordTextOpts = {},
 ): string[] {
 	const requestedMaxChars = Math.max(
-		1,
+		MIN_CHUNK_CHARS,
 		Math.floor(opts.maxChars ?? DEFAULT_MAX_CHARS),
 	);
 	const maxLines = Math.max(1, Math.floor(opts.maxLines ?? DEFAULT_MAX_LINES));
@@ -200,7 +217,7 @@ export function chunkDiscordText(
 	}
 
 	const maxChars = isReasoningItalicsPayload(body)
-		? Math.max(1, requestedMaxChars - 2)
+		? Math.max(MIN_CHUNK_CHARS, requestedMaxChars - 2)
 		: requestedMaxChars;
 
 	const alreadyOk = body.length <= maxChars && countLines(body) <= maxLines;
@@ -253,10 +270,17 @@ export function chunkDiscordText(
 		const reserveLines = nextOpenFence ? 1 : 0;
 		const effectiveMaxChars = maxChars - reserveChars;
 		const effectiveMaxLines = maxLines - reserveLines;
-		const charLimit = effectiveMaxChars > 0 ? effectiveMaxChars : maxChars;
+		// A closing fence marker (` ``` `, or longer/indented) can be wider than
+		// maxChars itself at small bounds; reserving its full width would drive
+		// charLimit non-positive. Floor at MIN_CHUNK_CHARS instead of falling
+		// back to the unreserved maxChars, so a chunk that ends up closing the
+		// fence exceeds the requested bound only by the fence marker's own
+		// (fixed, known) width -- not by silently dropping the reservation.
+		const charLimit =
+			effectiveMaxChars > 0 ? effectiveMaxChars : MIN_CHUNK_CHARS;
 		const lineLimit = effectiveMaxLines > 0 ? effectiveMaxLines : maxLines;
 		const prefixLen = current.length > 0 ? current.length + 1 : 0;
-		const segmentLimit = Math.max(1, charLimit - prefixLen);
+		const segmentLimit = Math.max(MIN_CHUNK_CHARS, charLimit - prefixLen);
 		const segments = splitLongLine(originalLine, segmentLimit, {
 			preserveWhitespace: wasInsideFence,
 		});

--- a/plugins/plugin-discord/messaging.ts
+++ b/plugins/plugin-discord/messaging.ts
@@ -380,25 +380,39 @@ export function chunkDiscordText(
 		for (let segIndex = 0; segIndex < segments.length; segIndex++) {
 			const segment = segments[segIndex];
 			const isLineContinuation = segIndex > 0;
-			const delimiter = isLineContinuation
+			const provisionalDelimiter = isLineContinuation
 				? ""
 				: current.length > 0
 					? "\n"
 					: "";
-			const addition = `${delimiter}${segment}`;
-			const nextLen = current.length + addition.length;
+			const provisionalAddition = `${provisionalDelimiter}${segment}`;
+			const nextLen = current.length + provisionalAddition.length;
 			const nextLines = currentLines + (isLineContinuation ? 0 : 1);
 
 			const wouldExceedChars = nextLen > charLimit;
 			const wouldExceedLines = nextLines > lineLimit;
 
+			let flushedForThisSegment = false;
 			if ((wouldExceedChars || wouldExceedLines) && current.length > 0) {
 				flush();
+				flushedForThisSegment = true;
 			}
+
+			// A flush can repopulate `current` with a reopened fence's opening
+			// line (see flush() above). This segment is never a continuation of
+			// that line -- gluing it on with the stale "" delimiter would merge
+			// content into the fence's info-string, corrupting the fence. It
+			// always needs its own newline here, regardless of isLineContinuation.
+			const delimiter = flushedForThisSegment
+				? current.length > 0
+					? "\n"
+					: ""
+				: provisionalDelimiter;
+			const addition = `${delimiter}${segment}`;
 
 			if (current.length > 0) {
 				current += addition;
-				if (!isLineContinuation) {
+				if (!isLineContinuation || flushedForThisSegment) {
 					currentLines += 1;
 				}
 			} else {

--- a/plugins/plugin-discord/messaging.ts
+++ b/plugins/plugin-discord/messaging.ts
@@ -3,6 +3,7 @@
  * length limit, escaping Discord markdown, and extracting user mentions from
  * message content.
  */
+import { truncateWellFormed } from "@elizaos/core";
 import type { Guild, MessageReaction } from "discord.js";
 
 /**
@@ -86,12 +87,17 @@ function splitLongLine(
 
 	while (remaining.length > limit) {
 		if (opts.preserveWhitespace) {
-			out.push(remaining.slice(0, limit));
-			remaining = remaining.slice(limit);
+			// A plain `.slice(0, limit)` can land inside a surrogate pair (e.g. an
+			// emoji), splitting one character across two chunks as a lone high
+			// surrogate + lone low surrogate. truncateWellFormed backs the cut off
+			// by one unit instead.
+			const chunk = truncateWellFormed(remaining, limit);
+			out.push(chunk);
+			remaining = remaining.slice(chunk.length);
 			continue;
 		}
 
-		const window = remaining.slice(0, limit);
+		const window = truncateWellFormed(remaining, limit);
 		let breakIdx = -1;
 		for (let i = window.length - 1; i >= 0; i--) {
 			if (/\s/.test(window[i])) {
@@ -101,7 +107,7 @@ function splitLongLine(
 		}
 
 		if (breakIdx <= 0) {
-			breakIdx = limit;
+			breakIdx = window.length;
 		}
 
 		out.push(remaining.slice(0, breakIdx));

--- a/plugins/plugin-discord/messaging.ts
+++ b/plugins/plugin-discord/messaging.ts
@@ -3,7 +3,7 @@
  * length limit, escaping Discord markdown, and extracting user mentions from
  * message content.
  */
-import { truncateWellFormed } from "@elizaos/core";
+import { ElizaError, truncateWellFormed } from "@elizaos/core";
 import type { Guild, MessageReaction } from "discord.js";
 
 /**
@@ -11,16 +11,16 @@ import type { Guild, MessageReaction } from "discord.js";
  */
 export interface ChunkDiscordTextOpts {
 	/**
-	 * Max characters per Discord message. Default: 2000.
+	 * Max characters per Discord message. Default: 2000. Must be a positive
+	 * integer.
 	 *
-	 * Values below {@link MIN_CHUNK_CHARS} are raised to it: `truncateWellFormed`
-	 * cannot guarantee a non-empty, well-formed cut below the width of a UTF-16
-	 * surrogate pair (an astral-plane emoji), so a smaller request can't be
-	 * honored exactly. Even at or above the floor, a chunk that closes an open
-	 * fenced code block or reasoning-italics wrapper may exceed this bound by
-	 * the wrapper's own fixed width -- there's no valid split short enough to
-	 * fit an arbitrarily small budget and still close the wrapper (e.g. you
-	 * cannot emit a closing ` ``` ` in fewer than 3 characters).
+	 * A transport limit is a hard cap, never advisory: `chunkDiscordText`
+	 * never emits a chunk longer than this value. If the requested bound is
+	 * too small to hold even one well-formed unit of the content (a surrogate
+	 * pair, or a wrapper like a closing code-fence marker plus one unit of
+	 * body), it throws an {@link ElizaError} (`DISCORD_CHUNK_LIMIT_INVALID` /
+	 * `DISCORD_CHUNK_LIMIT_TOO_SMALL`) instead of silently widening past it --
+	 * matching the fail-closed contract used by `chunkSlackText`.
 	 */
 	maxChars?: number;
 	/**
@@ -41,12 +41,44 @@ interface OpenFence {
 
 const DEFAULT_MAX_CHARS = 2000;
 const DEFAULT_MAX_LINES = 17;
-// The widest atomic unit truncateWellFormed can guarantee a cut around: a
-// UTF-16 surrogate pair (2 code units). Below this, no cut can both make
-// progress and stay well-formed when the text starts with an astral-plane
-// character, so every maxChars-derived limit floors here instead of at 1.
-export const MIN_CHUNK_CHARS = 2;
 const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+
+/**
+ * A hard per-chunk cap can never be honored for arbitrary text unless it's a
+ * positive integer that can hold at least one UTF-16 code unit; anything
+ * else (NaN, 0, negative, fractional) has no sensible "effective bound" and
+ * must fail closed instead of silently coercing into one.
+ */
+function requireValidChunkLimit(maxChars: number, fnName: string): void {
+	if (!Number.isInteger(maxChars) || maxChars < 1) {
+		throw new ElizaError(
+			`${fnName}: maxChars must be a positive integer, got ${maxChars}`,
+			{ code: "DISCORD_CHUNK_LIMIT_INVALID", context: { fnName, maxChars } },
+		);
+	}
+}
+
+/**
+ * `effectiveLimit` (the actual per-chunk budget after wrapper/fence
+ * accounting) is too small to hold even one well-formed unit of the
+ * remaining text. Widening past the caller's requested `maxChars` would
+ * silently break the "never emits more than maxChars" contract, so this
+ * fails closed instead -- matching the pattern already merged for
+ * `chunkSlackText`.
+ */
+function chunkLimitTooSmall(
+	fnName: string,
+	effectiveLimit: number,
+	maxChars: number,
+): never {
+	throw new ElizaError(
+		`${fnName}: a chunk limit of ${effectiveLimit} (from maxChars=${maxChars}) cannot hold the next well-formed unit without exceeding the requested bound`,
+		{
+			code: "DISCORD_CHUNK_LIMIT_TOO_SMALL",
+			context: { fnName, effectiveLimit, maxChars },
+		},
+	);
+}
 
 function countLines(text: string): number {
 	if (!text) {
@@ -88,25 +120,39 @@ function closeFenceIfNeeded(text: string, openFence: OpenFence | null): string {
 	return `${text}${closeLine}`;
 }
 
-// truncateWellFormed(remaining, limit) returns "" only when limit === 1 and
+// truncateWellFormed(remaining, limit) returns "" only when `limit` can't
+// hold even one well-formed unit of `remaining` (e.g. limit === 1 and
 // `remaining` opens with a surrogate pair: the pair needs 2 code units and
-// truncateWellFormed refuses to split it, so it backs the cut off to 0. An
-// empty chunk makes zero progress, turning the caller's while-loop infinite
-// instead of just malformed. Callers now floor `limit` at MIN_CHUNK_CHARS
-// (2), which already fits any single surrogate pair, so this widening is
-// unreachable through chunkDiscordText/chunkDiscordTextWithMode -- kept as a
-// defensive guarantee for any future direct caller of splitLongLine.
-function takeWellFormedChunk(text: string, limit: number): string {
+// truncateWellFormed refuses to split it). An empty chunk would make zero
+// progress, turning the caller's while-loop infinite -- and silently
+// widening past `limit` would violate the maxChars contract instead, so
+// this fails closed.
+function takeWellFormedChunkOrThrow(
+	text: string,
+	limit: number,
+	requestedMaxChars: number,
+): string {
 	const chunk = truncateWellFormed(text, limit);
-	return chunk.length > 0 ? chunk : truncateWellFormed(text, limit + 1);
+	if (chunk.length === 0) {
+		chunkLimitTooSmall(
+			"chunkDiscordText (splitLongLine)",
+			limit,
+			requestedMaxChars,
+		);
+	}
+	return chunk;
 }
 
+// `maxChars` here is the already-validated per-line character budget (never
+// less than 1 -- see the callers' fail-closed checks); `requestedMaxChars` is
+// only threaded through for error context.
 function splitLongLine(
 	line: string,
 	maxChars: number,
 	opts: { preserveWhitespace: boolean },
+	requestedMaxChars: number,
 ): string[] {
-	const limit = Math.max(MIN_CHUNK_CHARS, Math.floor(maxChars));
+	const limit = Math.floor(maxChars);
 	if (line.length <= limit) {
 		return [line];
 	}
@@ -120,13 +166,21 @@ function splitLongLine(
 			// emoji), splitting one character across two chunks as a lone high
 			// surrogate + lone low surrogate. truncateWellFormed backs the cut off
 			// by one unit instead.
-			const chunk = takeWellFormedChunk(remaining, limit);
+			const chunk = takeWellFormedChunkOrThrow(
+				remaining,
+				limit,
+				requestedMaxChars,
+			);
 			out.push(chunk);
 			remaining = remaining.slice(chunk.length);
 			continue;
 		}
 
-		const window = takeWellFormedChunk(remaining, limit);
+		const window = takeWellFormedChunkOrThrow(
+			remaining,
+			limit,
+			requestedMaxChars,
+		);
 		let breakIdx = -1;
 		for (let i = window.length - 1; i >= 0; i--) {
 			if (/\s/.test(window[i])) {
@@ -205,10 +259,8 @@ export function chunkDiscordText(
 	text: string,
 	opts: ChunkDiscordTextOpts = {},
 ): string[] {
-	const requestedMaxChars = Math.max(
-		MIN_CHUNK_CHARS,
-		Math.floor(opts.maxChars ?? DEFAULT_MAX_CHARS),
-	);
+	const requestedMaxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+	requireValidChunkLimit(requestedMaxChars, "chunkDiscordText");
 	const maxLines = Math.max(1, Math.floor(opts.maxLines ?? DEFAULT_MAX_LINES));
 
 	const body = text ?? "";
@@ -216,13 +268,26 @@ export function chunkDiscordText(
 		return [];
 	}
 
+	// Reserves room for the closing/reopening "_" a split reasoning-italics
+	// chunk needs (see rebalanceReasoningItalics). Only validated once
+	// chunking actually runs -- a payload that already fits `requestedMaxChars`
+	// as a single chunk never needs the reservation, so a tiny bound the
+	// caller only intended for other content shouldn't reject it.
 	const maxChars = isReasoningItalicsPayload(body)
-		? Math.max(MIN_CHUNK_CHARS, requestedMaxChars - 2)
+		? requestedMaxChars - 2
 		: requestedMaxChars;
 
 	const alreadyOk = body.length <= maxChars && countLines(body) <= maxLines;
 	if (alreadyOk) {
 		return [body];
+	}
+
+	if (maxChars <= 0) {
+		chunkLimitTooSmall(
+			"chunkDiscordText (reasoning-italics reservation)",
+			maxChars,
+			requestedMaxChars,
+		);
 	}
 
 	const lines = body.split("\n");
@@ -271,19 +336,46 @@ export function chunkDiscordText(
 		const effectiveMaxChars = maxChars - reserveChars;
 		const effectiveMaxLines = maxLines - reserveLines;
 		// A closing fence marker (` ``` `, or longer/indented) can be wider than
-		// maxChars itself at small bounds; reserving its full width would drive
-		// charLimit non-positive. Floor at MIN_CHUNK_CHARS instead of falling
-		// back to the unreserved maxChars, so a chunk that ends up closing the
-		// fence exceeds the requested bound only by the fence marker's own
-		// (fixed, known) width -- not by silently dropping the reservation.
-		const charLimit =
-			effectiveMaxChars > 0 ? effectiveMaxChars : MIN_CHUNK_CHARS;
+		// maxChars itself at small bounds. Reserving its full width can drive
+		// the remaining content budget non-positive -- there's no valid split
+		// that both fits the requested bound and still closes the fence, so
+		// this fails closed instead of silently falling back to the unreserved
+		// maxChars (which let a flushed chunk overrun by the fence's width).
+		if (effectiveMaxChars <= 0) {
+			chunkLimitTooSmall(
+				"chunkDiscordText (fence-close reservation)",
+				effectiveMaxChars,
+				requestedMaxChars,
+			);
+		}
+		const charLimit = effectiveMaxChars;
 		const lineLimit = effectiveMaxLines > 0 ? effectiveMaxLines : maxLines;
-		const prefixLen = current.length > 0 ? current.length + 1 : 0;
-		const segmentLimit = Math.max(MIN_CHUNK_CHARS, charLimit - prefixLen);
-		const segments = splitLongLine(originalLine, segmentLimit, {
-			preserveWhitespace: wasInsideFence,
-		});
+		// The append loop below flushes `current` first whenever a segment
+		// wouldn't fit alongside it, so segments don't need to be pre-shrunk by
+		// the current buffer's length. But when `wasInsideFence`, that flush
+		// reopens `current` with the fence's own opening line + a newline
+		// before appending the segment -- so a segment sized right up to
+		// `charLimit` would overrun once that reopened prefix is included.
+		// Reserve room for it too, symmetric to the close-fence reservation
+		// above.
+		const reopenPrefixLen =
+			wasInsideFence && openFence ? openFence.openLine.length + 1 : 0;
+		const segmentBudget = charLimit - reopenPrefixLen;
+		if (segmentBudget <= 0) {
+			chunkLimitTooSmall(
+				"chunkDiscordText (fence-reopen reservation)",
+				segmentBudget,
+				requestedMaxChars,
+			);
+		}
+		const segments = splitLongLine(
+			originalLine,
+			segmentBudget,
+			{
+				preserveWhitespace: wasInsideFence,
+			},
+			requestedMaxChars,
+		);
 
 		for (let segIndex = 0; segIndex < segments.length; segIndex++) {
 			const segment = segments[segIndex];
@@ -365,10 +457,10 @@ export function chunkDiscordTextWithMode(
 		return chunkDiscordText(text, opts);
 	}
 
-	const lineChunks = chunkMarkdownTextByNewline(
-		text,
-		Math.max(1, Math.floor(opts.maxChars ?? DEFAULT_MAX_CHARS)),
-	);
+	const requestedMaxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+	requireValidChunkLimit(requestedMaxChars, "chunkDiscordTextWithMode");
+
+	const lineChunks = chunkMarkdownTextByNewline(text, requestedMaxChars);
 
 	const chunks: string[] = [];
 	for (const line of lineChunks) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22206.

Companion fix to #22203 / #22204 (plugin-telegram, identical bug shape).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`e27ffd7056`); zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. `chunkDiscordText`, `chunkDiscordTextWithMode`, `splitLongLine`, and the
new validation helpers are the only touched code in
`plugins/plugin-discord/messaging.ts`; every pre-existing test still passes
unmodified (656/656 full plugin suite). No real caller in the repo ever
passes a custom `maxChars` at all (grepped every `chunkDiscordText`/
`chunkDiscordTextWithMode` call site; all use the 2000 default), so behavior
for every existing caller is unchanged — this only changes behavior for a
caller explicitly requesting a bound too small to honor.

**Addressed from the first review round (lalalune, CHANGES_REQUESTED at
`ea9b0372b7`):** `truncateWellFormed(remaining, limit)` returns `""` when
`limit === 1` and `remaining` opens with a surrogate pair, making both
`splitLongLine` branches loop forever with zero progress
(`RangeError: Invalid array length`).

**Addressed from the second review round (lalalune, re-review at
`f24eb7e9f1`):** the round-1 fix guaranteed non-empty, well-formed chunks but
never bounded them against the *documented* `maxChars` contract, and the
fence-reservation fallback silently reverted to the full unreserved budget
whenever a closing fence marker made the reservation go negative.

**Addressed from the third review round (lalalune, re-review at
`4d8119edb3`):** rounds 1-2's "widen by one unit, then float a floor"
approach still permitted fenced/reasoning chunks to exceed `maxChars`, and
never validated the `maxChars` option itself (`Math.max(2, Math.floor(NaN))`
is `NaN`). Per the review, this round abandons that approach entirely and
adopts the fail-closed contract already merged for `chunkSlackText`
(`plugins/plugin-slack/src/formatting.ts`):
- `requireValidChunkLimit` rejects a non-positive-integer `maxChars` up front
  with a typed `ElizaError` (`DISCORD_CHUNK_LIMIT_INVALID`), in both
  `chunkDiscordText` and `chunkDiscordTextWithMode`.
- `chunkLimitTooSmall` throws `DISCORD_CHUNK_LIMIT_TOO_SMALL` — instead of
  widening or flooring — whenever an effective per-chunk budget (the raw
  content path, the fence-close reservation, or the reasoning-italics
  reservation) can't hold even one well-formed unit. `MIN_CHUNK_CHARS` and
  every floor/widen call site are removed; `takeWellFormedChunk` becomes
  `takeWellFormedChunkOrThrow`.
- While rewriting the fenced path to prove every chunk stays within
  `maxChars`, found and fixed a **second, previously undetected** overrun:
  when a segment got flushed mid-fence, `current` was reset to the fence's
  re-opening line and the segment then appended unconditionally, without
  reserving room for that re-opening prefix's own width — so a segment sized
  right up to the already-reserved budget still overran once the prefix was
  added (reproduced: a chunk of length 13 against a requested `maxChars: 10`
  — see backend-logs). Fixed symmetrically to the existing close-fence
  reservation: `segmentBudget` now also reserves the re-opening prefix's
  width whenever a line is processed while already inside an open fence.
- The `maxChars: 1` tests that previously asserted "terminates and stays
  well-formed" (accepting the pre-existing widen-to-`MIN_CHUNK_CHARS`
  behavior) now assert the fail-closed contract instead: both throw
  `DISCORD_CHUNK_LIMIT_TOO_SMALL`. A new test asserts non-integer/NaN/
  negative/fractional `maxChars` throws `DISCORD_CHUNK_LIMIT_INVALID`. The
  pre-existing fence/reasoning bound-assertion tests are unchanged in intent
  and still pass, now for the stronger reason that they can no longer be
  silently violated.

# Background

## What does this PR do?

`chunkDiscordText`'s internal `splitLongLine`
(`plugins/plugin-discord/messaging.ts`) cut oversized lines with a raw
`remaining.slice(0, limit)` in two places: the fence-preserving branch (used
for content inside triple-backtick code blocks, where whitespace must be kept
verbatim) and the fallback used when no whitespace break point is found in
the regular-text branch. `String.prototype.slice` indexes by UTF-16 code
unit, not character — when either cut landed between the two code units of a
surrogate pair (most emoji), the pair was torn in half: one chunk ended with
a lone high surrogate, the next started with a lone low surrogate, and both
are malformed UTF-16 (`String.prototype.isWellFormed() === false`).

The file already had internal awareness of this hazard class —
`truncateUtf16Safe` (used only by `sanitizeThreadName`) is a local hand-rolled
surrogate-safe truncator — but it was never applied to `splitLongLine`, the
function that actually chunks outbound message content. Rather than add a
second local helper, this PR reuses the repo's canonical fix for exactly this
bug shape: `truncateWellFormed` in `packages/core/src/utils/well-formed.ts`
(backs the cut off by one code unit instead of splitting a pair), already
used at ~20 call sites across `packages/core`, `packages/agent`,
`packages/skills`, `plugin-openai`, and now `plugin-telegram` (#22204). No
new logic, no new dependency.

Four subsequent review rounds (see **Risks** above) hardened the fix: first
to guarantee forward progress at pathologically small bounds, then to bound
every returned chunk against the documented `maxChars` contract, then to
replace the widen/float-a-floor approach with a fail-closed contract that
rejects an unhonorable bound outright instead of trying to guarantee every
code path individually respects it, and finally (this round) to fix a
content-corruption bug in that fail-closed rewrite: when a mid-fence flush
reopened `current` with the fence's own opening line, the append loop still
used a delimiter computed *before* the flush, gluing the next segment
directly onto the reopened opener (e.g. `` ```😀 ``) instead of starting it
on its own line (`` ```\n😀 ``) — which Discord parses as fence
info/language metadata rather than code content, corrupting the block. The
fix recomputes the delimiter after any flush, based on whether `current`
still holds a fragment of the same source line versus a freshly reopened
fence buffer. This round also found the PR had been left in **draft** state
since creation (no hosted checks had ever run) and marked it ready for
review.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-discord/__tests__/messaging-chunking.test.ts` (13 tests) —
  drives the real exported `chunkDiscordText`: the original 2000-char
  no-whitespace/fence-preserving/whitespace-break cases, the fail-closed
  `maxChars: 1` and invalid-`maxChars` cases, the chunk-length-bound
  assertions for the fenced (close+reopen) and reasoning-italics paths, and
  (this round) five new tests asserting no content is ever glued onto a
  reopened fence's opening line across backtick/tilde/language-tag/indented
  fence variants, plus a fence-balance and exact-content-preservation check.

## Detailed testing steps

None: Automated tests are acceptable. Every assertion drives the real
exported `chunkDiscordText` — no test reads or matches implementation source
text.

- `bun run --cwd plugins/plugin-discord test -- __tests__/messaging-chunking.test.ts` (13 tests)
- Full plugin-discord suite (661 tests, no regressions): `bun run --cwd plugins/plugin-discord test`
- `bun run --cwd plugins/plugin-discord typecheck`
- `bunx biome check plugins/plugin-discord/messaging.ts plugins/plugin-discord/__tests__/messaging-chunking.test.ts`

I verified this round's 5 new tests are not tautologies: reverting only this
round's fix (restoring the pre-round-5 `messaging.ts`, head `090d0022f6`)
against the current test file fails exactly those 5 tests — see the
backend-logs evidence below for the actual control run.

# Evidence Gate

<!-- evidence-head:71a44d58ea541ba4466b1ef1c2e14bc047552bae -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only Discord message chunking change; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change, no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change, no user-facing flow to walk through
<!-- evidence-row:backend-logs -->
- [x] Real Vitest run at the current head, plus a control run proving this
      round's 5 new tests are load-bearing against the pre-round-5 (still
      buggy) code.

<details>
<summary>Backend logs — current head (fence-reopen delimiter fix applied), full suite, control run against pre-round-5 code</summary>

```
$ bun run --cwd plugins/plugin-discord test -- __tests__/messaging-chunking.test.ts --reporter=verbose

 ✓ chunkDiscordText surrogate-pair safety > never tears an emoji across chunks when no whitespace break exists
 ✓ chunkDiscordText surrogate-pair safety > never tears an emoji across chunks inside a fenced code block
 ✓ chunkDiscordText surrogate-pair safety > still breaks at whitespace when one is available near the limit
 ✓ chunkDiscordText surrogate-pair safety > fails closed at maxChars: 1 with emoji-leading content (no-whitespace path)
 ✓ chunkDiscordText surrogate-pair safety > fails closed at maxChars: 1 on a fenced/preserve-whitespace payload
 ✓ chunkDiscordText surrogate-pair safety > rejects a non-positive-integer maxChars instead of silently coercing it
 ✓ chunkDiscordText surrogate-pair safety > keeps every chunk within maxChars when closing/reopening a fence at a small bound
 ✓ chunkDiscordText surrogate-pair safety > separates a reopened fence opener from its content with a newline (backtick)
 ✓ chunkDiscordText surrogate-pair safety > separates a reopened fence opener from its content with a newline (tilde)
 ✓ chunkDiscordText surrogate-pair safety > separates a reopened fence opener from its content with a newline (language tag)
 ✓ chunkDiscordText surrogate-pair safety > separates a reopened fence opener from its content with a newline (indented)
 ✓ chunkDiscordText surrogate-pair safety > keeps fences balanced and preserves body content exactly across a close/reopen split
 ✓ chunkDiscordText surrogate-pair safety > keeps every chunk within maxChars when rebalancing reasoning italics

 Test Files  1 passed (1)
      Tests  13 passed (13)

$ bun run --cwd plugins/plugin-discord test   # full plugin suite

 Test Files  82 passed (82)
      Tests  661 passed (661)

$ bun run --cwd plugins/plugin-discord typecheck
(no output — clean)

$ bunx biome check plugins/plugin-discord/messaging.ts plugins/plugin-discord/__tests__/messaging-chunking.test.ts
Checked 2 files in 8ms. No fixes applied.

--- Control: swapped in the pre-round-5 messaging.ts (the round-4 head,
--- 090d0022f6, which still glues content onto a reopened fence opener)
--- against the CURRENT test file:

$ bun run --cwd plugins/plugin-discord test -- __tests__/messaging-chunking.test.ts

 FAIL  ... separates a reopened fence opener from its content with a newline (backtick)
 FAIL  ... separates a reopened fence opener from its content with a newline (tilde)
 FAIL  ... separates a reopened fence opener from its content with a newline (language tag)
 FAIL  ... separates a reopened fence opener from its content with a newline (indented)
 FAIL  ... keeps fences balanced and preserves body content exactly across a close/reopen split

 Tests  5 failed | 8 passed (13)

--- fix restored, full suite re-verified green (shown above).
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] Real standalone reproduction of the fence-reopen glue bug's absence:
      a fenced 30-emoji body at maxChars=10 forces multiple close/reopen
      cycles, and none of the resulting chunks glue content onto the
      reopened fence's opening line.

<details>
<summary>Domain artifact — fence-reopen content/newline proof, run against the current head</summary>

```
$ bun run repro-fence-glue.mjs
chunks: 31
glued (bug) chunks found: 0
first 3 chunks: ["```\nx\n```","```\n😀\n```","```\n😀\n```"]

--- reproduction script ---
import { chunkDiscordText } from "plugins/plugin-discord/messaging.ts";

const body = `x${"\u{1F600}".repeat(30)}`;
const text = `\`\`\`\n${body}\n\`\`\``;
const chunks = chunkDiscordText(text, { maxChars: 10, maxLines: 999 });

const glued = chunks.filter(c => c.startsWith("```") && c.length > 3 && c[3] !== "\n");
console.log(`chunks: ${chunks.length}`);
console.log("glued (bug) chunks found:", glued.length);
console.log("first 3 chunks:", JSON.stringify(chunks.slice(0, 3)));
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-manual]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza"} -->




