### PR TITLE
fix(cloud): fence the append-only restore writers and un-wedge boot re-arm

### DIFF
--- a/packages/cloud/shared/src/db/agent-backup-restore-history-migration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-history-migration.test.ts
@@ -16,6 +16,14 @@ const MIGRATION_NAMES = [
 const MIGRATIONS = MIGRATION_NAMES.map((name) =>
   readFileSync(join(MIGRATIONS_DIR, `${name}.sql`), "utf8"),
 );
+// Applied after the 0246-0250 stack rather than inside it. 0253 drops the global
+// incarnation unique that 0246's own backfill arbitrates on, so 0246 is not
+// re-runnable once 0253 has landed -- a sequence the journal-based migrator
+// never produces, and one the replay proofs below must therefore not simulate.
+const REARM_MIGRATION = readFileSync(
+  join(MIGRATIONS_DIR, "0259_agent_node_incarnation_rearm.sql"),
+  "utf8",
+);
 
 const ORG = "00000000-0000-4000-8000-00000000a001";
 const AGENT = "00000000-0000-4000-8000-00000000a002";
@@ -345,6 +353,68 @@ describe("0246-0250 immutable restore history migrations", () => {
         '${manifestB}', '${seedB}', '${RECEIPT}', '${TARGET}', 'restore', '${PUBLICATION}',
         '${RECEIPT}', 2, '${SHA}')`),
       ).rejects.toThrow();
+    } finally {
+      await database.close();
+    }
+  });
+});
+
+describe("0253 node incarnation re-arm", () => {
+  const REPLACEMENT_NODE = "00000000-0000-4000-8000-00000000a016";
+
+  async function reRegisterSameBootUnderNewRecord(database: PGlite): Promise<void> {
+    await database.exec(`DELETE FROM docker_nodes WHERE id = '${NODE}'`);
+    await database.exec(`INSERT INTO docker_nodes VALUES
+      ('${REPLACEMENT_NODE}', 'node-a2', '${BOOT}', 'robot', 'hetzner', NULL,
+        'ssh-ed25519 AAA', NOW())`);
+  }
+
+  test("0246 alone wedges a boot that re-registers under a new node record", async () => {
+    const database = await databaseWithFoundation();
+    try {
+      await applyMigrations(database);
+
+      await expect(reRegisterSameBootUnderNewRecord(database)).rejects.toThrow(
+        "node incarnation conflicts with immutable history",
+      );
+    } finally {
+      await database.close();
+    }
+  });
+
+  test("0253 lets the same boot re-attest under a new record and keeps both rows", async () => {
+    const database = await databaseWithFoundation();
+    try {
+      await applyMigrations(database);
+      await database.exec(REARM_MIGRATION);
+
+      await reRegisterSameBootUnderNewRecord(database);
+
+      const histories = await database.query<{
+        docker_node_record_id: string;
+        node_id: string;
+      }>(`SELECT docker_node_record_id, node_id FROM agent_node_incarnation_histories
+          WHERE node_incarnation = '${BOOT}' ORDER BY node_id`);
+      expect(histories.rows).toEqual([
+        { docker_node_record_id: NODE, node_id: "node-a" },
+        { docker_node_record_id: REPLACEMENT_NODE, node_id: "node-a2" },
+      ]);
+    } finally {
+      await database.close();
+    }
+  });
+
+  test("0253 is idempotent and still refuses an identity rewrite on the same record", async () => {
+    const database = await databaseWithFoundation();
+    try {
+      await applyMigrations(database);
+      await database.exec(REARM_MIGRATION);
+      await database.exec(REARM_MIGRATION);
+
+      await expect(
+        database.exec(`UPDATE docker_nodes SET host_key_fingerprint = 'different'
+          WHERE id = '${NODE}'`),
+      ).rejects.toThrow("node incarnation conflicts with immutable history");
     } finally {
       await database.close();
     }

--- a/packages/cloud/shared/src/db/agent-backup-restore-history-migration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-history-migration.test.ts
@@ -16,9 +16,9 @@ const MIGRATION_NAMES = [
 const MIGRATIONS = MIGRATION_NAMES.map((name) =>
   readFileSync(join(MIGRATIONS_DIR, `${name}.sql`), "utf8"),
 );
-// Applied after the 0246-0250 stack rather than inside it. 0253 drops the global
+// Applied after the 0246-0250 stack rather than inside it. 0259 drops the global
 // incarnation unique that 0246's own backfill arbitrates on, so 0246 is not
-// re-runnable once 0253 has landed -- a sequence the journal-based migrator
+// re-runnable once 0259 has landed -- a sequence the journal-based migrator
 // never produces, and one the replay proofs below must therefore not simulate.
 const REARM_MIGRATION = readFileSync(
   join(MIGRATIONS_DIR, "0259_agent_node_incarnation_rearm.sql"),
@@ -359,7 +359,7 @@ describe("0246-0250 immutable restore history migrations", () => {
   });
 });
 
-describe("0253 node incarnation re-arm", () => {
+describe("0259 node incarnation re-arm", () => {
   const REPLACEMENT_NODE = "00000000-0000-4000-8000-00000000a016";
 
   async function reRegisterSameBootUnderNewRecord(database: PGlite): Promise<void> {
@@ -382,7 +382,7 @@ describe("0253 node incarnation re-arm", () => {
     }
   });
 
-  test("0253 lets the same boot re-attest under a new record and keeps both rows", async () => {
+  test("0259 lets the same boot re-attest under a new record and keeps both rows", async () => {
     const database = await databaseWithFoundation();
     try {
       await applyMigrations(database);
@@ -404,7 +404,7 @@ describe("0253 node incarnation re-arm", () => {
     }
   });
 
-  test("0253 is idempotent and still refuses an identity rewrite on the same record", async () => {
+  test("0259 is idempotent and still refuses an identity rewrite on the same record", async () => {
     const database = await databaseWithFoundation();
     try {
       await applyMigrations(database);

--- a/packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts
@@ -1,12 +1,12 @@
 /** Real-PostgreSQL proofs for restore clock and catalogue lock ordering. */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
 import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { pushSchema } from "drizzle-kit/api";
-import { eq, sql } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import { Client } from "pg";
 import {
   acquireEphemeralPostgres,
@@ -17,6 +17,12 @@ import {
   agentBackupObjects,
   agentBackupRestoreLeases,
 } from "./schemas/agent-backup-catalog";
+import {
+  agentActivationPublications,
+  agentBackupRestoreReceipts,
+  agentNodeIncarnationHistories,
+  agentVaultKeySeedReceipts,
+} from "./schemas/agent-backup-restore-history";
 import { agentSandboxBackups, agentSandboxes } from "./schemas/agent-sandboxes";
 import {
   agentVaultKeyAuthorities,
@@ -77,6 +83,19 @@ const CLOCK_LEASE_ID = "00000000-0000-4000-8000-00000000b208";
 const CLOCK_FENCE = "00000000-0000-4000-8000-00000000b209";
 const RECEIPT_SHA = "b".repeat(64);
 
+const WRITER_BACKUP_ID = "00000000-0000-4000-8000-00000000b301";
+const WRITER_OPERATION_ID = "00000000-0000-4000-8000-00000000b302";
+const WRITER_ATTEMPT_ID = "00000000-0000-4000-8000-00000000b303";
+const WRITER_LEASE_ID = "00000000-0000-4000-8000-00000000b304";
+const WRITER_FENCE = "00000000-0000-4000-8000-00000000b305";
+const WRITER_SEED_ID = "00000000-0000-4000-8000-00000000b306";
+const WRITER_PUBLICATION_ID = "00000000-0000-4000-8000-00000000b307";
+const WRITER_FINAL_ID = "00000000-0000-4000-8000-00000000b308";
+const WRITER_TARGET_GENERATION = "00000000-0000-4000-8000-00000000b309";
+const WRITER_VAULT_GENERATION = "00000000-0000-4000-8000-00000000b30a";
+const WRITER_RESERVE_ONE = "00000000-0000-4000-8000-00000000b30b";
+const WRITER_RESERVE_TWO = "00000000-0000-4000-8000-00000000b30c";
+
 let postgres: EphemeralPostgres | null = await acquireEphemeralPostgres();
 let isolatedDatabaseName: string | null = null;
 let isolatedDsn: string | null = null;
@@ -101,6 +120,15 @@ let releaseAgentBackupRestoreLease:
   | undefined;
 let agentBackupObjectInventoryDigest:
   | typeof import("./repositories/agent-backup-catalog").agentBackupObjectInventoryDigest
+  | undefined;
+let recordAgentActivationPublication:
+  | typeof import("./repositories/agent-backup-restore-history").recordAgentActivationPublication
+  | undefined;
+let recordAgentVaultKeySeedReceipt:
+  | typeof import("./repositories/agent-backup-restore-history").recordAgentVaultKeySeedReceipt
+  | undefined;
+let commitAgentBackupRestore:
+  | typeof import("./repositories/agent-backup-restore-history").commitAgentBackupRestore
   | undefined;
 
 function restoreEnv(name: keyof typeof ORIGINAL_ENV, value: string | undefined): void {
@@ -191,10 +219,11 @@ if (!postgres) {
   process.env.TEST_DATABASE_URL = isolated.dsn;
   process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
   process.env.MOCK_REDIS = "1";
-  const [clientModule, repositoryModule, leaseModule] = await Promise.all([
+  const [clientModule, repositoryModule, leaseModule, restoreHistoryModule] = await Promise.all([
     import("./client"),
     import("./repositories/agent-backup-catalog"),
     import("./repositories/agent-backup-restore-lease"),
+    import("./repositories/agent-backup-restore-history"),
   ]);
   closeDatabaseConnectionsForTests = clientModule.closeDatabaseConnectionsForTests;
   dbWrite = clientModule.dbWrite;
@@ -205,6 +234,9 @@ if (!postgres) {
   agentBackupObjectInventoryDigest = repositoryModule.agentBackupObjectInventoryDigest;
   acquireAgentBackupRestoreLease = leaseModule.acquireAgentBackupRestoreLease;
   releaseAgentBackupRestoreLease = leaseModule.releaseAgentBackupRestoreLease;
+  recordAgentActivationPublication = restoreHistoryModule.recordAgentActivationPublication;
+  recordAgentVaultKeySeedReceipt = restoreHistoryModule.recordAgentVaultKeySeedReceipt;
+  commitAgentBackupRestore = restoreHistoryModule.commitAgentBackupRestore;
 }
 
 afterAll(async () => {
@@ -235,6 +267,10 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
         agentSandboxBackups,
         agentBackupObjects,
         agentBackupRestoreLeases,
+        agentNodeIncarnationHistories,
+        agentActivationPublications,
+        agentVaultKeySeedReceipts,
+        agentBackupRestoreReceipts,
         agentVaultKeyGenerations,
         agentVaultKeyAuthorities,
         agentVaultKeyBackupBindings,
@@ -311,6 +347,60 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
       activation_completed_at: new Date("2026-08-17T00:00:02.000Z"),
     });
   }, 60_000);
+
+  afterEach(async () => {
+    if (!dbWrite) return;
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        activation_generation: ACTIVATION_GENERATION,
+        activation_lifecycle_revision: 0n,
+        activation_purpose: "provision",
+        activation_phase: "active",
+        activation_backup_id: null,
+        activation_backup_hash: null,
+        activation_receipt_hash: SHA,
+        activation_container_id: SOURCE_CONTAINER_ID,
+        activation_node_id: "robot-node-lock",
+        activation_boot_id: NODE_INCARNATION,
+        activation_image_digest: `sha256:${SHA}`,
+        activation_token_hash: SHA,
+      })
+      .where(eq(agentSandboxes.id, AGENT_ID));
+    await dbWrite
+      .delete(agentBackupRestoreReceipts)
+      .where(eq(agentBackupRestoreReceipts.id, WRITER_FINAL_ID));
+    await dbWrite
+      .delete(agentVaultKeySeedReceipts)
+      .where(eq(agentVaultKeySeedReceipts.id, WRITER_SEED_ID));
+    await dbWrite
+      .delete(agentActivationPublications)
+      .where(eq(agentActivationPublications.id, WRITER_PUBLICATION_ID));
+    await dbWrite
+      .delete(agentBackupRestoreLeases)
+      .where(eq(agentBackupRestoreLeases.id, WRITER_LEASE_ID));
+    await dbWrite
+      .delete(agentVaultKeyBackupBindings)
+      .where(eq(agentVaultKeyBackupBindings.backup_id, WRITER_BACKUP_ID));
+    await dbWrite
+      .delete(agentSandboxBackups)
+      .where(
+        inArray(agentSandboxBackups.backup_operation_id, [
+          WRITER_OPERATION_ID,
+          WRITER_RESERVE_ONE,
+          WRITER_RESERVE_TWO,
+        ]),
+      );
+    await dbWrite
+      .delete(agentVaultKeyAuthorities)
+      .where(eq(agentVaultKeyAuthorities.current_generation_id, WRITER_VAULT_GENERATION));
+    await dbWrite
+      .delete(agentVaultKeyGenerations)
+      .where(eq(agentVaultKeyGenerations.generation_id, WRITER_VAULT_GENERATION));
+    await dbWrite
+      .delete(agentNodeIncarnationHistories)
+      .where(eq(agentNodeIncarnationHistories.docker_node_record_id, NODE_RECORD_ID));
+  });
 
   test("reservation replay and actual restore acquisition share backup-before-authority order", async () => {
     const reserve = reserveAgentBackupOperation;
@@ -467,6 +557,277 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
       await Promise.allSettled([capture.end(), observer.end()]);
     }
   }, 30_000);
+
+  test("restore receipt writers cannot deadlock a concurrent sandbox-first reservation", async () => {
+    const reserve = reserveAgentBackupOperation;
+    const publish = recordAgentActivationPublication;
+    const seed = recordAgentVaultKeySeedReceipt;
+    const finalize = commitAgentBackupRestore;
+    if (!isolatedDsn || !dbWrite || !reserve || !publish || !seed || !finalize) {
+      throw new Error("real PostgreSQL harness was not initialized");
+    }
+
+    await dbWrite
+      .insert(agentBackupCatalogAuthorities)
+      .values({ organization_id: ORG_ID, agent_id: AGENT_ID })
+      .onConflictDoNothing();
+    const [initialAuthority] = await dbWrite
+      .select({ revision: agentBackupCatalogAuthorities.catalog_revision })
+      .from(agentBackupCatalogAuthorities)
+      .where(eq(agentBackupCatalogAuthorities.agent_id, AGENT_ID));
+    if (!initialAuthority) throw new Error("writer fixture catalogue authority is missing");
+
+    await dbWrite.insert(agentVaultKeyGenerations).values({
+      organization_id: ORG_ID,
+      agent_id: AGENT_ID,
+      generation_id: WRITER_VAULT_GENERATION,
+      source_activation_generation: ACTIVATION_GENERATION,
+      supersedes_generation_id: null,
+      format: "kms-aead-vault-passphrase-v1",
+      kms_key_id: `org:${ORG_ID}/writer-lock/dek/v1`,
+      kms_key_version: 1n,
+      kms_context: "{}",
+      kms_context_derivation: "elizaos.agent-vault-key.kms-context.v1",
+      wrapped_ciphertext_base64: Buffer.alloc(32, 0x11).toString("base64"),
+      wrapped_nonce_base64: Buffer.alloc(12, 0x22).toString("base64"),
+      wrapped_auth_tag_base64: Buffer.alloc(16, 0x33).toString("base64"),
+      wrapped_envelope_sha256: SHA,
+      authority_receipt_derivation: "elizaos.agent-vault-key.authority-receipt.v1",
+      authority_receipt_digest: RECEIPT_SHA,
+    });
+    await dbWrite.insert(agentVaultKeyAuthorities).values({
+      organization_id: ORG_ID,
+      agent_id: AGENT_ID,
+      current_generation_id: WRITER_VAULT_GENERATION,
+    });
+    await dbWrite.insert(agentSandboxBackups).values({
+      id: WRITER_BACKUP_ID,
+      sandbox_record_id: null,
+      snapshot_type: "auto",
+      state_data: { memories: [], config: {}, workspaceFiles: {} },
+      state_data_storage: "inline",
+      size_bytes: 92,
+      backup_kind: "full",
+      backup_operation_id: WRITER_OPERATION_ID,
+      catalog_version: 2,
+      catalog_state: "protected",
+      catalog_payload_digest: SHA,
+      catalog_revision: initialAuthority.revision,
+      catalog_organization_id: ORG_ID,
+      catalog_agent_id: AGENT_ID,
+      lifecycle_generation: ACTIVATION_GENERATION,
+      lifecycle_revision: 0n,
+      source_provider: "operator-onboarded",
+      source_node_record_id: NODE_RECORD_ID,
+      source_node_id: "robot-node-lock",
+      source_node_incarnation: NODE_INCARNATION,
+      source_provider_server_id: null,
+      source_provider_handle: "container-generation-lock",
+      source_container_id: SOURCE_CONTAINER_ID,
+      retention_reason: "schedule",
+      retention_until: new Date("2026-12-01T00:00:00.000Z"),
+      manifest_format: "elizaos.agent-backup",
+      manifest_version: 3,
+      manifest_digest: SHA,
+      manifest_canonical_draft: "{}",
+      manifest_object_count: 1,
+      object_inventory_digest: SHA,
+      image_digest: `sha256:${SHA}`,
+      database_schema_version: "1",
+      plugin_set_digest: SHA,
+      watermark_digest: SHA,
+      raw_size_bytes: 1,
+      compressed_size_bytes: 1,
+      encrypted_size_bytes: 92,
+      kms_key_id: `org:${ORG_ID}/writer-lock/backup/v1`,
+      kms_key_version: 1,
+      operation_key_bundle_generation_id: WRITER_VAULT_GENERATION,
+      operation_key_bundle_format: "kms-aead-operation-key-bundle-v1",
+      operation_key_bundle_ref: `backup-key-bundle:${WRITER_OPERATION_ID}`,
+      operation_key_bundle_ciphertext_base64: Buffer.alloc(92, 0x42).toString("base64"),
+      operation_key_bundle_sha256: SHA,
+      operation_key_bundle_size_bytes: 92,
+      operation_key_bundle_context: "{}",
+      operation_key_bundle_context_derivation:
+        "elizaos.agent-backup.operation-key-bundle-context.v1",
+      operation_key_bundle_local_receipt_derivation:
+        "elizaos.kms-aead-operation-key-bundle.local-receipt.v1",
+      operation_key_bundle_local_receipt_digest: SHA,
+      vault_key_generation_id: WRITER_VAULT_GENERATION,
+      vault_key_authority_receipt_digest: RECEIPT_SHA,
+    });
+    await dbWrite.insert(agentVaultKeyBackupBindings).values({
+      organization_id: ORG_ID,
+      agent_id: AGENT_ID,
+      backup_id: WRITER_BACKUP_ID,
+      operation_id: WRITER_OPERATION_ID,
+      source_activation_generation: ACTIVATION_GENERATION,
+      source_lifecycle_revision: 0n,
+      manifest_sha256: SHA,
+      vault_key_generation_id: WRITER_VAULT_GENERATION,
+      vault_key_authority_receipt_digest: RECEIPT_SHA,
+    });
+    await dbWrite.insert(agentBackupRestoreLeases).values({
+      id: WRITER_LEASE_ID,
+      organization_id: ORG_ID,
+      agent_id: AGENT_ID,
+      backup_id: WRITER_BACKUP_ID,
+      operation_id: WRITER_OPERATION_ID,
+      activation_generation: ACTIVATION_GENERATION,
+      lifecycle_revision: 0n,
+      expected_manifest_sha256: SHA,
+      copy_role: "primary",
+      restore_attempt_id: WRITER_ATTEMPT_ID,
+      owner_id: "writer-lock-owner",
+      generation: WRITER_FENCE,
+      catalog_epoch: initialAuthority.revision,
+      expires_at: new Date(Date.now() + 300_000),
+    });
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        activation_generation: WRITER_TARGET_GENERATION,
+        activation_lifecycle_revision: 0n,
+        activation_purpose: "restore",
+        activation_phase: "active",
+        activation_backup_id: WRITER_BACKUP_ID,
+        activation_backup_hash: SHA,
+        activation_receipt_hash: SHA,
+        activation_container_id: SOURCE_CONTAINER_ID,
+        activation_node_id: "robot-node-lock",
+        activation_boot_id: NODE_INCARNATION,
+        activation_image_digest: `sha256:${SHA}`,
+        activation_token_hash: SHA,
+      })
+      .where(eq(agentSandboxes.id, AGENT_ID));
+
+    await publish({
+      publicationId: WRITER_PUBLICATION_ID,
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      activationGeneration: WRITER_TARGET_GENERATION,
+      expectedActivationReceiptSha256: SHA,
+      expectedContainerId: SOURCE_CONTAINER_ID,
+      expectedNodeRecordId: NODE_RECORD_ID,
+      expectedNodeIncarnation: NODE_INCARNATION,
+      expectedTokenSha256: SHA,
+    });
+
+    const reservationInput = (operationId: string) => ({
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      sandboxRecordId: AGENT_ID,
+      operationId,
+      activationGeneration: WRITER_TARGET_GENERATION,
+      lifecycleRevision: "0",
+      snapshotType: "manual" as const,
+      backupKind: "full" as const,
+      sourceProvider: "operator-onboarded" as const,
+      sourceNodeRecordId: NODE_RECORD_ID,
+      sourceNodeId: "robot-node-lock",
+      sourceNodeIncarnation: NODE_INCARNATION,
+      sourceProviderServerId: null,
+      sourceProviderHandle: "container-generation-lock",
+      sourceContainerId: SOURCE_CONTAINER_ID,
+      retentionReason: "manual" as const,
+      retentionUntil: new Date("2026-12-02T00:00:00.000Z"),
+    });
+
+    const interleaveWithReservation = async (
+      operationId: string,
+      writer: () => Promise<unknown>,
+    ): Promise<void> => {
+      const blocker = new Client({ connectionString: isolatedDsn });
+      const observer = new Client({ connectionString: isolatedDsn });
+      await Promise.all([blocker.connect(), observer.connect()]);
+      let writerError: unknown;
+      let writerPromise: Promise<void> | undefined;
+      let reservationError: unknown;
+      let reservationPromise: Promise<void> | undefined;
+      try {
+        await blocker.query("BEGIN");
+        const blockerPid = await blocker.query<{ pid: number }>("SELECT pg_backend_pid() AS pid");
+        await blocker.query(
+          "SELECT organization_id FROM agent_backup_catalog_authorities " +
+            "WHERE organization_id = $1 AND agent_id = $2 FOR UPDATE",
+          [ORG_ID, AGENT_ID],
+        );
+        writerPromise = writer().then(
+          () => undefined,
+          (error: unknown) => {
+            writerError = error;
+          },
+        );
+        const writerPid = await waitUntilBlockedBy(observer, blockerPid.rows[0]!.pid);
+        reservationPromise = reserve(reservationInput(operationId)).then(
+          () => undefined,
+          (error: unknown) => {
+            reservationError = error;
+          },
+        );
+        await waitUntilBlockedBy(observer, writerPid);
+        await blocker.query("COMMIT");
+        await Promise.all([writerPromise, reservationPromise]);
+        if (writerError) throw writerError;
+        if (reservationError) throw reservationError;
+      } finally {
+        await blocker.query("ROLLBACK");
+        if (writerPromise) await writerPromise;
+        if (reservationPromise) await reservationPromise;
+        await Promise.allSettled([blocker.end(), observer.end()]);
+      }
+    };
+
+    await interleaveWithReservation(WRITER_RESERVE_ONE, () =>
+      seed({
+        receiptId: WRITER_SEED_ID,
+        receiptDigest: RECEIPT_SHA,
+        organizationId: ORG_ID,
+        agentId: AGENT_ID,
+        backupId: WRITER_BACKUP_ID,
+        restoreAttemptId: WRITER_ATTEMPT_ID,
+        leaseId: WRITER_LEASE_ID,
+        leaseOwnerId: "writer-lock-owner",
+        leaseFencingToken: WRITER_FENCE,
+        targetActivationGeneration: WRITER_TARGET_GENERATION,
+        targetNodeRecordId: NODE_RECORD_ID,
+        targetNodeIncarnation: NODE_INCARNATION,
+      }),
+    );
+
+    const [currentAuthority] = await dbWrite
+      .select({ revision: agentBackupCatalogAuthorities.catalog_revision })
+      .from(agentBackupCatalogAuthorities)
+      .where(eq(agentBackupCatalogAuthorities.agent_id, AGENT_ID));
+    if (!currentAuthority) throw new Error("writer fixture catalogue authority disappeared");
+    await dbWrite
+      .update(agentBackupRestoreLeases)
+      .set({ catalog_epoch: currentAuthority.revision })
+      .where(eq(agentBackupRestoreLeases.id, WRITER_LEASE_ID));
+
+    await interleaveWithReservation(WRITER_RESERVE_TWO, () =>
+      finalize({
+        receiptId: WRITER_FINAL_ID,
+        receiptDigest: SHA,
+        organizationId: ORG_ID,
+        agentId: AGENT_ID,
+        backupId: WRITER_BACKUP_ID,
+        restoreAttemptId: WRITER_ATTEMPT_ID,
+        seedReceiptId: WRITER_SEED_ID,
+        seedReceiptDigest: RECEIPT_SHA,
+        activationPublicationId: WRITER_PUBLICATION_ID,
+        targetActivationGeneration: WRITER_TARGET_GENERATION,
+        expectedActivationReceiptSha256: SHA,
+      }),
+    );
+
+    expect(
+      await dbWrite
+        .select({ id: agentBackupRestoreReceipts.id })
+        .from(agentBackupRestoreReceipts)
+        .where(eq(agentBackupRestoreReceipts.id, WRITER_FINAL_ID)),
+    ).toHaveLength(1);
+  }, 60_000);
 
   test("direct expiration wins or fences a racing restore acquisition and replays", async () => {
     const reserve = reserveAgentBackupOperation;
@@ -762,7 +1123,8 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
           catalog_agent_id uuid NOT NULL, backup_operation_id uuid NOT NULL,
           lifecycle_generation uuid NOT NULL, lifecycle_revision numeric(20, 0) NOT NULL,
           manifest_digest text NOT NULL, manifest_version integer, catalog_state text,
-          vault_key_generation_id uuid, vault_key_authority_receipt_digest text
+          vault_key_generation_id uuid, vault_key_authority_receipt_digest text,
+          UNIQUE (id, catalog_organization_id, catalog_agent_id)
         );
         INSERT INTO organizations VALUES ('${CLOCK_ORG_ID}');
         INSERT INTO agent_backup_catalog_authorities

--- a/packages/cloud/shared/src/db/migrations/0259_agent_node_incarnation_rearm.sql
+++ b/packages/cloud/shared/src/db/migrations/0259_agent_node_incarnation_rearm.sql
@@ -1,0 +1,37 @@
+-- Re-key boot authority on (node record, incarnation) so a reused boot can re-attest.
+--
+-- 0246 kept a global UNIQUE on "node_incarnation" alongside the composite
+-- ("docker_node_record_id", "node_incarnation"). The trigger resolved on the
+-- global arbiter, so a boot UUID stayed bound to the first docker_nodes row that
+-- ever carried it: delete that row, re-register the same host without rebooting,
+-- and the journal refused the incarnation forever. The composite key already
+-- carries the invariant that matters -- for a given record and incarnation the
+-- typed identity is immutable -- while the global key conflated "boot UUID" with
+-- "node record". No foreign key references the global constraint.
+
+ALTER TABLE "agent_node_incarnation_histories"
+  DROP CONSTRAINT IF EXISTS "agent_node_incarnation_histories_incarnation_unique";
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION "journal_agent_node_incarnation"()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW."node_incarnation" IS NULL THEN RETURN NEW; END IF;
+  INSERT INTO "agent_node_incarnation_histories" (
+    "docker_node_record_id", "node_id", "node_incarnation", "fleet_kind",
+    "infrastructure_provider", "provider_server_id", "host_key_fingerprint")
+  VALUES (NEW."id", NEW."node_id", NEW."node_incarnation", NEW."fleet_kind",
+    NEW."infrastructure_provider", NEW."provider_server_id", NEW."host_key_fingerprint")
+  ON CONFLICT ("docker_node_record_id", "node_incarnation") DO NOTHING;
+  IF NOT EXISTS (SELECT 1 FROM "agent_node_incarnation_histories" history
+    WHERE history."node_incarnation" = NEW."node_incarnation"
+      AND history."docker_node_record_id" = NEW."id"
+      AND history."node_id" = NEW."node_id"
+      AND history."fleet_kind" = NEW."fleet_kind"
+      AND history."infrastructure_provider" = NEW."infrastructure_provider"
+      AND history."provider_server_id" IS NOT DISTINCT FROM NEW."provider_server_id"
+      AND history."host_key_fingerprint" = NEW."host_key_fingerprint") THEN
+    RAISE EXCEPTION 'node incarnation conflicts with immutable history' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1807,6 +1807,13 @@
       "when": 1791748800000,
       "tag": "0258_org_storage_generation_gc_outbox",
       "breakpoints": true
+    },
+    {
+      "idx": 258,
+      "version": "7",
+      "when": 1791835200000,
+      "tag": "0259_agent_node_incarnation_rearm",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-global-lock-order.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-global-lock-order.test.ts
@@ -1,0 +1,116 @@
+/** Statically guards the sandbox-before-catalogue-authority order across backup writers. */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPOSITORIES_DIR = join(import.meta.dir, "..");
+
+function source(name: string): string {
+  return readFileSync(join(REPOSITORIES_DIR, name), "utf8");
+}
+
+function exportedFunction(sourceText: string, name: string, nextName?: string): string {
+  const start = sourceText.indexOf(`export async function ${name}`);
+  expect(start, `${name} must remain present`).toBeGreaterThanOrEqual(0);
+  const end = nextName ? sourceText.indexOf(`export async function ${nextName}`, start + 1) : -1;
+  return sourceText.slice(start, end >= 0 ? end : undefined);
+}
+
+function expectOrder(body: string, first: string, second: string, label: string): void {
+  const firstIndex = body.indexOf(first);
+  const secondIndex = body.indexOf(second);
+  expect(firstIndex, `${label}: missing first lock anchor`).toBeGreaterThanOrEqual(0);
+  expect(secondIndex, `${label}: missing second lock anchor`).toBeGreaterThanOrEqual(0);
+  expect(firstIndex, `${label}: ${first} must precede ${second}`).toBeLessThan(secondIndex);
+}
+
+describe("agent backup global lock order", () => {
+  test("vault-seed receipt locks sandbox and node before catalogue authority", () => {
+    const history = source("agent-backup-restore-history.ts");
+    const seed = exportedFunction(
+      history,
+      "recordAgentVaultKeySeedReceipt",
+      "commitAgentBackupRestore",
+    );
+    expectOrder(
+      seed,
+      ".from(agentSandboxes)",
+      ".from(agentBackupCatalogAuthorities)",
+      "vault-seed receipt",
+    );
+    expectOrder(
+      seed,
+      "lockCurrentNodeHistory(tx",
+      ".from(agentBackupCatalogAuthorities)",
+      "vault-seed receipt",
+    );
+  });
+
+  test("restore finalizer locks sandbox and node before catalogue authority", () => {
+    const history = source("agent-backup-restore-history.ts");
+    const finalizer = exportedFunction(history, "commitAgentBackupRestore");
+    expectOrder(
+      finalizer,
+      ".from(agentSandboxes)",
+      ".from(agentBackupCatalogAuthorities)",
+      "restore finalizer",
+    );
+    expectOrder(
+      finalizer,
+      "lockCurrentNodeHistory(tx",
+      ".from(agentBackupCatalogAuthorities)",
+      "restore finalizer",
+    );
+  });
+
+  test("reservation, capture, and vault rotation preserve the same order", () => {
+    const catalog = source("agent-backup-catalog.ts");
+    const vault = source("agent-vault-key-authority.ts");
+    const reservation = exportedFunction(
+      catalog,
+      "reserveAgentBackupOperationInTransaction",
+      "claimDueAgentBackupOperations",
+    );
+    const capture = exportedFunction(
+      catalog,
+      "recordCapturedAgentBackupManifest",
+      "transitionAgentBackupOperation",
+    );
+    const rotation = exportedFunction(
+      vault,
+      "createOrRotateAgentVaultKeyGeneration",
+      "loadCurrentAgentVaultKeyAuthority",
+    );
+
+    expectOrder(
+      reservation,
+      ".from(agentSandboxes)",
+      "createAndLockCatalogAuthority(",
+      "reservation",
+    );
+    expectOrder(capture, ".from(agentSandboxes)", "lockAgentBackupCatalogAuthority(", "capture");
+    expectOrder(
+      rotation,
+      ".from(agentSandboxes)",
+      "lockAgentBackupCatalogAuthority(",
+      "vault rotation",
+    );
+  });
+
+  test("scheduler reservation joins backup order before its outer sandbox lock", () => {
+    const scheduler = source("agent-backup-scheduler.ts");
+    const reservation = exportedFunction(
+      scheduler,
+      "reserveClaimedAgentBackupSchedule",
+      "deferClaimedAgentBackupSchedule",
+    );
+
+    expectOrder(
+      reservation,
+      "lockAgentBackupReservationReplayInTransaction(tx",
+      "lockClaimedSandbox(tx",
+      "scheduler reservation",
+    );
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
@@ -1169,6 +1169,7 @@ describe("strict restore catalogue authority", () => {
       .select({ revision: agentBackupCatalogAuthorities.catalog_revision })
       .from(agentBackupCatalogAuthorities)
       .where(eq(agentBackupCatalogAuthorities.agent_id, AGENT_ID));
+    if (!epochBefore) throw new Error("Expected vault-created catalogue authority");
     await dbWrite
       .update(agentBackupCatalogAuthorities)
       .set({ catalog_revision: epochBefore.revision + 1n })

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
@@ -1163,6 +1163,29 @@ describe("strict restore catalogue authority", () => {
         targetNodeIncarnation: "00000000-0000-4000-8000-00000000d050",
       }),
     ).rejects.toThrow("unattested, changed, or blocked");
+    // The seed receipt is append-only (0250), so a stale catalogue epoch must be
+    // refused BEFORE the row exists rather than left as an unremovable record.
+    const [epochBefore] = await dbWrite
+      .select({ revision: agentBackupCatalogAuthorities.catalog_revision })
+      .from(agentBackupCatalogAuthorities)
+      .where(eq(agentBackupCatalogAuthorities.agent_id, AGENT_ID));
+    await dbWrite
+      .update(agentBackupCatalogAuthorities)
+      .set({ catalog_revision: epochBefore.revision + 1n })
+      .where(eq(agentBackupCatalogAuthorities.agent_id, AGENT_ID));
+    await expect(recordAgentVaultKeySeedReceipt(seedInput)).rejects.toThrow(
+      "lost its exact live restore lease",
+    );
+    const [seedAfterStaleEpoch] = await dbWrite
+      .select({ id: agentVaultKeySeedReceipts.id })
+      .from(agentVaultKeySeedReceipts)
+      .where(eq(agentVaultKeySeedReceipts.id, SEED_RECEIPT_ID));
+    expect(seedAfterStaleEpoch).toBeUndefined();
+    await dbWrite
+      .update(agentBackupCatalogAuthorities)
+      .set({ catalog_revision: epochBefore.revision })
+      .where(eq(agentBackupCatalogAuthorities.agent_id, AGENT_ID));
+
     const [seedFirst, seedReplay] = await Promise.all([
       recordAgentVaultKeySeedReceipt(seedInput),
       recordAgentVaultKeySeedReceipt(seedInput),
@@ -1212,6 +1235,20 @@ describe("strict restore catalogue authority", () => {
       .update(agentBackupRestoreLeases)
       .set({ expires_at: originalLeaseExpiry })
       .where(eq(agentBackupRestoreLeases.id, acquired.authority.leaseId));
+
+    // A target that reboots between publication and commit must not earn a
+    // permanent receipt naming an incarnation that no longer exists.
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: "00000000-0000-4000-8000-00000000d055" })
+      .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+    await expect(commitAgentBackupRestore(finalInput)).rejects.toThrow(
+      "Target node incarnation is absent",
+    );
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: TARGET_NODE_INCARNATION })
+      .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
 
     await releaseAgentBackupRestoreLease(acquired.authority);
     await expect(commitAgentBackupRestore(finalInput)).rejects.toThrow(

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
@@ -777,14 +777,11 @@ export async function commitAgentBackupRestore(
     // between publication and commit otherwise earns a receipt naming an
     // incarnation that no longer exists, which authorizeAgentActivationDispatch
     // already refuses to dispatch onto.
-    const history = await lockCurrentNodeHistory(tx, {
+    await lockCurrentNodeHistory(tx, {
       nodeRecordId: publication.docker_node_record_id,
       nodeId: publication.node_id,
       nodeIncarnation: publication.node_incarnation,
     });
-    if (history.id !== seed.node_history_id) {
-      conflict("Final restore target node incarnation changed since the vault seed");
-    }
     const verifiedAt = await readPostLockDatabaseNow(tx);
     if (lease.expires_at.getTime() <= verifiedAt.getTime()) {
       conflict("Final restore lease expired while mutable authorities were revalidated");

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
@@ -427,6 +427,23 @@ export async function recordAgentVaultKeySeedReceipt(
     ) {
       conflict("Vault seed source is absent or lacks restorable manifest-v3 authority");
     }
+    // Locked between the backup and the lease so both writers take the same
+    // order (commitAgentBackupRestore does backup -> authority -> lease ->
+    // sandbox); any other position deadlocks the two against each other.
+    const [authority] = await tx
+      .select()
+      .from(agentBackupCatalogAuthorities)
+      .where(
+        and(
+          eq(agentBackupCatalogAuthorities.organization_id, input.organizationId),
+          eq(agentBackupCatalogAuthorities.agent_id, input.agentId),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!authority) {
+      conflict("Vault seed catalogue authority is absent");
+    }
     const [lease] = await tx
       .select()
       .from(agentBackupRestoreLeases)
@@ -451,7 +468,8 @@ export async function recordAgentVaultKeySeedReceipt(
       lease.operation_id !== backup.backup_operation_id ||
       lease.activation_generation !== backup.lifecycle_generation ||
       lease.lifecycle_revision !== backup.lifecycle_revision ||
-      lease.expected_manifest_sha256 !== backup.manifest_digest
+      lease.expected_manifest_sha256 !== backup.manifest_digest ||
+      lease.catalog_epoch !== authority.catalog_revision
     ) {
       conflict("Vault seed lost its exact live restore lease");
     }
@@ -752,6 +770,20 @@ export async function commitAgentBackupRestore(
       sandbox.activation_lifecycle_revision !== publication.lifecycle_revision
     ) {
       conflict("Final restore lost exact current sandbox activation authority");
+    }
+    // The permanent receipt attests a restore onto a specific boot. Row-lock the
+    // node and re-prove that boot is still the live one, exactly as the seed
+    // writer does before its own append-only write: a target that reboots
+    // between publication and commit otherwise earns a receipt naming an
+    // incarnation that no longer exists, which authorizeAgentActivationDispatch
+    // already refuses to dispatch onto.
+    const history = await lockCurrentNodeHistory(tx, {
+      nodeRecordId: publication.docker_node_record_id,
+      nodeId: publication.node_id,
+      nodeIncarnation: publication.node_incarnation,
+    });
+    if (history.id !== seed.node_history_id) {
+      conflict("Final restore target node incarnation changed since the vault seed");
     }
     const verifiedAt = await readPostLockDatabaseNow(tx);
     if (lease.expires_at.getTime() <= verifiedAt.getTime()) {

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
@@ -77,11 +77,24 @@ async function lockCurrentNodeHistory(
       provider_server_id: node.provider_server_id,
       host_key_fingerprint: node.host_key_fingerprint,
     })
-    .onConflictDoNothing({ target: agentNodeIncarnationHistories.node_incarnation });
+    .onConflictDoNothing({
+      target: [
+        agentNodeIncarnationHistories.docker_node_record_id,
+        agentNodeIncarnationHistories.node_incarnation,
+      ],
+    });
+  // Read back on the same composite key the insert arbitrates on. A boot id is
+  // unique per node record, not globally (0259), so selecting on the incarnation
+  // alone would pick an arbitrary record's row once a host re-registers.
   const [history] = await tx
     .select()
     .from(agentNodeIncarnationHistories)
-    .where(eq(agentNodeIncarnationHistories.node_incarnation, input.nodeIncarnation))
+    .where(
+      and(
+        eq(agentNodeIncarnationHistories.docker_node_record_id, node.id),
+        eq(agentNodeIncarnationHistories.node_incarnation, input.nodeIncarnation),
+      ),
+    )
     .limit(1);
   if (
     !history ||

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
@@ -427,23 +427,6 @@ export async function recordAgentVaultKeySeedReceipt(
     ) {
       conflict("Vault seed source is absent or lacks restorable manifest-v3 authority");
     }
-    // Locked between the backup and the lease so both writers take the same
-    // order (commitAgentBackupRestore does backup -> authority -> lease ->
-    // sandbox); any other position deadlocks the two against each other.
-    const [authority] = await tx
-      .select()
-      .from(agentBackupCatalogAuthorities)
-      .where(
-        and(
-          eq(agentBackupCatalogAuthorities.organization_id, input.organizationId),
-          eq(agentBackupCatalogAuthorities.agent_id, input.agentId),
-        ),
-      )
-      .for("update")
-      .limit(1);
-    if (!authority) {
-      conflict("Vault seed catalogue authority is absent");
-    }
     const [lease] = await tx
       .select()
       .from(agentBackupRestoreLeases)
@@ -468,8 +451,7 @@ export async function recordAgentVaultKeySeedReceipt(
       lease.operation_id !== backup.backup_operation_id ||
       lease.activation_generation !== backup.lifecycle_generation ||
       lease.lifecycle_revision !== backup.lifecycle_revision ||
-      lease.expected_manifest_sha256 !== backup.manifest_digest ||
-      lease.catalog_epoch !== authority.catalog_revision
+      lease.expected_manifest_sha256 !== backup.manifest_digest
     ) {
       conflict("Vault seed lost its exact live restore lease");
     }
@@ -516,6 +498,24 @@ export async function recordAgentVaultKeySeedReceipt(
       nodeId: sandbox.activation_node_id,
       nodeIncarnation: input.targetNodeIncarnation,
     });
+    // Backup writers that also fence a live sandbox take sandbox and node
+    // authority before the per-agent catalogue authority. Keeping this global
+    // order aligned with reservation/capture and vault-key rotation prevents
+    // sandbox <-> catalogue-authority AB-BA deadlocks.
+    const [authority] = await tx
+      .select()
+      .from(agentBackupCatalogAuthorities)
+      .where(
+        and(
+          eq(agentBackupCatalogAuthorities.organization_id, input.organizationId),
+          eq(agentBackupCatalogAuthorities.agent_id, input.agentId),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!authority || lease.catalog_epoch !== authority.catalog_revision) {
+      conflict("Vault seed lost its exact live restore lease");
+    }
     const finalDatabaseNow = await readPostLockDatabaseNow(tx);
     if (lease.expires_at.getTime() <= finalDatabaseNow.getTime()) {
       conflict("Vault seed lease expired while mutable authorities were revalidated");
@@ -657,20 +657,6 @@ export async function commitAgentBackupRestore(
       conflict("Final restore source is absent, already finalized, or no longer restorable");
     }
     assertAgentBackupCatalogTransition({ from: backup.catalog_state, to: "restore_verified" });
-    const [authority] = await tx
-      .select()
-      .from(agentBackupCatalogAuthorities)
-      .where(
-        and(
-          eq(agentBackupCatalogAuthorities.organization_id, input.organizationId),
-          eq(agentBackupCatalogAuthorities.agent_id, input.agentId),
-        ),
-      )
-      .for("update")
-      .limit(1);
-    if (!authority || authority.restore_generation >= MAX_SIGNED_BIGINT) {
-      conflict("Restore generation authority is absent or exhausted");
-    }
     const [seed] = await tx
       .select()
       .from(agentVaultKeySeedReceipts)
@@ -738,8 +724,7 @@ export async function commitAgentBackupRestore(
       lease.operation_id !== seed.operation_id ||
       lease.activation_generation !== seed.source_activation_generation ||
       lease.lifecycle_revision !== seed.source_lifecycle_revision ||
-      lease.expected_manifest_sha256 !== seed.manifest_sha256 ||
-      lease.catalog_epoch !== authority.catalog_revision
+      lease.expected_manifest_sha256 !== seed.manifest_sha256
     ) {
       conflict("Final restore lost its exact live restore lease");
     }
@@ -782,6 +767,27 @@ export async function commitAgentBackupRestore(
       nodeId: publication.node_id,
       nodeIncarnation: publication.node_incarnation,
     });
+    // Match every sandbox-bearing backup writer: sandbox and node authority
+    // precede catalogue authority. Writers without a sandbox still serialize
+    // on the already-locked backup row before reaching this authority.
+    const [authority] = await tx
+      .select()
+      .from(agentBackupCatalogAuthorities)
+      .where(
+        and(
+          eq(agentBackupCatalogAuthorities.organization_id, input.organizationId),
+          eq(agentBackupCatalogAuthorities.agent_id, input.agentId),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (
+      !authority ||
+      authority.restore_generation >= MAX_SIGNED_BIGINT ||
+      lease.catalog_epoch !== authority.catalog_revision
+    ) {
+      conflict("Restore generation authority is absent, stale, or exhausted");
+    }
     const verifiedAt = await readPostLockDatabaseNow(tx);
     if (lease.expires_at.getTime() <= verifiedAt.getTime()) {
       conflict("Final restore lease expired while mutable authorities were revalidated");

--- a/packages/cloud/shared/src/db/schemas/agent-backup-restore-history.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-backup-restore-history.ts
@@ -37,9 +37,6 @@ export const agentNodeIncarnationHistories = pgTable(
     attested_at: timestamp("attested_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
-    incarnation_unique: unique("agent_node_incarnation_histories_incarnation_unique").on(
-      table.node_incarnation,
-    ),
     record_incarnation_unique: unique(
       "agent_node_incarnation_histories_record_incarnation_unique",
     ).on(table.docker_node_record_id, table.node_incarnation),


### PR DESCRIPTION
## Summary

This draft repairs the restore-authority foundation from #21851 on current `develop`. It keeps the useful append-only receipt design but closes the global lock inversion and node-incarnation re-arm wedge before dormant restore writers gain production callers.

Refs #22327.

- Both immutable receipt writers now lock the sandbox and exact node incarnation **before** catalogue authority, matching every live backup/restore writer chain.
- The lock-order contract covers seed/final writers, reservation, capture, vault rotation, and scheduler replay.
- Migration `0259_agent_node_incarnation_rearm` removes incorrect global boot UUID uniqueness and uses `(docker_node_record_id, node_incarnation)`. Repository lookup is composite too.
- Seed/final writers revalidate live catalogue epoch, lease, sandbox generation, exact node record/incarnation, and receipt graph under the shared order.
- The restore surface remains definition-only; this PR activates no production coordinator/caller.

## Corrected lock order

The prior draft took catalogue authority before sandbox/node. That inverted the established reservation/capture order and permitted a real PostgreSQL deadlock:

```
receipt writer: catalogue authority -> sandbox
reservation:    sandbox -> catalogue authority
```

The repair uses:

```
backup/replay -> lease -> sandbox -> node incarnation -> catalogue authority -> receipt append
```

Mutation proof restores the old order: PostgreSQL reproduces `40P01`, and seed/final static assertions fail.

## Migration

Live tail is `0256`, `0257`, `0258`, then `0259` at journal idx `258`, timestamp `1791835200000`. The migration is idempotent, preserves immutable typed identity per node record/incarnation, and tests the original 0246 wedge plus identity-rewrite rejection.

## Exact-head verification

Head: `7264e8c72d998f983315785c7261a3c6fe048fce`  
Base: `419e5ed811976141108ef4b0aaf1dfaa6a76281d`

- Migration replay: **11/11**, 24 assertions.
- Static global lock order: **4/4**, 30 assertions.
- Restore-authority PGlite: **9/9**, 94 assertions.
- Real multi-connection PostgreSQL: **5/5**, 10 assertions, including seed/final writers racing a sandbox-first reservation. A fresh isolated local PostgreSQL 16 cluster was used because the desktop Docker daemon was unresponsive; nothing was skipped or faked.
- Cloud-shared typecheck: pass.
- Package Biome: **2082 files**, pass.
- Drizzle: pass.
- Root `bun run verify`: **358/358**, pass.
- Diff check: pass.

The full cloud-shared lane stops at the unchanged `provisioning-jobs-delete-lifecycle.test.ts` assertion (`retried` expected 1, received 0). It reproduces isolated and does not import/touch this PR's files. All owned suites pass independently.

No shared migration, customer state, or production state was mutated. Keep draft until an independent reviewer checks this exact head.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI GPT-5.6`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - repository guide and direct audit`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

<!-- evidence-head:7264e8c72d998f983315785c7261a3c6fe048fce -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - database and repository change; no rendered UI
<!-- evidence-row:after-screenshots -->
- [ ] N/A - database and repository change; no rendered UI
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - dormant repository surface has no user-facing flow
<!-- evidence-row:backend-logs -->
- [x] [22230-exact-head-backend-logs-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22230-exact-head-backend-logs-v2.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or runtime path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent behavior
<!-- evidence-row:domain-artifacts -->
- [x] [22230-exact-head-domain-artifacts-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22230-exact-head-domain-artifacts-v2.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual artifact

