### PR TITLE
fix(plugin-imessage): keep UTF-16 surrogate pairs intact in splitMessageForIMessage

### DIFF
--- a/plugins/plugin-imessage/__tests__/integration.test.ts
+++ b/plugins/plugin-imessage/__tests__/integration.test.ts
@@ -235,6 +235,17 @@ describe("splitMessageForIMessage", () => {
     const result = splitMessageForIMessage("");
     expect(result).toEqual([""]);
   });
+
+  it("keeps surrogate pairs intact at hard break points", () => {
+    const text = "aaaaa\u{1F98A}bbbbb";
+    const result = splitMessageForIMessage(text, 6);
+    expect(result.length).toBeGreaterThan(1);
+    for (const chunk of result) {
+      expect(chunk.isWellFormed()).toBe(true);
+      expect(chunk.length).toBeLessThanOrEqual(6);
+    }
+    expect(result.join("")).toBe(text);
+  });
 });
 
 // ============================================================

--- a/plugins/plugin-imessage/src/types.ts
+++ b/plugins/plugin-imessage/src/types.ts
@@ -2,7 +2,7 @@
  * Type definitions for the iMessage plugin.
  */
 
-import type { Service } from "@elizaos/core";
+import { type Service, truncateWellFormed } from "@elizaos/core";
 
 /** Maximum message length for iMessage */
 export const MAX_IMESSAGE_MESSAGE_LENGTH = 4000;
@@ -308,8 +308,11 @@ export function splitMessageForIMessage(
       }
     }
 
-    chunks.push(remaining.slice(0, breakPoint).trimEnd());
-    remaining = remaining.slice(breakPoint).trimStart();
+    const chunkCandidate = truncateWellFormed(remaining, breakPoint);
+    const cutPoint = chunkCandidate.length > 0 ? chunkCandidate.length : breakPoint;
+
+    chunks.push(remaining.slice(0, cutPoint).trimEnd());
+    remaining = remaining.slice(cutPoint).trimStart();
   }
 
   return chunks;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c43d50aa11b99d37892ed208743f85b5f33c8489 -->

Fixes an issue in `splitMessageForIMessage` (`plugins/plugin-imessage/src/types.ts`) where chunking messages using raw `.slice(0, breakPoint)` could split UTF-16 surrogate pairs (such as emojis and astral plane characters) when falling back to hard break points, creating malformed strings and lone surrogate code units.

### Changes
- Replaces raw slicing with `truncateWellFormed(remaining, breakPoint)` from `@elizaos/core`.
- Adds regression unit test in `plugins/plugin-imessage/__tests__/integration.test.ts` verifying emoji surrogate pairs remain intact across message chunks.

### Testing
- `npx vitest run plugins/plugin-imessage/__tests__/integration.test.ts`: 87/87 tests passed.
- `biome check`: Clean.

<!-- contribution-provenance:v1
agent: eliza-auto-coder
source: packages/skills/skills/contribute-to-eliza
revision: 8808863b16a957a091a2b08a60d8cfc4f97213c6
timestamp: 2026-08-18T22:44:40Z
-->
