### PR TITLE
fix(cloud): survive immediate-bye Ink transport teardown

### DIFF
--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { describe, expect, it } from "bun:test";
+import { createServer } from "node:net";
+import { WebSocket as NodeWebSocket } from "ws";
 import {
   buildCartesiaInkUrl,
   CARTESIA_INK_API_VERSION,
@@ -99,6 +101,23 @@ function createHarness() {
     onEvent: (event) => events.push(event),
   });
   return { events, metrics, requests, session, socket };
+}
+
+async function reserveThenReleaseLoopbackPort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("loopback server did not expose a TCP port");
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return address.port;
 }
 
 describe("Cartesia Ink realtime adapter", () => {
@@ -270,9 +289,66 @@ describe("Cartesia Ink realtime adapter", () => {
       { type: "close", code: 1000, reason: "cancelled", wasClean: true },
     ]);
     expect(socket.listeners.message.size).toBe(0);
+    expect(socket.listeners.error.size).toBe(1);
+    socket.emitError();
+    expect(events).toHaveLength(1);
     expect(() =>
       session.sendAudioChunk(new Uint8Array(CARTESIA_INK_CHUNK_BYTES)),
     ).toThrow(CartesiaInkConnectionError);
+  });
+
+  it("survives immediate cancellation while Node ws is connecting", async () => {
+    const port = await reserveThenReleaseLoopbackPort();
+    const events: CartesiaInkRealtimeEvent[] = [];
+    let transport: NodeWebSocket | undefined;
+    const session = createCartesiaInkRealtimeSession({
+      cartesiaApiKey: "cartesia-secret",
+      baseUrl: `ws://127.0.0.1:${port}/stt/turns/websocket`,
+      webSocketFactory(request) {
+        transport = new NodeWebSocket(request.url);
+        return transport as unknown as CartesiaInkWebSocket;
+      },
+      onEvent: (event) => events.push(event),
+    });
+    if (!transport) throw new Error("transport factory was not called");
+    const closed = new Promise<void>((resolve) =>
+      transport?.once("close", resolve),
+    );
+
+    session.cancel("immediate-bye");
+    await closed;
+
+    expect(transport.readyState).toBe(NodeWebSocket.CLOSED);
+    expect(events).toEqual([
+      {
+        type: "close",
+        code: 1000,
+        reason: "immediate-bye",
+        wasClean: true,
+      },
+    ]);
+
+    const nextEvents: CartesiaInkRealtimeEvent[] = [];
+    let nextTransport: NodeWebSocket | undefined;
+    createCartesiaInkRealtimeSession({
+      cartesiaApiKey: "cartesia-secret",
+      baseUrl: `ws://127.0.0.1:${port}/stt/turns/websocket`,
+      webSocketFactory(request) {
+        nextTransport = new NodeWebSocket(request.url);
+        return nextTransport as unknown as CartesiaInkWebSocket;
+      },
+      onEvent: (event) => nextEvents.push(event),
+    });
+    if (!nextTransport)
+      throw new Error("next transport factory was not called");
+    await new Promise<void>((resolve) => nextTransport?.once("close", resolve));
+
+    expect(nextEvents).toContainEqual({
+      type: "error",
+      code: "transport_error",
+      message: "Cartesia Ink WebSocket transport reported an error",
+      cause: expect.any(Event),
+    });
   });
 
   it("surfaces metrics hook, transport error, and transport close events", () => {

--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
@@ -264,6 +264,8 @@ export function createCartesiaInkRealtimeSession(
     });
   };
 
+  const inertErrorHandler = () => {};
+
   const cleanup = () => {
     if (cleanedUp) return;
     cleanedUp = true;
@@ -272,6 +274,7 @@ export function createCartesiaInkRealtimeSession(
     socket.removeEventListener("error", onError);
     socket.removeEventListener("close", onClose);
     options.signal?.removeEventListener("abort", onAbort);
+    socket.addEventListener("error", inertErrorHandler);
   };
 
   const onClose = (event: CloseEvent) => {


### PR DESCRIPTION
Closes #22225

Supersedes closed duplicate #22243. This branch preserves contributor `byt61`'s source commit and adds the real refused-loopback regression.

## Summary

- Retain one inert Cartesia Ink transport `error` listener after session cleanup so a late Node `ws` connection failure cannot terminate the local voice gateway after an immediate `bye`.
- Preserve the live pre-cleanup `onError` path and its structured `transport_error` event.
- Prove immediate cancellation while CONNECTING survives, emits no duplicate session error, and leaves a subsequent session able to report its own structured transport error.

## Independent exact-head review

<!-- evidence-head:cf826d90eadd9bebc8c34785a6fac972c589a977 -->

Head: `cf826d90eadd9bebc8c34785a6fac972c589a977`
Base: `develop@b675b5b6e824528a5af5ef9f250ff145b9b30c0f`

- [x] Rebased without conflict; contributor authorship preserved.
- [x] Source review: normal transport errors still reach `onEvent`; cleanup removes the session listener, retains exactly one inert transport observer, and remains idempotent.
- [x] Real Node `ws` refused-loopback test plus adapter suite: **10 passed, 0 failed**.
- [x] The regression proves the immediate-cancel socket closes without process termination and a new session still emits `transport_error`.
- [x] TypeScript `tsc --noEmit` passes.
- [x] Biome over both touched files and `git diff --check origin/develop...HEAD` pass.
- [ ] The package's chained Worker dry-run reaches an unrelated current-`develop` failure: the Cloud API stub does not yet export `truncateWellFormed`, now imported by shared Discord/Telegram helpers. The PR does not touch those files or that contract.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend transport lifecycle; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend transport lifecycle; no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic nonvisual socket lifecycle.
<!-- evidence-row:backend-logs -->
- [x] Exact-head test output records 10/10 passing, including the real refused-loopback immediate-cancel and next-session case.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or agent behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - transient socket session; no persisted artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text.

## Provenance

The source fix was authored by `byt61` in #22243 and remains a distinct authored commit. The regression and review were added by the maintainer lane.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b675b5b6e824528a5af5ef9f250ff145b9b30c0f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [codex/pr22252-independent-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@b675b5b6e824528a5af5ef9f250ff145b9b30c0f:packages/skills/skills/contribute-to-eliza"} -->
