### PR TITLE
fix(agent): bound bug report fetch with timeout

### DIFF
--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -17,6 +17,27 @@ const BUG_REPORT_REPO_FALLBACK_ENV_KEY = "BUG_REPORT_REPO";
 
 export const DEFAULT_BUG_REPORT_FETCH_TIMEOUT_MS = 10_000;
 
+function createBugReportFetchSignal(req: RouteRequestContext["req"]): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const requestAbort = new AbortController();
+  const abortForDisconnectedClient = () => {
+    requestAbort.abort(
+      new DOMException("Bug report request was aborted", "AbortError"),
+    );
+  };
+  req.once("aborted", abortForDisconnectedClient);
+
+  return {
+    signal: AbortSignal.any([
+      requestAbort.signal,
+      AbortSignal.timeout(DEFAULT_BUG_REPORT_FETCH_TIMEOUT_MS),
+    ]),
+    cleanup: () => req.off("aborted", abortForDisconnectedClient),
+  };
+}
+
 function sanitizeRepoName(value: string | undefined): string | null {
   const trimmed = value?.trim();
   if (!trimmed) return null;
@@ -187,7 +208,10 @@ function getRemoteBugReportToken(): string | undefined {
   return process.env.ELIZA_BUG_REPORT_API_TOKEN;
 }
 
-async function submitToRemoteBugIntake(body: BugReportBody) {
+async function submitToRemoteBugIntake(
+  body: BugReportBody,
+  signal: AbortSignal,
+) {
   const remoteBugReportUrl = getRemoteBugReportUrl();
   if (!remoteBugReportUrl) return null;
   const payload = {
@@ -243,7 +267,7 @@ async function submitToRemoteBugIntake(body: BugReportBody) {
         : {}),
     },
     body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(DEFAULT_BUG_REPORT_FETCH_TIMEOUT_MS),
+    signal,
   });
 
   if (!response.ok) {
@@ -306,19 +330,24 @@ export async function handleBugReportRoutes(
     const body = parsedBug.data;
 
     if (getRemoteBugReportUrl()) {
+      const remoteFetch = createBugReportFetchSignal(req);
       try {
-        const result = await submitToRemoteBugIntake(body);
+        const result = await submitToRemoteBugIntake(body, remoteFetch.signal);
         if (!result) {
           error(res, "Failed to submit bug report", 502);
           return true;
         }
         json(res, result);
       } catch (err) {
+        // error-policy:J1 boundary translation — remote intake failures become
+        // an explicit upstream failure response at the HTTP route boundary.
         logger.error(
           { error: err },
           "[bug-report] Remote intake submission failed",
         );
         error(res, "Failed to submit bug report", 502);
+      } finally {
+        remoteFetch.cleanup();
       }
       return true;
     }
@@ -329,6 +358,7 @@ export async function handleBugReportRoutes(
       return true;
     }
 
+    const githubFetch = createBugReportFetchSignal(req);
     try {
       const sanitizedTitle = sanitize(body.description, 80).replace(
         /[\r\n]+/g,
@@ -347,7 +377,7 @@ export async function handleBugReportRoutes(
           body: issueBody,
           labels: ["bug", "triage", "user-reported"],
         }),
-        signal: AbortSignal.timeout(DEFAULT_BUG_REPORT_FETCH_TIMEOUT_MS),
+        signal: githubFetch.signal,
       });
 
       if (!issueRes.ok) {
@@ -366,8 +396,12 @@ export async function handleBugReportRoutes(
       }
       json(res, { url });
     } catch (err) {
+      // error-policy:J1 boundary translation — GitHub transport and response
+      // failures become an explicit route failure instead of fabricated success.
       logger.error({ error: err }, "[bug-report] GitHub issue creation failed");
-      error(res, "Failed to create GitHub issue", 500);
+      error(res, "Failed to create GitHub issue", 502);
+    } finally {
+      githubFetch.cleanup();
     }
     return true;
   }

--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -187,7 +187,7 @@ function getRemoteBugReportToken(): string | undefined {
   return process.env.ELIZA_BUG_REPORT_API_TOKEN;
 }
 
-export async function submitToRemoteBugIntake(body: BugReportBody) {
+async function submitToRemoteBugIntake(body: BugReportBody) {
   const remoteBugReportUrl = getRemoteBugReportUrl();
   if (!remoteBugReportUrl) return null;
   const payload = {

--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -15,6 +15,8 @@ export const DEFAULT_BUG_REPORT_REPO = "elizaOS/eliza";
 export const BUG_REPORT_REPO_ENV_KEY = "ELIZA_BUG_REPORT_REPO";
 const BUG_REPORT_REPO_FALLBACK_ENV_KEY = "BUG_REPORT_REPO";
 
+export const DEFAULT_BUG_REPORT_FETCH_TIMEOUT_MS = 10_000;
+
 function sanitizeRepoName(value: string | undefined): string | null {
   const trimmed = value?.trim();
   if (!trimmed) return null;
@@ -185,7 +187,7 @@ function getRemoteBugReportToken(): string | undefined {
   return process.env.ELIZA_BUG_REPORT_API_TOKEN;
 }
 
-async function submitToRemoteBugIntake(body: BugReportBody) {
+export async function submitToRemoteBugIntake(body: BugReportBody) {
   const remoteBugReportUrl = getRemoteBugReportUrl();
   if (!remoteBugReportUrl) return null;
   const payload = {
@@ -241,6 +243,7 @@ async function submitToRemoteBugIntake(body: BugReportBody) {
         : {}),
     },
     body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(DEFAULT_BUG_REPORT_FETCH_TIMEOUT_MS),
   });
 
   if (!response.ok) {
@@ -344,6 +347,7 @@ export async function handleBugReportRoutes(
           body: issueBody,
           labels: ["bug", "triage", "user-reported"],
         }),
+        signal: AbortSignal.timeout(DEFAULT_BUG_REPORT_FETCH_TIMEOUT_MS),
       });
 
       if (!issueRes.ok) {

--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -27,7 +27,11 @@ function createBugReportFetchSignal(req: RouteRequestContext["req"]): {
       new DOMException("Bug report request was aborted", "AbortError"),
     );
   };
-  req.once("aborted", abortForDisconnectedClient);
+  if (req.aborted) {
+    abortForDisconnectedClient();
+  } else {
+    req.once("aborted", abortForDisconnectedClient);
+  }
 
   return {
     signal: AbortSignal.any([

--- a/packages/agent/test/api/bug-report-routes.test.ts
+++ b/packages/agent/test/api/bug-report-routes.test.ts
@@ -1,4 +1,5 @@
 /** Exercises bug-report routing with deterministic environment and fetch fixtures. */
+import { EventEmitter } from "node:events";
 import type http from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -23,9 +24,9 @@ function createContext(
   responseBody?: unknown;
   responseStatus?: number;
 } {
-  const req = {
+  const req = Object.assign(new EventEmitter(), {
     socket: { remoteAddress: ip },
-  } as unknown as http.IncomingMessage;
+  }) as unknown as http.IncomingMessage;
   const res = {} as http.ServerResponse;
   const ctx = {
     req,

--- a/packages/agent/test/api/bug-report-routes.timeout.test.ts
+++ b/packages/agent/test/api/bug-report-routes.timeout.test.ts
@@ -274,4 +274,29 @@ describe("bug report fetch timeout", () => {
     expect(ctx.responseStatus).toBe(502);
     expect(ctx.req.listenerCount("aborted")).toBe(0);
   });
+
+  it("starts remote intake already aborted when the client disconnected while its body was read", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal;
+      signals.push(signal);
+      return Promise.reject(signal.reason);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.stubEnv(
+      "ELIZA_BUG_REPORT_API_URL",
+      "https://intake.example.test/reports",
+    );
+
+    const ctx = createContext();
+    Object.defineProperty(ctx.req, "aborted", { value: true });
+    await handleBugReportRoutes(ctx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[0]?.reason).toMatchObject({ name: "AbortError" });
+    expect(ctx.responseStatus).toBe(502);
+    expect(ctx.req.listenerCount("aborted")).toBe(0);
+  });
 });

--- a/packages/agent/test/api/bug-report-routes.timeout.test.ts
+++ b/packages/agent/test/api/bug-report-routes.timeout.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Bug report fetch deadlines — proves remote and GitHub intake abort on
+ * timeout, covers stalled headers and stalled bodies with a real hanging
+ * server, and pins the documented budget.
+ */
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BUG_REPORT_REPO_ENV_KEY,
+  DEFAULT_BUG_REPORT_FETCH_TIMEOUT_MS,
+  handleBugReportRoutes,
+  resetBugReportRateLimit,
+  submitToRemoteBugIntake,
+} from "../../src/api/bug-report-routes.ts";
+
+type BugReportRouteContext = Parameters<typeof handleBugReportRoutes>[0];
+
+const validBugReport = {
+  description: "The agent fails to start",
+  stepsToReproduce: "Run the agent",
+};
+
+function createContext(
+  body: Record<string, unknown> = validBugReport,
+  ip = "127.0.0.1",
+): BugReportRouteContext & { responseBody?: unknown; responseStatus?: number } {
+  const req = {
+    socket: { remoteAddress: ip },
+  } as unknown as import("node:http").IncomingMessage;
+  const res = {} as import("node:http").ServerResponse;
+  const ctx = {
+    req,
+    res,
+    method: "POST",
+    pathname: "/api/bug-report",
+    readJsonBody: vi.fn(async () => body),
+    json: vi.fn(
+      (
+        _res: import("node:http").ServerResponse,
+        responseBody: unknown,
+        status = 200,
+      ) => {
+        (ctx as unknown as { responseBody: unknown }).responseBody =
+          responseBody;
+        (ctx as unknown as { responseStatus: number }).responseStatus = status;
+      },
+    ),
+    error: vi.fn(
+      (
+        _res: import("node:http").ServerResponse,
+        message: string,
+        status = 500,
+      ) => {
+        (ctx as unknown as { responseBody: unknown }).responseBody = {
+          error: message,
+        };
+        (ctx as unknown as { responseStatus: number }).responseStatus = status;
+      },
+    ),
+  } as unknown as BugReportRouteContext & {
+    responseBody?: unknown;
+    responseStatus?: number;
+  };
+  return ctx;
+}
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      if (!signal) throw new Error("expected bug-report abort signal");
+      if (signal.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as typeof fetch;
+}
+
+describe("bug report fetch timeout", () => {
+  let originalTimeout: typeof AbortSignal.timeout;
+
+  beforeEach(() => {
+    originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+    resetBugReportRateLimit();
+    vi.stubEnv(BUG_REPORT_REPO_ENV_KEY, "");
+    vi.stubEnv("BUG_REPORT_REPO", "");
+    vi.stubEnv("GITHUB_TOKEN", "");
+    vi.stubEnv("ELIZA_BUG_REPORT_API_URL", "");
+    vi.stubEnv("ELIZA_BUG_REPORT_API_TOKEN", "");
+  });
+
+  afterEach(async () => {
+    resetBugReportRateLimit();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("exposes the documented ten-second budget", () => {
+    expect(DEFAULT_BUG_REPORT_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("aborts a stalled remote intake at the deadline (hanging fetch)", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() =>
+      originalTimeout(10),
+    );
+    vi.stubGlobal("fetch", stallUntilAborted());
+    vi.stubEnv(
+      "ELIZA_BUG_REPORT_API_URL",
+      "https://intake.example.test/reports",
+    );
+
+    await expect(
+      submitToRemoteBugIntake(
+        validBugReport as unknown as Parameters<
+          typeof submitToRemoteBugIntake
+        >[0],
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("aborts a stalled GitHub intake at the deadline (hanging fetch via route)", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() =>
+      originalTimeout(10),
+    );
+    const fetchMock = vi.fn(stallUntilAborted());
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.stubEnv("GITHUB_TOKEN", "test-token-not-a-credential");
+
+    const ctx = createContext();
+    await handleBugReportRoutes(ctx);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("api.github.com"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(ctx.responseStatus).toBe(500);
+    expect((ctx.responseBody as { error?: string })?.error).toBe(
+      "Failed to create GitHub issue",
+    );
+  });
+
+  it("keeps the deadline armed while the response body stalls (real server)", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write('{"accepted":true,');
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/reports`;
+
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() =>
+      originalTimeout(10),
+    );
+    vi.stubEnv("ELIZA_BUG_REPORT_API_URL", url);
+    // Use real fetch for this test (don't stub global fetch) - it will hit the real server
+    // Ensure we don't have a fetch mock; the injected timeout will abort the stalled body
+    try {
+      await expect(
+        submitToRemoteBugIntake(
+          validBugReport as unknown as Parameters<
+            typeof submitToRemoteBugIntake
+          >[0],
+        ),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("succeeds on a fast upstream and passes the abort signal", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.signal) signals.push(init.signal as AbortSignal);
+        return new Response(
+          JSON.stringify({
+            accepted: true,
+            id: "report-1",
+            url: "https://intake.example.test/reports/report-1",
+          }),
+          { status: 202, headers: { "content-type": "application/json" } },
+        );
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.stubEnv(
+      "ELIZA_BUG_REPORT_API_URL",
+      "https://intake.example.test/reports",
+    );
+    vi.stubEnv("ELIZA_BUG_REPORT_API_TOKEN", "remote-test-token");
+
+    const result = await submitToRemoteBugIntake(
+      validBugReport as unknown as Parameters<
+        typeof submitToRemoteBugIntake
+      >[0],
+    );
+
+    expect(result).toEqual({
+      accepted: true,
+      id: "report-1",
+      url: "https://intake.example.test/reports/report-1",
+      destination: "remote",
+    });
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+    const [, init] = fetchMock.mock.calls[0] as [unknown, RequestInit];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("succeeds for GitHub intake on a fast upstream", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "test-token-not-a-credential");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            html_url: "https://github.com/elizaOS/eliza/issues/123",
+          }),
+          {
+            status: 201,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const ctx = createContext();
+    await handleBugReportRoutes(ctx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [unknown, RequestInit];
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    expect(ctx.responseBody).toEqual({
+      url: "https://github.com/elizaOS/eliza/issues/123",
+    });
+    expect(ctx.responseStatus).toBe(200);
+  });
+});

--- a/packages/agent/test/api/bug-report-routes.timeout.test.ts
+++ b/packages/agent/test/api/bug-report-routes.timeout.test.ts
@@ -1,7 +1,9 @@
 /**
  * Bug report fetch deadlines — proves remote and GitHub intake abort on
  * timeout, covers stalled headers and stalled bodies with a real hanging
- * server, and pins the documented budget.
+ * server, and pins the documented budget. All remote-intake paths are
+ * exercised through the owning route handler so the timeout translation into
+ * a structured 502 response is validated at the route boundary.
  */
 import http from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,7 +12,6 @@ import {
   DEFAULT_BUG_REPORT_FETCH_TIMEOUT_MS,
   handleBugReportRoutes,
   resetBugReportRateLimit,
-  submitToRemoteBugIntake,
 } from "../../src/api/bug-report-routes.ts";
 
 type BugReportRouteContext = Parameters<typeof handleBugReportRoutes>[0];
@@ -103,7 +104,7 @@ describe("bug report fetch timeout", () => {
     expect(DEFAULT_BUG_REPORT_FETCH_TIMEOUT_MS).toBe(10_000);
   });
 
-  it("aborts a stalled remote intake at the deadline (hanging fetch)", async () => {
+  it("aborts a stalled remote intake at the deadline (hanging fetch) via route", async () => {
     vi.spyOn(AbortSignal, "timeout").mockImplementation(() =>
       originalTimeout(10),
     );
@@ -113,13 +114,13 @@ describe("bug report fetch timeout", () => {
       "https://intake.example.test/reports",
     );
 
-    await expect(
-      submitToRemoteBugIntake(
-        validBugReport as unknown as Parameters<
-          typeof submitToRemoteBugIntake
-        >[0],
-      ),
-    ).rejects.toMatchObject({ name: "TimeoutError" });
+    const ctx = createContext();
+    await handleBugReportRoutes(ctx);
+
+    expect(ctx.responseStatus).toBe(502);
+    expect((ctx.responseBody as { error?: string })?.error).toBe(
+      "Failed to submit bug report",
+    );
   });
 
   it("aborts a stalled GitHub intake at the deadline (hanging fetch via route)", async () => {
@@ -143,7 +144,7 @@ describe("bug report fetch timeout", () => {
     );
   });
 
-  it("keeps the deadline armed while the response body stalls (real server)", async () => {
+  it("keeps the deadline armed while the response body stalls (real server) via route", async () => {
     const server = http.createServer((_req, res) => {
       res.writeHead(200, { "content-type": "application/json" });
       res.write('{"accepted":true,');
@@ -158,22 +159,19 @@ describe("bug report fetch timeout", () => {
       originalTimeout(10),
     );
     vi.stubEnv("ELIZA_BUG_REPORT_API_URL", url);
-    // Use real fetch for this test (don't stub global fetch) - it will hit the real server
-    // Ensure we don't have a fetch mock; the injected timeout will abort the stalled body
+    const ctx = createContext();
     try {
-      await expect(
-        submitToRemoteBugIntake(
-          validBugReport as unknown as Parameters<
-            typeof submitToRemoteBugIntake
-          >[0],
-        ),
-      ).rejects.toMatchObject({ name: "TimeoutError" });
+      await handleBugReportRoutes(ctx);
+      expect(ctx.responseStatus).toBe(502);
+      expect((ctx.responseBody as { error?: string })?.error).toBe(
+        "Failed to submit bug report",
+      );
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
 
-  it("succeeds on a fast upstream and passes the abort signal", async () => {
+  it("succeeds on a fast remote upstream (via route) and passes the abort signal", async () => {
     const signals: AbortSignal[] = [];
     const fetchMock = vi.fn(
       async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -195,18 +193,16 @@ describe("bug report fetch timeout", () => {
     );
     vi.stubEnv("ELIZA_BUG_REPORT_API_TOKEN", "remote-test-token");
 
-    const result = await submitToRemoteBugIntake(
-      validBugReport as unknown as Parameters<
-        typeof submitToRemoteBugIntake
-      >[0],
-    );
+    const ctx = createContext();
+    await handleBugReportRoutes(ctx);
 
-    expect(result).toEqual({
+    expect(ctx.responseBody).toEqual({
       accepted: true,
       id: "report-1",
       url: "https://intake.example.test/reports/report-1",
       destination: "remote",
     });
+    expect(ctx.responseStatus).toBe(200);
     expect(signals).toHaveLength(1);
     expect(signals[0]?.aborted).toBe(false);
     const [, init] = fetchMock.mock.calls[0] as [unknown, RequestInit];

--- a/packages/agent/test/api/bug-report-routes.timeout.test.ts
+++ b/packages/agent/test/api/bug-report-routes.timeout.test.ts
@@ -5,6 +5,8 @@
  * exercised through the owning route handler so the timeout translation into
  * a structured 502 response is validated at the route boundary.
  */
+
+import { EventEmitter } from "node:events";
 import http from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -25,9 +27,9 @@ function createContext(
   body: Record<string, unknown> = validBugReport,
   ip = "127.0.0.1",
 ): BugReportRouteContext & { responseBody?: unknown; responseStatus?: number } {
-  const req = {
+  const req = Object.assign(new EventEmitter(), {
     socket: { remoteAddress: ip },
-  } as unknown as import("node:http").IncomingMessage;
+  }) as unknown as import("node:http").IncomingMessage;
   const res = {} as import("node:http").ServerResponse;
   const ctx = {
     req,
@@ -138,7 +140,7 @@ describe("bug report fetch timeout", () => {
       expect.stringContaining("api.github.com"),
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
-    expect(ctx.responseStatus).toBe(500);
+    expect(ctx.responseStatus).toBe(502);
     expect((ctx.responseBody as { error?: string })?.error).toBe(
       "Failed to create GitHub issue",
     );
@@ -167,6 +169,7 @@ describe("bug report fetch timeout", () => {
         "Failed to submit bug report",
       );
     } finally {
+      server.closeAllConnections();
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
@@ -205,6 +208,7 @@ describe("bug report fetch timeout", () => {
     expect(ctx.responseStatus).toBe(200);
     expect(signals).toHaveLength(1);
     expect(signals[0]?.aborted).toBe(false);
+    expect(ctx.req.listenerCount("aborted")).toBe(0);
     const [, init] = fetchMock.mock.calls[0] as [unknown, RequestInit];
     expect(init.signal).toBeInstanceOf(AbortSignal);
   });
@@ -231,9 +235,43 @@ describe("bug report fetch timeout", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, init] = fetchMock.mock.calls[0] as [unknown, RequestInit];
     expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    expect(ctx.req.listenerCount("aborted")).toBe(0);
     expect(ctx.responseBody).toEqual({
       url: "https://github.com/elizaOS/eliza/issues/123",
     });
     expect(ctx.responseStatus).toBe(200);
+  });
+
+  it("aborts remote intake when the client request disconnects and removes the listener", async () => {
+    let outboundSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          outboundSignal = init?.signal as AbortSignal | undefined;
+          outboundSignal?.addEventListener(
+            "abort",
+            () => reject(outboundSignal?.reason),
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.stubEnv(
+      "ELIZA_BUG_REPORT_API_URL",
+      "https://intake.example.test/reports",
+    );
+
+    const ctx = createContext();
+    const pending = handleBugReportRoutes(ctx);
+    await vi.waitFor(() => expect(outboundSignal).toBeDefined());
+    expect(ctx.req.listenerCount("aborted")).toBe(1);
+
+    ctx.req.emit("aborted");
+    await pending;
+
+    expect(outboundSignal?.aborted).toBe(true);
+    expect(outboundSignal?.reason).toMatchObject({ name: "AbortError" });
+    expect(ctx.responseStatus).toBe(502);
+    expect(ctx.req.listenerCount("aborted")).toBe(0);
   });
 });


### PR DESCRIPTION
# Relates to

Fixes #22323.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] Root `bun install` and `bun run verify` were not run in the isolated review worktree; exact focused evidence is recorded below.
- [x] A reviewer can confirm the changed behavior from the route-level regression tests and production diff.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9af374938212f5481975f067fd0cbc06d30e3fb6:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `9af374938212f5481975f067fd0cbc06d30e3fb6`, the latest `origin/develop` at final push; zero conflicts.
- [ ] Root verification is deferred to CI; both owning route suites pass on the exact head.

# Risks

Low and bounded to the bug-report HTTP boundary. Client disconnects now cancel the matching outbound request, and both remote intake and GitHub issue creation retain the existing ten-second deadline through response-body parsing. Upstream transport failures are translated to 502 rather than fabricated success.

# Background

## What does this PR do?

- Keeps `submitToRemoteBugIntake` private and exercises it through `handleBugReportRoutes`.
- Applies the documented ten-second timeout to both remote-intake and GitHub fetches, including stalled response bodies.
- Composes that deadline with the originating request `aborted` event via `AbortSignal.any`.
- Removes the request listener in every completion path.
- Classifies the route catches as J1 boundary translations and returns structured 502 responses for upstream transport failures.
- Adds production-route tests for hanging headers, a real stalled JSON body, fast paths, structured translations, client disconnect, and listener teardown.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. The public route contract and package exports are unchanged.

# Testing

## Where should a reviewer start?

Review `packages/agent/src/api/bug-report-routes.ts`, then `packages/agent/test/api/bug-report-routes.timeout.test.ts`.

## Detailed testing steps

Exact head: `84394e0d6db463db2a9524541e3e606c3d8f6fed`

```text
git diff --check origin/develop...HEAD
PASS

bunx biome check packages/agent/src/api/bug-report-routes.ts packages/agent/test/api/bug-report-routes.timeout.test.ts
PASS - 2 files checked, no fixes

gtimeout --foreground --signal=TERM --kill-after=10s 90s bunx vitest run packages/agent/test/api/bug-report-routes.timeout.test.ts -t 'starts remote intake already aborted' --testTimeout=15000 --hookTimeout=15000
PASS - 1 passed, 7 skipped; 5.25s

gtimeout --foreground --signal=TERM --kill-after=10s 90s bunx vitest run packages/agent/test/api/bug-report-routes.test.ts packages/agent/test/api/bug-report-routes.timeout.test.ts --testTimeout=15000 --hookTimeout=15000
PASS - 2 files, 20 tests; 7.65s

gtimeout --foreground --signal=TERM --kill-after=10s 120s bun run --cwd packages/agent typecheck
SPARSE-ENVIRONMENT BLOCKER - failed in 2.7s on omitted plugin/workspace packages and mixed dependency roots; no diagnostic references either changed file.
```

# Evidence Gate

<!-- evidence-head:84394e0d6db463db2a9524541e3e606c3d8f6fed -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend-only HTTP route behavior with no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - backend-only HTTP route behavior with no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no rendered or interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic route tests are the applicable evidence and pass 20/20 on the exact head.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model, prompt, provider, or agent behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no database, memory, scheduler, wallet, media, or generated-file output.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior.

## Backend + frontend logs

The production route suites pass 20/20 on the exact head. They cover hanging headers, a real stalled response body, client cancellation both before and after listener attachment, fast paths, structured error translation, and listener teardown.

## Screenshots (before / after) + video walkthrough

N/A - backend-only transport behavior.

## Audio / voice walkthrough

N/A - no audio or voice behavior.

## Known gaps / failures

- Earlier sparse-worktree retries were blocked first by ENOSPC and then missing generated/workspace dependencies. After materializing the required tracked workspace and generated artifacts, the exact-head focused suites passed 20/20.
- Agent package typecheck was attempted on the exact head but the sparse overlay lacks multiple plugin workspaces and resolves Drizzle from two dependency roots. It failed with missing-module and unrelated duplicate-private-type diagnostics; neither changed file appears in the diagnostics. CI must supply an authoritative full-workspace typecheck.
- Root `bun install` and `bun run verify` were not run in the isolated sparse worktree.
- Changed-file Biome and `git diff --check` pass on the exact head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@9af374938212f5481975f067fd0cbc06d30e3fb6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [byt61-proximity]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@9af374938212f5481975f067fd0cbc06d30e3fb6:packages/skills/skills/contribute-to-eliza"} -->
