### PR TITLE
fix(plugin-discord): keep UTF-16 surrogate pairs intact in splitMessage

### DIFF
--- a/plugins/plugin-discord/__tests__/post-to-thread-chunk.test.ts
+++ b/plugins/plugin-discord/__tests__/post-to-thread-chunk.test.ts
@@ -363,3 +363,18 @@ describe("postToConnectorThread delivery contract", () => {
 		expect(result).toBeDefined();
 	});
 });
+
+describe("splitMessage surrogate pair safety", () => {
+	it("keeps surrogate pairs intact when splitting across max length", async () => {
+		const { splitMessage } = await import("../utils");
+		const prefix = "a".repeat(1999);
+		const text = `${prefix}\u{1F98A}bbbb`;
+		const chunks = splitMessage(text, 2000);
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(chunk.isWellFormed()).toBe(true);
+			expect(chunk.length).toBeLessThanOrEqual(2000);
+		}
+		expect(chunks.join("")).toBe(text);
+	});
+});

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -19,6 +19,7 @@ import {
 	type ReplyToMode,
 	type SsrfPolicy,
 	trimTokens,
+	truncateWellFormed,
 } from "@elizaos/core";
 import {
 	ActionRowBuilder,
@@ -924,8 +925,11 @@ export function splitMessage(
 				splitIdx = lastSpace;
 			}
 
-			chunks.push(line.slice(0, splitIdx));
-			line = line.slice(splitIdx).trimStart();
+			const chunkCandidate = truncateWellFormed(line, splitIdx);
+			const cutPoint =
+				chunkCandidate.length > 0 ? chunkCandidate.length : splitIdx;
+			chunks.push(line.slice(0, cutPoint));
+			line = line.slice(cutPoint).trimStart();
 		}
 		chunks.push(line);
 		return chunks;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:ef89119dc446f4e2868dae4860207a34ccdb41ea -->

Fixes an issue in `splitMessage` (`plugins/plugin-discord/utils.ts`) where message chunking with raw `line.slice(0, splitIdx)` could cut UTF-16 surrogate pairs (e.g. emojis or astral plane characters) in half across `maxLength`, creating malformed strings and lone surrogate code units in outbound Discord messages.

### Changes
- Uses `truncateWellFormed(line, splitIdx)` from `@elizaos/core` to respect UTF-16 surrogate pairs during message chunking.
- Adds regression unit test in `plugins/plugin-discord/__tests__/post-to-thread-chunk.test.ts` verifying emoji surrogate pairs remain intact across message chunks.

### Testing
- `npx vitest run plugins/plugin-discord/__tests__/post-to-thread-chunk.test.ts`: 5/5 tests passed.
- `biome check`: Clean.

<!-- contribution-provenance:v1
agent: eliza-auto-coder
source: packages/skills/skills/contribute-to-eliza
revision: 8808863b16a957a091a2b08a60d8cfc4f97213c6
timestamp: 2026-08-18T22:47:55Z
-->
