### PR TITLE
fix(plugins): prevent hanging local HTTP servers with closeAllConnections

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/android/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/bridge.ts
@@ -542,5 +542,6 @@ export async function runAndroidBridgeCli(): Promise<void> {
 
 	await stopped;
 	server.close();
+	server.closeAllConnections();
 	_logToFile("[android-bridge] shutdown signal received, exiting.");
 }

--- a/plugins/plugin-x/src/client/auth-providers/interactive.ts
+++ b/plugins/plugin-x/src/client/auth-providers/interactive.ts
@@ -81,6 +81,7 @@ export async function waitForLoopbackCallback(
       else reject(new Error("OAuth callback finished without result"));
       try {
         server.close();
+        server.closeAllConnections();
       } catch {
         // ignore
       }


### PR DESCRIPTION
## Problem
Several plugins (`plugin-x` and `plugin-capacitor-bridge`) call `server.close()` to shut down their temporary local HTTP servers (such as interactive OAuth callback receivers). However, Node's `server.close()` does not forcefully terminate existing sockets (including HTTP keep-alive connections). If a browser keeps a connection alive after the callback is handled, `server.close()` will hang indefinitely, preventing the local server from tearing down and potentially blocking the parent process from exiting.

## Scope
- Adds `server.closeAllConnections()` immediately after `server.close()` in `plugin-x` and `plugin-capacitor-bridge`.
- Ensures local HTTP servers shut down deterministically, matching the Node.js native platform recommendation and the recent fix applied in `#21683`.

## Acceptance criteria
- [x] Local auth and bridge HTTP servers terminate immediately when shut down, dropping idle keep-alive sockets.
- [x] Unrelated test suites pass.

## Evidence plan
- Verified that `closeAllConnections` resolves the shutdown hang deterministically.

<!-- evidence-gate -->
<!-- evidence-head:cbc5cc3b2b737952adb712a722d3102effcd4ac4 -->
- [x] Change made against exact evidence-head locally.

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: Gemini 3.1 Pro
<!-- attribution-row:client -->
- Agent tooling: Antigravity IDE
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported
