### PR TITLE
fix(plugin-slack): use truncateWellFormed so chunking never splits a surrogate pair

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -5,6 +5,7 @@
  * must reject malformed boundary values; and markdown→mrkdwn must use Slack's
  * *bold* / _italic_ syntax rather than the markdown originals.
  */
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   buildSlackMessagePermalink,
@@ -162,15 +163,37 @@ describe("chunkSlackText", () => {
     const chunks = chunkSlackText(text, 100);
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.every((c) => c.isWellFormed())).toBe(true);
+    expect(chunks.every((c) => c.length > 0 && c.length <= 100)).toBe(true);
     // lossless: no unit dropped or duplicated at the surrogate-adjusted cut
     expect(chunks.join("")).toBe(text);
   });
 
-  it("still makes progress when a single surrogate pair can't fit under the limit", () => {
-    const chunks = chunkSlackText("😀", 1);
-    expect(chunks.join("")).toBe("😀");
-    expect(chunks.every((c) => c.isWellFormed())).toBe(true);
+  it("fails closed instead of exceeding maxChars when a surrogate pair can't fit", () => {
+    // Widening past maxChars=1 to fit the pair would silently break the
+    // "never emits more than maxChars" contract every other test here checks.
+    let thrown: unknown;
+    try {
+      chunkSlackText("😀", 1);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ElizaError);
+    expect((thrown as ElizaError).code).toBe("SLACK_CHUNK_LIMIT_TOO_SMALL");
   });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
+    "rejects an invalid maxChars (%s) instead of silently coercing it",
+    (maxChars) => {
+      let thrown: unknown;
+      try {
+        chunkSlackText("hello", maxChars);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(ElizaError);
+      expect((thrown as ElizaError).code).toBe("SLACK_CHUNK_LIMIT_INVALID");
+    },
+  );
 });
 
 describe("splitSlackText", () => {
@@ -193,14 +216,34 @@ describe("splitSlackText", () => {
     const chunks = splitSlackText(text, 100);
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.every((c) => c.isWellFormed())).toBe(true);
+    expect(chunks.every((c) => c.length > 0 && c.length <= 100)).toBe(true);
     expect(chunks.join("")).toBe(text);
   });
 
-  it("still makes progress when a single surrogate pair can't fit under the limit", () => {
-    const chunks = splitSlackText("😀", 1);
-    expect(chunks.join("")).toBe("😀");
-    expect(chunks.every((c) => c.isWellFormed())).toBe(true);
+  it("fails closed instead of exceeding maxChars when a surrogate pair can't fit", () => {
+    let thrown: unknown;
+    try {
+      splitSlackText("😀", 1);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ElizaError);
+    expect((thrown as ElizaError).code).toBe("SLACK_CHUNK_LIMIT_TOO_SMALL");
   });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
+    "rejects an invalid maxChars (%s) instead of silently coercing it",
+    (maxChars) => {
+      let thrown: unknown;
+      try {
+        splitSlackText("hello", maxChars);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(ElizaError);
+      expect((thrown as ElizaError).code).toBe("SLACK_CHUNK_LIMIT_INVALID");
+    },
+  );
 });
 
 describe("truncateText", () => {

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -153,6 +153,24 @@ describe("chunkSlackText", () => {
       expect((c.match(/```/g) || []).length % 2).toBe(0);
     }
   });
+
+  it("never splits an emoji surrogate pair across chunks on a break-free run", () => {
+    // "a" (1 unit) + 150 astral emoji (2 units each, no spaces/newlines) puts
+    // the hardLimit=96 break point (maxChars=100) exactly between the high
+    // and low surrogate of the 47th emoji, forcing the raw-slice fallback.
+    const text = `a${"😀".repeat(150)}`;
+    const chunks = chunkSlackText(text, 100);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((c) => c.isWellFormed())).toBe(true);
+    // lossless: no unit dropped or duplicated at the surrogate-adjusted cut
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("still makes progress when a single surrogate pair can't fit under the limit", () => {
+    const chunks = chunkSlackText("😀", 1);
+    expect(chunks.join("")).toBe("😀");
+    expect(chunks.every((c) => c.isWellFormed())).toBe(true);
+  });
 });
 
 describe("splitSlackText", () => {
@@ -167,6 +185,22 @@ describe("splitSlackText", () => {
       expect(chunks.join("")).toBe(text);
     },
   );
+
+  it("never splits an emoji surrogate pair across chunks on a break-free run", () => {
+    // "a" (1 unit) + 150 astral emoji puts the maxChars=100 cut exactly
+    // between the high and low surrogate of the 49th emoji.
+    const text = `a${"😀".repeat(150)}`;
+    const chunks = splitSlackText(text, 100);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((c) => c.isWellFormed())).toBe(true);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("still makes progress when a single surrogate pair can't fit under the limit", () => {
+    const chunks = splitSlackText("😀", 1);
+    expect(chunks.join("")).toBe("😀");
+    expect(chunks.every((c) => c.isWellFormed())).toBe(true);
+  });
 });
 
 describe("truncateText", () => {

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -8,6 +8,7 @@
  * channel-type / display-name helpers. Used by `service.ts` on the send/receive
  * paths and re-exported from `index.ts`.
  */
+import { truncateWellFormed } from "@elizaos/core";
 import {
   parseSlackArchivesUrl,
   type SlackChannel,
@@ -228,8 +229,15 @@ export function splitSlackText(
     }
 
     splitIndex = Math.min(splitIndex, maxChars);
-    messages.push(remaining.slice(0, splitIndex));
-    remaining = remaining.slice(splitIndex);
+    // truncateWellFormed backs the cut off by one unit instead of splitting a
+    // surrogate pair; remaining must resume from the actual chunk length, not
+    // the requested splitIndex, or one unit of text would be dropped.
+    let chunk = truncateWellFormed(remaining, splitIndex);
+    if (chunk.length === 0 && remaining.length > 0) {
+      chunk = truncateWellFormed(remaining, splitIndex + 1);
+    }
+    messages.push(chunk);
+    remaining = remaining.slice(chunk.length);
   }
 
   return messages;
@@ -282,7 +290,14 @@ export function chunkSlackText(
     // fence budget is spent, pushing the emitted chunk to maxChars + 1.
     breakPoint = Math.min(breakPoint, hardLimit);
 
-    let chunk = remaining.slice(0, breakPoint);
+    // truncateWellFormed backs the cut off by one unit instead of splitting a
+    // surrogate pair; consumedLength (not breakPoint) is how far `remaining`
+    // must advance, since the fence suffix appended below isn't part of it.
+    let chunk = truncateWellFormed(remaining, breakPoint);
+    if (chunk.length === 0 && remaining.length > 0) {
+      chunk = truncateWellFormed(remaining, breakPoint + 1);
+    }
+    const consumedLength = chunk.length;
 
     // Check if this chunk ends inside a code block — count fences in the
     // actual emitted chunk, not the max-size window, so a fence that sits
@@ -297,7 +312,7 @@ export function chunkSlackText(
 
     chunks.push(chunk);
 
-    remaining = remaining.slice(breakPoint);
+    remaining = remaining.slice(consumedLength);
 
     // If we were in a code block, reopen it
     if (inCodeBlock) {

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -8,7 +8,7 @@
  * channel-type / display-name helpers. Used by `service.ts` on the send/receive
  * paths and re-exported from `index.ts`.
  */
-import { truncateWellFormed } from "@elizaos/core";
+import { ElizaError, truncateWellFormed } from "@elizaos/core";
 import {
   parseSlackArchivesUrl,
   type SlackChannel,
@@ -196,14 +196,55 @@ export interface ChunkSlackTextOpts {
 const DEFAULT_MAX_CHARS = 4000;
 
 /**
+ * A hard per-chunk cap can never be honored for arbitrary text unless it's a
+ * positive integer that can hold at least one UTF-16 code unit; anything
+ * else (NaN, 0, negative, fractional) has no sensible "effective bound" and
+ * must fail closed instead of silently coercing into one.
+ */
+function requireValidChunkLimit(maxChars: number, fnName: string): void {
+  if (!Number.isInteger(maxChars) || maxChars < 1) {
+    throw new ElizaError(
+      `${fnName}: maxChars must be a positive integer, got ${maxChars}`,
+      { code: "SLACK_CHUNK_LIMIT_INVALID", context: { fnName, maxChars } },
+    );
+  }
+}
+
+/**
+ * `effectiveLimit` (the actual per-chunk budget after fence/break-point
+ * accounting) is too small to hold even one well-formed unit of the
+ * remaining text — e.g. an astral character needs 2 UTF-16 code units, so a
+ * 1-unit budget can't fit it without splitting a surrogate pair. Widening
+ * the chunk past the caller's requested `maxChars` would silently break the
+ * "never emits more than maxChars" contract, so this fails closed instead.
+ */
+function chunkLimitTooSmall(
+  fnName: string,
+  effectiveLimit: number,
+  maxChars: number,
+): never {
+  throw new ElizaError(
+    `${fnName}: a chunk limit of ${effectiveLimit} (from maxChars=${maxChars}) cannot hold the next well-formed character without splitting a surrogate pair`,
+    {
+      code: "SLACK_CHUNK_LIMIT_TOO_SMALL",
+      context: { fnName, effectiveLimit, maxChars },
+    },
+  );
+}
+
+/**
  * Splits plain Slack message text at newline/space boundaries without ever
  * emitting more than `maxChars`. Unlike `chunkSlackText`, this does not add
  * code-fence balancing characters.
+ *
+ * @throws {ElizaError} if `maxChars` isn't a positive integer, or is too
+ * small to fit the next well-formed character (see {@link chunkLimitTooSmall}).
  */
 export function splitSlackText(
   text: string,
   maxChars: number = DEFAULT_MAX_CHARS,
 ): string[] {
+  requireValidChunkLimit(maxChars, "splitSlackText");
   if (text.length <= maxChars) {
     return [text];
   }
@@ -232,9 +273,9 @@ export function splitSlackText(
     // truncateWellFormed backs the cut off by one unit instead of splitting a
     // surrogate pair; remaining must resume from the actual chunk length, not
     // the requested splitIndex, or one unit of text would be dropped.
-    let chunk = truncateWellFormed(remaining, splitIndex);
-    if (chunk.length === 0 && remaining.length > 0) {
-      chunk = truncateWellFormed(remaining, splitIndex + 1);
+    const chunk = truncateWellFormed(remaining, splitIndex);
+    if (chunk.length === 0) {
+      chunkLimitTooSmall("splitSlackText", splitIndex, maxChars);
     }
     messages.push(chunk);
     remaining = remaining.slice(chunk.length);
@@ -244,12 +285,16 @@ export function splitSlackText(
 }
 
 /**
- * Chunks Slack text while preserving code blocks
+ * Chunks Slack text while preserving code blocks.
+ *
+ * @throws {ElizaError} if `maxChars` isn't a positive integer, or is too
+ * small to fit the next well-formed character (see {@link chunkLimitTooSmall}).
  */
 export function chunkSlackText(
   text: string,
   maxChars: number = DEFAULT_MAX_CHARS,
 ): string[] {
+  requireValidChunkLimit(maxChars, "chunkSlackText");
   if (!text) {
     return [];
   }
@@ -294,8 +339,8 @@ export function chunkSlackText(
     // surrogate pair; consumedLength (not breakPoint) is how far `remaining`
     // must advance, since the fence suffix appended below isn't part of it.
     let chunk = truncateWellFormed(remaining, breakPoint);
-    if (chunk.length === 0 && remaining.length > 0) {
-      chunk = truncateWellFormed(remaining, breakPoint + 1);
+    if (chunk.length === 0) {
+      chunkLimitTooSmall("chunkSlackText", breakPoint, maxChars);
     }
     const consumedLength = chunk.length;
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #22217.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Both functions only change their hard-break fallback cut point (used
when no newline/space break exists near the limit); the newline/space-break
paths and every other branch are untouched. On the ordinary path,
`truncateWellFormed` only ever shortens the requested cut by at most one
UTF-16 code unit (to avoid splitting a surrogate pair) or leaves it
unchanged, so output is either identical to before or one unit shorter at
that single fallback cut, with the saved unit carried into the next chunk
(`remaining` resumes from the actual emitted chunk length, not the original
requested index). On the degenerate path (the effective per-chunk budget
can't fit even the next well-formed unit), the function now throws a typed
`ElizaError` instead of ever emitting a chunk over the caller's requested
`maxChars` — see **Addressed from review** below.

# Background

## What does this PR do?

`splitSlackText` and `chunkSlackText` both fall back to a raw index cut
(`remaining.slice(0, index)`) when no newline/space break point exists near
the character limit — e.g. a long run of consecutive emoji with no
whitespace. Since JS strings are UTF-16 and an emoji outside the BMP is a
2-unit surrogate pair, that raw cut can land exactly between the high and low
surrogate, producing two malformed chunks (each an unpaired surrogate).

Both functions now route that fallback cut through the repo's existing
`truncateWellFormed` helper (`packages/core/src/utils/well-formed.ts`), which
backs the cut off by one unit when it would split a pair. `remaining` is
advanced by the actual chunk length (`consumedLength`/`chunk.length`) rather
than the originally requested index, so the saved unit is carried forward
into the next chunk instead of being silently dropped — verified by a
lossless round-trip assertion (`chunks.join("") === text`) in the tests.

Same bug shape, same fix, as `plugin-telegram` (#22203/#22204, merged),
`plugin-discord` (#22206/#22209), and `plugin-whatsapp` (#22211/#22214),
found via a systematic sweep of platform message-chunking code for call
sites that never adopted `truncateWellFormed`.

## Addressed from review

`lalalune`'s review at the previous head (`35219c1f06`) flagged that the
original widen-by-one fallback — used when `truncateWellFormed(remaining,
limit)` returns `""` because `limit` is too small to fit a surrogate pair
without splitting it — silently emitted a chunk **larger than `maxChars`**,
breaking both functions' own documented "never emits more than `maxChars`"
contract. `NaN`/zero/negative/fractional `maxChars` also had no defined
contract and could produce an empty chunk with a non-advancing remainder
(an infinite loop).

Fixed by failing closed instead of widening:
- Both functions now validate `maxChars` up front (`requireValidChunkLimit`)
  and throw a typed `ElizaError` (`code: "SLACK_CHUNK_LIMIT_INVALID"`) for
  any non-positive-integer value (`NaN`, `Infinity`, `0`, negative,
  fractional) before doing any work.
- When the effective per-chunk budget (`splitIndex` / `breakPoint`) can't fit
  the next well-formed unit of `remaining`, the function now throws a typed
  `ElizaError` (`code: "SLACK_CHUNK_LIMIT_TOO_SMALL"`, via `chunkLimitTooSmall`)
  instead of emitting an oversized chunk — this can only happen at the
  degenerate `maxChars: 1`-with-leading-astral-character boundary; the
  ordinary path (`maxChars` large enough to hold real Slack messages) is
  unaffected.
- The two "never splits a surrogate pair" tests now additionally assert
  `chunk.length > 0 && chunk.length <= maxChars` on every emitted chunk (the
  hard-cap invariant the review said was missing), and new adversarial tests
  cover `maxChars` of `1`, `0`, `-1`, `NaN`, `Infinity`, and `1.5` for both
  functions, each verified to fail on the pre-fix code via a `git stash`
  control run.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-slack/src/formatting.test.ts` — `chunkSlackText` and
  `splitSlackText` describe blocks, new tests at the end of each.

## Detailed testing steps

None: Automated tests are acceptable. Every test drives the real exported
`chunkSlackText`/`splitSlackText` functions directly.

- `bun run --cwd plugins/plugin-slack test -- src/formatting.test.ts` (77 tests)
- Full plugin-slack suite (148 tests, no regressions): `bun run --cwd plugins/plugin-slack test`
- `bun run --cwd plugins/plugin-slack typecheck`
- `bunx biome check plugins/plugin-slack/src/formatting.ts plugins/plugin-slack/src/formatting.test.ts`

# Evidence Gate

<!-- evidence-head:732b168e751214ad95195cf0aa6d358f89d73744 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change (plugins/plugin-slack), no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change (plugins/plugin-slack), no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change, no user-facing flow to walk through
<!-- evidence-row:backend-logs -->
- [x] Real Vitest run, both the focused file and the full plugin-slack suite, at the rebased head.

<details>
<summary>Backend logs — formatting.test.ts, full plugin-slack suite, typecheck, biome</summary>

```
$ bun run --cwd plugins/plugin-slack test -- src/formatting.test.ts

 RUN  v4.1.5 plugins/plugin-slack

 Test Files  1 passed (1)
      Tests  77 passed (77)

$ bun run --cwd plugins/plugin-slack test

 RUN  v4.1.5 plugins/plugin-slack

 Test Files  7 passed (7)
      Tests  148 passed (148)

$ bun run --cwd plugins/plugin-slack typecheck
$ tsc --noEmit -p tsconfig.json
(no output — clean)

$ bunx biome check plugins/plugin-slack/src/formatting.ts plugins/plugin-slack/src/formatting.test.ts
Checked 2 files in 10ms. No fixes applied.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] Real before/after on the exact contract violation the review named, run
      against the unpatched (widen-by-one) and patched (fail-closed) code.

<details>
<summary>Domain artifact — contract-violating chunk before / typed rejection after</summary>

```
Reverted `plugins/plugin-slack/src/formatting.ts` to the previous (widen-by-one)
head via `git stash` and re-ran the new review-response tests against it:

 FAIL  chunkSlackText > rejects an invalid maxChars (NaN) instead of silently coercing it
   AssertionError: expected RangeError: Invalid array length to be an instance of ElizaError
 FAIL  splitSlackText > fails closed instead of exceeding maxChars when a surrogate pair can't fit
   AssertionError: expected undefined to be an instance of ElizaError
 FAIL  splitSlackText > rejects an invalid maxChars (0/Infinity/1.5/-1/NaN) instead of silently coercing it
   AssertionError: expected undefined to be an instance of ElizaError

 Test Files  1 failed (1)
      Tests  12 failed | 65 passed (77)

i.e. on the old code, chunkSlackText("😀", 1) returned ["😀"] (a 2-code-unit
chunk under a maxChars=1 cap — the exact contract violation the review named)
instead of throwing, and invalid maxChars values (NaN included) either
silently ran or crashed with an unrelated RangeError from Array(NaN) deep in
the affected code path, never a typed error.

Restored the fix (git stash pop) and re-ran: all 12 pass — both functions now
throw ElizaError{code: "SLACK_CHUNK_LIMIT_TOO_SMALL"} for the stuck-pair case
and ElizaError{code: "SLACK_CHUNK_LIMIT_INVALID"} for non-positive-integer
maxChars, and the pre-existing lossless/well-formed/hard-cap assertions on
the ordinary surrogate-pair path still hold unmodified.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-manual]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza"} -->