### PR TITLE
fix(voice): keep local gateway alive on early bye

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts
@@ -1,14 +1,21 @@
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import { spawnSync } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { connect } from "node:net";
 import { fileURLToPath } from "node:url";
 
 const calls: string[] = [];
 
-class FakeSocket {
+class FakeSocket extends EventEmitter {
+  static instances: FakeSocket[] = [];
+
+  constructor() {
+    super();
+    FakeSocket.instances.push(this);
+  }
+
   addEventListener() {}
   close() {}
-  on() {}
   send() {}
 }
 
@@ -112,7 +119,10 @@ if (process.env.ELIZA_PROCESS_ISOLATED_TEST === "1") {
         cartesiaInkWebSocketFactory(request: {
           url: string;
           headers: Record<string, string>;
-        }): { addEventListener(type: string, listener: () => void): void };
+        }): {
+          addEventListener(type: string, listener: () => void): void;
+          removeEventListener(type: string, listener: () => void): void;
+        };
         cartesiaWebSocketFactory(
           url: string,
           options: { headers: Record<string, string> },
@@ -123,7 +133,16 @@ if (process.env.ELIZA_PROCESS_ISOLATED_TEST === "1") {
           url: "ws://127.0.0.1:1/provider",
           headers: { "X-API-Key": "test" },
         });
-        ink.addEventListener("error", () => undefined);
+        const inkErrorListener = () => undefined;
+        ink.addEventListener("error", inkErrorListener);
+        ink.removeEventListener("error", inkErrorListener);
+        // The DOM adapter removes its own listener before closing. A late
+        // transport error from an outbound socket that is still connecting
+        // must remain process-safe (the exact local-gateway `bye` race).
+        FakeSocket.instances
+          .at(-1)
+          ?.emit("error", new Error("late connect error after cleanup"));
+        calls.push("late-error-absorbed");
         const cartesia = options.cartesiaWebSocketFactory(
           "ws://127.0.0.1:1/provider",
           {
@@ -247,6 +266,7 @@ if (process.env.ELIZA_PROCESS_ISOLATED_TEST === "1") {
       expect(minted.sessionId).toBeTruthy();
       expect(calls).toContain("signing");
       expect(calls).toContain("recorded");
+      expect(calls).toContain("late-error-absorbed");
       expect(logs).toContain("real voice server listening");
       expect(logs).toContain("minted real voice-session token");
 

--- a/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
+++ b/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
@@ -127,6 +127,14 @@ const MAX_LOCAL_TTS_TEXT_LENGTH = 4_000;
 type WsLike = CartesiaInkWebSocket & CartesiaWebSocketLike;
 
 function wrapNodeWsAsDom(socket: NodeWebSocket): WsLike {
+  // `ws` uses EventEmitter semantics: an `error` emitted after the last
+  // listener is removed terminates the whole Bun/Node process. The DOM-style
+  // provider adapters intentionally detach their listeners before closing a
+  // socket, so an error from an outbound connection that is still opening can
+  // otherwise escape during a perfectly normal client `bye`. Keep one inert
+  // transport listener for the lifetime of this harness socket; the adapter's
+  // own listener still receives and reports errors while it is attached.
+  socket.on("error", () => undefined);
   const listenerMap = new WeakMap<
     (e: unknown) => void,
     (...a: unknown[]) => void


### PR DESCRIPTION
# Relates to

Fixes #22225.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `e5f4bfc244e378bf6a97d6e3ca4ebc01bc452ed6`, the latest `origin/develop` at validation time; zero conflicts.
- [ ] Full-repository `bun run verify` was not rerun for this two-file local voice harness fix; the exact affected package gates and unrelated scope note are documented below.

# Risks

Low. The change adds a permanent inert Node `ws` error listener in the local real-server harness wrapper. The DOM adapter's own listener still receives structured errors while attached; after cleanup, a late EventEmitter error can no longer terminate the gateway process.

# Background

## What does this PR do?

It prevents the supervised local voice gateway from exiting when a client sends `bye` while the upstream Cartesia Ink socket is still connecting. The adapter removes its temporary error listener during teardown; Node `ws` can then emit a late `error`, and an EventEmitter with no remaining error listener terminates the process. The wrapper now retains one inert safety listener for the socket lifetime.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No product documentation change is needed. The behavior is covered by a focused regression test and linked implementation issue.

# Testing

## Where should a reviewer start?

Start at `packages/cloud/api/v1/voice/session/lib/harness-real-server.ts` and its focused test in `packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts`.

## Detailed testing steps

1. Run `bun test packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts` and confirm 1/1 passes.
2. Run `bun test packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts --dots --coverage-reporter=lcov` and confirm 60/60 passes.
3. Run Biome on the two changed files.
4. Run `bun run --cwd packages/cloud/api typecheck`; this also executes the Wrangler worker dry-run bundle check.
5. Start the local gateway with configured local credentials, mint a valid session, connect, wait for `ready`, send `bye`, and confirm `/health` remains `ready: true`.
6. POST `Ready.` to the local TTS endpoint and confirm HTTP 200 WAV output with `X-Eliza-TTS-Provider: cartesia-sonic-3.5`.

# Evidence Gate

<!-- evidence-head:4d148ad6b9a72046f2d4e2b703916652dc0a6459 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a nonvisual transport lifecycle defect with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this is a nonvisual transport lifecycle defect with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the reproduced behavior is a process-lifecycle transition, fully evidenced by the exact automated regression and live ready/bye/health sequence below.
<!-- evidence-row:backend-logs -->
- [x] Backend evidence is included inline below: the exact-head test counts and live ready/bye/health/TTS results.

```text
exact head: 4d148ad6b9a72046f2d4e2b703916652dc0a6459
focused lifecycle gates: 1/1 harness regression and 60/60 WebSocket lifecycle tests passed
live lifecycle: ready -> client bye -> server bye; GET /health remained HTTP 200 with ready=true
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - the fix does not change frontend code or frontend request/state behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the fix does not change an agent action, provider selection, prompt, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Domain evidence is included inline below: gateway health remained ready and real Cartesia TTS returned WAV bytes after the bye race.

```text
POST /tts input: Ready.
response: HTTP 200; Content-Type=audio/wav; Content-Length=34604
provider proof: X-Eliza-TTS-Provider=cartesia-sonic-3.5; gateway process remained alive
```
<!-- evidence-row:ocr-review -->
- [x] N/A - the change has no visual surface or rendered text.

# Evidence Details

## Real LLM-call trajectory

N/A - provider/model behavior is unchanged; this is local WebSocket cleanup containment.

## Backend + frontend logs

Exact head `4d148ad6b9a72046f2d4e2b703916652dc0a6459`:

```text
harness-real-server.test.ts: 1 pass, 0 fail
ws-lifecycle.test.ts: 60 pass, 0 fail, 222 expect() calls
Biome: Checked 2 files; no fixes applied
packages/cloud/api typecheck: passed
Wrangler production worker bundle dry-run: passed

live local gateway:
WebSocket: ready -> client bye -> server bye
GET /health after disconnect: HTTP 200, ready=true
POST /tts text="Ready.": HTTP 200, Content-Type=audio/wav,
  Content-Length=34604, X-Eliza-TTS-Provider=cartesia-sonic-3.5
gateway process remained alive and healthy
```

Frontend logs: N/A - no frontend code path changed.

## Screenshots (before / after) + video walkthrough

N/A - nonvisual lifecycle-only change.

## Audio / voice walkthrough

N/A - the changed behavior is connection teardown, not captured audio content. Real Cartesia TTS was exercised after the race and returned a valid WAV response. A new spoken STT utterance was not recorded because no human microphone/speech fixture was available; the live gateway did open the configured Cartesia Ink upstream connection before the immediate disconnect.

## Known gaps / failures

- Full-repository `bun run verify` was not rerun. The changed package passed its focused regression test, all 60 voice lifecycle tests, Biome, package typecheck, and worker dry-run bundle check. The repository-wide verify surface is disproportionate to this two-file local harness fix and is not required to reproduce or validate the defect.
- No new spoken STT utterance was captured. This does not block the cleanup fix: the reproduced failure occurs after the real Cartesia Ink connection is opened but before speech is required, and the post-fix gateway remained healthy after the same ready/bye sequence.
- No deployment or cloud infrastructure was changed.

— [ios-local-runtime]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
