### PR TITLE
fix(whatsapp): keep surrogate pairs intact when chunking/truncating outbound text

### DIFF
--- a/plugins/plugin-whatsapp/src/normalize.test.ts
+++ b/plugins/plugin-whatsapp/src/normalize.test.ts
@@ -142,4 +142,38 @@ describe("text chunking", () => {
     expect(truncated.isWellFormed()).toBe(true);
     expect(truncated).toBe("xxxx...");
   });
+
+  it("chunkWhatsAppText fails closed on a one-code-unit limit instead of looping forever", () => {
+    // A single code unit can never hold half of an astral character, so no
+    // limit of 1 can guarantee a non-empty well-formed chunk on every input.
+    expect(() => chunkWhatsAppText(`${"x".repeat(10)}\u{1F600}`, { limit: 1 })).toThrow(
+      /limit must be a finite number/
+    );
+  });
+
+  it.each([0, -5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "chunkWhatsAppText fails closed on limit %p",
+    (limit) => {
+      expect(() => chunkWhatsAppText("hello world", { limit })).toThrow(
+        /limit must be a finite number/
+      );
+    }
+  );
+
+  it("chunkWhatsAppText makes progress and stays well-formed at the minimum supported limit", () => {
+    // limit: 2 is the smallest bound that can ever hold one astral character
+    // whole. Every produced chunk must be non-empty, within the limit,
+    // well-formed, and the chunks must rejoin losslessly.
+    const text = `\u{1F600}\u{1F601}\u{1F602}`;
+
+    const chunks = chunkWhatsAppText(text, { limit: 2 });
+
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeGreaterThan(0);
+      expect(chunk.length).toBeLessThanOrEqual(2);
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+    expect(chunks.join("")).toBe(text);
+  });
 });

--- a/plugins/plugin-whatsapp/src/normalize.test.ts
+++ b/plugins/plugin-whatsapp/src/normalize.test.ts
@@ -115,4 +115,31 @@ describe("text chunking", () => {
     expect(truncateText("short", 20)).toBe("short");
     expect(truncateText("abcdefghij", 5).length).toBeLessThanOrEqual(5);
   });
+
+  it("chunkWhatsAppText keeps a surrogate pair (emoji) intact at the hard-break fallback", () => {
+    // No whitespace/newlines/sentence breaks in range, so splitAtBreakPoint
+    // falls through to the hard break at `limit`. A naive slice(0, 4096)
+    // would cut between the emoji's high and low surrogate.
+    const text = `${"x".repeat(4095)}\u{1F600}${"y".repeat(10)}`;
+
+    const chunks = chunkWhatsAppText(text);
+
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("truncateText keeps a surrogate pair (emoji) intact instead of splitting it", () => {
+    // maxLength - 3 (ellipsis reserve) lands right after the emoji's high
+    // surrogate; a naive slice(0, maxLength - 3) would strand it.
+    const text = `xxxx\u{1F600}zzzzz`;
+
+    const truncated = truncateText(text, 8);
+
+    expect(truncated.length).toBeLessThanOrEqual(8);
+    expect(truncated.isWellFormed()).toBe(true);
+    expect(truncated).toBe("xxxx...");
+  });
 });

--- a/plugins/plugin-whatsapp/src/normalize.ts
+++ b/plugins/plugin-whatsapp/src/normalize.ts
@@ -5,6 +5,8 @@
  * by the runtime service, message adapters, and account resolution.
  */
 
+import { truncateWellFormed } from "@elizaos/core";
+
 /**
  * WhatsApp text chunk limit
  */
@@ -277,10 +279,13 @@ function splitAtBreakPoint(text: string, limit: number): { chunk: string; remain
     };
   }
 
-  // Hard break at limit
+  // Hard break at limit -- truncateWellFormed backs off one unit instead of
+  // slicing through a surrogate pair (e.g. a long emoji run with no
+  // whitespace/newline/sentence break inside the search area).
+  const chunk = truncateWellFormed(text, limit);
   return {
-    chunk: text.slice(0, limit),
-    remainder: text.slice(limit),
+    chunk,
+    remainder: text.slice(chunk.length),
   };
 }
 
@@ -323,7 +328,7 @@ export function truncateText(text: string, maxLength: number): string {
   if (maxLength <= 3) {
     return "...".slice(0, maxLength);
   }
-  return `${text.slice(0, maxLength - 3)}...`;
+  return `${truncateWellFormed(text, maxLength - 3)}...`;
 }
 
 /**

--- a/plugins/plugin-whatsapp/src/normalize.ts
+++ b/plugins/plugin-whatsapp/src/normalize.ts
@@ -289,11 +289,25 @@ function splitAtBreakPoint(text: string, limit: number): { chunk: string; remain
   };
 }
 
+// The hard-break fallback backs a cut off by one code unit when it would
+// split a surrogate pair (see truncateWellFormed). At limit 1 that backoff
+// has nowhere to go -- a single code unit can never hold half of an astral
+// character -- so it returns "" and the loop makes no progress. Below this,
+// no limit can guarantee a non-empty well-formed chunk on every text.
+const MIN_CHUNK_LIMIT = 2;
+
 /**
  * Chunks text for WhatsApp messages
  */
 export function chunkWhatsAppText(text: string, opts: ChunkWhatsAppTextOpts = {}): string[] {
   const limit = opts.limit ?? WHATSAPP_TEXT_CHUNK_LIMIT;
+
+  if (!Number.isFinite(limit) || limit < MIN_CHUNK_LIMIT) {
+    throw new Error(
+      `chunkWhatsAppText: limit must be a finite number >= ${MIN_CHUNK_LIMIT} (got ${limit}) -- ` +
+        "a one-code-unit bound cannot both preserve an astral character and satisfy the limit."
+    );
+  }
 
   if (!text.trim()) {
     return [];
@@ -309,6 +323,13 @@ export function chunkWhatsAppText(text: string, opts: ChunkWhatsAppTextOpts = {}
 
   while (remaining.length > 0) {
     const { chunk, remainder } = splitAtBreakPoint(remaining, limit);
+    if (remainder.length >= remaining.length) {
+      // Invariant: every iteration must strictly shrink `remaining`, or this
+      // loop never terminates. limit >= MIN_CHUNK_LIMIT rules this out for
+      // any text reachable above; this is a fail-closed backstop, not an
+      // expected path.
+      throw new Error("chunkWhatsAppText: failed to make progress splitting text.");
+    }
     if (chunk) {
       chunks.push(chunk);
     }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22211.

Same bug shape as #22203 (plugin-telegram, merged via #22204) and #22206
(plugin-discord, #22209): a raw `slice(0, N)` cutting outbound text at a
UTF-16 code-unit boundary can split an emoji's surrogate pair in half.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Both changed functions are pure string helpers. `chunkWhatsAppText` now
throws synchronously for a limit that's non-finite or `< 2` instead of
accepting it; every real caller in the repo passes either the default
`WHATSAPP_TEXT_CHUNK_LIMIT` (4096) or a caller-supplied positive limit well
above 2, so this is not a behavior change for any current call site — it
converts a silent infinite hang into an explicit, immediate error for an
input class that was already unusable. Non-surrogate-boundary inputs (the
overwhelming majority of real messages) are byte-for-byte unaffected.

# Background

## What does this PR do?

`plugin-whatsapp/src/normalize.ts` has two outbound-text cut points that used
a raw `text.slice(0, N)`:

- `splitAtBreakPoint`'s hard-break fallback (reached by `chunkWhatsAppText`
  whenever a message exceeds `WHATSAPP_TEXT_CHUNK_LIMIT` with no
  paragraph/newline/sentence/word break in the search window — e.g. a long
  run of emoji with no whitespace).
- `truncateText`'s `maxLength - 3` cut (reserving room for the `...` suffix).

Both now call the repo's `truncateWellFormed` (`packages/core/src/utils/well-formed.ts`,
via `@elizaos/core`), which backs a cut off by one UTF-16 code unit when it
would otherwise land between a surrogate pair's high and low half. This is
the identical fix already applied to `plugin-telegram` (#22204) and
`plugin-discord` (#22209) for the same bug shape.

`splitAtBreakPoint`'s remainder is now derived as `text.slice(chunk.length)`
instead of a separately-computed `text.slice(limit)`, so the backed-off
character is never dropped -- it flows into the next chunk instead.

**Addressed from review at head `adc81e7f63`:** `lalalune` found that the
surrogate-safe backoff has a failure mode of its own -- at `limit: 1`,
`truncateWellFormed(remaining, 1)` correctly refuses to split a leading
surrogate pair and returns `""` (a single code unit can never hold half of
an astral character), so the old loop pushed nothing and looped on the same
unchanged `remaining` forever. Confirmed empirically: the unpatched code
genuinely hangs (not just misbehaves) on
`chunkWhatsAppText(text, { limit: 1 })` when `text` opens with an emoji.

Fixed by rejecting unsupported limits up front -- `chunkWhatsAppText` now
throws for any `limit` that is non-finite or `< 2` (2 is the smallest bound
that can ever hold one astral character whole) -- plus an explicit
loop-progress assertion inside `chunkWhatsAppText`'s `while` loop as a
fail-closed backstop (throws instead of spinning if a future change ever
breaks the invariant). `MIN_CHUNK_LIMIT = 2` is documented inline with the
reasoning above.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-whatsapp/src/normalize.test.ts` (`text chunking` describe
  block) -- two tests for the original surrogate-pair fix, plus three new
  tests for the fail-closed limit validation (one-code-unit hang, four
  non-finite/negative/zero limits via `it.each`, and a minimum-supported-limit
  success case proving forward progress + well-formedness + lossless
  rejoin).

## Detailed testing steps

None: Automated tests are acceptable. All new tests drive the real exported
`chunkWhatsAppText`/`truncateText` -- no test reads or matches implementation
source text. The original two surrogate-pair tests were verified against the
unpatched code (`git stash` the fix) to fail there before confirming they
pass with the fix. The new one-code-unit-limit test was verified against the
head-`adc81e7f63` code (fix present, validation absent) to genuinely hang
(process had to be killed after a bounded timeout, not just error) --
confirming the bug is a real infinite loop, not a benign edge case.

- `bun run --cwd plugins/plugin-whatsapp test -- src/normalize.test.ts` (19 tests)
- Full plugin-whatsapp suite (97 tests, no regressions): `bun run --cwd plugins/plugin-whatsapp test`
- `bun run --cwd plugins/plugin-whatsapp typecheck`
- `bunx biome check plugins/plugin-whatsapp/src/normalize.ts plugins/plugin-whatsapp/src/normalize.test.ts`

# Evidence Gate

<!-- evidence-head:bbd086b4a2d9e33e725e49e0e329ab7443c42fce -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change (plugins/plugin-whatsapp), no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change (plugins/plugin-whatsapp), no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change, no user-facing flow to walk through
<!-- evidence-row:backend-logs -->
- [x] Real Vitest run: original surrogate-pair tests confirmed to fail
      against the unpatched code first; the new one-code-unit-limit test
      confirmed to genuinely hang against the pre-fail-closed code (process
      killed after a bounded timeout); both pass with the fix; full plugin
      suite green at the rebased head.

<details>
<summary>Backend logs — regression proof against unpatched/pre-fail-closed code, then full suite at rebased head</summary>

```
# Original surrogate-pair fix, verified against the fully unpatched function:
$ git stash push -- plugins/plugin-whatsapp/src/normalize.ts
$ bun run --cwd plugins/plugin-whatsapp test -- src/normalize.test.ts
 ❯ src/normalize.test.ts (13 tests | 2 failed)
     × chunkWhatsAppText keeps a surrogate pair (emoji) intact at the hard-break fallback
     × truncateText keeps a surrogate pair (emoji) intact instead of splitting it
 AssertionError: expected false to be true // Object.is equality
   at src/normalize.test.ts:129:36  (chunk.isWellFormed())
   at src/normalize.test.ts:142:38  (truncated.isWellFormed())
 Test Files  1 failed (1)
      Tests  2 failed | 11 passed (13)
$ git stash pop   # restores the fix

# Fail-closed limit validation, verified against head adc81e7f63 (surrogate
# fix present, limit validation NOT yet present -- this is the exact code
# lalalune's review flagged):
$ git stash push -- plugins/plugin-whatsapp/src/normalize.ts   # only the fix, keeping the new test
$ bun run --cwd plugins/plugin-whatsapp test -- src/normalize.test.ts \
    -t "fails closed on a one-code-unit limit"
# genuinely hangs -- 100% CPU, no output, no exit. Killed after a bounded
# timeout to confirm this is a true infinite loop, not slow-but-terminating.
$ git stash pop   # restores the fix

# Full suite, typecheck, biome at the rebased head (bbd086b4a2):
$ bun run --cwd plugins/plugin-whatsapp test -- src/normalize.test.ts

 Test Files  1 passed (1)
      Tests  19 passed (19)

$ bun run --cwd plugins/plugin-whatsapp test

 Test Files  12 passed (12)
      Tests  97 passed (97)

$ bun run --cwd plugins/plugin-whatsapp typecheck
(no output — clean)

$ bunx biome check plugins/plugin-whatsapp/src/normalize.ts plugins/plugin-whatsapp/src/normalize.test.ts
Checked 2 files in 6ms. No fixes applied.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] N/A - pure string-processing bug, no DB/memory/wallet/on-chain state
      involved; the backend-logs before/after run above is the reproduction
      artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-manual]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza"} -->
