### PR TITLE
fix(plugin-imessage): never split a surrogate pair in splitMessageForIMessage

### DIFF
--- a/plugins/plugin-imessage/src/types.test.ts
+++ b/plugins/plugin-imessage/src/types.test.ts
@@ -1,11 +1,29 @@
 /**
  * Coverage for splitMessageForIMessage's chunk boundary: an unbroken run of
  * multi-byte text (no newline/space near the limit) must never cut a UTF-16
- * surrogate pair (emoji) in half.
+ * surrogate pair (emoji) in half, and the bound itself must be validated so
+ * a degenerate `maxLength` fails closed instead of looping forever.
+ *
+ * Well-formedness is asserted via toWellFormedUnicode's round-trip
+ * (`toWellFormedUnicode(chunk) === chunk`) rather than the native
+ * `String.prototype.isWellFormed`: the former exercises this repo's real
+ * fallback path on runtimes without the ES2024 method, so the check stays
+ * load-bearing everywhere instead of only where the native method exists.
  */
 
+import { toWellFormedUnicode } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { splitMessageForIMessage } from "./types";
+
+function expectWellFormedLosslessRejoin(text: string, maxLength: number) {
+  const chunks = splitMessageForIMessage(text, maxLength);
+  for (const chunk of chunks) {
+    expect(chunk.length).toBeGreaterThan(0);
+    expect(toWellFormedUnicode(chunk)).toBe(chunk);
+  }
+  expect(chunks.join("")).toBe(text);
+  return chunks;
+}
 
 describe("splitMessageForIMessage", () => {
   it("does not split a surrogate pair when no whitespace break point exists near the limit", () => {
@@ -16,12 +34,7 @@ describe("splitMessageForIMessage", () => {
     const text = emoji.repeat(50); // 100 UTF-16 code units, no whitespace
     const maxLength = 51; // odd cut point lands mid-pair without the fix
 
-    const chunks = splitMessageForIMessage(text, maxLength);
-
-    for (const chunk of chunks) {
-      expect(chunk.length === 0 || chunk.isWellFormed()).toBe(true);
-    }
-    expect(chunks.join("")).toBe(text);
+    expectWellFormedLosslessRejoin(text, maxLength);
   });
 
   it("still breaks on whitespace when available", () => {
@@ -33,4 +46,30 @@ describe("splitMessageForIMessage", () => {
   it("returns the input unchanged when under the limit", () => {
     expect(splitMessageForIMessage("hello", 4000)).toEqual(["hello"]);
   });
+
+  it("terminates and widens by exactly one unit for a leading surrogate pair at maxLength 1", () => {
+    // The one supported-but-degenerate bound: an astral scalar needs both
+    // surrogate halves, so no 1-unit head chunk can exist. The effective
+    // chunk is 2 code units here instead of 1 -- documented exception, not
+    // a bug -- but the loop must still terminate on well-formed, nonempty,
+    // losslessly-rejoinable chunks.
+    const text = "\u{1F389}\u{1F389}\u{1F389}"; // 🎉🎉🎉, no whitespace
+    const chunks = expectWellFormedLosslessRejoin(text, 1);
+    expect(chunks).toEqual(["\u{1F389}", "\u{1F389}", "\u{1F389}"]);
+  });
+
+  it("fits a single leading emoji exactly at maxLength 2 with no widening", () => {
+    const text = "\u{1F389}\u{1F389}"; // 🎉🎉, no whitespace
+    const chunks = expectWellFormedLosslessRejoin(text, 2);
+    expect(chunks).toEqual(["\u{1F389}", "\u{1F389}"]);
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "rejects a degenerate maxLength (%s) instead of looping forever",
+    (maxLength) => {
+      expect(() => splitMessageForIMessage("hello world", maxLength)).toThrow(
+        /maxLength must be a positive finite number/
+      );
+    }
+  );
 });

--- a/plugins/plugin-imessage/src/types.test.ts
+++ b/plugins/plugin-imessage/src/types.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Coverage for splitMessageForIMessage's chunk boundary: an unbroken run of
+ * multi-byte text (no newline/space near the limit) must never cut a UTF-16
+ * surrogate pair (emoji) in half.
+ */
+
+import { describe, expect, it } from "vitest";
+import { splitMessageForIMessage } from "./types";
+
+describe("splitMessageForIMessage", () => {
+  it("does not split a surrogate pair when no whitespace break point exists near the limit", () => {
+    // 🎉 is a surrogate pair (U+1F389, 2 UTF-16 code units). A run of them
+    // long enough to exceed maxLength with no space/newline forces the
+    // fallback hard cut at exactly maxLength.
+    const emoji = "\u{1F389}"; // 🎉
+    const text = emoji.repeat(50); // 100 UTF-16 code units, no whitespace
+    const maxLength = 51; // odd cut point lands mid-pair without the fix
+
+    const chunks = splitMessageForIMessage(text, maxLength);
+
+    for (const chunk of chunks) {
+      expect(chunk.length === 0 || chunk.isWellFormed()).toBe(true);
+    }
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("still breaks on whitespace when available", () => {
+    const text = `${"a".repeat(30)} ${"b".repeat(30)}`;
+    const chunks = splitMessageForIMessage(text, 32);
+    expect(chunks).toEqual(["a".repeat(30), "b".repeat(30)]);
+  });
+
+  it("returns the input unchanged when under the limit", () => {
+    expect(splitMessageForIMessage("hello", 4000)).toEqual(["hello"]);
+  });
+});

--- a/plugins/plugin-imessage/src/types.ts
+++ b/plugins/plugin-imessage/src/types.ts
@@ -2,7 +2,7 @@
  * Type definitions for the iMessage plugin.
  */
 
-import type { Service } from "@elizaos/core";
+import { type Service, truncateWellFormed } from "@elizaos/core";
 
 /** Maximum message length for iMessage */
 export const MAX_IMESSAGE_MESSAGE_LENGTH = 4000;
@@ -308,8 +308,11 @@ export function splitMessageForIMessage(
       }
     }
 
-    chunks.push(remaining.slice(0, breakPoint).trimEnd());
-    remaining = remaining.slice(breakPoint).trimStart();
+    // truncateWellFormed backs the cut off by one unit instead of splitting
+    // a surrogate pair (emoji) when no newline/space break point was found.
+    const head = truncateWellFormed(remaining, breakPoint);
+    chunks.push(head.trimEnd());
+    remaining = remaining.slice(head.length).trimStart();
   }
 
   return chunks;

--- a/plugins/plugin-imessage/src/types.ts
+++ b/plugins/plugin-imessage/src/types.ts
@@ -277,11 +277,31 @@ export function formatPhoneNumber(phone: string): string {
 /**
  * Split text for iMessage
  */
+// truncateWellFormed(text, 1) returns "" when text opens with a surrogate
+// pair (backing the one-unit cut off to 0): an astral scalar needs both
+// code units to stay well-formed, so no head chunk can honor a 1-unit
+// bound without either splitting the pair or producing nothing. Widening
+// by exactly one unit in that single case keeps the caller making forward
+// progress instead of looping forever on an empty chunk; every other
+// bound is unaffected since truncateWellFormed only ever backs off by one
+// unit, which stays non-empty for any limit >= 2.
+function takeAtLeastOneUnit(text: string, limit: number): string {
+  const chunk = truncateWellFormed(text, limit);
+  return chunk.length > 0 ? chunk : truncateWellFormed(text, limit + 1);
+}
+
 export function splitMessageForIMessage(
   text: string,
   maxLength: number = MAX_IMESSAGE_MESSAGE_LENGTH
 ): string[] {
-  if (text.length <= maxLength) {
+  if (!Number.isFinite(maxLength) || maxLength < 1) {
+    throw new Error(
+      `splitMessageForIMessage: maxLength must be a positive finite number, got ${maxLength}`
+    );
+  }
+  const limit = Math.floor(maxLength);
+
+  if (text.length <= limit) {
     return [text];
   }
 
@@ -289,28 +309,28 @@ export function splitMessageForIMessage(
   let remaining = text;
 
   while (remaining.length > 0) {
-    if (remaining.length <= maxLength) {
+    if (remaining.length <= limit) {
       chunks.push(remaining);
       break;
     }
 
-    let breakPoint = maxLength;
+    let breakPoint = limit;
 
     // Try newline first
-    const newlineIdx = remaining.lastIndexOf("\n", maxLength);
-    if (newlineIdx > maxLength / 2) {
+    const newlineIdx = remaining.lastIndexOf("\n", limit);
+    if (newlineIdx > limit / 2) {
       breakPoint = newlineIdx + 1;
     } else {
       // Try space
-      const spaceIdx = remaining.lastIndexOf(" ", maxLength);
-      if (spaceIdx > maxLength / 2) {
+      const spaceIdx = remaining.lastIndexOf(" ", limit);
+      if (spaceIdx > limit / 2) {
         breakPoint = spaceIdx + 1;
       }
     }
 
     // truncateWellFormed backs the cut off by one unit instead of splitting
     // a surrogate pair (emoji) when no newline/space break point was found.
-    const head = truncateWellFormed(remaining, breakPoint);
+    const head = takeAtLeastOneUnit(remaining, breakPoint);
     chunks.push(head.trimEnd());
     remaining = remaining.slice(head.length).trimStart();
   }


### PR DESCRIPTION
# Relates to

Closes #22218.

Same bug class as the already-merged #22203 (Telegram → #22204), #22206
(Discord → #22209), and #22211 (WhatsApp → #22214): a message-chunking
hard-break fallback used a raw `.slice(0, N)` cut instead of the repo's own
`truncateWellFormed` helper, so a long run of astral-plane characters
(emoji) with no whitespace near the cut point could have a surrogate pair
torn across two chunks.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Two changes to `splitMessageForIMessage`, both scoped to the single
hard-break fallback path:

1. The cut itself now goes through `takeAtLeastOneUnit` (`truncateWellFormed`,
   widened by one unit only in the single case it returns empty), same as
   before, and `remaining` advances by the returned string's actual length.
2. `maxLength` is validated (finite, `>= 1`) before the loop starts and
   throws otherwise, instead of silently accepting a bound that could never
   terminate.

No new dependencies (`truncateWellFormed` already exists in `@elizaos/core`,
already imported by three sibling plugins for the identical fix). The thrown
error is new observable behavior only for callers already passing an invalid
`maxLength` (0, negative, or non-finite) — previously either an infinite loop
(`RangeError: Invalid array length` once the JS array implementation gave up)
or, for `Infinity`, a silent no-op single-chunk return; grepped every current
caller in the monorepo and none passes a literal invalid bound.

# Background

## What does this PR do?

`splitMessageForIMessage` (`plugins/plugin-imessage/src/types.ts`) chunks long
outbound messages at `MAX_IMESSAGE_MESSAGE_LENGTH` (4000). It prefers to break
on a newline or space near the limit, but falls back to a hard cut at exactly
`maxLength` when neither is found within the second half of the window. That
hard cut used `remaining.slice(0, breakPoint)`, a plain UTF-16-code-unit slice
that can land between the two halves of a surrogate pair (e.g. an emoji),
producing two malformed chunks — one ending in a lone high surrogate, the next
starting with a lone low surrogate.

The fix swaps that cut for `truncateWellFormed` (`packages/core/src/utils/well-formed.ts`),
which performs the identical slice but backs the boundary off by one code unit
when it would otherwise split a pair. `remaining` is then advanced by the
returned string's length (not the original `breakPoint`) so the loop stays in
sync when the boundary shifted.

This is the fourth instance of the identical bug shape found and fixed this
session — the same raw-slice hard-break pattern was already fixed in
`plugin-telegram` (#22204), `plugin-discord` (#22209), and `plugin-whatsapp`
(#22214), all via the same `truncateWellFormed` swap.

**Addressed from review**: the exported `maxLength` parameter had no bound
validation, so `truncateWellFormed(remaining, 1)` on text opening with a
surrogate pair returns `""` — an empty chunk, zero-length slice advance, and
an infinite loop (`RangeError: Invalid array length` once the array
implementation gave up). Zero, negative, and non-finite bounds had no guard
either. Fixed with a fail-closed contract: `maxLength` is validated (finite,
`>= 1`) before the loop, throwing immediately on an invalid bound instead of
looping; and a `takeAtLeastOneUnit` helper (same pattern as the Discord fix's
`takeWellFormedChunk`) widens the cut by exactly one unit in the single
degenerate case (`maxLength === 1` with a leading surrogate pair) where no
smaller well-formed chunk can exist, guaranteeing forward progress. This
scalar-width exception is documented in code and covered by a dedicated test
(`maxLength: 1` with a leading emoji) rather than silently allowed. The test
suite's well-formedness oracle also switched from native
`String.prototype.isWellFormed()` to `toWellFormedUnicode`'s round-trip
(`toWellFormedUnicode(chunk) === chunk`), so the assertion exercises this
repo's real fallback path on runtimes without the ES2024 method instead of
only the native fast path.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-imessage/src/types.test.ts`

## Detailed testing steps

None: Automated tests are acceptable. The tests drive the real exported
`splitMessageForIMessage` function directly — no test reads or matches
implementation source text.

- `bun run --cwd plugins/plugin-imessage test -- src/types.test.ts` (10 tests)
- Full plugin-imessage suite (222 tests, no regressions): `bun run --cwd plugins/plugin-imessage test`
- `bun run --cwd plugins/plugin-imessage typecheck`
- `bunx biome check plugins/plugin-imessage/src/types.ts plugins/plugin-imessage/src/types.test.ts`

# Evidence Gate

<!-- evidence-head:d87f4a3eddb67def1dede6cb53642e67908d81cb -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change (plugins/plugin-imessage), no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change (plugins/plugin-imessage), no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change, no user-facing flow to walk through
<!-- evidence-row:backend-logs -->
- [x] Real Vitest run reproducing both the malformed split and the
      infinite-loop/no-guard bugs on unpatched code, and the corrected,
      terminating, well-formed behavior after the fix.

<details>
<summary>Backend logs — new tests against unpatched code (fail), against fixed code (pass), full suite, typecheck, biome</summary>

```
# Against unpatched code (git stash the fix commit, keep the new tests):
$ bun run --cwd plugins/plugin-imessage test -- src/types.test.ts

 ❯ splitMessageForIMessage src/types.ts:314:12   (RangeError: Invalid array length)
 FAIL  src/types.test.ts > ... > terminates and widens by exactly one unit for a leading surrogate pair at maxLength 1
 FAIL  src/types.test.ts > ... > rejects a degenerate maxLength (0) instead of looping forever
 FAIL  src/types.test.ts > ... > rejects a degenerate maxLength (-1) instead of looping forever
 FAIL  src/types.test.ts > ... > rejects a degenerate maxLength (NaN) instead of looping forever
 FAIL  src/types.test.ts > ... > rejects a degenerate maxLength (-Infinity) instead of looping forever
 FAIL  src/types.test.ts > ... > rejects a degenerate maxLength (Infinity) instead of looping forever

 Test Files  1 failed (1)
      Tests  6 failed | 4 passed (10)

# Against the fix (this PR's head):
$ bun run --cwd plugins/plugin-imessage test -- src/types.test.ts

 Test Files  1 passed (1)
      Tests  10 passed (10)

# Full plugin suite, no regressions:
$ bun run --cwd plugins/plugin-imessage test

 Test Files  17 passed (17)
      Tests  222 passed (222)

$ bun run --cwd plugins/plugin-imessage typecheck
(no output — clean)

$ bunx biome check plugins/plugin-imessage/src/types.ts plugins/plugin-imessage/src/types.test.ts
Checked 2 files in 12ms. No fixes applied.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] Real before/after chunk values from the actual `splitMessageForIMessage`
      call, shown below, including the degenerate `maxLength: 1` case.

<details>
<summary>Domain artifact — actual chunk values, before and after</summary>

```
Case 1 — mid-window cut (maxLength=51):
Input: "🎉".repeat(50) (100 UTF-16 code units, no whitespace)

BEFORE (remaining.slice(0, 51)):
  chunk[0] = "...🎉\ud83c"   toWellFormedUnicode(chunk) !== chunk  (dangling high surrogate)
  chunk[1] = "\udf89🎉..."   toWellFormedUnicode(chunk) !== chunk  (leading low surrogate)

AFTER (takeAtLeastOneUnit(remaining, 51)):
  chunk[0] = "...🎉"          well-formed  (backed off to 50 code units)
  chunk[1] = "🎉🎉..."        well-formed
  chunks.join("") === input   (no characters lost, only the cut point moved)

Case 2 — degenerate maxLength=1, leading surrogate pair:
Input: "🎉🎉🎉" (3 emoji, no whitespace), maxLength=1

BEFORE: truncateWellFormed(remaining, 1) === ""
  -> chunks.push(""), remaining = remaining.slice(0) [unchanged]
  -> infinite loop -> RangeError: Invalid array length

AFTER: takeAtLeastOneUnit widens to truncateWellFormed(remaining, 2) = "🎉"
  chunks = ["🎉", "🎉", "🎉"]   (effective chunk width 2, not the requested 1 —
                                  documented exception: an astral scalar needs
                                  both surrogate halves, so no smaller
                                  well-formed nonempty chunk can exist)
  chunks.join("") === input

Case 3 — invalid bound:
splitMessageForIMessage("hello world", 0)
  BEFORE: silent infinite loop (no bound check)
  AFTER:  throws "splitMessageForIMessage: maxLength must be a positive
          finite number, got 0" immediately
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-manual]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza"} -->