### PR TITLE
fix(plugin-signal): keep UTF-16 surrogate pairs intact in splitMessage

### DIFF
--- a/plugins/plugin-signal/src/connector.test.ts
+++ b/plugins/plugin-signal/src/connector.test.ts
@@ -334,3 +334,19 @@ describe("Signal message connector", () => {
     });
   });
 });
+
+describe("SignalService.splitMessage", () => {
+  it("keeps surrogate pairs intact when splitting long text", () => {
+    const service = Object.create(SignalService.prototype) as unknown as {
+      splitMessage: (text: string) => string[];
+    };
+    const prefix = "a".repeat(7999);
+    const text = `${prefix}\u{1F98A}bbbb`;
+    const chunks = service.splitMessage(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+    expect(chunks.join("")).toBe(text);
+  });
+});

--- a/plugins/plugin-signal/src/service.ts
+++ b/plugins/plugin-signal/src/service.ts
@@ -46,6 +46,7 @@ import {
   Service,
   stringToUuid,
   type TargetInfo,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
 import {
@@ -2356,8 +2357,10 @@ export class SignalService extends Service implements ISignalService {
         }
       }
 
-      messages.push(remaining.slice(0, splitIndex));
-      remaining = remaining.slice(splitIndex);
+      const chunkCandidate = truncateWellFormed(remaining, splitIndex);
+      const cutPoint = chunkCandidate.length > 0 ? chunkCandidate.length : splitIndex;
+      messages.push(remaining.slice(0, cutPoint));
+      remaining = remaining.slice(cutPoint);
     }
 
     return messages;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:39581be30fa99eb99f7c78c90a62f0036393b0fa -->

Fixes an issue in `SignalService.splitMessage` (`plugins/plugin-signal/src/service.ts`) where message chunking with raw `remaining.slice(0, splitIndex)` could cut UTF-16 surrogate pairs in half when splitting across `MAX_SIGNAL_MESSAGE_LENGTH`, resulting in malformed lone surrogate code units in outbound Signal messages.

### Changes
- Uses `truncateWellFormed(remaining, splitIndex)` from `@elizaos/core` to ensure chunking preserves UTF-16 surrogate pairs.
- Adds regression unit test in `plugins/plugin-signal/src/connector.test.ts` verifying emoji surrogate pairs remain intact across message chunks.

### Testing
- `npx vitest run plugins/plugin-signal/src/connector.test.ts`: 12/12 tests passed.
- `biome check`: Clean.

<!-- contribution-provenance:v1
agent: eliza-auto-coder
source: packages/skills/skills/contribute-to-eliza
revision: 8808863b16a957a091a2b08a60d8cfc4f97213c6
timestamp: 2026-08-18T22:46:20Z
-->
