### PR TITLE
fix(core): bound plugin registry fetch with timeout

### DIFF
--- a/packages/core/src/features/plugin-manager/services/pluginRegistryService.timeout.test.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginRegistryService.timeout.test.ts
@@ -144,6 +144,29 @@ describe("pluginRegistryService fetch timeout", () => {
 		expect((error as ElizaError).cause).toBeInstanceOf(SyntaxError);
 	});
 
+	it("preserves AbortError identity when response body consumption aborts", async () => {
+		const abort = new DOMException("body cancelled", "AbortError");
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.error(abort);
+			},
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(body, {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			),
+		);
+
+		const error = await loadRegistry().catch((cause: unknown) => cause);
+
+		expect(error).toBe(abort);
+		expect(error).not.toBeInstanceOf(ElizaError);
+	});
+
 	it("terminates a real headers-plus-partial-body stall and does not cache it", async () => {
 		const server = createServer((_request, response) => {
 			response.writeHead(200, { "Content-Type": "application/json" });

--- a/packages/core/src/features/plugin-manager/services/pluginRegistryService.timeout.test.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginRegistryService.timeout.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Plugin registry fetch timeout: every external fetch must be bounded and the
+ * same signal must remain active through response.json() so a stalled body is
+ * still aborted. Caller cancellation is composed via AbortSignal.any.
+ * Deterministic: real fetchGeneratedRegistry with injected fetch + real AbortSignal.timeout(10ms).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
+	fetchGeneratedRegistry,
+	resetRegistryCache,
+} from "./pluginRegistryService.ts";
+
+function stallUntilAborted(signal?: AbortSignal): Promise<Response> {
+	return new Promise<Response>((_resolve, reject) => {
+		if (!signal) return;
+		if (signal.aborted) {
+			reject(signal.reason);
+			return;
+		}
+		signal.addEventListener("abort", () => reject(signal.reason), {
+			once: true,
+		});
+	});
+}
+
+function stalledJsonResponse(signal?: AbortSignal): Response {
+	return {
+		ok: true,
+		status: 200,
+		statusText: "OK",
+		json: () =>
+			stallUntilAborted(signal).then(
+				() => ({ registry: {}, lastUpdatedAt: "2026-08-19" }) as never,
+			),
+		headers: new Headers(),
+	} as unknown as Response;
+}
+
+function makeRegistryResponse(
+	registry: Record<string, unknown> = {
+		"@elizaos/test-plugin": {
+			git: {
+				repo: "elizaOS/test-plugin",
+				v0: { version: null, branch: null },
+				v1: { version: null, branch: null },
+				v2: { version: "1.0.0", branch: "main" },
+			},
+			npm: {
+				repo: "@elizaos/test-plugin",
+				v0: null,
+				v1: null,
+				v2: "1.0.0",
+				v0CoreRange: null,
+				v1CoreRange: null,
+				v2CoreRange: null,
+			},
+			supports: { v0: false, v1: true, v2: true },
+			description: "test",
+			homepage: null,
+			topics: [],
+			stargazers_count: 5,
+			language: "TypeScript",
+		},
+	},
+): Response {
+	return new Response(
+		JSON.stringify({ registry, lastUpdatedAt: "2026-08-19T00:00:00Z" }),
+		{
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		},
+	);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	resetRegistryCache();
+});
+
+describe("pluginRegistryService fetch timeout", () => {
+	it("exposes DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS === 10_000", () => {
+		expect(DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS).toBe(10_000);
+	});
+
+	it("passes AbortSignal.timeout budget to fetch (hanging fetch → TimeoutError)", async () => {
+		const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+		const timeoutSpy = vi
+			.spyOn(AbortSignal, "timeout")
+			.mockImplementation((_ms: number) => origTimeout(10));
+
+		const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) =>
+			stallUntilAborted(init?.signal),
+		);
+
+		await expect(
+			fetchGeneratedRegistry({
+				fetchImpl: fetchSpy as unknown as typeof fetch,
+			}),
+		).rejects.toMatchObject({
+			name: "TimeoutError",
+		});
+
+		expect(timeoutSpy).toHaveBeenCalledWith(
+			DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
+		);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const init = fetchSpy.mock.calls[0][1] as RequestInit;
+		expect(init.signal).toBeDefined();
+		expect(init.signal?.aborted).toBe(true);
+	});
+
+	it("aborts stalled response.json() body via same timeout signal", async () => {
+		const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+		vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) =>
+			origTimeout(10),
+		);
+
+		const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) =>
+			stalledJsonResponse(init?.signal),
+		);
+
+		await expect(
+			fetchGeneratedRegistry({
+				fetchImpl: fetchSpy as unknown as typeof fetch,
+			}),
+		).rejects.toMatchObject({
+			name: "TimeoutError",
+		});
+	});
+
+	it("merges caller signal via AbortSignal.any when provided", async () => {
+		const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+		const timeoutSpy = vi
+			.spyOn(AbortSignal, "timeout")
+			.mockImplementation((_ms: number) => origTimeout(10));
+		const anySpy = vi.spyOn(AbortSignal, "any");
+
+		const callerCtrl = new AbortController();
+		const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) =>
+			stallUntilAborted(init?.signal),
+		);
+
+		const pending = fetchGeneratedRegistry({
+			fetchImpl: fetchSpy as unknown as typeof fetch,
+			signal: callerCtrl.signal,
+		});
+
+		callerCtrl.abort(new DOMException("caller abort", "AbortError"));
+
+		await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+		expect(timeoutSpy).toHaveBeenCalledWith(
+			DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
+		);
+		expect(anySpy).toHaveBeenCalled();
+		const anyArgs = anySpy.mock.calls[0][0] as AbortSignal[];
+		expect(anyArgs).toHaveLength(2);
+		expect(anyArgs[0]).toBe(callerCtrl.signal);
+	});
+
+	it("succeeds when fetch returns valid registry within budget", async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(makeRegistryResponse());
+		const plugins = await fetchGeneratedRegistry({
+			fetchImpl: fetchSpy as unknown as typeof fetch,
+		});
+		expect(plugins.size).toBe(1);
+		expect(plugins.get("@elizaos/test-plugin")?.description).toBe("test");
+	});
+});

--- a/packages/core/src/features/plugin-manager/services/pluginRegistryService.timeout.test.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginRegistryService.timeout.test.ts
@@ -1,8 +1,7 @@
 /**
- * Plugin registry fetch timeout: every external fetch must be bounded and the
- * same signal must remain active through response.json() so a stalled body is
- * still aborted. Caller cancellation is composed via AbortSignal.any.
- * Deterministic: real fetchGeneratedRegistry with injected fetch + real AbortSignal.timeout(10ms).
+ * Exercises plugin-registry request deadlines through the public load path.
+ * The suite uses real AbortSignal deadlines and a loopback HTTP body stall;
+ * global fetch replacement is confined to the test harness.
  */
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
@@ -10,12 +9,9 @@ import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ElizaError } from "../../../errors.ts";
+import { loadRegistry, resetRegistryCache } from "./pluginRegistryService.ts";
 
-import {
-	DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
-	fetchGeneratedRegistry,
-	resetRegistryCache,
-} from "./pluginRegistryService.ts";
+const originalFetch = globalThis.fetch.bind(globalThis);
 
 function stallUntilAborted(signal?: AbortSignal): Promise<Response> {
 	return new Promise<Response>((_resolve, reject) => {
@@ -30,231 +26,162 @@ function stallUntilAborted(signal?: AbortSignal): Promise<Response> {
 	});
 }
 
-function stalledJsonResponse(signal?: AbortSignal): Response {
-	return {
-		ok: true,
-		status: 200,
-		statusText: "OK",
-		json: () =>
-			stallUntilAborted(signal).then(
-				() => ({ registry: {}, lastUpdatedAt: "2026-08-19" }) as never,
-			),
-		headers: new Headers(),
-	} as unknown as Response;
-}
-
-function makeRegistryResponse(
-	registry: Record<string, unknown> = {
-		"@elizaos/test-plugin": {
-			git: {
-				repo: "elizaOS/test-plugin",
-				v0: { version: null, branch: null },
-				v1: { version: null, branch: null },
-				v2: { version: "1.0.0", branch: "main" },
-			},
-			npm: {
-				repo: "@elizaos/test-plugin",
-				v0: null,
-				v1: null,
-				v2: "1.0.0",
-				v0CoreRange: null,
-				v1CoreRange: null,
-				v2CoreRange: null,
-			},
-			supports: { v0: false, v1: true, v2: true },
-			description: "test",
-			homepage: null,
-			topics: [],
-			stargazers_count: 5,
-			language: "TypeScript",
-		},
-	},
-): Response {
+function makeRegistryResponse(): Response {
 	return new Response(
-		JSON.stringify({ registry, lastUpdatedAt: "2026-08-19T00:00:00Z" }),
-		{
-			status: 200,
-			headers: { "Content-Type": "application/json" },
-		},
+		JSON.stringify({
+			lastUpdatedAt: "2026-08-19T00:00:00Z",
+			registry: {
+				"@elizaos/test-plugin": {
+					git: {
+						repo: "elizaOS/test-plugin",
+						v0: { version: null, branch: null },
+						v1: { version: null, branch: null },
+						v2: { version: "1.0.0", branch: "main" },
+					},
+					npm: {
+						repo: "@elizaos/test-plugin",
+						v0: null,
+						v1: null,
+						v2: "1.0.0",
+						v0CoreRange: null,
+						v1CoreRange: null,
+						v2CoreRange: null,
+					},
+					supports: { v0: false, v1: true, v2: true },
+					description: "test",
+					homepage: null,
+					topics: [],
+					stargazers_count: 5,
+					language: "TypeScript",
+				},
+			},
+		}),
+		{ status: 200, headers: { "Content-Type": "application/json" } },
 	);
 }
 
 afterEach(() => {
+	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
 	resetRegistryCache();
 });
 
 describe("pluginRegistryService fetch timeout", () => {
-	it("exposes DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS === 10_000", () => {
-		expect(DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS).toBe(10_000);
-	});
-
-	it("passes AbortSignal.timeout budget to fetch (hanging fetch → ElizaError PLUGIN_REGISTRY_FETCH_TIMEOUT)", async () => {
-		const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+	it("bounds a hanging request and preserves the platform timeout as cause", async () => {
+		const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
 		const timeoutSpy = vi
 			.spyOn(AbortSignal, "timeout")
-			.mockImplementation((_ms: number) => origTimeout(10));
-
-		const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) =>
+			.mockImplementation(() => originalTimeout(10));
+		const fetchSpy = vi.fn((_url: string, init?: RequestInit) =>
 			stallUntilAborted(init?.signal),
 		);
+		vi.stubGlobal("fetch", fetchSpy);
 
-		let caught: unknown;
-		await expect(
-			fetchGeneratedRegistry({
-				fetchImpl: fetchSpy as unknown as typeof fetch,
-			}),
-		).rejects.toMatchObject({
-			name: "ElizaError",
-			code: "PLUGIN_REGISTRY_FETCH_TIMEOUT",
-		});
-		// verify preserved cause is TimeoutError and not raw TimeoutError escaping unwrapped
-		try {
-			await fetchGeneratedRegistry({
-				fetchImpl: fetchSpy as unknown as typeof fetch,
-			});
-		} catch (e) {
-			caught = e;
-		}
-		expect(caught).toBeInstanceOf(ElizaError);
-		expect((caught as ElizaError).code).toBe(
-			"PLUGIN_REGISTRY_FETCH_TIMEOUT",
-		);
-		expect((caught as ElizaError).cause).toMatchObject({
-			name: "TimeoutError",
-		});
+		const error = await loadRegistry().catch((cause: unknown) => cause);
 
-		expect(timeoutSpy).toHaveBeenCalledWith(
-			DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
-		);
-		expect(fetchSpy).toHaveBeenCalledTimes(2);
-		const init = fetchSpy.mock.calls[0][1] as RequestInit;
-		expect(init.signal).toBeDefined();
-		expect(init.signal?.aborted).toBe(true);
+		expect(error).toBeInstanceOf(ElizaError);
+		expect((error as ElizaError).code).toBe("PLUGIN_REGISTRY_FETCH_TIMEOUT");
+		expect((error as ElizaError).cause).toMatchObject({ name: "TimeoutError" });
+		expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+		expect(fetchSpy.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
 	});
 
-	it("aborts stalled response.json() body via same timeout signal → ElizaError", async () => {
-		const origTimeout = AbortSignal.timeout.bind(AbortSignal);
-		vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) =>
-			origTimeout(10),
-		);
+	it("preserves a non-timeout AbortError identity", async () => {
+		const abort = new DOMException("caller cancelled", "AbortError");
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abort));
 
-		const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) =>
-			stalledJsonResponse(init?.signal),
-		);
+		const error = await loadRegistry().catch((cause: unknown) => cause);
 
-		await expect(
-			fetchGeneratedRegistry({
-				fetchImpl: fetchSpy as unknown as typeof fetch,
-			}),
-		).rejects.toMatchObject({
-			name: "ElizaError",
-			code: "PLUGIN_REGISTRY_FETCH_TIMEOUT",
-		});
-		// raw TimeoutError must not escape
-		let err: unknown;
-		try {
-			await fetchGeneratedRegistry({
-				fetchImpl: fetchSpy as unknown as typeof fetch,
-			});
-		} catch (e) {
-			err = e;
-		}
-		expect(err).toBeInstanceOf(ElizaError);
-		expect((err as ElizaError).cause).toMatchObject({ name: "TimeoutError" });
+		expect(error).toBe(abort);
+		expect(error).not.toBeInstanceOf(ElizaError);
 	});
 
-	it("merges caller signal via AbortSignal.any when provided and retains AbortError identity", async () => {
-		const origTimeout = AbortSignal.timeout.bind(AbortSignal);
-		const timeoutSpy = vi
-			.spyOn(AbortSignal, "timeout")
-			.mockImplementation((_ms: number) => origTimeout(10));
-		const anySpy = vi.spyOn(AbortSignal, "any");
-
-		const callerCtrl = new AbortController();
-		const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) =>
-			stallUntilAborted(init?.signal),
-		);
-
-		const pending = fetchGeneratedRegistry({
-			fetchImpl: fetchSpy as unknown as typeof fetch,
-			signal: callerCtrl.signal,
-		});
-
-		callerCtrl.abort(new DOMException("caller abort", "AbortError"));
-
-		const err = await pending.catch((e: unknown) => e);
-		// caller AbortError must not be wrapped into ElizaError
-		expect(err).toMatchObject({ name: "AbortError" });
-		expect(err).not.toBeInstanceOf(ElizaError);
-		expect(timeoutSpy).toHaveBeenCalledWith(
-			DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
-		);
-		expect(anySpy).toHaveBeenCalled();
-		const anyArgs = anySpy.mock.calls[0][0] as AbortSignal[];
-		expect(anyArgs).toHaveLength(2);
-		expect(anyArgs[0]).toBe(callerCtrl.signal);
-	});
-
-	it("succeeds when fetch returns valid registry within budget", async () => {
+	it("caches only a successful registry response", async () => {
 		const fetchSpy = vi.fn().mockResolvedValue(makeRegistryResponse());
-		const plugins = await fetchGeneratedRegistry({
-			fetchImpl: fetchSpy as unknown as typeof fetch,
-		});
-		expect(plugins.size).toBe(1);
-		expect(plugins.get("@elizaos/test-plugin")?.description).toBe("test");
+		vi.stubGlobal("fetch", fetchSpy);
+
+		const first = await loadRegistry();
+		const second = await loadRegistry();
+
+		expect(first.get("@elizaos/test-plugin")?.description).toBe("test");
+		expect(second).toBe(first);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
 	});
 
-	it("terminates stalled real HTTP body (headers + partial JSON) at deadline via loopback and does not cache", async () => {
-		// Real transport test: proves AbortSignal.timeout + fetch + response.json() body
-		// stall is bounded on a real socket, not just an injected promise listening to signal.
-		const server = createServer((_req, res) => {
-			res.writeHead(200, { "Content-Type": "application/json" });
-			// Emit headers + partial body then stall forever without ending
-			res.write('{"registry":{');
-			// intentionally not calling res.end() — client must timeout
+	it("translates non-success responses to a typed HTTP error", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response("unavailable", {
+					status: 503,
+					statusText: "Service Unavailable",
+				}),
+			),
+		);
+
+		await expect(loadRegistry()).rejects.toMatchObject({
+			name: "ElizaError",
+			code: "PLUGIN_REGISTRY_FETCH_HTTP_ERROR",
+			context: { status: 503 },
+		});
+	});
+
+	it("translates malformed JSON without disguising it as a timeout", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response("{", {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			),
+		);
+
+		const error = await loadRegistry().catch((cause: unknown) => cause);
+
+		expect(error).toBeInstanceOf(ElizaError);
+		expect((error as ElizaError).code).toBe("PLUGIN_REGISTRY_RESPONSE_INVALID");
+		expect((error as ElizaError).cause).toBeInstanceOf(SyntaxError);
+	});
+
+	it("terminates a real headers-plus-partial-body stall and does not cache it", async () => {
+		const server = createServer((_request, response) => {
+			response.writeHead(200, { "Content-Type": "application/json" });
+			response.write('{"registry":{');
 		});
 		await new Promise<void>((resolve) =>
-			server.listen(0, "127.0.0.1", () => resolve()),
+			server.listen(0, "127.0.0.1", resolve),
 		);
-		const addr = server.address() as AddressInfo;
-		const loopbackUrl = `http://127.0.0.1:${addr.port}/generated-registry.json`;
-
-		// fetchImpl delegates to real fetch against loopback but honors the passed signal
-		const loopbackFetch: typeof fetch = (_input, init) =>
-			fetch(loopbackUrl, { signal: init?.signal });
-
-		const timeoutMs = 400;
+		const { port } = server.address() as AddressInfo;
+		const loopbackUrl = `http://127.0.0.1:${port}/generated-registry.json`;
+		const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+		vi.spyOn(AbortSignal, "timeout").mockImplementation(() =>
+			originalTimeout(400),
+		);
+		const fetchSpy = vi.fn((_url: string | URL | Request, init?: RequestInit) =>
+			originalFetch(loopbackUrl, { signal: init?.signal }),
+		);
+		vi.stubGlobal("fetch", fetchSpy);
 
 		try {
-			const start = Date.now();
-			const first = await fetchGeneratedRegistry({
-				fetchImpl: loopbackFetch,
-				timeoutMs,
-			}).catch((e: unknown) => e);
-			const elapsed = Date.now() - start;
-
-			expect(first).toBeInstanceOf(ElizaError);
-			expect((first as ElizaError).code).toBe(
-				"PLUGIN_REGISTRY_FETCH_TIMEOUT",
-			);
-			expect((first as ElizaError).cause).toMatchObject({
-				name: "TimeoutError",
+			const startedAt = Date.now();
+			const first = await loadRegistry().catch((cause: unknown) => cause);
+			const elapsedMs = Date.now() - startedAt;
+			expect(first).toMatchObject({
+				name: "ElizaError",
+				code: "PLUGIN_REGISTRY_FETCH_TIMEOUT",
 			});
-			// Must have terminated near the deadline, not hung
-			expect(elapsed).toBeGreaterThanOrEqual(300);
-			expect(elapsed).toBeLessThan(3000);
+			expect(elapsedMs).toBeGreaterThanOrEqual(300);
+			expect(elapsedMs).toBeLessThan(3_000);
 
-			// Second call must also timeout — proves failure was not cached as a successful registry
-			const second = await fetchGeneratedRegistry({
-				fetchImpl: loopbackFetch,
-				timeoutMs,
-			}).catch((e: unknown) => e);
-			expect(second).toBeInstanceOf(ElizaError);
-			expect((second as ElizaError).code).toBe(
-				"PLUGIN_REGISTRY_FETCH_TIMEOUT",
-			);
+			const second = await loadRegistry().catch((cause: unknown) => cause);
+			expect(second).toMatchObject({
+				name: "ElizaError",
+				code: "PLUGIN_REGISTRY_FETCH_TIMEOUT",
+			});
+			expect(fetchSpy).toHaveBeenCalledTimes(2);
 		} finally {
+			server.closeAllConnections();
 			await new Promise<void>((resolve) => server.close(() => resolve()));
 		}
 	});

--- a/packages/core/src/features/plugin-manager/services/pluginRegistryService.timeout.test.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginRegistryService.timeout.test.ts
@@ -4,7 +4,12 @@
  * still aborted. Caller cancellation is composed via AbortSignal.any.
  * Deterministic: real fetchGeneratedRegistry with injected fetch + real AbortSignal.timeout(10ms).
  */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ElizaError } from "../../../errors.ts";
 
 import {
 	DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
@@ -84,7 +89,7 @@ describe("pluginRegistryService fetch timeout", () => {
 		expect(DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS).toBe(10_000);
 	});
 
-	it("passes AbortSignal.timeout budget to fetch (hanging fetch → TimeoutError)", async () => {
+	it("passes AbortSignal.timeout budget to fetch (hanging fetch → ElizaError PLUGIN_REGISTRY_FETCH_TIMEOUT)", async () => {
 		const origTimeout = AbortSignal.timeout.bind(AbortSignal);
 		const timeoutSpy = vi
 			.spyOn(AbortSignal, "timeout")
@@ -94,24 +99,41 @@ describe("pluginRegistryService fetch timeout", () => {
 			stallUntilAborted(init?.signal),
 		);
 
+		let caught: unknown;
 		await expect(
 			fetchGeneratedRegistry({
 				fetchImpl: fetchSpy as unknown as typeof fetch,
 			}),
 		).rejects.toMatchObject({
+			name: "ElizaError",
+			code: "PLUGIN_REGISTRY_FETCH_TIMEOUT",
+		});
+		// verify preserved cause is TimeoutError and not raw TimeoutError escaping unwrapped
+		try {
+			await fetchGeneratedRegistry({
+				fetchImpl: fetchSpy as unknown as typeof fetch,
+			});
+		} catch (e) {
+			caught = e;
+		}
+		expect(caught).toBeInstanceOf(ElizaError);
+		expect((caught as ElizaError).code).toBe(
+			"PLUGIN_REGISTRY_FETCH_TIMEOUT",
+		);
+		expect((caught as ElizaError).cause).toMatchObject({
 			name: "TimeoutError",
 		});
 
 		expect(timeoutSpy).toHaveBeenCalledWith(
 			DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
 		);
-		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
 		const init = fetchSpy.mock.calls[0][1] as RequestInit;
 		expect(init.signal).toBeDefined();
 		expect(init.signal?.aborted).toBe(true);
 	});
 
-	it("aborts stalled response.json() body via same timeout signal", async () => {
+	it("aborts stalled response.json() body via same timeout signal → ElizaError", async () => {
 		const origTimeout = AbortSignal.timeout.bind(AbortSignal);
 		vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) =>
 			origTimeout(10),
@@ -126,11 +148,23 @@ describe("pluginRegistryService fetch timeout", () => {
 				fetchImpl: fetchSpy as unknown as typeof fetch,
 			}),
 		).rejects.toMatchObject({
-			name: "TimeoutError",
+			name: "ElizaError",
+			code: "PLUGIN_REGISTRY_FETCH_TIMEOUT",
 		});
+		// raw TimeoutError must not escape
+		let err: unknown;
+		try {
+			await fetchGeneratedRegistry({
+				fetchImpl: fetchSpy as unknown as typeof fetch,
+			});
+		} catch (e) {
+			err = e;
+		}
+		expect(err).toBeInstanceOf(ElizaError);
+		expect((err as ElizaError).cause).toMatchObject({ name: "TimeoutError" });
 	});
 
-	it("merges caller signal via AbortSignal.any when provided", async () => {
+	it("merges caller signal via AbortSignal.any when provided and retains AbortError identity", async () => {
 		const origTimeout = AbortSignal.timeout.bind(AbortSignal);
 		const timeoutSpy = vi
 			.spyOn(AbortSignal, "timeout")
@@ -149,7 +183,10 @@ describe("pluginRegistryService fetch timeout", () => {
 
 		callerCtrl.abort(new DOMException("caller abort", "AbortError"));
 
-		await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+		const err = await pending.catch((e: unknown) => e);
+		// caller AbortError must not be wrapped into ElizaError
+		expect(err).toMatchObject({ name: "AbortError" });
+		expect(err).not.toBeInstanceOf(ElizaError);
 		expect(timeoutSpy).toHaveBeenCalledWith(
 			DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
 		);
@@ -166,5 +203,59 @@ describe("pluginRegistryService fetch timeout", () => {
 		});
 		expect(plugins.size).toBe(1);
 		expect(plugins.get("@elizaos/test-plugin")?.description).toBe("test");
+	});
+
+	it("terminates stalled real HTTP body (headers + partial JSON) at deadline via loopback and does not cache", async () => {
+		// Real transport test: proves AbortSignal.timeout + fetch + response.json() body
+		// stall is bounded on a real socket, not just an injected promise listening to signal.
+		const server = createServer((_req, res) => {
+			res.writeHead(200, { "Content-Type": "application/json" });
+			// Emit headers + partial body then stall forever without ending
+			res.write('{"registry":{');
+			// intentionally not calling res.end() — client must timeout
+		});
+		await new Promise<void>((resolve) =>
+			server.listen(0, "127.0.0.1", () => resolve()),
+		);
+		const addr = server.address() as AddressInfo;
+		const loopbackUrl = `http://127.0.0.1:${addr.port}/generated-registry.json`;
+
+		// fetchImpl delegates to real fetch against loopback but honors the passed signal
+		const loopbackFetch: typeof fetch = (_input, init) =>
+			fetch(loopbackUrl, { signal: init?.signal });
+
+		const timeoutMs = 400;
+
+		try {
+			const start = Date.now();
+			const first = await fetchGeneratedRegistry({
+				fetchImpl: loopbackFetch,
+				timeoutMs,
+			}).catch((e: unknown) => e);
+			const elapsed = Date.now() - start;
+
+			expect(first).toBeInstanceOf(ElizaError);
+			expect((first as ElizaError).code).toBe(
+				"PLUGIN_REGISTRY_FETCH_TIMEOUT",
+			);
+			expect((first as ElizaError).cause).toMatchObject({
+				name: "TimeoutError",
+			});
+			// Must have terminated near the deadline, not hung
+			expect(elapsed).toBeGreaterThanOrEqual(300);
+			expect(elapsed).toBeLessThan(3000);
+
+			// Second call must also timeout — proves failure was not cached as a successful registry
+			const second = await fetchGeneratedRegistry({
+				fetchImpl: loopbackFetch,
+				timeoutMs,
+			}).catch((e: unknown) => e);
+			expect(second).toBeInstanceOf(ElizaError);
+			expect((second as ElizaError).code).toBe(
+				"PLUGIN_REGISTRY_FETCH_TIMEOUT",
+			);
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		}
 	});
 });

--- a/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
@@ -22,7 +22,7 @@ import type { PluginMetadata } from "../types.ts";
 
 const GENERATED_REGISTRY_URL =
 	"https://plugins.eliza.app/generated-registry.json";
-export const DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS = 10_000;
+const PLUGIN_REGISTRY_FETCH_TIMEOUT_MS = 10_000;
 const CACHE_DURATION = 3_600_000; // 1 hour
 
 // ---------------------------------------------------------------------------
@@ -371,44 +371,66 @@ function isTimeoutError(err: unknown): boolean {
 	return false;
 }
 
-export async function fetchGeneratedRegistry(
-	options: {
-		fetchImpl?: typeof fetch;
-		signal?: AbortSignal;
-		timeoutMs?: number;
-	} = {},
-): Promise<Map<string, RegistryPlugin>> {
-	const {
-		fetchImpl = fetch,
-		signal: callerSignal,
-		timeoutMs = DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
-	} = options;
-	const signal = callerSignal
-		? AbortSignal.any([callerSignal, AbortSignal.timeout(timeoutMs)])
-		: AbortSignal.timeout(timeoutMs);
+async function fetchGeneratedRegistry(): Promise<Map<string, RegistryPlugin>> {
+	const signal = AbortSignal.timeout(PLUGIN_REGISTRY_FETCH_TIMEOUT_MS);
 	let response: Response;
-	let data: GeneratedRegistryFile;
 	try {
-		response = await fetchImpl(GENERATED_REGISTRY_URL, { signal });
-		if (!response.ok) {
-			throw new Error(
-				`generated-registry.json: ${response.status} ${response.statusText}`,
-			);
-		}
-		data = (await response.json()) as GeneratedRegistryFile; // same signal still active
+		response = await fetch(GENERATED_REGISTRY_URL, { signal });
 	} catch (err) {
-		if (isTimeoutError(err)) {
+		// error-policy:J2 translate the internal deadline and preserve other causes
+		if (isTimeoutError(signal.reason) || isTimeoutError(err)) {
 			throw new ElizaError(
-				`Plugin registry fetch timed out after ${timeoutMs}ms`,
+				`Plugin registry fetch timed out after ${PLUGIN_REGISTRY_FETCH_TIMEOUT_MS}ms`,
 				{
 					code: "PLUGIN_REGISTRY_FETCH_TIMEOUT",
 					cause: err,
-					context: { timeoutMs, url: GENERATED_REGISTRY_URL },
+					context: {
+						timeoutMs: PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
+						url: GENERATED_REGISTRY_URL,
+					},
 					severity: "ephemeral",
 				},
 			);
 		}
 		throw err;
+	}
+
+	if (!response.ok) {
+		throw new ElizaError("Plugin registry request failed", {
+			code: "PLUGIN_REGISTRY_FETCH_HTTP_ERROR",
+			context: {
+				status: response.status,
+				statusText: response.statusText,
+				url: GENERATED_REGISTRY_URL,
+			},
+			severity: "ephemeral",
+		});
+	}
+
+	let data: GeneratedRegistryFile;
+	try {
+		data = (await response.json()) as GeneratedRegistryFile;
+	} catch (err) {
+		// error-policy:J2 distinguish the internal deadline from malformed data
+		if (isTimeoutError(signal.reason) || isTimeoutError(err)) {
+			throw new ElizaError(
+				`Plugin registry fetch timed out after ${PLUGIN_REGISTRY_FETCH_TIMEOUT_MS}ms`,
+				{
+					code: "PLUGIN_REGISTRY_FETCH_TIMEOUT",
+					cause: err,
+					context: {
+						timeoutMs: PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
+						url: GENERATED_REGISTRY_URL,
+					},
+					severity: "ephemeral",
+				},
+			);
+		}
+		throw new ElizaError("Plugin registry response was not valid JSON", {
+			code: "PLUGIN_REGISTRY_RESPONSE_INVALID",
+			cause: err,
+			context: { url: GENERATED_REGISTRY_URL },
+		});
 	}
 	const plugins = new Map<string, RegistryPlugin>();
 	for (const [name, entry] of Object.entries(data.registry)) {

--- a/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
@@ -371,6 +371,13 @@ function isTimeoutError(err: unknown): boolean {
 	return false;
 }
 
+function isAbortError(err: unknown): boolean {
+	return (
+		(err instanceof DOMException || err instanceof Error) &&
+		err.name === "AbortError"
+	);
+}
+
 async function fetchGeneratedRegistry(): Promise<Map<string, RegistryPlugin>> {
 	const signal = AbortSignal.timeout(PLUGIN_REGISTRY_FETCH_TIMEOUT_MS);
 	let response: Response;
@@ -426,6 +433,7 @@ async function fetchGeneratedRegistry(): Promise<Map<string, RegistryPlugin>> {
 				},
 			);
 		}
+		if (isAbortError(err)) throw err;
 		throw new ElizaError("Plugin registry response was not valid JSON", {
 			code: "PLUGIN_REGISTRY_RESPONSE_INVALID",
 			cause: err,

--- a/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
@@ -22,6 +22,7 @@ import type { PluginMetadata } from "../types.ts";
 
 const GENERATED_REGISTRY_URL =
 	"https://plugins.eliza.app/generated-registry.json";
+export const DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS = 10_000;
 const CACHE_DURATION = 3_600_000; // 1 hour
 
 // ---------------------------------------------------------------------------
@@ -356,14 +357,28 @@ async function scanLocalPlugins(): Promise<Map<string, RegistryPlugin>> {
 	return plugins;
 }
 
-async function fetchGeneratedRegistry(): Promise<Map<string, RegistryPlugin>> {
-	const response = await fetch(GENERATED_REGISTRY_URL);
+export async function fetchGeneratedRegistry(
+	options: {
+		fetchImpl?: typeof fetch;
+		signal?: AbortSignal;
+		timeoutMs?: number;
+	} = {},
+): Promise<Map<string, RegistryPlugin>> {
+	const {
+		fetchImpl = fetch,
+		signal: callerSignal,
+		timeoutMs = DEFAULT_PLUGIN_REGISTRY_FETCH_TIMEOUT_MS,
+	} = options;
+	const signal = callerSignal
+		? AbortSignal.any([callerSignal, AbortSignal.timeout(timeoutMs)])
+		: AbortSignal.timeout(timeoutMs);
+	const response = await fetchImpl(GENERATED_REGISTRY_URL, { signal });
 	if (!response.ok) {
 		throw new Error(
 			`generated-registry.json: ${response.status} ${response.statusText}`,
 		);
 	}
-	const data = (await response.json()) as GeneratedRegistryFile;
+	const data = (await response.json()) as GeneratedRegistryFile; // same signal still active
 	const plugins = new Map<string, RegistryPlugin>();
 	for (const [name, entry] of Object.entries(data.registry)) {
 		plugins.set(name, entryToPlugin(name, entry));

--- a/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
@@ -357,6 +357,20 @@ async function scanLocalPlugins(): Promise<Map<string, RegistryPlugin>> {
 	return plugins;
 }
 
+function isTimeoutError(err: unknown): boolean {
+	if (err instanceof DOMException) return err.name === "TimeoutError";
+	if (err instanceof Error) {
+		if (err.name === "TimeoutError") return true;
+		// Node fetch may wrap the abort reason as cause
+		const cause = (err as Error & { cause?: unknown }).cause;
+		if (cause instanceof DOMException && cause.name === "TimeoutError")
+			return true;
+		if (cause instanceof Error && (cause as Error).name === "TimeoutError")
+			return true;
+	}
+	return false;
+}
+
 export async function fetchGeneratedRegistry(
 	options: {
 		fetchImpl?: typeof fetch;
@@ -372,13 +386,30 @@ export async function fetchGeneratedRegistry(
 	const signal = callerSignal
 		? AbortSignal.any([callerSignal, AbortSignal.timeout(timeoutMs)])
 		: AbortSignal.timeout(timeoutMs);
-	const response = await fetchImpl(GENERATED_REGISTRY_URL, { signal });
-	if (!response.ok) {
-		throw new Error(
-			`generated-registry.json: ${response.status} ${response.statusText}`,
-		);
+	let response: Response;
+	let data: GeneratedRegistryFile;
+	try {
+		response = await fetchImpl(GENERATED_REGISTRY_URL, { signal });
+		if (!response.ok) {
+			throw new Error(
+				`generated-registry.json: ${response.status} ${response.statusText}`,
+			);
+		}
+		data = (await response.json()) as GeneratedRegistryFile; // same signal still active
+	} catch (err) {
+		if (isTimeoutError(err)) {
+			throw new ElizaError(
+				`Plugin registry fetch timed out after ${timeoutMs}ms`,
+				{
+					code: "PLUGIN_REGISTRY_FETCH_TIMEOUT",
+					cause: err,
+					context: { timeoutMs, url: GENERATED_REGISTRY_URL },
+					severity: "ephemeral",
+				},
+			);
+		}
+		throw err;
 	}
-	const data = (await response.json()) as GeneratedRegistryFile; // same signal still active
 	const plugins = new Map<string, RegistryPlugin>();
 	for (const [name, entry] of Object.entries(data.registry)) {
 		plugins.set(name, entryToPlugin(name, entry));


### PR DESCRIPTION
# Relates to

Closes #22326.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto `origin/develop@0d7408fcc30bf24089b7bc87dd7e34dcbb3ef099` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync. The exact environment blockers are recorded below.
- [x] A reviewer can confirm the changed path from the focused public-path suite and real loopback transport assertion below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used for this repair`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@0d7408fcc30bf24089b7bc87dd7e34dcbb3ef099`; zero conflicts.
- [ ] `bun run verify` passes post-sync. See the exact unrelated environment blockers below.

# Risks

Low. The plugin-manager registry request now has a private fixed deadline. Risk is limited to registry-load failure classification and timing; successful parsing, local-plugin merge order, and the one-hour success cache are unchanged.

# Background

## What does this PR do?

- Keeps the generated-registry fetch helper and its 10-second budget private; no public `fetchImpl`, caller-controlled timeout, signal, or exported budget is added.
- Applies the same internal signal to request headers and `response.json()` body consumption.
- Converts the internal deadline to `ElizaError` code `PLUGIN_REGISTRY_FETCH_TIMEOUT` with the platform cause and context.
- Preserves unrelated request and response-body `AbortError` identity.
- Adds typed HTTP and malformed-JSON failures.
- Caches only successful parsed loads.
- Tests the exported `loadRegistry` path, including a real loopback server that sends headers plus partial JSON and stalls.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

N/A - internal error handling and timeout behavior; no user-facing configuration or API was added.

# Testing

## Where should a reviewer start?

`packages/core/src/features/plugin-manager/services/pluginRegistryService.timeout.test.ts`, then the private fetch path in `pluginRegistryService.ts`.

## Detailed testing steps

1. Run `bunx vitest run packages/core/src/features/plugin-manager/services/pluginRegistryService.timeout.test.ts`.
2. Confirm 7/7 pass, including the loopback headers-plus-partial-body timeout and second-call non-cache assertion.
3. Run changed-file Biome and `git diff --check origin/develop...HEAD`.
4. Verify no production export or options object exposes `fetchImpl`, `timeoutMs`, or a caller signal.

# Evidence Gate

<!-- evidence-head:2c6d8f4c6d527eccb6bf4f59f51d29068fca9a31 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - this is an isolated core data-layer request; exact loopback transport output is recorded below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database or persistent domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

Exact head `2c6d8f4c6d527eccb6bf4f59f51d29068fca9a31`:

```text
bunx vitest run packages/core/src/features/plugin-manager/services/pluginRegistryService.timeout.test.ts
Test Files  1 passed (1)
Tests       7 passed (7)
Duration    6.73s (tests 844ms)
```

Changed-file Biome: pass, 2 files, no fixes.  
`git diff --check origin/develop...HEAD`: pass.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio or voice change.

## Known gaps / failures

- The broader `bunx vitest run packages/core/src/features/plugin-manager` attempt was bounded and stopped after approximately three minutes without test output while other independent Vitest lanes were running. It did not report a source assertion failure.
- `bun run --cwd packages/core typecheck` reached TypeScript but the sparse isolated checkout lacks existing dependencies `ai`, `mammoth`, `unpdf`, `dedent`, `markdown-it`, `file-type`, and `dotenv`; no error referenced either changed file.
- `bun install` and root `bun run verify` were not attempted because the host had only approximately 1.1 GiB free. This limitation is not represented as a green gate; independent review must run the exact head in a complete environment before merge.
- The focused run used pinned Bun 1.3.14; the host Node executable is 24.5.0 rather than the repository-pinned 24.15.0.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Attribution status: repair authored and self-reported
— [codex-repair-22224]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->