### PR TITLE
fix(plugin-slack): keep UTF-16 surrogate pairs intact in splitSlackText and chunkSlackText

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -525,3 +525,25 @@ describe("parseSlackMessageLink", () => {
     ).toBeNull();
   });
 });
+
+describe("splitSlackText and chunkSlackText surrogate pair safety", () => {
+  it("keeps surrogate pairs intact in splitSlackText", () => {
+    const text = "aaaaa\u{1F98A}bbbbb";
+    const chunks = splitSlackText(text, 6);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.isWellFormed()).toBe(true);
+      expect(chunk.length).toBeLessThanOrEqual(6);
+    }
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("keeps surrogate pairs intact in chunkSlackText", () => {
+    const text = "aaaaa\u{1F98A}bbbbb";
+    const chunks = chunkSlackText(text, 10);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+  });
+});

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -8,6 +8,7 @@
  * channel-type / display-name helpers. Used by `service.ts` on the send/receive
  * paths and re-exported from `index.ts`.
  */
+import { truncateWellFormed } from "@elizaos/core";
 import {
   parseSlackArchivesUrl,
   type SlackChannel,
@@ -228,8 +229,11 @@ export function splitSlackText(
     }
 
     splitIndex = Math.min(splitIndex, maxChars);
-    messages.push(remaining.slice(0, splitIndex));
-    remaining = remaining.slice(splitIndex);
+    const chunkCandidate = truncateWellFormed(remaining, splitIndex);
+    const cutPoint =
+      chunkCandidate.length > 0 ? chunkCandidate.length : splitIndex;
+    messages.push(remaining.slice(0, cutPoint));
+    remaining = remaining.slice(cutPoint);
   }
 
   return messages;
@@ -281,8 +285,11 @@ export function chunkSlackText(
     // exactly on hardLimit yields breakPoint = hardLimit + 1 and the reserved
     // fence budget is spent, pushing the emitted chunk to maxChars + 1.
     breakPoint = Math.min(breakPoint, hardLimit);
+    const chunkCandidate = truncateWellFormed(remaining, breakPoint);
+    const cutPoint =
+      chunkCandidate.length > 0 ? chunkCandidate.length : breakPoint;
 
-    let chunk = remaining.slice(0, breakPoint);
+    let chunk = remaining.slice(0, cutPoint);
 
     // Check if this chunk ends inside a code block — count fences in the
     // actual emitted chunk, not the max-size window, so a fence that sits
@@ -297,7 +304,7 @@ export function chunkSlackText(
 
     chunks.push(chunk);
 
-    remaining = remaining.slice(breakPoint);
+    remaining = remaining.slice(cutPoint);
 
     // If we were in a code block, reopen it
     if (inCodeBlock) {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:61a816a3c563df6f93d7a579f43fad2a65edd11b -->

Fixes an issue in `splitSlackText` and `chunkSlackText` (`plugins/plugin-slack/src/formatting.ts`) where chunking messages using raw `.slice(0, splitIndex)` / `.slice(0, breakPoint)` could slice UTF-16 surrogate pairs (e.g. emojis or astral plane characters) in half, resulting in malformed strings and lone surrogate code units in outbound Slack messages.

### Changes
- Uses `truncateWellFormed` from `@elizaos/core` to respect UTF-16 surrogate pairs during message and code block chunking.
- Adds regression unit tests in `plugins/plugin-slack/src/formatting.test.ts` verifying emoji surrogate pairs remain intact across message chunks.

### Testing
- `npx vitest run plugins/plugin-slack/src/formatting.test.ts`: 65/65 tests passed.
- `biome check`: Clean.

<!-- contribution-provenance:v1
agent: eliza-auto-coder
source: packages/skills/skills/contribute-to-eliza
revision: 8808863b16a957a091a2b08a60d8cfc4f97213c6
timestamp: 2026-08-18T22:47:15Z
-->
