### PR TITLE
fix(plugin-telegram): keep UTF-16 surrogate pairs intact in splitMessage

### DIFF
--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -974,3 +974,21 @@ describe("MessageManager typing-indicator resilience", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("MessageManager.splitMessage surrogate-pair resilience", () => {
+  it("keeps a surrogate pair (emoji) intact instead of splitting it across chunks", () => {
+    const { manager } = createManager();
+    const text = `a${"🙂".repeat(4096)}`;
+
+    const chunks = (
+      manager as unknown as { splitMessage(text: string): string[] }
+    ).splitMessage(text);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+    expect(chunks.join("")).toBe(text);
+  });
+});

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -33,6 +33,7 @@ import {
   type ResolvedAttachmentBytes,
   resolveAttachmentBytes,
   ServiceType,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
 import type {
@@ -1404,8 +1405,9 @@ export class MessageManager {
         }
 
         if (availableLength > 0) {
-          currentChunk += remaining.slice(0, availableLength);
-          remaining = remaining.slice(availableLength);
+          const head = truncateWellFormed(remaining, availableLength);
+          currentChunk += head;
+          remaining = remaining.slice(head.length);
         }
 
         if (currentChunk) {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:a5ce0d6661e9aa183f8968f46cdc62cb011d26c8 -->

### Description
In `plugins/plugin-telegram/src/messageManager.ts`, `splitMessage` previously did a raw `.slice(0, availableLength)` when chunking oversized text segments without nearby newline boundaries. When the maximum chunk limit lands between the high and low UTF-16 code units of a surrogate pair (e.g. an emoji or high code point character), the raw slice splits the code point in half, producing a malformed chunk with a lone surrogate that fails `isWellFormed()` and corrupts on the wire.

This PR replaces the raw slice cut with `truncateWellFormed(remaining, availableLength)` from `@elizaos/core`, ensuring fallback chunk boundaries back off cleanly before splitting a surrogate pair.

### Verification
- Added unit test in `plugins/plugin-telegram/src/messageManager.test.ts` exercising `splitMessage` against an odd-offset run of emoji exceeding the 4096 character limit.
- Verified all 28 unit tests pass in `src/messageManager.test.ts`.
- Verified Biome format and check pass cleanly.

```json contribution-provenance
{
  "schema": "eliza.contribution-provenance.v1",
  "skill_rev": "8808863b16a957a091a2b08a60d8cfc4f97213c6",
  "task": "fix(plugin-telegram): keep UTF-16 surrogate pairs intact in splitMessage"
}
```
