### PR TITLE
fix(plugin-google-workspace): enforce safe Google Chat chunk delivery

### DIFF
--- a/plugins/plugin-google-workspace/src/chat/connector.test.ts
+++ b/plugins/plugin-google-workspace/src/chat/connector.test.ts
@@ -7,6 +7,7 @@ import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { GoogleChatService } from "./service.js";
 import {
+  GoogleChatApiError,
   GoogleChatConfigurationError,
   MAX_GOOGLE_CHAT_MESSAGE_LENGTH,
   splitMessageForGoogleChat,
@@ -50,6 +51,17 @@ describe("Google Chat message connector", () => {
     ]);
     (service as { states: typeof states; defaultAccountId: string }).states = states;
     (service as { states: typeof states; defaultAccountId: string }).defaultAccountId = accountId;
+    return service;
+  }
+
+  function serviceWithFetch(fetchImpl: typeof fetch): GoogleChatService {
+    const service = serviceWithState();
+    Object.assign(service, {
+      fetchImpl,
+      chatTimeoutMs: 1_000,
+      runtime: undefined,
+    });
+    vi.spyOn(service, "getAccessToken").mockResolvedValue("test-token");
     return service;
   }
 
@@ -266,6 +278,56 @@ describe("Google Chat message connector", () => {
     );
   });
 
+  it("sends long text chunks in order with thread metadata and one attachment", async () => {
+    const requests: Array<Record<string, unknown>> = [];
+    const service = serviceWithFetch(async (_input, init) => {
+      requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return Response.json({ name: `spaces/AAA/messages/${requests.length}` });
+    });
+    const text = "🙂".repeat(2_500);
+
+    const result = await service.sendMessage({
+      accountId: "workspace",
+      space: "spaces/AAA",
+      thread: "spaces/AAA/threads/T1",
+      text,
+      attachments: [{ attachmentUploadToken: "upload-token", contentName: "file.txt" }],
+    });
+
+    expect(requests).toHaveLength(2);
+    const sentText = requests.map((request) => String(request.text));
+    expect(sentText.join("")).toBe(text);
+    expect(sentText.every((chunk) => chunk.length <= 4_000)).toBe(true);
+    expect(sentText.every((chunk) => chunk.isWellFormed())).toBe(true);
+    expect(requests.map((request) => request.thread)).toEqual([
+      { name: "spaces/AAA/threads/T1" },
+      { name: "spaces/AAA/threads/T1" },
+    ]);
+    expect(requests[0].attachment).toHaveLength(1);
+    expect(requests[1]).not.toHaveProperty("attachment");
+    expect(result.messageName).toBe("spaces/AAA/messages/2");
+  });
+
+  it("stops long-message delivery on the first provider failure", async () => {
+    let requestCount = 0;
+    const service = serviceWithFetch(async () => {
+      requestCount += 1;
+      return requestCount === 2
+        ? new Response("quota exceeded", { status: 429 })
+        : Response.json({ name: `spaces/AAA/messages/${requestCount}` });
+    });
+
+    await expect(
+      service.sendMessage({
+        accountId: "workspace",
+        space: "spaces/AAA",
+        text: "🙂".repeat(4_500),
+      })
+    ).rejects.toBeInstanceOf(GoogleChatApiError);
+
+    expect(requestCount).toBe(2);
+  });
+
   it("validates reaction, edit, and delete mutation parameters before API calls", async () => {
     const runtimeInstance = runtime();
     const service = serviceWithState();
@@ -307,5 +369,36 @@ describe("splitMessageForGoogleChat surrogate pair safety", () => {
 
   it("returns original text when under maxLength", () => {
     expect(splitMessageForGoogleChat("hello")).toEqual(["hello"]);
+  });
+
+  it("keeps the exact provider boundary and chunks one unit beyond it", () => {
+    const exact = "a".repeat(MAX_GOOGLE_CHAT_MESSAGE_LENGTH);
+    expect(splitMessageForGoogleChat(exact)).toEqual([exact]);
+
+    const over = `${exact}b`;
+    const chunks = splitMessageForGoogleChat(over);
+    expect(chunks.map((chunk) => chunk.length)).toEqual([4_000, 1]);
+    expect(chunks.join("")).toBe(over);
+  });
+
+  it("does not let a whitespace break exceed the provider limit", () => {
+    const chunks = splitMessageForGoogleChat(`${"a".repeat(MAX_GOOGLE_CHAT_MESSAGE_LENGTH)} b`);
+    expect(chunks.every((chunk) => chunk.length <= 4_000)).toBe(true);
+    expect(chunks).toEqual(["a".repeat(4_000), "b"]);
+  });
+
+  it.each([1, 0, -1, 2.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects an invalid maxLength %s instead of stalling",
+    (maxLength) => {
+      expect(() => splitMessageForGoogleChat("🙂x", maxLength)).toThrow(
+        "maxLength must be an integer of at least 2"
+      );
+    }
+  );
+
+  it("replaces pre-existing lone surrogates before returning wire text", () => {
+    const chunks = splitMessageForGoogleChat(`\uD83Dvalid\uDC00`);
+    expect(chunks).toEqual(["�valid�"]);
+    expect(chunks.every((chunk) => chunk.isWellFormed())).toBe(true);
   });
 });

--- a/plugins/plugin-google-workspace/src/chat/connector.test.ts
+++ b/plugins/plugin-google-workspace/src/chat/connector.test.ts
@@ -6,7 +6,11 @@
 import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { GoogleChatService } from "./service.js";
-import { GoogleChatConfigurationError } from "./types.js";
+import {
+  GoogleChatConfigurationError,
+  MAX_GOOGLE_CHAT_MESSAGE_LENGTH,
+  splitMessageForGoogleChat,
+} from "./types.js";
 
 describe("Google Chat message connector", () => {
   function runtime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime {
@@ -285,5 +289,23 @@ describe("Google Chat message connector", () => {
     expect(sendReaction).not.toHaveBeenCalled();
     expect(updateMessage).not.toHaveBeenCalled();
     expect(deleteMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("splitMessageForGoogleChat surrogate pair safety", () => {
+  it("keeps a surrogate pair (emoji) intact instead of splitting it across chunks", () => {
+    const text = `a${"🙂".repeat(MAX_GOOGLE_CHAT_MESSAGE_LENGTH)}`;
+
+    const chunks = splitMessageForGoogleChat(text);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(MAX_GOOGLE_CHAT_MESSAGE_LENGTH);
+      expect(chunk.isWellFormed()).toBe(true);
+    }
+  });
+
+  it("returns original text when under maxLength", () => {
+    expect(splitMessageForGoogleChat("hello")).toEqual(["hello"]);
   });
 });

--- a/plugins/plugin-google-workspace/src/chat/service.ts
+++ b/plugins/plugin-google-workspace/src/chat/service.ts
@@ -23,6 +23,7 @@ import {
   type MessageConnectorUserContext,
   Service,
   type TargetInfo,
+  toWellFormedUnicode,
   type UUID,
 } from "@elizaos/core";
 import { GoogleAuth } from "google-auth-library";
@@ -51,6 +52,7 @@ import {
   isDirectMessage,
   normalizeSpaceTarget,
   normalizeUserTarget,
+  splitMessageForGoogleChat,
 } from "./types.js";
 
 const CHAT_API_BASE = "https://chat.googleapis.com/v1";
@@ -646,13 +648,39 @@ export class GoogleChatService extends Service implements IGoogleChatService {
   }
 
   async sendMessage(options: GoogleChatMessageSendOptions): Promise<GoogleChatSendResult> {
-    const state = this.getState(options.accountId);
     if (!options.space) {
       return {
         success: false,
         error: "Space is required",
       };
     }
+
+    const textChunks = options.text ? splitMessageForGoogleChat(options.text) : [undefined];
+    let lastResult: GoogleChatSendResult | undefined;
+
+    // Sequential sends preserve visible chunk order and stop immediately on a
+    // provider failure. Attachments belong to the logical message, so only the
+    // first chunk carries them rather than duplicating uploads on every chunk.
+    for (let index = 0; index < textChunks.length; index += 1) {
+      lastResult = await this.sendSingleMessage({
+        ...options,
+        text: textChunks[index],
+        attachments: index === 0 ? options.attachments : undefined,
+      });
+    }
+
+    return (
+      lastResult ?? {
+        success: false,
+        error: "Google Chat message has no sendable content",
+      }
+    );
+  }
+
+  private async sendSingleMessage(
+    options: GoogleChatMessageSendOptions
+  ): Promise<GoogleChatSendResult> {
+    const state = this.getState(options.accountId);
 
     const body: Record<string, unknown> = {};
 
@@ -711,7 +739,7 @@ export class GoogleChatService extends Service implements IGoogleChatService {
       url,
       {
         method: "PATCH",
-        body: JSON.stringify({ text }),
+        body: JSON.stringify({ text: toWellFormedUnicode(text) }),
       },
       accountId
     );

--- a/plugins/plugin-google-workspace/src/chat/types.ts
+++ b/plugins/plugin-google-workspace/src/chat/types.ts
@@ -2,7 +2,7 @@
  * Type definitions for the Google Chat plugin.
  */
 
-import { type Service, truncateWellFormed } from "@elizaos/core";
+import { type Service, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 /** Maximum message length for Google Chat */
 export const MAX_GOOGLE_CHAT_MESSAGE_LENGTH = 4000;
@@ -310,17 +310,26 @@ export function isDirectMessage(space: GoogleChatSpace): boolean {
   return space.type === "DM" || space.singleUserBotDm === true;
 }
 
-/** Split long text into chunks for Google Chat */
+/**
+ * Returns provider-sized, well-formed Unicode chunks for Google Chat.
+ * Budgets below two UTF-16 code units cannot hold an astral character and are
+ * rejected so every iteration has a valid, non-empty prefix.
+ */
 export function splitMessageForGoogleChat(
   text: string,
   maxLength: number = MAX_GOOGLE_CHAT_MESSAGE_LENGTH
 ): string[] {
-  if (text.length <= maxLength) {
-    return [text];
+  if (!Number.isInteger(maxLength) || maxLength < 2) {
+    throw new RangeError("Google Chat message maxLength must be an integer of at least 2");
+  }
+
+  const wellFormedText = toWellFormedUnicode(text);
+  if (wellFormedText.length <= maxLength) {
+    return [wellFormedText];
   }
 
   const chunks: string[] = [];
-  let remaining = text;
+  let remaining = wellFormedText;
 
   while (remaining.length > 0) {
     if (remaining.length <= maxLength) {
@@ -330,11 +339,11 @@ export function splitMessageForGoogleChat(
 
     // Find a good break point
     let breakPoint = maxLength;
-    const newlineIndex = remaining.lastIndexOf("\n", maxLength);
+    const newlineIndex = remaining.lastIndexOf("\n", maxLength - 1);
     if (newlineIndex > maxLength * 0.5) {
       breakPoint = newlineIndex + 1;
     } else {
-      const spaceIndex = remaining.lastIndexOf(" ", maxLength);
+      const spaceIndex = remaining.lastIndexOf(" ", maxLength - 1);
       if (spaceIndex > maxLength * 0.5) {
         breakPoint = spaceIndex + 1;
       }

--- a/plugins/plugin-google-workspace/src/chat/types.ts
+++ b/plugins/plugin-google-workspace/src/chat/types.ts
@@ -2,7 +2,7 @@
  * Type definitions for the Google Chat plugin.
  */
 
-import type { Service } from "@elizaos/core";
+import { type Service, truncateWellFormed } from "@elizaos/core";
 
 /** Maximum message length for Google Chat */
 export const MAX_GOOGLE_CHAT_MESSAGE_LENGTH = 4000;
@@ -340,8 +340,9 @@ export function splitMessageForGoogleChat(
       }
     }
 
-    chunks.push(remaining.slice(0, breakPoint).trimEnd());
-    remaining = remaining.slice(breakPoint).trimStart();
+    const head = truncateWellFormed(remaining, breakPoint);
+    chunks.push(head.trimEnd());
+    remaining = remaining.slice(head.length).trimStart();
   }
 
   return chunks;


### PR DESCRIPTION
Closes #22232
Supersedes closed PR #22227 while preserving its original surrogate-boundary commit and authorship.

## Summary

- wires Google Chat chunking into the public `GoogleChatService.sendMessage` provider path used by connector and direct callers;
- sends chunks sequentially, preserves thread metadata, attaches uploads only to the first chunk, stops on the first provider error, and returns the final provider receipt;
- sanitizes pre-existing lone surrogates before send/edit JSON serialization;
- rejects non-integer, non-finite, or `< 2` custom budgets so an astral character with `maxLength = 1` cannot stall forever;
- fixes the newline/space search boundary so a break at index `maxLength` cannot emit `maxLength + 1` code units.

## Exact-head evidence

<!-- evidence-head:ed56afc81d50e49a7daf793b3263e1d1ab53e21b -->

```text
bun run --cwd plugins/plugin-google-workspace test
  18 files passed; 183 tests passed

bun run --cwd plugins/plugin-google-workspace typecheck
  PASS

bun run --cwd plugins/plugin-google-workspace build
  PASS

bun run --cwd plugins/plugin-google-workspace lint:check
  Checked 41 files; no fixes

git diff --check origin/develop...HEAD
  PASS
```

New real HTTP-boundary coverage proves ordered two-chunk delivery, exact reconstruction for non-whitespace text, 4,000-unit maximums, well-formed chunks, stable thread routing, one-time attachment placement, last-receipt return, and no third request after the second provider request fails. Pure boundary cases cover 4,000/4,001, a whitespace at index 4,000, lone high/low surrogates, and invalid budgets including `1`, decimals, NaN, and infinities.

## Evidence matrix

- Screenshots/video: N/A — server-side connector transport only.
- Backend artifact: mocked provider HTTP request bodies and ordering in the owning package tests.
- Frontend logs: N/A — no frontend surface.
- Live credentials: N/A — no account is required to validate deterministic JSON chunking; real credential mutation was not attempted.
- Model trajectory: N/A — no model behavior.

## Contribution provenance

- Original boundary fix: preserved commit from #22227 by Kayvan-Zahiri.
- Maintainer repair AI assistance: yes
- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex Desktop, lane `codex-cortex-plugins`
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","lane":"codex-cortex-plugins"} -->
