### PR TITLE
fix(ui): preserve Android SMS gateway error details with fetch timeout

### DIFF
--- a/packages/ui/src/components/pages/ElizaOsAppsView.sms-gateway.test.ts
+++ b/packages/ui/src/components/pages/ElizaOsAppsView.sms-gateway.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Preserve Android SMS gateway error details with fetch timeout.
+ * The helper must keep the deadline active through response.json(),
+ * return non-2xx bodies to the UI boundary with details, and still
+ * succeed on valid replies.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../agent-surface", () => ({ useAgentElement: () => undefined }));
+vi.mock("../../bridge/plugin-bridge", () => ({ getPlugins: () => ({}) }));
+vi.mock("../../state/TranslationContext.hooks", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("../ui/button", () => ({ Button: () => null }));
+vi.mock("../ui/input", () => ({ Input: () => null }));
+vi.mock("../ui/textarea", () => ({ Textarea: () => null }));
+vi.mock("../views/ShellViewAgentSurface", () => ({
+  ShellViewAgentSurface: () => null,
+}));
+
+import {
+  ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS,
+  forwardAndroidSmsGateway,
+  type IncomingSmsContext,
+} from "./ElizaOsAppsView";
+
+const incoming: IncomingSmsContext = {
+  sender: "+14155550100",
+  body: "hello",
+  timestamp: Date.now(),
+  messageId: "msg-1",
+};
+
+function stallOnSignal(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("expected abort signal");
+      const onAbort = () => reject(signal.reason);
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    })) as typeof fetch;
+}
+
+describe("forwardAndroidSmsGateway", () => {
+  it("keeps the deadline active for a stalled fetch", async () => {
+    const signal = new AbortController().signal;
+    await expect(
+      forwardAndroidSmsGateway(incoming, signal, stallOnSignal(), 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("keeps the deadline active while the response body is consumed", async () => {
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      const signal = init?.signal;
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            // do not enqueue or close, just wait for abort to error the stream
+            signal?.addEventListener(
+              "abort",
+              () => controller.error(signal.reason),
+              { once: true },
+            );
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+
+    const signal = new AbortController().signal;
+    await expect(
+      forwardAndroidSmsGateway(incoming, signal, fetchImpl, 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("preserves a completed provider error response body in the thrown error", async () => {
+    const errorBody = { error: "quota exceeded", code: 429 };
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify(errorBody), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      });
+
+    const signal = new AbortController().signal;
+    await expect(
+      forwardAndroidSmsGateway(incoming, signal, fetchImpl, 10_000),
+    ).rejects.toThrow(
+      `Cloud gateway failed (500): ${JSON.stringify(errorBody)}`,
+    );
+  });
+
+  it("returns a successfully parsed reply on 200", async () => {
+    const reply = { replyText: "hi from cloud", success: true };
+    const fetchImpl: typeof fetch = async () =>
+      Response.json(reply, { status: 200 });
+
+    const signal = new AbortController().signal;
+    await expect(
+      forwardAndroidSmsGateway(incoming, signal, fetchImpl, 10_000),
+    ).resolves.toEqual(reply);
+  });
+
+  it("throws unparseable for an ok response with invalid json shape", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify(null), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+
+    const signal = new AbortController().signal;
+    await expect(
+      forwardAndroidSmsGateway(incoming, signal, fetchImpl, 10_000),
+    ).rejects.toThrow("Cloud gateway returned an unparseable reply");
+  });
+
+  it("uses the exported timeout constant", () => {
+    expect(ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS).toBe(15_000);
+  });
+});

--- a/packages/ui/src/components/pages/ElizaOsAppsView.tsx
+++ b/packages/ui/src/components/pages/ElizaOsAppsView.tsx
@@ -141,7 +141,7 @@ const ANDROID_SMS_GATEWAY_PHONE_LABEL = String(
   import.meta.env.VITE_ELIZA_ANDROID_SMS_GATEWAY_PHONE_LABEL ??
     "Eliza Cloud Gateway (+14159611510)",
 );
-const ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS = 15_000;
+export const ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS = 15_000;
 
 function useLaunchParams(): URLSearchParams {
   const [params, setParams] = useState(() => readLaunchParams());
@@ -1476,14 +1476,14 @@ function messageTypeLabel(type: number): string {
   return `type ${type}`;
 }
 
-interface IncomingSmsContext {
+export interface IncomingSmsContext {
   sender: string;
   body: string;
   timestamp: number | null;
   messageId: string | null;
 }
 
-interface AndroidSmsGatewayReply {
+export interface AndroidSmsGatewayReply {
   success?: boolean;
   handled?: boolean;
   reason?: string;
@@ -1512,7 +1512,7 @@ function initialMessageBody(params: URLSearchParams): string {
     : (params.get("body") ?? "");
 }
 
-function androidSmsGatewayPayload(incoming: IncomingSmsContext) {
+export function androidSmsGatewayPayload(incoming: IncomingSmsContext) {
   return {
     type: "new-message",
     data: {
@@ -1543,9 +1543,11 @@ function androidSmsGatewayPayload(incoming: IncomingSmsContext) {
   };
 }
 
-async function forwardAndroidSmsGateway(
+export async function forwardAndroidSmsGateway(
   incoming: IncomingSmsContext,
   signal: AbortSignal,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs: number = ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS,
 ): Promise<AndroidSmsGatewayReply> {
   return await fetchWithDeadline(
     ANDROID_SMS_GATEWAY_WEBHOOK_URL,
@@ -1559,16 +1561,31 @@ async function forwardAndroidSmsGateway(
       body: JSON.stringify(androidSmsGatewayPayload(incoming)),
     },
     async (response) => {
-      if (!response.ok) {
-        throw new Error(`Cloud gateway failed (${response.status})`);
+      let cloudReply: AndroidSmsGatewayReply | Record<string, never> = {};
+      let parsed: unknown = cloudReply;
+      let parseFailed = false;
+      try {
+        parsed = await response.json();
+        cloudReply = parsed as AndroidSmsGatewayReply;
+      } catch {
+        parseFailed = true;
       }
-      const body: unknown = await response.json();
-      if (body === null || typeof body !== "object" || Array.isArray(body)) {
-        throw new Error("Cloud gateway returned an unparseable reply");
+      if (response.ok) {
+        if (
+          parseFailed ||
+          parsed === null ||
+          typeof parsed !== "object" ||
+          Array.isArray(parsed)
+        ) {
+          throw new Error("Cloud gateway returned an unparseable reply");
+        }
+        return cloudReply as AndroidSmsGatewayReply;
       }
-      return body as AndroidSmsGatewayReply;
+      throw new Error(
+        `Cloud gateway failed (${response.status}): ${JSON.stringify(cloudReply)}`,
+      );
     },
-    { signal, timeoutMs: ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS },
+    { signal, timeoutMs, fetchImpl },
   );
 }
 


### PR DESCRIPTION
Closes #21843

## Summary
- `forwardAndroidSmsGateway` in `ElizaOsAppsView.tsx` kept its 15s `fetchWithDeadline` but the extracted helper threw on every `!response.ok` **before** `response.json()`, discarding the provider's structured diagnostic body that `MessagesPageView`'s UI boundary is responsible for decoding and surfacing.
- Restores the pre-`#21816` detailed error path: `response.json()` is attempted regardless of status, the parsed body (or `{}` if unparseable and non-ok) is included as `JSON.stringify(cloudReply)` in the `Cloud gateway failed (status): ...` error, and `fetchWithDeadline` keeps the deadline active through `response.json()`. On `response.ok` a non-object/parse-failure still throws `Cloud gateway returned an unparseable reply`.

## What Changed
- `packages/ui/src/components/pages/ElizaOsAppsView.tsx`: export `ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS`, `IncomingSmsContext`, `AndroidSmsGatewayReply`, `androidSmsGatewayPayload`, and `forwardAndroidSmsGateway`; add `fetchImpl` and `timeoutMs` params (defaults to `fetch` and `15_000`) for testability; replace the `if (!response.ok) throw` + `await response.json()` block with a `try { parsed = await response.json() } catch` that preserves `cloudReply` and branches on `response.ok` to either return the parsed reply or throw `Cloud gateway failed (status): ${JSON.stringify(cloudReply)}`.
- `packages/ui/src/components/pages/ElizaOsAppsView.sms-gateway.test.ts` (new): 6 behavioral tests — stalled fetch timeout, stalled `response.json()` body timeout (deadline through body), completed provider-error body preservation, 200 success, unparseable-ok, and exported constant check.

## Exact-head evidence
Head: 69fa5b1ee8ee0c6b940f76205cb7cb87518d1378
Base: origin/develop@3c9d84940e2355ce0749ac1ad8a67bb37e4d1d23 with zero conflicts

## Verification / Definition of Done
- [x] Targets `develop`, rebased onto `origin/develop@3c9d84940e2355ce0749ac1ad8a67bb37e4d1d23` zero conflicts
- [x] `bun install --frozen-lockfile` — no lockfile change, passes
- [x] `bunx vitest run packages/ui/src/components/pages/ElizaOsAppsView.sms-gateway.test.ts` — 6/6 passed
- [x] `bunx vitest run packages/ui/src/components/pages/ElizaOsAppsView.encoding.test.ts packages/ui/src/components/pages/ElizaOsAppsView.permission-gate.test.ts` — 12/12 passed (no regression)
- [x] `bunx biome check packages/ui/src/components/pages/ElizaOsAppsView.tsx packages/ui/src/components/pages/ElizaOsAppsView.sms-gateway.test.ts` — no fixes, no errors
- [x] `git diff --check origin/develop...HEAD` — no whitespace errors
- [x] Reviewer can confirm from automated tests: stalled fetch and stalled body both reject with `TimeoutError`, 500 with `{"error":"quota exceeded"}` throws `Cloud gateway failed (500): {"error":"quota exceeded",...}`, 200 returns the reply, and unparseable ok throws `Cloud gateway returned an unparseable reply`.

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3c9d84940e2355ce0749ac1ad8a67bb37e4d1d23:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@3c9d84940e2355ce0749ac1ad8a67bb37e4d1d23:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3c9d84940e2355ce0749ac1ad8a67bb37e4d1d23:packages/skills/skills/contribute-to-eliza"} -->

Co-authored-by: byt61 <byt61@users.noreply.github.com>

# Sync with develop
- [x] Rebased onto current `origin/develop` before the exact-head validation; zero conflicts.
- [x] Frozen `bun install` completed.
- [x] Exact focused tests, Biome, and diff check pass.

# Risks
Low and bounded to the Android SMS gateway forward path in `ElizaOsAppsView.tsx` (`forwardAndroidSmsGateway` helper). The change only restores body preservation for non-2xx responses and keeps the existing `fetchWithDeadline` 15s deadline active through `response.json()`; successful 200 handling and the `MessagesPageView` UI error boundary are unchanged. No new dependencies, no migration, no I/O. The helper now exports `fetchImpl`/`timeoutMs` for tests but the `MessagesPageView` call site still uses defaults, so runtime behavior is identical except for the preserved diagnostic payload.

# Background
## What does this PR do?
Before `#21816` the `MessagesPageView` SMS forward did `await fetch(...)` then `try { cloudReply = await response.json() } catch { if (response.ok) throw unparseable }` and on `!response.ok` threw ``Cloud gateway failed (${status}): ${JSON.stringify(cloudReply)}`` — preserving the provider's structured error body for the UI's `setError` boundary. `#21816` extracted `forwardAndroidSmsGateway` with `fetchWithDeadline` but changed the consume to `if (!response.ok) throw` **before** `response.json()`, making every non-2xx discard its body and surface only `Cloud gateway failed (500)` without details. This PR restores the detailed path while keeping the 15s deadline (including through `response.json()` via `fetchWithDeadline`'s `Promise.race([consume, aborted])`).

## What kind of change is this?
Bug fix.

# Testing
## Where should a reviewer start?
- `packages/ui/src/components/pages/ElizaOsAppsView.tsx:144,1515-1585`
- `packages/ui/src/components/pages/ElizaOsAppsView.sms-gateway.test.ts:1-120`

## Detailed testing steps
On exact head `69fa5b1ee8ee0c6b940f76205cb7cb87518d1378`:
- `bunx vitest run packages/ui/src/components/pages/ElizaOsAppsView.sms-gateway.test.ts` — 6/6 passed:
  - `keeps the deadline active for a stalled fetch` — `stallOnSignal` fetch with `timeoutMs=10` rejects `TimeoutError`.
  - `keeps the deadline active while the response body is consumed` — `Response` with `ReadableStream` that errors on abort, `timeoutMs=10` rejects `TimeoutError` (proves deadline through `response.json()`).
  - `preserves a completed provider error response body` — `500` with `{"error":"quota exceeded"}` rejects `Cloud gateway failed (500): {"error":"quota exceeded",...}`.
  - `returns a successfully parsed reply on 200` — `200` with `{"replyText":"hi"}` resolves to that object.
  - `throws unparseable for an ok response with invalid json shape` — `200` with `null` body throws `Cloud gateway returned an unparseable reply`.
  - `uses the exported timeout constant` — `ANDROID_SMS_GATEWAY_FETCH_TIMEOUT_MS === 15_000`.
- `bunx vitest run packages/ui/src/components/pages/ElizaOsAppsView.encoding.test.ts packages/ui/src/components/pages/ElizaOsAppsView.permission-gate.test.ts` — 12/12 passed.
- `bunx biome check` — no fixes.
- `git diff --check origin/develop...HEAD` — no whitespace errors.

# Evidence Gate
<!-- evidence-head:69fa5b1ee8ee0c6b940f76205cb7cb87518d1378 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only SMS gateway forward; no rendered UI surface change beyond preserved error string.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only SMS gateway forward; no rendered UI surface change beyond preserved error string.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic fetch/timeout handling with no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Backend log: `bunx vitest run ...ElizaOsAppsView.sms-gateway.test.ts` 6/6 green and provider-error body preserved in thrown message (see Detailed testing steps).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request beyond the SMS gateway POST; error is surfaced via existing `setError` boundary.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action routing, or agent planning change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain artifact; gateway forward is transient.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text surface changed.

# Known gaps / failures
None. Focused and related tests pass on the exact head. Full `bun run verify` not run as only the SMS gateway forward boundary was touched; broader CI failures if any are unrelated and documented in CI.
