### PR TITLE
fix(browser): bind confirmed uploads to v2 authority

### DIFF
--- a/plugins/plugin-browser/README.md
+++ b/plugins/plugin-browser/README.md
@@ -51,6 +51,22 @@ The plugin uses a pluggable target registry in `BrowserService`. Targets are sel
 
 External plugins can register additional targets by calling `BrowserService.registerTarget(target)`.
 
+### Confirmed uploads
+
+Generic `eval`, `upload`, and `realistic-upload` commands fail closed. Uploads
+must use `BrowserService.executeConfirmedUpload` with the core v2 interaction
+contract: an explicitly granted account profile, a pinned adapter advertising
+the upload action, the exact semantic action digest, and an atomically
+consume-once confirmation. A target must separately opt in through
+`executeAuthorizedUpload` and return an applied effect receipt for the exact
+surface, generation, operation, and action idempotency key. The receipt records
+only opaque account and resource identities; file handles are excluded.
+
+The built-in `workspace`, `bridge`, and `stagehand` targets do not yet expose a
+proof-producing upload hook, so they reject uploads before consuming a
+confirmation. A custom target must not opt in until its underlying browser or
+provider can return authoritative acceptance evidence.
+
 ### Provider
 
 `browser_workspace` — Injects the current dispatch mode (`desktop` / `web`) and a capped list of open tabs into agent context. Active when the `browser` or `web` context is selected.

--- a/plugins/plugin-browser/README.md
+++ b/plugins/plugin-browser/README.md
@@ -60,7 +60,8 @@ the upload action, the exact semantic action digest, and an atomically
 consume-once confirmation. A target must separately opt in through
 `executeAuthorizedUpload` and return an applied effect receipt for the exact
 surface, generation, operation, and action idempotency key. The receipt records
-only opaque account and resource identities; file handles are excluded.
+only opaque session, account-grant, and resource identities; raw owner/profile
+handles and file handles are excluded.
 
 The built-in `workspace`, `bridge`, and `stagehand` targets do not yet expose a
 proof-producing upload hook, so they reject uploads before consuming a

--- a/plugins/plugin-browser/src/__tests__/browser-command-authority.test.ts
+++ b/plugins/plugin-browser/src/__tests__/browser-command-authority.test.ts
@@ -10,19 +10,25 @@ import {
   InteractionConfirmationCoordinator,
   type InteractionSession,
 } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   createBrowserUploadInteractionAction,
   normalizeBrowserUploadReceipt,
 } from "../browser-command-authority.js";
 import { BrowserService } from "../browser-service.js";
 import { executeBrowserWorkspaceCommand } from "../workspace/browser-workspace.js";
-import { executeDesktopBrowserWorkspaceUtilityCommand } from "../workspace/browser-workspace-desktop.js";
+import {
+  createDesktopBrowserWorkspaceCommandScript,
+  executeDesktopBrowserWorkspaceDomCommand,
+  executeDesktopBrowserWorkspaceUtilityCommand,
+} from "../workspace/browser-workspace-desktop.js";
 import { executeWebBrowserWorkspaceUtilityCommand } from "../workspace/browser-workspace-web.js";
 
 const now = Date.parse("2026-08-18T22:00:00.000Z");
 const requestedAt = "2026-08-18T21:59:00.000Z";
 const expiresAt = "2026-08-18T22:05:00.000Z";
+beforeAll(() => vi.spyOn(Date, "now").mockReturnValue(now));
+afterAll(() => vi.restoreAllMocks());
 const profileGrantVerifier = {
   verify: (
     grant: { profileHandle: string },
@@ -155,13 +161,13 @@ function serviceWithTarget() {
         outcome: "applied",
         commit: {
           kind: "provider_accepted",
-          id: action.actionId,
+          id: "provider-acceptance-1",
           committedAt: new Date(now).toISOString(),
         },
       },
     }),
   );
-  service.registerTarget({
+  const target = {
     id: capabilities.adapterId,
     name: "Bound workspace account",
     description: "Deterministic browser target",
@@ -169,8 +175,9 @@ function serviceWithTarget() {
     supports: (candidate) => candidate.subaction === "upload",
     execute: genericExecute,
     executeAuthorizedUpload: execute,
-  });
-  return { execute, genericExecute, service };
+  };
+  service.registerTarget(target);
+  return { execute, genericExecute, service, target };
 }
 
 describe("bound browser command authorization", () => {
@@ -236,7 +243,6 @@ describe("bound browser command authorization", () => {
         profileGrantVerifier,
         session: activeSession,
         capabilities,
-        now,
       }),
     ).rejects.toMatchObject({ kind: "UNSUPPORTED" });
     expect(consume).not.toHaveBeenCalled();
@@ -255,7 +261,6 @@ describe("bound browser command authorization", () => {
       profileGrantVerifier,
       session: activeSession,
       capabilities,
-      now,
     });
 
     expect(execute).toHaveBeenCalledWith(
@@ -268,8 +273,8 @@ describe("bound browser command authorization", () => {
       }),
     );
     expect(output.receipt.binding).toMatchObject({
-      ownerId: "owner-1",
-      accountId: "account-opaque-1",
+      sessionId: "session-1",
+      accountGrantId: "profile-grant-1",
       adapterId: capabilities.adapterId,
       capabilityId: "browser.upload",
       operation: "browser.upload",
@@ -281,6 +286,8 @@ describe("bound browser command authorization", () => {
     expect(JSON.stringify(output.receipt)).not.toContain(
       "opaque-file-handle-1",
     );
+    expect(JSON.stringify(output.receipt)).not.toContain("account-opaque-1");
+    expect(JSON.stringify(output.receipt)).not.toContain("owner-1");
     expect(
       normalizeBrowserUploadReceipt(output.receipt, {
         action: { ...draft, confirmationGrant: grant },
@@ -301,7 +308,6 @@ describe("bound browser command authorization", () => {
       profileGrantVerifier,
       session: activeSession,
       capabilities,
-      now,
     };
 
     const attempts = await Promise.allSettled([
@@ -349,7 +355,6 @@ describe("bound browser command authorization", () => {
         },
         session: activeSession,
         capabilities,
-        now,
       }),
     ).rejects.toMatchObject({ code: "STALE_INTERACTION_REFERENCE" });
     expect(execute).not.toHaveBeenCalled();
@@ -392,7 +397,6 @@ describe("bound browser command authorization", () => {
       profileGrantVerifier,
       session: activeSession,
       capabilities,
-      now,
     };
 
     await expect(
@@ -416,7 +420,6 @@ describe("bound browser command authorization", () => {
       profileGrantVerifier,
       session: activeSession,
       capabilities,
-      now,
     });
     const confirmedAction = { ...draft, confirmationGrant: grant };
 
@@ -424,7 +427,10 @@ describe("bound browser command authorization", () => {
       normalizeBrowserUploadReceipt(
         {
           ...output.receipt,
-          binding: { ...output.receipt.binding, accountId: "account-opaque-2" },
+          binding: {
+            ...output.receipt.binding,
+            accountGrantId: "profile-grant-2",
+          },
         },
         { action: confirmedAction, session: activeSession },
       ),
@@ -472,8 +478,186 @@ describe("bound browser command authorization", () => {
         profileGrantVerifier,
         session: substitutedSession,
         capabilities,
-        now,
       }),
     ).rejects.toThrow("not current and host-verified");
+  });
+
+  it("blocks normalized aliases and direct desktop upload helpers", async () => {
+    const { genericExecute, service } = serviceWithTarget();
+    await expect(
+      service.execute({
+        subaction: "state",
+        operation: "UPLOAD" as "upload",
+        selector: "#attachment",
+        files: ["opaque-file-handle-1"],
+      }),
+    ).rejects.toMatchObject({ kind: "POLICY_BLOCKED" });
+    await expect(
+      service.execute({ subaction: " EVAL" as "eval", script: "1" }),
+    ).rejects.toMatchObject({ kind: "POLICY_BLOCKED" });
+    await expect(
+      service.execute({ subaction: "REALISTIC_UPLOAD" as "realistic-upload" }),
+    ).rejects.toMatchObject({ kind: "POLICY_BLOCKED" });
+    await expect(
+      executeBrowserWorkspaceCommand(
+        { subaction: "eval", script: "1" },
+        { ELIZA_BROWSER_WORKSPACE_ALLOW_USER_SCRIPT: "1" },
+      ),
+    ).rejects.toThrow(/script execution is disabled|Generic browser eval/);
+    expect(() =>
+      createDesktopBrowserWorkspaceCommandScript({
+        subaction: "realistic-upload",
+        selector: "#attachment",
+        files: ["opaque-file-handle-1"],
+      }),
+    ).toThrow("proof-producing target");
+    await expect(
+      executeDesktopBrowserWorkspaceDomCommand(
+        {
+          subaction: "realistic-upload",
+          selector: "#attachment",
+          files: ["opaque-file-handle-1"],
+        },
+        {},
+      ),
+    ).rejects.toThrow("proof-producing target");
+    expect(genericExecute).not.toHaveBeenCalled();
+  });
+
+  it("binds authorization to a browser capability and pre-request account grant", async () => {
+    const changedSession = session();
+    changedSession.updatedAt = "2026-08-18T22:00:00.000Z";
+    if (!changedSession.profileGrant) throw new Error("missing profile grant");
+    changedSession.profileGrant = {
+      ...changedSession.profileGrant,
+      grantId: "profile-grant-2",
+      profileHandle: "account-opaque-2",
+      issuedAt: "2026-08-18T22:00:00.000Z",
+    };
+    const { coordinator, draft, grant } = confirmedUpload(changedSession);
+    const consume = vi.fn(coordinator.consume.bind(coordinator));
+    const { execute, service } = serviceWithTarget();
+
+    await expect(
+      service.executeConfirmedUpload(command, {
+        actionId: draft.actionId,
+        requestedAt,
+        confirmationGrant: grant,
+        confirmationGrantConsumer: { consume },
+        profileGrantVerifier: { verify: () => true },
+        session: changedSession,
+        capabilities,
+      }),
+    ).rejects.toMatchObject({ code: "STALE_INTERACTION_REFERENCE" });
+    expect(consume).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+
+    const activeSession = session();
+    const confirmed = confirmedUpload(activeSession);
+    await expect(
+      service.executeConfirmedUpload(command, {
+        actionId: confirmed.draft.actionId,
+        requestedAt,
+        confirmationGrant: confirmed.grant,
+        confirmationGrantConsumer: confirmed.coordinator,
+        profileGrantVerifier,
+        session: activeSession,
+        capabilities: { ...capabilities, controlPlanes: [] },
+      }),
+    ).rejects.toThrow("does not advertise browser control");
+  });
+
+  it("treats a mismatched result operation as uncertain", async () => {
+    const activeSession = session();
+    const confirmed = confirmedUpload(activeSession);
+    const { execute, service } = serviceWithTarget();
+    execute.mockImplementationOnce(async (action) => ({
+      result: { mode: "desktop", subaction: "navigate" },
+      effectReceipt: {
+        receiptId: `browser-upload:${action.actionId}`,
+        operation: "browser.upload",
+        resource: {
+          kind: "browser.surface",
+          id: action.surface.surfaceId,
+          version: String(action.surface.generation),
+        },
+        artifacts: [],
+        idempotency: { key: action.actionId, replayed: false },
+        observedAt: new Date(now).toISOString(),
+        outcome: "applied",
+        commit: {
+          kind: "provider_accepted",
+          id: "provider-receipt-1",
+          committedAt: new Date(now).toISOString(),
+        },
+      },
+    }));
+    await expect(
+      service.executeConfirmedUpload(command, {
+        actionId: confirmed.draft.actionId,
+        requestedAt,
+        confirmationGrant: confirmed.grant,
+        confirmationGrantConsumer: confirmed.coordinator,
+        profileGrantVerifier,
+        session: activeSession,
+        capabilities,
+      }),
+    ).rejects.toMatchObject({ kind: "UNCERTAIN_OUTCOME" });
+  });
+
+  it("rejects stale effect chronology and mutable target identity", async () => {
+    const activeSession = session();
+    const staleProof = confirmedUpload(activeSession);
+    const { execute, service } = serviceWithTarget();
+    const defaultExecution = execute.getMockImplementation();
+    if (!defaultExecution) throw new Error("missing target implementation");
+    execute.mockImplementationOnce(async (action) => {
+      const output = await defaultExecution(action);
+      return {
+        ...output,
+        effectReceipt: {
+          ...output.effectReceipt,
+          commit: {
+            kind: "provider_accepted" as const,
+            id: "provider-acceptance-stale",
+            committedAt: "2026-08-18T21:58:59.000Z",
+          },
+        },
+      };
+    });
+    await expect(
+      service.executeConfirmedUpload(command, {
+        actionId: staleProof.draft.actionId,
+        requestedAt,
+        confirmationGrant: staleProof.grant,
+        confirmationGrantConsumer: staleProof.coordinator,
+        profileGrantVerifier,
+        session: activeSession,
+        capabilities,
+      }),
+    ).rejects.toMatchObject({ kind: "UNCERTAIN_OUTCOME" });
+
+    const changedTarget = serviceWithTarget();
+    changedTarget.target.available = async () => {
+      changedTarget.target.id = "substituted-adapter";
+      return true;
+    };
+    const targetProof = confirmedUpload(activeSession);
+    const consume = vi.fn(
+      targetProof.coordinator.consume.bind(targetProof.coordinator),
+    );
+    await expect(
+      changedTarget.service.executeConfirmedUpload(command, {
+        actionId: targetProof.draft.actionId,
+        requestedAt,
+        confirmationGrant: targetProof.grant,
+        confirmationGrantConsumer: { consume },
+        profileGrantVerifier,
+        session: activeSession,
+        capabilities,
+      }),
+    ).rejects.toMatchObject({ kind: "UNSUPPORTED" });
+    expect(consume).not.toHaveBeenCalled();
+    expect(changedTarget.execute).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-browser/src/__tests__/browser-command-authority.test.ts
+++ b/plugins/plugin-browser/src/__tests__/browser-command-authority.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Exercises bound browser-upload authorization through the real dispatcher
+ * with an in-process consume-once coordinator and a deterministic target.
+ */
+
+import {
+  computeInteractionActionDigest,
+  type IAgentRuntime,
+  INTERACTION_CONTRACT_VERSION,
+  InteractionConfirmationCoordinator,
+  type InteractionSession,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createBrowserUploadInteractionAction,
+  normalizeBrowserUploadReceipt,
+} from "../browser-command-authority.js";
+import { BrowserService } from "../browser-service.js";
+import { executeBrowserWorkspaceCommand } from "../workspace/browser-workspace.js";
+import { executeDesktopBrowserWorkspaceUtilityCommand } from "../workspace/browser-workspace-desktop.js";
+import { executeWebBrowserWorkspaceUtilityCommand } from "../workspace/browser-workspace-web.js";
+
+const now = Date.parse("2026-08-18T22:00:00.000Z");
+const requestedAt = "2026-08-18T21:59:00.000Z";
+const expiresAt = "2026-08-18T22:05:00.000Z";
+const profileGrantVerifier = {
+  verify: (
+    grant: { profileHandle: string },
+    context: { ownerId: string; adapterId: string },
+  ) =>
+    grant.profileHandle === "account-opaque-1" &&
+    context.ownerId === "owner-1" &&
+    context.adapterId === capabilities.adapterId,
+};
+
+const capabilities = {
+  contractVersion: INTERACTION_CONTRACT_VERSION,
+  adapterId: "workspace-account-1",
+  controlPlanes: ["browser"],
+  surfaceKinds: ["browser_tab"],
+  observationChannels: ["dom"],
+  actionKinds: ["upload"],
+  background: { mode: "none", requiresForeground: ["upload"] },
+  profileAccess: { modes: ["existing_explicit"], requiresExplicitGrant: true },
+  concurrency: { mode: "single_surface", maxSessions: 1, sharedResources: [] },
+  limitations: [],
+} as const;
+
+function session(
+  ownerId = "owner-1",
+  profileHandle = "account-opaque-1",
+): InteractionSession {
+  return {
+    contractVersion: INTERACTION_CONTRACT_VERSION,
+    sessionId: "session-1",
+    ownerId,
+    adapterId: capabilities.adapterId,
+    state: "ready",
+    isolationMode: "managed_browser",
+    profileMode: "existing_explicit",
+    generation: 3,
+    createdAt: "2026-08-18T21:50:00.000Z",
+    updatedAt: "2026-08-18T21:58:00.000Z",
+    expiresAt,
+    profileGrant: {
+      grantId: "profile-grant-1",
+      sessionId: "session-1",
+      ownerId,
+      adapterId: capabilities.adapterId,
+      profileHandle,
+      issuedAt: "2026-08-18T21:49:00.000Z",
+      expiresAt,
+    },
+    surfaces: [
+      {
+        sessionId: "session-1",
+        adapterId: capabilities.adapterId,
+        surfaceId: "tab-1",
+        kind: "browser_tab",
+        generation: 3,
+        parentSurfaceId: null,
+      },
+    ],
+  };
+}
+
+const command = {
+  subaction: "upload" as const,
+  id: "tab-1",
+  selector: "#attachment",
+  files: ["opaque-file-handle-1"],
+};
+
+function confirmedUpload(activeSession: InteractionSession = session()) {
+  const coordinator = new InteractionConfirmationCoordinator();
+  const draft = createBrowserUploadInteractionAction({
+    actionId: "upload-action-1",
+    requestedAt,
+    confirmationGrant: null,
+    command,
+    session: activeSession,
+  });
+  coordinator.register(
+    {
+      confirmationId: "confirmation-1",
+      actionId: draft.actionId,
+      taxonomy: "browser.upload",
+      origin: null,
+      destination: null,
+      disclosures: ["One selected file will be attached to the current page."],
+      consequence: "The selected page receives the file attachment.",
+      actionDigest: computeInteractionActionDigest(draft),
+      requestedAt,
+      expiresAt,
+    },
+    draft,
+    now,
+  );
+  const grant = coordinator.issue(
+    "confirmation-1",
+    draft,
+    "2026-08-18T22:00:00.000Z",
+    now,
+  );
+  return { coordinator, draft, grant };
+}
+
+function serviceWithTarget() {
+  const service = new BrowserService({} as IAgentRuntime);
+  const genericExecute = vi.fn(async (dispatched: typeof command) => ({
+    mode: "desktop" as const,
+    subaction: dispatched.subaction,
+    value: { attached: dispatched.files?.length ?? 0 },
+  }));
+  const execute = vi.fn(
+    async (
+      action: ReturnType<typeof createBrowserUploadInteractionAction>,
+    ) => ({
+      result: {
+        mode: "desktop" as const,
+        subaction: "upload" as const,
+        value: { attached: 1 },
+      },
+      effectReceipt: {
+        receiptId: `browser-upload:${action.actionId}`,
+        operation: "browser.upload",
+        resource: {
+          kind: "browser.surface",
+          id: action.surface.surfaceId,
+          version: String(action.surface.generation),
+        },
+        artifacts: [],
+        idempotency: { key: action.actionId, replayed: false },
+        observedAt: new Date(now).toISOString(),
+        outcome: "applied",
+        commit: {
+          kind: "provider_accepted",
+          id: action.actionId,
+          committedAt: new Date(now).toISOString(),
+        },
+      },
+    }),
+  );
+  service.registerTarget({
+    id: capabilities.adapterId,
+    name: "Bound workspace account",
+    description: "Deterministic browser target",
+    available: async () => true,
+    supports: (candidate) => candidate.subaction === "upload",
+    execute: genericExecute,
+    executeAuthorizedUpload: execute,
+  });
+  return { execute, genericExecute, service };
+}
+
+describe("bound browser command authorization", () => {
+  it("blocks upload and eval on the generic dispatcher", async () => {
+    const { execute, genericExecute, service } = serviceWithTarget();
+
+    await expect(
+      service.execute(command, capabilities.adapterId),
+    ).rejects.toMatchObject({
+      kind: "POLICY_BLOCKED",
+    });
+    await expect(
+      service.execute(
+        { subaction: "eval", id: "tab-1", script: "document.cookie" },
+        capabilities.adapterId,
+      ),
+    ).rejects.toMatchObject({ kind: "POLICY_BLOCKED" });
+    await expect(
+      service.execute({
+        subaction: "batch",
+        steps: [{ subaction: "state" }, command],
+      }),
+    ).rejects.toMatchObject({ kind: "POLICY_BLOCKED" });
+    expect(execute).not.toHaveBeenCalled();
+    expect(genericExecute).not.toHaveBeenCalled();
+    await expect(executeBrowserWorkspaceCommand(command, {})).rejects.toThrow(
+      "proof-producing target",
+    );
+    await expect(
+      executeBrowserWorkspaceCommand(
+        { ...command, subaction: "realistic-upload" },
+        {},
+      ),
+    ).rejects.toThrow("proof-producing target");
+    await expect(
+      executeWebBrowserWorkspaceUtilityCommand(command),
+    ).rejects.toThrow("proof-producing target");
+    await expect(
+      executeDesktopBrowserWorkspaceUtilityCommand(command, {}),
+    ).rejects.toThrow("proof-producing target");
+  });
+
+  it("does not consume confirmation when the pinned target lacks upload proof", async () => {
+    const activeSession = session();
+    const { coordinator, draft, grant } = confirmedUpload(activeSession);
+    const consume = vi.fn(coordinator.consume.bind(coordinator));
+    const service = new BrowserService({} as IAgentRuntime);
+    service.registerTarget({
+      id: capabilities.adapterId,
+      name: "Generic target",
+      description: "No proof-producing upload hook",
+      available: async () => true,
+      supports: () => true,
+      execute: vi.fn(),
+    });
+
+    await expect(
+      service.executeConfirmedUpload(command, {
+        actionId: draft.actionId,
+        requestedAt,
+        confirmationGrant: grant,
+        confirmationGrantConsumer: { consume },
+        profileGrantVerifier,
+        session: activeSession,
+        capabilities,
+        now,
+      }),
+    ).rejects.toMatchObject({ kind: "UNSUPPORTED" });
+    expect(consume).not.toHaveBeenCalled();
+  });
+
+  it("consumes an exact confirmation and emits a context-bound receipt", async () => {
+    const activeSession = session();
+    const { coordinator, draft, grant } = confirmedUpload(activeSession);
+    const { execute, service } = serviceWithTarget();
+
+    const output = await service.executeConfirmedUpload(command, {
+      actionId: draft.actionId,
+      requestedAt,
+      confirmationGrant: grant,
+      confirmationGrantConsumer: coordinator,
+      profileGrantVerifier,
+      session: activeSession,
+      capabilities,
+      now,
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "upload",
+        payload: {
+          elementId: "#attachment",
+          fileHandles: ["opaque-file-handle-1"],
+        },
+      }),
+    );
+    expect(output.receipt.binding).toMatchObject({
+      ownerId: "owner-1",
+      accountId: "account-opaque-1",
+      adapterId: capabilities.adapterId,
+      capabilityId: "browser.upload",
+      operation: "browser.upload",
+      inputDigest: computeInteractionActionDigest({
+        ...draft,
+        confirmationGrant: grant,
+      }),
+    });
+    expect(JSON.stringify(output.receipt)).not.toContain(
+      "opaque-file-handle-1",
+    );
+    expect(
+      normalizeBrowserUploadReceipt(output.receipt, {
+        action: { ...draft, confirmationGrant: grant },
+        session: activeSession,
+      }),
+    ).toEqual(output.receipt);
+  });
+
+  it("rejects concurrent replay before a second dispatch", async () => {
+    const activeSession = session();
+    const { coordinator, draft, grant } = confirmedUpload(activeSession);
+    const { execute, service } = serviceWithTarget();
+    const authorization = {
+      actionId: draft.actionId,
+      requestedAt,
+      confirmationGrant: grant,
+      confirmationGrantConsumer: coordinator,
+      profileGrantVerifier,
+      session: activeSession,
+      capabilities,
+      now,
+    };
+
+    const attempts = await Promise.allSettled([
+      service.executeConfirmedUpload(command, authorization),
+      service.executeConfirmedUpload(command, authorization),
+    ]);
+
+    expect(
+      attempts.filter((attempt) => attempt.status === "fulfilled"),
+    ).toHaveLength(1);
+    expect(
+      attempts.filter((attempt) => attempt.status === "rejected"),
+    ).toHaveLength(1);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects account-grant substitution during atomic confirmation consume", async () => {
+    const activeSession = session();
+    const { coordinator, draft, grant } = confirmedUpload(activeSession);
+    const { execute, service } = serviceWithTarget();
+    const consume = vi.fn(
+      async (...args: Parameters<typeof coordinator.consume>) => {
+        await coordinator.consume(...args);
+        if (!activeSession.profileGrant) {
+          throw new Error("Test fixture requires a profile grant.");
+        }
+        activeSession.profileGrant = {
+          ...activeSession.profileGrant,
+          grantId: "profile-grant-2",
+          profileHandle: "account-opaque-2",
+        };
+      },
+    );
+
+    await expect(
+      service.executeConfirmedUpload(command, {
+        actionId: draft.actionId,
+        requestedAt,
+        confirmationGrant: grant,
+        confirmationGrantConsumer: { consume },
+        profileGrantVerifier: {
+          verify: (_profileGrant, context) =>
+            context.ownerId === "owner-1" &&
+            context.adapterId === capabilities.adapterId,
+        },
+        session: activeSession,
+        capabilities,
+        now,
+      }),
+    ).rejects.toMatchObject({ code: "STALE_INTERACTION_REFERENCE" });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("treats invalid post-dispatch effect proof as an uncertain outcome", async () => {
+    const activeSession = session();
+    const { coordinator, draft, grant } = confirmedUpload(activeSession);
+    const { execute, service } = serviceWithTarget();
+    execute.mockImplementationOnce(async (action) => ({
+      result: {
+        mode: "desktop" as const,
+        subaction: "upload" as const,
+        value: { attached: 1 },
+      },
+      effectReceipt: {
+        receiptId: `browser-upload:${action.actionId}`,
+        operation: "browser.submit",
+        resource: {
+          kind: "browser.surface",
+          id: action.surface.surfaceId,
+          version: String(action.surface.generation),
+        },
+        artifacts: [],
+        idempotency: { key: action.actionId, replayed: false },
+        observedAt: new Date(now).toISOString(),
+        outcome: "applied",
+        commit: {
+          kind: "provider_accepted",
+          id: "provider-receipt-1",
+          committedAt: new Date(now - 1_000).toISOString(),
+        },
+      },
+    }));
+    const authorization = {
+      actionId: draft.actionId,
+      requestedAt,
+      confirmationGrant: grant,
+      confirmationGrantConsumer: coordinator,
+      profileGrantVerifier,
+      session: activeSession,
+      capabilities,
+      now,
+    };
+
+    await expect(
+      service.executeConfirmedUpload(command, authorization),
+    ).rejects.toMatchObject({ kind: "UNCERTAIN_OUTCOME" });
+    await expect(
+      service.executeConfirmedUpload(command, authorization),
+    ).rejects.toThrow();
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects account substitution and receipt relabeling", async () => {
+    const activeSession = session();
+    const { coordinator, draft, grant } = confirmedUpload(activeSession);
+    const { service } = serviceWithTarget();
+    const output = await service.executeConfirmedUpload(command, {
+      actionId: draft.actionId,
+      requestedAt,
+      confirmationGrant: grant,
+      confirmationGrantConsumer: coordinator,
+      profileGrantVerifier,
+      session: activeSession,
+      capabilities,
+      now,
+    });
+    const confirmedAction = { ...draft, confirmationGrant: grant };
+
+    expect(() =>
+      normalizeBrowserUploadReceipt(
+        {
+          ...output.receipt,
+          binding: { ...output.receipt.binding, accountId: "account-opaque-2" },
+        },
+        { action: confirmedAction, session: activeSession },
+      ),
+    ).toThrow("binding does not match");
+    expect(() =>
+      normalizeBrowserUploadReceipt(
+        {
+          ...output.receipt,
+          effect: { ...output.receipt.effect, operation: "browser.submit" },
+        },
+        { action: confirmedAction, session: activeSession },
+      ),
+    ).toThrow("cannot be relabeled");
+
+    const substitutedSession = session("owner-2", "account-opaque-2");
+    const secondCoordinator = new InteractionConfirmationCoordinator();
+    secondCoordinator.register(
+      {
+        confirmationId: "confirmation-2",
+        actionId: draft.actionId,
+        taxonomy: "browser.upload",
+        origin: null,
+        destination: null,
+        disclosures: [],
+        consequence: "Attach a file.",
+        actionDigest: computeInteractionActionDigest(draft),
+        requestedAt,
+        expiresAt,
+      },
+      draft,
+      now,
+    );
+    const secondGrant = secondCoordinator.issue(
+      "confirmation-2",
+      draft,
+      "2026-08-18T22:00:00.000Z",
+      now,
+    );
+    await expect(
+      service.executeConfirmedUpload(command, {
+        actionId: draft.actionId,
+        requestedAt,
+        confirmationGrant: secondGrant,
+        confirmationGrantConsumer: secondCoordinator,
+        profileGrantVerifier,
+        session: substitutedSession,
+        capabilities,
+        now,
+      }),
+    ).rejects.toThrow("not current and host-verified");
+  });
+});

--- a/plugins/plugin-browser/src/browser-command-authority.ts
+++ b/plugins/plugin-browser/src/browser-command-authority.ts
@@ -1,0 +1,370 @@
+/**
+ * Binds confirmed browser uploads to the v2 interaction authorization
+ * contract. The selected session/account, adapter capability, upload
+ * operation, and normalized input digest are revalidated together before a
+ * receipt can be accepted; file handles never enter the receipt.
+ */
+
+import {
+  type AuthorizedInteractionAction,
+  authorizeInteractionDispatch,
+  computeInteractionActionDigest,
+  type EffectReceipt,
+  ElizaError,
+  INTERACTION_CONTRACT_VERSION,
+  type InteractionAction,
+  type InteractionCapabilitySet,
+  type InteractionConfirmationGrant,
+  type InteractionConfirmationGrantConsumer,
+  type InteractionProfileGrantVerifier,
+  type InteractionSession,
+  normalizeEffectReceipt,
+} from "@elizaos/core";
+import type {
+  BrowserWorkspaceCommand,
+  BrowserWorkspaceCommandResult,
+} from "./workspace/browser-workspace-types.js";
+
+export const BROWSER_UPLOAD_CAPABILITY_ID = "browser.upload";
+export const BROWSER_UPLOAD_OPERATION = "browser.upload";
+
+export interface BrowserUploadActionRequest {
+  actionId: string;
+  requestedAt: string;
+  confirmationGrant: InteractionConfirmationGrant | null;
+  command: BrowserWorkspaceCommand;
+  session: InteractionSession;
+}
+
+export interface BrowserUploadAuthorizationRequest
+  extends BrowserUploadActionRequest {
+  confirmationGrant: InteractionConfirmationGrant;
+  capabilities: InteractionCapabilitySet;
+  confirmationGrantConsumer: InteractionConfirmationGrantConsumer;
+  profileGrantVerifier?: InteractionProfileGrantVerifier;
+  now?: number;
+}
+
+export interface BrowserAuthorizedCommandBinding {
+  ownerId: string;
+  accountId: string;
+  adapterId: string;
+  capabilityId: typeof BROWSER_UPLOAD_CAPABILITY_ID;
+  operation: typeof BROWSER_UPLOAD_OPERATION;
+  inputDigest: string;
+}
+
+export interface BrowserAuthorizedCommandReceipt {
+  contractVersion: typeof INTERACTION_CONTRACT_VERSION;
+  authorizationId: string;
+  actionId: string;
+  binding: BrowserAuthorizedCommandBinding;
+  effect: EffectReceipt;
+  observedAt: string;
+}
+
+export interface AuthorizedBrowserUpload {
+  action: AuthorizedInteractionAction;
+  binding: BrowserAuthorizedCommandBinding;
+  command: BrowserWorkspaceCommand;
+}
+
+function invalid(
+  message: string,
+  context: Record<string, unknown> = {},
+): never {
+  throw new ElizaError(message, {
+    code: "INVALID_BROWSER_COMMAND_AUTHORIZATION",
+    context,
+    severity: "fatal",
+  });
+}
+
+function nonEmpty(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return invalid(
+      `Browser authorization field '${field}' must be a non-empty string.`,
+      {
+        field,
+      },
+    );
+  }
+  return value.trim();
+}
+
+function stale(message: string, sessionId: string): never {
+  throw new ElizaError(message, {
+    code: "STALE_INTERACTION_REFERENCE",
+    context: { sessionId },
+    severity: "ephemeral",
+  });
+}
+
+function accountIdForSession(session: InteractionSession): string {
+  if (session.profileMode !== "existing_explicit" || !session.profileGrant) {
+    return invalid(
+      "Bound browser upload requires an explicitly granted account profile.",
+      { sessionId: session.sessionId },
+    );
+  }
+  return session.profileGrant.profileHandle;
+}
+
+export function createBrowserUploadInteractionAction(
+  request: BrowserUploadActionRequest,
+): InteractionAction {
+  if (request.command.subaction !== "upload") {
+    return invalid(
+      "Bound browser authorization currently supports upload only.",
+      {
+        subaction: request.command.subaction,
+      },
+    );
+  }
+  const elementId = nonEmpty(request.command.selector, "command.selector");
+  const fileHandles = request.command.files?.map((file, index) =>
+    nonEmpty(file, `command.files[${index}]`),
+  );
+  if (!fileHandles || fileHandles.length === 0) {
+    return invalid(
+      "Bound browser upload requires at least one opaque file handle.",
+    );
+  }
+  const requestedSurfaceId = request.command.id?.trim();
+  const surface = requestedSurfaceId
+    ? request.session.surfaces.find(
+        (candidate) => candidate.surfaceId === requestedSurfaceId,
+      )
+    : request.session.surfaces.find(
+        (candidate) => candidate.kind === "browser_tab",
+      );
+  if (surface?.kind !== "browser_tab") {
+    return invalid(
+      "Bound browser upload requires a current browser-tab surface.",
+      {
+        sessionId: request.session.sessionId,
+      },
+    );
+  }
+  return {
+    contractVersion: INTERACTION_CONTRACT_VERSION,
+    actionId: nonEmpty(request.actionId, "actionId"),
+    sessionId: request.session.sessionId,
+    adapterId: request.session.adapterId,
+    surface,
+    kind: "upload",
+    payload: { elementId, fileHandles },
+    observationId: null,
+    observationSequence: null,
+    requestedAt: nonEmpty(request.requestedAt, "requestedAt"),
+    confirmationGrant: request.confirmationGrant,
+    leaseIds: [],
+  };
+}
+
+/** Atomically consumes the exact confirmation before returning dispatchable input. */
+export async function authorizeBrowserUpload(
+  request: BrowserUploadAuthorizationRequest,
+): Promise<AuthorizedBrowserUpload> {
+  if (request.session.adapterId !== request.capabilities.adapterId) {
+    return invalid(
+      "Browser session and capability adapter identities differ.",
+      {
+        sessionId: request.session.sessionId,
+      },
+    );
+  }
+  if (!request.capabilities.actionKinds.includes("upload")) {
+    return invalid(
+      "Selected browser adapter does not advertise upload capability.",
+      {
+        adapterId: request.capabilities.adapterId,
+      },
+    );
+  }
+  const accountId = accountIdForSession(request.session);
+  const profileGrantId = request.session.profileGrant?.grantId;
+  const action = createBrowserUploadInteractionAction(request);
+  const authorized = await authorizeInteractionDispatch(action, {
+    session: request.session,
+    capabilities: request.capabilities,
+    confirmationGrantConsumer: request.confirmationGrantConsumer,
+    ...(request.profileGrantVerifier
+      ? { profileGrantVerifier: request.profileGrantVerifier }
+      : {}),
+    leaseRequirements: [],
+    ...(request.now === undefined ? {} : { now: request.now }),
+  });
+  if (
+    accountIdForSession(request.session) !== accountId ||
+    request.session.profileGrant?.grantId !== profileGrantId
+  ) {
+    return stale(
+      "Browser account grant changed while dispatch authorization was pending.",
+      request.session.sessionId,
+    );
+  }
+  const payload = authorized.payload as {
+    elementId: string;
+    fileHandles: string[];
+  };
+  const binding = Object.freeze({
+    ownerId: request.session.ownerId,
+    accountId,
+    adapterId: request.session.adapterId,
+    capabilityId: BROWSER_UPLOAD_CAPABILITY_ID,
+    operation: BROWSER_UPLOAD_OPERATION,
+    inputDigest: computeInteractionActionDigest(authorized),
+  });
+  return Object.freeze({
+    action: authorized,
+    binding,
+    command: Object.freeze({
+      subaction: "upload" as const,
+      id: authorized.surface.surfaceId,
+      selector: payload.elementId,
+      files: [...payload.fileHandles],
+    }),
+  });
+}
+
+/** Creates the receipt only after the exact authorized target reports success. */
+export function createBrowserUploadReceipt(
+  authorized: AuthorizedBrowserUpload,
+  result: BrowserWorkspaceCommandResult,
+  effectValue: unknown,
+): BrowserAuthorizedCommandReceipt {
+  if (result.tab && result.tab.id !== authorized.action.surface.surfaceId) {
+    return invalid("Browser upload result came from a different surface.", {
+      actionId: authorized.action.actionId,
+    });
+  }
+  const effect = normalizeEffectReceipt(effectValue);
+  if (
+    effect.operation !== BROWSER_UPLOAD_OPERATION ||
+    effect.resource.kind !== "browser.surface" ||
+    effect.resource.id !== authorized.action.surface.surfaceId ||
+    effect.resource.version !== String(authorized.action.surface.generation) ||
+    effect.idempotency.key !== authorized.action.actionId ||
+    effect.idempotency.replayed ||
+    effect.outcome !== "applied"
+  ) {
+    return invalid(
+      "Browser target did not return effect proof for the exact authorized upload.",
+      {
+        actionId: authorized.action.actionId,
+        receiptId: effect.receiptId,
+      },
+    );
+  }
+  return Object.freeze({
+    contractVersion: INTERACTION_CONTRACT_VERSION,
+    authorizationId:
+      authorized.action.confirmationGrant?.confirmationId ??
+      invalid("Authorized browser upload lost its confirmation grant.", {
+        actionId: authorized.action.actionId,
+      }),
+    actionId: authorized.action.actionId,
+    binding: authorized.binding,
+    effect,
+    observedAt: effect.observedAt,
+  });
+}
+
+/**
+ * Revalidates an untrusted receipt against the expected session and exact
+ * action. A receipt is never authoritative without this trusted context.
+ */
+export function normalizeBrowserUploadReceipt(
+  value: unknown,
+  expected: {
+    action: InteractionAction;
+    session: InteractionSession;
+  },
+): BrowserAuthorizedCommandReceipt {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return invalid("Browser upload receipt must be an object.");
+  }
+  const raw = value as Record<string, unknown>;
+  const bindingRaw = raw.binding;
+  if (
+    bindingRaw === null ||
+    typeof bindingRaw !== "object" ||
+    Array.isArray(bindingRaw)
+  ) {
+    return invalid("Browser upload receipt binding must be an object.");
+  }
+  const binding = bindingRaw as Record<string, unknown>;
+  const expectedBinding = {
+    ownerId: expected.session.ownerId,
+    accountId: accountIdForSession(expected.session),
+    adapterId: expected.session.adapterId,
+    capabilityId: BROWSER_UPLOAD_CAPABILITY_ID,
+    operation: BROWSER_UPLOAD_OPERATION,
+    inputDigest: computeInteractionActionDigest(expected.action),
+  } as const;
+  for (const [field, expectedValue] of Object.entries(expectedBinding)) {
+    if (binding[field] !== expectedValue) {
+      return invalid(
+        "Browser upload receipt binding does not match trusted context.",
+        {
+          actionId: expected.action.actionId,
+          field,
+        },
+      );
+    }
+  }
+  const authorizationId = nonEmpty(raw.authorizationId, "authorizationId");
+  if (
+    expected.action.confirmationGrant?.confirmationId !== authorizationId ||
+    raw.actionId !== expected.action.actionId ||
+    raw.contractVersion !== INTERACTION_CONTRACT_VERSION
+  ) {
+    return invalid(
+      "Browser upload receipt authorization identity does not match.",
+      {
+        actionId: expected.action.actionId,
+      },
+    );
+  }
+  const effect = normalizeEffectReceipt(raw.effect);
+  if (
+    effect.operation !== BROWSER_UPLOAD_OPERATION ||
+    effect.resource.kind !== "browser.surface" ||
+    effect.resource.id !== expected.action.surface.surfaceId ||
+    effect.resource.version !== String(expected.action.surface.generation) ||
+    effect.idempotency.key !== expected.action.actionId ||
+    effect.idempotency.replayed ||
+    effect.outcome !== "applied"
+  ) {
+    return invalid(
+      "Browser upload effect receipt cannot be relabeled onto this action.",
+      {
+        actionId: expected.action.actionId,
+        receiptId: effect.receiptId,
+      },
+    );
+  }
+  const observedAt = nonEmpty(raw.observedAt, "observedAt");
+  if (effect.observedAt !== observedAt) {
+    return invalid(
+      "Browser upload receipt timestamps do not match its effect proof.",
+      {
+        actionId: expected.action.actionId,
+      },
+    );
+  }
+  return Object.freeze({
+    contractVersion: INTERACTION_CONTRACT_VERSION,
+    authorizationId,
+    actionId: expected.action.actionId,
+    binding: Object.freeze(expectedBinding),
+    effect,
+    observedAt,
+  });
+}
+
+export type BrowserAuthorizedUploadExecution = {
+  result: BrowserWorkspaceCommandResult;
+  receipt: BrowserAuthorizedCommandReceipt;
+};

--- a/plugins/plugin-browser/src/browser-command-authority.ts
+++ b/plugins/plugin-browser/src/browser-command-authority.ts
@@ -27,6 +27,7 @@ import type {
 
 export const BROWSER_UPLOAD_CAPABILITY_ID = "browser.upload";
 export const BROWSER_UPLOAD_OPERATION = "browser.upload";
+const BROWSER_EFFECT_CLOCK_SKEW_MS = 5 * 60 * 1_000;
 
 export interface BrowserUploadActionRequest {
   actionId: string;
@@ -42,12 +43,11 @@ export interface BrowserUploadAuthorizationRequest
   capabilities: InteractionCapabilitySet;
   confirmationGrantConsumer: InteractionConfirmationGrantConsumer;
   profileGrantVerifier?: InteractionProfileGrantVerifier;
-  now?: number;
 }
 
 export interface BrowserAuthorizedCommandBinding {
-  ownerId: string;
-  accountId: string;
+  sessionId: string;
+  accountGrantId: string;
   adapterId: string;
   capabilityId: typeof BROWSER_UPLOAD_CAPABILITY_ID;
   operation: typeof BROWSER_UPLOAD_OPERATION;
@@ -80,8 +80,12 @@ function invalid(
   });
 }
 
-function nonEmpty(value: unknown, field: string): string {
-  if (typeof value !== "string" || value.trim().length === 0) {
+function nonEmpty(value: unknown, field: string, maxChars = 512): string {
+  if (
+    typeof value !== "string" ||
+    value.trim().length === 0 ||
+    value.trim().length > maxChars
+  ) {
     return invalid(
       `Browser authorization field '${field}' must be a non-empty string.`,
       {
@@ -100,14 +104,14 @@ function stale(message: string, sessionId: string): never {
   });
 }
 
-function accountIdForSession(session: InteractionSession): string {
+function accountGrantForSession(session: InteractionSession) {
   if (session.profileMode !== "existing_explicit" || !session.profileGrant) {
     return invalid(
       "Bound browser upload requires an explicitly granted account profile.",
       { sessionId: session.sessionId },
     );
   }
-  return session.profileGrant.profileHandle;
+  return session.profileGrant;
 }
 
 export function createBrowserUploadInteractionAction(
@@ -121,14 +125,29 @@ export function createBrowserUploadInteractionAction(
       },
     );
   }
-  const elementId = nonEmpty(request.command.selector, "command.selector");
+  const elementId = nonEmpty(
+    request.command.selector,
+    "command.selector",
+    4_096,
+  );
   const fileHandles = request.command.files?.map((file, index) =>
-    nonEmpty(file, `command.files[${index}]`),
+    nonEmpty(file, `command.files[${index}]`, 4_096),
   );
   if (!fileHandles || fileHandles.length === 0) {
     return invalid(
       "Bound browser upload requires at least one opaque file handle.",
     );
+  }
+  if (
+    fileHandles.length > 32 ||
+    new Set(fileHandles).size !== fileHandles.length
+  ) {
+    return invalid(
+      "Bound browser upload file handles must be unique and limited to 32 entries.",
+    );
+  }
+  if (request.command.id !== undefined && !request.command.id.trim()) {
+    return invalid("Bound browser upload surface id cannot be blank.");
   }
   const requestedSurfaceId = request.command.id?.trim();
   const surface = requestedSurfaceId
@@ -174,6 +193,11 @@ export async function authorizeBrowserUpload(
       },
     );
   }
+  if (!request.capabilities.controlPlanes.includes("browser")) {
+    return invalid("Selected adapter does not advertise browser control.", {
+      adapterId: request.capabilities.adapterId,
+    });
+  }
   if (!request.capabilities.actionKinds.includes("upload")) {
     return invalid(
       "Selected browser adapter does not advertise upload capability.",
@@ -182,9 +206,19 @@ export async function authorizeBrowserUpload(
       },
     );
   }
-  const accountId = accountIdForSession(request.session);
-  const profileGrantId = request.session.profileGrant?.grantId;
   const action = createBrowserUploadInteractionAction(request);
+  const accountGrant = accountGrantForSession(request.session);
+  if (
+    Date.parse(request.session.updatedAt) > Date.parse(action.requestedAt) ||
+    Date.parse(accountGrant.issuedAt) > Date.parse(action.requestedAt)
+  ) {
+    return stale(
+      "Browser session or account grant changed after the upload was requested.",
+      request.session.sessionId,
+    );
+  }
+  const accountProfileHandle = accountGrant.profileHandle;
+  const accountGrantId = accountGrant.grantId;
   const authorized = await authorizeInteractionDispatch(action, {
     session: request.session,
     capabilities: request.capabilities,
@@ -193,11 +227,11 @@ export async function authorizeBrowserUpload(
       ? { profileGrantVerifier: request.profileGrantVerifier }
       : {}),
     leaseRequirements: [],
-    ...(request.now === undefined ? {} : { now: request.now }),
   });
   if (
-    accountIdForSession(request.session) !== accountId ||
-    request.session.profileGrant?.grantId !== profileGrantId
+    accountGrantForSession(request.session).profileHandle !==
+      accountProfileHandle ||
+    request.session.profileGrant?.grantId !== accountGrantId
   ) {
     return stale(
       "Browser account grant changed while dispatch authorization was pending.",
@@ -209,8 +243,8 @@ export async function authorizeBrowserUpload(
     fileHandles: string[];
   };
   const binding = Object.freeze({
-    ownerId: request.session.ownerId,
-    accountId,
+    sessionId: request.session.sessionId,
+    accountGrantId,
     adapterId: request.session.adapterId,
     capabilityId: BROWSER_UPLOAD_CAPABILITY_ID,
     operation: BROWSER_UPLOAD_OPERATION,
@@ -239,7 +273,17 @@ export function createBrowserUploadReceipt(
       actionId: authorized.action.actionId,
     });
   }
+  if (result.subaction !== "upload") {
+    return invalid("Browser upload result reports a different operation.", {
+      actionId: authorized.action.actionId,
+      subaction: result.subaction,
+    });
+  }
   const effect = normalizeEffectReceipt(effectValue);
+  const requestedAt = Date.parse(authorized.action.requestedAt);
+  const observedAt = Date.parse(effect.observedAt);
+  const committedAt =
+    effect.outcome === "applied" ? Date.parse(effect.commit.committedAt) : NaN;
   if (
     effect.operation !== BROWSER_UPLOAD_OPERATION ||
     effect.resource.kind !== "browser.surface" ||
@@ -247,7 +291,10 @@ export function createBrowserUploadReceipt(
     effect.resource.version !== String(authorized.action.surface.generation) ||
     effect.idempotency.key !== authorized.action.actionId ||
     effect.idempotency.replayed ||
-    effect.outcome !== "applied"
+    effect.outcome !== "applied" ||
+    committedAt < requestedAt ||
+    observedAt < committedAt ||
+    observedAt > Date.now() + BROWSER_EFFECT_CLOCK_SKEW_MS
   ) {
     return invalid(
       "Browser target did not return effect proof for the exact authorized upload.",
@@ -296,8 +343,8 @@ export function normalizeBrowserUploadReceipt(
   }
   const binding = bindingRaw as Record<string, unknown>;
   const expectedBinding = {
-    ownerId: expected.session.ownerId,
-    accountId: accountIdForSession(expected.session),
+    sessionId: expected.session.sessionId,
+    accountGrantId: accountGrantForSession(expected.session).grantId,
     adapterId: expected.session.adapterId,
     capabilityId: BROWSER_UPLOAD_CAPABILITY_ID,
     operation: BROWSER_UPLOAD_OPERATION,
@@ -328,6 +375,10 @@ export function normalizeBrowserUploadReceipt(
     );
   }
   const effect = normalizeEffectReceipt(raw.effect);
+  const requestedAt = Date.parse(expected.action.requestedAt);
+  const observedEffectAt = Date.parse(effect.observedAt);
+  const committedAt =
+    effect.outcome === "applied" ? Date.parse(effect.commit.committedAt) : NaN;
   if (
     effect.operation !== BROWSER_UPLOAD_OPERATION ||
     effect.resource.kind !== "browser.surface" ||
@@ -335,7 +386,10 @@ export function normalizeBrowserUploadReceipt(
     effect.resource.version !== String(expected.action.surface.generation) ||
     effect.idempotency.key !== expected.action.actionId ||
     effect.idempotency.replayed ||
-    effect.outcome !== "applied"
+    effect.outcome !== "applied" ||
+    committedAt < requestedAt ||
+    observedEffectAt < committedAt ||
+    observedEffectAt > Date.now() + BROWSER_EFFECT_CLOCK_SKEW_MS
   ) {
     return invalid(
       "Browser upload effect receipt cannot be relabeled onto this action.",

--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -27,7 +27,23 @@
  * the whole point of the pattern. The BROWSER action stays one action.
  */
 
-import { ElizaError, type IAgentRuntime, logger, Service } from "@elizaos/core";
+import {
+  type AuthorizedInteractionAction,
+  ElizaError,
+  type IAgentRuntime,
+  type InteractionCapabilitySet,
+  type InteractionConfirmationGrant,
+  type InteractionConfirmationGrantConsumer,
+  type InteractionProfileGrantVerifier,
+  type InteractionSession,
+  logger,
+  Service,
+} from "@elizaos/core";
+import {
+  authorizeBrowserUpload,
+  type BrowserAuthorizedUploadExecution,
+  createBrowserUploadReceipt,
+} from "./browser-command-authority.js";
 import {
   BrowserDispatchFailure,
   isBrowserDispatchFailure,
@@ -120,6 +136,37 @@ export interface BrowserTarget {
   execute(
     command: BrowserWorkspaceCommand,
   ): Promise<BrowserWorkspaceCommandResult>;
+  /**
+   * Optional proof-producing upload boundary. Generic `execute(upload)` is
+   * never called; a target must opt in and return an exact effect receipt.
+   */
+  executeAuthorizedUpload?(action: AuthorizedInteractionAction): Promise<{
+    result: BrowserWorkspaceCommandResult;
+    effectReceipt: unknown;
+  }>;
+}
+
+function findBlockedGenericCommand(
+  command: BrowserWorkspaceCommand,
+): "eval" | "upload" | "realistic-upload" | null {
+  const pending = [command];
+  const visited = new Set<BrowserWorkspaceCommand>();
+  while (pending.length > 0) {
+    const candidate = pending.pop();
+    if (!candidate || visited.has(candidate)) continue;
+    visited.add(candidate);
+    if (
+      candidate.subaction === "eval" ||
+      candidate.subaction === "upload" ||
+      candidate.subaction === "realistic-upload"
+    ) {
+      return candidate.subaction;
+    }
+    if (candidate.subaction === "batch" && Array.isArray(candidate.steps)) {
+      pending.push(...candidate.steps);
+    }
+  }
+  return null;
 }
 
 export class BrowserService extends Service {
@@ -325,6 +372,91 @@ export class BrowserService extends Service {
    * throwing deep inside the target).
    */
   async execute(
+    command: BrowserWorkspaceCommand,
+    targetId?: string,
+  ): Promise<BrowserWorkspaceCommandResult> {
+    const blockedCommand = findBlockedGenericCommand(command);
+    if (blockedCommand) {
+      throw new BrowserDispatchFailure(
+        "POLICY_BLOCKED",
+        blockedCommand === "eval"
+          ? "Generic browser eval is disabled. Use typed browser commands instead."
+          : "Browser upload requires an exact consume-once interaction confirmation.",
+        { targetId: targetId ?? null },
+      );
+    }
+    return this.executeSelected(command, targetId);
+  }
+
+  /**
+   * Executes one confirmed upload through the v2 interaction contract. The
+   * confirmation is consumed before dispatch and the target is pinned to the
+   * session adapter, preventing account or backend substitution.
+   */
+  async executeConfirmedUpload(
+    command: BrowserWorkspaceCommand,
+    authorization: {
+      actionId: string;
+      requestedAt: string;
+      confirmationGrant: InteractionConfirmationGrant;
+      confirmationGrantConsumer: InteractionConfirmationGrantConsumer;
+      profileGrantVerifier?: InteractionProfileGrantVerifier;
+      session: InteractionSession;
+      capabilities: InteractionCapabilitySet;
+      now?: number;
+    },
+  ): Promise<BrowserAuthorizedUploadExecution> {
+    const [target] = await this.resolveTargets(
+      authorization.session.adapterId,
+      command,
+    );
+    const executeAuthorizedUpload =
+      target?.executeAuthorizedUpload?.bind(target);
+    if (!target || !executeAuthorizedUpload) {
+      throw new BrowserDispatchFailure(
+        "UNSUPPORTED",
+        `Browser target "${authorization.session.adapterId}" does not provide proof-producing upload execution.`,
+        { targetId: authorization.session.adapterId },
+      );
+    }
+    if (target.supports && !target.supports(command)) {
+      throw new BrowserDispatchFailure(
+        "UNSUPPORTED",
+        `Browser target "${authorization.session.adapterId}" does not support confirmed upload execution.`,
+        { targetId: authorization.session.adapterId },
+      );
+    }
+    const authorized = await authorizeBrowserUpload({
+      ...authorization,
+      command,
+    });
+    try {
+      const targetOutput = await executeAuthorizedUpload(authorized.action);
+      return Object.freeze({
+        result: targetOutput.result,
+        receipt: createBrowserUploadReceipt(
+          authorized,
+          targetOutput.result,
+          targetOutput.effectReceipt,
+        ),
+      });
+    } catch (error) {
+      // error-policy:J1 The dispatch boundary preserves uncertain mutation outcomes as a typed failure.
+      if (
+        isBrowserDispatchFailure(error) &&
+        error.kind === "UNCERTAIN_OUTCOME"
+      ) {
+        throw error;
+      }
+      throw new BrowserDispatchFailure(
+        "UNCERTAIN_OUTCOME",
+        `Browser target "${target.id}" failed after confirmed upload dispatch; the outcome is uncertain and must not be replayed.`,
+        { targetId: target.id, cause: error },
+      );
+    }
+  }
+
+  private async executeSelected(
     command: BrowserWorkspaceCommand,
     targetId?: string,
   ): Promise<BrowserWorkspaceCommandResult> {

--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -59,6 +59,7 @@ import {
   ensureBrowserWorkspaceDefaultTabWithRetry,
   getBrowserWorkspaceSnapshot,
 } from "./workspace/browser-workspace.js";
+import { normalizeBrowserWorkspaceCommand } from "./workspace/browser-workspace-helpers.js";
 import type {
   BrowserWorkspaceCommand,
   BrowserWorkspaceCommandResult,
@@ -155,12 +156,18 @@ function findBlockedGenericCommand(
     const candidate = pending.pop();
     if (!candidate || visited.has(candidate)) continue;
     visited.add(candidate);
-    if (
-      candidate.subaction === "eval" ||
-      candidate.subaction === "upload" ||
-      candidate.subaction === "realistic-upload"
-    ) {
-      return candidate.subaction;
+    for (const value of [candidate.subaction, candidate.operation]) {
+      const normalized =
+        typeof value === "string"
+          ? value.trim().toLowerCase().replaceAll("_", "-")
+          : "";
+      if (
+        normalized === "eval" ||
+        normalized === "upload" ||
+        normalized === "realistic-upload"
+      ) {
+        return normalized;
+      }
     }
     if (candidate.subaction === "batch" && Array.isArray(candidate.steps)) {
       pending.push(...candidate.steps);
@@ -375,6 +382,7 @@ export class BrowserService extends Service {
     command: BrowserWorkspaceCommand,
     targetId?: string,
   ): Promise<BrowserWorkspaceCommandResult> {
+    command = normalizeBrowserWorkspaceCommand(command);
     const blockedCommand = findBlockedGenericCommand(command);
     if (blockedCommand) {
       throw new BrowserDispatchFailure(
@@ -403,13 +411,19 @@ export class BrowserService extends Service {
       profileGrantVerifier?: InteractionProfileGrantVerifier;
       session: InteractionSession;
       capabilities: InteractionCapabilitySet;
-      now?: number;
     },
   ): Promise<BrowserAuthorizedUploadExecution> {
     const [target] = await this.resolveTargets(
       authorization.session.adapterId,
       command,
     );
+    if (target && target.id !== authorization.session.adapterId) {
+      throw new BrowserDispatchFailure(
+        "UNSUPPORTED",
+        "Resolved browser target identity changed before authorization.",
+        { targetId: authorization.session.adapterId },
+      );
+    }
     const executeAuthorizedUpload =
       target?.executeAuthorizedUpload?.bind(target);
     if (!target || !executeAuthorizedUpload) {

--- a/plugins/plugin-browser/src/index.ts
+++ b/plugins/plugin-browser/src/index.ts
@@ -35,6 +35,7 @@ export {
 export * from "./bridge-policy.js";
 export * from "./bridge-readiness.js";
 export * from "./bridge-records.js";
+export * from "./browser-command-authority.js";
 export {
   BROWSER_SERVICE_TYPE,
   BrowserService,
@@ -76,6 +77,7 @@ import { buildWaitForUrlPredicate as _bs_14_buildWaitForUrlPredicate } from "./a
 import { resolveBrowserBridgeCompanionPairingTokenExpiresAt as _bs_13_resolveBrowserBridgeCompanionPairingTokenExpiresAt } from "./bridge-policy.js";
 import { resolveBrowserBridgeReadiness as _bs_11_resolveBrowserBridgeReadiness } from "./bridge-readiness.js";
 import { createBrowserBridgeCompanionStatus as _bs_12_createBrowserBridgeCompanionStatus } from "./bridge-records.js";
+import { BROWSER_UPLOAD_CAPABILITY_ID as _bs_17_BROWSER_UPLOAD_CAPABILITY_ID } from "./browser-command-authority.js";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -112,6 +114,7 @@ const __bundle_safety_PLUGINS_PLUGIN_BROWSER_SRC_INDEX__ = [
   _bs_14_buildWaitForUrlPredicate,
   _bs_15_waitForUrl,
   _bs_16_validateBrowserParityMatrix,
+  _bs_17_BROWSER_UPLOAD_CAPABILITY_ID,
 ];
 const bundleSafetyGlobal = globalThis as typeof globalThis & {
   __bundle_safety_PLUGINS_PLUGIN_BROWSER_SRC_INDEX__?: typeof __bundle_safety_PLUGINS_PLUGIN_BROWSER_SRC_INDEX__;

--- a/plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts
@@ -189,6 +189,14 @@ export function createDesktopBrowserWorkspaceCommandScript(
   command: BrowserWorkspaceCommand,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
+  if (
+    command.subaction === "upload" ||
+    command.subaction === "realistic-upload"
+  ) {
+    throw new Error(
+      "Browser workspace upload requires a proof-producing target and an exact consume-once interaction confirmation.",
+    );
+  }
   const waitScriptBranch = desktopBrowserWorkspaceWaitScriptBranch(env);
   return `
 (() => {
@@ -1623,6 +1631,14 @@ export async function executeDesktopBrowserWorkspaceDomCommand(
   command: BrowserWorkspaceCommand,
   env: NodeJS.ProcessEnv,
 ): Promise<BrowserWorkspaceCommandResult> {
+  if (
+    command.subaction === "upload" ||
+    command.subaction === "realistic-upload"
+  ) {
+    throw new Error(
+      "Browser workspace upload requires a proof-producing target and an exact consume-once interaction confirmation.",
+    );
+  }
   assertBrowserWorkspaceUserScriptAllowed(
     command.script,
     "wait",

--- a/plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts
@@ -1285,11 +1285,7 @@ export function createDesktopBrowserWorkspaceUtilityScript(
       return { source: buildSelector(source), target: buildSelector(target) };
     }
     case "upload": {
-      const target = resolveTarget();
-      if (!target || target.tagName !== "INPUT") throw new Error("Eliza browser workspace upload requires a file input target.");
-      const files = Array.isArray(command.files) ? command.files.map((entry) => String(entry).split(/[\\\\/]/).pop()) : [];
-      target.setAttribute("data-eliza-uploaded-files", files.join(","));
-      return { files, selector: buildSelector(target) };
+      throw new Error("Browser workspace upload requires a proof-producing target and an exact consume-once interaction confirmation.");
     }
     case "set": {
       const action = command.setAction || "viewport";
@@ -1445,6 +1441,14 @@ export async function executeDesktopBrowserWorkspaceUtilityCommand(
   command: BrowserWorkspaceCommand,
   env: NodeJS.ProcessEnv,
 ): Promise<BrowserWorkspaceCommandResult> {
+  if (
+    command.subaction === "upload" ||
+    command.subaction === "realistic-upload"
+  ) {
+    throw new Error(
+      "Browser workspace upload requires a proof-producing target and an exact consume-once interaction confirmation.",
+    );
+  }
   const id = await resolveDesktopBrowserWorkspaceTargetTabId(command, env);
   if (
     command.subaction === "cookies" ||

--- a/plugins/plugin-browser/src/workspace/browser-workspace-web.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-web.ts
@@ -141,6 +141,11 @@ export function findWebBrowserWorkspaceTargetTabId(
 export async function executeWebBrowserWorkspaceUtilityCommand(
   command: BrowserWorkspaceCommand,
 ): Promise<BrowserWorkspaceCommandResult | null> {
+  if (command.subaction === "upload") {
+    throw new Error(
+      "Browser workspace upload requires a proof-producing target and an exact consume-once interaction confirmation.",
+    );
+  }
   return withWebStateLock(async () => {
     if (
       ![
@@ -341,24 +346,9 @@ export async function executeWebBrowserWorkspaceUtilityCommand(
         };
       }
       case "upload": {
-        const target = resolveTarget();
-        if (target?.tagName !== "INPUT") {
-          throw new Error(
-            "Eliza browser workspace upload requires a file input target.",
-          );
-        }
-        const files = (command.files ?? []).map((entry) =>
-          path.basename(entry),
+        throw new Error(
+          "Browser workspace upload requires a proof-producing target and an exact consume-once interaction confirmation.",
         );
-        target.setAttribute("data-eliza-uploaded-files", files.join(","));
-        return {
-          mode: "web",
-          subaction: command.subaction,
-          value: {
-            files,
-            selector: buildBrowserWorkspaceElementSelector(target),
-          },
-        };
       }
       case "set": {
         const action = command.setAction ?? "viewport";
@@ -918,6 +908,14 @@ export async function executeWebBrowserWorkspaceUtilityCommand(
 export async function executeWebBrowserWorkspaceDomCommand(
   command: BrowserWorkspaceCommand,
 ): Promise<BrowserWorkspaceCommandResult> {
+  if (
+    command.subaction === "upload" ||
+    command.subaction === "realistic-upload"
+  ) {
+    throw new Error(
+      "Browser workspace upload requires a proof-producing target and an exact consume-once interaction confirmation.",
+    );
+  }
   return withWebStateLock(async () => {
     const id = findWebBrowserWorkspaceTargetTabId(command);
     command = resolveBrowserWorkspaceCommandElementRefs(command, "web", id);

--- a/plugins/plugin-browser/src/workspace/browser-workspace.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace.ts
@@ -749,6 +749,27 @@ export async function executeBrowserWorkspaceCommand(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<BrowserWorkspaceCommandResult> {
   command = normalizeBrowserWorkspaceCommand(command);
+  const pending = [command];
+  let blockedUpload = false;
+  while (pending.length > 0) {
+    const candidate = pending.pop();
+    if (!candidate) break;
+    if (
+      candidate.subaction === "upload" ||
+      candidate.subaction === "realistic-upload"
+    ) {
+      blockedUpload = true;
+      break;
+    }
+    if (candidate.subaction === "batch" && Array.isArray(candidate.steps)) {
+      pending.push(...candidate.steps);
+    }
+  }
+  if (blockedUpload) {
+    throw new Error(
+      "Browser workspace upload requires a proof-producing target and an exact consume-once interaction confirmation.",
+    );
+  }
   switch (command.subaction) {
     case "batch": {
       const steps = Array.isArray(command.steps) ? command.steps : [];
@@ -892,8 +913,7 @@ export async function executeBrowserWorkspaceCommand(
     case "mouse":
     case "network":
     case "set":
-    case "storage":
-    case "upload": {
+    case "storage": {
       if (!isBrowserWorkspaceBridgeConfigured(env)) {
         return (await executeWebBrowserWorkspaceUtilityCommand(
           command,
@@ -1252,7 +1272,6 @@ export async function executeBrowserWorkspaceCommand(
     case "realistic-fill":
     case "realistic-type":
     case "realistic-press":
-    case "realistic-upload":
     case "cursor-move":
     case "cursor-hide":
       if (
@@ -1277,6 +1296,11 @@ export async function executeBrowserWorkspaceCommand(
         return executeDesktopBrowserWorkspaceDomCommand(command, env);
       }
       return executeWebBrowserWorkspaceDomCommand(command);
+    case "upload":
+    case "realistic-upload":
+      throw new Error(
+        "Browser workspace upload requires a proof-producing target and an exact consume-once interaction confirmation.",
+      );
     default: {
       const exhaustive: never = command.subaction;
       throw new Error(`Unsupported browser workspace subaction: ${exhaustive}`);

--- a/plugins/plugin-browser/src/workspace/browser-workspace.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace.ts
@@ -105,6 +105,7 @@ import {
   assertBrowserWorkspaceConnectorSecretsNotExported,
   assertBrowserWorkspaceUrl,
   assertBrowserWorkspaceUserScriptAllowed,
+  createBrowserWorkspaceJsdomScriptExecutionError,
   createBrowserWorkspaceNotFoundError,
   DEFAULT_WEB_PARTITION,
   inferBrowserWorkspaceTitle,
@@ -750,7 +751,7 @@ export async function executeBrowserWorkspaceCommand(
 ): Promise<BrowserWorkspaceCommandResult> {
   command = normalizeBrowserWorkspaceCommand(command);
   const pending = [command];
-  let blockedUpload = false;
+  let blockedCommand: "eval" | "upload" | "realistic-upload" | null = null;
   while (pending.length > 0) {
     const candidate = pending.pop();
     if (!candidate) break;
@@ -758,16 +759,25 @@ export async function executeBrowserWorkspaceCommand(
       candidate.subaction === "upload" ||
       candidate.subaction === "realistic-upload"
     ) {
-      blockedUpload = true;
+      blockedCommand = candidate.subaction;
+      break;
+    }
+    if (candidate.subaction === "eval") {
+      blockedCommand = "eval";
       break;
     }
     if (candidate.subaction === "batch" && Array.isArray(candidate.steps)) {
       pending.push(...candidate.steps);
     }
   }
-  if (blockedUpload) {
+  if (blockedCommand) {
+    if (blockedCommand === "eval" && !isBrowserWorkspaceBridgeConfigured(env)) {
+      throw createBrowserWorkspaceJsdomScriptExecutionError("eval");
+    }
     throw new Error(
-      "Browser workspace upload requires a proof-producing target and an exact consume-once interaction confirmation.",
+      blockedCommand === "eval"
+        ? "Generic browser eval is disabled. Use typed browser commands instead."
+        : "Browser workspace upload requires a proof-producing target and an exact consume-once interaction confirmation.",
     );
   }
   switch (command.subaction) {


### PR DESCRIPTION
## Summary

- fail closed for generic `eval`, `upload`, and `realistic-upload` browser commands, including commands nested in batches
- add an opt-in, proof-producing upload path bound to the core v2 interaction authority contract
- bind confirmation and receipts to the exact owner, opaque account profile, adapter, session, browser surface, capability, operation, and upload-input digest
- preserve consume-once semantics under concurrency and classify malformed post-dispatch proofs as `UNCERTAIN_OUTCOME` so callers cannot safely replay them
- remove the web/desktop upload shims that previously reported success without performing an upload

## Scope

This is the first dependency-safe slice of #19882, not closure of the tracker. It establishes the authority boundary needed before browser adapters can perform dangerous uploads. Built-in workspace, bridge, and Stagehand targets do not yet implement the proof-producing hook and therefore remain fail-closed.

Still open under #19882: per-domain policy hooks, credential redaction outside the receipt contract, submit interception, vendor cost metering, and live sandbox evidence for a built-in upload adapter.

Refs #19882

## Safety contract

- Generic browser execution cannot invoke dangerous upload or arbitrary evaluation commands.
- The authorized path pins the target before awaiting confirmation and verifies that the account grant is unchanged afterward.
- Confirmation is consumed atomically and only after support/profile checks pass.
- Exactly one concurrent caller reaches the adapter.
- The returned effect proof must match the expected operation, surface, generation, and idempotency key.
- Receipts expose only an opaque account-profile handle and input digest; file handles are not copied into receipts.
- Any failure after adapter dispatch is an uncertain outcome and cannot be replayed with the consumed confirmation.

## Verification

Exact branch head `ceb222c9362966aeddeba2f0a35039b70c5490c4`, rebased on `develop@b0339c67e958e299f3640ea7f92f62c3343dbb8a`:

- `bun install` — pass
- `bun run --cwd plugins/plugin-browser test` — pass, 29 files / 229 tests
- `bun run --cwd plugins/plugin-browser test -- src/__tests__/browser-command-authority.test.ts` — pass, 11 tests
- `bun run --cwd plugins/plugin-browser typecheck` — pass
- `bun run --cwd plugins/plugin-browser lint:check` — pass, 82 files
- `bun run --cwd plugins/plugin-browser build` — pass
- `git diff --check` — pass

The repository-wide `bun run verify` is not claimed green. An earlier-base run reached an unrelated existing `packages/ui` typecheck failure involving non-exported timeout test helpers. A subsequent rebased run was interrupted by `ENOSPC` while verifying the core package archive. Focused package validation above was rerun after the final rebase.

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Unit/adversarial contract tests | Pass: generic bypass, nested batch bypass, unsupported targets, exact receipt binding, concurrent replay, account substitution, malformed effect proof, and receipt relabeling |
| Package build/typecheck/lint | Pass on the exact submitted head |
| Desktop/mobile screenshots | N/A: no UI surface changed |
| MP4 walkthrough | N/A: built-in upload adapters intentionally remain fail-closed in this slice |
| Live integration proof | N/A for this draft: no built-in adapter is authorized to perform uploads yet |
| Privacy review | Pass: receipts retain an opaque profile handle and digest, not uploaded file handles |

## Provenance

- Author: lalalune
- Tool: Codex Desktop
- Model: OpenAI gpt-5.6-sol
- Contribution workflow: `elizaOS/eliza@ceb222c9362966aeddeba2f0a35039b70c5490c4:packages/skills/skills/contribute-to-eliza`

<!-- evidence-head:ceb222c9362966aeddeba2f0a35039b70c5490c4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - No UI or rendered browser surface changed; this PR adds a runtime authority contract.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - No UI or rendered browser surface changed; this PR adds a runtime authority contract.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Built-in upload adapters intentionally remain fail-closed, so there is no user-facing flow to record.

<!-- evidence-row:backend-logs -->
- [ ] N/A - No backend process or transport changed; focused Vitest contract results are listed in Verification.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend code or browser console behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No prompt, planner, model, or agent behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No generated domain artifact exists; the changed artifact is the tested TypeScript authority and receipt contract.



