### PR TITLE
fix(plugin-browser): reject malformed nested batch commands

### DIFF
--- a/plugins/plugin-browser/src/routes/workspace-routes.test.ts
+++ b/plugins/plugin-browser/src/routes/workspace-routes.test.ts
@@ -145,6 +145,205 @@ describe("browser workspace HTTP routes", () => {
     expect(res.body).toEqual({ error: "request body must be a JSON object" });
   });
 
+  it.each([
+    [null, "command.steps[0] must be a JSON object"],
+    ["click", "command.steps[0] must be a JSON object"],
+    [42, "command.steps[0] must be a JSON object"],
+    [true, "command.steps[0] must be a JSON object"],
+    [[], "command.steps[0] must be a JSON object"],
+  ])("rejects a malformed batch step %# as a 400", async (step, error) => {
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/browser-workspace/command",
+      body: { subaction: "batch", steps: [step] },
+    });
+
+    await expect(handleBrowserWorkspaceRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error });
+  });
+
+  it("rejects sparse and deeply nested malformed batch steps as a 400", async () => {
+    const sparseSteps = new Array(1);
+    const malformedBodies = [
+      { subaction: "batch", steps: sparseSteps },
+      {
+        subaction: "batch",
+        steps: [{ subaction: "batch", steps: [null] }],
+      },
+      { subaction: "batch", steps: "not-an-array" },
+    ];
+
+    for (const body of malformedBodies) {
+      const { ctx, res } = buildCtx({
+        method: "POST",
+        pathname: "/api/browser-workspace/command",
+        body,
+      });
+
+      await expect(handleBrowserWorkspaceRoutes(ctx)).resolves.toBe(true);
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({
+        error: expect.stringMatching(/^command(?:\.steps\[\d+\])?\.steps/),
+      });
+    }
+  });
+
+  it.each([{}, { operation: 42 }, { subaction: "   " }])(
+    "rejects a nested command missing a usable subaction",
+    async (step) => {
+      const { ctx, res } = buildCtx({
+        method: "POST",
+        pathname: "/api/browser-workspace/command",
+        body: { subaction: "batch", steps: [step] },
+      });
+
+      await expect(handleBrowserWorkspaceRoutes(ctx)).resolves.toBe(true);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({
+        error: "command.steps[0].subaction is required",
+      });
+    },
+  );
+
+  it("rejects excessive command nesting before recursive normalization", async () => {
+    let nested: Record<string, unknown> = { subaction: "list" };
+    for (let depth = 0; depth < 33; depth += 1) {
+      nested = { subaction: "batch", steps: [nested] };
+    }
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/browser-workspace/command",
+      body: nested,
+    });
+
+    await expect(handleBrowserWorkspaceRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: expect.stringContaining("exceeds the maximum nesting depth of 32"),
+    });
+  });
+
+  it("accepts exactly 256 total commands through the real route", async () => {
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/browser-workspace/command",
+      body: {
+        subaction: "batch",
+        steps: Array.from({ length: 255 }, () => ({ operation: "list" })),
+      },
+    });
+
+    await expect(handleBrowserWorkspaceRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      subaction: "batch",
+    });
+    const steps = (res.body as { steps: Array<{ subaction: string }> }).steps;
+    expect(steps).toHaveLength(255);
+    expect(steps.every((step) => step.subaction === "list")).toBe(true);
+  });
+
+  it("rejects 257 total commands before gating or execution", async () => {
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/browser-workspace/command",
+      body: {
+        subaction: "batch",
+        connectorProvider: "would-require-a-runtime-if-gating-ran",
+        connectorAccountId: "untrusted",
+        steps: Array.from({ length: 256 }, () => ({ operation: "list" })),
+      },
+    });
+
+    await expect(handleBrowserWorkspaceRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: "command tree exceeds the maximum of 256 commands",
+    });
+  });
+
+  it("applies the 256-command cap across nested batches", async () => {
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/browser-workspace/command",
+      body: {
+        subaction: "batch",
+        steps: [
+          {
+            subaction: "batch",
+            steps: Array.from({ length: 127 }, () => ({ operation: "list" })),
+          },
+          {
+            subaction: "batch",
+            steps: Array.from({ length: 127 }, () => ({ operation: "list" })),
+          },
+        ],
+      },
+    });
+
+    await expect(handleBrowserWorkspaceRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: "command tree exceeds the maximum of 256 commands",
+    });
+  });
+
+  it.each([
+    { subaction: "batch" },
+    { subaction: "batch", steps: [] },
+    {
+      subaction: "batch",
+      steps: [{ operation: "batch" }],
+    },
+  ])("rejects missing or empty batch steps as a 400", async (body) => {
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/browser-workspace/command",
+      body,
+    });
+
+    await expect(handleBrowserWorkspaceRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: expect.stringMatching(
+        /\.steps must contain at least one command$/,
+      ),
+    });
+  });
+
+  it("preserves operation aliases and valid nested batch execution", async () => {
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/browser-workspace/command",
+      body: {
+        operation: "batch",
+        steps: [
+          { operation: "batch", steps: [{ operation: "list" }] },
+          { subaction: " LIST " },
+        ],
+      },
+    });
+
+    await expect(handleBrowserWorkspaceRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      subaction: "batch",
+      steps: [
+        { subaction: "batch", steps: [{ subaction: "list" }] },
+        { subaction: "list" },
+      ],
+    });
+  });
+
   it("rejects malformed encoded tab ids as a 400", async () => {
     const { ctx, res } = buildCtx({
       method: "DELETE",

--- a/plugins/plugin-browser/src/routes/workspace.ts
+++ b/plugins/plugin-browser/src/routes/workspace.ts
@@ -71,6 +71,9 @@ type BrowserWorkspaceConnectorReference = {
   connectorAccountId?: string | null;
 };
 
+const MAX_BROWSER_WORKSPACE_COMMAND_DEPTH = 32;
+const MAX_BROWSER_WORKSPACE_COMMANDS = 256;
+
 export interface BrowserWorkspaceRouteContext extends RouteRequestContext {
   url?: URL;
   state?: {
@@ -164,6 +167,79 @@ function isBrowserWorkspaceRouteBodyObject(
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
+function validateBrowserWorkspaceCommandTree(
+  value: unknown,
+  path = "command",
+  depth = 0,
+  state = { commandCount: 0 },
+): string | null {
+  if (!isBrowserWorkspaceRouteBodyObject(value)) {
+    return `${path} must be a JSON object`;
+  }
+  if (depth > MAX_BROWSER_WORKSPACE_COMMAND_DEPTH) {
+    return `${path} exceeds the maximum nesting depth of ${MAX_BROWSER_WORKSPACE_COMMAND_DEPTH}`;
+  }
+  state.commandCount += 1;
+  if (state.commandCount > MAX_BROWSER_WORKSPACE_COMMANDS) {
+    return `command tree exceeds the maximum of ${MAX_BROWSER_WORKSPACE_COMMANDS} commands`;
+  }
+
+  if (value.steps === undefined) {
+    return null;
+  }
+  if (!Array.isArray(value.steps)) {
+    return `${path}.steps must be an array`;
+  }
+
+  for (let index = 0; index < value.steps.length; index += 1) {
+    if (!(index in value.steps)) {
+      return `${path}.steps[${index}] must be a JSON object`;
+    }
+    const nestedError = validateBrowserWorkspaceCommandTree(
+      value.steps[index],
+      `${path}.steps[${index}]`,
+      depth + 1,
+      state,
+    );
+    if (nestedError) {
+      return nestedError;
+    }
+  }
+  return null;
+}
+
+function validateBrowserWorkspaceBatchSteps(
+  command: BrowserWorkspaceCommand,
+  path = "command",
+): string | null {
+  if (
+    typeof command.subaction !== "string" ||
+    command.subaction.trim().length === 0
+  ) {
+    return `${path}.subaction is required`;
+  }
+  if (
+    command.subaction === "batch" &&
+    (!Array.isArray(command.steps) || command.steps.length === 0)
+  ) {
+    return `${path}.steps must contain at least one command`;
+  }
+
+  if (!Array.isArray(command.steps)) {
+    return null;
+  }
+  for (let index = 0; index < command.steps.length; index += 1) {
+    const nestedError = validateBrowserWorkspaceBatchSteps(
+      command.steps[index],
+      `${path}.steps[${index}]`,
+    );
+    if (nestedError) {
+      return nestedError;
+    }
+  }
+  return null;
+}
+
 function rejectMalformedBrowserWorkspacePayload(
   ctx: BrowserWorkspaceRouteContext,
 ): true {
@@ -245,6 +321,11 @@ export async function handleBrowserWorkspaceRoutes(
       if (!isBrowserWorkspaceRouteBodyObject(body)) {
         return rejectMalformedBrowserWorkspacePayload(ctx);
       }
+      const shapeError = validateBrowserWorkspaceCommandTree(body);
+      if (shapeError) {
+        json(res, { error: shapeError }, 400);
+        return true;
+      }
       // Normalize once at the boundary so `operation` aliases and
       // case/whitespace variants resolve before subaction validation and
       // account-gating, matching the action path's canonicalization.
@@ -254,6 +335,11 @@ export async function handleBrowserWorkspaceRoutes(
         command.subaction.trim().length === 0
       ) {
         json(res, { error: "subaction is required" }, 400);
+        return true;
+      }
+      const batchError = validateBrowserWorkspaceBatchSteps(command);
+      if (batchError) {
+        json(res, { error: batchError }, 400);
         return true;
       }
       await assertBrowserWorkspaceCommandConnectorAccountGate({


### PR DESCRIPTION
Closes #22205

## Summary

Fail closed at the browser workspace command HTTP boundary before recursive normalization, connector-account gating, or execution:

- require every root/nested command to be a non-array JSON object;
- require any present `steps` field to be an array without sparse entries;
- require every normalized nested command to have a usable subaction;
- require every batch to contain at least one command;
- cap recursive command depth at 32 and the entire tree at 256 commands before calling the existing recursive normalizer.

Valid operation aliases, nested batches, account gating, and execution order are preserved.

## Exact-head evidence

<!-- evidence-head:fbe34d1d15938942652e8a7b4c194777c522b9d4 -->

```text
bunx vitest run src/routes/workspace-routes.test.ts src/workspace/browser-workspace-helpers.normalize-command.test.ts --maxWorkers=1
  2 files passed; 44 tests passed

bun run typecheck
  PASS

bun run build:types
  PASS

bunx biome check src/routes/workspace.ts src/routes/workspace-routes.test.ts
  Checked 2 files; no fixes

git diff --check origin/develop...HEAD
  PASS

bun run check:agents-claude
  PASS: 43 tracked pairs byte-identical
```

The real route regressions cover null/string/number/boolean/array steps, sparse arrays, non-array `steps`, deeper malformed batches, missing/empty batches, missing nested subactions, excessive depth, exactly 256 accepted commands, 257 rejected before gating/execution, and nested aggregate counting. A valid nested batch using operation aliases reaches the real executor and returns 200 with ordered nested results.

## Known environment gaps

- The full plugin test command executed 204/204 runnable tests; two unrelated suites failed during import because this sparse review worktree lacks `@elizaos/vault` and `drizzle-orm/pg-core` workspace dependencies.
- JavaScript bundling could not start because the sparse shared install lacks `tsup`; declaration build and package typecheck are green.
- `bun install --frozen-lockfile` cannot complete in a sparse worktree because workspace packages outside the checkout are intentionally absent. No lockfile or generated artifacts changed.

## Evidence matrix

- Screenshots/video: N/A — server-side JSON validation only; no UI surface.
- Backend artifact: real route test responses and exact commands above.
- Frontend logs: N/A — no frontend change.
- Model trajectory: N/A — deterministic transport validation; no model behavior.
- Domain artifact: N/A — malformed commands are rejected before mutation.

## Contribution provenance

- AI assistance: yes
- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex Desktop, lane `codex-cortex-plugins`
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","lane":"codex-cortex-plugins"} -->
