### PR TITLE
fix(cloud): make surrogate-safe message chunking terminate

### DIFF
--- a/packages/cloud/shared/src/lib/utils/discord-helpers.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-helpers.ts
@@ -1,3 +1,5 @@
+import { truncateWellFormed } from "@elizaos/core";
+
 /**
  * Discord Utility Functions
  *
@@ -102,8 +104,9 @@ export function splitMessage(text: string, maxLength = 2000): string[] {
       breakPoint = maxLength;
     }
 
-    messages.push(remaining.substring(0, breakPoint));
-    remaining = remaining.substring(breakPoint).trimStart();
+    const head = truncateWellFormed(remaining, breakPoint);
+    messages.push(head);
+    remaining = remaining.slice(head.length).trimStart();
   }
 
   return messages;
@@ -178,7 +181,7 @@ export function hyperlink(text: string, url: string): string {
  */
 export function truncate(text: string, maxLength: number): string {
   if (!text || text.length <= maxLength) return text;
-  return text.substring(0, maxLength - 3) + "...";
+  return `${truncateWellFormed(text, maxLength - 3)}...`;
 }
 
 /**

--- a/packages/cloud/shared/src/lib/utils/discord-helpers.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-helpers.ts
@@ -1,4 +1,5 @@
 import { truncateWellFormed } from "@elizaos/core";
+import { assertValidMessageChunkLength } from "./message-chunking";
 
 /**
  * Discord Utility Functions
@@ -83,6 +84,7 @@ export function isTextChannel(type: number): boolean {
  * Split long messages for Discord's 2000 char limit
  */
 export function splitMessage(text: string, maxLength = 2000): string[] {
+  assertValidMessageChunkLength(maxLength);
   if (!text) return [];
   if (text.length <= maxLength) return [text];
 

--- a/packages/cloud/shared/src/lib/utils/message-chunking.ts
+++ b/packages/cloud/shared/src/lib/utils/message-chunking.ts
@@ -1,0 +1,7 @@
+/** Validates caller-supplied UTF-16 message chunk limits before splitting. */
+
+export function assertValidMessageChunkLength(maxLength: number): void {
+  if (!Number.isFinite(maxLength) || !Number.isInteger(maxLength) || maxLength < 2) {
+    throw new RangeError("maxLength must be a finite integer of at least 2 UTF-16 code units");
+  }
+}

--- a/packages/cloud/shared/src/lib/utils/surrogate-chunking.test.ts
+++ b/packages/cloud/shared/src/lib/utils/surrogate-chunking.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  splitMessage as splitDiscordMessage,
+  truncate as truncateDiscord,
+} from "./discord-helpers";
+import { splitMessage as splitTelegramMessage } from "./telegram-helpers";
+
+describe("cloud/shared telegram and discord surrogate-pair chunking", () => {
+  it("keeps surrogate pairs intact in telegram splitMessage", () => {
+    const text = `a${"🙂".repeat(4096)}`;
+    const chunks = splitTelegramMessage(text, 4096);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+  });
+
+  it("keeps surrogate pairs intact in discord splitMessage", () => {
+    const text = `a${"🙂".repeat(2000)}`;
+    const chunks = splitDiscordMessage(text, 2000);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(2000);
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+  });
+
+  it("keeps surrogate pairs intact in discord truncate", () => {
+    const text = `a${"🙂".repeat(20)}`;
+    const truncated = truncateDiscord(text, 10);
+    expect(truncated.endsWith("...")).toBe(true);
+    expect(truncated.isWellFormed()).toBe(true);
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/surrogate-chunking.test.ts
+++ b/packages/cloud/shared/src/lib/utils/surrogate-chunking.test.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   splitMessage as splitDiscordMessage,
@@ -6,13 +7,23 @@ import {
 import { splitMessage as splitTelegramMessage } from "./telegram-helpers";
 
 describe("cloud/shared telegram and discord surrogate-pair chunking", () => {
+  const invalidLimits = [
+    1,
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+  ];
+
   it("keeps surrogate pairs intact in telegram splitMessage", () => {
     const text = `a${"🙂".repeat(4096)}`;
     const chunks = splitTelegramMessage(text, 4096);
     expect(chunks.length).toBeGreaterThan(1);
     for (const chunk of chunks) {
       expect(chunk.length).toBeLessThanOrEqual(4096);
-      expect(chunk.isWellFormed()).toBe(true);
+      expect(toWellFormedUnicode(chunk)).toBe(chunk);
     }
   });
 
@@ -22,7 +33,7 @@ describe("cloud/shared telegram and discord surrogate-pair chunking", () => {
     expect(chunks.length).toBeGreaterThan(1);
     for (const chunk of chunks) {
       expect(chunk.length).toBeLessThanOrEqual(2000);
-      expect(chunk.isWellFormed()).toBe(true);
+      expect(toWellFormedUnicode(chunk)).toBe(chunk);
     }
   });
 
@@ -30,6 +41,30 @@ describe("cloud/shared telegram and discord surrogate-pair chunking", () => {
     const text = `a${"🙂".repeat(20)}`;
     const truncated = truncateDiscord(text, 10);
     expect(truncated.endsWith("...")).toBe(true);
-    expect(truncated.isWellFormed()).toBe(true);
+    expect(toWellFormedUnicode(truncated)).toBe(truncated);
   });
+
+  it.each([
+    ["telegram", splitTelegramMessage],
+    ["discord", splitDiscordMessage],
+  ] as const)("rejects unsafe %s chunk limits before splitting", (_name, splitMessage) => {
+    for (const limit of invalidLimits) {
+      expect(() => splitMessage("😀x", limit)).toThrow(RangeError);
+    }
+  });
+
+  it.each([
+    ["telegram", splitTelegramMessage],
+    ["discord", splitDiscordMessage],
+  ] as const)(
+    "makes nonempty, lossless progress at the minimum %s limit",
+    (_name, splitMessage) => {
+      const text = "😀😀x";
+      const chunks = splitMessage(text, 2);
+
+      expect(chunks.join("")).toBe(text);
+      expect(chunks.every((chunk) => chunk.length > 0 && chunk.length <= 2)).toBe(true);
+      expect(chunks.every((chunk) => toWellFormedUnicode(chunk) === chunk)).toBe(true);
+    },
+  );
 });

--- a/packages/cloud/shared/src/lib/utils/telegram-helpers.ts
+++ b/packages/cloud/shared/src/lib/utils/telegram-helpers.ts
@@ -1,3 +1,5 @@
+import { truncateWellFormed } from "@elizaos/core";
+
 // Provides cloud utility telegram helpers helpers shared by backend services.
 export function escapeMarkdownV2(text: string): string {
   if (!text) return "";
@@ -18,8 +20,9 @@ export function splitMessage(text: string, maxLength = 4096): string[] {
       if (line.length > maxLength) {
         let remaining = line;
         while (remaining.length > maxLength) {
-          chunks.push(remaining.slice(0, maxLength));
-          remaining = remaining.slice(maxLength);
+          const head = truncateWellFormed(remaining, maxLength);
+          chunks.push(head);
+          remaining = remaining.slice(head.length);
         }
         current = remaining;
       } else {

--- a/packages/cloud/shared/src/lib/utils/telegram-helpers.ts
+++ b/packages/cloud/shared/src/lib/utils/telegram-helpers.ts
@@ -1,4 +1,5 @@
 import { truncateWellFormed } from "@elizaos/core";
+import { assertValidMessageChunkLength } from "./message-chunking";
 
 // Provides cloud utility telegram helpers helpers shared by backend services.
 export function escapeMarkdownV2(text: string): string {
@@ -7,6 +8,7 @@ export function escapeMarkdownV2(text: string): string {
 }
 
 export function splitMessage(text: string, maxLength = 4096): string[] {
+  assertValidMessageChunkLength(maxLength);
   const chunks: string[] = [];
   if (!text) return chunks;
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:597693bb76d20a82f8c7cd29ddc15794d0604e60 -->

# Relates to

Fixes #22246. Replacement for closed, unmerged #22228.

# Summary

Cloud Shared's Telegram and Discord splitters now use the canonical surrogate-safe truncator without risking a zero-progress loop. A shared boundary validator rejects non-finite, non-integer, and sub-two-code-unit limits before either splitter enters its loop. The minimum supported limit is exercised for forward progress, nonempty chunks, exact reconstruction, effective-bound compliance, and portable repository-level Unicode well-formedness.

# Testing

- `NODE_OPTIONS=--conditions=eliza-source bun test packages/cloud/shared/src/lib/utils/surrogate-chunking.test.ts packages/cloud/shared/src/lib/utils/telegram-helpers.test.ts packages/cloud/shared/src/lib/utils/discord-helpers.test.ts` — 18 passed, 0 failed, 79 assertions.
- Focused TypeScript 7 compile of the four touched source/test files with ES2024/bundler resolution — clean.
- Biome check of all four touched files — clean.
- `git diff --check upstream/develop...HEAD` — clean.

The aggregate package typecheck was also attempted in the sparse review clone. Its generated-code phase completed, but the borrowed cross-worktree dependency symlinks resolve two different builds of Drizzle 0.45.2 and produce unrelated existing DB repository private-type incompatibilities. No touched utility appears in that failure; exact clean-workspace CI and independent review remain required before merge.

# Evidence

Backend-only utility behavior; screenshots, video, frontend logs, live-model trajectories, OCR, and external integration captures are N/A. The focused tests execute the real exported Telegram and Discord helpers. They cover normal-limit emoji boundaries, Discord truncation, fail-fast values `1`, `0`, `-1`, `1.5`, `NaN`, and both infinities for both helpers, plus minimum-limit nonempty/lossless/well-formed bounded output.

<!-- evidence-row:before-screenshots -->
- [x] N/A — backend-only utility change; no visual surface exists before the patch.
<!-- evidence-row:after-screenshots -->
- [x] N/A — backend-only utility change; no visual surface exists after the patch.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no interactive flow or UI is changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head focused test transcript:
```text
bun test v1.3.14 (0d9b296a)
18 pass, 0 fail, 79 expect() calls
Ran 18 tests across 3 files at 597693bb76d20a82f8c7cd29ddc15794d0604e60.
```
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend code or browser runtime is involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model, prompt, action, provider, or planner behavior is involved.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic contract artifact from both exported helpers:
```text
unsafe limits: 1, 0, -1, 1.5, NaN, +Infinity, -Infinity -> RangeError
minimum supported limit: 2; input: 😀😀x; exact reconstruction: true
all chunks: nonempty=true, length<=2=true, toWellFormedUnicode(chunk)===chunk=true
```
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered pixels exist.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@238c3463e5118fbb74d2c0291befbc64bcaf90e7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-pr-wave/cortex-2]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@238c3463e5118fbb74d2c0291befbc64bcaf90e7:packages/skills/skills/contribute-to-eliza"} -->
