### PR TITLE
fix(plugin-instagram): keep UTF-16 surrogate pairs intact in splitMessage

### DIFF
--- a/plugins/plugin-instagram/src/__tests__/split-message.test.ts
+++ b/plugins/plugin-instagram/src/__tests__/split-message.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { splitMessage } from "../service";
+
+describe("splitMessage", () => {
+  it("keeps surrogate pairs intact when splitting words by characters", () => {
+    // 5 chars + emoji (2 code units) at position 5-6 + more chars
+    // With maxLength = 6, naive slice(0, 6) splits the emoji surrogate pair.
+    const text = "aaaaa\u{1F98A}bbbbb";
+    const parts = splitMessage(text, 6);
+    expect(parts.length).toBeGreaterThan(1);
+    for (const part of parts) {
+      expect(part.isWellFormed()).toBe(true);
+      expect(part.length).toBeLessThanOrEqual(6);
+    }
+    expect(parts.join("")).toBe(text);
+  });
+
+  it("handles basic message splitting within limits", () => {
+    const msg = "Hello world from instagram connector test";
+    const parts = splitMessage(msg, 10);
+    expect(parts.length).toBeGreaterThan(1);
+    for (const part of parts) {
+      expect(part.length).toBeLessThanOrEqual(10);
+    }
+  });
+});

--- a/plugins/plugin-instagram/src/service.ts
+++ b/plugins/plugin-instagram/src/service.ts
@@ -23,6 +23,7 @@ import {
   Service,
   stringToUuid,
   type TargetInfo,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
 import {
@@ -1017,9 +1018,13 @@ export function splitMessage(content: string, maxLength: number): string[] {
             }
 
             if (word.length > maxLength) {
-              // Split by characters
-              for (let i = 0; i < word.length; i += maxLength) {
-                parts.push(word.slice(i, i + maxLength));
+              // Split by characters (surrogate-safe)
+              let remainingWord = word;
+              while (remainingWord.length > 0) {
+                const chunk = truncateWellFormed(remainingWord, maxLength);
+                const cutPoint = chunk.length > 0 ? chunk.length : maxLength;
+                parts.push(remainingWord.slice(0, cutPoint));
+                remainingWord = remainingWord.slice(cutPoint);
               }
             } else {
               current = word;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:2c35de486877dacbf21805d6b55e413ddc2cf779 -->

Fixes an issue in `splitMessage` (`plugins/plugin-instagram/src/service.ts`) where long words split across character limits using raw `.slice(i, i + maxLength)` could cut UTF-16 surrogate pairs (e.g. emojis or astral plane characters) in half, creating malformed strings and lone surrogate code units.

### Changes
- Uses `truncateWellFormed(remainingWord, maxLength)` from `@elizaos/core` to ensure character boundaries respect UTF-16 surrogate pairs.
- Adds regression unit test in `plugins/plugin-instagram/src/__tests__/split-message.test.ts` verifying emoji surrogate pairs remain intact across message chunks.

### Testing
- `npx vitest run plugins/plugin-instagram/src/__tests__/split-message.test.ts plugins/plugin-instagram/src/__tests__/accounts.test.ts`: 24/24 tests passed.
- `biome check`: Clean.

<!-- contribution-provenance:v1
agent: eliza-auto-coder
source: packages/skills/skills/contribute-to-eliza
revision: 8808863b16a957a091a2b08a60d8cfc4f97213c6
timestamp: 2026-08-18T22:45:25Z
-->
