### PR TITLE
fix(cloud): keep UTF-16 surrogate pairs intact when chunking telegram and discord messages

### DIFF
--- a/packages/cloud/shared/src/lib/utils/discord-helpers.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-helpers.ts
@@ -1,3 +1,5 @@
+import { truncateWellFormed } from "@elizaos/core";
+
 /**
  * Discord Utility Functions
  *
@@ -102,8 +104,9 @@ export function splitMessage(text: string, maxLength = 2000): string[] {
       breakPoint = maxLength;
     }
 
-    messages.push(remaining.substring(0, breakPoint));
-    remaining = remaining.substring(breakPoint).trimStart();
+    const head = truncateWellFormed(remaining, breakPoint);
+    messages.push(head);
+    remaining = remaining.slice(head.length).trimStart();
   }
 
   return messages;
@@ -178,7 +181,7 @@ export function hyperlink(text: string, url: string): string {
  */
 export function truncate(text: string, maxLength: number): string {
   if (!text || text.length <= maxLength) return text;
-  return text.substring(0, maxLength - 3) + "...";
+  return `${truncateWellFormed(text, maxLength - 3)}...`;
 }
 
 /**

--- a/packages/cloud/shared/src/lib/utils/surrogate-chunking.test.ts
+++ b/packages/cloud/shared/src/lib/utils/surrogate-chunking.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  splitMessage as splitDiscordMessage,
+  truncate as truncateDiscord,
+} from "./discord-helpers";
+import { splitMessage as splitTelegramMessage } from "./telegram-helpers";
+
+describe("cloud/shared telegram and discord surrogate-pair chunking", () => {
+  it("keeps surrogate pairs intact in telegram splitMessage", () => {
+    const text = `a${"🙂".repeat(4096)}`;
+    const chunks = splitTelegramMessage(text, 4096);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+  });
+
+  it("keeps surrogate pairs intact in discord splitMessage", () => {
+    const text = `a${"🙂".repeat(2000)}`;
+    const chunks = splitDiscordMessage(text, 2000);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(2000);
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+  });
+
+  it("keeps surrogate pairs intact in discord truncate", () => {
+    const text = `a${"🙂".repeat(20)}`;
+    const truncated = truncateDiscord(text, 10);
+    expect(truncated.endsWith("...")).toBe(true);
+    expect(truncated.isWellFormed()).toBe(true);
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/telegram-helpers.ts
+++ b/packages/cloud/shared/src/lib/utils/telegram-helpers.ts
@@ -1,3 +1,5 @@
+import { truncateWellFormed } from "@elizaos/core";
+
 // Provides cloud utility telegram helpers helpers shared by backend services.
 export function escapeMarkdownV2(text: string): string {
   if (!text) return "";
@@ -18,8 +20,9 @@ export function splitMessage(text: string, maxLength = 4096): string[] {
       if (line.length > maxLength) {
         let remaining = line;
         while (remaining.length > maxLength) {
-          chunks.push(remaining.slice(0, maxLength));
-          remaining = remaining.slice(maxLength);
+          const head = truncateWellFormed(remaining, maxLength);
+          chunks.push(head);
+          remaining = remaining.slice(head.length);
         }
         current = remaining;
       } else {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:d2d4363c84c4fef96a22ef6a395e9b9c224a0053 -->

### Description
In `packages/cloud/shared/src/lib/utils/telegram-helpers.ts` and `discord-helpers.ts`, message splitting functions (`splitMessage` and `truncate`) used raw `.slice()` and `.substring()` when breaking long message lines or finding fallback cut points. If a boundary lands between the high and low surrogate units of a UTF-16 code point (such as emoji), the character is split, producing malformed Unicode that fails `isWellFormed()`.

This PR replaces the raw slicing with `truncateWellFormed()` from `@elizaos/core`, ensuring cloud automation message chunking never splits surrogate pairs.

### Verification
- Added test suite `packages/cloud/shared/src/lib/utils/surrogate-chunking.test.ts` verifying surrogate pair preservation in both Telegram and Discord splitting / truncation.
- Verified test suite passes with `bun test`.
- Verified Biome checks pass cleanly.

```json contribution-provenance
{
  "schema": "eliza.contribution-provenance.v1",
  "skill_rev": "8808863b16a957a091a2b08a60d8cfc4f97213c6",
  "task": "fix(cloud): keep UTF-16 surrogate pairs intact when chunking telegram and discord messages"
}
```
