### PR TITLE
fix(plugin-wechat): keep UTF-16 surrogate pairs intact in reply dispatcher chunking

### DIFF
--- a/plugins/plugin-wechat/src/index.test.ts
+++ b/plugins/plugin-wechat/src/index.test.ts
@@ -358,4 +358,72 @@ describe("@elizaos/plugin-wechat", () => {
     expect(client.sendText).toHaveBeenNthCalledWith(1, "wxid_alice", "hello");
     expect(client.sendText).toHaveBeenNthCalledWith(2, "wxid_alice", "world");
   });
+
+  it("keeps surrogate pairs intact when chunking text through the proxy client", async () => {
+    const client = {
+      sendText: vi.fn(async () => undefined),
+    } as unknown as ProxyClient;
+    const dispatcher = new ReplyDispatcher({ client, chunkSize: 6 });
+
+    await dispatcher.sendText("wxid_alice", "aaaaa\u{1F98A}bbbbb");
+
+    const sent = vi.mocked(client.sendText).mock.calls.map((c) => c[1]);
+    expect(sent.length).toBeGreaterThan(1);
+    for (const chunk of sent) {
+      expect(chunk.isWellFormed()).toBe(true);
+      expect(chunk.length).toBeLessThanOrEqual(6);
+    }
+  });
+
+  it.each([0, -1, Number.NaN, 1.5])(
+    "rejects invalid reply chunk size %s",
+    (chunkSize) => {
+      const client = {
+        sendText: vi.fn(async () => undefined),
+      } as unknown as ProxyClient;
+
+      expect(() => new ReplyDispatcher({ client, chunkSize })).toThrow(
+        expect.objectContaining({ code: "WECHAT_REPLY_CHUNK_SIZE_INVALID" }),
+      );
+    },
+  );
+
+  it("fails before sending when the chunk cap cannot fit an emoji", async () => {
+    const client = {
+      sendText: vi.fn(async () => undefined),
+    } as unknown as ProxyClient;
+    const dispatcher = new ReplyDispatcher({ client, chunkSize: 1 });
+
+    await expect(dispatcher.sendText("wxid_alice", "🦊abc")).rejects.toEqual(
+      expect.objectContaining({ code: "WECHAT_REPLY_CHUNK_SIZE_TOO_SMALL" }),
+    );
+    expect(client.sendText).not.toHaveBeenCalled();
+  });
+
+  it("keeps the established whitespace-boundary policy explicit", async () => {
+    const client = {
+      sendText: vi.fn(async () => undefined),
+    } as unknown as ProxyClient;
+    const dispatcher = new ReplyDispatcher({ client, chunkSize: 6 });
+
+    await dispatcher.sendText("wxid_alice", "hello  world");
+
+    expect(
+      vi.mocked(client.sendText).mock.calls.map((call) => call[1]),
+    ).toEqual(["hello ", "world"]);
+  });
+
+  it("sanitizes pre-existing lone surrogates before sending", async () => {
+    const client = {
+      sendText: vi.fn(async () => undefined),
+    } as unknown as ProxyClient;
+    const dispatcher = new ReplyDispatcher({ client, chunkSize: 3 });
+
+    await dispatcher.sendText("wxid_alice", "a\ud800bc");
+
+    const sent = vi.mocked(client.sendText).mock.calls.map((call) => call[1]);
+    expect(sent).toEqual(["a�b", "c"]);
+    expect(sent.every((chunk) => chunk.isWellFormed())).toBe(true);
+    expect(sent.every((chunk) => chunk.length <= 3)).toBe(true);
+  });
 });

--- a/plugins/plugin-wechat/src/reply-dispatcher.ts
+++ b/plugins/plugin-wechat/src/reply-dispatcher.ts
@@ -2,6 +2,11 @@
  * Outbound send path for WeChat replies: splits long text into proxy-safe chunks
  * and sends each chunk (and images) through the `ProxyClient`.
  */
+import {
+  ElizaError,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import type { ProxyClient } from "./proxy-client";
 
 const DEFAULT_CHUNK_SIZE = 2000;
@@ -17,7 +22,17 @@ export class ReplyDispatcher {
 
   constructor(options: ReplyDispatcherOptions) {
     this.client = options.client;
-    this.chunkSize = options.chunkSize ?? DEFAULT_CHUNK_SIZE;
+    const chunkSize = options.chunkSize ?? DEFAULT_CHUNK_SIZE;
+    if (!Number.isSafeInteger(chunkSize) || chunkSize <= 0) {
+      throw new ElizaError(
+        "WeChat reply chunk size must be a positive integer",
+        {
+          code: "WECHAT_REPLY_CHUNK_SIZE_INVALID",
+          context: { chunkSize },
+        },
+      );
+    }
+    this.chunkSize = chunkSize;
   }
 
   async sendText(to: string, text: string): Promise<void> {
@@ -46,12 +61,13 @@ export class ReplyDispatcher {
   }
 
   private chunk(text: string): string[] {
-    if (text.length <= this.chunkSize) {
-      return [text];
+    const wellFormedText = toWellFormedUnicode(text);
+    if (wellFormedText.length <= this.chunkSize) {
+      return [wellFormedText];
     }
 
     const chunks: string[] = [];
-    let remaining = text;
+    let remaining = wellFormedText;
 
     while (remaining.length > 0) {
       if (remaining.length <= this.chunkSize) {
@@ -70,8 +86,19 @@ export class ReplyDispatcher {
         breakAt = this.chunkSize;
       }
 
-      chunks.push(remaining.slice(0, breakAt));
-      remaining = remaining.slice(breakAt).trimStart();
+      const chunkCandidate = truncateWellFormed(remaining, breakAt);
+      if (chunkCandidate.length === 0) {
+        throw new ElizaError(
+          "WeChat reply chunk size cannot fit the next Unicode character",
+          {
+            code: "WECHAT_REPLY_CHUNK_SIZE_TOO_SMALL",
+            context: { chunkSize: this.chunkSize },
+          },
+        );
+      }
+      const cutPoint = chunkCandidate.length;
+      chunks.push(remaining.slice(0, cutPoint));
+      remaining = remaining.slice(cutPoint).trimStart();
     }
 
     return chunks;


### PR DESCRIPTION
Closes #23158.

## Summary

Keeps UTF-16 surrogate pairs intact when the WeChat reply dispatcher chunks outbound text. The dispatcher now sanitizes pre-existing lone surrogates, validates its configured cap, and fails closed with typed ElizaError codes when a cap cannot fit the next Unicode scalar instead of raw-slicing malformed text.

## Validation

- bun run --cwd plugins/plugin-wechat test: 63/63 passed
- bun run --cwd plugins/plugin-wechat typecheck: passed
- bun run --cwd plugins/plugin-wechat lint:check: passed
- git diff --check origin/develop...HEAD: passed
- rebased onto origin/develop@7ddb6b0b4ea971b277af795d20dbe922de15072c without conflicts

## Evidence gate

<!-- evidence-head:8376d6759fa2fc2ae8096ea41386585945dcd797 -->

- Before/after screenshots: N/A — no rendered UI surface.
- Walkthrough video: N/A — no rendered user flow.
- Backend/frontend logs: N/A — deterministic connector-domain tests cover the changed outbound boundary without credentials.
- LLM trajectory: N/A — no prompt, model, provider, or agent behavior changed.
- Domain artifact: the owning package suite exercises proxy sendText calls and proves every emitted chunk is well formed, within the cap, preserves the established whitespace policy, and performs no send when the cap is too small.
- OCR/manual review: N/A — no visual artifact.

## Contribution provenance

Original implementation assistance: eliza-auto-coder; skill revision 8808863b16a957a091a2b08a60d8cfc4f97213c6 (preserved from the submitted body).

Completion/rebase review:
AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop multi-agent completion
Contribution skill revision: N/A - repository completion workflow; no contribution skill used
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository completion workflow; no contribution skill used"} -->