### PR TITLE
fix(plugin-google-workspace): keep UTF-16 surrogate pairs intact in splitMessageForGoogleChat

### DIFF
--- a/plugins/plugin-google-workspace/src/chat/connector.test.ts
+++ b/plugins/plugin-google-workspace/src/chat/connector.test.ts
@@ -6,7 +6,11 @@
 import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { GoogleChatService } from "./service.js";
-import { GoogleChatConfigurationError } from "./types.js";
+import {
+  GoogleChatConfigurationError,
+  MAX_GOOGLE_CHAT_MESSAGE_LENGTH,
+  splitMessageForGoogleChat,
+} from "./types.js";
 
 describe("Google Chat message connector", () => {
   function runtime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime {
@@ -285,5 +289,23 @@ describe("Google Chat message connector", () => {
     expect(sendReaction).not.toHaveBeenCalled();
     expect(updateMessage).not.toHaveBeenCalled();
     expect(deleteMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("splitMessageForGoogleChat surrogate pair safety", () => {
+  it("keeps a surrogate pair (emoji) intact instead of splitting it across chunks", () => {
+    const text = `a${"🙂".repeat(MAX_GOOGLE_CHAT_MESSAGE_LENGTH)}`;
+
+    const chunks = splitMessageForGoogleChat(text);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(MAX_GOOGLE_CHAT_MESSAGE_LENGTH);
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+  });
+
+  it("returns original text when under maxLength", () => {
+    expect(splitMessageForGoogleChat("hello")).toEqual(["hello"]);
   });
 });

--- a/plugins/plugin-google-workspace/src/chat/types.ts
+++ b/plugins/plugin-google-workspace/src/chat/types.ts
@@ -2,7 +2,7 @@
  * Type definitions for the Google Chat plugin.
  */
 
-import type { Service } from "@elizaos/core";
+import { type Service, truncateWellFormed } from "@elizaos/core";
 
 /** Maximum message length for Google Chat */
 export const MAX_GOOGLE_CHAT_MESSAGE_LENGTH = 4000;
@@ -340,8 +340,9 @@ export function splitMessageForGoogleChat(
       }
     }
 
-    chunks.push(remaining.slice(0, breakPoint).trimEnd());
-    remaining = remaining.slice(breakPoint).trimStart();
+    const head = truncateWellFormed(remaining, breakPoint);
+    chunks.push(head.trimEnd());
+    remaining = remaining.slice(head.length).trimStart();
   }
 
   return chunks;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:d597445bad06c91908be232704cb62321dec4d01 -->

### Description
In `plugins/plugin-google-workspace/src/chat/types.ts`, `splitMessageForGoogleChat` previously sliced text segments using `remaining.slice(0, breakPoint)` when chunking text exceeding `MAX_GOOGLE_CHAT_MESSAGE_LENGTH` (4000 chars). When a chunk boundary falls between the high and low surrogate units of a UTF-16 code point (such as emoji), the raw slice cuts the code point in half, producing invalid Unicode that fails `isWellFormed()`.

This PR replaces the raw slice with `truncateWellFormed(remaining, breakPoint)` from `@elizaos/core`, ensuring surrogate pairs are never split across Google Chat message chunks.

### Verification
- Added unit tests in `plugins/plugin-google-workspace/src/chat/connector.test.ts` verifying emoji runs exceeding 4000 characters chunk without splitting surrogate pairs and produce well-formed chunks.
- Ran test suite: all 9 tests in `src/chat/connector.test.ts` pass.
- Verified Biome formatting and linting pass with zero errors.

```json contribution-provenance
{
  "schema": "eliza.contribution-provenance.v1",
  "skill_rev": "8808863b16a957a091a2b08a60d8cfc4f97213c6",
  "task": "fix(plugin-google-workspace): keep UTF-16 surrogate pairs intact in splitMessageForGoogleChat"
}
```
