### PR TITLE
fix(plugin-browser): guard malformed batch steps from surfacing TypeError as 500

### DIFF
--- a/plugins/plugin-browser/src/routes/workspace-routes.test.ts
+++ b/plugins/plugin-browser/src/routes/workspace-routes.test.ts
@@ -145,6 +145,37 @@ describe("browser workspace HTTP routes", () => {
     expect(res.body).toEqual({ error: "request body must be a JSON object" });
   });
 
+  it("rejects malformed nested batch steps with 400", async () => {
+    const cases: unknown[] = [
+      [null],
+      [[]],
+      ["oops"],
+      [42],
+      [true],
+      Array(2),
+      [{ subaction: "batch", steps: [null] }],
+      [{ subaction: "batch", steps: [{ subaction: "batch", steps: ["oops"] }] }],
+    ];
+    for (const steps of cases) {
+      const { ctx, res } = buildCtx({
+        method: "POST",
+        pathname: "/api/browser-workspace/command",
+        body: { subaction: "batch", steps },
+      });
+      await expect(handleBrowserWorkspaceRoutes(ctx)).resolves.toBe(true);
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ error: "request body must be a JSON object" });
+    }
+    // Valid batch should not be rejected as malformed
+    const { ctx: validCtx, res: validRes } = buildCtx({
+      method: "POST",
+      pathname: "/api/browser-workspace/command",
+      body: { subaction: "batch", steps: [{ subaction: "click", selector: "#a" }] },
+    });
+    await expect(handleBrowserWorkspaceRoutes(validCtx)).resolves.toBe(true);
+    expect(validRes.statusCode).not.toBe(400);
+  });
+
   it("rejects malformed encoded tab ids as a 400", async () => {
     const { ctx, res } = buildCtx({
       method: "DELETE",

--- a/plugins/plugin-browser/src/routes/workspace.ts
+++ b/plugins/plugin-browser/src/routes/workspace.ts
@@ -171,6 +171,35 @@ function rejectMalformedBrowserWorkspacePayload(
   return true;
 }
 
+function hasInvalidBrowserWorkspaceBatchSteps(
+  value: unknown,
+): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const command = value as Record<string, unknown>;
+  const steps = command.steps;
+  if (steps === undefined) {
+    return false;
+  }
+  if (!Array.isArray(steps)) {
+    return true;
+  }
+  for (let i = 0; i < steps.length; i++) {
+    if (!(i in steps)) {
+      return true;
+    }
+    const step = steps[i];
+    if (!step || typeof step !== "object" || Array.isArray(step)) {
+      return true;
+    }
+    if (hasInvalidBrowserWorkspaceBatchSteps(step)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function decodeBrowserWorkspaceTabId(raw: string | undefined): string | null {
   if (typeof raw !== "string") return null;
   try {
@@ -243,6 +272,9 @@ export async function handleBrowserWorkspaceRoutes(
       const body =
         (await readJsonBody<BrowserWorkspaceCommandBody>(req, res)) ?? null;
       if (!isBrowserWorkspaceRouteBodyObject(body)) {
+        return rejectMalformedBrowserWorkspacePayload(ctx);
+      }
+      if (hasInvalidBrowserWorkspaceBatchSteps(body)) {
         return rejectMalformedBrowserWorkspacePayload(ctx);
       }
       // Normalize once at the boundary so `operation` aliases and

--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
@@ -217,6 +217,17 @@ export async function writeBrowserWorkspaceFile(
 export function normalizeBrowserWorkspaceCommand(
   command: BrowserWorkspaceCommand,
 ): BrowserWorkspaceCommand {
+  if (
+    !command ||
+    typeof command !== "object" ||
+    Array.isArray(command)
+  ) {
+    throw createBrowserWorkspaceError(
+      "invalid_url",
+      "url_validation",
+      "request body must be a JSON object",
+    );
+  }
   const raw = command as BrowserWorkspaceCommand & Record<string, unknown>;
   // A trimmed-empty `subaction` is absent, not a value: fall back to
   // `operation` before resolving so whitespace cannot mask a valid alias.
@@ -241,13 +252,39 @@ export function normalizeBrowserWorkspaceCommand(
     parseBrowserWorkspaceNumberLike(raw.ms) ??
     parseBrowserWorkspaceNumberLike(raw.milliseconds);
 
+  const normalizedSteps = (() => {
+    if (!Array.isArray(command.steps)) {
+      return command.steps;
+    }
+    const out: BrowserWorkspaceCommand[] = [];
+    for (let i = 0; i < command.steps.length; i++) {
+      if (!(i in command.steps)) {
+        throw createBrowserWorkspaceError(
+          "invalid_url",
+          "url_validation",
+          "request body must be a JSON object",
+        );
+      }
+      const step = command.steps[i];
+      if (!step || typeof step !== "object" || Array.isArray(step)) {
+        throw createBrowserWorkspaceError(
+          "invalid_url",
+          "url_validation",
+          "request body must be a JSON object",
+        );
+      }
+      out.push(
+        normalizeBrowserWorkspaceCommand(step as BrowserWorkspaceCommand),
+      );
+    }
+    return out;
+  })();
+
   return {
     ...command,
     subaction,
     timeoutMs,
-    steps: Array.isArray(command.steps)
-      ? command.steps.map((step) => normalizeBrowserWorkspaceCommand(step))
-      : command.steps,
+    steps: normalizedSteps,
   };
 }
 


### PR DESCRIPTION
Closes #22205

## Summary
- Guards `normalizeBrowserWorkspaceCommand` and the `POST /api/browser-workspace/command` boundary against malformed batch steps that previously dereferenced `raw.subaction` on `null`/primitive/array/sparse holes and threw raw `TypeError`, which the route's catch mapped to HTTP 500 (`plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts:217-288`, `plugins/plugin-browser/src/routes/workspace.ts:163-275`).
- Adds shape validation at helper entry (reject non-object root) and recursive validation of every `steps` element (including `index in steps` for sparse arrays and deeper nested batches), throwing `createBrowserWorkspaceError("invalid_url","url_validation","request body must be a JSON object")` → 400. Adds `hasInvalidBrowserWorkspaceBatchSteps` pre-check at the HTTP boundary to fail-closed before normalization/gating/execution.
- Adds route test pinning 400 for `null`, `[]` (array element), `"oops"`, `42`, `true`, sparse `Array(2)`, nested `batch→[null]` and deeper nested `batch→batch→["oops"]`, plus valid batch pass-through.

## What Changed
- `plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts`: validate `command` is non-array object at entry; replace `steps.map` with loop that checks `!(i in steps)` and `!step || typeof step !== "object" || Array.isArray(step)` for every element and recursively validates nested batches, throwing structured 400 error; preserves alias/normalization and valid batch behavior.
- `plugins/plugin-browser/src/routes/workspace.ts`: add `hasInvalidBrowserWorkspaceBatchSteps` helper and pre-check `if (hasInvalidBrowserWorkspaceBatchSteps(body)) return rejectMalformedBrowserWorkspacePayload(ctx)` before `normalizeBrowserWorkspaceCommand`, so malformed nested shapes return 400 without leaking TypeError.
- `plugins/plugin-browser/src/routes/workspace-routes.test.ts`: +31 lines, new `it("rejects malformed nested batch steps with 400")` covering 8 malformed shapes plus valid batch assertion (17 total).

## Exact-head evidence
Head: faf5f0be44f672c5db10c14ac02c6f0c8f62b163
Base: origin/develop@98d6a3b99a01f86e104aa1b5faad7fa7f84d69a5 with zero conflicts

## Verification / Definition of Done
- [x] Targets `develop`, rebased onto `origin/develop@98d6a3b99a01f86e104aa1b5faad7fa7f84d69a5` zero conflicts
- [x] `bun install --frozen-lockfile` completed (bun.lock unchanged)
- [x] `bunx vitest run plugins/plugin-browser/src/routes/workspace-routes.test.ts` — 17/17 passed (including new malformed batch 400 cases and valid batch)
- [x] `bunx vitest run plugins/plugin-browser/src/workspace` — 69/69 passed (11 files, helper + routes + web-security + tab-lifecycle etc.)
- [x] Manual helper probe: `normalizeBrowserWorkspaceCommand(null)` / `batch:[null]` / `batch:[[]]` / `batch:["oops"]` / sparse `Array(2)` / nested `batch→[null]` all throw `request body must be a JSON object` (400), valid `batch→[click]` passes
- [x] `git diff --check origin/develop...HEAD` — clean
- [x] Reviewer can confirm from deterministic unit tests / negative control (pre-fix `TypeError: null is not an object`, post-fix 400)

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@98d6a3b99a01f86e104aa1b5faad7fa7f84d69a5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@98d6a3b99a01f86e104aa1b5faad7fa7f84d69a5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@98d6a3b99a01f86e104aa1b5faad7fa7f84d69a5:packages/skills/skills/contribute-to-eliza"} -->

Co-authored-by: byt61 <byt61@users.noreply.github.com>

# Sync with develop

- [x] Rebased onto current `origin/develop` before the exact-head validation; zero conflicts.
- [x] Frozen `bun install` completed.
- [x] Exact focused tests, Node typecheck, and diff check pass.

# Risks

Low and bounded to browser workspace command boundary (`POST /api/browser-workspace/command` batch path). Validation only adds fail-closed 400 for shapes that previously threw 500 TypeError; valid commands (including nested valid batches) retain identical normalization, timeout coalescing, and execution order. No new dependencies, no migration, no I/O. Existing `goto`→`navigate` / `read`→`get` alias and whitespace handling from #22198 is preserved.

# Background

## What does this PR do?

Prevents attacker-controlled malformed JSON (`null`, array, primitive, sparse holes, or nested batch containing non-objects) from reaching `normalizeBrowserWorkspaceCommand`'s `raw.subaction` dereference. The helper now validates its input and every batch element recursively, throwing a structured `invalid_url` → 400 error instead of raw `TypeError`. The route additionally pre-validates `hasInvalidBrowserWorkspaceBatchSteps` before normalization/gating/execution and returns `request body must be a JSON object` 400, so the generic 500 catch is never reached for these shapes. Valid batch commands continue to recurse and normalize correctly.

## What kind of change is this?

Bug fix.

# Testing

## Where should a reviewer start?

- `plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts:217-288`
- `plugins/plugin-browser/src/routes/workspace.ts:161-275`
- `plugins/plugin-browser/src/routes/workspace-routes.test.ts:135-175`

## Detailed testing steps

On exact head `faf5f0be44f672c5db10c14ac02c6f0c8f62b163`:

- `bunx vitest run plugins/plugin-browser/src/routes/workspace-routes.test.ts` from repo root: 17/17 passed.
  - `rejects malformed nested batch steps with 400` — iterates 8 malformed `steps` shapes (`[null]`, `[[]]`, `["oops"]`, `[42]`, `[true]`, sparse `Array(2)`, nested `[batch→[null]]`, deep nested) → each 400 `{ error: "request body must be a JSON object" }`; valid `batch→[click]` → not 400.
  - Existing 16 route tests (workspace snapshot, missing subaction, operation alias, whitespace subaction, non-object payload, tab-id, etc.) remain green.
- `bunx vitest run plugins/plugin-browser/src/workspace` — 69/69 passed (helpers, snapshots, web-security, tab-lifecycle, web-real-code, default-tab).
- Helper direct probe: `normalizeBrowserWorkspaceCommand({subaction:"batch", steps:[null]})` throws `request body must be a JSON object` (400) via `createBrowserWorkspaceError`; `batch→[click]` normalizes correctly.
- `git diff --check origin/develop...HEAD` — no whitespace errors.

# Evidence Gate

<!-- evidence-head:faf5f0be44f672c5db10c14ac02c6f0c8f62b163 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only browser workspace command boundary; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only browser workspace command boundary; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic request validation with no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Backend log: `bunx vitest run ...workspace-routes.test.ts` 17/17 green and helper probe throws for malformed shapes (see Detailed testing steps); pre-fix raw `TypeError: null is not an object` no longer surfaces.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action routing, or agent planning change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain artifact; command is transient validation.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text surface changed.

# Known gaps / failures

None. Focused and workspace-wide tests pass on the exact head. Full `bun run verify` not run as only `plugin-browser` boundary was touched; broader CI failures if any are unrelated and documented in CI.

