### PR TITLE
fix(agent): navigate before view acknowledgement

### DIFF
--- a/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
+++ b/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
@@ -168,7 +168,7 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
     );
   });
 
-  it("records completed-action navigation without requiring a WebSocket client", async () => {
+  it("best-effort delivers completed-action navigation before its acknowledgement", async () => {
     const { ctx, json, broadcastWs, broadcastWsToClientId } = makeNavigateCtx(
       "calendar",
       {
@@ -181,7 +181,14 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
     await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
 
     expect(broadcastWs).not.toHaveBeenCalled();
-    expect(broadcastWsToClientId).not.toHaveBeenCalled();
+    expect(broadcastWsToClientId).toHaveBeenCalledWith(
+      "seeker-rest-client",
+      expect.objectContaining({
+        type: SHELL_NAVIGATE_VIEW_WS_EVENT,
+        viewId: "calendar",
+        viewPath: null,
+      }),
+    );
     expect(getCurrentViewState()).toMatchObject({
       viewId: "calendar",
       source: "agent",

--- a/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
+++ b/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
@@ -197,6 +197,9 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
       ctx.res,
       expect.objectContaining({ ok: true, viewId: "calendar" }),
     );
+    expect(broadcastWsToClientId.mock.invocationCallOrder[0]).toBeLessThan(
+      json.mock.invocationCallOrder[0],
+    );
   });
 
   it("delivers app-chat navigation only to its originating client", async () => {

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -1049,8 +1049,9 @@ export async function handleViewsRoutes(
   // Broadcasts a shell:navigate:view WebSocket event to connected clients unless
   // the caller owns a narrower delivery channel. Realtime voice returns the
   // validated VIEWS result through its originating WebSocket session; normal app
-  // chat returns it in the completed stream action result. A global echo from
-  // either path would navigate unrelated browsers and devices.
+  // chat keeps the completed stream action result as its fallback and may also
+  // best-effort target the live originating renderer. A global echo from either
+  // path would navigate unrelated browsers and devices.
   //
   // Optional body fields:
   //   action: "pin-tab"    — tells the shell to add to desktop tab bar
@@ -1207,9 +1208,18 @@ export async function handleViewsRoutes(
       }
     }
 
-    // Skip the echo when the client already navigated or when the caller owns a
-    // narrower delivery channel such as realtime voice or the app chat stream.
-    if (reportedSource !== "user" && !callerOwnedDelivery) {
+    // Realtime voice returns navigation through its own control channel. App
+    // chat normally has the completed action as a reliable fallback, but when
+    // its originating renderer still has a live WebSocket, deliver there now:
+    // the navigate frame is emitted before the action callback can claim
+    // "Opened …", while the later completed-action handoff remains a no-op (or
+    // recovers the switch when this best-effort delivery misses).
+    const shouldTargetCompletedAction =
+      body?.delivery === "completed-action" && Boolean(originatingClientId);
+    if (
+      reportedSource !== "user" &&
+      (!callerOwnedDelivery || shouldTargetCompletedAction)
+    ) {
       const navigatePayload: ShellNavigateViewPayload = {
         viewId: id,
         viewPath,
@@ -1228,7 +1238,10 @@ export async function handleViewsRoutes(
           originatingClientId,
           frame,
         );
-        if (delivered === undefined || delivered <= 0) {
+        if (
+          !shouldTargetCompletedAction &&
+          (delivered === undefined || delivered <= 0)
+        ) {
           error(
             res,
             `No connected view client "${originatingClientId}" is available for "${id}".`,


### PR DESCRIPTION
# Relates to

Closes #22239

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` completed with no changes. `bun run verify` reached 123/137
      Turbo tasks before the unrelated native SourceKitten blocker recorded
      below; focused browser gates pass.
- [x] A reviewer can confirm the change from the timestamped live evidence and
      focused route/handoff tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] `bun run verify` result and unrelated blocker are documented below.

# Risks

Low. The change only sends an existing navigation frame to the originating live
renderer earlier. It retains the terminal completed-action fallback, treats a
missing WebSocket client as non-fatal, and never broadcasts to unrelated
clients.

# Background

## What does this PR do?

It prevents a browser `VIEWS` action from displaying a successful `Opened
<view>.` acknowledgement before the target route begins navigating.

For `delivery: "completed-action"`, the route now attempts a best-effort
client-targeted navigation frame before returning the successful action
callback. The existing completed-action handoff remains the fallback when the
originating renderer is unavailable.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the existing action-completion contract without changing a
public API or user configuration.

# Testing

## Where should a reviewer start?

- `packages/agent/src/api/views-routes.ts`
- `packages/agent/src/api/views-routes.navigate-broadcast.test.ts`

## Detailed testing steps

1. Run the local browser UI/API and open chat from a non-Notes route.
2. Ask the agent to open Notes.
3. Confirm `/notes` navigation starts before or with the successful
   acknowledgement.
4. Disconnect the originating WebSocket client and confirm the route remains
   successful so the terminal completed-action fallback can still run.
5. Confirm no frame is globally broadcast to other clients.

# Evidence Gate

<!-- evidence-head:12dc16f791dcd365a4b6b7461e3a60d5734952b9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes server event ordering only; no
      rendered component, CSS, SVG, or pixel output changes, and a still image
      cannot show the timing defect.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no rendered visual surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - the exact temporal behavior is captured below as
      Browser URL/DOM/ack timestamps and deterministic event-delivery tests.
<!-- evidence-row:backend-logs -->
- [x] [22245-backend-events-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22245-backend-events-v2.log)
<!-- evidence-row:frontend-logs -->
- [x] [22245-frontend-browser-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22245-frontend-browser-v2.log)
<!-- evidence-row:llm-trajectory -->
- [x] [22245-trajectory-v2.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/22245-trajectory-v2.json)
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - the action changes only the active browser route.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered text or visual source changed.

# Evidence Details

## Real LLM-call trajectory

- provider/model: `cerebras` / `gpt-oss-120b`
- input intent: open the Notes view
- selected action: `VIEWS`, action `show`, view `notes`
- 8621 prompt tokens, 51 completion tokens, 6400 cache-read tokens, zero retry
- action result: success/completed
- the public trajectory viewer intentionally omits full prompt text; no prompt,
  credential, or private session identifier is included here

## Backend + frontend logs

Before:

```text
SSE heartbeat/thinking                         +124 ms
provisional acknowledgement + running VIEWS  +1698 ms
terminal done/action result                   +2747 ms
Browser acknowledgement visible               2694 ms
Browser URL changed to /notes                  3778 ms
Notes DOM visible                              3829 ms
```

After on exact head `1e2243e0a6f1332864c77eddb498282c75f0bedb`:

```text
Browser URL changed to /notes                  2029 ms
Browser acknowledgement visible               2143 ms
Notes DOM visible                              2176 ms
fresh post-restart Browser console warnings       0
fresh post-restart Browser console errors         0
UI / API / voice health                         200 / ready / ready
```

The route now leads the acknowledgement by 114 ms. The remaining approximately
two-second action latency is the existing candidate/planner/provider path and is
not changed by this PR.

## Screenshots (before / after) + video walkthrough

N/A for the specific reasons in the evidence rows. No rendered source changed.

## Audio / voice walkthrough

N/A - this PR does not change STT, TTS, transcript, or voice code. Browser
Cartesia message playback was independently exercised during integration QA.

## Known gaps / failures

`bun install` completed with no changes. `bun run verify` reached 123 of 137
Turbo tasks, then failed in the unchanged native
`@elizaos/capacitor-gateway#lint:check` task because SourceKitten could not load
`sourcekitdInProc.framework`. This is outside the browser lane and none of the
two changed files are native code.

Post-sync focused gates:

```text
agent route: 1 file, 21 tests passed
UI handoff + voice output: 2 files, 27 tests passed
Biome: 2 changed files passed
@elizaos/agent build: passed
git diff --check: passed
```

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [browser-web-local]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza"} -->


## Current-head audit restamp (2026-08-18)

- Current head: `12dc16f791dcd365a4b6b7461e3a60d5734952b9`.
- Rebased cleanly onto `e27ffd70564c8f2d69ac1dc705b011af71b7a2c6`; `develop` advanced to `b0339c67e958e299f3640ea7f92f62c3343dbb8a` after the lease-safe push, with no overlap in either changed path. The branch remains merge-clean.
- Reviewer repair: the focused regression now explicitly proves `broadcastWsToClientId` is invoked before the JSON acknowledgement.
- Current-head Biome and `git diff --check`: passed.
- Current-head focused route test: **21/21 passed** under repository Vitest 4.1.5. Dependencies were resolved without install or network from the existing shared `node_modules` plus bun.lock-pinned cached `@noble/curves@2.2.0` and `@noble/hashes@2.2.0`; no shared dependency tree was mutated.
- The live Browser artifacts were captured on predecessor `1e2243e0a6f1332864c77eddb498282c75f0bedb`. The production source blob for `views-routes.ts` is byte-identical at current head (`aa3152dc2044100d6dc9bf17cc87d29069aab4ea`), but this does not claim a current-head runtime capture.

