### PR TITLE
fix(signal): keep surrogate pairs intact when chunking outbound messages

### DIFF
--- a/plugins/plugin-signal/src/service.test.ts
+++ b/plugins/plugin-signal/src/service.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit test for SignalService's outbound message chunking: a raw-limit
+ * fallback cut must never split a UTF-16 surrogate pair (emoji) across
+ * chunks. splitMessage is pure (no runtime/client state), so it's exercised
+ * directly on a no-arg instance rather than standing up a full service.
+ */
+import { describe, expect, it } from "vitest";
+import { SignalService } from "./service";
+import { MAX_SIGNAL_MESSAGE_LENGTH } from "./types";
+
+function splitMessage(text: string): string[] {
+  const service = new SignalService();
+  return (service as unknown as { splitMessage(text: string): string[] }).splitMessage(text);
+}
+
+describe("SignalService.splitMessage", () => {
+  it("keeps a surrogate pair (emoji) intact instead of splitting it across chunks", () => {
+    // A leading single-width char shifts the emoji run onto an odd offset,
+    // so the raw-limit fallback cut (no newline/space nearby) lands between
+    // a pair's high and low surrogate instead of coincidentally on a
+    // pair boundary.
+    const text = `a${"🙂".repeat(MAX_SIGNAL_MESSAGE_LENGTH)}`;
+
+    const chunks = splitMessage(text);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(MAX_SIGNAL_MESSAGE_LENGTH);
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("still prefers a newline boundary when one is available near the limit", () => {
+    const firstLine = "x".repeat(MAX_SIGNAL_MESSAGE_LENGTH - 1);
+    const secondLine = "y".repeat(10);
+    const text = `${firstLine}\n${secondLine}`;
+
+    const chunks = splitMessage(text);
+
+    expect(chunks).toEqual([`${firstLine}\n`, secondLine]);
+  });
+
+  it("returns the original text unchanged when under the limit", () => {
+    const text = "hello world";
+    expect(splitMessage(text)).toEqual([text]);
+  });
+});

--- a/plugins/plugin-signal/src/service.ts
+++ b/plugins/plugin-signal/src/service.ts
@@ -46,6 +46,7 @@ import {
   Service,
   stringToUuid,
   type TargetInfo,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
 import {
@@ -2356,8 +2357,13 @@ export class SignalService extends Service implements ISignalService {
         }
       }
 
-      messages.push(remaining.slice(0, splitIndex));
-      remaining = remaining.slice(splitIndex);
+      // A raw slice() can land between the two UTF-16 code units of a
+      // surrogate pair (most emoji), leaving a lone surrogate at the
+      // chunk boundary that corrupts the character on the wire.
+      // truncateWellFormed backs the cut off by one unit instead.
+      const head = truncateWellFormed(remaining, splitIndex);
+      messages.push(head);
+      remaining = remaining.slice(head.length);
     }
 
     return messages;


### PR DESCRIPTION
# Relates to

Closes #22216.

Companion fix to #22203/#22204 (plugin-telegram, merged) and #22206/#22209
(plugin-discord) — same bug shape, different plugin.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Single call site changed (`SignalService.splitMessage`'s raw-limit
fallback cut), pure string logic, no new dependency. The newline/space
preference paths are untouched; only the final raw-cut fallback now backs off
by at most one UTF-16 code unit versus before. Grepped `plugins/plugin-signal`
for other `.slice(0,` call sites operating on outbound message text — none
found besides this one.

# Background

## What does this PR do?

`SignalService.splitMessage` chunks outbound text over
`MAX_SIGNAL_MESSAGE_LENGTH` (4000 chars), preferring a newline or space break
point near the limit, falling back to a raw cut at the exact limit when no
whitespace break is found nearby. That raw cut used
`remaining.slice(0, splitIndex)`, a plain UTF-16 code-unit slice — it can land
between the two code units of a surrogate pair (most emoji), tearing the pair
into two lone-surrogate chunks.

This swaps that one cut point for core's `truncateWellFormed`
(`packages/core/src/utils/well-formed.ts`), which backs the cut off by one
code unit when it would otherwise split a pair. Same helper, same fix pattern
already merged for `plugin-telegram` (#22204) and open for `plugin-discord`
(#22209) — `plugin-signal` just hadn't adopted it yet.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-signal/src/service.test.ts` (new file)

## Detailed testing steps

None: Automated tests are acceptable. `splitMessage` is pure (no
runtime/client state), so it's exercised directly on a no-arg
`SignalService` instance rather than standing up a full service — same
approach the file's constructor already supports for the no-runtime case.

- `bun run --cwd plugins/plugin-signal test -- src/service.test.ts` (3 tests)
- Full plugin-signal suite (58 tests, no regressions): `bun run --cwd plugins/plugin-signal test`
- `bun run --cwd plugins/plugin-signal typecheck`
- `bunx biome check plugins/plugin-signal/src/service.ts plugins/plugin-signal/src/service.test.ts`

# Evidence Gate

<!-- evidence-head:bb83f9d14c270d52eeb77d90e0ce213bc173e1c9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change (plugins/plugin-signal), no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change (plugins/plugin-signal), no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change, no user-facing flow to walk through
<!-- evidence-row:backend-logs -->
- [x] Real Vitest run proving the new test fails on unpatched code (via a
      `git stash` control) and passes with the fix.

<details>
<summary>Backend logs — new test (with and without the fix), full plugin-signal suite, typecheck, biome</summary>

```
$ bun run --cwd plugins/plugin-signal test -- src/service.test.ts
(fix applied)

 Test Files  1 passed (1)
      Tests  3 passed (3)

$ git stash push -- plugins/plugin-signal/src/service.ts   # remove the fix
$ bun run --cwd plugins/plugin-signal test -- src/service.test.ts
(fix removed - control run)

 ❯ src/service.test.ts (3 tests | 1 failed) 3ms
     × keeps a surrogate pair (emoji) intact instead of splitting it across chunks

 FAIL  src/service.test.ts > SignalService.splitMessage > keeps a surrogate pair (emoji) intact instead of splitting it across chunks
AssertionError: expected false to be true // Object.is equality
  at src/service.test.ts:29:36  (expect(chunk.isWellFormed()).toBe(true))

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)

$ git stash pop   # fix restored

$ bun run --cwd plugins/plugin-signal test
(fix applied, full suite)

 Test Files  7 passed (7)
      Tests  58 passed (58)

$ bun run --cwd plugins/plugin-signal typecheck
(no output — clean)

$ bunx @biomejs/biome check plugins/plugin-signal/src/service.ts plugins/plugin-signal/src/service.test.ts
Checked 2 files in 32ms. No fixes applied.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed, pure string-chunking logic
<!-- evidence-row:domain-artifacts -->
- [x] Real before/after chunk-boundary values for the exact repro from the
      linked issue, run against the real (unmocked) `SignalService.splitMessage`.

<details>
<summary>Domain artifact — real before/after surrogate-pair boundary values</summary>

```
text = "a" + "🙂".repeat(4000)   // 8001 UTF-16 code units total
MAX_SIGNAL_MESSAGE_LENGTH = 4000

BEFORE (raw slice(0, 4000)):
  chunk[0].length === 4000
  chunk[0].isWellFormed() === false   // ends on a lone high surrogate (U+D83D)
  chunk[1] begins with a lone low surrogate (U+DE42)

AFTER (truncateWellFormed(remaining, 4000)):
  chunk[0].length === 3999            // backed off by one code unit
  chunk[0].isWellFormed() === true
  chunk[1].isWellFormed() === true
  chunks.join("") === text            // no data loss, just a shifted boundary
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-manual]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"Claude Code","skill_revision":"elizaOS/eliza@6cf2ff64bb5a27f7b04cb2dbc56d53af460d40a2:packages/skills/skills/contribute-to-eliza"} -->
